### PR TITLE
LG-9568 link sent controller

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -26,6 +26,9 @@ module IdvStepConcern
 
     if flow_path == 'standard'
       redirect_to idv_document_capture_url
+    elsif flow_path == 'hybrid' &&
+          IdentityConfig.store.doc_auth_link_sent_controller_enabled
+      redirect_to idv_link_sent_url
     else
       flow_session.delete('Idv::Steps::DocumentCaptureStep')
       redirect_to idv_doc_auth_url

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -35,7 +35,7 @@ module Idv
     end
 
     def extra_view_variables
-      { phone: idv_session[:phone_for_mobile_flow] }
+      { phone: flow_session[:phone_for_mobile_flow] }
     end
 
     private

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -37,8 +37,7 @@ module Idv
 
     def extra_view_variables
       { phone: flow_session[:phone_for_mobile_flow],
-        flow_session: flow_session,
-      }
+        flow_session: flow_session }
     end
 
     private
@@ -66,6 +65,7 @@ module Idv
       {
         step: 'link_sent',
         analytics_id: 'Doc Auth',
+        flow_path: 'hybrid',
         irs_reproofing: irs_reproofing?,
       }.merge(**acuant_sdk_ab_test_analytics_args)
     end
@@ -74,7 +74,7 @@ module Idv
       save_proofing_components
       extract_pii_from_doc(get_results_response, store_in_session: true)
       mark_upload_step_complete
-      #flow_session[:flow_path] = @flow.flow_path
+      flow_session[:flow_path] = 'hybrid'
     end
 
     def render_document_capture_cancelled

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -5,6 +5,7 @@ module Idv
     include StepIndicatorConcern
     include StepUtilitiesConcern
 
+    before_action :render_404_if_link_sent_controller_disabled
     before_action :confirm_two_factor_authenticated
     before_action :confirm_upload_step_complete
     before_action :confirm_document_capture_needed
@@ -39,6 +40,10 @@ module Idv
     end
 
     private
+
+    def render_404_if_link_sent_controller_disabled
+      render_not_found unless IdentityConfig.store.doc_auth_link_sent_controller_enabled
+    end
 
     def confirm_upload_step_complete
       return if flow_session['Idv::Steps::UploadStep']

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -21,7 +21,7 @@ module Idv
     end
 
     def update
