### PR TITLE
Update supported countries to match AWS documentation

### DIFF
--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -128,11 +128,6 @@ BJ:
   name: Benin
   supports_sms: true
   supports_voice: false
-BL:
-  country_code: '590'
-  name: Burundi
-  supports_sms: true
-  supports_voice: false
 BM:
   country_code: '1441'
   name: Bermuda

--- a/config/pinpoint_supported_countries.yml
+++ b/config/pinpoint_supported_countries.yml
@@ -94,8 +94,8 @@ BH:
   name: Bahrain
   supports_sms: true
   supports_voice: true
-BL:
-  country_code: '590'
+BI:
+  country_code: '257'
   name: Burundi
   supports_sms: true
   supports_voice: false


### PR DESCRIPTION
- Disambiguates between Burundi and Saint Barthélemy

I got a spec failure on an [unrelated PR](https://github.com/18F/identity-idp/pull/8278), so I am fixing this

