### PR TITLE
LG-9390: Add page titles

### DIFF
--- a/app/presenters/webauthn_setup_presenter.rb
+++ b/app/presenters/webauthn_setup_presenter.rb
@@ -27,6 +27,15 @@ class WebauthnSetupPresenter < SetupPresenter
     end
   end
 
+  def page_title
+    if @platform_authenticator
+      # TODO: A new key will likely be needed
+      t('headings.webauthn_platform_setup.new')
+    else
+      t('headings.webauthn_setup.new')
+    end    
+  end
+
   def heading
     if @platform_authenticator
       t('headings.webauthn_platform_setup.new')

--- a/app/presenters/webauthn_setup_presenter.rb
+++ b/app/presenters/webauthn_setup_presenter.rb
@@ -29,10 +29,10 @@ class WebauthnSetupPresenter < SetupPresenter
 
   def page_title
     if @platform_authenticator
-      # TODO: A new key will likely be needed
+      # Note: The following title is incorrect and awaiting copy
       t('headings.webauthn_platform_setup.new')
     else
-      t('headings.webauthn_setup.new')
+      t('titles.webauthn_setup')
     end    
   end
 

--- a/app/presenters/webauthn_setup_presenter.rb
+++ b/app/presenters/webauthn_setup_presenter.rb
@@ -33,7 +33,7 @@ class WebauthnSetupPresenter < SetupPresenter
       t('headings.webauthn_platform_setup.new')
     else
       t('titles.webauthn_setup')
-    end    
+    end
   end
 
   def heading

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -1,3 +1,5 @@
+<% title t('forms.backup_code.are_you_sure_title') %>
+
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code.are_you_sure_title')) %>
 
 <% t('forms.backup_code.are_you_sure_desc_html').each do |desc_p| %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.totp_setup.new') %>
+<% title @presenter.page_title %>
 
 <%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2' %>
 

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -84,3 +84,4 @@ en:
     verify_profile: Activate your account
     visitors:
       index: Welcome
+    webauthn_setup: Add your security key

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -85,3 +85,4 @@ es:
     verify_profile: Active su cuenta
     visitors:
       index: Bienvenido/a
+    webauthn_setup: Añade tu clave de seguridad

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -85,3 +85,4 @@ fr:
     verify_profile: Activez votre compte
     visitors:
       index: Bienvenue
+    webauthn_setup: Ajoutez votre clé de sécurité

--- a/spec/presenters/webauthn_setup_presenter_spec.rb
+++ b/spec/presenters/webauthn_setup_presenter_spec.rb
@@ -25,7 +25,13 @@ describe WebauthnSetupPresenter do
   describe '#image_path' do
     subject { presenter.image_path }
 
-    it { is_expected.to  eq('security-key.svg') }
+    it { is_expected.to eq('security-key.svg') }
+  end
+
+  describe '#page_title' do
+    subject { presenter.image_path }
+
+    it { is_expected.to t('headings.webauthn_setup.new') }
   end
 
   describe '#heading' do
@@ -71,7 +77,13 @@ describe WebauthnSetupPresenter do
     describe '#image_path' do
       subject { presenter.image_path }
 
-      it { is_expected.to  eq('platform-authenticator.svg') }
+      it { is_expected.to eq('platform-authenticator.svg') }
+    end
+
+    describe '#page_title' do
+      subject { presenter.image_path }
+
+      it { is_expected.to t('headings.webauthn_platform_setup.new') }
     end
 
     describe '#heading' do

--- a/spec/presenters/webauthn_setup_presenter_spec.rb
+++ b/spec/presenters/webauthn_setup_presenter_spec.rb
@@ -31,7 +31,7 @@ describe WebauthnSetupPresenter do
   describe '#page_title' do
     subject { presenter.image_path }
 
-    it { is_expected.to t('headings.webauthn_setup.new') }
+    it { is_expected.to t('titles.webauthn_setup') }
   end
 
   describe '#heading' do

--- a/spec/presenters/webauthn_setup_presenter_spec.rb
+++ b/spec/presenters/webauthn_setup_presenter_spec.rb
@@ -29,9 +29,9 @@ describe WebauthnSetupPresenter do
   end
 
   describe '#page_title' do
-    subject { presenter.image_path }
+    subject { presenter.page_title }
 
-    it { is_expected.to t('titles.webauthn_setup') }
+    it { is_expected.to eq(t('titles.webauthn_setup')) }
   end
 
   describe '#heading' do
@@ -81,9 +81,9 @@ describe WebauthnSetupPresenter do
     end
 
     describe '#page_title' do
-      subject { presenter.image_path }
+      subject { presenter.page_title }
 
-      it { is_expected.to t('headings.webauthn_platform_setup.new') }
+      it { is_expected.to eq(t('headings.webauthn_platform_setup.new')) }
     end
 
     describe '#heading' do

--- a/spec/views/users/backup_code_setup/index.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe 'users/backup_code_setup/index.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with( \
+    expect(view).to receive(:title).with(
       t('forms.backup_code.are_you_sure_title'),
     )
 

--- a/spec/views/users/backup_code_setup/index.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/index.html.erb_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'users/backup_code_setup/index.html.erb' do
+  let(:user) { build(:user) }
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with( \
+      t('forms.backup_code.are_you_sure_title'),
+    )
+
+    render
+  end
+end

--- a/spec/views/users/webauthn_setup/new.html.erb_spec.rb
+++ b/spec/views/users/webauthn_setup/new.html.erb_spec.rb
@@ -27,6 +27,12 @@ describe 'users/webauthn_setup/new.html.erb' do
       assign(:presenter, presenter)
     end
 
+    it 'has a localized title' do
+      expect(view).to receive(:title).with(presenter.page_title)
+
+      render
+    end
+
     it 'displays warning alert' do
       render
 


### PR DESCRIPTION
[LG-9390](https://cm-jira.usa.gov/browse/LG-9390)

Changes titles for Webauthn setup page and backup code setup page. Note, the title for Webauthn Platform is still incorrect and is awaiting copy.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
