### PR TITLE
LG-8617 Add a boolean column to mark that a profile is pending GPO review

### DIFF
--- a/db/primary_migrate/20230419190148_add_gpo_verification_pending_to_profile.rb
+++ b/db/primary_migrate/20230419190148_add_gpo_verification_pending_to_profile.rb
@@ -1,0 +1,8 @@
+class AddGpoVerificationPendingToProfile < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :profiles, :gpo_verification_pending, :boolean
+    add_index :profiles, :gpo_verification_pending, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_11_160948) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_19_190148) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -448,9 +448,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_11_160948) do
     t.boolean "fraud_rejection", default: false
     t.datetime "fraud_review_pending_at"
     t.datetime "fraud_rejection_at"
+    t.boolean "gpo_verification_pending"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending"], name: "index_profiles_on_fraud_review_pending"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
+    t.index ["gpo_verification_pending"], name: "index_profiles_on_gpo_verification_pending"
     t.index ["name_zip_birth_year_signature"], name: "index_profiles_on_name_zip_birth_year_signature"
     t.index ["reproof_at"], name: "index_profiles_on_reproof_at"
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"


### PR DESCRIPTION
As part of our profile state work we are unloading the `deactivation_reason` column. This involves adding new columns to represent whether a profile satisfies one of several conditions that renders it inactive. This is necessary since as time has gone on we have a number of temporary conditions that render a profile inactive and can exist simultaneously.

This commit adds a column for tracking that a user is pending GPO review. We cannot start writing to this column until after this migration has been deployed and run in production.
