### PR TITLE
Create return_to_sp url directly for DocumentCapture step (no FSM)

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -40,7 +40,7 @@ module Idv
         flow_session: flow_session,
         flow_path: 'standard',
         sp_name: decorated_session.sp_name,
-        failure_to_proof_url: idv_doc_auth_return_to_sp_url,
+        failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
 
         front_image_upload_url: url_builder.presigned_image_upload_url(
           image_type: 'front',

--- a/app/views/idv/document_capture/show.html.erb
+++ b/app/views/idv/document_capture/show.html.erb
@@ -3,7 +3,7 @@
       flow_session: flow_session,
       flow_path: 'standard',
       sp_name: decorated_session.sp_name,
-      failure_to_proof_url: idv_doc_auth_return_to_sp_url,
+      failure_to_proof_url: failure_to_proof_url,
       front_image_upload_url: front_image_upload_url,
       back_image_upload_url: back_image_upload_url,
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,


### PR DESCRIPTION
## 🎫 Ticket
[LG-9106](https://cm-jira.usa.gov/browse/LG-9106)

## 🛠 Summary of changes
This is part of the effort to delete unused parts of the FSM DocumentCaptureStep (see also PR #8218)

There is a doc_auth#return_to_sp route that adds the current step to analytics when a user clicks the return_to_sp url, using the Flow State Machine. We can't use that in the new DocumentCaptureController once the DocumentCaptureStep is deleted from DocAuthFlow, so set the return_to_sp url more directly.


