### PR TITLE
Remove async camera check from document-capture-welcome.ts

### DIFF
--- a/app/javascript/packages/device/index.js
+++ b/app/javascript/packages/device/index.js
@@ -31,18 +31,6 @@ export function hasMediaAccess() {
 }
 
 /**
- * Returns a boolean promise of whether or not the device has a video input device.
- *
- * @return {Promise}
- */
-export async function hasCamera() {
-  if (hasMediaAccess()) {
-    const devices = await navigator.mediaDevices.enumerateDevices();
-    return devices.some((device) => device.kind === 'videoinput');
-  }
-}
-
-/**
  * Returns true if the current device is assumed to be a mobile device where a camera is available,
  * or false otherwise. This is a rough approximation, using device user agent sniffing and
  * availability of camera device APIs.

--- a/app/javascript/packs/document-capture-welcome.ts
+++ b/app/javascript/packs/document-capture-welcome.ts
@@ -1,67 +1,9 @@
-import { trackEvent } from '@18f/identity-analytics';
-import { hasCamera, isCameraCapableMobile } from '@18f/identity-device';
+import { isCameraCapableMobile } from '@18f/identity-device';
 
-const GRACE_TIME_FOR_CAMERA_CHECK_MS = 2000;
-const DEVICE_CHECK_EVENT = 'IdV: Mobile device and camera check';
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+if (isCameraCapableMobile()) {
+  const form = document.querySelector<HTMLFormElement>('.js-consent-continue-form')!;
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.name = 'skip_upload';
+  form.appendChild(input);
 }
-
-async function measure<T>(func: () => Promise<T>): Promise<{ result: T; duration: number }> {
-  const start = performance.now();
-  const result = await func();
-  const duration = performance.now() - start;
-  return { result, duration };
-}
-
-function addFormInputsForMobileDeviceCapabilities() {
-  const form = document.querySelector<HTMLFormElement>('.js-consent-continue-form');
-
-  if (!form) {
-    return;
-  }
-
-  if (!isCameraCapableMobile()) {
-    trackEvent(DEVICE_CHECK_EVENT, {
-      is_camera_capable_mobile: false,
-    });
-    return;
-  }
-
-  // The check for a camera on the device is async -- kick it off here and intercept
-  // submit() to ensure that it completes in time.
-  const cameraCheckPromise = measure(hasCamera).then(
-    async ({ result: cameraPresent, duration }) => {
-      if (cameraPresent) {
-        // Signal to the backend that this is a mobile device with a camera,
-        // and this user should skip the hybrid handoff ("upload") step.
-        const input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = 'skip_upload';
-        form.appendChild(input);
-      }
-
-      await trackEvent(DEVICE_CHECK_EVENT, {
-        is_camera_capable_mobile: true,
-        camera_present: !!cameraPresent,
-        grace_time: GRACE_TIME_FOR_CAMERA_CHECK_MS,
-        duration: Math.floor(duration),
-      });
-    },
-  );
-
-  form.addEventListener('submit', (event) => {
-    event.preventDefault();
-
-    for (const spinner of form.querySelectorAll('lg-spinner-button')) {
-      spinner.toggleSpinner(true);
-    }
-
-    Promise.race([delay(GRACE_TIME_FOR_CAMERA_CHECK_MS), cameraCheckPromise]).then(() =>
-      form.submit(),
-    );
-  });
-}
-
-addFormInputsForMobileDeviceCapabilities();

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -52,13 +52,7 @@
                         url: url_for,
                         method: 'put',
                         html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
-      <%= render(
-            SpinnerButtonComponent.new(
-              type: :submit,
-              big: true,
-              wide: true,
-            ).with_content(t('doc_auth.buttons.continue')),
-          ) %>
+      <%= f.submit t('doc_auth.buttons.continue') %>
     <% end %>
 
     <%= render(

--- a/spec/features/idv/doc_auth/agreement_step_spec.rb
+++ b/spec/features/idv/doc_auth/agreement_step_spec.rb
@@ -90,27 +90,25 @@ feature 'doc auth welcome step' do
   end
 
   context 'during the acuant maintenance window' do
-    context 'during the acuant maintenance window' do
-      let(:start) { Time.zone.parse('2020-01-01T00:00:00Z') }
-      let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
-      let(:finish) { Time.zone.parse('2020-01-01T23:59:59Z') }
+    let(:start) { Time.zone.parse('2020-01-01T00:00:00Z') }
+    let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
+    let(:finish) { Time.zone.parse('2020-01-01T23:59:59Z') }
 
-      before do
-        allow(IdentityConfig.store).to receive(:acuant_maintenance_window_start).and_return(start)
-        allow(IdentityConfig.store).to receive(:acuant_maintenance_window_finish).and_return(finish)
+    before do
+      allow(IdentityConfig.store).to receive(:acuant_maintenance_window_start).and_return(start)
+      allow(IdentityConfig.store).to receive(:acuant_maintenance_window_finish).and_return(finish)
 
-        sign_in_and_2fa_user
-        complete_doc_auth_steps_before_welcome_step
-      end
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_welcome_step
+    end
 
-      around do |ex|
-        travel_to(now) { ex.run }
-      end
+    around do |ex|
+      travel_to(now) { ex.run }
+    end
 
-      it 'renders the warning banner but no other content' do
-        expect(page).to have_content('We are currently under maintenance')
-        expect(page).to_not have_content(t('doc_auth.headings.welcome'))
-      end
+    it 'renders the warning banner but no other content' do
+      expect(page).to have_content('We are currently under maintenance')
+      expect(page).to_not have_content(t('doc_auth.headings.welcome'))
     end
   end
 end

--- a/spec/features/idv/doc_auth/welcome_step_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_step_spec.rb
@@ -86,20 +86,18 @@ feature 'doc auth welcome step' do
   end
 
   context 'during the acuant maintenance window' do
-    context 'during the acuant maintenance window' do
-      let(:maintenance_window) do
-        [Time.zone.parse('2020-01-01T00:00:00Z'), Time.zone.parse('2020-01-01T23:59:59Z')]
-      end
-      let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
+    let(:maintenance_window) do
+      [Time.zone.parse('2020-01-01T00:00:00Z'), Time.zone.parse('2020-01-01T23:59:59Z')]
+    end
+    let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
 
-      around do |ex|
-        travel_to(now) { ex.run }
-      end
+    around do |ex|
+      travel_to(now) { ex.run }
+    end
 
-      it 'renders the warning banner but no other content' do
-        expect(page).to have_content('We are currently under maintenance')
-        expect(page).to_not have_content(t('doc_auth.headings.welcome'))
-      end
+    it 'renders the warning banner but no other content' do
+      expect(page).to have_content('We are currently under maintenance')
+      expect(page).to_not have_content(t('doc_auth.headings.welcome'))
     end
   end
 end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -81,7 +81,7 @@ module DocAuthHelper
   end
 
   def complete_welcome_step
-    click_spinner_button_and_wait t('doc_auth.buttons.continue')
+    click_on t('doc_auth.buttons.continue')
   end
 
   def complete_doc_auth_steps_before_agreement_step(expect_accessible: false)


### PR DESCRIPTION
## 🎫 Ticket

[LG-9567](https://cm-jira.usa.gov/browse/LG-9567)

## 🛠 Summary of changes

Followup to #8249 and comments there indicating that the async check for a camera was no longer needed. @aduth pointed out it was unnecessary and @matthinz confirmed, "Looks like over the last 4 weeks, 99.97% of these checks where we called the device "camera capable mobile" also then subsequently reported actually having a camera present."

## 📜 Testing Plan

- [ ] Identity verification on mobile phone with camera, confirm that skips upload step
- [ ] Identity verification on desktop, confirm that offers upload step
