### PR TITLE
LG-9533 Start writing to GPO verification pending column

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -95,6 +95,6 @@ class GpoVerifyForm
   end
 
   def activate_profile
-    user.pending_profile&.activate
+    user.pending_profile&.activate_after_gpo_verification
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -39,7 +39,7 @@ class Profile < ApplicationRecord
 
   # rubocop:disable Rails/SkipsModelValidations
   def activate
-    return if deactivation_checks
+    return if has_deactivation_reason?
     now = Time.zone.now
     is_reproof = Profile.find_by(user_id: user_id, active: true)
     transaction do
@@ -80,7 +80,7 @@ class Profile < ApplicationRecord
     update!(active: false, deactivation_reason: reason)
   end
 
-  def deactivation_checks
+  def has_deactivation_reason?
     fraud_review_pending? || fraud_rejection? || gpo_verification_pending?
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -48,6 +48,7 @@ class Profile < ApplicationRecord
         active: true,
         activated_at: now,
         deactivation_reason: nil,
+        gpo_verification_pending_at: nil,
         fraud_review_pending: false,
         fraud_rejection: false,
         fraud_review_pending_at: nil,
@@ -58,6 +59,11 @@ class Profile < ApplicationRecord
     send_push_notifications if is_reproof
   end
   # rubocop:enable Rails/SkipsModelValidations
+
+  def activate_after_gpo_verification
+    update!(gpo_verification_pending_at: nil)
+    activate
+  end
 
   def activate_after_passing_review
     update!(

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -9,13 +9,19 @@ module Idv
       self.initiating_service_provider = initiating_service_provider
     end
 
-    def save_profile(active:, fraud_review_needed:, deactivation_reason: nil)
+    def save_profile(
+      active:,
+      fraud_review_needed:,
+      gpo_verification_needed:,
+      deactivation_reason: nil
+    )
       profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason)
       profile.initiating_service_provider = initiating_service_provider
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
       profile.save!
       profile.activate if active
+      profile.deactivate_for_gpo_verification if gpo_verification_needed
       profile.deactivate_for_fraud_review if fraud_review_needed
       profile
     end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -51,6 +51,7 @@ module Idv
         active: deactivation_reason.nil?,
         deactivation_reason: deactivation_reason,
         fraud_review_needed: threatmetrix_failed_and_needs_review?,
+        gpo_verification_needed: gpo_verification_needed?,
       )
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id
@@ -72,11 +73,15 @@ module Idv
     end
 
     def deactivation_reason
-      if !phone_confirmed? || address_verification_mechanism == 'gpo'
+      if gpo_verification_needed?
         :gpo_verification_pending
       elsif in_person_enrollment?
         :in_person_verification_pending
       end
+    end
+
+    def gpo_verification_needed?
+      !phone_confirmed? || address_verification_mechanism == 'gpo'
     end
 
     def cache_encrypted_pii(password)

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -13,7 +13,11 @@ describe Idv::PersonalKeyController do
       user: user,
       user_password: password,
     )
-    profile = profile_maker.save_profile(active: false, fraud_review_needed: false)
+    profile = profile_maker.save_profile(
+      active: false,
+      fraud_review_needed: false,
+      gpo_verification_needed: false,
+    )
     idv_session.pii = profile_maker.pii_attributes
     idv_session.profile_id = profile.id
     idv_session.personal_key = profile.personal_key

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -263,18 +263,27 @@ describe Profile do
       profile.activate
     end
 
-    it 'does not activate a profile if under fraud review' do
-      profile.update(fraud_review_pending_at: 1.day.ago)
-      profile.activate
+    context 'activation guards against deactivation reasons' do
+      it 'does not activate a profile with gpo verification pending' do
+        profile.update(gpo_verification_pending_at: 1.day.ago)
+        profile.activate
 
-      expect(profile).to_not be_active
-    end
+        expect(profile).to_not be_active
+      end
 
-    it 'does not activate a profile if rejected for fraud' do
-      profile.update(fraud_rejection_at: Time.zone.now - 1.day)
-      profile.activate
+      it 'does not activate a profile if under fraud review' do
+        profile.update(fraud_review_pending_at: 1.day.ago)
+        profile.activate
 
