### PR TITLE
LG-9613 Add command_line args and move parse_duration method

### DIFF
--- a/bin/query-cloudwatch
+++ b/bin/query-cloudwatch
@@ -12,6 +12,7 @@ require 'optparse/time'
 
 $LOAD_PATH.unshift(File.expand_path(File.join(__dir__, '../lib')))
 require 'reporting/cloudwatch_client'
+require 'reporting/cloudwatch_query_time_slice'
 
 class QueryCloudwatch
   Config = Struct.new(
@@ -250,26 +251,7 @@ class QueryCloudwatch
   # @param [String] value a string such as 1min, 2h, 3d, 4w, 5mon, 6y
   # @return [ActiveSupport::Duration]
   def self.parse_duration(value)
-    if (match = value.match(/^(?<number>\d+)(?<unit>\D+)$/))
-      number = Integer(match[:number], 10)
-
-      duration = case match[:unit]
-      when 'min'
-        number.minutes
-      when 'h'
-        number.hours
-      when 'd'
-        number.days
-      when 'w'
-        number.weeks
-      when 'mon'
-        number.months
-      when 'y'
-        number.years
-      end
-
-      return duration if duration
-    end
+    Reporting::CloudwatchQueryTimeSlice.parse_duration(value)
   end
 end
 

--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -30,7 +30,8 @@ module Reporting
 
     # @param [String] isssuer
     # @param [Range<Time>] time_range
-    def initialize(issuer:, time_range:, verbose: false, progress: false, slice: 3.hours, threads: 5)
+    def initialize(issuer:, time_range:, verbose: false, progress: false, slice: 3.hours,
+                   threads: 5)
       @issuer = issuer
       @time_range = time_range
       @verbose = verbose

--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -30,11 +30,13 @@ module Reporting
 
     # @param [String] isssuer
     # @param [Range<Time>] time_range
-    def initialize(issuer:, time_range:, verbose: false, progress: false)
+    def initialize(issuer:, time_range:, verbose: false, progress: false, slice: 3.hours, threads: 5)
       @issuer = issuer
       @time_range = time_range
       @verbose = verbose
       @progress = progress
+      @slice = slice
+      @threads = threads
     end
 
     def verbose?
@@ -171,8 +173,9 @@ module Reporting
 
     def cloudwatch_client
       @cloudwatch_client ||= Reporting::CloudwatchClient.new(
+        num_threads: @threads,
         ensure_complete_logs: true,
-        slice_interval: 3.hours,
+        slice_interval: @slice,
         progress: progress?,
         logger: verbose? ? Logger.new(STDERR) : nil,
       )

--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -30,8 +30,14 @@ module Reporting
 
     # @param [String] isssuer
     # @param [Range<Time>] time_range
-    def initialize(issuer:, time_range:, verbose: false, progress: false, slice: 3.hours,
-                   threads: 5)
+    def initialize(
+      issuer:,
+      time_range:,
+      verbose: false,
+      progress: false,
+      slice: 3.hours,
+      threads: 5
+    )
       @issuer = issuer
       @time_range = time_range
       @verbose = verbose

--- a/lib/reporting/cloudwatch_query_time_slice.rb
+++ b/lib/reporting/cloudwatch_query_time_slice.rb
@@ -1,0 +1,28 @@
+module Reporting
+  module CloudwatchQueryTimeSlice
+    # @param [String] value a string such as 1min, 2h, 3d, 4w, 5mon, 6y
+    # @return [ActiveSupport::Duration]
+    def self.parse_duration(value)
+      if (match = value.match(/^(?<number>\d+)(?<unit>\D+)$/))
+        number = Integer(match[:number], 10)
+
+        duration = case match[:unit]
+        when 'min'
+          number.minutes
+        when 'h'
+          number.hours
+        when 'd'
+          number.days
+        when 'w'
+          number.weeks
+        when 'mon'
+          number.months
+        when 'y'
+          number.years
+        end
+
+        return duration if duration
+      end
+    end
+  end
+end

--- a/lib/reporting/command_line_options.rb
+++ b/lib/reporting/command_line_options.rb
@@ -2,7 +2,6 @@ require 'reporting/cloudwatch_query_time_slice'
 
 module Reporting
   class CommandLineOptions
-    include Reporting::CloudwatchQueryTimeSlice
     # rubocop:disable Rails/Exit
     # @return [Hash]
     def parse!(argv, out: STDOUT)
@@ -11,8 +10,8 @@ module Reporting
       verbose = false
       progress = true
       period = nil
-      slice = 3.hours
-      threads = 5
+      slice = nil
+      threads = nil
 
       program_name = Pathname.new($PROGRAM_NAME).relative_path_from(__dir__)
 
@@ -45,8 +44,8 @@ module Reporting
           date = Date.parse(date_v)
           period = :month
 
-          slice = 1.hour if slice == 3.hours
-          threads = 10 if threads == 5
+          slice ||= 1.hour
+          threads ||= 10
         end
 
         opts.on('--issuer=ISSUER') do |issuer_v|
@@ -99,8 +98,8 @@ module Reporting
           issuer: issuer,
           verbose: verbose,
           progress: progress,
-          slice: slice,
-          threads: threads,
+          slice: slice || 3.hours,
+          threads: threads || 5,
         }
       end
     end

