### PR TITLE
Switch to using constants for auth_method values

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -57,7 +57,9 @@ module RememberDeviceConcern
   private
 
   def expired_for_interval?(user, interval)
-    return false unless user_session[:auth_method] == 'remember_device'
+    unless user_session[:auth_method] == TwoFactorAuthenticatable::AUTH_METHOD_REMEMBER_DEVICE
+      return false
+    end
     remember_cookie = remember_device_cookie
     return true if remember_cookie.nil?
 
@@ -68,7 +70,7 @@ module RememberDeviceConcern
   end
 
   def handle_valid_remember_device_cookie
-    user_session[:auth_method] = 'remember_device'
+    user_session[:auth_method] = TwoFactorAuthenticatable::AUTH_METHOD_REMEMBER_DEVICE
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics
     bypass_sign_in current_user

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -57,7 +57,7 @@ module RememberDeviceConcern
   private
 
   def expired_for_interval?(user, interval)
-    unless user_session[:auth_method] == TwoFactorAuthenticatable::AUTH_METHOD_REMEMBER_DEVICE
+    unless user_session[:auth_method] == TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
       return false
     end
     remember_cookie = remember_device_cookie
@@ -70,7 +70,7 @@ module RememberDeviceConcern
   end
 
   def handle_valid_remember_device_cookie
-    user_session[:auth_method] = TwoFactorAuthenticatable::AUTH_METHOD_REMEMBER_DEVICE
+    user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics
     bypass_sign_in current_user

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -10,15 +10,27 @@ module TwoFactorAuthenticatable
   DIRECT_OTP_VALID_FOR_MINUTES = IdentityConfig.store.otp_valid_for
   DIRECT_OTP_VALID_FOR_SECONDS = DIRECT_OTP_VALID_FOR_MINUTES * 60
   REMEMBER_2FA_COOKIE = 'remember_tfa'.freeze
-  AUTH_METHOD_BACKUP_CODE = 'backup_code'
-  AUTH_METHOD_PERSONAL_KEY = 'personal_key'
-  AUTH_METHOD_PIV_CAC = 'piv_cac'
-  AUTH_METHOD_REMEMBER_DEVICE = 'remember_device'
-  AUTH_METHOD_SMS = 'sms'
-  AUTH_METHOD_TOTP = 'totp'
-  AUTH_METHOD_VOICE = 'voice'
-  AUTH_METHOD_WEBAUTHN = 'webauthn'
-  AUTH_METHOD_WEBAUTHN_PLATFORM = 'webauthn_platform'
+
+  class AuthMethod
+    BACKUP_CODE = 'backup_code'
+    PERSONAL_KEY = 'personal_key'
+    PIV_CAC = 'piv_cac'
+    REMEMBER_DEVICE = 'remember_device'
+    SMS = 'sms'
+    TOTP = 'totp'
+    VOICE = 'voice'
+    WEBAUTHN = 'webauthn'
+    WEBAUTHN_PLATFORM = 'webauthn_platform'
+    PHISHING_RESISTANT_METHODS = [
+      WEBAUTHN,
+      WEBAUTHN_PLATFORM,
+      PIV_CAC,
+    ].freeze
+
+    def self.phishing_resistant?(auth_method)
+      PHISHING_RESISTANT_METHODS.include?(auth_method)
+    end
+  end
 
   included do
     # rubocop:disable Rails/LexicallyScopedActionFilter

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -10,6 +10,15 @@ module TwoFactorAuthenticatable
   DIRECT_OTP_VALID_FOR_MINUTES = IdentityConfig.store.otp_valid_for
   DIRECT_OTP_VALID_FOR_SECONDS = DIRECT_OTP_VALID_FOR_MINUTES * 60
   REMEMBER_2FA_COOKIE = 'remember_tfa'.freeze
