### PR TITLE
LG-9494 capture complete checks if previous step is done

### DIFF
--- a/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
+++ b/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
@@ -19,6 +19,12 @@ module Idv
         return handle_invalid_document_capture_session if document_capture_session.expired?
       end
 
+      def confirm_document_capture_session_complete
+        return if document_capture_session&.load_result&.success?
+
+        redirect_to idv_hybrid_mobile_document_capture_url
+      end
+
       def document_capture_session
         return @document_capture_session if defined?(@document_capture_session)
         @document_capture_session =

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -28,7 +28,11 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('document_capture', :update, true)
 
-      redirect_to idv_ssn_url
+      if result.success?
+        redirect_to idv_ssn_url
+      else
+        redirect_to idv_document_capture_url
+      end
     end
 
     def extra_view_variables

--- a/app/controllers/idv/hybrid_mobile/capture_complete_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/capture_complete_controller.rb
@@ -4,6 +4,7 @@ module Idv
       include HybridMobileConcern
 
       before_action :check_valid_document_capture_session
+      before_action :confirm_document_capture_session_complete
 
       def show
         analytics.idv_doc_auth_capture_complete_visited(**analytics_arguments)

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -23,7 +23,11 @@ module Idv
         Funnel::DocAuth::RegisterStep.new(document_capture_user.id, sp_session[:issuer]).
           call('document_capture', :update, true)
 
-        redirect_to idv_hybrid_mobile_capture_complete_url
+        if result.success?
+          redirect_to idv_hybrid_mobile_capture_complete_url
+        else
+          redirect_to idv_hybrid_mobile_document_capture_url
+        end
       end
 
       def extra_view_variables

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -7,6 +7,11 @@ module Idv
       before_action :override_csp_to_allow_acuant
 
       def show
+        if document_capture_session&.load_result&.success?
+          redirect_to idv_hybrid_mobile_capture_complete_url
+          return
+        end
+
         analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)
 
         Funnel::DocAuth::RegisterStep.new(document_capture_user.id, sp_session[:issuer]).

--- a/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
@@ -25,6 +25,8 @@ describe Idv::HybridMobile::CaptureCompleteController do
   before do
     session[:doc_capture_user_id] = user&.id
     session[:document_capture_session_uuid] = document_capture_session_uuid
+    allow(subject).to receive(:confirm_document_capture_session_complete).
+      and_return(true)
   end
 
   describe 'before_actions' do
@@ -32,6 +34,13 @@ describe Idv::HybridMobile::CaptureCompleteController do
       expect(subject).to have_actions(
         :before,
         :check_valid_document_capture_session,
+      )
+    end
+
+    it 'includes document capture session complete before action' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_document_capture_session_complete,
       )
     end
   end

--- a/spec/features/idv/hybrid_flow_spec.rb
+++ b/spec/features/idv/hybrid_flow_spec.rb
@@ -9,7 +9,7 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
 
   before do
     allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
-    allow(IdentityConfig.store).to receive(:doc_auth_enable_presigned_s3_urls).and_return(true)
+    allow(IdentityConfig.store).to receive(:doc_auth_enable_presigned_s3_urls).and_return(false)
     allow(Identity::Hostdata::EC2).to receive(:load).
       and_return(OpenStruct.new(region: 'us-west-2', account_id: '123456789'))
   end

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -40,6 +40,11 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
 
     perform_in_browser(:mobile) do
       visit @sms_link
+
+      # Confirm app disallows jumping ahead to CaptureComplete page
+      visit idv_hybrid_mobile_capture_complete_url
+      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -12,7 +12,7 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
       and_return(true)
 
     allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
-    allow(IdentityConfig.store).to receive(:doc_auth_enable_presigned_s3_urls).and_return(true)
+    allow(IdentityConfig.store).to receive(:doc_auth_enable_presigned_s3_urls).and_return(false)
     allow(Identity::Hostdata::EC2).to receive(:load).
       and_return(OpenStruct.new(region: 'us-west-2', account_id: '123456789'))
   end

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -51,6 +51,10 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
       expect(page).to have_content(t('doc_auth.headings.capture_complete'))
       expect(page).to have_text(t('doc_auth.instructions.switch_back'))
       expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+      # Confirm app disallows jumping back to DocumentCapture page
+      visit idv_hybrid_mobile_document_capture_url
+      expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
     end
 
     perform_in_browser(:desktop) do


### PR DESCRIPTION
[LG-9494](https://cm-jira.usa.gov/browse/LG-9494)

## 🛠 Summary of changes

Add before action to CaptureCompleteController to redirect if DocumentCapture step was not successful, in the hybrid flow. Also in DocumentCapture#show, redirect to CaptureComplete if document capture is already done.

Set aysnc to false in hybrid flow feature specs.

Note: Do we want/need to check if document capture was successful before leaving DocumentCaptureController#update, or do we rely on the following controller (CaptureComplete or Ssn) to redirect backwards when needed?

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create account
- [ ] Start IdV, choose hybrid mobile flow
- [ ] Visit /verify/hybrid_mobile/capture_complete before uploading documents
- [ ] Expect to stay on document capture step.
- [ ] Upload docs, submit
- [ ] Visit /verify/hybrid_mobile/document_capture
- [ ] Expect to stay on capture complete step
