### PR TITLE
LG-9404: Rename DAV PII fields to be forwards compatible with generic identity documents

### DIFF
--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -3,9 +3,9 @@ module Idv
     include ActiveModel::Model
     include FormStateIdValidator
 
-    ATTRIBUTES = %i[first_name last_name dob state_id_address1 state_id_address2
-                    state_id_city state_id_zipcode state_id_jurisdiction
-                    state_id_state state_id_number same_address_as_id].freeze
+    ATTRIBUTES = %i[first_name last_name dob identity_doc_address1 identity_doc_address2
+                    identity_doc_city identity_doc_zipcode state_id_jurisdiction
+                    identity_doc_state state_id_number same_address_as_id].freeze
 
     attr_accessor(*ATTRIBUTES)
 
@@ -23,9 +23,9 @@ module Idv
       cleaned_errors = errors.dup
       cleaned_errors.delete(:first_name, :nontransliterable_field)
       cleaned_errors.delete(:last_name, :nontransliterable_field)
-      cleaned_errors.delete(:state_id_city, :nontransliterable_field)
-      cleaned_errors.delete(:state_id_address1, :nontransliterable_field)
-      cleaned_errors.delete(:state_id_address2, :nontransliterable_field)
+      cleaned_errors.delete(:identity_doc_city, :nontransliterable_field)
+      cleaned_errors.delete(:identity_doc_address1, :nontransliterable_field)
+      cleaned_errors.delete(:identity_doc_address2, :nontransliterable_field)
 
       FormResponse.new(
         success: valid?,

--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -5,7 +5,7 @@ module Idv
 
     ATTRIBUTES = %i[first_name last_name dob identity_doc_address1 identity_doc_address2
                     identity_doc_city identity_doc_zipcode state_id_jurisdiction
-                    identity_doc_state state_id_number same_address_as_id].freeze
+                    identity_doc_address_state state_id_number same_address_as_id].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/app/services/idv/steps/in_person/state_id_step.rb
+++ b/app/services/idv/steps/in_person/state_id_step.rb
@@ -21,11 +21,11 @@ module Idv
           formatted_dob = MemorableDateComponent.extract_date_param flow_params&.[](:dob)
           pii_from_user[:dob] = formatted_dob if formatted_dob
           if capture_secondary_id_enabled? && pii_from_user[:same_address_as_id] == 'true'
-            pii_from_user[:address1] = flow_params[:state_id_address1]
-            pii_from_user[:address2] = flow_params[:state_id_address2]
-            pii_from_user[:city] = flow_params[:state_id_city]
-            pii_from_user[:state] = flow_params[:state_id_state]
-            pii_from_user[:zipcode] = flow_params[:state_id_zipcode]
+            pii_from_user[:address1] = flow_params[:identity_doc_address1]
+            pii_from_user[:address2] = flow_params[:identity_doc_address2]
+            pii_from_user[:city] = flow_params[:identity_doc_city]
+            pii_from_user[:state] = flow_params[:identity_doc_state]
+            pii_from_user[:zipcode] = flow_params[:identity_doc_zipcode]
             mark_step_complete(:address)
           end
         end

--- a/app/services/idv/steps/in_person/state_id_step.rb
+++ b/app/services/idv/steps/in_person/state_id_step.rb
@@ -24,7 +24,7 @@ module Idv
             pii_from_user[:address1] = flow_params[:identity_doc_address1]
             pii_from_user[:address2] = flow_params[:identity_doc_address2]
             pii_from_user[:city] = flow_params[:identity_doc_city]
-            pii_from_user[:state] = flow_params[:identity_doc_state]
+            pii_from_user[:state] = flow_params[:identity_doc_address_state]
             pii_from_user[:zipcode] = flow_params[:identity_doc_zipcode]
             mark_step_complete(:address)
           end

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -10,11 +10,11 @@ module Pii
     # The user's residential address
     :address1, :address2, :city, :state, :zipcode, :same_address_as_id,
     # The address on a user's state-issued ID, which may be different from their residential address
-    :state_id_address1, :state_id_address2, :state_id_city, :state_id_zipcode,
+    :identity_doc_address1, :identity_doc_address2, :identity_doc_city, :identity_doc_zipcode,
     # the state that issued the id, which may be different than the state in the state id address
     :state_id_jurisdiction,
     # the state in the state id address, which may not be the state that issued the ID
-    :state_id_state,
+    :identity_doc_state,
     :ssn, :dob, :phone,
     *DEPRECATED_PII_ATTRIBUTES
   ) do

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -14,7 +14,7 @@ module Pii
     # the state that issued the id, which may be different than the state in the state id address
     :state_id_jurisdiction,
     # the state in the state id address, which may not be the state that issued the ID
-    :identity_doc_state,
+    :identity_doc_address_state,
     :ssn, :dob, :phone,
     *DEPRECATED_PII_ATTRIBUTES
   ) do

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -98,7 +98,7 @@ module UspsInPersonProofing
         identity_doc_address1: :address1,
         identity_doc_address2: :address2,
         identity_doc_city: :city,
-        identity_doc_state: :state,
+        identity_doc_address_state: :state,
         identity_doc_zipcode: :zipcode,
       }.freeze
 

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -95,11 +95,11 @@ module UspsInPersonProofing
       private
 
       SECONDARY_ID_ADDRESS_MAP = {
-        state_id_address1: :address1,
-        state_id_address2: :address2,
-        state_id_city: :city,
-        state_id_state: :state,
-        state_id_zipcode: :zipcode,
+        identity_doc_address1: :address1,
+        identity_doc_address2: :address2,
+        identity_doc_city: :city,
+        identity_doc_state: :state,
+        identity_doc_zipcode: :zipcode,
       }.freeze
 
       def handle_bad_request_error(err, enrollment)

