### PR TITLE
Store AAMVA tokens in Rails.cache instead of behind an application mutex

### DIFF
--- a/app/services/proofing/aamva/authentication_client.rb
+++ b/app/services/proofing/aamva/authentication_client.rb
@@ -2,28 +2,20 @@ module Proofing
   module Aamva
     class AuthenticationClient
       AAMVA_TOKEN_FRESHNESS_SECONDS = 28 * 60
+      AUTH_TOKEN_CACHE_KEY = 'aamva_api_auth_token'
 
-      class << self
-        attr_accessor :auth_token
-        attr_accessor :auth_token_expiration
-      end
-
-      def self.token_mutex
-        @token_mutex ||= Mutex.new
-      end
-
-      def fetch_token(config)
-        AuthenticationClient.token_mutex.synchronize do
-          if AuthenticationClient.auth_token.nil? || auth_token_expired?
-            send_auth_token_request(config)
-          end
-          AuthenticationClient.auth_token
+      def self.auth_token(config)
+        Rails.cache.fetch(
+          AUTH_TOKEN_CACHE_KEY,
+          skip_nil: true,
+          expires_in: AAMVA_TOKEN_FRESHNESS_SECONDS,
+        ) do
+          send_auth_token_request(config)
         end
       end
 
-      private
-
-      def send_auth_token_request(config)
+      private_class_method
+      def self.send_auth_token_request(config)
         sct_request = Request::SecurityTokenRequest.new(config)
         sct_response = sct_request.send
         token_request = Request::AuthenticationTokenRequest.new(
@@ -34,12 +26,7 @@ module Proofing
           server_hmac_secret: sct_response.nonce,
         )
         token_response = token_request.send
-        AuthenticationClient.auth_token = token_response.auth_token
-        AuthenticationClient.auth_token_expiration = Time.zone.now + AAMVA_TOKEN_FRESHNESS_SECONDS
-      end
-
-      def auth_token_expired?
-        (AuthenticationClient.auth_token_expiration - Time.zone.now).negative?
+        token_response.auth_token
       end
     end
   end

--- a/app/services/proofing/aamva/verification_client.rb
+++ b/app/services/proofing/aamva/verification_client.rb
@@ -20,7 +20,7 @@ module Proofing
       private
 
       def auth_token
-        @auth_token ||= AuthenticationClient.new.fetch_token(config)
+        @auth_token ||= AuthenticationClient.auth_token(config)
       end
     end
   end

--- a/spec/services/proofing/aamva/authentication_client_spec.rb
+++ b/spec/services/proofing/aamva/authentication_client_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe Proofing::Aamva::AuthenticationClient do
   let(:config) { AamvaFixtures.example_config }
-  let(:current_time) { Time.utc(2017) }
   let(:security_token_request_stub) do
     stub_request(:post, config.auth_url).
       with(body: AamvaFixtures.security_token_request).
@@ -48,71 +47,36 @@ describe Proofing::Aamva::AuthenticationClient do
         ).
         and_return(auth_token_request)
       auth_token_request_stub
-
-      allow(Time).to receive(:now).and_return(current_time)
     end
 
-    context 'when the auth token is nil' do
-      before do
-        Proofing::Aamva::AuthenticationClient.auth_token = nil
-        Proofing::Aamva::AuthenticationClient.auth_token_expiration = nil
-      end
-
+    context 'when the auth token is not set' do
       it 'should send an authentication request then save and return the token' do
-        token = subject.fetch_token(AamvaFixtures.example_config)
+        token = Proofing::Aamva::AuthenticationClient.auth_token(AamvaFixtures.example_config)
+        token2 = Proofing::Aamva::AuthenticationClient.auth_token(AamvaFixtures.example_config)
 
         expect(token).to eq('KEYKEYKEY')
-        expect(Proofing::Aamva::AuthenticationClient.auth_token).to eq('KEYKEYKEY')
-        expect(Proofing::Aamva::AuthenticationClient.auth_token_expiration).to eq(
-          current_time + Proofing::Aamva::AuthenticationClient::AAMVA_TOKEN_FRESHNESS_SECONDS,
-        )
-        expect(security_token_request_stub).to have_been_requested
-        expect(auth_token_request_stub).to have_been_requested
+        expect(token2).to eq('KEYKEYKEY')
+        expect(security_token_request_stub).to have_been_requested.once
+        expect(auth_token_request_stub).to have_been_requested.once
       end
     end
 
     context 'when the auth token is present and fresh' do
       before do
