### PR TITLE
LG-9429: Avoid sending new device notification before fully registered

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ApplicationRecord
   end
 
   def fully_registered?
-    MfaPolicy.new(self).two_factor_enabled?
+    !!registration_log&.registered_at
   end
 
   def confirmed?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,10 @@ class User < ApplicationRecord
     MfaPolicy.new(self).two_factor_enabled?
   end
 
+  def fully_registered?
+    !!registration_log&.registered_at
+  end
+
   def confirmed?
     email_addresses.where.not(confirmed_at: nil).any?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -324,7 +324,7 @@ class User < ApplicationRecord
       map(&:decorate)
   end
 
-  def recent_devices?
+  def has_devices?
     !recent_devices.empty?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,12 +66,8 @@ class User < ApplicationRecord
     email_addresses.where.not(confirmed_at: nil).order('last_sign_in_at DESC NULLS LAST')
   end
 
-  def need_two_factor_authentication?(_request)
-    MfaPolicy.new(self).two_factor_enabled?
-  end
-
   def fully_registered?
-    !!registration_log&.registered_at
+    MfaPolicy.new(self).two_factor_enabled?
   end
 
   def confirmed?

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -76,9 +76,7 @@ class UserEventCreator
 
   # @return [Array(Event, String)] an (event, disavowal_token) tuple
   def create_event_for_new_device(event_type:, user:, disavowal_token:)
