### PR TITLE
Update parser gem to fix warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,7 +435,7 @@ GEM
       openssl (> 2.0, < 3.1)
     orm_adapter (0.5.0)
     parallel (1.22.1)
-    parser (3.2.0.0)
+    parser (3.2.2.0)
       ast (~> 2.4.1)
     pg (1.4.5)
     pg_query (2.2.0)


### PR DESCRIPTION
> warning: parser/current is loading parser/ruby32, which recognizes 3.2.0-compliant syntax, but you are running 3.2.2.
> Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