--- a/lib/reporting/command_line_options.rb
+++ b/lib/reporting/command_line_options.rb
@@ -58,12 +58,15 @@ module Reporting
           progress = progress_v
         end
 
-        opts.on('--slice SLICE', '(optional) query slice size duration, defaults to 1w') do |slice_v|
+        opts.on(
+          '--slice SLICE',
+          '(optional) query slice size duration, defaults to 1w',
+        ) do |slice_v|
           slice = CloudwatchQueryTimeSlice.parse_duration(slice_v)
         end
 
         opts.on('--threads THREADS', '(optional) number of threads, defaults to 5') do |threads_v|
-          threads = threads_v.to_i if threads_v.to_i.between?(1,30)
+          threads = threads_v.to_i if threads_v.to_i.between?(1, 30)
         end
 
         opts.on('-h', '--help') do
@@ -85,7 +88,7 @@ module Reporting
           verbose: verbose,
           progress: progress,
           slice: slice,
-          threads: threads
+          threads: threads,
         }
       end
     end

--- a/lib/reporting/command_line_options.rb
+++ b/lib/reporting/command_line_options.rb
@@ -1,5 +1,8 @@
+require 'reporting/cloudwatch_query_time_slice'
+
 module Reporting
   class CommandLineOptions
+    include Reporting::CloudwatchQueryTimeSlice
     # rubocop:disable Rails/Exit
     # @return [Hash]
     def parse!(argv, out: STDOUT)
@@ -8,6 +11,8 @@ module Reporting
       verbose = false
       progress = true
       period = nil
+      slice = 3.hours
+      threads = 5
 
       program_name = Pathname.new($PROGRAM_NAME).relative_path_from(__dir__)
 
@@ -27,10 +32,18 @@ module Reporting
         end
 
         opts.on('--week=DATE', <<~STR.squish) do |date_v|
-          run the report for the week (Sun-Sat) that includes the date in YYYY-MM-DD format'
+          run the report for the week (Sun-Sat) that includes the date in YYYY-MM-DD format
         STR
           date = Date.parse(date_v)
           period = :week
+        end
+
+        opts.on('--month=DATE', <<~STR.squish) do |date_v|
+          run the report for the month that includes the date in YYYY-MM-DD format. recommended
+          to include `--threads 10` and `--slice 1h` to reduce likelihood of timeout
+        STR
+          date = Date.parse(date_v)
+          period = :month
         end
 
         opts.on('--issuer=ISSUER') do |issuer_v|
@@ -43,6 +56,14 @@ module Reporting
 
         opts.on('--[no-]progress', 'shows a progress bar or hides it, defaults on') do |progress_v|
           progress = progress_v