-      analytics.idv_doc_auth_link_sent_submitted(analytics_arguments)
+      analytics.idv_doc_auth_link_sent_submitted(**analytics_arguments)
 
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('link_sent', :update, true)

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -1,0 +1,125 @@
+module Idv
+  class LinkSentController < ApplicationController
+    include IdvSession
+    include IdvStepConcern
+    include StepIndicatorConcern
+    include StepUtilitiesConcern
+
+    before_action :confirm_two_factor_authenticated
+    before_action :confirm_upload_step_complete
+    before_action :confirm_document_capture_needed
+
+    def show
+      analytics.idv_doc_auth_link_sent_visited(**analytics_arguments)
+
+      Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
+        call('link_sent', :view, true)
+
+      render :show, locals: extra_view_variables
+    end
+
+    def update
+      flow_session['redo_document_capture'] = nil # done with this redo
+
+      analytics.idv_doc_auth_link_sent_submitted(analytics_arguments)
+
+      Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
+        call('link_sent', :update, true)
+
+      redirect_to idv_ssn_url
+    end
+
+    def extra_view_variables
+      # Used to call :verify_document_status in idv/shared/_document_capture.html.erb
+      # That code can be updated after the hybrid flow is out of the FSM, and then
+      # this can be removed.
+      @step_url = :idv_doc_auth_step_url
+
+      url_builder = ImageUploadPresignedUrlGenerator.new
+
+      {
+        flow_session: flow_session,
+        flow_path: 'standard',
+        sp_name: decorated_session.sp_name,
+        failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
+
+        front_image_upload_url: url_builder.presigned_image_upload_url(
+          image_type: 'front',
+          transaction_id: flow_session[:document_capture_session_uuid],
+        ),
+        back_image_upload_url: url_builder.presigned_image_upload_url(
+          image_type: 'back',
+          transaction_id: flow_session[:document_capture_session_uuid],
+        ),
+      }.merge(
+        acuant_sdk_upgrade_a_b_testing_variables,
+        in_person_cta_variant_testing_variables,
+      )
+    end
+
+    private
+
+    def confirm_upload_step_complete
+      return if flow_session['Idv::Steps::UploadStep']
+
+      redirect_to idv_doc_auth_url
+    end
+
+    def confirm_document_capture_needed
+      return if flow_session['redo_document_capture']
+
+      pii = flow_session['pii_from_doc'] # hash with indifferent access
+      return if pii.blank? && !idv_session.verify_info_step_complete?
+
+      redirect_to idv_ssn_url
+    end
+
+    def analytics_arguments
+      {
+        flow_path: flow_path,
+        step: 'link_sent',
+        analytics_id: 'Doc Auth',
+        irs_reproofing: irs_reproofing?,
+      }.merge(**acuant_sdk_ab_test_analytics_args)
+    end
+
+    def acuant_sdk_upgrade_a_b_testing_variables
+      bucket = AbTests::ACUANT_SDK.bucket(flow_session[:document_capture_session_uuid])
+      testing_enabled = IdentityConfig.store.idv_acuant_sdk_upgrade_a_b_testing_enabled
+      use_alternate_sdk = (bucket == :use_alternate_sdk)
+      if use_alternate_sdk
+        acuant_version = IdentityConfig.store.idv_acuant_sdk_version_alternate
+      else
+        acuant_version = IdentityConfig.store.idv_acuant_sdk_version_default
+      end
+      {
+        acuant_sdk_upgrade_a_b_testing_enabled:
+            testing_enabled,
+        use_alternate_sdk: use_alternate_sdk,
+        acuant_version: acuant_version,
+      }
+    end
+
+    def in_person_cta_variant_testing_variables
+      bucket = AbTests::IN_PERSON_CTA.bucket(flow_session[:document_capture_session_uuid])
+      session[:in_person_cta_variant] = bucket
+      {
+        in_person_cta_variant_testing_enabled:
+        IdentityConfig.store.in_person_cta_variant_testing_enabled,
+        in_person_cta_variant_active: bucket,
+      }
+    end
+
+    def successful_response
+      FormResponse.new(success: true)
+    end
+
+    # copied from Flow::Failure module
+    def failure(message, extra = nil)
+      flow_session[:error_message] = message
+      form_response_params = { success: false, errors: { message: message } }
+      form_response_params[:extra] = extra unless extra.nil?
+      FormResponse.new(**form_response_params)
+    end
+  end
+end

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -36,7 +36,9 @@ module Idv
     end
 
     def extra_view_variables
-      { phone: flow_session[:phone_for_mobile_flow] }
+      { phone: flow_session[:phone_for_mobile_flow],
+        flow_session: flow_session,
+      }
     end
 
     private
@@ -62,7 +64,6 @@ module Idv
 
     def analytics_arguments
       {
-        flow_path: flow_path,
         step: 'link_sent',
         analytics_id: 'Doc Auth',
         irs_reproofing: irs_reproofing?,
@@ -73,7 +74,7 @@ module Idv
       save_proofing_components
       extract_pii_from_doc(get_results_response, store_in_session: true)
       mark_upload_step_complete
-      flow_session[:flow_path] = @flow.flow_path
+      #flow_session[:flow_path] = @flow.flow_path
     end
 
     def render_document_capture_cancelled

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -76,7 +76,7 @@ module Idv
         )
 
         if IdentityConfig.store.doc_auth_link_sent_controller_enabled
