### PR TITLE
Log completed SAML Remote Logout requests

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -24,7 +24,7 @@ module SamlIdpLogoutConcern
   def handle_valid_sp_remote_logout_request(user_id:, issuer:)
     # Remotely delete the user's current session
     session_id = ServiceProviderIdentity.
-      where(user_id: user_id, service_provider: saml_request.issuer).pick(:rails_session_id)
+      where(user_id: user_id, service_provider: issuer).pick(:rails_session_id)
 
     if session_id
       OutOfBandSessionAccessor.new(session_id).destroy

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -62,8 +62,9 @@ class SamlIdpController < ApplicationController
     return head(:bad_request) if raw_saml_request.nil?
 
     decode_request(raw_saml_request)
+    issuer = saml_request&.issuer
 
-    track_remote_logout_event
+    track_remote_logout_event(issuer)
 
     return head(:bad_request) unless valid_saml_request?
 
@@ -71,7 +72,7 @@ class SamlIdpController < ApplicationController
 
     return head(:bad_request) unless user_id.present?
 
-    handle_valid_sp_remote_logout_request(user_id)
+    handle_valid_sp_remote_logout_request(user_id: user_id, issuer: issuer)
   end
 
   def external_saml_request?

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2439,7 +2439,7 @@ module AnalyticsEvents
     track_event('Remembered device used for authentication')
   end
 
-  # User initiated remote logout
+  # Service provider initiated remote logout
   # @param [String] service_provider
   # @param [Boolean] saml_request_valid
   def remote_logout_initiated(
@@ -2451,6 +2451,22 @@ module AnalyticsEvents
       'Remote Logout initiated',
       service_provider: service_provider,
       saml_request_valid: saml_request_valid,
+      **extra,
+    )
+  end
+
+  # Service provider completed remote logout
+  # @param [String] service_provider
+  # @param [String] user_id
+  def remote_logout_completed(
+    service_provider:,
+    user_id:,
+    **extra
+  )
+    track_event(
+      'Remote Logout completed',
+      service_provider: service_provider,
+      user_id: user_id,
       **extra,
     )
   end

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -150,6 +150,9 @@ feature 'SAML logout' do
     let(:agency) { sp.agency }
 
     it "terminates the user's session remotely" do
+      fake_analytics = FakeAnalytics.new
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+
       # set up SP identity and agency identity
       user = sign_in_live_with_2fa
       visit_saml_authn_request_url
@@ -166,6 +169,13 @@ feature 'SAML logout' do
       send_saml_remote_logout_request(overrides: { sessionindex: agency_uuid })
 
       expect(OutOfBandSessionAccessor.new(identity.rails_session_id).exists?).to eq false
+
+      expect(fake_analytics.events['Remote Logout initiated']).to eq(
+        [{ service_provider: sp.issuer, saml_request_valid: true }],
+      )
+      expect(fake_analytics.events['Remote Logout completed']).to eq(
+        [{ service_provider: sp.issuer, user_id: user.uuid }],
+      )
 
       # should be logged out...
       visit account_path


### PR DESCRIPTION
## 🛠 Summary of changes

To better understand the impact of remote logout on the user experience, this PR adds a log event for when a user's session is deleted from Redis (though it may already be expired).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