+        end
+
+        opts.on('--slice SLICE', '(optional) query slice size duration, defaults to 1w') do |slice_v|
+          slice = CloudwatchQueryTimeSlice.parse_duration(slice_v)
+        end
+
+        opts.on('--threads THREADS', '(optional) number of threads, defaults to 5') do |threads_v|
+          threads = threads_v.to_i if threads_v.to_i.between?(1,30)
         end
 
         opts.on('-h', '--help') do
@@ -63,6 +84,8 @@ module Reporting
           issuer: issuer,
           verbose: verbose,
           progress: progress,
+          slice: slice,
+          threads: threads
         }
       end
     end
@@ -81,6 +104,8 @@ module Reporting
         utc.all_day
       when :week
         utc.all_week
+      when :month
+        utc.all_month
       else
         raise "unknown period=#{period}"
       end

--- a/lib/reporting/command_line_options.rb
+++ b/lib/reporting/command_line_options.rb
@@ -39,11 +39,14 @@ module Reporting
         end
 
         opts.on('--month=DATE', <<~STR.squish) do |date_v|
-          run the report for the month that includes the date in YYYY-MM-DD format. recommended
-          to include `--threads 10` and `--slice 1h` to reduce likelihood of timeout
+          run the report for the month that includes the date in YYYY-MM-DD format.
+          changes defaults to `--threads 10` and `--slice 1 hour` to reduce likelihood of timeout
         STR
           date = Date.parse(date_v)
           period = :month
+
+          slice = 1.hour if slice == 3.hours
+          threads = 10 if threads == 5
         end
 
         opts.on('--issuer=ISSUER') do |issuer_v|
@@ -60,13 +63,22 @@ module Reporting
 
         opts.on(
           '--slice SLICE',
-          '(optional) query slice size duration, defaults to 1w',
+          '(optional) query slice size duration, defaults to 3h',
         ) do |slice_v|
           slice = CloudwatchQueryTimeSlice.parse_duration(slice_v)
         end
 
-        opts.on('--threads THREADS', '(optional) number of threads, defaults to 5') do |threads_v|
-          threads = threads_v.to_i if threads_v.to_i.between?(1, 30)
+        opts.on(
+          '--threads THREADS',
+          '(optional) number of threads between 1 and 30 inclusive, defaults to 5. ',
+        ) do |threads_v|
+          if !threads_v.to_i.between?(1, 30)
+            raise StandardError.new(
+              'Number of threads must be between 1 and 30 inclusive',
+            )
+          end
+
+          threads = threads_v.to_i
         end
 
         opts.on('-h', '--help') do

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -31,8 +31,14 @@ module Reporting
 
     # @param [String] isssuer
     # @param [Range<Time>] date
-    def initialize(issuer:, time_range:, verbose: false, progress: false, slice: 3.hours,
-                   threads: 5)
+    def initialize(
+      issuer:,
+      time_range:,
+      verbose: false,
+      progress: false,
+      slice: 3.hours,
+      threads: 5
+    )
       @issuer = issuer
       @time_range = time_range
       @verbose = verbose

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -31,11 +31,14 @@ module Reporting
 
     # @param [String] isssuer
     # @param [Range<Time>] date
-    def initialize(issuer:, time_range:, verbose: false, progress: false)
+    def initialize(issuer:, time_range:, verbose: false, progress: false, slice: 3.hours,
+                   threads: 5)
       @issuer = issuer
       @time_range = time_range
       @verbose = verbose
       @progress = progress
+      @slice = slice
+      @threads = threads
     end
 
     def verbose?
@@ -156,8 +159,9 @@ module Reporting
 
     def cloudwatch_client
       @cloudwatch_client ||= Reporting::CloudwatchClient.new(
+        num_threads: @threads,
         ensure_complete_logs: true,
-        slice_interval: 3.hours,
+        slice_interval: @slice,
         progress: progress?,
         logger: verbose? ? Logger.new(STDERR) : nil,
       )

