### PR TITLE
Skip session more fully when skipping session loading

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -379,6 +379,7 @@ class ApplicationController < ActionController::Base
   end
 
   def skip_session_load
+    request.session_options[:skip] = true
     @skip_session_load = true
   end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,9 +2,11 @@ require 'session_encryptor'
 require 'legacy_session_encryptor'
 require 'session_encryptor_error_handler'
 
+APPLICATION_SESSION_COOKIE_KEY = '_identity_idp_session'.freeze
+
 Rails.application.config.session_store(
   :redis_session_store,
-  key: '_identity_idp_session',
+  key: APPLICATION_SESSION_COOKIE_KEY,
   redis: {
     # cookie expires with browser close
     expire_after: nil,

--- a/spec/requests/openid_connect_userinfo_spec.rb
+++ b/spec/requests/openid_connect_userinfo_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'OpenID Connect UserInfo controller' do
+  describe 'show endpoint' do
+    it 'does not include IDP session cookie' do
+      access_token = SecureRandom.hex
+      identity = create(
+        :service_provider_identity,
+        rails_session_id: SecureRandom.hex,
+        access_token: access_token,
+        user: create(:user),
+      )
+      authorization_header = "Bearer #{access_token}"
+      OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 50)
+      get api_openid_connect_userinfo_path,
+          headers: { 'HTTP_AUTHORIZATION' => authorization_header }
+      expect(response.headers['Set-Cookie']).to_not include(APPLICATION_SESSION_COOKIE_KEY)
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Currently, a session will be loaded or created on routes that use the `skip_session_load` action when the session is accessed. The current behavior results from the analytics functionality accessing and mutating the session, which causes it to be created.

This change will not delete sessions or remove the session cookie, it should simply ignore it. It makes use of the the `:skip` option outlined in Rack [here](https://github.com/rack/rack-session/blob/c9beee68e974e0e0f52f18e4847edceace8290e3/lib/rack/session/abstract/id.rb#L220-L222):

>     # * :skip will not a set a cookie in the response nor update the session state
>     # * :defer will not set a cookie in the response but still update the session
>     #   state if it is used with a backend

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