-          flow_session[:flow_path] = @flow.flow_path
+          flow_session[:flow_path] = 'hybrid'
           redirect_to idv_link_sent_url
         end
 

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -63,6 +63,7 @@ module Idv
         throttle.increment!
         return throttled_failure if throttle.throttled?
         idv_session[:phone_for_mobile_flow] = permit(:phone)[:phone]
+        flow_session[:phone_for_mobile_flow] = idv_session[:phone_for_mobile_flow]
         telephony_result = send_link
         failure_reason = nil
         if !telephony_result.success?

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -75,6 +75,11 @@ module Idv
           failure_reason: failure_reason,
         )
 
+        if IdentityConfig.store.doc_auth_link_sent_controller_enabled
+          flow_session[:flow_path] = @flow.flow_path
+          redirect_to idv_link_sent_url
+        end
+
         build_telephony_form_response(telephony_result)
       end
 

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -57,4 +57,4 @@
   <%= javascript_packs_tag_once 'doc-capture-polling' %>
 <% end %>
 
-<%= render 'idv/shared/back', action: 'cancel_link_sent', class: 'link-sent-back-link' %>
+<%= render 'idv/shared/back', action: 'cancel_link_sent', class: 'link-sent-back-link', step_url: :idv_doc_auth_url %>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -48,4 +48,4 @@
   <%= javascript_packs_tag_once 'doc-capture-polling' %>
 <% end %>
 
-<%= render 'idv/shared/back', action: 'cancel_link_sent', class: 'link-sent-back-link', step_url: idv_doc_auth_url %>
+<%= render 'idv/shared/back', action: 'cancel_link_sent', class: 'link-sent-back-link' %>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -45,8 +45,8 @@
 
 <div class="margin-top-4 margin-bottom-0">
   <%= button_to(
-        idv_ssn_url,
-        method: :get,
+        idv_link_sent_url,
+        method: :put,
         class: 'usa-button usa-button--big usa-button--wide',
         form_class: 'link-sent-continue-button-form',
       ) { t('forms.buttons.continue') } %>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -1,3 +1,12 @@
+<% content_for(:pre_flash_content) do %>
+  <%= render StepIndicatorComponent.new(
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        current_step: :verify_id,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      ) %>
+<% end %>
+
 <% title t('titles.doc_auth.link_sent') %>
 
 <!-- Hide meta refresh if we are polling -->

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -1,0 +1,51 @@
+<% title t('titles.doc_auth.link_sent') %>
+
+<!-- Hide meta refresh if we are polling -->
+<% if @meta_refresh && !FeatureManagement.doc_capture_polling_enabled? %>
+  <%= content_for(:meta_refresh) { @meta_refresh.to_s } %>
+<% end %>
+<% if flow_session[:error_message] %>
+  <%= render AlertComponent.new(
+        type: :error,
+        class: 'margin-bottom-4',
+        message: flow_session[:error_message],
+      ) %>
+<% end %>
+
+<%= render AlertComponent.new(type: :warning, class: 'margin-bottom-4') do %>
+  <strong class="display-block"><%= t('doc_auth.info.keep_window_open') %></strong>
+  <% if FeatureManagement.doc_capture_polling_enabled? %>
+    <%= t('doc_auth.info.link_sent_complete_polling') %>
+  <% else %>
+    <%= t('doc_auth.info.link_sent_complete_no_polling') %>
+  <% end %>
+<% end %>
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.text_message')) %>
+<div class="grid-row">
+  <div class="grid-col-12 tablet:grid-col-3">
+    <%= image_tag asset_url('idv/phone-icon.svg'), width: 88, height: 88, alt: t('image_description.camera_mobile_phone') %>
+  </div>
+  <div class="grid-col-12 tablet:grid-col-9">
+    <p>
+      <%= t('doc_auth.info.you_entered') %>
+      <strong><%= local_assigns[:phone] %></strong>
+    </p>
+    <p><%= t('doc_auth.info.link_sent') %></p>
+  </div>
+</div>
+
+<div class="margin-top-4 margin-bottom-0">
+  <%= button_to(
+        idv_ssn_url,
+        method: :get,
+        class: 'usa-button usa-button--big usa-button--wide',
+        form_class: 'link-sent-continue-button-form',
+      ) { t('forms.buttons.continue') } %>
+</div>
+
+<% if FeatureManagement.doc_capture_polling_enabled? %>
+  <%= content_tag 'script', '', data: { status_endpoint: idv_capture_doc_status_url } %>
+  <%= javascript_packs_tag_once 'doc-capture-polling' %>
+<% end %>
+
+<%= render 'idv/shared/back', action: 'cancel_link_sent', class: 'link-sent-back-link', step_url: idv_doc_auth_url %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -91,6 +91,7 @@ doc_auth_s3_request_timeout: 5
 doc_auth_error_dpi_threshold: 290
 doc_auth_error_glare_threshold: 40
 doc_auth_error_sharpness_threshold: 40