--- a/app/validators/idv/form_state_id_validator.rb
+++ b/app/validators/idv/form_state_id_validator.rb
@@ -11,7 +11,7 @@ module Idv
                 presence: true
 
       validates_with UspsInPersonProofing::TransliterableValidator,
-                     fields: [:first_name, :last_name, :state_id_city],
+                     fields: [:first_name, :last_name, :identity_doc_city],
                      reject_chars: /[^A-Za-z\-' ]/,
                      message: ->(invalid_chars) do
                        I18n.t(
@@ -21,7 +21,7 @@ module Idv
                      end
 
       validates_with UspsInPersonProofing::TransliterableValidator,
-                     fields: [:state_id_address1, :state_id_address2],
+                     fields: [:identity_doc_address1, :identity_doc_address2],
                      reject_chars: /[^A-Za-z0-9\-' .\/#]/,
                      message: ->(invalid_chars) do
                        I18n.t(

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -127,14 +127,14 @@
   <% if capture_secondary_id_enabled %>
     <h2> <%= t('in_person_proofing.headings.id_address') %> </h2>
       <%= render ValidatedFieldComponent.new(
-            name: :identity_doc_state,
+            name: :identity_doc_address_state,
             collection: us_states_territories,
             form: f,
-            label: t('in_person_proofing.form.state_id.identity_doc_state'),
+            label: t('in_person_proofing.form.state_id.identity_doc_address_state'),
             label_html: { class: 'usa-label' },
-            prompt: t('in_person_proofing.form.state_id.identity_doc_state_prompt'),
+            prompt: t('in_person_proofing.form.state_id.identity_doc_address_state_prompt'),
             required: true,
-            selected: pii[:identity_doc_state],
+            selected: pii[:identity_doc_address_state],
           ) %>
       <%= render ValidatedFieldComponent.new(
             name: :identity_doc_address1,
@@ -172,7 +172,7 @@
             name: :state_id_jurisdiction,
             collection: us_states_territories,
             form: f,
-            hint: t('in_person_proofing.form.state_id.identity_doc_state_hint'),
+            hint: t('in_person_proofing.form.state_id.identity_doc_address_state_hint'),
             label: t('in_person_proofing.form.state_id.state_id_jurisdiction'),
             label_html: { class: 'usa-label' },
             prompt: t('in_person_proofing.form.state_id.state_id_jurisdiction_prompt'),

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -127,19 +127,19 @@
   <% if capture_secondary_id_enabled %>
     <h2> <%= t('in_person_proofing.headings.id_address') %> </h2>
       <%= render ValidatedFieldComponent.new(
-            name: :state_id_state,
+            name: :identity_doc_state,
             collection: us_states_territories,
             form: f,
-            label: t('in_person_proofing.form.state_id.state_id_state'),
+            label: t('in_person_proofing.form.state_id.identity_doc_state'),
             label_html: { class: 'usa-label' },
-            prompt: t('in_person_proofing.form.state_id.state_id_state_prompt'),
+            prompt: t('in_person_proofing.form.state_id.identity_doc_state_prompt'),
             required: true,
-            selected: pii[:state_id_state],
+            selected: pii[:identity_doc_state],
           ) %>
       <%= render ValidatedFieldComponent.new(
-            name: :state_id_address1,
+            name: :identity_doc_address1,
             form: f,
-            input_html: { value: pii[:state_id_address1] },
+            input_html: { value: pii[:identity_doc_address1] },
             label: t('in_person_proofing.form.state_id.address1'),
             label_html: { class: 'usa-label' },
             maxlength: 255,
@@ -147,9 +147,9 @@
           ) %>
 
       <%= render ValidatedFieldComponent.new(
-            name: :state_id_address2,
+            name: :identity_doc_address2,
             form: f,
-            input_html: { value: pii[:state_id_address2] },
+            input_html: { value: pii[:identity_doc_address2] },
             label: t('in_person_proofing.form.state_id.address2'),
             label_html: { class: 'usa-label' },
             maxlength: 255,
@@ -157,9 +157,9 @@
           ) %>
  
       <%= render ValidatedFieldComponent.new(
-            name: :state_id_city,
+            name: :identity_doc_city,
             form: f,
-            input_html: { value: pii[:state_id_city] },
+            input_html: { value: pii[:identity_doc_city] },
             label: t('in_person_proofing.form.state_id.city'),
             label_html: { class: 'usa-label' },
             maxlength: 255,
@@ -172,7 +172,7 @@
             name: :state_id_jurisdiction,
             collection: us_states_territories,
             form: f,
-            hint: t('in_person_proofing.form.state_id.state_id_state_hint'),
+            hint: t('in_person_proofing.form.state_id.identity_doc_state_hint'),
             label: t('in_person_proofing.form.state_id.state_id_jurisdiction'),
             label_html: { class: 'usa-label' },
             prompt: t('in_person_proofing.form.state_id.state_id_jurisdiction_prompt'),
@@ -184,9 +184,9 @@
   <% if capture_secondary_id_enabled %>
     <div class="tablet:grid-col-8 margin-bottom-5">
       <%= render ValidatedFieldComponent.new(
-            name: :state_id_zipcode,
+            name: :identity_doc_zipcode,
             form: f,
-            input_html: { value: pii[:state_id_zipcode] },
+            input_html: { value: pii[:identity_doc_zipcode] },
             label: t('in_person_proofing.form.state_id.zipcode'),
             label_html: { class: 'usa-label' },
             maxlength: 255,

--- a/app/views/idv/shared/_verify.html.erb
+++ b/app/views/idv/shared/_verify.html.erb
@@ -44,23 +44,23 @@ locals:
       <% if !remote_identity_proofing && capture_secondary_id_enabled %>
         <div class="margin-top-105">
           <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
-          <dd class="display-inline margin-left-0"> <%= pii[:state_id_address1] %> </dd>
+          <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_address1] %> </dd>
         </div>
         <div>
           <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
-          <dd class="display-inline margin-left-0"> <%= pii[:state_id_address2] %> </dd>
+          <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_address2] %> </dd>
         </div>
         <div>
           <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
-          <dd class="display-inline margin-left-0"> <%= pii[:state_id_city] %> </dd>
+          <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_city] %> </dd>
         </div>
         <div>
           <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
-          <dd class="display-inline margin-left-0"> <%= pii[:state_id_state] %> </dd>
+          <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_state] %> </dd>
         </div>
         <div>
           <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
-          <dd class="display-inline margin-left-0"> <%= pii[:state_id_zipcode] %> </dd>
+          <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_zipcode] %> </dd>
         </div>
       <% end %>
     </dl>

--- a/app/views/idv/shared/_verify.html.erb
+++ b/app/views/idv/shared/_verify.html.erb
@@ -56,7 +56,7 @@ locals:
         </div>
         <div>
           <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
-          <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_state] %> </dd>
+          <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_address_state] %> </dd>
         </div>
         <div>
           <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -119,9 +119,9 @@ en:
         state_id_jurisdiction_prompt: '- Select -'
         state_id_number: ID number
         state_id_number_hint: May include letters and numbers
