### PR TITLE
Rename translation tags from combined_upload to upload

### DIFF
--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -3,11 +3,11 @@
 <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
 <%= render PageHeadingComponent.new do %>
-  <%= t('doc_auth.headings.combined_upload') %>
+  <%= t('doc_auth.headings.upload') %>
 <% end %>
 
 <p>
-  <%= t('doc_auth.info.combined_upload') %>
+  <%= t('doc_auth.info.upload') %>
 </p>
 
 <div class="grid-row grid-gap grid-gap-2">
@@ -24,9 +24,9 @@
       <%= t('doc_auth.info.tag') %>
     </div>
     <h2 class="margin-y-105">
-      <%= t('doc_auth.headings.combined_upload_from_phone') %>
+      <%= t('doc_auth.headings.upload_from_phone') %>
     </h2>
-    <%= t('doc_auth.info.combined_upload_from_phone') %>
+    <%= t('doc_auth.info.upload_from_phone') %>
     <%= simple_form_for(
           idv_phone_form,
           as: :doc_auth,
@@ -57,9 +57,9 @@
   </div>
   <div class="grid-col-12 tablet:grid-col-fill">
     <h2 class="margin-y-105">
-      <%= t('doc_auth.headings.combined_upload_from_computer') %>
+      <%= t('doc_auth.headings.upload_from_computer') %>
     </h2>
-    <%= t('doc_auth.info.combined_upload_from_computer') %>&nbsp;
+    <%= t('doc_auth.info.upload_from_computer') %>&nbsp;
     <%= simple_form_for(
           :doc_auth,
           url: url_for(type: :desktop),

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -112,9 +112,6 @@ en:
         information below is incorrect, please %{link} of your state-issued ID.
       capture_scan_warning_link: upload new photos
       capture_troubleshooting_tips: Having trouble adding your state-issued ID?
-      combined_upload: How would you like to add your ID?
-      combined_upload_from_computer: Continue on this computer
-      combined_upload_from_phone: Use your phone to take photos
       document_capture: Add your state-issued ID
       document_capture_back: Back of your ID
       document_capture_front: Front of your ID
@@ -126,6 +123,9 @@ en:
       ssn: Enter your Social Security number
       ssn_update: Update your Social Security number
       text_message: We sent a message to your phone
+      upload: How would you like to add your ID?
+      upload_from_computer: Continue on this computer
+      upload_from_phone: Use your phone to take photos
       verify_identity: Verify your identity
       welcome: Get started verifying your identity
     hybrid_flow_warning:
@@ -146,11 +146,6 @@ en:
       capture_status_none: Align
       capture_status_small_document: Move Closer
       capture_status_tap_to_capture: Tap to Capture
-      combined_upload: We’ll collect information about you by reading your state-issued ID.
-      combined_upload_from_computer: Don’t have a phone? Upload photos of your ID from this computer.
-      combined_upload_from_phone: You won’t have to sign in again, and you’ll switch
-        back to this computer after you take photos. Your mobile phone must have
-        a camera and a web browser.
       document_capture_intro_acknowledgment: We’ll collect information about you by
         reading your state-issued ID. We use this information to verify your
         identity.
@@ -179,6 +174,11 @@ en:
         address.
       tag: Recommended
       upload: We’ll collect information about you by reading your state-issued ID.
+      upload_from_computer: Don’t have a phone? Upload photos of your ID from this computer.
+      upload_from_phone: You won’t have to sign in again, and you’ll switch back to
+        this computer after you take photos. Your mobile phone must have a
+        camera and a web browser.
+
       verify_identity: We’ll ask for your personal information to verify your identity
         against public records.
       welcome_html: '%{sp_name} needs to make sure you are you — not someone

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -178,7 +178,6 @@ en:
       upload_from_phone: You won’t have to sign in again, and you’ll switch back to
         this computer after you take photos. Your mobile phone must have a
         camera and a web browser.
-
       verify_identity: We’ll ask for your personal information to verify your identity
         against public records.
       welcome_html: '%{sp_name} needs to make sure you are you — not someone

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -138,9 +138,6 @@ es:
         de su ID emitido por el estado.
       capture_scan_warning_link: suba nuevas fotos
       capture_troubleshooting_tips: '¿Tiene problemas para agregar su identificación emitida por el estado?'
-      combined_upload: '¿Cómo desea añadir su documento de identidad?'
-      combined_upload_from_computer: Continuar en esta computadora
-      combined_upload_from_phone: Utilice su teléfono para tomar las fotos
       document_capture: Añada su documento de identidad expedido por el estado
       document_capture_back: Parte trasera de su documento de identidad
       document_capture_front: Parte delantera de su documento de identidad
@@ -152,6 +149,9 @@ es:
       ssn: Ingresa tu número de Seguro Social
       ssn_update: Actualice su número de Seguro Social
       text_message: Enviamos un mensaje a su teléfono
+      upload: '¿Cómo desea añadir su documento de identidad?'
+      upload_from_computer: Continuar en esta computadora
+      upload_from_phone: Utilice su teléfono para tomar las fotos
       verify_identity: Verifique su identidad
       welcome: Comience a verificar su identidad
     hybrid_flow_warning:
@@ -175,13 +175,6 @@ es:
       capture_status_none: Alinea
       capture_status_small_document: Muévete mas cerca
       capture_status_tap_to_capture: Toque para capturar
-      combined_upload: Recopilaremos información sobre usted leyendo su documento de
-        identidad expedido por el estado.
-      combined_upload_from_computer: ¿No tiene teléfono? Suba fotos de su documento de
-        identidad desde esta computadora.
-      combined_upload_from_phone: No tendrá que volver a iniciar sesión y volverá a
-        cambiar a esta computadora después de tomar las fotos. Su teléfono móvil
-        debe tener una cámara y un navegador web.
       document_capture_intro_acknowledgment: Recopilaremos información sobre usted
         leyendo su documento de identidad expedido por el Estado. Usamos esta
         información para verificar su identidad.
@@ -214,6 +207,12 @@ es:
       tag: Recomendado
       upload: Recopilaremos información sobre usted leyendo su documento de identidad
         expedido por el estado.
+      upload_from_computer: ¿No tiene teléfono? Suba fotos de su documento de
+        identidad desde esta computadora.
+      upload_from_phone: No tendrá que volver a iniciar sesión y volverá a cambiar a
+        esta computadora después de tomar las fotos. Su teléfono móvil debe
+        tener una cámara y un navegador web.
+
       verify_identity: Le preguntaremos sus datos personales para verificar su
         identidad comparándola con los registros públicos.
       welcome_html: '%{sp_name} necesita asegurarse de que es usted y no es alguien

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -212,7 +212,6 @@ es:
       upload_from_phone: No tendrá que volver a iniciar sesión y volverá a cambiar a
         esta computadora después de tomar las fotos. Su teléfono móvil debe
         tener una cámara y un navegador web.
-
       verify_identity: Le preguntaremos sus datos personales para verificar su
         identidad comparándola con los registros públicos.
       welcome_html: '%{sp_name} necesita asegurarse de que es usted y no es alguien

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -144,9 +144,6 @@ fr:
         veuillez %{link} de votre carte d’identité délivrée par l’État.
       capture_scan_warning_link: télécharger de nouvelles photos
       capture_troubleshooting_tips: Vous rencontrez des difficultés pour ajouter votre pièce d’identité?
-      combined_upload: Comment voulez-vous ajouter votre identifiant ?
-      combined_upload_from_computer: Continuer sur cet ordinateur
-      combined_upload_from_phone: Utilisez votre téléphone pour prendre des photos
       document_capture: Ajoutez votre carte d’identité délivrée par l’État
       document_capture_back: Verso de votre carte d’identité
       document_capture_front: Recto de votre carte d’identité
@@ -158,6 +155,9 @@ fr:
       ssn: Saisissez votre numéro de sécurité sociale
       ssn_update: Mettre à jour votre numéro de Sécurité Sociale
       text_message: Nous avons envoyé un message à votre téléphone
+      upload: Comment voulez-vous ajouter votre identifiant ?
+      upload_from_computer: Continuer sur cet ordinateur
+      upload_from_phone: Utilisez votre téléphone pour prendre des photos
       verify_identity: Vérifier votre identité
       welcome: Commencez à vérifier votre identité
     hybrid_flow_warning:
@@ -180,13 +180,6 @@ fr:
       capture_status_none: Alignez
       capture_status_small_document: Approchez-vous
       capture_status_tap_to_capture: Appuyez pour capturer
-      combined_upload: Nous recueillons des informations sur vous en lisant votre
-        carte d’identité délivrée par l’État.
-      combined_upload_from_computer: Vous n’avez pas de téléphone ? Téléchargez les
-        photos de votre carte d’identité depuis cet ordinateur.
-      combined_upload_from_phone: Vous n’aurez pas à vous reconnecter. Vous reviendrez
-        sur cet ordinateur après avoir pris des photos. Votre téléphone portable
-        doit être équipé d’un appareil photo et d’un navigateur web.
       document_capture_intro_acknowledgment: Nous recueillons des informations sur
         vous en lisant votre pièce d’identité délivrée par l’État. Nous
         utilisons ces informations pour vérifier votre identité.
@@ -221,6 +214,11 @@ fr:
       tag: Recommandation
       upload: Nous recueillons des informations sur vous en lisant votre carte
         d’identité délivrée par l’État.
+      upload_from_computer: Vous n’avez pas de téléphone ? Téléchargez les photos de
+        votre carte d’identité depuis cet ordinateur.
+      upload_from_phone: Vous n’aurez pas à vous reconnecter. Vous reviendrez sur cet
+        ordinateur après avoir pris des photos. Votre téléphone portable doit
+        être équipé d’un appareil photo et d’un navigateur web.
       verify_identity: Nous vous demanderons vos informations personnelles afin de
         vérifier votre identité par rapport aux registres publics.
       welcome_html: '%{sp_name} doit s’assurer que vous êtes bien vous, et non

--- a/spec/features/idv/doc_auth/upload_step_spec.rb
+++ b/spec/features/idv/doc_auth/upload_step_spec.rb
@@ -28,9 +28,9 @@ feature 'doc auth upload step' do
     end
 
     it 'displays with the expected content' do
-      expect(page).to have_content(t('doc_auth.headings.combined_upload_from_computer'))
-      expect(page).to have_content(t('doc_auth.info.combined_upload_from_computer'))
-      expect(page).to have_content(t('doc_auth.headings.combined_upload_from_phone'))
+      expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
+      expect(page).to have_content(t('doc_auth.info.upload_from_computer'))
+      expect(page).to have_content(t('doc_auth.headings.upload_from_phone'))
     end
 
     it 'proceeds to document capture when user chooses to upload from computer' do


### PR DESCRIPTION
These names were left over from the feature flagged stage of creating the combined hybrid handoff.

Pulled this commit out of closed PR #8213 which was addressing ticket LG-9313.
