### PR TITLE
Replace word I skipped on accident

### DIFF
--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -161,7 +161,7 @@ es:
       only_add_sp_services_html: Está tratando de acceder a los servicios
         <strong>%{service_provider_name}</strong>
     info:
-      address_guidance_puerto_rico_html: Residentes de Puerto Rico:<br><br>Edite su
+      address_guidance_puerto_rico_html: Residentes en Puerto Rico:<br><br>Edite su
         dirección para que figure su urbanización o condominio en la línea de
         dirección 2.
       capture_status_big_document: Demasiado cerca


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-9527

## 🛠 Summary of changes

Fixes an accidental oversight in PR #8283 — a wrong word in Spanish

## 📜 Testing Plan

Perform workflow using (or switching to) a Puerto Rico address in Spanish language mode and confirm the phrase "Residentes en Puerto Rico" appears in the banner
