### PR TITLE
Remap Pinpoint KV country code

### DIFF
--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -130,6 +130,7 @@ class PinpointSupportedCountries
       'BDE' => 'BD',
       'DN' => 'DM',
       'H' => 'HT',
+      'KV' => 'XK',
       'TX' => 'TZ',
     }.fetch(iso_code, iso_code)
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an error causing all builds to fail due to missing phone data for the "KV" country code listed on [Pinpoint's documentation](https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html). The Kosovo country code is "XK" in the Phonelib library, so the changes here introduce a mapping from "KV" to "XK".

Related resources:

- https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html
- https://en.wikipedia.org/wiki/XK_(user_assigned_code)

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1682519068993279

## 📜 Testing Plan

Confirm no errors when running `make lint_country_dialing_codes`