### PR TITLE
Remove hybrid mobile 404 action if feature flag disabled

### DIFF
--- a/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
+++ b/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
@@ -5,10 +5,6 @@ module Idv
 
       include AcuantConcern
 
-      included do
-        before_action :render_404_if_hybrid_mobile_controllers_disabled
-      end
-
       def check_valid_document_capture_session
         if !document_capture_user
           # The user has not "logged in" to document capture via the EntryController

--- a/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
+++ b/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
@@ -44,10 +44,6 @@ module Idv
           service_provider: current_sp,
         ).present?
       end
-
-      def render_404_if_hybrid_mobile_controllers_disabled
-        render_not_found unless IdentityConfig.store.doc_auth_hybrid_mobile_controllers_enabled
-      end
     end
   end
 end

--- a/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
@@ -34,13 +34,6 @@ describe Idv::HybridMobile::CaptureCompleteController do
         :check_valid_document_capture_session,
       )
     end
-
-    it 'checks that feature flag is enabled' do
-      expect(subject).to have_actions(
-        :before,
-        :render_404_if_hybrid_mobile_controllers_disabled,
-      )
-    end
   end
 
   context 'when doc_auth_hybrid_mobile_controllers_enabled' do

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -88,14 +88,6 @@ describe Idv::HybridMobile::DocumentCaptureController do
         )
       end
 
-      context 'feature flag disabled' do
-        let(:feature_flag_enabled) { false }
-        it 'returns a 404' do
-          get :show
-          expect(response.status).to eql(404)
-        end
-      end
-
       context 'with expired DocumentCaptureSession' do
         let(:document_capture_session_requested_at) do
           Time.zone.now.advance(

--- a/spec/controllers/idv/hybrid_mobile/entry_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/entry_controller_spec.rb
@@ -25,22 +25,6 @@ describe Idv::HybridMobile::EntryController do
         and_return(feature_flag_enabled)
     end
 
-    context 'feature flag disabled' do
-      let(:feature_flag_enabled) { false }
-
-      before do
-        get :show, params: { 'document-capture-session': session_uuid }
-      end
-
-      it '404s' do
-        expect(response).to have_http_status(:not_found)
-      end
-
-      it 'does not log that phone upload link was used' do
-        expect(@irs_attempts_api_tracker.events).not_to have_key(:idv_phone_upload_link_used)
-      end
-    end
-
     context 'with no session' do
       before do
         get :show


### PR DESCRIPTION
## 🎫 Ticket

[LG-9605](https://cm-jira.usa.gov/browse/LG-9605)

## 🛠 Summary of changes

The Plan:
1) Deploy Hybrid Mobile code #8243 
2) Merge and deploy this PR to remove 404 action
3) Test 50/50 state in int
4) Turn on feature flag doc_auth_hybrid_mobile_controllers_enabled in production
5) Merge and deploy delete PR for now-unused FSM capture doc flow.