### PR TITLE
Ensure account deletion emails get sent even when emails are configured to send asynchronously

### DIFF
--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -57,12 +57,14 @@ module AccountReset
       PushNotification::HttpPush.deliver(event)
     end
 
+    # rubocop:disable IdentityIdp/MailLaterLinter
     def notify_user_via_email_of_deletion
       user.confirmed_email_addresses.each do |email_address|
         UserMailer.with(user: user, email_address: email_address).
-          account_reset_complete.deliver_now_or_later
+          account_reset_complete.deliver_now
       end
     end
+    # rubocop:enable IdentityIdp/MailLaterLinter
 
     def extra_analytics_attributes
       {


### PR DESCRIPTION
## 🛠 Summary of changes

A similar problem to the one solved in #7495. If accounts and emails are deleted, we will be unable to load them if we try to send the email asynchronously. This PR changes the delivery to only send synchronously to avoid the error.


[NewRelic Error](https://onenr.io/0BR68oxM0QO)
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
