### PR TITLE
Rename "signed_up" spec trait to "fully_registered"

### DIFF
--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe AccountReset::CancelController do
   include AccountResetHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   describe '#create' do
     it 'tracks IRS attempts event account_reset_cancel_request' do

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -10,7 +10,7 @@ describe AccountReset::DeleteAccountController do
 
   describe '#delete' do
     it 'logs a good token to the analytics' do
-      user = create(:user, :signed_up, :with_backup_code)
+      user = create(:user, :fully_registered, :with_backup_code)
       create(:phone_configuration, user: user, phone: Faker::PhoneNumber.cell_phone)
       create_list(:webauthn_configuration, 2, user: user)
       create_account_reset_request_for(user)

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -53,7 +53,7 @@ describe AccountReset::RequestController do
     end
 
     it 'logs sms user in the analytics' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       stub_sign_in_before_2fa(user)
 
       stub_analytics

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Accounts::PersonalKeysController do
     end
 
     it 'prompts for password if PII is not present' do
-      user = create(:user, :signed_up, :with_piv_or_cac)
+      user = create(:user, :fully_registered, :with_piv_or_cac)
       create(:profile, :active, :verified, user: user)
       stub_sign_in(user)
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -14,7 +14,7 @@ describe AccountsController do
     context 'when user has an active identity' do
       it 'renders the profile and does not redirect out of the app' do
         stub_analytics
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         user.identities << ServiceProviderIdentity.create(
           service_provider: 'http://localhost:3000',
           last_authenticated_at: Time.zone.now,
@@ -34,7 +34,7 @@ describe AccountsController do
       it 'renders the profile and shows a deactivation banner' do
         user = create(
           :user,
-          :signed_up,
+          :fully_registered,
           profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
         )
         user.active_profile.deactivate(:password_reset)
@@ -62,7 +62,7 @@ describe AccountsController do
       it 'renders the pending profile banner' do
         user = create(
           :user,
-          :signed_up,
+          :fully_registered,
           profiles: [build(:profile, deactivation_reason: :gpo_verification_pending)],
         )
 
@@ -79,7 +79,7 @@ describe AccountsController do
         it 'renders a locked profile' do
           user = create(
             :user,
-            :signed_up,
+            :fully_registered,
             profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
           )
 

--- a/spec/controllers/api/internal/sessions_controller_spec.rb
+++ b/spec/controllers/api/internal/sessions_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::Internal::SessionsController do
     end
 
     context 'signed in' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       it 'responds with live and timeout properties' do
         expect(response).to eq(live: true, timeout: User.timeout_in.from_now.as_json)

--- a/spec/controllers/api/verify/document_capture_controller_spec.rb
+++ b/spec/controllers/api/verify/document_capture_controller_spec.rb
@@ -19,7 +19,7 @@ describe Api::Verify::DocumentCaptureController do
   let!(:document_capture_session) { DocumentCaptureSession.create!(user: create(:user)) }
   let(:document_capture_session_uuid) { document_capture_session.uuid }
   let(:password) { 'iambatman' }
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:flow_path) { 'standard' }
   let(:analytics_data) do
     { browser_attributes:

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'IdvStepConcern' do
-  let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
+  let(:user) { create(:user, :fully_registered, email: 'old_email@example.com') }
   let(:idv_session) do
     Idv::Session.new(user_session: subject.user_session, current_user: user, service_provider: nil)
   end

--- a/spec/controllers/concerns/reauthentication_required_concern_spec.rb
+++ b/spec/controllers/concerns/reauthentication_required_concern_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe ReauthenticationRequiredConcern, type: :controller do
-  let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
+  let(:user) { create(:user, :fully_registered, email: 'old_email@example.com') }
 
   describe '#confirm_recently_authenticated' do
     controller ApplicationController do

--- a/spec/controllers/idv/come_back_later_controller_spec.rb
+++ b/spec/controllers/idv/come_back_later_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::ComeBackLaterController do
-  let(:user) { build_stubbed(:user, :signed_up) }
+  let(:user) { build_stubbed(:user, :fully_registered) }
   let(:pending_profile_requires_verification) { true }
 
   before do

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -417,7 +417,7 @@ describe Idv::DocAuthController do
     allow_any_instance_of(Idv::Flows::DocAuthFlow).to receive(:next_step).and_return(step)
   end
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:document_capture_session_uuid) { DocumentCaptureSession.create!(user: user).uuid }
 
   def mock_document_capture_step

--- a/spec/controllers/idv/not_verified_controller_spec.rb
+++ b/spec/controllers/idv/not_verified_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::NotVerifiedController do
-  let(:user) { build_stubbed(:user, :signed_up) }
+  let(:user) { build_stubbed(:user, :fully_registered) }
 
   before do
     stub_sign_in(user)

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -28,7 +28,7 @@ describe Idv::PersonalKeyController do
   end
 
   let(:password) { 'sekrit phrase' }
-  let(:user) { create(:user, :signed_up, password: password) }
+  let(:user) { create(:user, :fully_registered, password: password) }
   let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
   let(:profile) { subject.idv_session.profile }
   let(:idv_session) do

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -6,7 +6,7 @@ describe Idv::ReviewController do
   let(:user) do
     create(
       :user,
-      :signed_up,
+      :fully_registered,
       password: ControllerHelper::VALID_PASSWORD,
       email: 'old_email@example.com',
     )

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -53,7 +53,7 @@ shared_examples_for 'an idv session errors controller action' do
 
   context 'the user is not authenticated and in doc capture flow' do
     before do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       controller.session[:doc_capture_user_id] = user.id
     end
     it 'renders the error' do

--- a/spec/controllers/mfa_confirmation_controller_spec.rb
+++ b/spec/controllers/mfa_confirmation_controller_spec.rb
@@ -99,7 +99,7 @@ describe MfaConfirmationController do
   describe 'password attempts counter' do
     context 'max password attempts reached' do
       it 'signs the user out' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         sign_in user
         session[:password_attempts] = 0
         stub_analytics

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
     subject(:action) { get :index, params: params }
 
     context 'user is signed in' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
       before do
         stub_sign_in user
       end

--- a/spec/controllers/password_capture_controller_spec.rb
+++ b/spec/controllers/password_capture_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe PasswordCaptureController do
   describe '#update' do
-    let(:user) { create(:user, :signed_up, password: 'a really long sekrit') }
+    let(:user) { create(:user, :fully_registered, password: 'a really long sekrit') }
 
     context 'form returns success' do
       let(:pii) { { first_name: 'Jane', ssn: '111-11-1111' } }

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -144,8 +144,8 @@ describe SamlIdpController do
     let(:other_sp) { create(:service_provider, active: true, agency_id: agency.id) }
 
     let(:session_id) { 'abc123' }
-    let(:user) { create(:user, :signed_up) }
-    let(:other_user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
+    let(:other_user) { create(:user, :fully_registered) }
 
     let!(:identity) do
       ServiceProviderIdentity.create(
@@ -622,7 +622,7 @@ describe SamlIdpController do
 
     context 'with IAL1' do
       it 'does not redirect the user to the IdV URL' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         generate_saml_response(user, saml_settings)
 
         expect(response).to_not be_redirect
@@ -775,7 +775,7 @@ describe SamlIdpController do
     end
 
     context 'authn_context scenarios' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       context 'authn_context is missing' do
         let(:auth_settings) { saml_settings(overrides: { authn_context: nil }) }
@@ -891,7 +891,7 @@ describe SamlIdpController do
     end
 
     context 'with ForceAuthn' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       it 'signs user out if a session is active and sp_session[:final_auth_request] is falsey' do
         sign_in(user)
@@ -921,7 +921,7 @@ describe SamlIdpController do
 
     context 'service provider is inactive' do
       it 'responds with an error page' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
 
         generate_saml_response(
           user,
@@ -936,7 +936,7 @@ describe SamlIdpController do
 
     context 'service provider is invalid' do
       it 'responds with an error page' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
 
         stub_analytics
         allow(@analytics).to receive(:track_event)
@@ -965,7 +965,7 @@ describe SamlIdpController do
 
     context 'both service provider and authn_context are invalid' do
       it 'responds with an error page' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
 
         stub_analytics
         allow(@analytics).to receive(:track_event)
@@ -1033,7 +1033,7 @@ describe SamlIdpController do
       end
 
       it 'encrypts the response to the right key' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         generate_saml_response(user, second_cert_settings)
 
         expect(response).to_not be_redirect
@@ -1055,7 +1055,7 @@ describe SamlIdpController do
       end
 
       it 'deoes not blow up' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
 
         expect { generate_saml_response(user, second_cert_settings) }.to_not raise_error
       end
@@ -1063,7 +1063,7 @@ describe SamlIdpController do
 
     context 'POST to auth correctly stores SP in session' do
       before do
-        @user = create(:user, :signed_up)
+        @user = create(:user, :fully_registered)
         @saml_request = saml_request(saml_settings)
         @post_request = saml_post_auth(@saml_request)
         @stored_request_url = @post_request.request.original_url +
@@ -1097,7 +1097,7 @@ describe SamlIdpController do
 
     context 'service provider is valid' do
       before do
-        @user = create(:user, :signed_up)
+        @user = create(:user, :fully_registered)
         @saml_request = saml_get_auth(saml_settings)
       end
 
@@ -1158,7 +1158,7 @@ describe SamlIdpController do
     end
 
     context 'service provider uses email NameID format and is allowed to use email' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       before do
         settings = saml_settings(
@@ -1204,7 +1204,7 @@ describe SamlIdpController do
     end
 
     context 'no matching cert from the SAML request' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       before do
         stub_analytics
@@ -1254,7 +1254,7 @@ describe SamlIdpController do
     end
 
     context 'no IAL explicitly requested' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       before do
         stub_analytics
@@ -1295,7 +1295,7 @@ describe SamlIdpController do
     end
 
     context 'nameid_format is missing' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       before do
         stub_analytics
@@ -1397,7 +1397,7 @@ describe SamlIdpController do
     end
 
     context 'service provider sends unsupported NameID format' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
       let(:xmldoc) { SamlResponseDoc.new('controller', 'response_assertion', response) }
       let(:subject) { xmldoc.subject_nodeset[0] }
       let(:name_id) { subject.at('//ds:NameID', ds: Saml::XML::Namespaces::ASSERTION) }
@@ -1549,7 +1549,7 @@ describe SamlIdpController do
 
     context 'after signing in' do
       it 'does not call IdentityLinker' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         linker = instance_double(IdentityLinker)
 
         expect(IdentityLinker).to_not receive(:new)
@@ -1563,7 +1563,7 @@ describe SamlIdpController do
       let(:issuer) { xmldoc.issuer_nodeset[0] }
       let(:status) { xmldoc.status[0] }
       let(:status_code) { xmldoc.status_code[0] }
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       before do
         generate_saml_response(user, saml_settings)
@@ -2005,7 +2005,7 @@ describe SamlIdpController do
 
     context 'user is not redirected to IdV' do
       it 'tracks the authentication without IdV redirection event' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
 
         stub_analytics
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
@@ -2040,7 +2040,7 @@ describe SamlIdpController do
 
     context 'user has not finished verifying profile' do
       it 'tracks the authentication with finish_profile==true' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
 
         stub_analytics
         allow(controller).to receive(:identity_needs_verification?).and_return(false)

--- a/spec/controllers/saml_signed_message_spec.rb
+++ b/spec/controllers/saml_signed_message_spec.rb
@@ -14,7 +14,7 @@ describe SamlIdpController do
 
   describe 'GET /api/saml/auth' do
     context "SP's can have signed_response_message_requested set" do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
       let(:saml_response_encoded) do
         Nokogiri::HTML(response.body).css('#SAMLResponse').first.attributes['value'].to_s
       end

--- a/spec/controllers/two_factor_authentication/otp_expired_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_expired_controller_spec.rb
@@ -10,9 +10,11 @@ describe TwoFactorAuthentication::OtpExpiredController do
   describe '#show' do
     it 'global otp_delivery_preference variable properly defined' do
       user = create(
-        :user, :signed_up, otp_delivery_preference: delivery_preference,
-                           direct_otp_sent_at: direct_otp_sent_at,
-                           with: { phone: '+1 (703) 555-0000' }
+        :user,
+        :fully_registered,
+        otp_delivery_preference: delivery_preference,
+        direct_otp_sent_at: direct_otp_sent_at,
+        with: { phone: '+1 (703) 555-0000' },
       )
       stub_sign_in_before_2fa(user)
 
@@ -23,9 +25,11 @@ describe TwoFactorAuthentication::OtpExpiredController do
 
     it 'renders template' do
       user = create(
-        :user, :signed_up, otp_delivery_preference: delivery_preference,
-                           direct_otp_sent_at: direct_otp_sent_at,
-                           with: { phone: '+1 (703) 555-0000' }
+        :user,
+        :fully_registered,
+        otp_delivery_preference: delivery_preference,
+        direct_otp_sent_at: direct_otp_sent_at,
+        with: { phone: '+1 (703) 555-0000' },
       )
       stub_sign_in_before_2fa(user)
 
@@ -36,9 +40,11 @@ describe TwoFactorAuthentication::OtpExpiredController do
 
     it 'tracks user otp expired navigation analytics' do
       user = create(
-        :user, :signed_up, otp_delivery_preference: delivery_preference,
-                           direct_otp_sent_at: direct_otp_sent_at,
-                           with: { phone: '+1 (703) 555-0000' }
+        :user,
+        :fully_registered,
+        otp_delivery_preference: delivery_preference,
+        direct_otp_sent_at: direct_otp_sent_at,
+        with: { phone: '+1 (703) 555-0000' },
       )
       stub_analytics
       otp_expiration = direct_otp_sent_at + TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -173,7 +173,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
       it 'tracks the event' do
         user = create(
           :user,
-          :signed_up,
+          :fully_registered,
           second_factor_attempts_count:
             IdentityConfig.store.login_otp_confirmation_max_attempts - 1,
         )
@@ -382,7 +382,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
     end
 
     context 'phone confirmation' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
       before do
         sign_in_as_user(user)
         subject.user_session[:unconfirmed_phone] = '+1 (703) 555-5555'

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe TwoFactorAuthentication::PivCacVerificationController do
   let(:user) do
     create(
-      :user, :signed_up, :with_piv_or_cac,
+      :user, :fully_registered, :with_piv_or_cac,
       with: { phone: '+1 (703) 555-0000' }
     )
   end
@@ -234,7 +234,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
 
       let(:user) do
         create(
-          :user, :signed_up, :with_piv_or_cac,
+          :user, :fully_registered, :with_piv_or_cac,
           second_factor_locked_at: Time.zone.now - lockout_period - 1.second,
           second_factor_attempts_count: 3
         )

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -80,7 +80,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
       it 'tracks the event' do
         user = create(
           :user,
-          :signed_up,
+          :fully_registered,
           second_factor_attempts_count:
             IdentityConfig.store.login_otp_confirmation_max_attempts - 1,
         )
@@ -117,7 +117,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         lockout_period = IdentityConfig.store.lockout_period_in_minutes.minutes
         user = create(
           :user,
-          :signed_up,
+          :fully_registered,
           second_factor_locked_at: Time.zone.now - lockout_period - 1.second,
           second_factor_attempts_count: 3,
         )

--- a/spec/controllers/users/authorization_confirmation_controller_spec.rb
+++ b/spec/controllers/users/authorization_confirmation_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Users::AuthorizationConfirmationController do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:sp) { create(:service_provider) }
   let(:issuer) { sp.issuer }
   let(:sp_request_url) { 'http://example.com/request/url' }

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -14,7 +14,7 @@ describe Users::BackupCodeSetupController do
   end
 
   it 'creates backup codes and logs expected events' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     stub_sign_in(user)
     analytics = stub_analytics
     stub_attempts_tracker
@@ -45,7 +45,7 @@ describe Users::BackupCodeSetupController do
   end
 
   it 'creating backup codes revokes remember device cookies' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     stub_sign_in(user)
     expect(user.remember_device_revoked_at).to eq nil
 
@@ -56,7 +56,7 @@ describe Users::BackupCodeSetupController do
   end
 
   it 'deletes backup codes' do
-    user = build(:user, :signed_up, :with_authentication_app, :with_backup_code)
+    user = build(:user, :fully_registered, :with_authentication_app, :with_backup_code)
     stub_sign_in(user)
     expect(user.backup_code_configurations.length).to eq 10
 
@@ -67,7 +67,7 @@ describe Users::BackupCodeSetupController do
   end
 
   it 'deleting backup codes revokes remember device cookies' do
-    user = build(:user, :signed_up, :with_authentication_app, :with_backup_code)
+    user = build(:user, :fully_registered, :with_authentication_app, :with_backup_code)
     stub_sign_in(user)
     expect(user.remember_device_revoked_at).to eq nil
 
@@ -118,7 +118,7 @@ describe Users::BackupCodeSetupController do
 
   context 'with multiple MFA selection turned off' do
     it 'redirects to account page' do
-      user = build(:user, :signed_up)
+      user = build(:user, :fully_registered)
       stub_sign_in(user)
       codes = BackupCodeGenerator.new(user).create
       controller.user_session[:backup_codes] = codes
@@ -131,7 +131,7 @@ describe Users::BackupCodeSetupController do
     render_views
 
     it 'does not 500 when codes have not been generated' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       stub_sign_in(user)
       get :refreshed
 

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -96,7 +96,7 @@ describe Users::DeleteController do
   def stub_signed_in_user
     user = create(
       :user,
-      :signed_up,
+      :fully_registered,
       email: 'old_email@example.com',
       password: ControllerHelper::VALID_PASSWORD,
     )

--- a/spec/controllers/users/edit_phone_controller_spec.rb
+++ b/spec/controllers/users/edit_phone_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Users::EditPhoneController do
   describe '#update' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:phone_configuration) { user.phone_configurations.first }
 
     before do
@@ -58,7 +58,7 @@ describe Users::EditPhoneController do
   end
 
   describe '#destroy' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:phone_configuration) { create(:phone_configuration, user: user) }
 
     it 'deletes the phone configuration' do

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -5,7 +5,7 @@ describe Users::MfaSelectionController do
 
   describe '#index' do
     before do
-      user = build(:user, :signed_up)
+      user = build(:user, :fully_registered)
       stub_sign_in(user)
     end
 
@@ -148,7 +148,7 @@ describe Users::MfaSelectionController do
     end
 
     context 'when the form is empty' do
-      let(:user) { build(:user, :signed_up) }
+      let(:user) { build(:user, :fully_registered) }
 
       before do
         stub_sign_in(user)

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Users::PersonalKeysController do
       it 'redirects to the sign up completed url for ial 1' do
         controller.session[:sp] = { ial2: false }
 
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })
         user.active_profile.deactivate(:password_reset)
         sign_in user