+doc_auth_link_sent_controller_enabled: false
 doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_tips: 3
 doc_auth_max_capture_attempts_before_native_camera: 2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -333,6 +333,8 @@ Rails.application.routes.draw do
       get '/hybrid_mobile/document_capture' => 'hybrid_mobile/document_capture#show'
       put '/hybrid_mobile/document_capture' => 'hybrid_mobile/document_capture#update'
       get '/hybrid_mobile/capture_complete' => 'hybrid_mobile/capture_complete#show'
+      get '/link_sent' => 'link_sent#show'
+      put '/link_sent' => 'link_sent#update'
       get '/ssn' => 'ssn#show'
       put '/ssn' => 'ssn#update'
       get '/verify_info' => 'verify_info#show'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -161,6 +161,7 @@ class IdentityConfig
     config.add(:doc_auth_error_glare_threshold, type: :integer)
     config.add(:doc_auth_error_sharpness_threshold, type: :integer)
     config.add(:doc_auth_extend_timeout_by_minutes, type: :integer)
+    config.add(:doc_auth_link_sent_controller_enabled, type: :boolean)
     config.add(:doc_auth_max_attempts, type: :integer)
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -96,24 +96,4 @@ describe Idv::LinkSentController do
       end
     end
   end
-
-  describe '#update' do
-    let(:analytics_name) { 'IdV: doc auth link_sent submitted' }
-    let(:analytics_args) do
-      {
-        success: true,
-        errors: {},
-        analytics_id: 'Doc Auth',
-        flow_path: 'hybrid',
-        irs_reproofing: false,
-        step: 'link_sent',
-      }
-    end
-
-    it 'sends analytics_submitted event' do
-      put :update
-
-      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
-    end
-  end
 end

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+describe Idv::LinkSentController do
+  include IdvHelper
+
+  let(:flow_session) do
+    { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
+      :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
+      :flow_path => 'hybrid',
+      'Idv::Steps::UploadStep' => true }
+  end
+
+  let(:user) { create(:user) }
+  let(:service_provider) do
+    create(
+      :service_provider,
+      issuer: 'http://sp.example.com',
+      app_id: '123',
+    )
+  end
+
+  let(:default_sdk_version) { IdentityConfig.store.idv_acuant_sdk_version_default }
+  let(:alternate_sdk_version) { IdentityConfig.store.idv_acuant_sdk_version_alternate }
+
+  before do
+    allow(subject).to receive(:flow_session).and_return(flow_session)
+    stub_sign_in(user)
+    stub_analytics
+    stub_attempts_tracker
+    allow(@analytics).to receive(:track_event)
+  end
+
+  describe 'before_actions' do
+    it 'includes authentication before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+      )
+    end
+
+    it 'checks that upload step is complete' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_upload_step_complete,
+      )
+    end
+  end
+
+  describe '#show' do
+    let(:analytics_name) { 'IdV: doc auth link_sent visited' }
+    let(:analytics_args) do
+      {
+        analytics_id: 'Doc Auth',
+        flow_path: 'hybrid',
+        irs_reproofing: false,
+        step: 'link_sent',
+      }
+    end
+
+    it 'renders the show template' do
+      get :show
+
+      expect(response).to render_template :show
+    end
+
+    it 'sends analytics_visited event' do
+      get :show
+
+      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+    end
+
+    it 'updates DocAuthLog link_sent_view_count' do
+      doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+      expect { get :show }.to(
+        change { doc_auth_log.reload.link_sent_view_count }.from(0).to(1),
+      )
+    end
+
+    context 'upload step is not complete' do
+      it 'redirects to idv_doc_auth_url' do
+        flow_session['Idv::Steps::UploadStep'] = nil
+
+        get :show
+
+        expect(response).to redirect_to(idv_doc_auth_url)
+      end
+    end
+
+    context 'with pii in session' do
+      it 'redirects to ssn step' do
+        flow_session['pii_from_doc'] = Idp::Constants::MOCK_IDV_APPLICANT
+        get :show
+
+        expect(response).to redirect_to(idv_ssn_url)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:analytics_name) { 'IdV: doc auth link_sent submitted' }
+    let(:analytics_args) do
+      {
+        success: true,
+        errors: {},
+        analytics_id: 'Doc Auth',
+        flow_path: 'hybrid',
+        irs_reproofing: false,
+        step: 'link_sent',
+      }
+    end
+
+    it 'sends analytics_submitted event' do
+      put :update
+
+      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+    end
+  end
+end

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -7,6 +7,7 @@ describe Idv::LinkSentController do
     { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
       :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
       :flow_path => 'hybrid',
+      :phone_for_mobile_flow => '201-555-1212',
       'Idv::Steps::UploadStep' => true }
   end
 

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -19,9 +19,6 @@ describe Idv::LinkSentController do
     )
   end
 
