### PR TITLE
Add `make download_acuant_sdk` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 	build_artifact \
 	check \
 	docker_setup \
+	download_acuant_sdk \
 	fast_setup \
 	fast_test \
 	help \
@@ -259,3 +260,6 @@ update: ## Update dependencies, useful after a git pull
 
 README.md: docs/ ## Generates README.md based on the contents of the docs directory
 	bundle exec ruby scripts/generate_readme.rb --docs-dir $< > $@
+
+download_acuant_sdk: ## Downloads the most recent Acuant SDK release from Github
+	@scripts/download_acuant_sdk.sh

--- a/docs/sdk-upgrade.md
+++ b/docs/sdk-upgrade.md
@@ -24,35 +24,31 @@ You will need:
 
 Steps:
 
-1. From [the list of Acuant SDK releases](https://github.com/Acuant/JavascriptWebSDKV11/releases), download the most recent release. Note the version number. The download will be a `.zip` or `.tar.gz` file. Uncompress it locally.
+1. From the terminal, run `make download_acuant_sdk`. This command will place the most recent Acuant SDK files in a directory under [`/public/acuant`](/public/acuant) named for the version you downloaded. The name will be similar to `/public/acuant/11.N.N`. It should exist alongside a few previous versions.
 
-2. In your local checkout of the identity-idp repo, create a new version number directory under [`/public/acuant`](/public/acuant) named for the version you downloaded. The name will be similar to `/public/acuant/11.N.N`. You will be placing it alongside a few previous versions.
+2. This would be a good time to create a new Git branch, if you haven't done so already, and to commit the new version-numbered directory and its new SDK files.
 
-3. In your uncompressed download, open the `webSdk` folder. Copy all `.min.js` or `.wasm` files from here into the empty directory you created in the previous step. These files should have the same (or similar) names as files in the neighboring directories with previous version numbers.
-
-4. This would be a good time to create a new Git branch, if you haven't done so already, and to commit the new version-numbered directory and its new SDK files.
-
-5. Next, we must test the new SDK version. We will switch it on by setting our local default version of the Acuant SDK to our new version. Open the `/config/application.yml` file in your local repo. Set the `idv_acuant_sdk_version_default` key to the new version number. Create the key if it does not yet exist. The result will look like:
+3. Next, we must test the new SDK version. We will switch it on by setting our local default version of the Acuant SDK to our new version. Open the `/config/application.yml` file in your local repo. Set the `idv_acuant_sdk_version_default` key to the new version number. Create the key if it does not yet exist. The result will look like:
     ```yml
     ---
     development:
       idv_acuant_sdk_version_default: '11.N.N' # new version
     ```
 
-6. Follow [these instructions to use the app from your mobile phone](mobile.md). Complete both the "Use the app from a mobile device" section, which lets you view the app from your phone, and the "Debugging with the desktop browser" section, which hooks your desktop/laptop browser debugging tools to your phone via USB cable.
+4. Follow [these instructions to use the app from your mobile phone](mobile.md). Complete both the "Use the app from a mobile device" section, which lets you view the app from your phone, and the "Debugging with the desktop browser" section, which hooks your desktop/laptop browser debugging tools to your phone via USB cable.
 
-7. With your phone plugged into your computer via USB cable, and with your computer's browser debugging tools set to inspect a browser tab on your phone, navigate on your phone to the app's document capture page. This is the page that asks you to photograph your state ID card.
+5. With your phone plugged into your computer via USB cable, and with your computer's browser debugging tools set to inspect a browser tab on your phone, navigate on your phone to the app's document capture page. This is the page that asks you to photograph your state ID card.
 
-8. Inspect the `Sources` of the page. Expand the local IP address from which you are serving the page. You should see a folder with a version number in the name, like `acuant/11.N.N`. Check that the version here is the new one &mdash; the version you noted in step 1. This screenshot shows where the version number appears in Chrome:
+6. Inspect the `Sources` of the page. Expand the local IP address from which you are serving the page. You should see a folder with a version number in the name, like `acuant/11.N.N`. Check that the version here is the new one &mdash; the version you noted in step 1. This screenshot shows where the version number appears in Chrome:
 
     ![acuant-vesion-location](https://user-images.githubusercontent.com/546123/232644328-35922329-ad30-489e-943f-4125c009f74d.png)
 
 
-9. Assuming the version is correct, you are ready to test it. On your phone, tap to photograph your state ID card. Point the camera at the card. Ensure the SDK finds the edges of the card and captures an image. Normally the SDK will put a yellowish box over the card to show where it believes the edges are.
+7. Assuming the version is correct, you are ready to test it. On your phone, tap to photograph your state ID card. Point the camera at the card. Ensure the SDK finds the edges of the card and captures an image. Normally the SDK will put a yellowish box over the card to show where it believes the edges are.
 
-10. After you have photographed the front and back of your card, you have tested the SDK locally. You do not need to submit the images. If you have both an Android and an iPhone, test the SDK with both of them. (Or, pair with someone who has the other type of phone.)
+8. After you have photographed the front and back of your card, you have tested the SDK locally. You do not need to submit the images. If you have both an Android and an iPhone, test the SDK with both of them. (Or, pair with someone who has the other type of phone.)
 
-11. Open a pull request for the modified SDK files. The next process &mdash; A/B testing the new version &mdash; can only take place after the files are accepted into the main branch.
+9. Open a pull request for the modified SDK files. The next process &mdash; A/B testing the new version &mdash; can only take place after the files are accepted into the main branch.
 
 ## Turn on A/B testing
 

--- a/scripts/download_acuant_sdk.sh
+++ b/scripts/download_acuant_sdk.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! which jq; then
+    echo "This script requires jq (https://stedolan.github.io/jq/)."
+    echo "You can install it using 'brew install jq'."
+    exit 1
+fi
+
+VERSION=${1:-}
+
+TEMP_DIR=$(mktemp -d  tmp/acuant_sdk_XXXXXXXXXXXX)
+ACUANT_RELEASES=${TEMP_DIR}/acuant_releases.json
+
+echo "Getting list of Acuant releases..."
+
+curl --silent -H 'Accept: application/vnd.github+json' \
+    https://api.github.com/repos/Acuant/JavascriptWebSDKV11/releases \
+    > "$ACUANT_RELEASES"
+
+if [ "$VERSION" == "" ]; then
+    echo "Determining latest Acuant SDK version..."
+    VERSION=$(jq -r 'sort_by(.id) | reverse | .[0].tag_name' < "$ACUANT_RELEASES")
+    echo "It's ${VERSION}."
+fi
+
+RELEASE_INFO=$(jq ".[] | select(.tag_name == \"${VERSION}\")" < "$ACUANT_RELEASES")
+
+if [ "$RELEASE_INFO" == "" ]; then
+    echo "$VERSION is not a valid Acuant release tag."
+    exit 1
+fi
+
+PUBLIC_DIR="public/acuant/${VERSION}"
+if [ -d "$PUBLIC_DIR" ]; then
+    echo "This version of the SDK is already present at '${PUBLIC_DIR}'"
+    echo "To replace it, first delete that directory (rm -rf '${PUBLIC_DIR}') and try again."
+    exit 1
+fi
+
+TARBALL_URL=$(echo "$RELEASE_INFO" | jq -r '.tarball_url')
+if [ "$TARBALL_URL" == "" ]; then
+    echo "Could not determine tarball url for ${VERSION}!"
+    exit 1
+fi
+
+echo "Downloading tarball for $VERSION (${TARBALL_URL})..."
+
+TGZ_FILE="${TEMP_DIR}/sdk.tgz"
+curl --silent --output "$TGZ_FILE" -L "${TARBALL_URL}"
+tar -C "$TEMP_DIR" -xzf "$TGZ_FILE"
+
+echo "Copying SDK files to '${PUBLIC_DIR}'..."
+mkdir -p "$PUBLIC_DIR"
+cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/*.min.js "$PUBLIC_DIR/"
+cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/*.wasm "$PUBLIC_DIR/"
+
+echo "Done! You can commit the files in ${PUBLIC_DIR}."
+
+rm -rf "$TEMP_DIR"


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

## 🛠 Summary of changes

This PR adds a new command, `make download_acuant_sdk`, that will download the most recent Acuant SDK version from their Github page, unzip it, and put the relevant files in a subdirectory inside `public/acuant`.

This more or less automates the first couple steps of @jskinne3's [SDK upgrade doc](https://github.com/18F/identity-idp/blob/main/docs/sdk-upgrade.md), which I have updated accordingly.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Run `make download_acuant_sdk`
- [ ] Observe that SDK files have been placed in `public/acuant/11.8.2` (current version as of this writing)

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