-        state_id_state: State
-        state_id_state_hint: Select the state shown on your ID
-        state_id_state_prompt: '- Select -'
+        identity_doc_state: State
+        identity_doc_state_hint: Select the state shown on your ID
+        identity_doc_state_prompt: '- Select -'
         zipcode: ZIP Code
     headings:
       address: Enter your current residential address

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -104,6 +104,9 @@ en:
           unsupported_chars: 'Our system cannot read the following characters:
             %{char_list}. Please try again using the characters on your ID.'
         first_name: First name
+        identity_doc_state: State
+        identity_doc_state_hint: Select the state shown on your ID
+        identity_doc_state_prompt: '- Select -'
         last_name: Last name
         memorable_date:
           errors:
@@ -119,9 +122,6 @@ en:
         state_id_jurisdiction_prompt: '- Select -'
         state_id_number: ID number
         state_id_number_hint: May include letters and numbers
-        identity_doc_state: State
-        identity_doc_state_hint: Select the state shown on your ID
-        identity_doc_state_prompt: '- Select -'
         zipcode: ZIP Code
     headings:
       address: Enter your current residential address

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -104,9 +104,9 @@ en:
           unsupported_chars: 'Our system cannot read the following characters:
             %{char_list}. Please try again using the characters on your ID.'
         first_name: First name
-        identity_doc_state: State
-        identity_doc_state_hint: Select the state shown on your ID
-        identity_doc_state_prompt: '- Select -'
+        identity_doc_address_state: State
+        identity_doc_address_state_hint: Select the state shown on your ID
+        identity_doc_address_state_prompt: '- Select -'
         last_name: Last name
         memorable_date:
           errors:

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -134,9 +134,9 @@ es:
         state_id_jurisdiction_prompt: '- Seleccione -'
         state_id_number: Número de cédula
         state_id_number_hint: Puede incluir letras y números
-        state_id_state: Estado emisor
-        state_id_state_hint: Este es el estado que emitió su identificación
-        state_id_state_prompt: '- Seleccione -'
+        identity_doc_state: Estado emisor
+        identity_doc_state_hint: Este es el estado que emitió su identificación
+        identity_doc_state_prompt: '- Seleccione -'
         zipcode: Código postal
     headings:
       address: Ingresa tu domicilio actual

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -118,9 +118,9 @@ es:
             sistema: %{char_list}. Inténtelo nuevamente usando los caracteres de
             su documento de identidad.'
         first_name: Nombre
-        identity_doc_state: Estado emisor
-        identity_doc_state_hint: Este es el estado que emitió su identificación
-        identity_doc_state_prompt: '- Seleccione -'
+        identity_doc_address_state: Estado emisor
+        identity_doc_address_state_hint: Este es el estado que emitió su identificación
+        identity_doc_address_state_prompt: '- Seleccione -'
         last_name: Apellido
         memorable_date:
           errors:

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -118,6 +118,9 @@ es:
             sistema: %{char_list}. Inténtelo nuevamente usando los caracteres de
             su documento de identidad.'
         first_name: Nombre
+        identity_doc_state: Estado emisor
+        identity_doc_state_hint: Este es el estado que emitió su identificación
+        identity_doc_state_prompt: '- Seleccione -'
         last_name: Apellido
         memorable_date:
           errors:
@@ -134,9 +137,6 @@ es:
         state_id_jurisdiction_prompt: '- Seleccione -'
         state_id_number: Número de cédula
         state_id_number_hint: Puede incluir letras y números
-        identity_doc_state: Estado emisor
-        identity_doc_state_hint: Este es el estado que emitió su identificación
-        identity_doc_state_prompt: '- Seleccione -'
         zipcode: Código postal
     headings:
       address: Ingresa tu domicilio actual

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -118,6 +118,9 @@ fr:
             : %{char_list}. Veuillez réessayer en utilisant les caractères de
             votre carte d’identité.'
         first_name: Prénom
+        identity_doc_state: État émetteur
+        identity_doc_state_hint: Il s’agit de l’État qui a émis votre pièce d’identité
+        identity_doc_state_prompt: '- Sélectionnez -'
         last_name: Nom de famille
         memorable_date:
           errors:
@@ -135,9 +138,6 @@ fr:
         state_id_jurisdiction_prompt: '- Sélectionnez -'
         state_id_number: Numéro d’identification
         state_id_number_hint: Peut comprendre des lettres et des chiffres
-        identity_doc_state: État émetteur
-        identity_doc_state_hint: Il s’agit de l’État qui a émis votre pièce d’identité
-        identity_doc_state_prompt: '- Sélectionnez -'
         zipcode: Code postal
     headings:
       address: Indiquez votre adresse résidentielle actuelle

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -135,9 +135,9 @@ fr:
         state_id_jurisdiction_prompt: '- Sélectionnez -'
         state_id_number: Numéro d’identification
         state_id_number_hint: Peut comprendre des lettres et des chiffres