-  let(:default_sdk_version) { IdentityConfig.store.idv_acuant_sdk_version_default }
-  let(:alternate_sdk_version) { IdentityConfig.store.idv_acuant_sdk_version_alternate }
-
   before do
     allow(subject).to receive(:flow_session).and_return(flow_session)
     stub_sign_in(user)

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -20,7 +20,11 @@ describe Idv::LinkSentController do
     )
   end
 
+  let(:feature_flag_enabled) { true }
+
   before do
+    allow(IdentityConfig.store).to receive(:doc_auth_link_sent_controller_enabled).
+      and_return(feature_flag_enabled)
     allow(subject).to receive(:flow_session).and_return(flow_session)
     stub_sign_in(user)
     stub_analytics
@@ -92,6 +96,14 @@ describe Idv::LinkSentController do
 
         expect(response).to redirect_to(idv_ssn_url)
       end
+    end
+  end
+
+  context 'feature flag disabled' do
+    let(:feature_flag_enabled) { false }
+    it 'returns a 404' do
+      get :show
+      expect(response.status).to eql(404)
     end
   end
 end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -32,7 +32,9 @@ feature 'doc auth link sent step' do
     context 'when link sent polling is enabled' do
       let(:doc_capture_polling_enabled) { true }
 
-      it 'Does not show continue button' do
+      # Currently get a javascript error when explicitly visiting the new url
+      # Try this again once upload redirects here.
+      xit 'Does not show continue button' do
         expect(page).not_to have_content('Continue') # doc_auth.buttons.continue
       end
     end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+feature 'doc auth link sent step' do