-    user_has_multiple_devices = user.recent_devices?
-
-    if user_has_multiple_devices && disavowal_token.nil?
+    if user.fully_registered? && user.recent_devices? && disavowal_token.nil?
       device, event, disavowal_token = Device.transaction do
         device = create_device_for_user(user)
         event, disavowal_token = create_user_event_with_disavowal(

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -76,7 +76,7 @@ class UserEventCreator
 
   # @return [Array(Event, String)] an (event, disavowal_token) tuple
   def create_event_for_new_device(event_type:, user:, disavowal_token:)
-    if user.fully_registered? && user.recent_devices? && disavowal_token.nil?
+    if user.fully_registered? && user.has_devices? && disavowal_token.nil?
       device, event, disavowal_token = Device.transaction do
         device = create_device_for_user(user)
         event, disavowal_token = create_user_event_with_disavowal(

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -39,6 +39,6 @@ Warden::Manager.after_authentication do |user, auth, options|
 
   unless bypass_by_cookie
     auth.session(options[:scope])[TwoFactorAuthenticatable::NEED_AUTHENTICATION] =
-      user.need_two_factor_authentication?(auth.request)
+      MfaPolicy.new(user).two_factor_enabled?
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -177,6 +177,10 @@ FactoryBot.define do
 
     trait :signed_up do
       with_phone
+
+      after :create do |user|
+        user.create_registration_log(registered_at: Time.zone.now)
+      end
     end
 
     trait :unconfirmed do

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'New device tracking' do
+  include SamlAuthHelper
+
   let(:user) { create(:user, :signed_up) }
 
   context 'user has existing devices' do
@@ -37,28 +39,21 @@ describe 'New device tracking' do
     end
   end
 
-  context 'user does not have a phone configured' do
-    let(:user) { create(:user) }
+  context 'user signs up and confirms email in a different browser' do
+    # let(:email) { 'example@example.com' }
+    let(:user) { build(:user) }
 
-    before do
-      create(:device, user: user)
-    end
+    it 'does not send an email' do
+      perform_in_browser(:one) do
+        visit_idp_from_sp_with_ial1(:oidc)
+        sign_up_user_from_sp_without_confirming_email(user.email)
+      end
 
-    it 'does not send an SMS' do
-      sign_in_user(user)
-
-      expect(user.reload.devices.length).to eq 2
-
-      device = user.devices.order(created_at: :desc).first
-      expect_delivered_email_count(1)
-      expect_delivered_email(
-        to: [user.email_addresses.first.email],
-        subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
-        body: [device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
-              strftime('%B %-d, %Y %H:%M Eastern Time'),
-               'From 127.0.0.1 (IP address potentially located in United States)'],
-      )
-      expect(Telephony::Test::Message.messages.count).to eq 0
+      perform_in_browser(:two) do
+        expect do
+          confirm_email_in_a_different_browser(user.email)
+        end.not_to change { ActionMailer::Base.deliveries.count }
+      end
     end
   end
 end

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -40,7 +40,6 @@ describe 'New device tracking' do
   end
 
   context 'user signs up and confirms email in a different browser' do
-    # let(:email) { 'example@example.com' }
     let(:user) { build(:user) }
 
     it 'does not send an email' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,6 +113,29 @@ RSpec.describe User do
     end
   end
 
+  describe '#fully_registered?' do
+    let(:user) { create(:user) }
+    subject(:fully_registered?) { user.fully_registered? }
+
+    context 'with unconfirmed user' do
+      let(:user) { create(:user, :unconfirmed) }
+
+      it { expect(fully_registered?).to eq(false) }
+    end
+
+    context 'with confirmed user' do
+      let(:user) { create(:user) }
+
+      it { expect(fully_registered?).to eq(false) }
+    end
+
+    context 'with mfa-enabled user' do
+      let(:user) { create(:user, :signed_up) }
+
+      it { expect(fully_registered?).to eq(true) }
+    end
+  end
+
   context '#need_two_factor_authentication?' do
     let(:request) { ActionController::TestRequest.new }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -136,30 +136,6 @@ RSpec.describe User do
     end
   end
 
-  context '#need_two_factor_authentication?' do
-    let(:request) { ActionController::TestRequest.new }
-
-    it 'is true when two_factor_enabled' do
-      user = build_stubbed(:user)
-
-      mock_mfa = MfaPolicy.new(user)
-      allow(mock_mfa).to receive(:two_factor_enabled?).and_return true
-      allow(MfaPolicy).to receive(:new).with(user).and_return mock_mfa
-
-      expect(user.need_two_factor_authentication?(nil)).to be_truthy
-    end
-
-    it 'is false when not two_factor_enabled' do
-      user = build_stubbed(:user)
-
-      mock_mfa = MfaPolicy.new(user)
-      allow(mock_mfa).to receive(:two_factor_enabled?).and_return false
-      allow(MfaPolicy).to receive(:new).with(user).and_return(mock_mfa)
-
-      expect(user.need_two_factor_authentication?(nil)).to be_falsey
-    end
-  end
-
   context 'when identities are present' do
     let(:user) { create(:user, :signed_up) }
     let(:active_identity) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1156,6 +1156,23 @@ RSpec.describe User do
     end
   end
 
+  describe '#has_devices?' do
+    let(:user) { create(:user) }
+    let(:has_devices?) { user.has_devices? }
+
+    context 'with no devices' do
+      it { expect(has_devices?).to eq(false) }
+    end
+
+    context 'with a device' do
+      before do
+        create(:device, user:)
+      end
+
+      it { expect(has_devices?).to eq(true) }
+    end
+  end
+
   describe '#password_reset_profile' do
     let(:user) { create(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1134,7 +1134,7 @@ RSpec.describe User do
 
   describe '#has_devices?' do
     let(:user) { create(:user) }
-    let(:has_devices?) { user.has_devices? }
+    subject(:has_devices?) { user.has_devices? }
 
     context 'with no devices' do
       it { expect(has_devices?).to eq(false) }

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -18,7 +18,7 @@ describe UserEventCreator do
       cookie_jar: cookie_jar,
     )
   end
-  let(:user) { create(:user) }
+  let(:user) { create(:user, :signed_up) }
   let(:device) { create(:device, user: user, cookie_uuid: existing_device_cookie) }
   let(:event_type) { 'account_created' }
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -196,7 +196,6 @@ module Features
 
     def sign_in_with_warden(user, auth_method: nil)
       login_as(user, scope: :user, run_callbacks: false)
-      allow(user).to receive(:need_two_factor_authentication?).and_return(false)
 
       Warden.on_next_request do |proxy|
         session = proxy.env['rack.session']


### PR DESCRIPTION
## 🎫 Ticket

[LG-9429](https://cm-jira.usa.gov/browse/LG-9429)

## 🛠 Summary of changes

Updates device notification logic to avoid sending new device notifications prior to the user being fully registered, so that a user doesn't receive a "New Sign-In" notification if they complete account registration on a second device, which is common if they were to start the process on a computer and complete it on their phone.

~**DRAFT:** Leaving this as draft for now because, while I think "fully registered" aligning to the RegistrationLog record makes a lot of sense, it's unclear if this is reliable enough to exist for users who have existed since prior to the introduction of that table in #3121. Instead, it may make more sense to have it reflect the presence of any MFAs, essentially aliasing `fully_registered?` to `two_factor_enabled?` or using the method directly (though I think "fully registered" adds some clarity of intent).~ Updated as of b7661d0.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Click "Create an account"
3. Enter an email
4. Confirm Rules of Use checkbox
5. Click "Submit"
6. Open the email you received
7. In a separate session from what you used for Steps 1-6 (e.g. on your mobile device, or in a different browser, or in an Incognito/private window), open the link to confirm your email address
8. Complete the password selection step
9. Select phone as MFA
10. Complete the phone MFA setup

**Before:** An email notification is sent about "New sign-in" to your account 
**After:** No email is sent about "New sign-in" to your account when the user is in the middle of account creation