-        state_id_state: État émetteur
-        state_id_state_hint: Il s’agit de l’État qui a émis votre pièce d’identité
-        state_id_state_prompt: '- Sélectionnez -'
+        identity_doc_state: État émetteur
+        identity_doc_state_hint: Il s’agit de l’État qui a émis votre pièce d’identité
+        identity_doc_state_prompt: '- Sélectionnez -'
         zipcode: Code postal
     headings:
       address: Indiquez votre adresse résidentielle actuelle

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -118,9 +118,9 @@ fr:
             : %{char_list}. Veuillez réessayer en utilisant les caractères de
             votre carte d’identité.'
         first_name: Prénom
-        identity_doc_state: État émetteur
-        identity_doc_state_hint: Il s’agit de l’État qui a émis votre pièce d’identité
-        identity_doc_state_prompt: '- Sélectionnez -'
+        identity_doc_address_state: État émetteur
+        identity_doc_address_state_hint: Il s’agit de l’État qui a émis votre pièce d’identité
+        identity_doc_address_state_prompt: '- Sélectionnez -'
         last_name: Nom de famille
         memorable_date:
           errors:

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -106,7 +106,7 @@ module Idp
       identity_doc_address2: '2nd Address Line',
       identity_doc_city: 'Best City',
       identity_doc_zipcode: '12345',
-      identity_doc_state: 'VA',
+      identity_doc_address_state: 'VA',
     ).freeze
 
     MOCK_IDV_APPLICANT_WITH_SSN = MOCK_IDV_APPLICANT.merge(ssn: '900-66-1234').freeze
@@ -115,6 +115,6 @@ module Idp
 
     MOCK_IDV_APPLICANT_FULL_STATE_ID_JURISDICTION = 'North Dakota'
     MOCK_IDV_APPLICANT_FULL_STATE = 'Montana'
-    MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_STATE = 'Virginia'
+    MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_ADDRESS_STATE = 'Virginia'
   end
 end

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -102,11 +102,11 @@ module Idp
     }.freeze
 
     MOCK_IDV_APPLICANT_STATE_ID_ADDRESS = MOCK_IDV_APPLICANT.merge(
-      state_id_address1: '123 Way St',
-      state_id_address2: '2nd Address Line',
-      state_id_city: 'Best City',
-      state_id_zipcode: '12345',
-      state_id_state: 'VA',
+      identity_doc_address1: '123 Way St',
+      identity_doc_address2: '2nd Address Line',
+      identity_doc_city: 'Best City',
+      identity_doc_zipcode: '12345',
+      identity_doc_state: 'VA',
     ).freeze
 
     MOCK_IDV_APPLICANT_WITH_SSN = MOCK_IDV_APPLICANT.merge(ssn: '900-66-1234').freeze
@@ -115,6 +115,6 @@ module Idp
 
     MOCK_IDV_APPLICANT_FULL_STATE_ID_JURISDICTION = 'North Dakota'
     MOCK_IDV_APPLICANT_FULL_STATE = 'Montana'
-    MOCK_IDV_APPLICANT_FULL_STATE_ID_STATE = 'Virginia'
+    MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_STATE = 'Virginia'
   end
 end

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -9,7 +9,7 @@ class SessionEncryptor
   SENSITIVE_KEYS = [
     'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
     'zip_code', 'identity_doc_address1', 'identity_doc_address2', 'identity_doc_city',
-    'identity_doc_zipcode', 'identity_doc_state', 'state_id_jurisdiction',
+    'identity_doc_zipcode', 'identity_doc_address_state', 'state_id_jurisdiction',
     'same_address_as_id', 'dob', 'phone_number', 'phone', 'ssn',
     'prev_address1', 'prev_address2', 'prev_city', 'prev_state', 'prev_zipcode', 'pii',
     'pii_from_doc', 'pii_from_user', 'password', 'personal_key', 'email', 'email_address',

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -8,8 +8,8 @@ class SessionEncryptor
   MINIMUM_COMPRESS_LIMIT = 300
   SENSITIVE_KEYS = [
     'first_name', 'middle_name', 'last_name', 'address1', 'address2', 'city', 'state', 'zipcode',
-    'zip_code', 'state_id_address1', 'state_id_address2', 'state_id_city',
-    'state_id_zipcode', 'state_id_state', 'state_id_jurisdiction',
+    'zip_code', 'identity_doc_address1', 'identity_doc_address2', 'identity_doc_city',
+    'identity_doc_zipcode', 'identity_doc_state', 'state_id_jurisdiction',
     'same_address_as_id', 'dob', 'phone_number', 'phone', 'ssn',
     'prev_address1', 'prev_address2', 'prev_city', 'prev_state', 'prev_zipcode', 'pii',
     'pii_from_doc', 'pii_from_user', 'password', 'personal_key', 'email', 'email_address',

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -490,10 +490,10 @@ RSpec.describe 'In Person Proofing', js: true do
         fill_in t('in_person_proofing.form.state_id.last_name'),
                 with: InPersonHelper::GOOD_LAST_NAME
         fill_in t('in_person_proofing.form.state_id.address1'),
-                with: InPersonHelper::GOOD_STATE_ID_ADDRESS1
+                with: InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1
         fill_in t('in_person_proofing.form.state_id.address2'),
-                with: InPersonHelper::GOOD_STATE_ID_ADDRESS2
-        fill_in t('in_person_proofing.form.state_id.city'), with: InPersonHelper::GOOD_STATE_ID_CITY
+                with: InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2
+        fill_in t('in_person_proofing.form.state_id.city'), with: InPersonHelper::GOOD_IDENTITY_DOC_CITY
         click_idv_continue
 
         expect(page).to have_current_path(idv_in_person_step_path(step: :address), wait: 10)

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -493,7 +493,8 @@ RSpec.describe 'In Person Proofing', js: true do
                 with: InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1
         fill_in t('in_person_proofing.form.state_id.address2'),
                 with: InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2
-        fill_in t('in_person_proofing.form.state_id.city'), with: InPersonHelper::GOOD_IDENTITY_DOC_CITY
+        fill_in t('in_person_proofing.form.state_id.city'),
+                with: InPersonHelper::GOOD_IDENTITY_DOC_CITY
         click_idv_continue
 
         expect(page).to have_current_path(idv_in_person_step_path(step: :address), wait: 10)

--- a/spec/features/idv/steps/in_person/verify_step_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_step_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe 'doc auth IPP Verify Step', js: true do
       expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
       expect(page).to have_text(
         Idp::Constants::
-                MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_state],
+                MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address_state],
       ).twice
       expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]).once
       expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice

--- a/spec/features/idv/steps/in_person/verify_step_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_step_spec.rb
@@ -164,15 +164,15 @@ RSpec.describe 'doc auth IPP Verify Step', js: true do
         MOCK_IDV_APPLICANT_STATE_ID_JURISDICTION}",
       )
       expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
-      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_ADDRESS1).twice
-      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_ADDRESS2).twice
-      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_CITY).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
       expect(page).to have_text(
         Idp::Constants::
-                MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_state],
+                MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_state],
       ).twice
       expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]).once
-      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_ZIPCODE).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
       expect(page).to have_content(t('headings.residential_address'))
       expect(page).to have_content(t('headings.ssn'))
       expect(page).to have_text('9**-**-***4')

--- a/spec/services/idv/steps/in_person/state_id_step_spec.rb
+++ b/spec/services/idv/steps/in_person/state_id_step_spec.rb
@@ -29,14 +29,14 @@ describe Idv::Steps::InPerson::StateIdStep do
       let(:first_name) { 'Natalya' }
       let(:last_name) { 'Rostova' }
       let(:dob) { '1980-01-01' }
-      let(:state_id_state) { 'Nevada' }
+      let(:identity_doc_state) { 'Nevada' }
       let(:state_id_number) { 'ABC123234' }
       let(:submitted_values) do
         {
           first_name: first_name,
           last_name: last_name,
           dob: dob,
-          state_id_state: state_id_state,
+          identity_doc_state: identity_doc_state,
           state_id_number: state_id_number,
         }
       end
@@ -59,7 +59,7 @@ describe Idv::Steps::InPerson::StateIdStep do
         expect(pii_from_user[:first_name]).to eq first_name
         expect(pii_from_user[:last_name]).to eq last_name
         expect(pii_from_user[:dob]).to eq dob
-        expect(pii_from_user[:state_id_state]).to eq state_id_state
+        expect(pii_from_user[:identity_doc_state]).to eq identity_doc_state
         expect(pii_from_user[:state_id_number]).to eq state_id_number
       end
 
@@ -166,20 +166,20 @@ describe Idv::Steps::InPerson::StateIdStep do
     let(:capture_secondary_id_enabled) { true }
     let(:enrollment) { InPersonEnrollment.new(capture_secondary_id_enabled:) }
     let(:dob) { '1980-01-01' }
-    let(:state_id_state) { 'Nevada' }
-    let(:state_id_city) { 'Twin Peaks' }
-    let(:state_id_address1) { '123 Sesame Street' }
-    let(:state_id_address2) { 'Apt. #C' }
-    let(:state_id_zipcode) { '90001' }
+    let(:identity_doc_state) { 'Nevada' }
+    let(:identity_doc_city) { 'Twin Peaks' }
+    let(:identity_doc_address1) { '123 Sesame Street' }
+    let(:identity_doc_address2) { 'Apt. #C' }
+    let(:identity_doc_zipcode) { '90001' }
     let(:same_address_as_id) { 'true' }
     let(:submitted_values) do
       {
         dob: dob,
-        state_id_state: state_id_state,
-        state_id_city: state_id_city,
-        state_id_address1: state_id_address1,
-        state_id_address2: state_id_address2,
-        state_id_zipcode: state_id_zipcode,
+        identity_doc_state: identity_doc_state,
+        identity_doc_city: identity_doc_city,
+        identity_doc_address1: identity_doc_address1,
+        identity_doc_address2: identity_doc_address2,
+        identity_doc_zipcode: identity_doc_zipcode,
         same_address_as_id: same_address_as_id,
       }
     end
@@ -203,11 +203,11 @@ describe Idv::Steps::InPerson::StateIdStep do
         step.call
 
         pii_from_user = flow.flow_session[:pii_from_user]
-        expect(pii_from_user[:address1]).to eq state_id_address1
-        expect(pii_from_user[:address2]).to eq state_id_address2
-        expect(pii_from_user[:city]).to eq state_id_city
-        expect(pii_from_user[:state]).to eq state_id_state
-        expect(pii_from_user[:zipcode]).to eq state_id_zipcode
+        expect(pii_from_user[:address1]).to eq identity_doc_address1
+        expect(pii_from_user[:address2]).to eq identity_doc_address2
+        expect(pii_from_user[:city]).to eq identity_doc_city
+        expect(pii_from_user[:state]).to eq identity_doc_state
+        expect(pii_from_user[:zipcode]).to eq identity_doc_zipcode
       end
     end
 
@@ -217,11 +217,11 @@ describe Idv::Steps::InPerson::StateIdStep do
         step.call
 
         pii_from_user = flow.flow_session[:pii_from_user]
