### PR TITLE
Remove unnecessary bypass_sign_in calls

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -73,7 +73,6 @@ module RememberDeviceConcern
     user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics
-    bypass_sign_in current_user
     redirect_to after_otp_verification_confirmation_url unless reauthn?
     reset_otp_session_data
   end

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -187,7 +187,6 @@ module TwoFactorAuthenticatableMethods
   def handle_valid_otp_for_authentication_context(auth_method:)
     user_session[:auth_method] = auth_method
     mark_user_session_authenticated(:valid_2fa)
-    bypass_sign_in current_user
     create_user_event(:sign_in_after_2fa)
 
     reset_second_factor_attempts_count

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -47,6 +47,8 @@ module Users
     def handle_valid_password
       send_password_reset_risc_event
       create_event_and_notify_user_about_password_change
+      # Changing the password hash terminates the warden session, and bypass_sign_in ensures
+      # that the user remains authenticated.
       bypass_sign_in current_user
 
       flash[:personal_key] = @update_user_password_form.personal_key

--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -20,7 +20,6 @@ module Users
       result = @new_phone_form.submit(user_params)
       if result.success?
         confirm_phone
-        bypass_sign_in current_user
       elsif recoverable_recaptcha_error?(result)
         render 'users/phone_setup/spam_protection'
       else


### PR DESCRIPTION
## 🛠 Summary of changes

The calls to `bypass_sign_in` removed in this PR seem to be unnecessary and are at best confusing since we should be able to rely on Devise to handle assignment of the user resource. The one exception is when [updating the password](https://github.com/18F/identity-idp/blob/c5c793a8b53c3f6f81dc1f296e9b382d6a4a4a05/app/controllers/users/passwords_controller.rb#L50) while already authenticated because a change in the password hash terminates existing sessions.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
