### PR TITLE
Require less cleanup after updating Acuant

### DIFF
--- a/app/javascript/packages/document-capture/context/acuant.tsx
+++ b/app/javascript/packages/document-capture/context/acuant.tsx
@@ -193,8 +193,8 @@ const getActualAcuantCamera = (): AcuantCameraInterface => {
 };
 
 function AcuantContextProvider({
-  sdkSrc = '/acuant/11.8.1/AcuantJavascriptWebSdk.min.js',
-  cameraSrc = '/acuant/11.8.1/AcuantCamera.min.js',
+  sdkSrc = '/acuant/11.8.2/AcuantJavascriptWebSdk.min.js',
+  cameraSrc = '/acuant/11.8.2/AcuantCamera.min.js',
   credentials = null,
   endpoint = null,
   glareThreshold = DEFAULT_ACCEPTABLE_GLARE_SCORE,

--- a/app/javascript/packages/document-capture/context/acuant.tsx
+++ b/app/javascript/packages/document-capture/context/acuant.tsx
@@ -193,8 +193,8 @@ const getActualAcuantCamera = (): AcuantCameraInterface => {
 };
 
 function AcuantContextProvider({
-  sdkSrc = '/acuant/11.8.2/AcuantJavascriptWebSdk.min.js',
-  cameraSrc = '/acuant/11.8.2/AcuantCamera.min.js',
+  sdkSrc,
+  cameraSrc,
   credentials = null,
   endpoint = null,
   glareThreshold = DEFAULT_ACCEPTABLE_GLARE_SCORE,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -124,8 +124,8 @@ idv_available: true
 idv_contact_phone_number: (844) 555-5555
 idv_max_attempts: 5
 idv_min_age_years: 13
-idv_acuant_sdk_version_default: '11.8.1'
-idv_acuant_sdk_version_alternate: '11.8.0'
+idv_acuant_sdk_version_default: '11.8.2'
+idv_acuant_sdk_version_alternate: '11.8.1'
 idv_acuant_sdk_upgrade_a_b_testing_enabled: false
 idv_acuant_sdk_upgrade_a_b_testing_percent: 50
 idv_send_link_attempt_window_in_minutes: 10

--- a/spec/javascript/packages/document-capture/components/acuant-sdk-spec.js
+++ b/spec/javascript/packages/document-capture/components/acuant-sdk-spec.js
@@ -15,6 +15,10 @@ describe('Acuant SDK Loading Tests', async () => {
     VERSION_REGEX.test(dir),
   );
 
+  if (!sdks.length) {
+    throw new Error('Expected to find at least one SDK version, but found none');
+  }
+
   sdks.forEach((version) => {
     describe(version, () => {
       const TEST_URL = `file://${__dirname}/index.html`;

--- a/spec/javascript/packages/document-capture/components/acuant-sdk-spec.js
+++ b/spec/javascript/packages/document-capture/components/acuant-sdk-spec.js
@@ -3,10 +3,10 @@
  *
  */
 import { JSDOM } from 'jsdom';
-import AcuantJavascriptWebSdk from '../../../../../public/acuant/11.8.1/AcuantJavascriptWebSdk.min.js';
+import AcuantJavascriptWebSdk from '../../../../../public/acuant/11.8.2/AcuantJavascriptWebSdk.min.js';
 
 const sdkPaths = {
-  '11.8.1': '../../../../../public/acuant/11.8.1/AcuantJavascriptWebSdk.min.js',
+  '11.8.2': '../../../../../public/acuant/11.8.2/AcuantJavascriptWebSdk.min.js',
 };
 
 const TEST_URL = `file://${__dirname}/index.html`;
@@ -25,14 +25,14 @@ describe('Acuant SDK Loading Tests', () => {
   it('Can load something from the SDK file', () => {
     expect(AcuantJavascriptWebSdk).to.exist();
   });
-  describe('DOM Loading 11.8.1', () => {
+  describe('DOM Loading 11.8.2', () => {
     before((done) => {
       const scriptEl = document.createElement('script');
       scriptEl.id = 'test-acuant-sdk-script';
       scriptEl.onload = () => {
         done();
       };
-      scriptEl.src = sdkPaths['11.8.1'];
+      scriptEl.src = sdkPaths['11.8.2'];
       document.body.append(scriptEl);
     });
     it('There is a script element in the DOM', () => {

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -15,7 +15,7 @@ describe 'idv/shared/_document_capture.html.erb' do
   let(:back_image_upload_url) { nil }
   let(:acuant_sdk_upgrade_a_b_testing_enabled) { false }
   let(:use_alternate_sdk) { false }
-  let(:acuant_version) { '11.8.1' }
+  let(:acuant_version) { '11.8.2' }
   let(:in_person_cta_variant_testing_enabled) { false }
   let(:in_person_cta_variant_active) { '' }
 

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -15,7 +15,7 @@ describe 'idv/shared/_document_capture.html.erb' do
   let(:back_image_upload_url) { nil }
   let(:acuant_sdk_upgrade_a_b_testing_enabled) { false }
   let(:use_alternate_sdk) { false }
-  let(:acuant_version) { '11.8.2' }
+  let(:acuant_version) { '1.3.3.7' }
   let(:in_person_cta_variant_testing_enabled) { false }
   let(:in_person_cta_variant_active) { '' }
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9566](https://cm-jira.usa.gov/browse/LG-9566)

## 🛠 Summary of changes

We have a few places in the codebase where we refer to specific versions of the Acuant SDK. This means we have to make additional code updates after upgrading the SDK. This PR attempts to reduce the amount of cleanup work necessary by:

- Updating frontend JS specs to just test all Acuant versions present in git rather than hardcoding a version
- Removing a couple other unnecessary hardcoded references to the Acuant SDK
