### PR TITLE
LG-8891: Update reCAPTCHA enabled logic to allow blank secret key if Enterprise

### DIFF
--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -118,11 +118,14 @@ class FeatureManagement
   end
 
   def self.phone_recaptcha_enabled?
-    IdentityConfig.store.recaptcha_site_key_v2.present? &&
-      IdentityConfig.store.recaptcha_site_key_v3.present? &&
+    return false if IdentityConfig.store.recaptcha_site_key_v2.blank? ||
+                    IdentityConfig.store.recaptcha_site_key_v3.blank? ||
+                    !IdentityConfig.store.phone_recaptcha_score_threshold.positive?
+
+    recaptcha_enterprise? || (
       IdentityConfig.store.recaptcha_secret_key_v2.present? &&
-      IdentityConfig.store.recaptcha_secret_key_v3.present? &&
-      IdentityConfig.store.phone_recaptcha_score_threshold.positive?
+      IdentityConfig.store.recaptcha_secret_key_v3.present?
+    )
   end
 
   def self.recaptcha_enterprise?

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -412,6 +412,8 @@ describe 'FeatureManagement' do
     let(:recaptcha_site_key_v3) { '' }
     let(:recaptcha_secret_key_v2) { '' }
     let(:recaptcha_secret_key_v3) { '' }
+    let(:recaptcha_enterprise_api_key) { '' }
+    let(:recaptcha_enterprise_project_id) { '' }
     let(:phone_recaptcha_score_threshold) { 0.0 }
 
     subject(:phone_recaptcha_enabled) { FeatureManagement.phone_recaptcha_enabled? }
@@ -427,6 +429,10 @@ describe 'FeatureManagement' do
         and_return(recaptcha_secret_key_v3)
       allow(IdentityConfig.store).to receive(:phone_recaptcha_score_threshold).
         and_return(phone_recaptcha_score_threshold)
+      allow(IdentityConfig.store).to receive(:recaptcha_enterprise_api_key).
+        and_return(recaptcha_enterprise_api_key)
+      allow(IdentityConfig.store).to receive(:recaptcha_enterprise_project_id).
+        and_return(recaptcha_enterprise_project_id)
     end
 
     it { expect(phone_recaptcha_enabled).to eq(false) }
@@ -436,23 +442,35 @@ describe 'FeatureManagement' do
 
       it { expect(phone_recaptcha_enabled).to eq(false) }
 
-      context 'with configured recaptcha v2 secret key' do
-        let(:recaptcha_secret_key_v2) { 'key' }
+      context 'with configured recaptcha v3 site key' do
+        let(:recaptcha_site_key_v3) { 'key' }
 
         it { expect(phone_recaptcha_enabled).to eq(false) }
 
-        context 'with configured recaptcha v3 site key' do
-          let(:recaptcha_site_key_v3) { 'key' }
+        context 'with configured default success rate threshold greater than 0' do
+          let(:phone_recaptcha_score_threshold) { 1.0 }
 
           it { expect(phone_recaptcha_enabled).to eq(false) }
 
           context 'with configured recaptcha v2 secret key' do
-            let(:recaptcha_secret_key_v3) { 'key' }
+            let(:recaptcha_secret_key_v2) { 'key' }
 
             it { expect(phone_recaptcha_enabled).to eq(false) }
 
-            context 'with configured default success rate threshold greater than 0' do
-              let(:phone_recaptcha_score_threshold) { 1.0 }
+            context 'with configured recaptcha v2 secret key' do
+              let(:recaptcha_secret_key_v3) { 'key' }
+
+              it { expect(phone_recaptcha_enabled).to eq(true) }
+            end
+          end
+
+          context 'with configured recaptcha enterprise api key' do
+            let(:recaptcha_enterprise_api_key) { 'key' }
+
+            it { expect(phone_recaptcha_enabled).to eq(false) }
+
+            context 'with configured recaptcha enterprise project id' do
+              let(:recaptcha_enterprise_project_id) { 'project-id' }
 
               it { expect(phone_recaptcha_enabled).to eq(true) }
             end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8891](https://cm-jira.usa.gov/browse/LG-8891)

## 🛠 Summary of changes

Updates `FeatureManagement.phone_recaptcha_enabled?` to consider "enabled" if secret keys are not provided.

[Secret keys are considered "legacy" with reCAPTCHA Enterprise](https://cloud.google.com/recaptcha-enterprise/docs/create-key#find-key), and are superseded by API key. When enabling the feature added in #8271 in deployed environments, it was observed that this was not working correctly when the secret keys were removed.

A workaround could be to continue providing them, but since they're not required, it makes sense to consider this as part of the logic.

## 📜 Testing Plan

Repeat Testing Plan from #8274

Confirm updated FeatureManagement specs pass:

```
rspec spec/lib/feature_management_spec.rb
```