### PR TITLE
Require re-authentication for PIV/CAC setup from sign in process

### DIFF
--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -2,8 +2,12 @@ module Users
   class PivCacSetupFromSignInController < ApplicationController
     include PivCacConcern
     include SecureHeadersConcern
+    include ReauthenticationRequiredConcern
 
     before_action :confirm_two_factor_authenticated
+    before_action :confirm_recently_authenticated_2fa, if: -> do
+      IdentityConfig.store.reauthentication_for_second_factor_management_enabled
+    end
     before_action :apply_secure_headers_override, only: :success
     before_action :set_piv_cac_setup_csp_form_action_uris, only: :prompt
 


### PR DESCRIPTION
## 🛠 Summary of changes

The `PivCacSetupFromSignInController` is intended for users that have signed in with another method after not being able to sign in with PIV/CAC, so it should only be accessible by users that are fully and recently authenticated. This is a followup to #8037 to require re-authentication in this controller. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