--- a/spec/bin/query-cloudwatch_spec.rb
+++ b/spec/bin/query-cloudwatch_spec.rb
@@ -170,36 +170,6 @@ RSpec.describe QueryCloudwatch do
     end
   end
 
-  describe '.parse_duration' do
-    it 'parses min as minutes' do
-      expect(QueryCloudwatch.parse_duration('1111min')).to eq(1111.minutes)
-    end
-
-    it 'parses h as hours' do
-      expect(QueryCloudwatch.parse_duration('2h')).to eq(2.hours)
-    end
-
-    it 'parses d as days' do
-      expect(QueryCloudwatch.parse_duration('3d')).to eq(3.days)
-    end
-
-    it 'parses w as weeks' do
-      expect(QueryCloudwatch.parse_duration('4w')).to eq(4.weeks)
-    end
-
-    it 'parses mon as months' do
-      expect(QueryCloudwatch.parse_duration('5mon')).to eq(5.months)
-    end
-
-    it 'parses y as years' do
-      expect(QueryCloudwatch.parse_duration('6y')).to eq(6.years)
-    end
-
-    it 'is nil for unknown' do
-      expect(QueryCloudwatch.parse_duration('7x')).to be_nil
-    end
-  end
-
   describe '#run' do
     let(:format) { :csv }
     let(:config) do

--- a/spec/lib/reporting/authentication_report_spec.rb
+++ b/spec/lib/reporting/authentication_report_spec.rb
@@ -70,4 +70,75 @@ RSpec.describe Reporting::AuthenticationReport do
       end
     end
   end
+
+  describe "#cloudwatch_client" do
+    let(:opts) { {} }
+    let(:subject) { described_class.new(issuer:, time_range:, **opts)}
+    let(:default_args) do
+      {
+        num_threads: 5,
+        ensure_complete_logs: true,
+        slice_interval: 3.hours,
+        progress: false,
+        logger: nil
+      }
+    end
+
+    describe "when all args are default" do
+      it "creates a client with the default options" do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe "when verbose is passed in" do
+      let(:opts) { {verbose: true} }
+      let(:logger) { double Logger }
+
+      before do
+        expect(Logger).to receive(:new).with(STDERR).and_return logger
+        default_args[:logger] = logger
+      end
+
+      it "creates a client with the expected logger" do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe "when progress is passed in as true" do
+      let(:opts) { {progress: true} }
+      before { default_args[:progress] = true }
+
+      it "creates a client with progress as true" do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe "when threads is passed in" do
+      let(:opts) { {threads: 17} }
+      before { default_args[:num_threads] = 17 }
+
+      it "creates a client with the expected thread count" do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe "when slice is passed in" do
+      let(:opts) { {slice: 2.weeks} }
+      before { default_args[:slice_interval] = 2.weeks }
+
+      it "creates a client with expected time sline" do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+  end
 end

--- a/spec/lib/reporting/authentication_report_spec.rb
+++ b/spec/lib/reporting/authentication_report_spec.rb
@@ -71,29 +71,29 @@ RSpec.describe Reporting::AuthenticationReport do
     end
   end
 
-  describe "#cloudwatch_client" do
+  describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) { described_class.new(issuer:, time_range:, **opts)}
+    let(:subject) { described_class.new(issuer:, time_range:, **opts) }
     let(:default_args) do
       {
         num_threads: 5,
         ensure_complete_logs: true,
         slice_interval: 3.hours,
         progress: false,
-        logger: nil
+        logger: nil,
       }
     end
 
-    describe "when all args are default" do
-      it "creates a client with the default options" do
+    describe 'when all args are default' do
+      it 'creates a client with the default options' do
         expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
 
         subject.cloudwatch_client
       end
     end
 
-    describe "when verbose is passed in" do
-      let(:opts) { {verbose: true} }
+    describe 'when verbose is passed in' do
+      let(:opts) { { verbose: true } }
       let(:logger) { double Logger }
 
       before do
@@ -101,40 +101,40 @@ RSpec.describe Reporting::AuthenticationReport do
         default_args[:logger] = logger
       end
 
