### PR TITLE
Do not allow accessing PhoneSetupController unless you are in account setup

### DIFF
--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -7,6 +7,7 @@ module Users
 
     before_action :authenticate_user
     before_action :confirm_user_authenticated_for_2fa_setup
+    before_action :confirm_user_in_account_setup
     before_action :set_setup_presenter
     before_action :allow_csp_recaptcha_src, if: :recaptcha_enabled?
 
@@ -89,6 +90,12 @@ module Users
         :recaptcha_version,
         :recaptcha_mock_score,
       )
+    end
+
+    def confirm_user_in_account_setup
+      return if user_fully_authenticated? && in_multi_mfa_selection_flow?
+      return unless MfaPolicy.new(current_user).two_factor_enabled?
+      redirect_to account_path
     end
   end
 end

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -34,6 +34,30 @@ describe Users::PhoneSetupController do
         expect(response).to render_template(:index)
       end
     end
+
+    context 'when fully registered and signed in' do
+      it 'redirects to account page' do
+        stub_analytics
+        user = build(:user, :with_phone)
+        stub_sign_in(user)
+
+        get :index
+
+        expect(response).to redirect_to(account_path)
+      end
+    end
+
+    context 'when fully registered and partially signed in' do
+      it 'redirects to 2FA page' do
+        stub_analytics
+        user = build(:user, :with_phone)
+        stub_sign_in_before_2fa(user)
+
+        get :index
+
+        expect(response).to redirect_to(user_two_factor_authentication_path)
+      end
+    end
   end
 
   describe 'PATCH create' do


### PR DESCRIPTION
## 🛠 Summary of changes

The `Users::PhoneSetupController` is intended for use by users that are in account registration. Users that are not in account setup use the `Users::PhonesController` and `Users::EditPhoneController`, both of which require recent authentication. To prevent users from managing 2FA without being recently authenticated, this PR adds a check so that only users going through account registration can access this controller.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
