### PR TITLE
LG-9320 Remove phone outage banner from IDV welcome page

### DIFF
--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -1,7 +1,5 @@
 <% title t('doc_auth.headings.welcome') %>
 
-<%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice], only_if_all: true, context: :idv)) %>
-
 <%= render 'shared/maintenance_window_alert' do %>
   <%= render JavascriptRequiredComponent.new(
         header: t('idv.welcome.no_js_header'),

--- a/spec/views/idv/doc_auth/welcome.html.erb_spec.rb
+++ b/spec/views/idv/doc_auth/welcome.html.erb_spec.rb
@@ -102,16 +102,4 @@ describe 'idv/doc_auth/welcome.html.erb' do
       )
     end
   end
-
-  context 'phone vendor outage' do
-    before do
-      allow_any_instance_of(OutageStatus).to receive(:all_vendor_outage?).and_return(true)
-    end
-
-    it 'renders alert banner' do
-      render template: 'idv/doc_auth/welcome'
-
-      expect(rendered).to have_selector('.usa-alert.usa-alert--error')
-    end
-  end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-9320](https://cm-jira.usa.gov/browse/LG-9320)


## 🛠 Summary of changes
Removed the outage banner from the doc_auth welcome.html template.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] set the sms and voice outage FFs
- [x] navigate to the welcome page for IDV and verify banner is no longer present


## 👀 Screenshots
<details>
<summary>Before:</summary>
<img width="1466" alt="LG-9320_before" src="https://user-images.githubusercontent.com/1261794/234040011-218e551f-d4c6-401d-a61d-e2d7c6f44eee.png">

https://user-images.githubusercontent.com/1261794/234040065-a0451f8b-89c9-4811-93ff-057aa8a05e06.mov

</details>

<details>
<summary>After:</summary>
<img width="1511" alt="LG-9320_after" src="https://user-images.githubusercontent.com/1261794/234040140-058784f1-00d9-4a4f-8b34-c113f9f7da0e.png">

https://user-images.githubusercontent.com/1261794/234041003-0f9e6374-fc43-4f99-b2b0-672c61d8fef6.mov

</details>