-      expect(profile).to_not be_active
+        expect(profile).to_not be_active
+      end
+
+      it 'does not activate a profile if rejected for fraud' do
+        profile.update(fraud_rejection_at: Time.zone.now - 1.day)
+        profile.activate
+
+        expect(profile).to_not be_active
+      end
     end
   end
 
@@ -364,6 +373,16 @@ describe Profile do
         expect(profile.irs_attempts_api_tracker).not_to receive(:fraud_review_adjudicated)
         profile.activate_after_passing_review
       end
+    end
+  end
+
+  describe '#deactivate_for_gpo_verification' do
+    it 'sets a timestamp for gpo_verification_pending_at' do
+      profile = create(:profile, user: user)
+      profile.deactivate_for_gpo_verification
+
+      expect(profile).to_not be_active
+      expect(profile.gpo_verification_pending_at).to_not be_nil
     end
   end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -301,6 +301,18 @@ describe Profile do
     end
   end
 
+  describe '#activate_after_gpo_verification' do
+    it 'activates a profile after gpo verification' do
+      profile = create(
+        :profile, user: user, active: false,
+                  gpo_verification_pending_at: 1.day.ago
+      )
+      profile.activate_after_gpo_verification
+
+      expect(profile).to be_active
+    end
+  end
+
   describe '#activate_after_passing_review' do
     it 'activates a profile if it passes fraud review' do
       profile = create(

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -18,7 +18,11 @@ describe Idv::ProfileMaker do
 
     it 'creates an inactive Profile with encrypted PII' do
       proofing_component = ProofingComponent.create(user_id: user.id, document_check: 'acuant')
-      profile = subject.save_profile(active: false, fraud_review_needed: false)
+      profile = subject.save_profile(
+        active: false,
+        fraud_review_needed: false,
+        gpo_verification_needed: false,
+      )
       pii = subject.pii_attributes
 
       expect(profile).to be_a Profile
@@ -39,11 +43,12 @@ describe Idv::ProfileMaker do
         profile = subject.save_profile(
           active: false,
           fraud_review_needed: false,
-          deactivation_reason: :gpo_verification_pending,
+          gpo_verification_needed: false,
+          deactivation_reason: :encryption_error,
         )
 
         expect(profile.active).to eq false
-        expect(profile.deactivation_reason).to eq 'gpo_verification_pending'
+        expect(profile.deactivation_reason).to eq 'encryption_error'
       end
     end
 
@@ -52,6 +57,7 @@ describe Idv::ProfileMaker do
         profile = subject.save_profile(
           active: false,
           fraud_review_needed: true,
+          gpo_verification_needed: false,
           deactivation_reason: nil,
         )
 
@@ -60,11 +66,26 @@ describe Idv::ProfileMaker do
       end
     end
 
+    context 'with gpo_verification_needed' do
+      it 'deactivates a profile for gpo verification' do
+        profile = subject.save_profile(
+          active: false,
+          fraud_review_needed: false,
+          gpo_verification_needed: true,
+          deactivation_reason: nil,
+        )
+
+        expect(profile.active).to eq false
+        expect(profile.gpo_verification_pending_at.present?).to eq true
+      end
+    end
+
     context 'as active' do
       it 'creates an active profile' do
         profile = subject.save_profile(
           active: true,
           fraud_review_needed: false,
+          gpo_verification_needed: false,
           deactivation_reason: nil,
         )
 
@@ -80,6 +101,7 @@ describe Idv::ProfileMaker do
         profile = subject.save_profile(
           active: true,
           fraud_review_needed: false,
+          gpo_verification_needed: false,
           deactivation_reason: nil,
         )
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-9533](https://cm-jira.usa.gov/browse/LG-9533)


## 🛠 Summary of changes

When a user goes through the GPO flow, it will now save a timestamp for `gpo_verification_pending`. When they verify with their one time code, it will set the field to `nil` and activate the profile. 



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV GPO flow.
- [ ] Check to make sure everything is working as intended.
- [ ] ???
- [ ] Profit


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