+  AUTH_METHOD_BACKUP_CODE = 'backup_code'
+  AUTH_METHOD_PERSONAL_KEY = 'personal_key'
+  AUTH_METHOD_PIV_CAC = 'piv_cac'
+  AUTH_METHOD_REMEMBER_DEVICE = 'remember_device'
+  AUTH_METHOD_SMS = 'sms'
+  AUTH_METHOD_TOTP = 'totp'
+  AUTH_METHOD_VOICE = 'voice'
+  AUTH_METHOD_WEBAUTHN = 'webauthn'
+  AUTH_METHOD_WEBAUTHN_PLATFORM = 'webauthn_platform'
 
   included do
     # rubocop:disable Rails/LexicallyScopedActionFilter

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -21,11 +21,12 @@ module TwoFactorAuthenticatable
     VOICE = 'voice'
     WEBAUTHN = 'webauthn'
     WEBAUTHN_PLATFORM = 'webauthn_platform'
+
     PHISHING_RESISTANT_METHODS = [
       WEBAUTHN,
       WEBAUTHN_PLATFORM,
       PIV_CAC,
-    ].freeze
+    ].to_set.freeze
 
     def self.phishing_resistant?(auth_method)
       PHISHING_RESISTANT_METHODS.include?(auth_method)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -74,7 +74,10 @@ module TwoFactorAuthenticatableMethods
     return unless service_provider_mfa_policy.user_needs_sp_auth_method_verification?
     return if service_provider_mfa_policy.phishing_resistant_required? &&
               ServiceProviderMfaPolicy::PHISHING_RESISTANT_METHODS.include?(auth_method)
-    return if service_provider_mfa_policy.piv_cac_required? && auth_method == 'piv_cac'
+    if service_provider_mfa_policy.piv_cac_required? &&
+       auth_method == TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC
+      return
+    end
     prompt_to_verify_sp_required_mfa
   end
 

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -73,9 +73,9 @@ module TwoFactorAuthenticatableMethods
   def check_sp_required_mfa_bypass(auth_method:)
     return unless service_provider_mfa_policy.user_needs_sp_auth_method_verification?
     return if service_provider_mfa_policy.phishing_resistant_required? &&
-              ServiceProviderMfaPolicy::PHISHING_RESISTANT_METHODS.include?(auth_method)
+              TwoFactorAuthenticatable::AuthMethod.phishing_resistant?(auth_method)
     if service_provider_mfa_policy.piv_cac_required? &&
-       auth_method == TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC
+       auth_method == TwoFactorAuthenticatable::AuthMethod::PIV_CAC
       return
     end
     prompt_to_verify_sp_required_mfa

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -62,7 +62,7 @@ module TwoFactorAuthentication
     def handle_result(result)
       if result.success?
         handle_valid_otp_for_authentication_context(
-          auth_method: TwoFactorAuthenticatable::AUTH_METHOD_BACKUP_CODE,
+          auth_method: TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
         )
         return handle_last_code if all_codes_used?
         handle_valid_backup_code

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -61,7 +61,9 @@ module TwoFactorAuthentication
 
     def handle_result(result)
       if result.success?
-        handle_valid_otp_for_authentication_context(auth_method: 'backup_code')
+        handle_valid_otp_for_authentication_context(
+          auth_method: TwoFactorAuthenticatable::AUTH_METHOD_BACKUP_CODE,
+        )
         return handle_last_code if all_codes_used?
         handle_valid_backup_code
       else

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -89,7 +89,9 @@ module TwoFactorAuthentication
     end
 
     def handle_valid_otp
-      handle_valid_otp_for_authentication_context(auth_method: 'personal_key')
+      handle_valid_otp_for_authentication_context(
+        auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PERSONAL_KEY,
+      )
       if current_user.identity_verified? || current_user.password_reset_profile.present?
         redirect_to manage_personal_key_url
       elsif MfaPolicy.new(current_user).two_factor_enabled?

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -90,7 +90,7 @@ module TwoFactorAuthentication
 
     def handle_valid_otp
       handle_valid_otp_for_authentication_context(
-        auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PERSONAL_KEY,
+        auth_method: TwoFactorAuthenticatable::AuthMethod::PERSONAL_KEY,
       )
       if current_user.identity_verified? || current_user.password_reset_profile.present?
         redirect_to manage_personal_key_url

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -50,7 +50,9 @@ module TwoFactorAuthentication
         presented: true,
       )
 