-        expect(pii_from_user[:address1]).to_not eq state_id_address1
-        expect(pii_from_user[:address2]).to_not eq state_id_address2
-        expect(pii_from_user[:city]).to_not eq state_id_city
-        expect(pii_from_user[:state]).to_not eq state_id_state
-        expect(pii_from_user[:zipcode]).to_not eq state_id_zipcode
+        expect(pii_from_user[:address1]).to_not eq identity_doc_address1
+        expect(pii_from_user[:address2]).to_not eq identity_doc_address2
+        expect(pii_from_user[:city]).to_not eq identity_doc_city
+        expect(pii_from_user[:state]).to_not eq identity_doc_state
+        expect(pii_from_user[:zipcode]).to_not eq identity_doc_zipcode
       end
     end
   end

--- a/spec/services/idv/steps/in_person/state_id_step_spec.rb
+++ b/spec/services/idv/steps/in_person/state_id_step_spec.rb
@@ -29,14 +29,14 @@ describe Idv::Steps::InPerson::StateIdStep do
       let(:first_name) { 'Natalya' }
       let(:last_name) { 'Rostova' }
       let(:dob) { '1980-01-01' }
-      let(:identity_doc_state) { 'Nevada' }
+      let(:identity_doc_address_state) { 'Nevada' }
       let(:state_id_number) { 'ABC123234' }
       let(:submitted_values) do
         {
           first_name: first_name,
           last_name: last_name,
           dob: dob,
-          identity_doc_state: identity_doc_state,
+          identity_doc_address_state: identity_doc_address_state,
           state_id_number: state_id_number,
         }
       end
@@ -59,7 +59,7 @@ describe Idv::Steps::InPerson::StateIdStep do
         expect(pii_from_user[:first_name]).to eq first_name
         expect(pii_from_user[:last_name]).to eq last_name
         expect(pii_from_user[:dob]).to eq dob
-        expect(pii_from_user[:identity_doc_state]).to eq identity_doc_state
+        expect(pii_from_user[:identity_doc_address_state]).to eq identity_doc_address_state
         expect(pii_from_user[:state_id_number]).to eq state_id_number
       end
 
@@ -166,7 +166,7 @@ describe Idv::Steps::InPerson::StateIdStep do
     let(:capture_secondary_id_enabled) { true }
     let(:enrollment) { InPersonEnrollment.new(capture_secondary_id_enabled:) }
     let(:dob) { '1980-01-01' }
-    let(:identity_doc_state) { 'Nevada' }
+    let(:identity_doc_address_state) { 'Nevada' }
     let(:identity_doc_city) { 'Twin Peaks' }
     let(:identity_doc_address1) { '123 Sesame Street' }
     let(:identity_doc_address2) { 'Apt. #C' }
@@ -175,7 +175,7 @@ describe Idv::Steps::InPerson::StateIdStep do
     let(:submitted_values) do
       {
         dob: dob,
-        identity_doc_state: identity_doc_state,
+        identity_doc_address_state: identity_doc_address_state,
         identity_doc_city: identity_doc_city,
         identity_doc_address1: identity_doc_address1,
         identity_doc_address2: identity_doc_address2,
@@ -206,7 +206,7 @@ describe Idv::Steps::InPerson::StateIdStep do
         expect(pii_from_user[:address1]).to eq identity_doc_address1
         expect(pii_from_user[:address2]).to eq identity_doc_address2
         expect(pii_from_user[:city]).to eq identity_doc_city
-        expect(pii_from_user[:state]).to eq identity_doc_state
+        expect(pii_from_user[:state]).to eq identity_doc_address_state
         expect(pii_from_user[:zipcode]).to eq identity_doc_zipcode
       end
     end
@@ -220,7 +220,7 @@ describe Idv::Steps::InPerson::StateIdStep do
         expect(pii_from_user[:address1]).to_not eq identity_doc_address1
         expect(pii_from_user[:address2]).to_not eq identity_doc_address2
         expect(pii_from_user[:city]).to_not eq identity_doc_city
-        expect(pii_from_user[:state]).to_not eq identity_doc_state
+        expect(pii_from_user[:state]).to_not eq identity_doc_address_state
         expect(pii_from_user[:zipcode]).to_not eq identity_doc_zipcode
       end
     end

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -43,7 +43,7 @@ describe Pii::Attributes do
         identity_doc_city: 'Washington',
         state_id_jurisdiction: 'DC',
         identity_doc_zipcode: '20005',
-        identity_doc_state: 'NY',
+        identity_doc_address_state: 'NY',
       )
 
       expect(pii.identity_doc_address1).to eq('1600 Pennsylvania Avenue')
@@ -51,7 +51,7 @@ describe Pii::Attributes do
       expect(pii.identity_doc_city).to eq('Washington')
       expect(pii.state_id_jurisdiction).to eq('DC')
       expect(pii.identity_doc_zipcode).to eq('20005')
-      expect(pii.identity_doc_state).to eq('NY')
+      expect(pii.identity_doc_address_state).to eq('NY')
     end
   end
 

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -38,20 +38,20 @@ describe Pii::Attributes do
 
     it 'parses state ID address keys' do
       pii = described_class.new_from_hash(
-        state_id_address1: '1600 Pennsylvania Avenue',
-        state_id_address2: 'Apt 2',
-        state_id_city: 'Washington',
+        identity_doc_address1: '1600 Pennsylvania Avenue',
+        identity_doc_address2: 'Apt 2',
+        identity_doc_city: 'Washington',
         state_id_jurisdiction: 'DC',
-        state_id_zipcode: '20005',
-        state_id_state: 'NY',
+        identity_doc_zipcode: '20005',
+        identity_doc_state: 'NY',
       )
 
-      expect(pii.state_id_address1).to eq('1600 Pennsylvania Avenue')
-      expect(pii.state_id_address2).to eq('Apt 2')
-      expect(pii.state_id_city).to eq('Washington')
+      expect(pii.identity_doc_address1).to eq('1600 Pennsylvania Avenue')
+      expect(pii.identity_doc_address2).to eq('Apt 2')
+      expect(pii.identity_doc_city).to eq('Washington')
       expect(pii.state_id_jurisdiction).to eq('DC')
