### PR TITLE
Fix updating saml_idp gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 6bce0e98b3c60f45c990de335386d129a81bc77d
+  revision: 5d9a9b0411e3bd79bf1159c94293ec55053884d4
   tag: 0.18.2-18f
   specs:
     saml_idp (0.18.2.pre.18f)


### PR DESCRIPTION
## 🛠 Summary of changes

Something appears to have went wrong in #8271 such that the SHA in Gemfile.lock does not exist anymore:

```
Git error: command `git reset --hard 6bce0e98b3c60f45c990de335386d129a81bc77d` in directory
/Users/mitchellehenke/projects/identity-idp/.gem/ruby/3.2.2/bundler/gems/saml_idp-6bce0e98b3c6 has failed.
fatal: Could not parse object '6bce0e98b3c60f45c990de335386d129a81bc77d'.
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
