### PR TITLE
Move changelog check to test stage to allow other tests to run

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,8 +68,25 @@ workflow:
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "stages/prod"'
     - if: '$CI_MERGE_REQUEST_IID || $CI_EXTERNAL_PULL_REQUEST_IID'
 
-check_changelog:
+install:
   stage: build
+  variables:
+    RAILS_ENV: test
+  cache:
+    - <<: *ruby_cache
+      policy: pull-push
+    - <<: *yarn_cache
+      policy: pull-push
+    - <<: *assets_cache
+      policy: push
+
+  script:
+    - *bundle_install
+    - *yarn_install
+    - bundle exec rake assets:precompile
+
+check_changelog:
+  stage: test
   variables:
     GIT_DEPTH: 100
   script:
@@ -87,22 +104,6 @@ check_changelog:
         echo "Skipping because this is not a PR or is not targeting main"
         exit 0
       fi
-install:
-  stage: build
-  variables:
-    RAILS_ENV: test
-  cache:
-    - <<: *ruby_cache
-      policy: pull-push
-    - <<: *yarn_cache
-      policy: pull-push
-    - <<: *assets_cache
-      policy: push
-
-  script:
-    - *bundle_install
-    - *yarn_install
-    - bundle exec rake assets:precompile
 
 specs:
   stage: test


### PR DESCRIPTION
This commit is missing a change log, so it is testing the concept. Clever?  You know, I have been called worse...

## 🛠 Summary of changes

This moves the changelog CI step into the `test` phase to allow the full test suite to run while our heroic developers add a conventional commit message.

## 📜 Testing Plan

- [x] Open a PR without a correct changelog entry
- [x] Ensure the test phase runs

## 👀 Screenshots

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/59626817/234782639-39560aac-dd0d-499f-89a6-5603cc4e8598.png)

</details>