### PR TITLE
Use the flash message for document capture success

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -125,6 +125,7 @@ module Idv
       if stored_result&.success?
         save_proofing_components
         extract_pii_from_doc(stored_result, store_in_session: !hybrid_flow_mobile?)
+        flash[:success] = t('doc_auth.headings.capture_complete')
         successful_response
       else
         extra = { stored_result_present: stored_result.present? }

--- a/app/views/idv/ssn/show.html.erb
+++ b/app/views/idv/ssn/show.html.erb
@@ -17,15 +17,6 @@ locals:
 
 <% title t('titles.doc_auth.ssn') %>
 
-<% if !@ssn_form.updating_ssn? %>
-  <%= render AlertComponent.new(
-        type: :success,
-        class: 'margin-bottom-4',
-      ) do %>
-    <%= t('doc_auth.headings.capture_complete') %>
-  <% end %>
-<% end %>
-
 <% if @ssn_form.updating_ssn? %>
   <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.ssn_update')) %>
 <% else %>

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -77,6 +77,7 @@ feature 'doc auth verify_info step', :js do
     click_link t('idv.buttons.change_ssn_label')
 
     expect(page).to have_current_path(idv_ssn_path)
+    expect(page).to_not have_content(t('doc_auth.headings.capture_complete'))
     expect(
       find_field(t('idv.form.ssn_label_html')).value,
     ).to eq(DocAuthHelper::GOOD_SSN.gsub(/\D/, ''))

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -33,6 +33,7 @@ feature 'doc capture document capture step', js: true do
     attach_and_submit_images
 
     expect(page).to have_current_path(next_step)
+    expect(page).to have_content(t('doc_auth.headings.capture_complete'))
   end
 
   it 'offers the user the option to cancel and return to desktop' do


### PR DESCRIPTION
The flow state machine made using flash messages difficult. Since it no longer controls to SSN and document capture step we can use the flashes here. The flash messages are handled in the application layout so just adding the message to the flash hash ensures it is rendered.
