### PR TITLE
Add SAML authentication request attributes to logging metadata

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -136,6 +136,8 @@ class SamlIdpController < ApplicationController
 
     analytics.saml_auth_request(
       requested_ial: requested_ial,
+      requested_aal_authn_context: saml_request&.requested_aal_authn_context,
+      force_authn: saml_request&.force_authn?,
       service_provider: saml_request&.issuer,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2684,10 +2684,14 @@ module AnalyticsEvents
   end
 
   # @param [Integer] requested_ial
+  # @param [String,nil] requested_aal_authn_context
+  # @param [Boolean,nil] force_authn
   # @param [String] service_provider
   # An external request for SAML Authentication was received
   def saml_auth_request(
     requested_ial:,
+    requested_aal_authn_context:,
+    force_authn:,
     service_provider:,
     **extra
   )
@@ -2695,6 +2699,8 @@ module AnalyticsEvents
       'SAML Auth Request',
       {
         requested_ial: requested_ial,
+        requested_aal_authn_context: requested_aal_authn_context,
+        force_authn: force_authn,
         service_provider: service_provider,
         **extra,
       }.compact,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -569,6 +569,7 @@ describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: authn_context,
             service_provider: sp1_issuer,
+            force_authn: false,
           })
         expect(@analytics).to receive(:track_event).
           with('SAML Auth', {
@@ -710,6 +711,7 @@ describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: 'ialmax',
             service_provider: sp1_issuer,
+            force_authn: false,
           })
         expect(@analytics).to receive(:track_event).
           with('SAML Auth', {
@@ -924,6 +926,19 @@ describe SamlIdpController do
         controller.session[:sp] = { final_auth_request: true }
         saml_final_post_auth(saml_request(saml_settings(overrides: { force_authn: true })))
         expect(session[:sp][:final_auth_request]).to be_falsey
+      end
+
+      it 'logs SAML Auth Request' do
+        stub_analytics
+        expect(@analytics).to receive(:track_event).
+          with('SAML Auth Request', {
+            requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            service_provider: 'http://localhost:3000',
+            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            force_authn: true,
+          })
+
+        saml_get_auth(saml_settings(overrides: { force_authn: true }))
       end
     end
 
@@ -1549,6 +1564,8 @@ describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
+            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            force_authn: false,
           })
 
         saml_get_auth(saml_settings)
@@ -1992,6 +2009,8 @@ describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
+            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            force_authn: false,
           })
         expect(@analytics).to receive(:track_event).
           with('SAML Auth', analytics_hash)
@@ -2037,6 +2056,8 @@ describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
+            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            force_authn: false,
           })
         expect(@analytics).to receive(:track_event).with('SAML Auth', analytics_hash)
         expect(@analytics).to receive(:track_event).
@@ -2073,6 +2094,8 @@ describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
+            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            force_authn: false,
           })
         expect(@analytics).to receive(:track_event).with('SAML Auth', analytics_hash)
         expect(@analytics).to receive(:track_event).

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -407,7 +407,9 @@ feature 'saml api' do
 
       expect(fake_analytics.events['SAML Auth Request']).to eq(
         [{ requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
-           service_provider: 'http://localhost:3000' }],
+           service_provider: 'http://localhost:3000',
+           requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+           force_authn: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
 
@@ -439,7 +441,8 @@ feature 'saml api' do
 
       expect(fake_analytics.events['SAML Auth Request']).to eq(
         [{ requested_ial: 'http://idmanagement.gov/ns/assurance/ial/2',
-           service_provider: 'saml_sp_ial2' }],
+           service_provider: 'saml_sp_ial2',
+           force_authn: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
 
@@ -463,7 +466,9 @@ feature 'saml api' do
 
       expect(fake_analytics.events['SAML Auth Request']).to eq(
         [{ requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
-           service_provider: 'http://localhost:3000' }],
+           service_provider: 'http://localhost:3000',
+           requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+           force_authn: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
 


### PR DESCRIPTION
## 🛠 Summary of changes

Similar to #8261 to add some more information about the types of SAML requests we receive when we log them

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