-      it "creates a client with the expected logger" do
+      it 'creates a client with the expected logger' do
         expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
 
         subject.cloudwatch_client
       end
     end
 
-    describe "when progress is passed in as true" do
-      let(:opts) { {progress: true} }
+    describe 'when progress is passed in as true' do
+      let(:opts) { { progress: true } }
       before { default_args[:progress] = true }
 
-      it "creates a client with progress as true" do
+      it 'creates a client with progress as true' do
         expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
 
         subject.cloudwatch_client
       end
     end
 
-    describe "when threads is passed in" do
-      let(:opts) { {threads: 17} }
+    describe 'when threads is passed in' do
+      let(:opts) { { threads: 17 } }
       before { default_args[:num_threads] = 17 }
 
-      it "creates a client with the expected thread count" do
+      it 'creates a client with the expected thread count' do
         expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
 
         subject.cloudwatch_client
       end
     end
 
-    describe "when slice is passed in" do
-      let(:opts) { {slice: 2.weeks} }
+    describe 'when slice is passed in' do
+      let(:opts) { { slice: 2.weeks } }
       before { default_args[:slice_interval] = 2.weeks }
 
-      it "creates a client with expected time sline" do
+      it 'creates a client with expected time slice' do
         expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
 
         subject.cloudwatch_client

--- a/spec/lib/reporting/cloudwatch_query_time_slice_spec.rb
+++ b/spec/lib/reporting/cloudwatch_query_time_slice_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require 'reporting/cloudwatch_query_time_slice'
+
+RSpec.describe Reporting::CloudwatchQueryTimeSlice do
+  describe '#self.parse_duration' do
+    it 'parses min as minutes' do
+      expect(described_class.parse_duration('1111min')).to eq(1111.minutes)
+    end
+
+    it 'parses h as hours' do
+      expect(described_class.parse_duration('2h')).to eq(2.hours)
+    end
+
+    it 'parses d as days' do
+      expect(described_class.parse_duration('3d')).to eq(3.days)
+    end
+
+    it 'parses w as weeks' do
+      expect(described_class.parse_duration('4w')).to eq(4.weeks)
+    end
+
+    it 'parses mon as months' do
+      expect(described_class.parse_duration('5mon')).to eq(5.months)
+    end
+
+    it 'parses y as years' do
+      expect(described_class.parse_duration('6y')).to eq(6.years)
+    end
+
+    it 'is nil for unknown' do
+      expect(described_class.parse_duration('7x')).to be_nil
+    end
+  end
+end

--- a/spec/lib/reporting/command_line_options_spec.rb
+++ b/spec/lib/reporting/command_line_options_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe Reporting::CommandLineOptions do
 
         expect(parse![:time_range]).to eq(jan_1.beginning_of_day..jan_last.end_of_day)
       end
+
+      it 'updates slice to 1.hr if slice is not passed in' do
+        expect(parse![:slice]).to eq 1.hour
+      end
+
+      it 'updates threads to 10 if threads is not passed in' do
+        expect(parse![:threads]).to eq 10
+      end
     end
 
     context 'with --slice' do
@@ -88,10 +96,10 @@ RSpec.describe Reporting::CommandLineOptions do
       end
 
       context 'with --slice in hours' do
-        let(:argv) { %W[--slice 3h --month 2023-1-1 --issuer #{issuer}] }
+        let(:argv) { %W[--slice 2h --month 2023-1-1 --issuer #{issuer}] }
 
-        it 'slice is 3 hours' do
-          expect(parse![:slice]).to eq 3.hours
+        it 'slice is 2 hours' do
+          expect(parse![:slice]).to eq 2.hours
         end
       end
 
@@ -141,23 +149,23 @@ RSpec.describe Reporting::CommandLineOptions do
         let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads abcd ] }
 
         it 'thread is the default of 5' do
-          expect(parse![:threads]).to eq 5
+          expect { parse! }.to raise_error(StandardError, 'Number of threads must be between 1 and 30 inclusive')
         end
       end
 
       context 'if threads is below 0' do
         let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads -3 ] }
 