-      handle_valid_otp_for_authentication_context(auth_method: 'piv_cac')
+      handle_valid_otp_for_authentication_context(
+        auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC,
+      )
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
     end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -51,7 +51,7 @@ module TwoFactorAuthentication
       )
 
       handle_valid_otp_for_authentication_context(
-        auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC,
+        auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -76,7 +76,7 @@ module Users
 
       handle_valid_otp(
         next_url: next_step,
-        auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC,
+        auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )
     end
 

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -74,7 +74,10 @@ module Users
         presented: true,
       )
 
-      handle_valid_otp(next_url: next_step, auth_method: 'piv_cac')
+      handle_valid_otp(
+        next_url: next_step,
+        auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC,
+      )
     end
 
     def next_step

--- a/app/policies/service_provider_mfa_policy.rb
+++ b/app/policies/service_provider_mfa_policy.rb
@@ -1,5 +1,9 @@
 class ServiceProviderMfaPolicy
-  PHISHING_RESISTANT_METHODS = %w[webauthn webauthn_platform piv_cac].freeze
+  PHISHING_RESISTANT_METHODS = [
+    TwoFactorAuthenticatable::AUTH_METHOD_WEBAUTHN,
+    TwoFactorAuthenticatable::AUTH_METHOD_WEBAUTHN_PLATFORM,
+    TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC,
+  ].freeze
 
   attr_reader :mfa_context, :auth_method, :service_provider
 
@@ -26,7 +30,7 @@ class ServiceProviderMfaPolicy
     return false if user_needs_sp_auth_method_setup?
 
     if piv_cac_required?
-      auth_method.to_s != 'piv_cac'
+      auth_method.to_s != TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC
     elsif phishing_resistant_required?
       !PHISHING_RESISTANT_METHODS.include?(auth_method.to_s)
     else

--- a/app/policies/service_provider_mfa_policy.rb
+++ b/app/policies/service_provider_mfa_policy.rb
@@ -1,10 +1,4 @@
 class ServiceProviderMfaPolicy