+  include IdvStepHelper
+  include DocAuthHelper
+  include DocCaptureHelper
+
+  context 'with combined upload step enabled', js: true do
+    let(:user) { sign_in_and_2fa_user }
+    let(:doc_capture_polling_enabled) { false }
+    let(:phone_number) { '415-555-0199' }
+
+    before do
+      allow(FeatureManagement).
+        to(receive(:doc_capture_polling_enabled?).and_return(doc_capture_polling_enabled))
+      user
+      complete_doc_auth_steps_before_upload_step
+      fill_in :doc_auth_phone, with: ''
+      fill_in :doc_auth_phone, with: phone_number
+      click_send_link
+    end
+
+    it 'Correctly renders the link sent step page' do
+      expect(page).to have_current_path(idv_doc_auth_link_sent_step)
+      expect(page).to have_content(phone_number)
+    end
+  end
+end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -33,7 +33,7 @@ feature 'doc auth link sent step' do
       let(:doc_capture_polling_enabled) { true }
 
       it 'Does not show continue button' do
-        expect(page).not_to have_content('Continue') #doc_auth.buttons.continue
+        expect(page).not_to have_content('Continue') # doc_auth.buttons.continue
       end
     end
   end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -24,7 +24,7 @@ feature 'doc auth link sent step' do
     end
 
     it 'Correctly renders the link sent step page' do
-      expect(page).to have_current_path(idv_link_sent_step)
+      expect(page).to have_current_path(idv_link_sent_url)
       expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
       expect(page).to have_content(phone_number)
     end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -25,6 +25,10 @@ feature 'doc auth link sent step' do
     expect(page).to have_current_path(idv_link_sent_url)
     expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
     expect(page).to have_content(phone_number)
+
+    # does not allow skipping ahead to ssn step
+    visit(idv_ssn_url)
+    expect(page).to have_current_path(idv_link_sent_url)
   end
 
   context 'when link sent polling is enabled' do

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -6,12 +6,11 @@ feature 'doc auth link sent step' do
   include DocCaptureHelper
 
   let(:user) { sign_in_and_2fa_user }
-  let(:doc_capture_polling_enabled) { false }
   let(:phone_number) { '415-555-0199' }
 
   before do
     allow(FeatureManagement).
-      to(receive(:doc_capture_polling_enabled?).and_return(doc_capture_polling_enabled))
+      to(receive(:doc_capture_polling_enabled?).and_return(false))
     allow(IdentityConfig.store).
       to(receive(:doc_auth_link_sent_controller_enabled).and_return(true))
 
@@ -29,17 +28,5 @@ feature 'doc auth link sent step' do
     # does not allow skipping ahead to ssn step
     visit(idv_ssn_url)
     expect(page).to have_current_path(idv_link_sent_url)
-  end
-
-  context 'when link sent polling is enabled' do
-    let(:doc_capture_polling_enabled) { true }
-
-    it 'Does not show continue button', :js do
-      # Prevent errors caused by "Do you want to leave this page?" alert
-      page.evaluate_script('window.onbeforeunload = null;')
-      page.evaluate_script('window.onunload = null;')
-
-      expect(page).not_to have_content(I18n.t('doc_auth.buttons.continue'))
-    end
   end
 end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -13,15 +13,28 @@ feature 'doc auth link sent step' do
     before do
       allow(FeatureManagement).
         to(receive(:doc_capture_polling_enabled?).and_return(doc_capture_polling_enabled))
+      allow(IdentityConfig.store).
+        to(receive(:doc_auth_link_sent_controller_enabled).and_return(true))
+
       user
       complete_doc_auth_steps_before_upload_step
       clear_and_fill_in(:doc_auth_phone, phone_number)
       click_send_link
+      visit(idv_link_sent_url)
     end
 
     it 'Correctly renders the link sent step page' do
-      expect(page).to have_current_path(idv_doc_auth_link_sent_step)
+      expect(page).to have_current_path(idv_link_sent_step)
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
       expect(page).to have_content(phone_number)
+    end
+
+    context 'when link sent polling is enabled' do
+      let(:doc_capture_polling_enabled) { true }
+
+      it 'Does not show continue button' do
+        expect(page).not_to have_content('Continue') #doc_auth.buttons.continue
+      end
     end
   end
 end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -15,8 +15,7 @@ feature 'doc auth link sent step' do
         to(receive(:doc_capture_polling_enabled?).and_return(doc_capture_polling_enabled))
       user
       complete_doc_auth_steps_before_upload_step