-        it 'thread is the default of 5' do
-          expect(parse![:threads]).to eq 5
+        it 'throws an error' do
+          expect { parse! }.to raise_error(StandardError, 'Number of threads must be between 1 and 30 inclusive')
         end
       end
 
       context 'if threads is above 31' do
         let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads 31 ] }
 
-        it 'thread is the default of 5' do
-          expect(parse![:threads]).to eq 5
+        it 'throws an error' do
+          expect { parse! }.to raise_error(StandardError, 'Number of threads must be between 1 and 30 inclusive')
         end
       end
     end

--- a/spec/lib/reporting/command_line_options_spec.rb
+++ b/spec/lib/reporting/command_line_options_spec.rb
@@ -149,7 +149,9 @@ RSpec.describe Reporting::CommandLineOptions do
         let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads abcd ] }
 
         it 'thread is the default of 5' do
-          expect { parse! }.to raise_error(StandardError, 'Number of threads must be between 1 and 30 inclusive')
+          expect { parse! }.to raise_error(
+            StandardError, 'Number of threads must be between 1 and 30 inclusive'
+          )
         end
       end
 
@@ -157,7 +159,9 @@ RSpec.describe Reporting::CommandLineOptions do
         let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads -3 ] }
 
         it 'throws an error' do
-          expect { parse! }.to raise_error(StandardError, 'Number of threads must be between 1 and 30 inclusive')
+          expect { parse! }.to raise_error(
+            StandardError, 'Number of threads must be between 1 and 30 inclusive'
+          )
         end
       end
 
@@ -165,7 +169,9 @@ RSpec.describe Reporting::CommandLineOptions do
         let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads 31 ] }
 
         it 'throws an error' do
-          expect { parse! }.to raise_error(StandardError, 'Number of threads must be between 1 and 30 inclusive')
+          expect { parse! }.to raise_error(
+            StandardError, 'Number of threads must be between 1 and 30 inclusive'
+          )
         end
       end
     end

--- a/spec/lib/reporting/command_line_options_spec.rb
+++ b/spec/lib/reporting/command_line_options_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe Reporting::CommandLineOptions do
           issuer: issuer,
           verbose: false,
           progress: true,
+          slice: 3.hours,
+          threads: 5
         )
       end
     end
@@ -62,6 +64,101 @@ RSpec.describe Reporting::CommandLineOptions do
         expect(saturday).to be_saturday
 
         expect(parse![:time_range]).to eq(sunday.beginning_of_day..saturday.end_of_day)
