### PR TITLE
CI speedup with support for more parallel jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,7 @@ check_changelog:
 
 specs:
   stage: test
-  parallel: 30
+  parallel: 22
   cache:
     - <<: *ruby_cache
     - <<: *yarn_cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@
 
 variables:
   GITLAB_CI: 'true'
+  FF_SCRIPT_SECTIONS: 'true'
   JUNIT_OUTPUT: 'true'
   ECR_REGISTRY: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
   IDP_CI_SHA: 'sha256:e846ed99aa3c8f9083731105b8ef25536c7ab3ed5e9f2b781b63431badcb091b'
@@ -107,7 +108,7 @@ check_changelog:
 
 specs:
   stage: test
-  parallel: 11
+  parallel: 30
   cache:
     - <<: *ruby_cache
     - <<: *yarn_cache
@@ -128,6 +129,7 @@ specs:
   services:
     - name: postgres:13.9
       alias: db-postgres
+      command: ["--fsync=false", "--synchronous_commit=false", "--full_page_writes=false"]
     - name: redis:7.0
       alias: db-redis
   artifacts:


### PR DESCRIPTION
## 🛠 Summary of changes

This fixes a problem where using parallelization over 11 caused
account deletion email specs to fail.  

<details> <summary>(Failing account deletion email specs here.)</summary>

~~~
Failures:
  1) Account Reset Request: Delete Account as an IAL1 user sends push notifications if push_notifications_enabled is true
     Failure/Error: open_last_email
     RuntimeError:
       No email has been sent!
     # ./spec/features/account_reset/delete_account_spec.rb:138:in `block (4 levels) in <top (required)>'
     # ./spec/features/account_reset/delete_account_spec.rb:124:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:135:in `block (2 levels) in <top (required)>'
  2) Account Reset Request: Delete Account as an IAL1 user allows the user to delete their account after 24 hours
     Failure/Error: open_last_email
     RuntimeError:
       No email has been sent!
     # ./spec/features/account_reset/delete_account_spec.rb:55:in `block (4 levels) in <top (required)>'
     # ./spec/features/account_reset/delete_account_spec.rb:53:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:135:in `block (2 levels) in <top (required)>'
  3) Account Reset Request: Delete Account logs IRS attempts api events allows the user to delete their account after 24 hours and log irs event
     Failure/Error: open_last_email
     RuntimeError:
       No email has been sent!
     # ./spec/features/account_reset/delete_account_spec.rb:239:in `block (4 levels) in <top (required)>'
     # ./spec/features/account_reset/delete_account_spec.rb:237:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:135:in `block (2 levels) in <top (required)>'
~~~

</details>

Correction - My current "fix" is catching the wrong email by the look of it.  Back to WIP!

This boosts parallel processing to 20 jobs for the `test` job.
This seems to be as wide as we can go with it still making a
difference time.

Finally, this also adds per-script-step timing in the job log.  This reinforces
the sad truth that Knapsack timings already show: We have some slow specs.
(Looking at YOU `spec/features/users/sign_in_spec.rb`.)

## 📜 Testing Plan

- [x] Push changes in new PR
- [x] Confirm CI completes normally

## 👀 Screenshots

This PR is at the bottom and shows a speedup of a 90 or more seconds.

![image](https://user-images.githubusercontent.com/59626817/235492882-80ecaf8c-0356-4ea6-b40b-9b481ef7052e.png)


changelog: Internal, CI, Experimentation
