### PR TITLE
Update "return to profile" link language on GPO verify page

### DIFF
--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -52,5 +52,5 @@
     ) { t('idv.messages.clear_and_start_over') } %>
 
 <div class="margin-top-2 padding-top-2 border-top border-primary-light">
-  <%= link_to t('idv.buttons.cancel'), account_path %>
+  <%= link_to t('forms.verify_profile.return_to_profile'), account_path %>
 </div>

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -136,6 +136,7 @@ en:
     verify_profile:
       instructions: Enter the 10-character code from the letter you received.
       name: One-time code
+      return_to_profile: Return to your profile
       submit: Confirm account
       title: Confirm your account
       welcome_back: Welcome back

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -144,6 +144,7 @@ es:
     verify_profile:
       instructions: Introduzca el código de 10 caracteres de la carta que ha recibido.
       name: Código único
+      return_to_profile: Regrese a su perfil
       submit: Confirmar cuenta
       title: Confirme su cuenta
       welcome_back: Bienvenido de nuevo

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -146,6 +146,7 @@ fr:
       instructions: Entrez le code à 10 caractères figurant sur la lettre que vous
         avez reçue.
       name: Code à usage unique
+      return_to_profile: Retourner à votre profil
       submit: Confirmer le compte
       title: Confirmez votre compte
       welcome_back: Content de vous revoir

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -4,7 +4,6 @@ en:
     accessible_labels:
       masked_ssn: secure text, starting with %{first_number} and ending with %{last_number}
     buttons:
-      cancel: Cancel and return to your profile
       change_address_label: Update address
       change_label: Update
       change_ssn_label: Update Social Security number

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -5,7 +5,6 @@ es:
       masked_ssn: texto seguro, comenzando con %{first_number} y terminando con
         %{last_number}
     buttons:
-      cancel: Cancele y regrese a su perfil
       change_address_label: Actualizar su dirección actual
       change_label: Actualizar
       change_ssn_label: Actualizar su número de la Seguridad Social

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -5,7 +5,6 @@ fr:
       masked_ssn: Texte sécurisé, commençant par %{first_number} et finissant par
         %{last_number}
     buttons:
-      cancel: Annuler et retourner à votre profil
       change_address_label: Mettre à jour votre adresse actuelle
       change_label: Mettre à jour
       change_ssn_label: Mettre à jour votre numéro de Sécurité Sociale

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -51,7 +51,7 @@ feature 'idv gpo step', :js do
       fill_in 'Password', with: user_password
       click_continue
       visit root_path
-      click_on t('idv.buttons.cancel')
+      click_on t('forms.verify_profile.return_to_profile')
       first(:link, t('links.sign_out')).click
       sign_in_live_with_2fa(user)
       click_on t('idv.messages.gpo.resend')


### PR DESCRIPTION
## 🎫 Ticket

[LG-9563](https://cm-jira.usa.gov/browse/LG-9563)

## 🛠 Summary of changes

Previously it said "Cancel and return to your profile" but it does not cancel identity verification, so change to "Return to your profile." Add new translation key `forms.verify_profile.return_to_profile`. Delete now-unused key `idv.buttons.cancel`.

## 👀 Screenshots

<details>
<summary>English:</summary>
  
![Return to profile English](https://user-images.githubusercontent.com/2381438/234139262-77766cae-8c76-4091-8fec-fd4b2d30f685.png)
</details>

<details>
<summary>Spanish:</summary>
  
![Return to profile Spanish](https://user-images.githubusercontent.com/2381438/234139282-681bf3ff-3a2d-4a2b-84d9-a43586669a53.png)
</details>

<details>
<summary>French:</summary>
  
![Return to profile French](https://user-images.githubusercontent.com/2381438/234139306-001d8131-d94f-4b0d-95e8-326ecd81d077.png)
</details>