+      end
+    end
+
+    context 'with --month and --issuer' do
+      let(:argv) { %W[--month 2023-1-1 --issuer #{issuer}] }
+
+      it 'uses the whole month given from the first at 12am to the last midnight' do
+        jan_1 = Date.new(2023, 1, 1).in_time_zone('UTC')
+        jan_last = Date.new(2023, 1, 31).in_time_zone('UTC')
+
+        expect(parse![:time_range]).to eq(jan_1.beginning_of_day..jan_last.end_of_day)
+      end
+    end
+
+    context 'with --slice' do
+      context 'with --slice in minutes' do
+        let(:argv) { %W[--slice 2min --month 2023-1-1 --issuer #{issuer}] }
+
+        it 'slice is 2 minutes' do
+          expect(parse![:slice]).to eq 2.minutes
+        end
+      end
+
+      context 'with --slice in hours' do
+        let(:argv) { %W[--slice 3h --month 2023-1-1 --issuer #{issuer}] }
+
+        it 'slice is 3 hours' do
+          expect(parse![:slice]).to eq 3.hours
+        end
+      end
+
+      context 'with --slice in days' do
+        let(:argv) { %W[--slice 3d --month 2023-1-1 --issuer #{issuer}] }
+
+        it 'slice is 3 days' do
+          expect(parse![:slice]).to eq 3.days
+        end
+      end
+
+      context 'with --slice in weeks' do
+        let(:argv) { %W[--slice 3w --month 2023-1-1 --issuer #{issuer}] }
+
+        it 'slice is 3 weeks' do
+          expect(parse![:slice]).to eq 3.weeks
+        end
+      end
+
+      context 'with --slice in months' do
+        let(:argv) { %W[--slice 3mon --month 2023-1-1 --issuer #{issuer}] }
+
+        it 'slice is 3 months' do
+          expect(parse![:slice]).to eq 3.months
+        end
+      end
+
+      context 'with --slice in years' do
+        let(:argv) { %W[--slice 3y --month 2023-1-1 --issuer #{issuer}] }
+
+        it 'slice is 3 years' do
+          expect(parse![:slice]).to eq 3.years
+        end
+      end
+    end
+
+    context 'with --threads' do
+      context 'if threads is a string of a num between 1 and 30' do
+        let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads 9 ] }
+
+        it 'thread is that number' do
+          expect(parse![:threads]).to eq 9
+        end
+      end
+
+      context 'if threads is a random string' do
+        let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads abcd ] }
+
+        it 'thread is the default of 5' do
+          expect(parse![:threads]).to eq 5
+        end
+      end
+
+      context 'if threads is below 0' do
+        let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads -3 ] }
+
+        it 'thread is the default of 5' do
+          expect(parse![:threads]).to eq 5
+        end
+      end
+
+      context 'if threads is above 31' do
+        let(:argv) { %W[--date 2023-1-1 --issuer #{issuer} --threads 31 ] }
+
+        it 'thread is the default of 5' do
+          expect(parse![:threads]).to eq 5
+        end
       end
     end
 

--- a/spec/lib/reporting/command_line_options_spec.rb
+++ b/spec/lib/reporting/command_line_options_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Reporting::CommandLineOptions do
           verbose: false,
           progress: true,
           slice: 3.hours,
-          threads: 5
+          threads: 5,
         )
       end
     end

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -76,4 +76,75 @@ RSpec.describe Reporting::IdentityVerificationReport do
       )
     end
   end
+
+  describe '#cloudwatch_client' do
+    let(:opts) { {} }
+    let(:subject) { described_class.new(issuer:, time_range:, **opts) }
+    let(:default_args) do
+      {
+        num_threads: 5,
+        ensure_complete_logs: true,
+        slice_interval: 3.hours,
+        progress: false,
+        logger: nil,
+      }
+    end
+
+    describe 'when all args are default' do
+      it 'creates a client with the default options' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe 'when verbose is passed in' do
+      let(:opts) { { verbose: true } }
+      let(:logger) { double Logger }
+
+      before do
+        expect(Logger).to receive(:new).with(STDERR).and_return logger
+        default_args[:logger] = logger
+      end
+
+      it 'creates a client with the expected logger' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe 'when progress is passed in as true' do
+      let(:opts) { { progress: true } }
+      before { default_args[:progress] = true }
+
+      it 'creates a client with progress as true' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe 'when threads is passed in' do
+      let(:opts) { { threads: 17 } }
+      before { default_args[:num_threads] = 17 }
+
+      it 'creates a client with the expected thread count' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe 'when slice is passed in' do
+      let(:opts) { { slice: 2.weeks } }
+      before { default_args[:slice_interval] = 2.weeks }
+
+      it 'creates a client with expected time slice' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket
https://cm-jira.usa.gov/browse/LG-9613

## 🛠 Summary of changes
This change:

- adds a --threads, --slice and --month flag to the Reporting::CommandLineOptions class
- updates AuthenticationReport and IdentityVerificationReport to accept those flags
- moves parse_duration method into a shareable module

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] from the command line, run:
`aws-vault exec prod-analytics -- bundle exec rails runner lib/reporting/authentication_report.rb --month 2023-04-01 --issuer $ISSUER --threads 10 --slice 1h`
- [ ] wait awhile (doing this for SSA takes about 40 min)
- [ ] query should complete with a csv output