@@ -88,7 +88,7 @@ RSpec.describe Users::PersonalKeysController do
       it 'redirects to the reactivate account url for ial 2' do
         controller.session[:sp] = { ial2: true }
 
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })
         user.active_profile.deactivate(:password_reset)
         sign_in user

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Users::PhonesController do
-  let(:user) { create(:user, :signed_up, with: { phone: '+1 (202) 555-1234' }) }
+  let(:user) { create(:user, :fully_registered, with: { phone: '+1 (202) 555-1234' }) }
   before do
     stub_sign_in(user)
 

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -43,7 +43,7 @@ describe Users::PivCacAuthenticationSetupController do
   describe 'when signing in' do
     before(:each) { stub_sign_in_before_2fa(user) }
     let(:user) do
-      create(:user, :signed_up, :with_piv_or_cac, with: { phone: '+1 (703) 555-0000' })
+      create(:user, :fully_registered, :with_piv_or_cac, with: { phone: '+1 (703) 555-0000' })
     end
 
     describe 'GET index' do
@@ -66,7 +66,7 @@ describe Users::PivCacAuthenticationSetupController do
 
     context 'without associated piv/cac' do
       let(:user) do
-        create(:user, :signed_up, with: { phone: '+1 (703) 555-0000' })
+        create(:user, :fully_registered, with: { phone: '+1 (703) 555-0000' })
       end
       let(:nickname) { 'Card 1' }
 
@@ -226,7 +226,7 @@ describe Users::PivCacAuthenticationSetupController do
     end
 
     context 'with associated piv/cac' do
-      let(:user) { create(:user, :signed_up, :with_piv_or_cac) }
+      let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
       describe 'GET index' do
         it 'does not redirect to account page because we allow multiple PIV/CACs' do

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -128,7 +128,7 @@ describe Users::ResetPasswordsController, devise: true do
           Devise.token_generator.generate(User, :reset_password_token)
         user = create(
           :user,
-          :signed_up,
+          :fully_registered,
           reset_password_sent_at: Time.zone.now - Devise.reset_password_within - 1.hour,
           reset_password_token: db_confirmation_token,
         )
@@ -165,7 +165,7 @@ describe Users::ResetPasswordsController, devise: true do
           Devise.token_generator.generate(User, :reset_password_token)
         user = create(
           :user,
-          :signed_up,
+          :fully_registered,
           reset_password_token: db_confirmation_token,
           reset_password_sent_at: Time.zone.now,
         )
@@ -226,7 +226,7 @@ describe Users::ResetPasswordsController, devise: true do
         freeze_time do
           user = create(
             :user,
-            :signed_up,
+            :fully_registered,
             reset_password_token: db_confirmation_token,
             reset_password_sent_at: Time.zone.now,
           )
@@ -404,7 +404,7 @@ describe Users::ResetPasswordsController, devise: true do
     context 'user exists' do
       let(:email) { 'test@example.com' }
       let(:email_param) { { email: email } }
