### PR TITLE
DRAFT LG-9072 Applicant verify your information page "update state ID" workflows 

### DIFF
--- a/app/services/idv/steps/in_person/address_step.rb
+++ b/app/services/idv/steps/in_person/address_step.rb
@@ -39,7 +39,11 @@ module Idv
         end
 
         def updating_address
-          flow_session[:pii_from_user].has_key?(:address1)
+          if IdentityConfig.store.in_person_capture_secondary_id_enabled
+            flow_session[:pii_from_user].has_key?(:address1) && !(flow_session[:pii_from_user][:address1].nil?)
+          else
+            flow_session[:pii_from_user].has_key?(:address1)
+          end
         end
 
         def pii

--- a/app/services/idv/steps/in_person/state_id_step.rb
+++ b/app/services/idv/steps/in_person/state_id_step.rb
@@ -28,6 +28,15 @@ module Idv
             pii_from_user[:zipcode] = flow_params[:state_id_zipcode]
             mark_step_complete(:address)
           end
+
+          if capture_secondary_id_enabled? && pii_from_user[:same_address_as_id] == 'false' && (pii_from_user[:address1] === pii_from_user[:state_id_address1])
+            pii_from_user.delete(:address1)
+            pii_from_user.delete(:address2)
+            pii_from_user.delete(:city)
+            pii_from_user.delete(:state)
+            pii_from_user.delete(:zipcode)
+            mark_step_incomplete(:address)
+          end
         end
 
         def extra_view_variables

--- a/spec/services/idv/steps/in_person/address_step_spec.rb
+++ b/spec/services/idv/steps/in_person/address_step_spec.rb
@@ -142,4 +142,69 @@ describe Idv::Steps::InPerson::AddressStep do
       end
     end
   end
+
+  describe '#updating_address effects on extra_view_variables.updating_address' do
+    let(:address1) { '123 Fourth St' }
+    let(:uuid) { '0000' }
+    let(:params) { ActionController::Parameters.new }
+    
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_capture_secondary_id_enabled).
+        and_return(true)
+    end
+  
+    context 'with secondary capture enabled' do
+      let(:capture_secondary_id_enabled) { true }
+
+      it 'capture secondary id enabled returns true' do
+        expect(step.extra_view_variables).to include(
+          capture_secondary_id_enabled: true,
+        )
+      end
+
+      it 'returns true when flow_session has key address1 and the value is not nil' do
+        pii_from_user[:address1] = address1
+        expect(step.extra_view_variables).to include(
+          updating_address: true,
+        )
+      end
+
+      it 'returns false when flow_session has key address1 but the value is nil' do
+        pii_from_user[:address1] = nil
+        expect(step.extra_view_variables).to include(
+          updating_address: false,
+        )
+      end
+
+      it 'returns false when flow_session does not have key address1' do
+        pii_from_user[:uuid] = uuid
+        expect(step.extra_view_variables).to include(
+          updating_address: false,
+        )
+      end
+    end
+
+    context 'with secondary capture disabled' do
+      let(:capture_secondary_id_enabled) { false }
+
+      it 'capture secondary id enabled returns false' do
+        expect(step.extra_view_variables).to include(
+          capture_secondary_id_enabled: false,
+        )
+      end
+
+      it 'returns true when flow_session has key address1' do
+        pii_from_user[:address1] = address1
+        expect(step.extra_view_variables).to include(
+          updating_address: true,
+        )
+      end
+
+      it 'returns false when flow_session does not have key address1' do
+        expect(step.extra_view_variables).to include(
+          updating_address: false,
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket
[LG-9072](https://cm-jira.usa.gov/browse/LG-9072) Applicant verify your information page "update state ID" workflows 

## 🛠 Summary of changes
I am making workflow updates only after the **Verify your info page** (only behind the in_person_capture_secondary_id_enabled feature flag) to caputure different scenarios/flows a user might encounter related to state id address and their current residential address when a user selects Update on Verify your information for State-issued ID.

## 📜 Testing Plan
- [ ] Step 1: Set env variable in_person_capture_secondary_id_enabled to true to test the following. 
- [ ] Step 1A: Test [Scenario 1](https://www.figma.com/file/t3pPLpCfEyHcVoX7QbTpQV/Milestone-2---Double-Address-Verification?node-id=606-19639&t=yKPNADYQSWU1l2j8-0) Given a user who changes their indication from current address IS NOT LISTED to IS LISTED (“No” to “Yes”)
```
1. Route user to Update info on your state ID page
2. When user changes the radio options from "No" to "Yes" and clicks Update, route user back to the Verify Info page
3. Show the state ID address for the residential address
4. If any additional changes were made to the State ID page, they should be reflected on the Verify Info page
```
- [ ] Step 1B: Test [Scenario 2](https://www.figma.com/file/t3pPLpCfEyHcVoX7QbTpQV/Milestone-2---Double-Address-Verification?node-id=606-19643&t=yKPNADYQSWU1l2j8-0) Given a user who changes their indication from IS LISTED to IS NOT LISTED (“Yes” to “No”)
```
1. Route user to Update info on your state ID page
2. When user changes the radio options from "Yes" to "No" and clicks Update, route the user to a blank Enter your current residential address page
3. When user clicks Continue, route user back to the Verify Info page (skip SSN page)
4. Show updates to residential address
```
- [ ] Step 1C Test [Scenario 4:](https://www.figma.com/file/t3pPLpCfEyHcVoX7QbTpQV/Milestone-2---Double-Address-Verification?node-id=606-19641&t=yKPNADYQSWU1l2j8-0) Given a user updates state ID page and DOES NOT change the radio options (this should be current behavior)
```
1. Route user to Update info your state ID page
2. When a user clicks Update, route user back to Verify info page and show their updates in the State ID section
```
- [ ] Step 2: Set env variable in_person_capture_secondary_id_enabled to false and ensure the existing flows have not been affected

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