-      expect(pii.state_id_zipcode).to eq('20005')
-      expect(pii.state_id_state).to eq('NY')
+      expect(pii.identity_doc_zipcode).to eq('20005')
+      expect(pii.identity_doc_state).to eq('NY')
     end
   end
 

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -123,7 +123,8 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
                   state: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
                     :identity_doc_state
                   ],
-                  zip_code: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode],
+                  zip_code:
+                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode],
                 )
                 UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant)
               end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
                   }",
                   city: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city],
                   state: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
-                    :identity_doc_state
+                    :identity_doc_address_state
                   ],
                   zip_code:
                     Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode],

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -115,15 +115,15 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
                 ADDR = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS
                 expect(applicant).to have_attributes(
                   address: "#{
-                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_address1]
+                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address1]
                   } #{
-                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_address2]
+                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address2]
                   }",
-                  city: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_city],
+                  city: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city],
                   state: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
-                    :state_id_state
+                    :identity_doc_state
                   ],
-                  zip_code: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_zipcode],
+                  zip_code: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode],
                 )
                 UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant)
               end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -21,11 +21,14 @@ module InPersonHelper
   GOOD_CITY = Idp::Constants::MOCK_IDV_APPLICANT[:city]
   GOOD_ZIPCODE = Idp::Constants::MOCK_IDV_APPLICANT[:zipcode]
   GOOD_STATE = Idp::Constants::MOCK_IDV_APPLICANT_FULL_STATE
-  GOOD_IDENTITY_DOC_ADDRESS1 = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address1]
-  GOOD_IDENTITY_DOC_ADDRESS2 = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address2]
+  GOOD_IDENTITY_DOC_ADDRESS1 =
+    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address1]
+  GOOD_IDENTITY_DOC_ADDRESS2 =
+    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address2]
   GOOD_IDENTITY_DOC_STATE = Idp::Constants::MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_STATE
   GOOD_IDENTITY_DOC_CITY = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city]
-  GOOD_IDENTITY_DOC_ZIPCODE = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode]
+  GOOD_IDENTITY_DOC_ZIPCODE =
+    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode]
 
   def fill_out_state_id_form_ok(double_address_verification: false, same_address_as_id: false)
     fill_in t('in_person_proofing.form.state_id.first_name'), with: GOOD_FIRST_NAME
@@ -44,7 +47,8 @@ module InPersonHelper
       fill_in t('in_person_proofing.form.state_id.city'), with: GOOD_IDENTITY_DOC_CITY
       fill_in t('in_person_proofing.form.state_id.zipcode'), with: GOOD_IDENTITY_DOC_ZIPCODE
       if same_address_as_id
-        select GOOD_IDENTITY_DOC_STATE, from: t('in_person_proofing.form.state_id.identity_doc_state')
+        select GOOD_IDENTITY_DOC_STATE,
+               from: t('in_person_proofing.form.state_id.identity_doc_state')
         choose t('in_person_proofing.form.state_id.same_address_as_id_yes')
       else
         select GOOD_STATE, from: t('in_person_proofing.form.state_id.identity_doc_state')
@@ -60,7 +64,8 @@ module InPersonHelper
     fill_in t('idv.form.address2'),
             with: same_address_as_id ? GOOD_IDENTITY_DOC_ADDRESS2 : GOOD_ADDRESS2
     fill_in t('idv.form.city'), with: same_address_as_id ? GOOD_IDENTITY_DOC_CITY : GOOD_CITY
-    fill_in t('idv.form.zipcode'), with: same_address_as_id ? GOOD_IDENTITY_DOC_ZIPCODE : GOOD_ZIPCODE
+    fill_in t('idv.form.zipcode'),
+            with: same_address_as_id ? GOOD_IDENTITY_DOC_ZIPCODE : GOOD_ZIPCODE
     if same_address_as_id
       select GOOD_IDENTITY_DOC_STATE, from: t('idv.form.state')
     else

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -21,11 +21,11 @@ module InPersonHelper
   GOOD_CITY = Idp::Constants::MOCK_IDV_APPLICANT[:city]
   GOOD_ZIPCODE = Idp::Constants::MOCK_IDV_APPLICANT[:zipcode]
   GOOD_STATE = Idp::Constants::MOCK_IDV_APPLICANT_FULL_STATE
-  GOOD_STATE_ID_ADDRESS1 = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_address1]
-  GOOD_STATE_ID_ADDRESS2 = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:state_id_address2]
-  GOOD_STATE_ID_STATE = Idp::Constants::MOCK_IDV_APPLICANT_FULL_STATE_ID_STATE
-  GOOD_STATE_ID_CITY = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:city]
-  GOOD_STATE_ID_ZIPCODE = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:zipcode]
+  GOOD_IDENTITY_DOC_ADDRESS1 = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address1]
+  GOOD_IDENTITY_DOC_ADDRESS2 = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address2]
+  GOOD_IDENTITY_DOC_STATE = Idp::Constants::MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_STATE
+  GOOD_IDENTITY_DOC_CITY = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city]
+  GOOD_IDENTITY_DOC_ZIPCODE = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode]
 
   def fill_out_state_id_form_ok(double_address_verification: false, same_address_as_id: false)
     fill_in t('in_person_proofing.form.state_id.first_name'), with: GOOD_FIRST_NAME
@@ -39,15 +39,15 @@ module InPersonHelper
     fill_in t('in_person_proofing.form.state_id.state_id_number'), with: GOOD_STATE_ID_NUMBER
 
     if double_address_verification
