### PR TITLE
Fix javascript tests using updated new_window/new_tab content

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
@@ -182,7 +182,7 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
 
       expect(
         queryByRole('link', {
-          name: 'idv.troubleshooting.options.get_help_at_sp links.new_window',
+          name: 'idv.troubleshooting.options.get_help_at_sp links.new_tab',
         }),
       ).to.not.exist();
     });

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -213,7 +213,7 @@ describe('document-capture/components/review-issues-step', () => {
     );
 
     expect(
-      queryByRole('link', { name: 'idv.troubleshooting.options.get_help_at_sp links.new_window' }),
+      queryByRole('link', { name: 'idv.troubleshooting.options.get_help_at_sp links.new_tab' }),
     ).to.not.exist();
   });
 
@@ -232,8 +232,7 @@ describe('document-capture/components/review-issues-step', () => {
     );
 
     expect(
-      getByRole('link', { name: 'idv.troubleshooting.options.get_help_at_sp links.new_window' })
-        .href,
+      getByRole('link', { name: 'idv.troubleshooting.options.get_help_at_sp links.new_tab' }).href,
     ).to.equal(
       'https://example.com/?step=document_capture&location=document_capture_troubleshooting_options',
     );


### PR DESCRIPTION
## 🛠 Summary of changes

Looks like https://github.com/18F/identity-idp/pull/8321 was merged after https://github.com/18F/identity-idp/pull/8317 and the outdated values are causing tests to fail. This PR updates the tests to use the new `new_tab` content.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
