### PR TITLE
LG-9294 Rate limit for 'Verify your ID' must include a link back to SP

### DIFF
--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class SessionErrorsController < ApplicationController
+    include StepIndicatorConcern
     include IdvSession
     include EffectiveUser
 

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -24,7 +24,7 @@
           <strong>
             <%= link_to(
                   t(
-                    'idv.cancel.headings.exit.with_sp',
+                    'idv.failure.exit.with_sp',
                     app_name: APP_NAME, sp_name: decorated_session.sp_name,
                   ),
                   return_to_sp_failure_to_proof_path(

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -22,15 +22,29 @@
       </p>
       <p>
         <strong>
-          <% exit_link_text = 'idv.failure.exit.without_sp' %>
-          <% exit_link_text = 'idv.failure.exit.with_sp' if decorated_session.sp_name.present? %>
-          <%= link_to(
-                t(exit_link_text, app_name: APP_NAME, sp_name: decorated_session.sp_name),
-                return_to_sp_failure_to_proof_path(
-                  step: 'verify_id',
-                  location: request.params[:action],
-                ),
-              ) %>
+          <% if decorated_session.sp_name.present? %>
+            <%= link_to(
+                  t(
+                    'idv.failure.exit.with_sp',
+                    app_name: APP_NAME, sp_name: decorated_session.sp_name,
+                  ),
+                  return_to_sp_failure_to_proof_path(
+                    step: 'verify_id',
+                    location: request.params[:action],
+                  ),
+                ) %>
+          <% else %>
+            <%= link_to(
+                  t(
+                    'idv.failure.exit.without_sp',
+                    app_name: APP_NAME,
+                  ),
+                  return_to_sp_failure_to_proof_path(
+                    step: 'verify_id',
+                    location: request.params[:action],
+                  ),
+                ) %>
+          <% end %>
         </strong>
       </p>
     <% end %>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -22,11 +22,9 @@
       </p>
       <p>
         <strong>
+          <% exit_msg = decorated_session.sp_name.present? ? 'idv.failure.exit.with_sp' : 'idv.failure.exit.without_sp' %>
           <%= link_to(
-                t(
-                  decorated_session.sp_name.present? ? 'idv.failure.exit.with_sp' : 'idv.failure.exit.without_sp',
-                  app_name: APP_NAME, sp_name: decorated_session.sp_name,
-                ),
+                t(exit_msg, app_name: APP_NAME, sp_name: decorated_session.sp_name),
                 return_to_sp_failure_to_proof_path(
                   step: 'verify_id',
                   location: request.params[:action],

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -24,26 +24,26 @@
         <strong>
           <% if decorated_session.sp_name.present? %>
             <%= link_to(
-                t(
-                  'idv.failure.exit.with_sp',
-                  app_name: APP_NAME, sp_name: decorated_session.sp_name,
-                ),
-                return_to_sp_failure_to_proof_path(
-                  step: 'verify_id',
-                  location: request.params[:action],
-                ),
-              ) %>
+                  t(
+                    'idv.failure.exit.with_sp',
+                    app_name: APP_NAME, sp_name: decorated_session.sp_name,
+                  ),
+                  return_to_sp_failure_to_proof_path(
+                    step: 'verify_id',
+                    location: request.params[:action],
+                  ),
+                ) %>
           <% else %>
             <%= link_to(
-                t(
-                  'idv.failure.exit.without_sp',
-                  app_name: APP_NAME,
-                ),
-                return_to_sp_failure_to_proof_path(
-                  step: 'verify_id',
-                  location: request.params[:action],
-                ),
-              ) %>
+                  t(
+                    'idv.failure.exit.without_sp',
+                    app_name: APP_NAME,
+                  ),
+                  return_to_sp_failure_to_proof_path(
+                    step: 'verify_id',
+                    location: request.params[:action],
+                  ),
+                ) %>
           <% end %>
         </strong>
       </p>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -22,9 +22,10 @@
       </p>
       <p>
         <strong>
-          <% exit_msg = decorated_session.sp_name.present? ? 'idv.failure.exit.with_sp' : 'idv.failure.exit.without_sp' %>
+          <% exit_text =  'idv.failure.exit.without_sp' %>
+          <% exit_text = 'idv.failure.exit.with_sp' if decorated_session.sp_name.present? %>
           <%= link_to(
-                t(exit_msg, app_name: APP_NAME, sp_name: decorated_session.sp_name),
+                t(exit_text, app_name: APP_NAME, sp_name: decorated_session.sp_name),
                 return_to_sp_failure_to_proof_path(
                   step: 'verify_id',
                   location: request.params[:action],

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -18,22 +18,22 @@
                 except: :seconds,
               ),
             ) %>
-          <% if decorated_session.sp_name.present? %>
-            <p>
-              <strong>
-                <%= link_to(
-                  t(
-                    'idv.cancel.headings.exit.with_sp',
-                    app_name: APP_NAME, sp_name: decorated_session.sp_name,
-                  ),
-                  return_to_sp_failure_to_proof_path(
-                    step: 'verify_info',
-                    location: request.params[:action],
-                  ),
-                ) %>
-              </strong>
-            </p>
-          <% end %>
       </p>
+      <% if decorated_session.sp_name.present? %>
+        <p>
+          <strong>
+            <%= link_to(
+              t(
+                'idv.cancel.headings.exit.with_sp',
+                app_name: APP_NAME, sp_name: decorated_session.sp_name,
+              ),
+              return_to_sp_failure_to_proof_path(
+                step: 'verify_info',
+                location: request.params[:action],
+              ),
+            ) %>
+          </strong>
+        </p>
+      <% end %>
     <% end %>
 

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -23,15 +23,15 @@
         <p>
           <strong>
             <%= link_to(
-              t(
-                'idv.cancel.headings.exit.with_sp',
-                app_name: APP_NAME, sp_name: decorated_session.sp_name,
-              ),
-              return_to_sp_failure_to_proof_path(
-                step: 'verify_info',
-                location: request.params[:action],
-              ),
-            ) %>
+                  t(
+                    'idv.cancel.headings.exit.with_sp',
+                    app_name: APP_NAME, sp_name: decorated_session.sp_name,
+                  ),
+                  return_to_sp_failure_to_proof_path(
+                    step: 'verify_info',
+                    location: request.params[:action],
+                  ),
+                ) %>
           </strong>
         </p>
       <% end %>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -22,10 +22,10 @@
       </p>
       <p>
         <strong>
-          <% exit_text =  'idv.failure.exit.without_sp' %>
-          <% exit_text = 'idv.failure.exit.with_sp' if decorated_session.sp_name.present? %>
+          <% exit_link_text = 'idv.failure.exit.without_sp' %>
+          <% exit_link_text = 'idv.failure.exit.with_sp' if decorated_session.sp_name.present? %>
           <%= link_to(
-                t(exit_text, app_name: APP_NAME, sp_name: decorated_session.sp_name),
+                t(exit_link_text, app_name: APP_NAME, sp_name: decorated_session.sp_name),
                 return_to_sp_failure_to_proof_path(
                   step: 'verify_id',
                   location: request.params[:action],

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -22,16 +22,29 @@
       </p>
       <p>
         <strong>
-          <%= link_to(
+          <% if decorated_session.sp_name.present? %>
+            <%= link_to(
                 t(
-                  decorated_session.sp_name.present? ? 'idv.failure.exit.with_sp' : 'idv.failure.exit.without_sp',
+                  'idv.failure.exit.with_sp',
                   app_name: APP_NAME, sp_name: decorated_session.sp_name,
                 ),
                 return_to_sp_failure_to_proof_path(
-                  step: 'verify_info',
+                  step: 'verify_id',
                   location: request.params[:action],
                 ),
               ) %>
+          <% else %>
+            <%= link_to(
+                t(
+                  'idv.failure.exit.without_sp',
+                  app_name: APP_NAME,
+                ),
+                return_to_sp_failure_to_proof_path(
+                  step: 'verify_id',
+                  location: request.params[:action],
+                ),
+              ) %>
+          <% end %>
         </strong>
       </p>
     <% end %>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -2,14 +2,6 @@
       'idv/shared/error',
       heading: t('errors.doc_auth.throttled_heading'),
       options: [
-        decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path(
-            step: 'verify_info',
-            location: request.params[:action],
-          ),
-          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-          new_tab: true,
-        },
         {
           url: MarketingSite.contact_url,
           text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
@@ -26,6 +18,22 @@
                 except: :seconds,
               ),
             ) %>
+          <% if decorated_session.sp_name.present? %>
+            <p>
+              <strong>
+                <%= link_to(
+                  t(
+                    'idv.cancel.headings.exit.with_sp',
+                    app_name: APP_NAME, sp_name: decorated_session.sp_name,
+                  ),
+                  return_to_sp_failure_to_proof_path(
+                    step: 'verify_info',
+                    location: request.params[:action],
+                  ),
+                ) %>
+              </strong>
+            </p>
+          <% end %>
       </p>
     <% end %>
 

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -22,29 +22,16 @@
       </p>
       <p>
         <strong>
-          <% if decorated_session.sp_name.present? %>
-            <%= link_to(
-                  t(
-                    'idv.failure.exit.with_sp',
-                    app_name: APP_NAME, sp_name: decorated_session.sp_name,
-                  ),
-                  return_to_sp_failure_to_proof_path(
-                    step: 'verify_id',
-                    location: request.params[:action],
-                  ),
-                ) %>
-          <% else %>
-            <%= link_to(
-                  t(
-                    'idv.failure.exit.without_sp',
-                    app_name: APP_NAME,
-                  ),
-                  return_to_sp_failure_to_proof_path(
-                    step: 'verify_id',
-                    location: request.params[:action],
-                  ),
-                ) %>
-          <% end %>
+          <%= link_to(
+                t(
+                  decorated_session.sp_name.present? ? 'idv.failure.exit.with_sp' : 'idv.failure.exit.without_sp',
+                  app_name: APP_NAME, sp_name: decorated_session.sp_name,
+                ),
+                return_to_sp_failure_to_proof_path(
+                  step: 'verify_id',
+                  location: request.params[:action],
+                ),
+              ) %>
         </strong>
       </p>
     <% end %>

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -1,6 +1,7 @@
 <%= render(
       'idv/shared/error',
       heading: t('errors.doc_auth.throttled_heading'),
+      current_step: :verify_id,
       options: [
         {
           url: MarketingSite.contact_url,
@@ -19,21 +20,18 @@
               ),
             ) %>
       </p>
-      <% if decorated_session.sp_name.present? %>
-        <p>
-          <strong>
-            <%= link_to(
-                  t(
-                    'idv.failure.exit.with_sp',
-                    app_name: APP_NAME, sp_name: decorated_session.sp_name,
-                  ),
-                  return_to_sp_failure_to_proof_path(
-                    step: 'verify_info',
-                    location: request.params[:action],
-                  ),
-                ) %>
-          </strong>
-        </p>
-      <% end %>
+      <p>
+        <strong>
+          <%= link_to(
+                t(
+                  decorated_session.sp_name.present? ? 'idv.failure.exit.with_sp' : 'idv.failure.exit.without_sp',
+                  app_name: APP_NAME, sp_name: decorated_session.sp_name,
+                ),
+                return_to_sp_failure_to_proof_path(
+                  step: 'verify_info',
+                  location: request.params[:action],
+                ),
+              ) %>
+        </strong>
+      </p>
     <% end %>
-

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -28,11 +28,11 @@ en:
         before continuing. We sent you a link with instructions.
       send_link_throttle: You tried too many times, please try again in %{timeout}.
         You can also go back and choose to use your computer instead.
-      throttled_heading: We could not verify your ID
+      throttled_heading: We couldn't verify your ID
       throttled_subheading: Try taking new pictures
-      throttled_text_html: '<strong>Please try again in %{timeout}.</strong> For your
+      throttled_text_html: 'For your
         security, we limit the number of times you can attempt to verify a
-        document online.'
+        document online. <strong>Try again in %{timeout}.</strong>'
     general: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You’ve entered too many incorrect passwords. You

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -28,11 +28,11 @@ en:
         before continuing. We sent you a link with instructions.
       send_link_throttle: You tried too many times, please try again in %{timeout}.
         You can also go back and choose to use your computer instead.
-      throttled_heading: We couldn't verify your ID
+      throttled_heading: We couldn’t verify your ID
       throttled_subheading: Try taking new pictures
-      throttled_text_html: 'For your
-        security, we limit the number of times you can attempt to verify a
-        document online. <strong>Try again in %{timeout}.</strong>'
+      throttled_text_html: 'For your security, we limit the number of times you can
+        attempt to verify a document online. <strong>Try again in
+        %{timeout}.</strong>'
     general: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You’ve entered too many incorrect passwords. You

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -31,9 +31,9 @@ es:
         como alternativa.
       throttled_heading: No pudimos verificar la identificación
       throttled_subheading: Intente tomar nuevas fotografías.
-      throttled_text_html: '<strong>Por favor, inténtelo de nuevo en
-        %{timeout}.</strong> Por su seguridad, limitamos el número de veces que
-        puede intentar verificar un documento en línea.'
+      throttled_text_html: 'Por su seguridad, limitamos el número de veces que
+        puede intentar verificar un documento en línea. <strong>Inténtelo de nuevo en
+        %{timeout}.</strong>'
     general: '¡Oops! Algo salió mal. Inténtelo de nuevo.'
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -31,8 +31,8 @@ es:
         como alternativa.
       throttled_heading: No pudimos verificar la identificación
       throttled_subheading: Intente tomar nuevas fotografías.
-      throttled_text_html: 'Por su seguridad, limitamos el número de veces que
-        puede intentar verificar un documento en línea. <strong>Inténtelo de nuevo en
+      throttled_text_html: 'Por su seguridad, limitamos el número de veces que puede
+        intentar verificar un documento en línea. <strong>Inténtelo de nuevo en
         %{timeout}.</strong>'
     general: '¡Oops! Algo salió mal. Inténtelo de nuevo.'
     invalid_totp: El código es inválido. Vuelva a intentarlo.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -35,9 +35,9 @@ fr:
         d’utiliser votre ordinateur à la place.
       throttled_heading: Nous n’avons pas pu vérifier votre identité
       throttled_subheading: Essayez de prendre de nouvelles photos.
-      throttled_text_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour
-        votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de
-        vérifier un document en ligne.'
+      throttled_text_html: 'Pour votre sécurité, nous limitons le nombre de fois
+        où vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
+        réessayer dans %{timeout}.</strong>'
     general: Oups, une erreur s’est produite. Veuillez essayer de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.
     max_password_attempts_reached: Vous avez inscrit des mots de passe incorrects un

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -35,8 +35,8 @@ fr:
         d’utiliser votre ordinateur à la place.
       throttled_heading: Nous n’avons pas pu vérifier votre identité
       throttled_subheading: Essayez de prendre de nouvelles photos.
-      throttled_text_html: 'Pour votre sécurité, nous limitons le nombre de fois
-        où vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
+      throttled_text_html: 'Pour votre sécurité, nous limitons le nombre de fois où
+        vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
         réessayer dans %{timeout}.</strong>'
     general: Oups, une erreur s’est produite. Veuillez essayer de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -74,6 +74,9 @@ en:
           Try searching for a Post Office again. If this issue continues, come
           back later.
         text_html: Please try again. If you keep getting these errors, %{link}.
+      exit:
+        with_sp: Exit %{app_name} and return to %{sp_name}
+        without_sp: Exit identity verification and go to your account page
       phone:
         heading: We could not match this phone number to other records
         jobfail: Something went wrong and we cannot process your request at this time.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -79,6 +79,9 @@ es:
           Trate de buscar de nuevo una oficina de correos. Si el problema
           continúa, regrese más tarde.
         text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
+      exit:
+        with_sp: Salir de %{app_name} y volver a %{sp_name}
+        without_sp: Salir de la verificación de identidad e ir a la página de su cuenta
       phone:
         heading: No pudimos encontrar coincidencias entre este número de teléfono y
           otros registros

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -85,8 +85,7 @@ fr:
         text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
       exit:
         with_sp: Quittez %{app_name} et retournez à %{sp_name}
-        without_sp: Quittez la vérification d’identité et accédez à la page de votre
-          compte
+        without_sp: Quittez la vérification d’identité et accédez à la page de votre compte
       phone:
         heading: Nous n’avons pas pu faire correspondre ce numéro de téléphone à
           d’autres enregistrements

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -83,6 +83,10 @@ fr:
           moment. Essayez de chercher à nouveau un bureau de poste. Si le
           problème persiste, revenez plus tard.
         text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
+      exit:
+        with_sp: Quittez %{app_name} et retournez à %{sp_name}
+        without_sp: Quittez la vérification d’identité et accédez à la page de votre
+          compte
       phone:
         heading: Nous n’avons pas pu faire correspondre ce numéro de téléphone à
           d’autres enregistrements

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -210,7 +210,7 @@ describe Idv::ImageUploadsController do
         expect(json).to eq(
           {
             success: false,
-            errors: [{ field: 'limit', message: 'We could not verify your ID' }],
+            errors: [{ field: 'limit', message: 'We couldn\'t verify your ID' }],
             redirect: idv_session_errors_throttled_url,
             remaining_attempts: 0,
             result_failed: false,
@@ -258,7 +258,7 @@ describe Idv::ImageUploadsController do
             document_issued: nil,
             document_number: nil,
             document_state: nil,
-            failure_reason: { limit: ['We could not verify your ID'] },
+            failure_reason: { limit: ['We couldn\'t verify your ID'] },
             first_name: nil,
             last_name: nil,
             success: false },

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -210,7 +210,7 @@ describe Idv::ImageUploadsController do
         expect(json).to eq(
           {
             success: false,
-            errors: [{ field: 'limit', message: 'We couldn\'t verify your ID' }],
+            errors: [{ field: 'limit', message: 'We couldn’t verify your ID' }],
             redirect: idv_session_errors_throttled_url,
             remaining_attempts: 0,
             result_failed: false,
@@ -258,7 +258,7 @@ describe Idv::ImageUploadsController do
             document_issued: nil,
             document_number: nil,
             document_state: nil,
-            failure_reason: { limit: ['We couldn\'t verify your ID'] },
+            failure_reason: { limit: ['We couldn’t verify your ID'] },
             first_name: nil,
             last_name: nil,
             success: false },

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -35,7 +35,7 @@ describe 'idv/session_errors/throttled.html.erb' do
         href: MarketingSite.contact_url,
       )
       expect(rendered).to have_link(
-        t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+        t('idv.cancel.headings.exit.with_sp',  app_name: APP_NAME, sp_name: sp_name),
         href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'throttled'),
       )
     end

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -21,7 +21,10 @@ describe 'idv/session_errors/throttled.html.erb' do
         t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
         href: MarketingSite.contact_url,
       )
-      expect(rendered).not_to have_link(href: return_to_sp_cancel_path)
+      expect(rendered).to have_link(
+        t('idv.failure.exit.without_sp', app_name: APP_NAME),
+        href: return_to_sp_failure_to_proof_path(step: 'verify_id', location: 'throttled'),
+      )
     end
   end
 

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -36,7 +36,7 @@ describe 'idv/session_errors/throttled.html.erb' do
       )
       expect(rendered).to have_link(
         t('idv.failure.exit.with_sp', app_name: APP_NAME, sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'throttled'),
+        href: return_to_sp_failure_to_proof_path(step: 'verify_id', location: 'throttled'),
       )
     end
   end

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -35,7 +35,7 @@ describe 'idv/session_errors/throttled.html.erb' do
         href: MarketingSite.contact_url,
       )
       expect(rendered).to have_link(
-        t('idv.cancel.headings.exit.with_sp', app_name: APP_NAME, sp_name: sp_name),
+        t('idv.failure.exit.with_sp', app_name: APP_NAME, sp_name: sp_name),
         href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'throttled'),
       )
     end

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -35,7 +35,7 @@ describe 'idv/session_errors/throttled.html.erb' do
         href: MarketingSite.contact_url,
       )
       expect(rendered).to have_link(
-        t('idv.cancel.headings.exit.with_sp',  app_name: APP_NAME, sp_name: sp_name),
+        t('idv.cancel.headings.exit.with_sp', app_name: APP_NAME, sp_name: sp_name),
         href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'throttled'),
       )
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


[ 🎫 Ticket](https://cm-jira.usa.gov/browse/LG-9294)

## 🛠 Summary of changes
Add link to throttled error page enabled rate limited user to link back to SP using defined failure to proof url
- removed the failure to proof url from the action/secondary actions
- added failure to proof url in the paragraph error
- add progress bar

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] During the verification process visit the /verify/session/errors/throttled path

## 👀 Screenshots
<details>
<summary>Before:</summary>
<img width="998" alt="ftp_before" src="https://user-images.githubusercontent.com/1261794/234994526-ec0eb11c-e515-45c6-8954-6313bec6d82a.png">

</details>

<details>
<summary>After:</summary>
<img width="1038" alt="Screen Shot 2023-05-02 at 1 51 16 PM" src="https://user-images.githubusercontent.com/1261794/235745427-64962570-21b0-42ca-ad41-47c8810ae359.png">

</details>