-        Proofing::Aamva::AuthenticationClient.auth_token = 'THEOTHERKEY'
-        Proofing::Aamva::AuthenticationClient.auth_token_expiration = current_time + 60
+        Rails.cache.write(
+          Proofing::Aamva::AuthenticationClient::AUTH_TOKEN_CACHE_KEY,
+          'THEOTHERKEY',
+          expires_in: Proofing::Aamva::AuthenticationClient::AAMVA_TOKEN_FRESHNESS_SECONDS,
+        )
       end
 
       it 'should return the auth token' do
-        token = subject.fetch_token(AamvaFixtures.example_config)
-
+        token = Proofing::Aamva::AuthenticationClient.auth_token(AamvaFixtures.example_config)
         expect(token).to eq('THEOTHERKEY')
-        expect(Proofing::Aamva::AuthenticationClient.auth_token).to eq('THEOTHERKEY')
-        expect(Proofing::Aamva::AuthenticationClient.auth_token_expiration).to eq(
-          current_time + 60,
-        )
+
         expect(security_token_request_stub).to_not have_been_requested
         expect(auth_token_request_stub).to_not have_been_requested
       end
-    end
-
-    context 'when the auth token is present and expired' do
-      before do
-        Proofing::Aamva::AuthenticationClient.auth_token = 'THEOTHERKEY'
-        Proofing::Aamva::AuthenticationClient.auth_token_expiration = current_time - 60
-      end
-
-      it 'should send an authentication request then save and return the token' do
-        token = subject.fetch_token(AamvaFixtures.example_config)
-
-        expect(token).to eq('KEYKEYKEY')
-        expect(Proofing::Aamva::AuthenticationClient.auth_token).to eq('KEYKEYKEY')
-        expect(Proofing::Aamva::AuthenticationClient.auth_token_expiration).to eq(
-          current_time + Proofing::Aamva::AuthenticationClient::AAMVA_TOKEN_FRESHNESS_SECONDS,
-        )
-        expect(security_token_request_stub).to have_been_requested
-        expect(auth_token_request_stub).to have_been_requested
-      end
-    end
-
-    it 'should use the token mutex' do
-      expect(Proofing::Aamva::AuthenticationClient.token_mutex).to receive(:synchronize)
-
-      subject.fetch_token(AamvaFixtures.example_config)
     end
   end
 end

--- a/spec/services/proofing/aamva/verification_client_spec.rb
+++ b/spec/services/proofing/aamva/verification_client_spec.rb
@@ -20,9 +20,8 @@ describe Proofing::Aamva::VerificationClient do
 
   describe '#send_verification_request' do
     before do
-      auth_client = instance_double(Proofing::Aamva::AuthenticationClient)
-      allow(auth_client).to receive(:fetch_token).and_return('ThisIsTheToken')
-      allow(Proofing::Aamva::AuthenticationClient).to receive(:new).and_return(auth_client)
+      allow(Proofing::Aamva::AuthenticationClient).to receive(:auth_token).
+        and_return('ThisIsTheToken')
     end
 
     it 'gets the auth token from the auth client' do
@@ -46,9 +45,8 @@ describe Proofing::Aamva::VerificationClient do
     let(:response_http_status) { 200 }
 
     before do
-      auth_client = instance_double(Proofing::Aamva::AuthenticationClient)
-      allow(auth_client).to receive(:fetch_token).and_return('ThisIsTheToken')
-      allow(Proofing::Aamva::AuthenticationClient).to receive(:new).and_return(auth_client)
+      allow(Proofing::Aamva::AuthenticationClient).to receive(:auth_token).
+        and_return('ThisIsTheToken')
 
       stub_request(:post, AamvaFixtures.example_config.verification_url).
         to_return(body: response_body, status: response_http_status)


### PR DESCRIPTION
## 🛠 Summary of changes

We are seeing some test flakiness due to the token being stored in a mutex that is not cleared between tests and it can create different states for different tests depending on the order they run. This PR moves the token storage to `Rails.cache` and relies on it to handle writing and expiration of the token.

The mutex looks to originate from the [original implementation](https://github.com/18F/identity-aamva-api-client-gem/pull/1/files#diff-4f2b27308e24f75d1c085fe627286b9c10e79fae844a6012d9fe8e0032f22df2R12-R23) of the AAMVA client.

[Slack discussion](https://gsa-tts.slack.com/archives/C0NGESUN5/p1683140569799729?thread_ts=1683140405.486229&cid=C0NGESUN5), [CI Example Failure 1](https://gitlab.login.gov/lg/identity-idp/-/jobs/447217), [CI Example Failure 2](https://gitlab.login.gov/lg/identity-idp/-/jobs/447589)

The flaky test can be reproduced reliably with:

```
rspec spec/services/proofing/aamva/proofer_spec.rb spec/services/proofing/resolution/progessive_proofer_spec.rb --seed 933
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