-  PHISHING_RESISTANT_METHODS = [
-    TwoFactorAuthenticatable::AUTH_METHOD_WEBAUTHN,
-    TwoFactorAuthenticatable::AUTH_METHOD_WEBAUTHN_PLATFORM,
-    TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC,
-  ].freeze
-
   attr_reader :mfa_context, :auth_method, :service_provider
 
   def initialize(
@@ -30,9 +24,9 @@ class ServiceProviderMfaPolicy
     return false if user_needs_sp_auth_method_setup?
 
     if piv_cac_required?
-      auth_method.to_s != TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC
+      auth_method.to_s != TwoFactorAuthenticatable::AuthMethod::PIV_CAC
     elsif phishing_resistant_required?
-      !PHISHING_RESISTANT_METHODS.include?(auth_method.to_s)
+      !TwoFactorAuthenticatable::AuthMethod.phishing_resistant?(auth_method)
     else
       false
     end

--- a/spec/controllers/concerns/reauthentication_required_concern_spec.rb
+++ b/spec/controllers/concerns/reauthentication_required_concern_spec.rb
@@ -89,7 +89,7 @@ describe ReauthenticationRequiredConcern, type: :controller do
       end
 
       it 'records analytics' do
-        controller.user_session[:auth_method] = TwoFactorAuthenticatable::AUTH_METHOD_TOTP
+        controller.user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::TOTP
         stub_analytics
         expect(@analytics).to receive(:track_event).with(
           'User 2FA Reauthentication Required',

--- a/spec/controllers/concerns/reauthentication_required_concern_spec.rb
+++ b/spec/controllers/concerns/reauthentication_required_concern_spec.rb
@@ -89,7 +89,7 @@ describe ReauthenticationRequiredConcern, type: :controller do
       end
 
       it 'records analytics' do
-        controller.user_session[:auth_method] = 'totp'
+        controller.user_session[:auth_method] = TwoFactorAuthenticatable::AUTH_METHOD_TOTP
         stub_analytics
         expect(@analytics).to receive(:track_event).with(
           'User 2FA Reauthentication Required',

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -827,7 +827,9 @@ describe SamlIdpController do
         end
 
         it 'returns AAL3 authn_context when AAL3 is requested' do
-          allow(controller).to receive(:user_session).and_return({ auth_method: 'piv_cac' })
+          allow(controller).to receive(:user_session).and_return(
+            { auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC },
+          )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
             overrides: { authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF },
@@ -842,7 +844,9 @@ describe SamlIdpController do
         end
 
         it 'returns AAL3-HSPD12 authn_context when AAL3-HSPD12 is requested' do
-          allow(controller).to receive(:user_session).and_return({ auth_method: 'piv_cac' })
+          allow(controller).to receive(:user_session).and_return(
+            { auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC },
+          )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
             overrides: { authn_context: Saml::Idp::Constants::AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF },
@@ -857,7 +861,9 @@ describe SamlIdpController do
         end
 
         it 'returns AAL2-HSPD12 authn_context when AAL2-HSPD12 is requested' do
-          allow(controller).to receive(:user_session).and_return({ auth_method: 'piv_cac' })
+          allow(controller).to receive(:user_session).and_return(
+            { auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC },
+          )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
             overrides: { authn_context: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF },
@@ -872,7 +878,9 @@ describe SamlIdpController do
         end
 
         it 'returns AAL2-phishing-resistant authn_context when AAL2-phishing-resistant requested' do
-          allow(controller).to receive(:user_session).and_return({ auth_method: 'webauthn' })
+          allow(controller).to receive(:user_session).and_return(
+            { auth_method: TwoFactorAuthenticatable::AUTH_METHOD_WEBAUTHN },
+          )
           user = create(:user, :with_webauthn)
           auth_settings = saml_settings(
             overrides: {

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -828,7 +828,7 @@ describe SamlIdpController do
 
         it 'returns AAL3 authn_context when AAL3 is requested' do
           allow(controller).to receive(:user_session).and_return(
-            { auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC },
+            { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC },
           )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
@@ -845,7 +845,7 @@ describe SamlIdpController do
 
         it 'returns AAL3-HSPD12 authn_context when AAL3-HSPD12 is requested' do
           allow(controller).to receive(:user_session).and_return(
-            { auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC },
+            { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC },
           )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
@@ -862,7 +862,7 @@ describe SamlIdpController do
 
         it 'returns AAL2-HSPD12 authn_context when AAL2-HSPD12 is requested' do
           allow(controller).to receive(:user_session).and_return(
-            { auth_method: TwoFactorAuthenticatable::AUTH_METHOD_PIV_CAC },
+            { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC },
           )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
@@ -879,7 +879,7 @@ describe SamlIdpController do
 
         it 'returns AAL2-phishing-resistant authn_context when AAL2-phishing-resistant requested' do
           allow(controller).to receive(:user_session).and_return(
-            { auth_method: TwoFactorAuthenticatable::AUTH_METHOD_WEBAUTHN },
+            { auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN },
           )
           user = create(:user, :with_webauthn)
           auth_settings = saml_settings(

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -76,7 +76,7 @@ describe Users::PivCacAuthenticationSetupController do
         allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
         subject.user_session[:piv_cac_nickname] = nickname
         subject.user_session[:authn_at] = Time.zone.now
-        subject.user_session[:auth_method] = TwoFactorAuthenticatable::AUTH_METHOD_SMS
+        subject.user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::SMS
       end
 
       let(:nonce) { 'nonce' }

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -76,7 +76,7 @@ describe Users::PivCacAuthenticationSetupController do
         allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
         subject.user_session[:piv_cac_nickname] = nickname
         subject.user_session[:authn_at] = Time.zone.now
-        subject.user_session[:auth_method] = 'phone'
+        subject.user_session[:auth_method] = TwoFactorAuthenticatable::AUTH_METHOD_SMS
       end
 
       let(:nonce) { 'nonce' }

--- a/spec/policies/service_provider_mfa_policy_spec.rb
+++ b/spec/policies/service_provider_mfa_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ServiceProviderMfaPolicy do
   let(:user) { create(:user) }
   let(:service_provider) { create(:service_provider) }
-  let(:auth_method) { 'phone' }
+  let(:auth_method) { TwoFactorAuthenticatable::AUTH_METHOD_SMS }
   let(:aal_level_requested) { 1 }
   let(:piv_cac_requested) { false }
   let(:phishing_resistant_requested) { nil }
@@ -83,7 +83,7 @@ describe ServiceProviderMfaPolicy do
       end
 
       context 'the user did not use an AAL3 method' do
-        let(:auth_method) { 'phone' }
+        let(:auth_method) { TwoFactorAuthenticatable::AUTH_METHOD_SMS }
 
         before do
           setup_user_phone
@@ -124,7 +124,7 @@ describe ServiceProviderMfaPolicy do
       end
 
       context 'the user did not use an AAL3 method' do
-        let(:auth_method) { 'phone' }
+        let(:auth_method) { TwoFactorAuthenticatable::AUTH_METHOD_SMS }
 
         before do
           setup_user_phone

--- a/spec/policies/service_provider_mfa_policy_spec.rb
+++ b/spec/policies/service_provider_mfa_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ServiceProviderMfaPolicy do
   let(:user) { create(:user) }
   let(:service_provider) { create(:service_provider) }
-  let(:auth_method) { TwoFactorAuthenticatable::AUTH_METHOD_SMS }
+  let(:auth_method) { TwoFactorAuthenticatable::AuthMethod::SMS }
   let(:aal_level_requested) { 1 }
   let(:piv_cac_requested) { false }
   let(:phishing_resistant_requested) { nil }
@@ -83,7 +83,7 @@ describe ServiceProviderMfaPolicy do
       end
 
       context 'the user did not use an AAL3 method' do
-        let(:auth_method) { TwoFactorAuthenticatable::AUTH_METHOD_SMS }
+        let(:auth_method) { TwoFactorAuthenticatable::AuthMethod::SMS }
 
         before do
           setup_user_phone
@@ -124,7 +124,7 @@ describe ServiceProviderMfaPolicy do
       end
 
       context 'the user did not use an AAL3 method' do
-        let(:auth_method) { TwoFactorAuthenticatable::AUTH_METHOD_SMS }
+        let(:auth_method) { TwoFactorAuthenticatable::AuthMethod::SMS }
 
         before do
           setup_user_phone

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -18,7 +18,7 @@ module ControllerHelper
     allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(request.env['warden']).to receive(:session).and_return(user: {})
     allow(controller).to receive(:user_session).and_return(authn_at: Time.zone.now)
-    controller.user_session[:auth_method] ||= TwoFactorAuthenticatable::AUTH_METHOD_SMS
+    controller.user_session[:auth_method] ||= TwoFactorAuthenticatable::AuthMethod::SMS
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:confirm_two_factor_authenticated).and_return(true)
     allow(controller).to receive(:user_fully_authenticated?).and_return(true)

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -18,7 +18,7 @@ module ControllerHelper
     allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(request.env['warden']).to receive(:session).and_return(user: {})
     allow(controller).to receive(:user_session).and_return(authn_at: Time.zone.now)
-    controller.user_session[:auth_method] ||= 'phone'
+    controller.user_session[:auth_method] ||= TwoFactorAuthenticatable::AUTH_METHOD_SMS
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:confirm_two_factor_authenticated).and_return(true)
     allow(controller).to receive(:user_fully_authenticated?).and_return(true)


### PR DESCRIPTION
## 🛠 Summary of changes

Inspired by @zachmargolis' comment [here](https://github.com/18F/identity-idp/pull/8037#discussion_r1143745831) to move away from copying different strings everywhere, this PR defines and uses constants for assigning and checking values in the session's `auth_method` so that we can more easily continue to develop around these pieces of functionality.

This PR should be neutral in terms of behavior.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
