### PR TITLE
Don't use `verified_at` for pending fraud review

### DIFF
--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -53,22 +53,6 @@ describe 'review_profile' do
         expect(stdout.string).to include('Error: Could not find user with that UUID')
       end
     end
-
-    context 'when the user profile has a nil verified_at' do
-      let(:user) do
-        create(
-          :user,
-          :with_pending_in_person_enrollment,
-          proofing_component: build(:proofing_component),
-        )
-      end
-
-      it 'prints an error' do
-        invoke_task
-
-        expect(stdout.string).to include('Error: User does not have a pending fraud review')
-      end
-    end
   end
 
   describe 'users:review:reject' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

changelog: Internal, Identity Verification, Remove unnecessary fraud review task test

## 🛠 Summary of changes

`Profile#verified_at` was previously used to determine a profile's fraud status, but now is no longer needed. The code before this PR reflects that change, and as a result, the enclosing test is now unnecessary and can be safely removed.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
