### PR TITLE
Ensure authentication method is stored when setting up backup codes or PIV/CAC

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -112,6 +112,7 @@ module Users
     end
 
     def mark_user_as_fully_authenticated
+      user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE
       user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
       user_session[:authn_at] = Time.zone.now
     end

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -118,6 +118,7 @@ module Users
     end
 
     def process_valid_submission
+      mark_user_as_fully_authenticated
       flash[:success] = t('notices.piv_cac_configured')
       save_piv_cac_information(
         subject: user_piv_cac_form.x509_dn,
@@ -129,6 +130,13 @@ module Users
       session[:needs_to_setup_piv_cac_after_sign_in] = false
       final_path = after_sign_in_path_for(current_user)
       redirect_to next_setup_path || final_path
+    end
+
+    def mark_user_as_fully_authenticated
+      user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::PIV_CAC
+
+      user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
+      user_session[:authn_at] = Time.zone.now
     end
 
     def track_mfa_method_added

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -245,6 +245,18 @@ feature 'Sign Up' do
     expect(page).to have_current_path account_path
   end
 
+  it 'allows a user to sign up with PIV/CAC and only verifying once when HSPD12 is requested' do
+    visit_idp_from_oidc_sp_with_hspd12_and_require_piv_cac
+    sign_up_and_set_password
+    set_up_2fa_with_piv_cac
+    skip_second_mfa_prompt
+    click_agree_and_continue
+
+    redirect_uri = URI(current_url)
+
+    expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+  end
+
   it 'does not allow PIV/CAC during setup on mobile' do
     allow(BrowserCache).to receive(:parse).and_return(mobile_device)
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -363,4 +363,14 @@ feature 'Sign Up' do
     select_2fa_option('piv_cac')
     expect(page).to_not have_content(t('two_factor_authentication.piv_cac_fallback.question'))
   end
+
+  it 'allows a user to sign up with backup codes and add methods after without reauthentication' do
+    sign_in_user
+    set_up_2fa_with_backup_codes
+    skip_second_mfa_prompt
+
+    expect(page).to have_current_path account_path
+    visit add_phone_path
+    expect(page).to have_current_path add_phone_path
+  end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -567,6 +567,14 @@ module Features
       click_button 'Submit'
     end
 
+    def set_up_2fa_with_backup_codes
+      select_2fa_option('backup_code')
+
+      expect(page).to have_current_path backup_code_setup_path
+
+      click_button 'Continue'
+    end
+
     def register_user_with_piv_cac(email = 'test@test.com')
       confirm_email_and_password(email)
       expect(page).to have_current_path authentication_methods_setup_path


### PR DESCRIPTION
## 🛠 Summary of changes
The `auth_method` value in the session is used for doing re-authentication checks and for checking whether an account's authentication method meets a service provider's authentication level (AAL2, AAL2-phishing-resistant, AAL2-HSPD12). The setting is currently inconsistent, and is not set when registering backup codes or PIV/CAC.

OTP-based 2FA methods ([TOTP](https://github.com/18F/identity-idp/blob/a285c62c5a1b2231efe6edd9310635125cf03268/app/controllers/two_factor_authentication/totp_verification_controller.rb#L26), [phone](https://github.com/18F/identity-idp/blob/a285c62c5a1b2231efe6edd9310635125cf03268/app/controllers/two_factor_authentication/otp_verification_controller.rb#L24)) call [handle_valid_otp](https://github.com/18F/identity-idp/blob/a285c62c5a1b2231efe6edd9310635125cf03268/app/controllers/concerns/two_factor_authenticatable_methods.rb#L93-L99) during setup since they have to be confirmed which sets `auth_method` in the session during account registration. [Webauthn](https://github.com/18F/identity-idp/blob/a285c62c5a1b2231efe6edd9310635125cf03268/app/controllers/users/webauthn_setup_controller.rb#L165-L174) does it directly in the setup controller since it does not use the separate verification controller when registering new webauthn authenticators.

Since we do not set `auth_method` when registering backup codes and PIV/CAC, this leads two a couple of issues:

1. If you are arriving from an SP that requires HSPD12 (PIV/CAC), and need to create a new account, you will have to verify your PIV/CAC twice. It is required the first time to register the PIV/CAC in your account, and this should be sufficient. Since we do not set `auth_method`, the [auth_method check](https://github.com/18F/identity-idp/blob/a285c62c5a1b2231efe6edd9310635125cf03268/app/policies/service_provider_mfa_policy.rb#L29) fails and you are required to go through PIV/CAC authentication again.
2. If you sign up for an account with only backup codes and/or PIV/CAC, you will not be considered ["recently authenticated"](https://github.com/18F/identity-idp/blob/a285c62c5a1b2231efe6edd9310635125cf03268/app/controllers/concerns/reauthentication_required_concern.rb#L19-L20) since you do not have an `auth_method`. This means if you attempt to take account management actions like adding 2FA, emails, etc., you will be asked to re-authenticate (potentially with one of the backup codes you just received). This issue does not affect production currently.

To address this, this PR sets the `auth_method` after successfully setting up backup codes and PIV/CAC.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