-      let!(:user) { create(:user, :signed_up, **email_param) }
+      let!(:user) { create(:user, :fully_registered, **email_param) }
       let(:analytics_hash) do
         {
           success: true,
@@ -483,7 +483,7 @@ describe Users::ResetPasswordsController, devise: true do
         stub_analytics
         stub_attempts_tracker
 
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         create(:profile, :active, :verified, user: user)
 
         analytics_hash = {

--- a/spec/controllers/users/rules_of_use_controller_spec.rb
+++ b/spec/controllers/users/rules_of_use_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Users::RulesOfUseController do
   let(:rules_of_use_updated_at) { 1.day.ago }
   let(:accepted_terms_at) { nil }
-  let(:user) { create(:user, :signed_up, accepted_terms_at: accepted_terms_at) }
+  let(:user) { create(:user, :fully_registered, accepted_terms_at: accepted_terms_at) }
   before do
     allow(IdentityConfig.store).to receive(:rules_of_use_updated_at).
       and_return(rules_of_use_updated_at)

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -17,7 +17,7 @@ describe Users::TotpSetupController, devise: true do
     context 'user is setting up authenticator app after account creation' do
       before do
         stub_analytics
-        user = create(:user, :signed_up, :with_phone, with: { phone: '703-555-1212' })
+        user = create(:user, :fully_registered, :with_phone, with: { phone: '703-555-1212' })
         stub_sign_in(user)
         allow(@analytics).to receive(:track_event)
         get :new
@@ -128,7 +128,7 @@ describe Users::TotpSetupController, devise: true do
 
       context 'when user presents correct code' do
         before do
-          user = create(:user, :signed_up)
+          user = create(:user, :fully_registered)
           secret = ROTP::Base32.random_base32
           stub_sign_in(user)
           stub_analytics
@@ -165,7 +165,7 @@ describe Users::TotpSetupController, devise: true do
 
       context 'when user presents nil code' do
         before do
-          user = create(:user, :signed_up)
+          user = create(:user, :fully_registered)
           secret = ROTP::Base32.random_base32
           stub_sign_in(user)
           stub_analytics
@@ -203,7 +203,7 @@ describe Users::TotpSetupController, devise: true do
 
       context 'when user omits name' do
         before do
-          user = create(:user, :signed_up)
+          user = create(:user, :fully_registered)
           secret = ROTP::Base32.random_base32
           stub_sign_in(user)
           stub_analytics
@@ -382,7 +382,7 @@ describe Users::TotpSetupController, devise: true do
   describe '#disable' do
     context 'when a user has configured TOTP' do
       it 'disables TOTP' do
-        user = create(:user, :signed_up, :with_phone)
+        user = create(:user, :fully_registered, :with_phone)
         totp_app = user.auth_app_configurations.create(otp_secret_key: 'foo', name: 'My Auth App')
         user.save
         stub_sign_in(user)
@@ -403,7 +403,7 @@ describe Users::TotpSetupController, devise: true do
       end
 
       it 'revokes remember device cookies' do
-        user = create(:user, :signed_up, :with_phone)
+        user = create(:user, :fully_registered, :with_phone)
         totp_app = user.auth_app_configurations.create(otp_secret_key: 'foo', name: 'My Auth App')
         user.save
         stub_sign_in(user)

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -4,7 +4,7 @@ describe Users::TwoFactorAuthenticationController do
   include ActionView::Helpers::DateHelper
 
   let(:otp_preference_sms) { { otp_delivery_preference: 'sms' } }
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   describe 'before_actions' do
     it 'includes the appropriate before_actions' do
@@ -446,7 +446,7 @@ describe Users::TwoFactorAuthenticationController do
 
     context 'when selecting voice OTP delivery' do
       before do
-        user = create(:user, :signed_up, otp_delivery_preference: 'voice')
+        user = create(:user, :fully_registered, otp_delivery_preference: 'voice')
         sign_in_before_2fa(user)
         @old_otp = subject.current_user.direct_otp
         allow(Telephony).to receive(:send_authentication_otp).and_call_original
@@ -517,7 +517,7 @@ describe Users::TwoFactorAuthenticationController do
 
       context 'when selecting specific phone configuration' do
         before do
-          user = create(:user, :signed_up)
+          user = create(:user, :fully_registered)
           sign_in_before_2fa(user)
         end
       end

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -22,7 +22,7 @@ describe Users::TwoFactorAuthenticationSetupController do
 
     context 'when fully authenticated and MFA enabled' do
       it 'loads the account page' do
-        user = build(:user, :signed_up)
+        user = build(:user, :fully_registered)
         stub_sign_in(user)
 
         get :index
@@ -43,7 +43,7 @@ describe Users::TwoFactorAuthenticationSetupController do
 
     context 'already two factor enabled but not fully authenticated' do
       it 'prompts for 2FA' do
-        user = build(:user, :signed_up)
+        user = build(:user, :fully_registered)
         stub_sign_in_before_2fa(user)
 
         get :index

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -34,7 +34,7 @@ describe Users::WebauthnSetupController do
   end
 
   describe 'when signed in and not account creation' do
-    let(:user) { create(:user, :signed_up, :with_authentication_app) }
+    let(:user) { create(:user, :fully_registered, :with_authentication_app) }
 
     before do
       stub_analytics

--- a/spec/decorators/email_context_spec.rb
+++ b/spec/decorators/email_context_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe EmailContext do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   subject { described_class.new(user) }
 

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     profile { association :profile, user: user }
     selected_location_details { { name: 'BALTIMORE' } }
     unique_id { InPersonEnrollment.generate_unique_id }
-    user { association :user, :signed_up }
+    user { association :user, :fully_registered }
 
     trait :establishing do
       status { :establishing }

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :profile do
-    association :user, factory: %i[user signed_up]
+    association :user, factory: %i[user fully_registered]
 
     transient do
       pii { false }

--- a/spec/factories/proofing_components.rb
+++ b/spec/factories/proofing_components.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :proofing_component do
-    association :user, factory: %i[user signed_up]
+    association :user, factory: %i[user fully_registered]
 
     trait :eligible_for_review do
       verified_at { Time.zone.now }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -175,7 +175,7 @@ FactoryBot.define do
       role { :tech }
     end
 
-    trait :signed_up do
+    trait :fully_registered do
       with_phone
 
       after :create do |user|
@@ -189,7 +189,7 @@ FactoryBot.define do
     end
 
     trait :proofed do
-      signed_up
+      fully_registered
 
       after :build do |user|
         create(:profile, :active, :verified, :with_pii, user: user)
@@ -215,7 +215,7 @@ FactoryBot.define do
     end
 
     trait :deactivated_fraud_profile do
-      signed_up
+      fully_registered
 
       after :build do |user|
         create(
@@ -229,7 +229,7 @@ FactoryBot.define do
     end
 
     trait :deactivated_password_reset_profile do
-      signed_up
+      fully_registered
 
       after :build do |user|
         create(:profile, :password_reset, :with_pii, user: user)

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -58,7 +58,7 @@ feature 'Accessibility on pages that require authentication', :js do
     end
 
     scenario 'two factor auth page' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
 
       expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: 'sms'))

--- a/spec/features/account/backup_codes_spec.rb
+++ b/spec/features/account/backup_codes_spec.rb
@@ -7,7 +7,7 @@ feature 'Backup codes' do
   end
 
   context 'with backup codes' do
-    let(:user) { create(:user, :signed_up, :with_piv_or_cac, :with_backup_code) }
+    let(:user) { create(:user, :fully_registered, :with_piv_or_cac, :with_backup_code) }
 
     it 'backup code generated and can be regenerated' do
       expect(page).to have_content(t('account.index.backup_codes_exist'))

--- a/spec/features/account/device_spec.rb
+++ b/spec/features/account/device_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe 'Devices' do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   before do
-    user = create(:user, :signed_up, otp_delivery_preference: 'sms')
+    user = create(:user, :fully_registered, otp_delivery_preference: 'sms')
     sign_in_and_2fa_user(user)
     create(
       :device,

--- a/spec/features/account/unphishable_badge_spec.rb
+++ b/spec/features/account/unphishable_badge_spec.rb
@@ -14,7 +14,7 @@ feature 'Unphishable account badge' do
   end
 
   context 'with phishable configuration' do
-    let(:user) { create(:user, :signed_up, :with_webauthn) }
+    let(:user) { create(:user, :fully_registered, :with_webauthn) }
 
     it 'does not show an "Unphishable" badge' do
       expect(page).to_not have_css(

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Account connected applications' do
-  let(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
+  let(:user) { create(:user, :fully_registered, created_at: Time.zone.now - 100.days) }
   let(:identity_with_link) do
     create(
       :service_provider_identity,

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Account history' do
-  let(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
+  let(:user) { create(:user, :fully_registered, created_at: Time.zone.now - 100.days) }
   let(:account_created_event) { create(:event, user: user, created_at: Time.zone.now - 98.days) }
   let(:gpo_mail_sent_event) do
     create(:event, user: user, event_type: :gpo_mail_sent, created_at: Time.zone.now - 90.days)

--- a/spec/features/account_reset/cancel_request_spec.rb
+++ b/spec/features/account_reset/cancel_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Account Reset Request: Cancellation' do
   context 'user cancels from the second email after the request has been granted' do
     it 'cancels the request and does not delete the user', email: true do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       signin(user.email, user.password)
       click_link t('two_factor_authentication.login_options_link_text')
       click_link t('two_factor_authentication.account_reset.link')

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -5,7 +5,7 @@ describe 'Account Reset Request: Delete Account', email: true do
   include OidcAuthHelper
   include IrsAttemptsApiTrackingHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:user_email) { user.email_addresses.first.email }
   let(:push_notification_url) { 'http://localhost/push_notifications' }
 

--- a/spec/features/account_reset/pending_request_spec.rb
+++ b/spec/features/account_reset/pending_request_spec.rb
@@ -4,7 +4,7 @@ feature 'Pending account reset request sign in' do
   it 'gives the option to cancel the request on sign in' do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(999)
 
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_user(user)
     click_link t('two_factor_authentication.login_options_link_text')
     click_link t('two_factor_authentication.account_reset.link')

--- a/spec/features/device_tracking_spec.rb
+++ b/spec/features/device_tracking_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Device tracking' do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:now) { Time.zone.now }
   let(:device) { create(:device, user: user, last_ip: '4.3.2.1', last_used_at: now) }
 

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'disavowing an action' do
-  let(:user) { create(:user, :signed_up, :with_personal_key) }
+  let(:user) { create(:user, :fully_registered, :with_personal_key) }
 
   scenario 'disavowing a password reset' do
     perform_disavowable_password_reset

--- a/spec/features/ialmax/saml_sign_in_spec.rb
+++ b/spec/features/ialmax/saml_sign_in_spec.rb
@@ -25,7 +25,7 @@ feature 'SAML IALMAX sign in' do
       end
 
       scenario 'password sign in' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         visit_idp_from_saml_sp_with_ialmax
         sign_in_live_with_2fa(user)
         click_submit_default

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -275,7 +275,7 @@ feature 'doc auth verify_info step', :js do
         allow(IdentityConfig.store).to receive(:aamva_supported_jurisdictions).and_return(
           mock_state_id_jurisdiction,
         )
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         expect_any_instance_of(Idv::Agent).
           to receive(:proof_resolution).
           with(
@@ -300,7 +300,7 @@ feature 'doc auth verify_info step', :js do
           IdentityConfig.store.aamva_supported_jurisdictions -
             mock_state_id_jurisdiction,
         )
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         expect_any_instance_of(Idv::Agent).
           to receive(:proof_resolution).
           with(
@@ -323,7 +323,7 @@ feature 'doc auth verify_info step', :js do
       it 'does not perform the state ID check' do
         allow(IdentityConfig.store).to receive(:aamva_sp_banlist_issuers).
           and_return('["urn:gov:gsa:openidconnect:sp:server"]')
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         expect_any_instance_of(Idv::Agent).
           to receive(:proof_resolution).
           with(

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -16,7 +16,7 @@ feature 'IdV Outage Spec' do
   include PersonalKeyHelper
   include IdvStepHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:new_password) { 'some really awesome new password' }
   let(:pii) { { ssn: '666-66-1234', dob: '1920-01-01', first_name: 'alice' } }
 

--- a/spec/features/idv/threatmetrix_pending_spec.rb
+++ b/spec/features/idv/threatmetrix_pending_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Users pending threatmetrix review', :js do
 
   scenario 'users pending threatmetrix see sad face screen and cannot perform idv' do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(300)
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
 
     start_idv_from_sp
     sign_in_and_2fa_user(user)
@@ -88,7 +88,7 @@ RSpec.feature 'Users pending threatmetrix review', :js do
 
   scenario 'users pending threatmetrix No Result, it results in an error', :js do
     freeze_time do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_ial1_oidc_sp(
         client_id: service_provider.issuer,
         irs_attempts_api_session_id: 'test-session-id',

--- a/spec/features/irs_attempts_api/event_tracking_spec.rb
+++ b/spec/features/irs_attempts_api/event_tracking_spec.rb
@@ -21,7 +21,7 @@ feature 'IRS Attempts API Event Tracking' do
 
   scenario 'signing in from an IRS SP with an attempts api session id tracks events' do
     freeze_time do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit_idp_from_ial1_oidc_sp(
         client_id: service_provider.issuer,
@@ -48,7 +48,7 @@ feature 'IRS Attempts API Event Tracking' do
 
   scenario 'signing in from an IRS SP with a tid tracks events' do
     freeze_time do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit_idp_from_ial1_oidc_sp(
         client_id: service_provider.issuer,
@@ -77,7 +77,7 @@ feature 'IRS Attempts API Event Tracking' do
     freeze_time do
       service_provider.update!(irs_attempts_api_enabled: false)
 
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit_idp_from_ial1_oidc_sp(
         client_id: service_provider.issuer,
@@ -94,7 +94,7 @@ feature 'IRS Attempts API Event Tracking' do
 
   scenario 'signing in from an IRS SP without an attempts api session id or tid tracks events' do
     freeze_time do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit_idp_from_ial1_oidc_sp(
         client_id: service_provider.issuer,
@@ -112,7 +112,7 @@ feature 'IRS Attempts API Event Tracking' do
     freeze_time do
       service_provider.update!(irs_attempts_api_enabled: false)
 
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit_idp_from_ial1_oidc_sp(
         client_id: service_provider.issuer,
@@ -129,7 +129,7 @@ feature 'IRS Attempts API Event Tracking' do
 
   scenario 'reset password from an IRS with new browser session and request_id tracks events' do
     freeze_time do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_ial1_oidc_sp(
         client_id: service_provider.issuer,
         irs_attempts_api_session_id: 'test-session-id',

--- a/spec/features/legacy_passwords_spec.rb
+++ b/spec/features/legacy_passwords_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'legacy passwords' do
   scenario 'signing in with a password digested by the uak verifier updates the digest' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     user.update!(
       encrypted_password_digest: Encryption::UakPasswordVerifier.digest('legacy password'),
     )
@@ -23,7 +23,7 @@ feature 'legacy passwords' do
   end
 
   scenario 'signing in with an incorrect uak password digest does not grant access' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     user.update!(
       encrypted_password_digest: Encryption::UakPasswordVerifier.digest('legacy password'),
     )
@@ -37,7 +37,7 @@ feature 'legacy passwords' do
   end
 
   scenario 'signing in with a personal key digested by the uak verifier make a new digest' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     user.update!(
       encrypted_recovery_code_digest: Encryption::UakPasswordVerifier.digest('1111 2222 3333 4444'),
     )
@@ -56,7 +56,7 @@ feature 'legacy passwords' do
   end
 
   scenario 'signing in with an incorrect uak personal key digest does not grant access' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     user.update!(
       encrypted_recovery_code_digest: Encryption::UakPasswordVerifier.digest('1111 2222 3333 4444'),
     )

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -4,7 +4,7 @@ feature 'adding email address' do
   let(:email) { 'test@test.com' }
 
   it 'allows the user to add an email and confirm with an active session' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     original_email = user.email_addresses.first.email
     sign_in_user_and_add_email(user)
     unconfirmed_email_text = "#{email}  #{t('email_addresses.unconfirmed')}"
@@ -36,7 +36,7 @@ feature 'adding email address' do
   end
 
   it 'allows the user to add an email and confirm without an active session' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     original_email = user.email_addresses.first.email
     sign_in_user_and_add_email(user)
 
@@ -64,7 +64,7 @@ feature 'adding email address' do
   end
 
   it 'notifies user they are already confirmed without an active session' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_user_and_add_email(user)
 
     Capybara.reset_session!
@@ -85,7 +85,7 @@ feature 'adding email address' do
   end
 
   it 'notifies user they are already confirmed with an active session' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_user_and_add_email(user)
 
     email_to_click_on = last_email_sent
@@ -103,11 +103,11 @@ feature 'adding email address' do
   end
 
   it 'notifies user they are already confirmed on another account after clicking on link' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_user_and_add_email(user)
 
     email_to_click_on = last_email_sent
-    create(:user, :signed_up, email: email)
+    create(:user, :fully_registered, email: email)
     click_on_link_in_confirmation_email(email_to_click_on)
 
     expect(page).to have_current_path(account_path)
@@ -123,9 +123,9 @@ feature 'adding email address' do
   end
 
   it 'notifies user they are already confirmed on another account via email' do
-    initial_user = create(:user, :signed_up, email: email)
+    initial_user = create(:user, :fully_registered, email: email)
 
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_user_and_add_email(user, false)
 
     expect(last_email_sent.default_part_body.to_s).to have_content(
@@ -167,7 +167,7 @@ feature 'adding email address' do
 
   it 'does not allow the user to add an email when max emails is reached' do
     allow(IdentityConfig.store).to receive(:max_emails_per_account).and_return(1)
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_and_2fa_user(user)
 
     expect(page).to_not have_link(t('account.index.email_add'))
@@ -177,7 +177,7 @@ feature 'adding email address' do
   end
 
   it 'stays on form with bad email' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_and_2fa_user(user)
     visit account_path
     within('.sidenav') do
@@ -193,7 +193,7 @@ feature 'adding email address' do
   end
 
   it 'stays on form and gives an error message when adding an email already on the account' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_and_2fa_user(user)
     visit account_path
     within('.sidenav') do
@@ -210,7 +210,7 @@ feature 'adding email address' do
   end
 
   it 'does not show verify screen without an email in session from add email' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_and_2fa_user(user)
     visit add_email_verify_email_path
 
@@ -218,7 +218,7 @@ feature 'adding email address' do
   end
 
   it 'allows user to resend add email link' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_user_and_add_email(user)
 
     click_button t('links.resend')
@@ -237,7 +237,7 @@ feature 'adding email address' do
   end
 
   it 'invalidates the confirmation email/token after 24 hours' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_user_and_add_email(user)
 
     Capybara.reset_session!
@@ -256,7 +256,7 @@ feature 'adding email address' do
   end
 
   it 'does not raise a 500 if user submits in rapid succession violating a db constraint' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_and_2fa_user(user)
 
     visit account_path

--- a/spec/features/multiple_emails/email_management_spec.rb
+++ b/spec/features/multiple_emails/email_management_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 feature 'managing email address' do
   context 'show one email address if only one is configured' do
     scenario 'shows one email address for a user with only one' do
-      user = create(:user, :signed_up, :with_multiple_emails)
+      user = create(:user, :fully_registered, :with_multiple_emails)
       sign_in_and_2fa_user(user)
 
       expect(page).to have_content(user.email_addresses.first.email)
     end
 
     scenario 'shows all email address for a user with multiple emails' do
-      user = create(:user, :signed_up, :with_multiple_emails)
+      user = create(:user, :fully_registered, :with_multiple_emails)
       email1, email2 = user.reload.email_addresses.map(&:email)
       sign_in_and_2fa_user(user)
 
@@ -19,7 +19,7 @@ feature 'managing email address' do
     end
 
     scenario 'does not show a unconfirmed email with a expired confirmation period' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       confirmed_email = user.reload.email_addresses.first.email
 
       expired_unconfirmed_email_address = create(
@@ -39,7 +39,7 @@ feature 'managing email address' do
 
   context 'allows deletion of email address' do
     it 'does not allow last confirmed email to be deleted' do
-      user = create(:user, :signed_up, email: 'test@example.com ')
+      user = create(:user, :fully_registered, email: 'test@example.com ')
       confirmed_email = user.confirmed_email_addresses.first
       unconfirmed_email = create(:email_address, user: user, confirmed_at: nil)
       user.email_addresses.reload
@@ -55,7 +55,7 @@ feature 'managing email address' do
     end
 
     it 'Allows delete when more than one confirmed email exists' do
-      user = create(:user, :signed_up, email: 'test@example.com ')
+      user = create(:user, :fully_registered, email: 'test@example.com ')
       confirmed_email1 = user.confirmed_email_addresses.first
       confirmed_email2 = create(
         :email_address, user: user,
@@ -73,7 +73,7 @@ feature 'managing email address' do
     end
 
     it 'sends notification to all confirmed emails when email address is deleted' do
-      user = create(:user, :signed_up, email: 'test@example.com ')
+      user = create(:user, :fully_registered, email: 'test@example.com ')
       confirmed_email1 = user.confirmed_email_addresses.first
       confirmed_email2 = create(:email_address, user: user, confirmed_at: Time.zone.now)
 
@@ -93,7 +93,7 @@ feature 'managing email address' do
     end
 
     it 'allows a user to create an account with the old email address' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       original_email = user.email
       original_email_address = user.email_addresses.first
       create(:email_address, user: user)

--- a/spec/features/multiple_emails/sign_in_spec.rb
+++ b/spec/features/multiple_emails/sign_in_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'sign in with any email address' do
   scenario 'signing in with any email address' do
-    user = create(:user, :signed_up, :with_multiple_emails)
+    user = create(:user, :fully_registered, :with_multiple_emails)
 
     email1, email2 = user.reload.email_addresses.map(&:email)
 
@@ -23,7 +23,7 @@ feature 'sign in with any email address' do
   end
 
   scenario 'signing in with an unconfirmed email results in an error' do
-    user = create(:user, :signed_up, :with_multiple_emails)
+    user = create(:user, :fully_registered, :with_multiple_emails)
 
     email_address = user.email_addresses.first
     email_address.update!(confirmed_at: nil)
@@ -37,7 +37,7 @@ feature 'sign in with any email address' do
   end
 
   scenario 'it shows the email address used to sign in on the account page' do
-    user = create(:user, :signed_up, :with_multiple_emails)
+    user = create(:user, :fully_registered, :with_multiple_emails)
 
     email1, email2 = user.reload.email_addresses.map(&:email)
 

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -5,7 +5,7 @@ feature 'signing into an SP with multiple emails enabled' do
 
   context 'with the email scope' do
     scenario 'signing in with OIDC sends the email address used to sign in' do
-      user = create(:user, :signed_up, :with_multiple_emails)
+      user = create(:user, :fully_registered, :with_multiple_emails)
       emails = user.reload.email_addresses.map(&:email)
 
       expect(emails.count).to eq(2)
@@ -26,7 +26,7 @@ feature 'signing into an SP with multiple emails enabled' do
     end
 
     scenario 'signing in with SAML sends the email address used to sign in' do
-      user = create(:user, :signed_up, :with_multiple_emails)
+      user = create(:user, :fully_registered, :with_multiple_emails)
       emails = user.reload.email_addresses.map(&:email)
 
       expect(emails.count).to eq(2)
@@ -51,7 +51,7 @@ feature 'signing into an SP with multiple emails enabled' do
 
   context 'with the all_emails scope' do
     scenario 'signing in with OIDC sends all emails' do
-      user = create(:user, :signed_up, :with_multiple_emails)
+      user = create(:user, :fully_registered, :with_multiple_emails)
       emails = user.reload.email_addresses.map(&:email)
 
       expect(emails.count).to eq(2)
@@ -67,7 +67,7 @@ feature 'signing into an SP with multiple emails enabled' do
     end
 
     scenario 'signing in with SAML sends all emails' do
-      user = create(:user, :signed_up, :with_multiple_emails)
+      user = create(:user, :fully_registered, :with_multiple_emails)
       emails = user.reload.email_addresses.map(&:email)
 
       expect(emails.count).to eq(2)

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'New device tracking' do
   include SamlAuthHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   context 'user has existing devices' do
     before do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -757,7 +757,7 @@ describe 'OpenID Connect' do
 
   context 'canceling sign in with active identities present' do
     it 'signs the user out and returns to the home page' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit_idp_from_ial1_oidc_sp(prompt: 'select_account')
       fill_in_credentials_and_submit(user.email, user.password)

--- a/spec/features/openid_connect/redirect_uri_validation_spec.rb
+++ b/spec/features/openid_connect/redirect_uri_validation_spec.rb
@@ -109,7 +109,7 @@ describe 'redirect_uri validation' do
 
   context 'when the user is already signed in via an SP' do
     it 'displays error instead of redirecting' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_sp_with_ial1_with_valid_redirect_uri
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
@@ -141,7 +141,7 @@ describe 'redirect_uri validation' do
 
   context 'when the SP has multiple registered redirect_uris and the second one is requested' do
     it 'considers the request valid and redirects to the one requested' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_sp_with_ial1_with_second_valid_redirect_uri
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
@@ -158,7 +158,7 @@ describe 'redirect_uri validation' do
 
   context 'when the SP does not have any registered redirect_uris' do
     it 'considers the request invalid and does not redirect if the user signs in' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_sp_that_does_not_have_redirect_uris
       current_host = URI.parse(page.current_url).host
 

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'Add a new phone number' do
   scenario 'Adding and confirming a new phone number allows the phone number to be used for MFA' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     phone = '+1 (225) 278-1234'
 
     sign_in_and_2fa_user(user)
@@ -22,7 +22,7 @@ describe 'Add a new phone number' do
   end
 
   scenario 'adding a new phone number sends the user an email with a disavowal link' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     phone = '+1 (225) 278-1234'
 
     sign_in_and_2fa_user(user)
@@ -42,7 +42,7 @@ describe 'Add a new phone number' do
   end
 
   scenario 'adding a new phone number validates number', :js do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_and_2fa_user(user)
     within('.sidenav') do
       click_on t('account.navigation.add_phone_number')
@@ -127,7 +127,7 @@ describe 'Add a new phone number' do
 
   scenario 'Displays an error message when max phone numbers are reached' do
     allow(IdentityConfig.store).to receive(:max_phone_numbers_per_account).and_return(1)
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_and_2fa_user(user)
     expect(page).to_not have_link(t('account.index.phone_add'), normalize_ws: true, exact: true)
     within('.sidenav') do
@@ -140,7 +140,7 @@ describe 'Add a new phone number' do
   end
 
   scenario 'adding a phone that is already on the user account shows error message', :js do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     # Regression handling: Previously, non-U.S. "+1" numbers were not correctly disambiguated, and
     # would fail to check uniqueness.
     user.phone_configurations.create(phone: '+1 3065550100')
@@ -172,7 +172,7 @@ describe 'Add a new phone number' do
     allow(IdentityConfig.store).to receive(:voip_block).and_return(true)
     allow(IdentityConfig.store).to receive(:phone_service_check).and_return(true)
 
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
 
     sign_in_and_2fa_user(user)
     within('.sidenav') do
@@ -184,7 +184,7 @@ describe 'Add a new phone number' do
   end
 
   scenario 'adding a phone in a different country', :js do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
 
     sign_in_and_2fa_user(user)
     within('.sidenav') do
@@ -205,7 +205,7 @@ describe 'Add a new phone number' do
   end
 
   scenario 'adding a phone with a reCAPTCHA challenge', :js do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
 
     allow(IdentityConfig.store).to receive(:phone_recaptcha_mock_validator).and_return(true)
     allow(IdentityConfig.store).to receive(:phone_recaptcha_score_threshold).and_return(0.6)

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -34,7 +34,7 @@ describe 'phone otp confirmation' do
   end
 
   context 'on sign in' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:phone) { user.phone_configurations.first.phone }
 
     it_behaves_like 'phone otp confirmation', :sms
@@ -57,7 +57,7 @@ describe 'phone otp confirmation' do
   end
 
   context 'add phone' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
 
     it_behaves_like 'phone otp confirmation', :sms
     it_behaves_like 'phone otp confirmation', :voice

--- a/spec/features/phone/edit_phone_spec.rb
+++ b/spec/features/phone/edit_phone_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'editing a phone' do
   it 'allows a user to edit one of their phone numbers' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     phone_configuration = user.phone_configurations.first
     sign_in_and_2fa_user(user)
 
@@ -13,7 +13,7 @@ describe 'editing a phone' do
   end
 
   it "does not allow a user to edit another user's phone number" do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_and_2fa_user(user)
 
     visit(manage_phone_path(id: create(:phone_configuration).id))
@@ -23,7 +23,7 @@ describe 'editing a phone' do
 
   context 'with only one phone number' do
     it 'does not allow you to check default phone number if only one number is set up' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       phone_configuration = user.phone_configurations.first
       sign_in_and_2fa_user(user)
 

--- a/spec/features/phone/rate_limitting_spec.rb
+++ b/spec/features/phone/rate_limitting_spec.rb
@@ -18,7 +18,7 @@ describe 'phone rate limitting' do
   end
 
   context 'on add phone' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
 
     it_behaves_like 'phone rate limitting', :sms
     it_behaves_like 'phone rate limitting', :voice

--- a/spec/features/phone/remove_phone_spec.rb
+++ b/spec/features/phone/remove_phone_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'removing a phone number from an account' do
   scenario 'deleting a phone number' do
-    user = create(:user, :signed_up, :with_piv_or_cac)
+    user = create(:user, :fully_registered, :with_piv_or_cac)
     phone_configuration = user.phone_configurations.first
     sign_in_and_2fa_user(user)
     visit manage_phone_path(id: phone_configuration.id)
@@ -21,7 +21,7 @@ feature 'removing a phone number from an account' do
 
   context 'when deleting will mean the user will not have enough MFA methods' do
     scenario 'the option to delete the phone number is not available' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       phone_configuration = user.phone_configurations.first
       sign_in_and_2fa_user(user)
 

--- a/spec/features/remember_device/revocation_spec.rb
+++ b/spec/features/remember_device/revocation_spec.rb
@@ -8,7 +8,7 @@ feature 'taking an action that revokes remember device' do
   end
 
   context 'clicking forget browsers' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
 
     it 'forgets the current browser' do
       sign_in_with_remember_device_and_sign_out

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -5,7 +5,7 @@ describe 'Remembering a TOTP device' do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(1000)
   end
 
-  let(:user) { create(:user, :signed_up, :with_authentication_app) }
+  let(:user) { create(:user, :fully_registered, :with_authentication_app) }
 
   context 'sign in' do
     def remember_device_and_sign_out_user

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -85,7 +85,7 @@ describe 'Unchecking remember device' do
 
   describe '2fa verification' do
     context 'when the 2fa is totp' do
-      let(:user) { create(:user, :signed_up, :with_authentication_app) }
+      let(:user) { create(:user, :fully_registered, :with_authentication_app) }
 
       before do
         sign_in_user(user)
@@ -105,7 +105,7 @@ describe 'Unchecking remember device' do
     context 'when the 2fa is webauthn' do
       include WebAuthnHelper
 
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       before do
         create(

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -8,7 +8,7 @@ describe 'Remembering a webauthn device' do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(1000)
   end
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   context 'roaming authenticator' do
     context 'sign in' do

--- a/spec/features/reports/authorization_count_spec.rb
+++ b/spec/features/reports/authorization_count_spec.rb
@@ -46,7 +46,7 @@ describe 'authorization count' do
   let(:issuer_2) { 'https://rp3.serviceprovider.com/auth/saml/metadata' }
 
   context 'an IAL1 user with an active session' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
 
     before do
       reset_monthly_auth_count_and_login(user)

--- a/spec/features/reports/sp_active_users_report_spec.rb
+++ b/spec/features/reports/sp_active_users_report_spec.rb
@@ -5,7 +5,7 @@ feature 'sp active users report' do
   include IdvHelper
 
   it 'reports a user as ial1 active for an ial1 sign in' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     visit_idp_from_sp_with_ial1(:oidc)
     fill_in_credentials_and_submit(user.email, user.password)
     fill_in_code_with_last_phone_otp

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -36,7 +36,7 @@ feature 'IAL1 Single Sign On' do
     end
 
     it 'takes user to the service provider, allows user to visit IDP' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       request_url = saml_authn_request_url
 
       visit request_url
@@ -73,7 +73,7 @@ feature 'IAL1 Single Sign On' do
     end
 
     it 'after session timeout, signing in takes user back to SP' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       request_url = saml_authn_request_url
 
       visit request_url
@@ -92,7 +92,7 @@ feature 'IAL1 Single Sign On' do
   end
 
   context 'fully signed up user authenticates new sp' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:saml_authn_request) { saml_authn_request_url }
 
     before do
@@ -138,7 +138,7 @@ feature 'IAL1 Single Sign On' do
 
   context 'fully signed up user is signed in with email and password only' do
     it 'prompts to enter OTP' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_user(user)
 
       visit saml_authn_request_url
@@ -187,7 +187,7 @@ feature 'IAL1 Single Sign On' do
 
   context 'canceling sign in after email and password' do
     it 'returns to the branded landing page' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit saml_authn_request_url
       fill_in_credentials_and_submit(user.email, user.password)
@@ -202,7 +202,7 @@ feature 'IAL1 Single Sign On' do
 
   context 'requesting verified_at for an IAL1 account' do
     it 'shows verified_at as a requested attribute, even if blank' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       saml_authn_request = saml_authn_request_url(
         overrides: {
           issuer: sp1_issuer,

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -89,7 +89,7 @@ feature 'IAL2 Single Sign On' do
 
       context 'provides an option to send another letter' do
         it 'without signing out' do
-          user = create(:user, :signed_up)
+          user = create(:user, :fully_registered)
 
           perform_id_verification_with_gpo_without_confirming_code(user)
 
@@ -112,7 +112,7 @@ feature 'IAL2 Single Sign On' do
         end
 
         it 'after signing out' do
-          user = create(:user, :signed_up)
+          user = create(:user, :fully_registered)
 
           perform_id_verification_with_gpo_without_confirming_code(user)
           visit account_path

--- a/spec/features/saml/multiple_endpoints_spec.rb
+++ b/spec/features/saml/multiple_endpoints_spec.rb
@@ -5,7 +5,7 @@ describe 'multiple saml endpoints' do
   include IdvHelper
 
   let(:endpoint_suffix) { '2023' }
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   let(:endpoint_saml_settings) do
     settings = saml_settings

--- a/spec/features/saml/redirect_uri_validation_spec.rb
+++ b/spec/features/saml/redirect_uri_validation_spec.rb
@@ -5,7 +5,7 @@ describe 'redirect_uri validation' do
 
   context 'when redirect_uri param is included in SAML request' do
     it 'uses the return_to_sp_url URL and not the redirect_uri' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit api_saml_auth_path(
         path_year: SamlAuthHelper::PATH_YEAR,
         SAMLRequest: CGI.unescape(saml_request(saml_settings)),

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'SAML logout' do
   include SamlAuthHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   context 'with a SAML request' do
     context 'when logging out from the SP' do

--- a/spec/features/saml/saml_relay_state_spec.rb
+++ b/spec/features/saml/saml_relay_state_spec.rb
@@ -4,7 +4,7 @@ feature 'SAML RelayState' do
   include SamlAuthHelper
 
   context 'when RelayState is passed in authn request' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:relay_state_value) { '8431d690-2ed1-11eb-adc1-0242ac120002' }
     let(:params) { { RelayState: relay_state_value } }
 
@@ -41,7 +41,7 @@ feature 'SAML RelayState' do
   end
 
   context 'when RelayState is NOT passed in authn request' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
 
     it 'does not return RelayState on GET authn request' do
       visit_saml_authn_request_url(

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -4,7 +4,7 @@ feature 'saml api' do
   include SamlAuthHelper
   include IdvHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:sp) { ServiceProvider.find_by(issuer: 'http://localhost:3000') }
 
   context 'when assertion consumer service url is defined' do
@@ -217,7 +217,7 @@ feature 'saml api' do
 
   context 'visiting /api/saml/logout' do
     context 'session timed out' do
-      let(:logout_user) { create(:user, :signed_up) }
+      let(:logout_user) { create(:user, :fully_registered) }
 
       before do
         sign_in_and_2fa_user(logout_user)

--- a/spec/features/sign_in/banned_users_spec.rb
+++ b/spec/features/sign_in/banned_users_spec.rb
@@ -5,7 +5,7 @@ feature 'Banning users for an SP' do
 
   context 'a user is banned from all SPs' do
     it 'does not let the user sign in to any SP' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       SignInRestriction.create(user: user)
 
@@ -24,7 +24,7 @@ feature 'Banning users for an SP' do
 
   context 'a user is banned for a SAML SP' do
     it 'bans the user from signing in to the banned SP but allows other sign ins' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       SignInRestriction.create(user: user, service_provider: 'http://localhost:3000')
 
@@ -43,7 +43,7 @@ feature 'Banning users for an SP' do
 
   context 'a user is banner for an OIDC SP' do
     it 'bans the user from signing in to the banned SP but allows other sign ins' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       SignInRestriction.create(user: user, service_provider: 'urn:gov:gsa:openidconnect:sp:server')
 

--- a/spec/features/sign_in/remember_device_default_spec.rb
+++ b/spec/features/sign_in/remember_device_default_spec.rb
@@ -5,7 +5,7 @@ describe 'Remember device checkbox' do
 
   context 'when the user signs in and arrives at the 2FA page' do
     it "has a checked 'remember device' box" do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_user(user)
 
       expect(page).
@@ -20,7 +20,7 @@ describe 'Remember device checkbox' do
     end
 
     it 'does not have remember device checked' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_sp_with_ial1(:oidc)
       fill_in_credentials_and_submit(user.email, user.password)
       expect(page).to_not have_checked_field t('forms.messages.remember_device')
@@ -29,7 +29,7 @@ describe 'Remember device checkbox' do
 
   context 'when signing in from an SP that has not opted out of remember device' do
     it 'does have remember device checked' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_sp_with_ial1(:oidc)
       fill_in_credentials_and_submit(user.email, user.password)
       expect(page).to have_checked_field t('forms.messages.remember_device')

--- a/spec/features/sign_in/two_factor_options_spec.rb
+++ b/spec/features/sign_in/two_factor_options_spec.rb
@@ -12,7 +12,7 @@ end
 describe '2FA options when signing in' do
   context 'when the user only has SMS configured' do
     it 'only displays SMS and Voice' do
-      user = create(:user, :signed_up, otp_delivery_preference: 'sms')
+      user = create(:user, :fully_registered, otp_delivery_preference: 'sms')
       sign_in_user(user)
 
       click_link t('two_factor_authentication.login_options_link_text')
@@ -52,7 +52,7 @@ describe '2FA options when signing in' do
 
   context 'when the user only has Voice configured' do
     it 'only displays SMS, Voice and Personal key' do
-      user = create(:user, :signed_up, otp_delivery_preference: 'voice')
+      user = create(:user, :fully_registered, otp_delivery_preference: 'voice')
       sign_in_user(user)
 
       click_link t('two_factor_authentication.login_options_link_text')
@@ -73,7 +73,7 @@ describe '2FA options when signing in' do
   context 'when the user only has SMS configured with a number that we cannot call' do
     it 'only displays SMS and Personal key' do
       user = create(
-        :user, :signed_up,
+        :user, :fully_registered,
         otp_delivery_preference: 'sms', with: { phone: '+12423270143' }
       )
       sign_in_user(user)
@@ -96,7 +96,7 @@ describe '2FA options when signing in' do
   context "the user's otp_delivery_preference is voice but number is unsupported" do
     it 'only displays SMS and Personal key' do
       user = create(
-        :user, :signed_up,
+        :user, :fully_registered,
         otp_delivery_preference: 'voice', with: { phone: '+12423270143' }
       )
       sign_in_user(user)
@@ -158,7 +158,7 @@ describe '2FA options when signing in' do
 
   context 'when the user only has SMS and TOTP configured' do
     it 'only displays SMS, Voice, TOTP and Personal key' do
-      user = create(:user, :signed_up, :with_authentication_app)
+      user = create(:user, :fully_registered, :with_authentication_app)
       sign_in_user(user)
 
       click_link t('two_factor_authentication.login_options_link_text')
@@ -178,7 +178,7 @@ describe '2FA options when signing in' do
 
   context 'when the user only has SMS and PIV/CAC configured' do
     it 'only displays SMS, Voice, PIV/CAC and Personal key' do
-      user = create(:user, :signed_up, :with_piv_or_cac)
+      user = create(:user, :fully_registered, :with_piv_or_cac)
       sign_in_user(user)
 
       click_link t('two_factor_authentication.login_options_link_text')
@@ -218,7 +218,7 @@ describe '2FA options when signing in' do
 
   context 'when the user has SMS, TOTP and PIV/CAC configured' do
     it 'only displays SMS, Voice, PIV/CAC, TOTP, and Personal key' do
-      user = create(:user, :signed_up, :with_authentication_app, :with_piv_or_cac)
+      user = create(:user, :fully_registered, :with_authentication_app, :with_piv_or_cac)
       sign_in_user(user)
 
       click_link t('two_factor_authentication.login_options_link_text')
@@ -238,7 +238,7 @@ describe '2FA options when signing in' do
 
   context 'when the user has multiple webauthn keys configured' do
     it 'only displays the webauthn option once' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       create(:webauthn_configuration, user: user)
       create(:webauthn_configuration, user: user)
       sign_in_user(user)
@@ -261,7 +261,7 @@ describe '2FA options when signing in' do
 
   context 'when the user has multiple phones configured' do
     it 'displays sms and voice options for each MFA-enabled phone, and only shows last 4 digits' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       create(:phone_configuration, user: user, phone: '+1 202-555-1213')
       phone_ids = user.reload.phone_configurations.pluck(:id)
       first_id = phone_ids[0]

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -33,7 +33,7 @@ feature 'sign up with backup code' do
   end
 
   it 'works for each code and refreshes the codes on the last one' do
-    user = create(:user, :signed_up, :with_authentication_app)
+    user = create(:user, :fully_registered, :with_authentication_app)
 
     codes = BackupCodeGenerator.new(user).create
 
@@ -77,7 +77,7 @@ feature 'sign up with backup code' do
   end
 
   context 'when the user needs a backup code reminder' do
-    let!(:user) { create(:user, :signed_up, :with_authentication_app, :with_backup_code) }
+    let!(:user) { create(:user, :fully_registered, :with_authentication_app, :with_backup_code) }
     let!(:event) do
       create(:event, user: user, event_type: :sign_in_after_2fa, created_at: 9.months.ago)
     end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -227,7 +227,7 @@ feature 'Two Factor Authentication' do
 
   describe 'When the user has already set up 2FA' do
     it 'automatically sends the OTP to the preferred delivery method' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
 
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
@@ -250,7 +250,7 @@ feature 'Two Factor Authentication' do
     end
 
     scenario 'user can return to the 2fa options screen' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
       click_link t('links.cancel')
 
@@ -258,14 +258,14 @@ feature 'Two Factor Authentication' do
     end
 
     scenario 'user does not have to focus on OTP field', js: true do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
 
       expect(page.evaluate_script('document.activeElement.id')).to start_with('code')
     end
 
     scenario 'user enters incorrect OTP', js: true do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
 
       expect(page.evaluate_script('document.activeElement.id')).to start_with('code')
@@ -275,7 +275,7 @@ feature 'Two Factor Authentication' do
     end
 
     scenario 'the user changes delivery method' do
-      user = create(:user, :signed_up, otp_delivery_preference: :sms)
+      user = create(:user, :fully_registered, otp_delivery_preference: :sms)
       sign_in_before_2fa(user)
 
       choose_another_security_option('voice')
@@ -304,7 +304,7 @@ feature 'Two Factor Authentication' do
     end
 
     it 'allows totp fallback when configured' do
-      user = create(:user, :signed_up, :with_piv_or_cac, :with_authentication_app)
+      user = create(:user, :fully_registered, :with_piv_or_cac, :with_authentication_app)
       sign_in_before_2fa(user)
 
       expect(current_path).to eq login_two_factor_piv_cac_path
@@ -315,7 +315,7 @@ feature 'Two Factor Authentication' do
     end
 
     scenario 'user can cancel PIV/CAC process' do
-      user = create(:user, :signed_up, :with_piv_or_cac)
+      user = create(:user, :fully_registered, :with_piv_or_cac)
       sign_in_before_2fa(user)
 
       expect(current_path).to eq login_two_factor_piv_cac_path
@@ -362,7 +362,7 @@ feature 'Two Factor Authentication' do
     context 'user with Voice preference sends SMS, causing a Telephony error' do
       let(:user) do
         create(
-          :user, :signed_up,
+          :user, :fully_registered,
           otp_delivery_preference: 'voice',
           with: { phone: '+12255551000', delivery_preference: 'voice' }
         )
@@ -390,7 +390,7 @@ feature 'Two Factor Authentication' do
 
   describe 'when the user is not piv/cac enabled' do
     it 'has no link to piv/cac during login' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
 
       expect(page).not_to have_link(t('two_factor_authentication.piv_cac_fallback.question'))
@@ -414,7 +414,7 @@ feature 'Two Factor Authentication' do
     end
 
     scenario 'user can cancel TOTP process' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
       click_link t('links.cancel')
 
@@ -423,7 +423,7 @@ feature 'Two Factor Authentication' do
 
     scenario 'attempting to reuse a TOTP code results in an error' do
       secret = 'abcdefghi'
-      user = create(:user, :signed_up, :with_authentication_app)
+      user = create(:user, :fully_registered, :with_authentication_app)
       Db::AuthAppConfiguration.create(user, secret, nil, 'foo')
       otp = generate_totp_code(secret)
 
@@ -466,7 +466,7 @@ feature 'Two Factor Authentication' do
 
   describe 'clicking the logo image during 2fa process' do
     it 'returns them to the home page' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_user(user)
       click_link 'Login.gov'
       expect(current_path).to eq root_path
@@ -475,7 +475,7 @@ feature 'Two Factor Authentication' do
 
   describe 'clicking footer links during 2FA' do
     it 'renders the requested pages' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
       click_link t('links.help'), match: :first
 
@@ -572,7 +572,7 @@ feature 'Two Factor Authentication' do
 
   describe 'rate limiting' do
     let(:max_attempts) { 2 }
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     before do
       allow(IdentityConfig.store).to receive(:login_otp_confirmation_max_attempts).
         and_return(max_attempts)

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Signing in via one-time use personal key' do
   it 'destroys old key, does not offer new one' do
     user = create(
-      :user, :signed_up, :with_phone, :with_personal_key,
+      :user, :fully_registered, :with_phone, :with_personal_key,
       with: { phone: '+1 (202) 345-6789' }
     )
     raw_key = PersonalKeyGenerator.new(user).create
@@ -30,7 +30,7 @@ feature 'Signing in via one-time use personal key' do
     it 'locks user out when max login attempts has been reached' do
       user = create(
         :user,
-        :signed_up,
+        :fully_registered,
         second_factor_attempts_count: IdentityConfig.store.login_otp_confirmation_max_attempts - 1,
       )
       sign_in_before_2fa(user)

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -6,7 +6,7 @@ feature 'Password recovery via personal key' do
   include SamlAuthHelper
   include SpAuthHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:new_password) { 'some really awesome new password' }
   let(:pii) { { ssn: '666-66-1234', dob: '1920-01-01', first_name: 'alice' } }
 

--- a/spec/features/users/password_reset_with_pending_profile_spec.rb
+++ b/spec/features/users/password_reset_with_pending_profile_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'reset password with pending profile' do
   include PersonalKeyHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   scenario 'password reset email includes warning for pending profile' do
     profile = create(

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -9,7 +9,7 @@ feature 'PIV/CAC Management' do
 
   context 'with no piv/cac associated yet' do
     let(:uuid) { SecureRandom.uuid }
-    let(:user) { create(:user, :signed_up, :with_phone, with: { phone: '+1 202-555-1212' }) }
+    let(:user) { create(:user, :fully_registered, :with_phone, with: { phone: '+1 202-555-1212' }) }
 
     scenario 'allows association of a piv/cac with an account' do
       allow(Identity::Hostdata).to receive(:env).and_return('test')
@@ -152,7 +152,13 @@ feature 'PIV/CAC Management' do
 
   context 'with a piv/cac associated' do
     let(:user) do
-      create(:user, :signed_up, :with_piv_or_cac, :with_phone, with: { phone: '+1 202-555-1212' })
+      create(
+        :user,
+        :fully_registered,
+        :with_piv_or_cac,
+        :with_phone,
+        with: { phone: '+1 202-555-1212' },
+      )
     end
 
     scenario 'does allow association of another piv/cac with the account' do

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -5,7 +5,7 @@ feature 'View personal key' do
   include PersonalKeyHelper
   include SamlAuthHelper
 
-  let(:user) { create(:user, :signed_up, :with_personal_key) }
+  let(:user) { create(:user, :fully_registered, :with_personal_key) }
 
   context 'after sign up' do
     context 'regenerating personal key' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -298,7 +298,7 @@ feature 'Sign in' do
       allow(IdentityConfig.store).to receive(:session_timeout_warning_seconds).
         and_return(Devise.timeout_in)
 
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       sign_in_user(user)
       visit user_two_factor_authentication_path
 
@@ -436,7 +436,7 @@ feature 'Sign in' do
         email = 'test@example.com'
         password = 'salty pickles'
 
-        create(:user, :signed_up, email: email, password: password)
+        create(:user, :fully_registered, email: email, password: password)
 
         user = User.find_with_email(email)
         encrypted_email = user.confirmed_email_addresses.first.encrypted_email
@@ -456,7 +456,7 @@ feature 'Sign in' do
         email = 'test@example.com'
         password = 'salty pickles'
 
-        create(:user, :signed_up, email: email, password: password)
+        create(:user, :fully_registered, email: email, password: password)
 
         user = User.find_with_email(email)
         encrypted_email = user.confirmed_email_addresses.first.encrypted_email
@@ -490,7 +490,7 @@ feature 'Sign in' do
 
   context 'invalid request_id' do
     it 'allows the user to sign in and does not try to redirect to any SP' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit new_user_session_path(request_id: 'invalid')
       fill_in_credentials_and_submit(user.email, user.password)
@@ -502,7 +502,7 @@ feature 'Sign in' do
     context 'with email and password' do
       it 'allows the user to sign in and does not try to redirect to any SP' do
         allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
 
         visit new_user_session_path(request_id: 'invalid')
         fill_in_credentials_and_submit(user.email, user.password)
@@ -514,7 +514,7 @@ feature 'Sign in' do
 
     context 'with piv/cac' do
       it 'allows the user to sign in and does not try to redirect to any SP' do
-        user = create(:user, :signed_up, :with_piv_or_cac)
+        user = create(:user, :fully_registered, :with_piv_or_cac)
 
         visit new_user_session_path(request_id: 'invalid')
         signin_with_piv(user)
@@ -526,7 +526,7 @@ feature 'Sign in' do
 
   context 'CSRF error' do
     it 'redirects to sign in page with flash message' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit new_user_session_path(request_id: '123')
       allow_any_instance_of(Users::SessionsController).
         to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
@@ -553,7 +553,7 @@ feature 'Sign in' do
   context 'user signs in with Voice OTP delivery preference to an unsupported country' do
     it 'falls back to SMS with an error message if SMS is supported' do
       user = create(
-        :user, :signed_up,
+        :user, :fully_registered,
         otp_delivery_preference: 'voice', with: { phone: '+61 02 1234 5678' }
       )
       signin(user.email, user.password)
@@ -571,7 +571,7 @@ feature 'Sign in' do
 
     it 'shows error message if SMS and Voice are not supported' do
       user = create(
-        :user, :signed_up,
+        :user, :fully_registered,
         otp_delivery_preference: 'voice', with: { phone: '+213 09 1234 5678' }
       )
       signin(user.email, user.password)
@@ -595,7 +595,7 @@ feature 'Sign in' do
   context 'user tries to visit /login/two_factor/voice with an unsupported phone' do
     it 'displays an error message but does not send another SMS' do
       user = create(
-        :user, :signed_up,
+        :user, :fully_registered,
         otp_delivery_preference: 'sms', with: { phone: unsupported_country_phone_number }
       )
       signin(user.email, user.password)
@@ -616,7 +616,7 @@ feature 'Sign in' do
   context 'user tries to visit /otp/send with voice delivery to an unsupported phone' do
     it 'displays an error message but does not send another SMS' do
       user = create(
-        :user, :signed_up,
+        :user, :fully_registered,
         otp_delivery_preference: 'sms', with: { phone: unsupported_country_phone_number }
       )
       signin(user.email, user.password)
@@ -639,7 +639,7 @@ feature 'Sign in' do
   context 'user with voice delivery preference visits /otp/send' do
     it 'displays an error message but does not send another SMS' do
       user = create(
-        :user, :signed_up,
+        :user, :fully_registered,
         otp_delivery_preference: 'voice', with: { phone: unsupported_country_phone_number }
       )
       signin(user.email, user.password)
@@ -677,7 +677,7 @@ feature 'Sign in' do
 
   context 'user signs in and chooses another authentication method' do
     it 'signs out the user if they choose to cancel' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       signin(user.email, user.password)
       accept_rules_of_use_and_continue_if_displayed
       click_link t('two_factor_authentication.login_options_link_text')
@@ -690,7 +690,7 @@ feature 'Sign in' do
 
   context 'user signs in when accepted_terms_at is out of date', js: true do
     it 'validates terms checkbox and signs in successfully' do
-      user = create(:user, :signed_up, accepted_terms_at: nil)
+      user = create(:user, :fully_registered, accepted_terms_at: nil)
       signin(user.email, user.password)
 
       click_button t('forms.buttons.continue')
@@ -706,7 +706,7 @@ feature 'Sign in' do
   context 'user signs in with personal key, visits account page' do
     # this can happen if you submit the personal key form multiple times quickly
     it 'does not redirect to the personal key page' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       old_personal_key = PersonalKeyGenerator.new(user).create
       signin(user.email, user.password)
       choose_another_security_option('personal_key')
@@ -719,7 +719,7 @@ feature 'Sign in' do
 
   context 'user attempts sign in with bad personal key' do
     it 'remains on the login with personal key page' do
-      user = create(:user, :signed_up, :with_personal_key)
+      user = create(:user, :fully_registered, :with_personal_key)
       signin(user.email, user.password)
       choose_another_security_option('personal_key')
       enter_personal_key(personal_key: 'foo')
@@ -762,7 +762,7 @@ feature 'Sign in' do
 
   context 'visiting via SP1, then via SP2, then signing in' do
     it 'redirects to SP2' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_sp_with_ial1(:saml)
       visit_idp_from_sp_with_ial1(:oidc)
       fill_in_credentials_and_submit(user.email, user.password)
@@ -778,7 +778,7 @@ feature 'Sign in' do
 
   context 'a prompt login sp redirects back to auth url immediately after we redirect to them' do
     it 'logs an SP bounce and displays the bounced error screen' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_oidc_sp_with_loa1_prompt_login
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
@@ -792,7 +792,7 @@ feature 'Sign in' do
 
   context 'multiple piv cacs' do
     it 'allows you to sign in with either' do
-      user = create(:user, :signed_up, :with_piv_or_cac)
+      user = create(:user, :fully_registered, :with_piv_or_cac)
       user_id = user.id
       ::PivCacConfiguration.create!(user_id: user_id, x509_dn_uuid: 'foo', name: 'key1')
       ::PivCacConfiguration.create!(user_id: user_id, x509_dn_uuid: 'bar', name: 'key2')
@@ -815,7 +815,7 @@ feature 'Sign in' do
 
   context 'multiple auth apps' do
     it 'allows you to sign in with either' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       Db::AuthAppConfiguration.create(user, 'foo', nil, 'foo')
       Db::AuthAppConfiguration.create(user, 'bar', nil, 'bar')
 
@@ -839,7 +839,7 @@ feature 'Sign in' do
 
   context 'oidc sp requests ialmax' do
     it 'returns ial1 info for a non-verified user' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_oidc_sp_with_ialmax
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
@@ -874,7 +874,7 @@ feature 'Sign in' do
 
   context 'saml sp requests ialmax' do
     it 'returns ial1 info for a non-verified user' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_saml_authn_request_url(
         overrides: {
           issuer: sp1_issuer,
@@ -932,7 +932,7 @@ feature 'Sign in' do
     end
 
     it 'forces user to add a piv/cac if they do not have one' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
       click_submit_default
@@ -953,7 +953,7 @@ feature 'Sign in' do
 
   context 'double clicking on "Agree and Continue"' do
     it 'should not blow up' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_sp_with_ial1(:oidc)
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
@@ -974,7 +974,7 @@ feature 'Sign in' do
   end
 
   def perform_steps_to_get_to_add_piv_cac_during_sign_up
-    user = create(:user, :signed_up, :with_phone)
+    user = create(:user, :fully_registered, :with_phone)
     visit_idp_from_sp_with_ial1(:oidc)
     click_on t('account.login.piv_cac')
     allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -194,7 +194,7 @@ feature 'Sign Up' do
 
   context 'user accesses password screen with already confirmed token', email: true do
     it 'returns them to the home page' do
-      create(:user, :signed_up, confirmation_token: 'foo')
+      create(:user, :fully_registered, confirmation_token: 'foo')
 
       visit sign_up_enter_password_path(confirmation_token: 'foo', request_id: 'bar')
 
@@ -219,7 +219,7 @@ feature 'Sign Up' do
 
   context "user A is signed in and accesses password creation page with User B's token" do
     it "redirects to User A's account page" do
-      create(:user, :signed_up, email: 'userb@test.com', confirmation_token: 'foo')
+      create(:user, :fully_registered, email: 'userb@test.com', confirmation_token: 'foo')
       sign_in_and_2fa_user
       visit sign_up_enter_password_path(confirmation_token: 'foo')
 
@@ -255,7 +255,7 @@ feature 'Sign Up' do
   end
 
   it 'does not bypass 2FA when accessing authenticator_setup_path if the user is 2FA enabled' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     sign_in_user(user)
     visit authenticator_setup_path
 
@@ -264,7 +264,7 @@ feature 'Sign Up' do
   end
 
   it 'prompts to sign in when accessing authenticator_setup_path before signing in' do
-    create(:user, :signed_up)
+    create(:user, :fully_registered)
     visit authenticator_setup_path
 
     expect(page).to have_current_path root_path

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'totp management' do
   context 'when the user has totp enabled' do
-    let(:user) { create(:user, :signed_up, :with_authentication_app) }
+    let(:user) { create(:user, :fully_registered, :with_authentication_app) }
 
     it 'allows the user to disable their totp app' do
       sign_in_and_2fa_user(user)
@@ -35,7 +35,7 @@ describe 'totp management' do
   end
 
   context 'when the user has totp disabled' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
 
     it 'allows the user to setup a totp app' do
       sign_in_and_2fa_user(user)

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'User edit' do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   context 'editing password' do
     before do

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'verify profile with OTP' do
   include IdvStepHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:otp) { 'ABC123' }
 
   before do

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -8,7 +8,7 @@ feature 'Password Recovery' do
   context 'user enters valid email in forgot password form', email: true do
     it 'redirects to forgot_password path and sends an email to the user' do
       allow(IdentityConfig.store).to receive(:participate_in_dap).and_return(true)
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
 
       visit root_path
       click_link t('links.passwords.forgot')
@@ -116,7 +116,7 @@ feature 'Password Recovery' do
 
   context 'user with 2FA confirmation resets password', email: true do
     before do
-      @user = create(:user, :signed_up)
+      @user = create(:user, :fully_registered)
       trigger_reset_password_and_click_email_link(@user.email)
     end
 
@@ -141,7 +141,7 @@ feature 'Password Recovery' do
 
   context 'user can reset their password' do
     before do
-      @user = create(:user, :signed_up)
+      @user = create(:user, :fully_registered)
 
       perform_in_browser(:one) do
         visit_idp_from_sp_with_ial1(:oidc)
@@ -243,7 +243,7 @@ feature 'Password Recovery' do
   end
 
   scenario 'user takes too long to click the reset password link' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
 
     visit new_user_password_path
     fill_in t('account.index.email'), with: user.email
@@ -265,7 +265,7 @@ feature 'Password Recovery' do
   end
 
   it 'throttles reset passwords requests' do
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     email = user.email
 
     max_attempts = IdentityConfig.store.reset_password_email_max_attempts

--- a/spec/features/webauthn/hidden_spec.rb
+++ b/spec/features/webauthn/hidden_spec.rb
@@ -20,7 +20,7 @@ describe 'webauthn hide' do
   end
 
   context 'on sign in' do
-    let(:user) { create(:user, :signed_up, :with_webauthn) }
+    let(:user) { create(:user, :fully_registered, :with_webauthn) }
 
     context 'with javascript enabled', :js do
       it 'displays the security key option' do

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'webauthn management' do
   include WebAuthnHelper
 
-  let(:user) { create(:user, :signed_up, with: { phone: '+1 202-555-1212' }) }
+  let(:user) { create(:user, :fully_registered, with: { phone: '+1 202-555-1212' }) }
   let(:view) { ActionController::Base.new.view_context }
 
   it_behaves_like 'webauthn setup'

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -27,7 +27,7 @@ describe DeleteUserEmailForm do
     end
 
     context 'with multiple email addresses' do
-      let(:user) { create(:user, :signed_up, :with_multiple_emails) }
+      let(:user) { create(:user, :fully_registered, :with_multiple_emails) }
       let(:email_address) { user.email_addresses.first }
       let(:form) { described_class.new(user, email_address) }
 
@@ -63,8 +63,8 @@ describe DeleteUserEmailForm do
     end
 
     context 'with a email of a different user' do
-      let(:user) { create(:user, :signed_up, :with_multiple_emails) }
-      let(:other_user) { create(:user, :signed_up, :with_multiple_emails) }
+      let(:user) { create(:user, :fully_registered, :with_multiple_emails) }
+      let(:other_user) { create(:user, :fully_registered, :with_multiple_emails) }
       let(:email_address) { other_user.email_addresses.first }
       let(:form) { described_class.new(user, email_address) }
 

--- a/spec/forms/edit_phone_form_spec.rb
+++ b/spec/forms/edit_phone_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe EditPhoneForm do
   include Shoulda::Matchers::ActiveModel
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:phone_configuration) { user.phone_configurations.first }
   let(:params) do
     {
@@ -110,7 +110,7 @@ describe EditPhoneForm do
 
   describe '#one_phone_configured?' do
     context 'when editing a form with only one number set up' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
       let(:phone_configuration) { user.phone_configurations.first }
 
       it 'recognizes it as the only method set up' do

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -5,7 +5,7 @@ describe GpoVerifyForm do
     GpoVerifyForm.new(user: user, pii: applicant, otp: entered_otp)
   end
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.merge(same_address_as_id: true) }
   let(:entered_otp) { otp }
   let(:otp) { 'ABC123' }

--- a/spec/forms/idv/phone_confirmation_otp_verification_form_spec.rb
+++ b/spec/forms/idv/phone_confirmation_otp_verification_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::PhoneConfirmationOtpVerificationForm do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:phone) { '+1 (225) 555-5000' }
   let(:phone_confirmation_otp_sent_at) { Time.zone.now }
   let(:phone_confirmation_otp_code) { '123456' }

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::PhoneForm do
-  let(:user) { build_stubbed(:user, :signed_up) }
+  let(:user) { build_stubbed(:user, :fully_registered) }
   let(:phone) { '703-555-5000' }
   let(:params) { { phone: phone } }
   let(:previous_params) { nil }
@@ -47,7 +47,7 @@ describe Idv::PhoneForm do
 
     context 'with user phone number' do
       let(:phone) { '7035551234' }
-      let(:user) { build_stubbed(:user, :signed_up, with: { phone: phone }) }
+      let(:user) { build_stubbed(:user, :fully_registered, with: { phone: phone }) }
 
       it 'uses the formatted phone number as the initial phone value' do
         expect(subject.phone).to eq('+1 703-555-1234')
@@ -101,7 +101,7 @@ describe Idv::PhoneForm do
     end
 
     context 'with previously submitted value' do
-      let(:user) { build_stubbed(:user, :signed_up, with: { phone: '7035551234' }) }
+      let(:user) { build_stubbed(:user, :fully_registered, with: { phone: '7035551234' }) }
       let(:previous_params) { { phone: '2255555000' } }
 
       it 'uses the previously submitted value as the initial phone value' do

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe NewPhoneForm do
   include Shoulda::Matchers::ActiveModel
 
-  let(:user) { build(:user, :signed_up) }
+  let(:user) { build(:user, :fully_registered) }
   let(:phone) { '703-555-5000' }
   let(:international_code) { 'US' }
   let(:params) { { phone:, international_code:, otp_delivery_preference: 'sms' } }

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -9,7 +9,7 @@ describe PasswordResetEmailForm do
   describe '#submit' do
     context 'when email is valid and user exists' do
       it 'returns hash with properties about the event and the user' do
-        user = create(:user, :signed_up, email: 'test1@test.com')
+        user = create(:user, :fully_registered, email: 'test1@test.com')
         subject = PasswordResetEmailForm.new('Test1@test.com')
 
         expect(subject.submit.to_h).to eq(

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -22,7 +22,7 @@ describe PersonalKeyForm do
 
     context 'when the form is invalid' do
       it 'returns FormResponse with success: false' do
-        user = create(:user, :signed_up, personal_key: 'code')
+        user = create(:user, :fully_registered, personal_key: 'code')
         errors = { personal_key: ['Incorrect personal key'] }
 
         form = PersonalKeyForm.new(user, 'foo')

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -10,7 +10,7 @@ describe RegisterUserEmailForm do
   describe '#submit' do
     context 'when email is already taken' do
       let(:email_address) { 'taken@gmail.com' }
-      let!(:existing_user) { create(:user, :signed_up, email: email_address) }
+      let!(:existing_user) { create(:user, :fully_registered, email: email_address) }
       let(:extra_params) do
         {
           email_already_exists: true,

--- a/spec/forms/two_factor_authentication/phone_deletion_form_spec.rb
+++ b/spec/forms/two_factor_authentication/phone_deletion_form_spec.rb
@@ -30,7 +30,7 @@ describe TwoFactorAuthentication::PhoneDeletionForm do
     end
 
     context 'with multiple mfa methods available' do
-      let(:user) { create(:user, :signed_up, :with_phone, :with_piv_or_cac) }
+      let(:user) { create(:user, :fully_registered, :with_phone, :with_piv_or_cac) }
 
       it 'returns success' do
         expect(result.success?).to eq true
@@ -81,7 +81,7 @@ describe TwoFactorAuthentication::PhoneDeletionForm do
     context 'with a phone of a different user' do
       let(:user) { create(:user, :with_phone, :with_piv_or_cac) }
       let(:configuration) { other_user.phone_configurations.first }
-      let(:other_user) { create(:user, :signed_up) }
+      let(:other_user) { create(:user, :fully_registered) }
 
       it 'returns failure' do
         expect(result.success?).to eq false

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:document_capture_session) { DocumentCaptureSession.new(result_id: SecureRandom.hex) }
   let(:should_proof_state_id) { true }
   let(:trace_id) { SecureRandom.uuid }
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:request_ip) { Faker::Internet.ip_v4_address }
   let(:threatmetrix_session_id) { SecureRandom.uuid }
   let(:proofing_device_profiling) { :enabled }

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Profile do
-  let(:user) { create(:user, :signed_up, password: 'a really long sekrit') }
-  let(:another_user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered, password: 'a really long sekrit') }
+  let(:another_user) { create(:user, :fully_registered) }
   let(:profile) { user.profiles.create }
 
   let(:dob) { '1920-01-01' }

--- a/spec/models/service_provider_identity_spec.rb
+++ b/spec/models/service_provider_identity_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ServiceProviderIdentity do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:identity) do
     ServiceProviderIdentity.create(
       user_id: user.id,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -130,14 +130,14 @@ RSpec.describe User do
     end
 
     context 'with mfa-enabled user' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       it { expect(fully_registered?).to eq(true) }
     end
   end
 
   context 'when identities are present' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:active_identity) do
       ServiceProviderIdentity.create(service_provider: 'entity_id', session_uuid: SecureRandom.uuid)
     end
@@ -155,7 +155,7 @@ RSpec.describe User do
   end
 
   context 'when user has multiple identities' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
 
     before do
       user.identities << ServiceProviderIdentity.create(
@@ -180,7 +180,7 @@ RSpec.describe User do
   context 'when user has multiple profiles' do
     describe '#active_profile' do
       it 'returns the only active profile' do
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
         profile1 = create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })
         _profile2 = create(:profile, :verified, user: user, pii: { first_name: 'Susan' })
 
@@ -190,7 +190,7 @@ RSpec.describe User do
   end
 
   context 'when user has IPP enrollments' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
 
     let(:failed_enrollment_profile) do
       create(:profile, :verification_cancelled, user: user, pii: { first_name: 'Jane' })
@@ -307,7 +307,7 @@ RSpec.describe User do
 
   describe 'deleting identities' do
     it 'does not delete identities when the user is destroyed preventing uuid reuse' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       user.identities << ServiceProviderIdentity.create(
         service_provider: 'entity_id', session_uuid: SecureRandom.uuid,
       )
@@ -384,7 +384,7 @@ RSpec.describe User do
     let(:rules_of_use_horizon_years) { 6 }
     let(:rules_of_use_updated_at) { 1.day.ago }
     let(:accepted_terms_at) { nil }
-    let(:user) { create(:user, :signed_up, accepted_terms_at: accepted_terms_at) }
+    let(:user) { create(:user, :fully_registered, accepted_terms_at: accepted_terms_at) }
     before do
       allow(IdentityConfig.store).to receive(:rules_of_use_horizon_years).
         and_return(rules_of_use_horizon_years)
@@ -1111,7 +1111,7 @@ RSpec.describe User do
   end
 
   describe '#recent_events' do
-    let!(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
+    let!(:user) { create(:user, :fully_registered, created_at: Time.zone.now - 100.days) }
 
     let!(:event) { create(:event, user: user, created_at: Time.zone.now - 98.days) }
     let!(:identity) do

--- a/spec/policies/user_mfa_policy_spec.rb
+++ b/spec/policies/user_mfa_policy_spec.rb
@@ -32,7 +32,7 @@ describe MfaPolicy do
     end
 
     context 'with phishable configuration' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
 
       it { expect(subject.unphishable?).to eq false }
     end

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -10,7 +10,7 @@ describe CompletionsPresenter do
       ),
     ]
   end
-  let(:current_user) { create(:user, :signed_up, identities: identities) }
+  let(:current_user) { create(:user, :fully_registered, identities: identities) }
   let(:current_sp) { create(:service_provider, friendly_name: 'Friendly service provider') }
   let(:decrypted_pii) do
     {

--- a/spec/presenters/confirm_delete_email_presenter_spec.rb
+++ b/spec/presenters/confirm_delete_email_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe ConfirmDeleteEmailPresenter do
-  let(:user) { create(:user, :signed_up, email: 'email@example.com') }
+  let(:user) { create(:user, :fully_registered, email: 'email@example.com') }
   let(:email_address) { user.email_addresses.first }
   let(:presenter) { described_class.new(user, email_address) }
 

--- a/spec/requests/openid_connect_authorize_spec.rb
+++ b/spec/requests/openid_connect_authorize_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'user signs in partially and visits openid_connect/authorize' do
-  let(:user) { create(:user, :signed_up, with: { phone: '+1 (202) 555-1213' }) }
+  let(:user) { create(:user, :fully_registered, with: { phone: '+1 (202) 555-1213' }) }
 
   it 'prompts the user to 2FA' do
     openid_test('select_account')

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -125,7 +125,7 @@ describe 'throttling requests' do
         allow(Analytics).to receive(:new).and_return(analytics)
         allow(analytics).to receive(:track_event)
 
-        user = create(:user, :signed_up)
+        user = create(:user, :fully_registered)
 
         post(
           new_user_session_path,

--- a/spec/services/account_reset/cancel_spec.rb
+++ b/spec/services/account_reset/cancel_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe AccountReset::Cancel do
   include AccountResetHelper
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   it 'validates presence of token' do
     request = AccountReset::Cancel.new(nil).call

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe AttributeAsserter do
   include SamlAuthHelper
 
-  let(:ial1_user) { create(:user, :signed_up) }
+  let(:ial1_user) { create(:user, :fully_registered) }
   let(:user) { create(:profile, :active, :verified).user }
   let(:user_session) { {} }
   let(:identity) do

--- a/spec/services/email_confirmation_token_validator_spec.rb
+++ b/spec/services/email_confirmation_token_validator_spec.rb
@@ -5,7 +5,7 @@ describe EmailConfirmationTokenValidator do
     subject { described_class.new(email_address, current_user) }
 
     context 'the email of the user does not match the user confirming' do
-      let(:current_user) { create(:user, :signed_up) }
+      let(:current_user) { create(:user, :fully_registered) }
       let(:email_address) do
         create(:email_address, confirmed_at: nil, confirmation_sent_at: Time.zone.now)
       end

--- a/spec/services/ial_context_spec.rb
+++ b/spec/services/ial_context_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe IalContext do
     end
 
     context 'when the user has not proofed' do
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
       it { expect(ial_context.user_ial2_verified?).to eq(false) }
     end
 
@@ -106,7 +106,7 @@ RSpec.describe IalContext do
       let(:user) do
         create(
           :user,
-          :signed_up,
+          :fully_registered,
           profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
         )
       end
@@ -171,7 +171,7 @@ RSpec.describe IalContext do
 
     context 'when ial max and the user has not proofed' do
       let(:ial) { Idp::Constants::IAL_MAX }
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
       it { expect(ial_context.bill_for_ial_1_or_2).to eq(1) }
     end
 
@@ -180,7 +180,7 @@ RSpec.describe IalContext do
       let(:user) do
         create(
           :user,
-          :signed_up,
+          :fully_registered,
           profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
         )
       end
@@ -243,7 +243,7 @@ RSpec.describe IalContext do
 
     context 'when ialmax is requested with a user with no profile' do
       let(:ial) { Idp::Constants::IAL_MAX }
-      let(:user) { create(:user, :signed_up) }
+      let(:user) { create(:user, :fully_registered) }
       it { expect(ial_context.ial2_requested?).to eq(false) }
     end
 

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Idv::ProfileMaker do
   describe '#save_profile' do
     let(:applicant) { { first_name: 'Some', last_name: 'One' } }
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:user_password) { user.password }
     let(:initiating_service_provider) { nil }
 

--- a/spec/services/idv/send_phone_confirmation_otp_spec.rb
+++ b/spec/services/idv/send_phone_confirmation_otp_spec.rb
@@ -17,7 +17,7 @@ describe Idv::SendPhoneConfirmationOtp do
     Idv::Session.new(user_session: {}, current_user: user, service_provider: nil)
   end
 
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   let(:exceeded_otp_send_limit) { false }
   let(:otp_rate_limiter) { OtpRateLimiter.new(user: user, phone: phone, phone_confirmed: true) }

--- a/spec/services/proofing/resolution/progessive_proofer_spec.rb
+++ b/spec/services/proofing/resolution/progessive_proofer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
   let(:request_ip) { Faker::Internet.ip_v4_address }
   let(:threatmetrix_session_id) { SecureRandom.uuid }
   let(:timer) { JobHelpers::Timer.new }
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:instant_verify_proofer) { instance_double(Proofing::LexisNexis::InstantVerify::Proofer) }
   let(:instance) { described_class.new }
 

--- a/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe UserAlerts::AlertUserAboutAccountVerified do
   describe '#call' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:device) { create(:device, user: user) }
     let(:date_time) { Time.zone.now }
 

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe UserAlerts::AlertUserAboutNewDevice do
   describe '#call' do
-    let(:user) { create(:user, :signed_up) }
+    let(:user) { create(:user, :fully_registered) }
     let(:disavowal_token) { 'the_disavowal_token' }
     let(:device) { create(:device, user: user) }
 

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -18,7 +18,7 @@ describe UserEventCreator do
       cookie_jar: cookie_jar,
     )
   end
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:device) { create(:device, user: user, cookie_uuid: existing_device_cookie) }
   let(:event_type) { 'account_created' }
 

--- a/spec/services/uuid_reporter_spec.rb
+++ b/spec/services/uuid_reporter_spec.rb
@@ -83,9 +83,9 @@ RSpec.describe UuidReporter do
 
   describe '.run' do
     context 'with valid inputs' do
-      let!(:user1) { create(:user, :signed_up, email: 'user1@example.com') }
-      let!(:user2) { create(:user, :signed_up, email: 'user2@example.com') }
-      let!(:user3) { create(:user, :signed_up, email: 'user3@example.com') }
+      let!(:user1) { create(:user, :fully_registered, email: 'user1@example.com') }
+      let!(:user2) { create(:user, :fully_registered, email: 'user2@example.com') }
+      let!(:user3) { create(:user, :fully_registered, email: 'user3@example.com') }
       let!(:uuid1) do
         IdentityLinker.new(user1, sp1).link_identity
         AgencyIdentity.find_by(user_id: user1.id, agency_id: agency.id).uuid

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -1,13 +1,13 @@
 module ControllerHelper
   VALID_PASSWORD = 'salted peanuts are best'.freeze
 
-  def sign_in_as_user(user = create(:user, :signed_up, password: VALID_PASSWORD))
+  def sign_in_as_user(user = create(:user, :fully_registered, password: VALID_PASSWORD))
     @request.env['devise.mapping'] = Devise.mappings[:user]
     sign_in user
     user
   end
 
-  def sign_in_before_2fa(user = create(:user, :signed_up))
+  def sign_in_before_2fa(user = create(:user, :fully_registered))
     sign_in_as_user(user)
     controller.current_user.create_direct_otp
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -302,7 +302,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
 
   def complete_all_idv_steps_with(threatmetrix:)
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(300)
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     visit_idp_from_ial1_oidc_sp(
       client_id: service_provider.issuer,
       irs_attempts_api_session_id: 'test-session-id',

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -211,7 +211,7 @@ module Features
     end
 
     def user_with_2fa
-      create(:user, :signed_up, with: { phone: '+1 202-555-1212' }, password: VALID_PASSWORD)
+      create(:user, :fully_registered, with: { phone: '+1 202-555-1212' }, password: VALID_PASSWORD)
     end
 
     def user_verified
@@ -223,16 +223,16 @@ module Features
     end
 
     def user_with_totp_2fa
-      create(:user, :signed_up, :with_authentication_app, password: VALID_PASSWORD)
+      create(:user, :fully_registered, :with_authentication_app, password: VALID_PASSWORD)
     end
 
     def user_with_phishing_resistant_2fa
-      create(:user, :signed_up, :with_webauthn, password: VALID_PASSWORD)
+      create(:user, :fully_registered, :with_webauthn, password: VALID_PASSWORD)
     end
 
     def user_with_piv_cac
       create(
-        :user, :signed_up, :with_piv_or_cac,
+        :user, :fully_registered, :with_piv_or_cac,
         with: { phone: '+1 (703) 555-0000' },
         password: VALID_PASSWORD
       )
@@ -324,7 +324,7 @@ module Features
     end
 
     def sign_in_with_totp_enabled_user
-      user = build(:user, :signed_up, :with_authentication_app, password: VALID_PASSWORD)
+      user = build(:user, :fully_registered, :with_authentication_app, password: VALID_PASSWORD)
       sign_in_user(user)
       fill_in 'code', with: generate_totp_code(@secret)
       click_submit_default

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -2,7 +2,7 @@ module RequestHelper
   VALID_PASSWORD = 'Val!d Pass w0rd'.freeze
 
   def user_with_2fa
-    create(:user, :signed_up, with: { phone: '+1 202-555-1212' }, password: VALID_PASSWORD)
+    create(:user, :fully_registered, with: { phone: '+1 202-555-1212' }, password: VALID_PASSWORD)
   end
 
   def sign_in_user(user = user_with_2fa)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -2,7 +2,7 @@ shared_examples 'signing in with the site in Spanish' do |sp|
   it 'redirects to the SP' do
     Capybara.current_session.driver.header('Accept-Language', 'es')
 
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     visit_idp_from_sp_with_ial1(sp)
     fill_in_credentials_and_submit(user.email, user.password)
     continue_as(user.email)
@@ -180,7 +180,7 @@ shared_examples 'signing in with wrong credentials' do |sp|
     it 'links to forgot password page with locale and request_id' do
       Capybara.current_session.driver.header('Accept-Language', 'es')
 
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       visit_idp_from_sp_with_ial1(sp)
       sp_request_id = ServiceProviderRequestProxy.last.uuid
       fill_in_credentials_and_submit(user.email, 'password')

--- a/spec/support/shared_examples_for_phone_validation.rb
+++ b/spec/support/shared_examples_for_phone_validation.rb
@@ -13,7 +13,7 @@ shared_examples 'a phone form' do
   describe 'phone uniqueness' do
     context 'when phone is already taken' do
       it 'is valid' do
-        second_user = build_stubbed(:user, :signed_up, with: { phone: '+1 (202) 555-1213' })
+        second_user = build_stubbed(:user, :fully_registered, with: { phone: '+1 (202) 555-1213' })
         allow(User).to receive(:exists?).with(email: 'new@gmail.com').and_return(false)
         allow(User).to receive(:exists?).with(
           phone_configuration: {

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -12,7 +12,7 @@ module SpAuthHelper
   end
 
   def create_ial2_account_go_back_to_sp_and_sign_out(sp)
-    user = create(:user, :signed_up)
+    user = create(:user, :fully_registered)
     visit_idp_from_sp_with_ial2(sp)
     fill_in_credentials_and_submit(user.email, user.password)
     fill_in_code_with_last_phone_otp

--- a/spec/views/account_reset/request/show.html.erb_spec.rb
+++ b/spec/views/account_reset/request/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'account_reset/request/show.html.erb' do
   before do
-    user = create(:user, :signed_up, :with_personal_key)
+    user = create(:user, :fully_registered, :with_personal_key)
     allow(view).to receive(:current_user).and_return(user)
   end
 

--- a/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 describe 'accounts/connected_accounts/show.html.erb' do
-  let(:user) { create(:user, :signed_up, :with_personal_key) }
+  let(:user) { create(:user, :fully_registered, :with_personal_key) }
 
   before do
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/accounts/history/show.html.erb_spec.rb
+++ b/spec/views/accounts/history/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'accounts/history/show.html.erb' do
-  let(:user) { create(:user, :signed_up, :with_personal_key) }
+  let(:user) { create(:user, :fully_registered, :with_personal_key) }
 
   before do
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'accounts/show.html.erb' do
-  let(:user) { create(:user, :signed_up, :with_personal_key) }
+  let(:user) { create(:user, :fully_registered, :with_personal_key) }
 
   before do
     allow(view).to receive(:current_user).and_return(user)
@@ -72,7 +72,7 @@ describe 'accounts/show.html.erb' do
   context 'phone listing and adding' do
     context 'user has no phone' do
       let(:user) do
-        record = create(:user, :signed_up, :with_piv_or_cac)
+        record = create(:user, :fully_registered, :with_piv_or_cac)
         record.phone_configurations = []
         record
       end
@@ -102,7 +102,7 @@ describe 'accounts/show.html.erb' do
 
   context 'auth app listing and adding' do
     context 'user has no auth app' do
-      let(:user) { create(:user, :signed_up, :with_piv_or_cac) }
+      let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
       it 'does not render auth app' do
         expect(view).to_not render_template(partial: '_auth_apps')
@@ -110,7 +110,7 @@ describe 'accounts/show.html.erb' do
     end
 
     context 'user has an auth app' do
-      let(:user) { create(:user, :signed_up, :with_authentication_app) }
+      let(:user) { create(:user, :fully_registered, :with_authentication_app) }
       it 'renders the auth app section' do
         render
 
@@ -121,7 +121,7 @@ describe 'accounts/show.html.erb' do
 
   context 'PIV/CAC listing and adding' do
     context 'user has no piv/cac' do
-      let(:user) { create(:user, :signed_up, :with_authentication_app) }
+      let(:user) { create(:user, :fully_registered, :with_authentication_app) }
 
       it 'does not render piv/cac' do
         expect(view).to_not render_template(partial: '_piv_cac')
@@ -129,7 +129,7 @@ describe 'accounts/show.html.erb' do
     end
 
     context 'user has a piv/cac' do
-      let(:user) { create(:user, :signed_up, :with_piv_or_cac) }
+      let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
       it 'renders the piv/cac section' do
         render
 

--- a/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
+++ b/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'accounts/two_factor_authentication/show.html.erb' do
-  let(:user) { create(:user, :signed_up, :with_personal_key) }
+  let(:user) { create(:user, :fully_registered, :with_personal_key) }
 
   before do
     allow(view).to receive(:current_user).and_return(user)
@@ -25,7 +25,7 @@ describe 'accounts/two_factor_authentication/show.html.erb' do
   end
 
   context 'when user is TOTP enabled' do
-    let(:user) { create(:user, :signed_up, :with_authentication_app) }
+    let(:user) { create(:user, :fully_registered, :with_authentication_app) }
 
     before do
       assign(

--- a/spec/views/devise/passwords/edit.html.erb_spec.rb
+++ b/spec/views/devise/passwords/edit.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'devise/passwords/edit.html.erb' do
   before do
-    user = build_stubbed(:user, :signed_up)
+    user = build_stubbed(:user, :fully_registered)
     @reset_password_form = ResetPasswordForm.new(user)
   end
 

--- a/spec/views/idv/gpo/index.html.erb_spec.rb
+++ b/spec/views/idv/gpo/index.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'idv/gpo/index.html.erb' do
   let(:go_back_path) { nil }
   let(:step_indicator_steps) { Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS }
   let(:presenter) do
-    user = build_stubbed(:user, :signed_up)
+    user = build_stubbed(:user, :fully_registered)
     Idv::GpoPresenter.new(user, {})
   end
 

--- a/spec/views/idv/review/new.html.erb_spec.rb
+++ b/spec/views/idv/review/new.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'idv/review/new.html.erb' do
     let(:dob) { '1972-03-29' }
 
     before do
-      user = build_stubbed(:user, :signed_up)
+      user = build_stubbed(:user, :fully_registered)
       allow(view).to receive(:current_user).and_return(user)
       allow(view).to receive(:step_indicator_steps).
         and_return(Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS)

--- a/spec/views/mfa_confirmation/show.html.erb_spec.rb
+++ b/spec/views/mfa_confirmation/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'mfa_confirmation/show.html.erb' do
-  let(:user) { create(:user, :signed_up, :with_personal_key) }
+  let(:user) { create(:user, :fully_registered, :with_personal_key) }
 
   before do
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'sign_up/completions/show.html.erb' do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
   let(:service_provider) { create(:service_provider) }
   let(:decrypted_pii) { {} }
   let(:requested_attributes) { [:email] }

--- a/spec/views/two_factor_authentication/otp_expired/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_expired/show.html.erb_spec.rb
@@ -55,7 +55,7 @@ describe 'two_factor_authentication/otp_expired/show.html.erb' do
   end
 
   context 'if a user is signing in to an existing account' do
-    let(:user) { create(:user, :signed_up, :with_phone) }
+    let(:user) { create(:user, :fully_registered, :with_phone) }
 
     it 'use another phone number option is not on screen' do
       render

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -82,7 +82,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
 
     context 'user signed up' do
       before do
-        user = create(:user, :signed_up, personal_key: '1')
+        user = create(:user, :fully_registered, personal_key: '1')
         allow(view).to receive(:current_user).and_return(user)
         render
       end
@@ -97,7 +97,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
 
     context 'user is reauthenticating' do
       before do
-        user = create(:user, :signed_up, personal_key: '1')
+        user = create(:user, :fully_registered, personal_key: '1')
         allow(view).to receive(:current_user).and_return(user)
         allow(@presenter).to receive(:reauthn).and_return(true)
         render
@@ -119,7 +119,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
 
     context 'user is changing phone number' do
       it 'provides a cancel link to return to profile' do
-        user = create(:user, :signed_up, personal_key: '1')
+        user = create(:user, :fully_registered, personal_key: '1')
         allow(view).to receive(:current_user).and_return(user)
         data = presenter_data.merge(confirmation_for_add_phone: true)
         @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
@@ -281,8 +281,10 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
     context 'when user has otp_expiration but the otp_expired redirect flag off' do
       before do
         user = create(
-          :user, :signed_up, otp_delivery_preference: 'voice',
-                             direct_otp_sent_at: Time.zone.now
+          :user,
+          :fully_registered,
+          otp_delivery_preference: 'voice',
+          direct_otp_sent_at: Time.zone.now,
         )
         allow(view).to receive(:current_user).and_return(user)
         otp_expiration = user.direct_otp_sent_at +
@@ -303,8 +305,10 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
     context 'when user has otp_expiration but the otp_expired redirect flag on' do
       before do
         user = create(
-          :user, :signed_up, otp_delivery_preference: 'voice',
-                             direct_otp_sent_at: Time.zone.now
+          :user,
+          :fully_registered,
+          otp_delivery_preference: 'voice',
+          direct_otp_sent_at: Time.zone.now,
         )
         allow(view).to receive(:current_user).and_return(user)
         otp_expiration = user.direct_otp_sent_at +

--- a/spec/views/two_factor_authentication/personal_key_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/personal_key_verification/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'two_factor_authentication/personal_key_verification/show.html.erb' do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   before do
     @presenter = TwoFactorAuthCode::PersonalKeyPresenter.new

--- a/spec/views/two_factor_authentication/totp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'two_factor_authentication/totp_verification/show.html.erb' do
-  let(:user) { create(:user, :signed_up, :with_authentication_app) }
+  let(:user) { create(:user, :fully_registered, :with_authentication_app) }
   let(:presenter_data) do
     attributes_for(:generic_otp_presenter).merge(
       two_factor_authentication_method: 'authenticator',

--- a/spec/views/users/backup_code_setup/create.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/create.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'users/backup_code_setup/create.html.erb' do
-  let(:user) { build(:user, :signed_up) }
+  let(:user) { build(:user, :fully_registered) }
 
   before do
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/users/delete/show.html.erb_spec.rb
+++ b/spec/views/users/delete/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'users/delete/show.html.erb' do
-  let(:user) { build_stubbed(:user, :signed_up) }
+  let(:user) { build_stubbed(:user, :fully_registered) }
 
   before do
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/users/piv_cac_authentication_setup/new.html.erb_spec.rb
+++ b/spec/views/users/piv_cac_authentication_setup/new.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'users/piv_cac_authentication_setup/new.html.erb' do
   context 'user has sufficient factors' do
     it 'renders a link to cancel and go back to the account page' do
-      user = create(:user, :signed_up)
+      user = create(:user, :fully_registered)
       allow(view).to receive(:current_user).and_return(user)
       allow(view).to receive(:user_session).and_return(signing_up: false)
       allow(view).to receive(:in_multi_mfa_selection_flow?).and_return(false)

--- a/spec/views/users/totp_setup/new.html.erb_spec.rb
+++ b/spec/views/users/totp_setup/new.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'users/totp_setup/new.html.erb' do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   context 'user has sufficient factors enabled' do
     before do

--- a/spec/views/users/webauthn_setup/new.html.erb_spec.rb
+++ b/spec/views/users/webauthn_setup/new.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'users/webauthn_setup/new.html.erb' do
-  let(:user) { create(:user, :signed_up) }
+  let(:user) { create(:user, :fully_registered) }
 
   context 'webauthn platform' do
     let(:platform_authenticator) { true }


### PR DESCRIPTION
## 🛠 Summary of changes

Renames the User spec factory `signed_up` trait to `fully_registered`, to improve clarity that this reflects a user who has completed all of (a) submitting their email address, (b) confirming their email address, and (c) adding a multi-factor authentication method. This also improves consistency with the new [`User#fully_registered?`](https://github.com/18F/identity-idp/blob/f60d49f861691dc34845392a1cc675aeb6de67b8/app/models/user.rb#L69-L71) method.

See: https://github.com/18F/identity-idp/pull/8270/files#r1176848052

## 📜 Testing Plan

```
rspec
```