-      fill_in :doc_auth_phone, with: ''
-      fill_in :doc_auth_phone, with: phone_number
+      clear_and_fill_in(:doc_auth_phone, phone_number)
       click_send_link
     end
 

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -19,7 +19,6 @@ feature 'doc auth link sent step' do
     complete_doc_auth_steps_before_upload_step
     clear_and_fill_in(:doc_auth_phone, phone_number)
     click_send_link
-    visit(idv_link_sent_url)
   end
 
   it 'Correctly renders the link sent step page' do
@@ -31,10 +30,8 @@ feature 'doc auth link sent step' do
   context 'when link sent polling is enabled' do
     let(:doc_capture_polling_enabled) { true }
 
-    # Currently get a javascript error when explicitly visiting the new url
-    # Try this again once upload redirects here.
-    xit 'Does not show continue button', :js do
-      expect(page).not_to have_content('Continue') # doc_auth.buttons.continue
+    it 'Does not show continue button', :js do
+      expect(page).not_to have_content(I18n.t('doc_auth.buttons.continue'))
     end
   end
 end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -5,38 +5,36 @@ feature 'doc auth link sent step' do
   include DocAuthHelper
   include DocCaptureHelper
 
-  context 'with combined upload step enabled', js: true do
-    let(:user) { sign_in_and_2fa_user }
-    let(:doc_capture_polling_enabled) { false }
-    let(:phone_number) { '415-555-0199' }
+  let(:user) { sign_in_and_2fa_user }
+  let(:doc_capture_polling_enabled) { false }
+  let(:phone_number) { '415-555-0199' }
 
-    before do
-      allow(FeatureManagement).
-        to(receive(:doc_capture_polling_enabled?).and_return(doc_capture_polling_enabled))
-      allow(IdentityConfig.store).
-        to(receive(:doc_auth_link_sent_controller_enabled).and_return(true))
+  before do
+    allow(FeatureManagement).
+      to(receive(:doc_capture_polling_enabled?).and_return(doc_capture_polling_enabled))
+    allow(IdentityConfig.store).
+      to(receive(:doc_auth_link_sent_controller_enabled).and_return(true))
 
-      user
-      complete_doc_auth_steps_before_upload_step
-      clear_and_fill_in(:doc_auth_phone, phone_number)
-      click_send_link
-      visit(idv_link_sent_url)
-    end
+    user
+    complete_doc_auth_steps_before_upload_step
+    clear_and_fill_in(:doc_auth_phone, phone_number)
+    click_send_link
+    visit(idv_link_sent_url)
+  end
 
-    it 'Correctly renders the link sent step page' do
-      expect(page).to have_current_path(idv_link_sent_url)
-      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-      expect(page).to have_content(phone_number)
-    end
+  it 'Correctly renders the link sent step page' do
+    expect(page).to have_current_path(idv_link_sent_url)
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+    expect(page).to have_content(phone_number)
+  end
 
-    context 'when link sent polling is enabled' do
-      let(:doc_capture_polling_enabled) { true }
+  context 'when link sent polling is enabled' do
+    let(:doc_capture_polling_enabled) { true }
 
-      # Currently get a javascript error when explicitly visiting the new url
-      # Try this again once upload redirects here.
-      xit 'Does not show continue button' do
-        expect(page).not_to have_content('Continue') # doc_auth.buttons.continue
-      end
+    # Currently get a javascript error when explicitly visiting the new url
+    # Try this again once upload redirects here.
+    xit 'Does not show continue button', :js do
+      expect(page).not_to have_content('Continue') # doc_auth.buttons.continue
     end
   end
 end

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -31,6 +31,10 @@ feature 'doc auth link sent step' do
     let(:doc_capture_polling_enabled) { true }
 
     it 'Does not show continue button', :js do
