### PR TITLE
Remove the last couple selfie references

### DIFF
--- a/app/services/funnel/doc_auth/register_step.rb
+++ b/app/services/funnel/doc_auth/register_step.rb
@@ -10,7 +10,6 @@ module Funnel
         back_image
         mobile_front_image
         mobile_back_image
-        selfie
         ssn
         verify
         verify_phone

--- a/spec/services/db/add_document_verification_and_selfie_costs_spec.rb
+++ b/spec/services/db/add_document_verification_and_selfie_costs_spec.rb
@@ -39,7 +39,6 @@ describe Db::AddDocumentVerificationAndSelfieCosts do
     expect(costing_for(:acuant_front_image)).to be_present
     expect(costing_for(:acuant_back_image)).to be_present
     expect(costing_for(:acuant_result)).to be_present
-    expect(costing_for(:acuant_selfie)).to be_nil
   end
 
   it 'has costing for front, back, but not result when not billed' do
@@ -48,7 +47,6 @@ describe Db::AddDocumentVerificationAndSelfieCosts do
     expect(costing_for(:acuant_front_image)).to be_present
     expect(costing_for(:acuant_back_image)).to be_present
     expect(costing_for(:acuant_result)).to be_nil
-    expect(costing_for(:acuant_selfie)).to be_nil
   end
 
   def costing_for(cost_type)


### PR DESCRIPTION
We managed to find a few more references to "selfie" which were left behind when we made an effort to remove all of the selfie capture code.