-      fill_in t('in_person_proofing.form.state_id.address1'), with: GOOD_STATE_ID_ADDRESS1
-      fill_in t('in_person_proofing.form.state_id.address2'), with: GOOD_STATE_ID_ADDRESS2
-      fill_in t('in_person_proofing.form.state_id.city'), with: GOOD_STATE_ID_CITY
-      fill_in t('in_person_proofing.form.state_id.zipcode'), with: GOOD_STATE_ID_ZIPCODE
+      fill_in t('in_person_proofing.form.state_id.address1'), with: GOOD_IDENTITY_DOC_ADDRESS1
+      fill_in t('in_person_proofing.form.state_id.address2'), with: GOOD_IDENTITY_DOC_ADDRESS2
+      fill_in t('in_person_proofing.form.state_id.city'), with: GOOD_IDENTITY_DOC_CITY
+      fill_in t('in_person_proofing.form.state_id.zipcode'), with: GOOD_IDENTITY_DOC_ZIPCODE
       if same_address_as_id
-        select GOOD_STATE_ID_STATE, from: t('in_person_proofing.form.state_id.state_id_state')
+        select GOOD_IDENTITY_DOC_STATE, from: t('in_person_proofing.form.state_id.identity_doc_state')
         choose t('in_person_proofing.form.state_id.same_address_as_id_yes')
       else
-        select GOOD_STATE, from: t('in_person_proofing.form.state_id.state_id_state')
+        select GOOD_STATE, from: t('in_person_proofing.form.state_id.identity_doc_state')
         choose t('in_person_proofing.form.state_id.same_address_as_id_no')
       end
     end
@@ -55,14 +55,14 @@ module InPersonHelper
 
   def fill_out_address_form_ok(double_address_verification: false, same_address_as_id: false)
     fill_in t('idv.form.address1'),
-            with: same_address_as_id ? GOOD_STATE_ID_ADDRESS1 : GOOD_ADDRESS1
+            with: same_address_as_id ? GOOD_IDENTITY_DOC_ADDRESS1 : GOOD_ADDRESS1
     fill_in t('idv.form.address2_optional'), with: GOOD_ADDRESS2 unless double_address_verification
     fill_in t('idv.form.address2'),
-            with: same_address_as_id ? GOOD_STATE_ID_ADDRESS2 : GOOD_ADDRESS2
-    fill_in t('idv.form.city'), with: same_address_as_id ? GOOD_STATE_ID_CITY : GOOD_CITY
-    fill_in t('idv.form.zipcode'), with: same_address_as_id ? GOOD_STATE_ID_ZIPCODE : GOOD_ZIPCODE
+            with: same_address_as_id ? GOOD_IDENTITY_DOC_ADDRESS2 : GOOD_ADDRESS2
+    fill_in t('idv.form.city'), with: same_address_as_id ? GOOD_IDENTITY_DOC_CITY : GOOD_CITY
+    fill_in t('idv.form.zipcode'), with: same_address_as_id ? GOOD_IDENTITY_DOC_ZIPCODE : GOOD_ZIPCODE
     if same_address_as_id
-      select GOOD_STATE_ID_STATE, from: t('idv.form.state')
+      select GOOD_IDENTITY_DOC_STATE, from: t('idv.form.state')
     else
       select GOOD_STATE, from: t('idv.form.state')
     end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -25,7 +25,8 @@ module InPersonHelper
     Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address1]
   GOOD_IDENTITY_DOC_ADDRESS2 =
     Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address2]
-  GOOD_IDENTITY_DOC_STATE = Idp::Constants::MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_STATE
+  GOOD_IDENTITY_DOC_ADDRESS_STATE =
+    Idp::Constants::MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_ADDRESS_STATE
   GOOD_IDENTITY_DOC_CITY = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city]
   GOOD_IDENTITY_DOC_ZIPCODE =
     Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode]
@@ -47,11 +48,11 @@ module InPersonHelper
       fill_in t('in_person_proofing.form.state_id.city'), with: GOOD_IDENTITY_DOC_CITY
       fill_in t('in_person_proofing.form.state_id.zipcode'), with: GOOD_IDENTITY_DOC_ZIPCODE
       if same_address_as_id
-        select GOOD_IDENTITY_DOC_STATE,
-               from: t('in_person_proofing.form.state_id.identity_doc_state')
+        select GOOD_IDENTITY_DOC_ADDRESS_STATE,
+               from: t('in_person_proofing.form.state_id.identity_doc_address_state')
         choose t('in_person_proofing.form.state_id.same_address_as_id_yes')
       else
-        select GOOD_STATE, from: t('in_person_proofing.form.state_id.identity_doc_state')
+        select GOOD_STATE, from: t('in_person_proofing.form.state_id.identity_doc_address_state')
         choose t('in_person_proofing.form.state_id.same_address_as_id_no')
       end
     end
@@ -67,7 +68,7 @@ module InPersonHelper
     fill_in t('idv.form.zipcode'),
             with: same_address_as_id ? GOOD_IDENTITY_DOC_ZIPCODE : GOOD_ZIPCODE
     if same_address_as_id
-      select GOOD_IDENTITY_DOC_STATE, from: t('idv.form.state')
+      select GOOD_IDENTITY_DOC_ADDRESS_STATE, from: t('idv.form.state')
     else
       select GOOD_STATE, from: t('idv.form.state')
     end

--- a/spec/support/features/verify_step_helper.rb
+++ b/spec/support/features/verify_step_helper.rb
@@ -2,11 +2,11 @@ module VerifyStepHelper
   include InPersonHelper
 
   def expect_good_state_id_address
-    expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_ADDRESS1)
-    expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_ADDRESS2)
-    expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_CITY)
+    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1)
+    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2)
+    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY)
     expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction])
-    expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_ZIPCODE)
+    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE)
   end
 
   def expect_good_address


### PR DESCRIPTION
## 🎫 Ticket

[LG-9404](https://cm-jira.usa.gov/browse/LG-9404)

## 🛠 Summary of changes

Renames the DAV PII attributes and session encryptor keys to be forwards compatible with any identity document instead of just state IDs.
