### PR TITLE
LG-8871: Allow users to prefix otp with '#'

### DIFF
--- a/app/components/one_time_code_input_component.rb
+++ b/app/components/one_time_code_input_component.rb
@@ -27,7 +27,7 @@ class OneTimeCodeInputComponent < BaseComponent
     form:,
     name: :code,
     value: nil,
-    maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
+    maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH + 1, # to allow for leading '#'
     autofocus: false,
     transport: 'sms',
     numeric: true,
@@ -55,9 +55,9 @@ class OneTimeCodeInputComponent < BaseComponent
 
   def input_pattern
     if numeric?
-      '[0-9]*'
+      '#?[0-9]*'
     else
-      '[a-zA-Z0-9]*'
+      '#?[a-zA-Z0-9]*'
     end
   end
 

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -89,9 +89,7 @@ module TwoFactorAuthentication
     end
 
     def sanitized_otp_code
-      code = form_params[:code].to_s.strip
-      code = code[1..] if code[0] == '#'
-      code
+      form_params[:code].to_s.strip.sub(/^#/, '')
     end
 
     def form_params

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -89,7 +89,9 @@ module TwoFactorAuthentication
     end
 
     def sanitized_otp_code
-      form_params[:code].to_s.strip
+      code = form_params[:code].to_s.strip
+      code = code[1..] if code[0] == '#'
+      code
     end
 
     def form_params

--- a/app/services/idv/phone_confirmation_session.rb
+++ b/app/services/idv/phone_confirmation_session.rb
@@ -36,6 +36,7 @@ module Idv
     def matches_code?(candidate_code)
       return Devise.secure_compare(candidate_code, code) if code.nil? || candidate_code.nil?
 
+      candidate_code = candidate_code[1..] if candidate_code[0] == '#'
       crockford_candidate_code = Base32::Crockford.normalize(candidate_code)
       crockford_code = Base32::Crockford.normalize(code)
       Devise.secure_compare(crockford_candidate_code, crockford_code)

--- a/app/services/idv/phone_confirmation_session.rb
+++ b/app/services/idv/phone_confirmation_session.rb
@@ -36,8 +36,7 @@ module Idv
     def matches_code?(candidate_code)
       return Devise.secure_compare(candidate_code, code) if code.nil? || candidate_code.nil?
 
-      candidate_code = candidate_code[1..] if candidate_code[0] == '#'
-      crockford_candidate_code = Base32::Crockford.normalize(candidate_code)
+      crockford_candidate_code = Base32::Crockford.normalize(candidate_code.sub(/^#/, ''))
       crockford_code = Base32::Crockford.normalize(code)
       Devise.secure_compare(crockford_candidate_code, crockford_code)
     end

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -21,7 +21,7 @@
         value: @code,
         numeric: false,
         autofocus: true,
-        maxlength: TwoFactorAuthenticatable::PROOFING_DIRECT_OTP_LENGTH,
+        maxlength: TwoFactorAuthenticatable::PROOFING_DIRECT_OTP_LENGTH + 1,
         class: 'margin-bottom-5',
       ) %>
   <%= f.submit t('forms.buttons.submit.default'), class: 'margin-bottom-5' %>

--- a/spec/components/one_time_code_input_component_spec.rb
+++ b/spec/components/one_time_code_input_component_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
 
   describe 'maxlength' do
     context 'no maxlength given' do
-      it 'renders input maxlength DIRECT_OTP_LENGTH' do
+      it 'renders input maxlength DIRECT_OTP_LENGTH + 1' do
         expect(rendered).to have_selector(
-          "[maxlength=\"#{TwoFactorAuthenticatable::DIRECT_OTP_LENGTH}\"]",
+          "[maxlength=\"#{TwoFactorAuthenticatable::DIRECT_OTP_LENGTH + 1}\"]",
         )
       end
     end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -219,10 +219,6 @@ describe TwoFactorAuthentication::OtpVerificationController do
     context 'when the user enters a valid OTP' do
       before do
         sign_in_before_2fa
-        form = OtpVerificationForm.new(subject.current_user, nil)
-        result = FormResponse.new(success: true, serialize_error_details_only: {})
-        expect(form).to receive(:submit).and_return(result)
-        expect(subject).to receive(:otp_verification_form).and_return(form)
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
       end
 
@@ -288,6 +284,17 @@ describe TwoFactorAuthentication::OtpVerificationController do
           code: subject.current_user.reload.direct_otp,
           otp_delivery_preference: 'sms',
         }
+      end
+
+      context "with a leading '#' sign" do
+        it 'redirects to the profile' do
+          post :create, params: {
+            code: "##{subject.current_user.reload.direct_otp}",
+            otp_delivery_preference: 'sms',
+          }
+
+          expect(response).to redirect_to account_path
+        end
       end
 
       context 'with remember_device in the params' do

--- a/spec/services/idv/phone_confirmation_session_spec.rb
+++ b/spec/services/idv/phone_confirmation_session_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe Idv::PhoneConfirmationSession do
       expect(subject.matches_code?(uppercase_code)).to eq(true)
     end
 
+    it 'returns true if the code is prefixed with a # sign' do
+      prefixed_code = "##{code}"
+
+      expect(subject.matches_code?(prefixed_code)).to eq(true)
+    end
+
     it 'returns false if the code does not match' do
       bad_code = '1' * (TwoFactorAuthenticatable::DIRECT_OTP_LENGTH - 1)
       expect(subject.matches_code?(bad_code)).to eq(false)


### PR DESCRIPTION
## 🎫 Ticket

[LG-8871: Allowing a user to enter “#” before a one-time code](https://cm-jira.usa.gov/browse/LG-8871)

## 🛠 Summary of changes

The texts we send to users with a one-time code show the code twice:
- once as is, e.g., '123456'
- once with a '#' in front, e.g., '#123456'

This change allows the user to enter the code either way.

## 📜 Testing Plan

1. Create a new user with SMS set for 2FA
2. When entering the 2FA, prepend a '#' in front of the code
3. Verify that the code was accepted
4. Go through identity verification until you get to the phone step
5. When entering the 2FA, prepend a '#' in front of the code
6. Verify that the code was accepted