+      # Prevent errors caused by "Do you want to leave this page?" alert
+      page.evaluate_script('window.onbeforeunload = null;')
+      page.evaluate_script('window.onunload = null;')
+
       expect(page).not_to have_content(I18n.t('doc_auth.buttons.continue'))
     end
   end

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -107,4 +107,71 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
       expect(page).to have_content(t('doc_auth.headings.text_message'))
     end
   end
+
+  # delete this whole context when the feature flag is deleted
+  context 'with doc_auth_link_sent_controller_enabled set to true' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_link_sent_controller_enabled).
+        and_return(true)
+    end
+
+    it 'proofs and hands off to mobile', js: true do
+      user = nil
+
+      perform_in_browser(:desktop) do
+        user = sign_in_and_2fa_user
+        complete_doc_auth_steps_before_upload_step
+        clear_and_fill_in(:doc_auth_phone, phone_number)
+        click_send_link
+
+        expect(page).to have_content(t('doc_auth.headings.text_message'))
+
+        # Confirm that Continue button is not shown when polling is enabled
+        expect(page).not_to have_content(t('doc_auth.buttons.continue'))
+      end
+
+      expect(@sms_link).to be_present
+
+      perform_in_browser(:mobile) do
+        visit @sms_link
+
+        # Confirm app disallows jumping ahead to CaptureComplete page
+        visit idv_hybrid_mobile_capture_complete_url
+        expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+
+        attach_and_submit_images
+
+        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+        expect(page).to have_content(t('doc_auth.headings.capture_complete').tr(' ', ' '))
+        expect(page).to have_text(t('doc_auth.instructions.switch_back'))
+        expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+        # Confirm app disallows jumping back to DocumentCapture page
+        visit idv_hybrid_mobile_document_capture_url
+        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+      end
+
+      perform_in_browser(:desktop) do
+        expect(page).to_not have_content(t('doc_auth.headings.text_message'), wait: 10)
+        expect(page).to have_current_path(idv_ssn_path)
+
+        fill_out_ssn_form_ok
+        click_idv_continue
+
+        expect(page).to have_content(t('headings.verify'))
+        click_idv_continue
+
+        fill_out_phone_form_ok
+        verify_phone_otp
+
+        fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
+        click_idv_continue
+
+        acknowledge_and_confirm_personal_key
+
+        expect(page).to have_current_path(account_path)
+        expect(page).to have_content(t('headings.account.verified_account'))
+      end
+    end
+  end
 end

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -30,6 +30,9 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
       click_send_link
 
       expect(page).to have_content(t('doc_auth.headings.text_message'))
+
+      # Confirm that Continue button is not shown when polling is enabled
+      expect(page).not_to have_content(t('doc_auth.buttons.continue'))
     end
 
     expect(@sms_link).to be_present


### PR DESCRIPTION
## 🎫 Ticket

[LG-9494](https://cm-jira.usa.gov/browse/LG-9494)

## 🛠 Summary of changes

New LinkSentController behind feature flag will replace LinkSentStep. 

Note: Continue button is visible when link sent polling is off, which is only in tests.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create account
- [ ] Start IdV
- [ ] Choose "Send Link" on hybrid handoff step
- [ ] Note that LinkSent URL is `/verify/link_sent` (without `doc_auth`)
- [ ] Complete hybrid flow, either by texting your phone or by using `/test/telephony` to open the texted link in a different browser. (If you open it in another window of the same browser, it logs you out, last time I tried it.)
- [ ] Note that LinkSent page automatically redirects to Ssn page when hybrid flow is complete
- [ ] Enter Ssn and click Continue on VerifyInfo page to confirm that documents are being processed successfully.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>New view:</summary>
  
![LinkSent](https://github.com/18F/identity-idp/assets/2381438/a28034ad-3a97-4be1-9c5f-538ec9f3fa5a)
</details>
