### PR TITLE
LG-9295: Rate limit for “Verify your information” must include a link back to SP

### DIFF
--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -29,6 +29,7 @@ module Idv
         throttle_type: :idv_resolution,
       )
       @expires_at = throttle.expires_at
+      @sp_name = decorated_session.sp_name
       log_event(based_on_throttle: throttle)
     end
 

--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -3,14 +3,6 @@
       title: t('titles.failure.information_not_verified'),
       heading: t('idv.failure.sessions.heading'),
       options: [
-        decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path(
-            step: 'verify_info',
-            location: request.params[:action],
-          ),
-          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-          new_tab: true,
-        },
         {
           url: MarketingSite.contact_url,
           text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
@@ -27,5 +19,18 @@
                 except: :seconds,
               ),
             ) %>
+      </p>
+      <p>
+        <strong>
+          <%= link_to(
+                @sp_name ?
+                  t('idv.failure.exit.with_sp', app_name: APP_NAME, sp_name: @sp_name) :
+                  t('idv.failure.exit.without_sp'),
+                return_to_sp_failure_to_proof_path(
+                  step: 'verify_id',
+                  location: 'failure',
+                ),
+              ) %>
+        </strong>
       </p>
     <% end %>

--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -2,6 +2,7 @@
       'idv/shared/error',
       title: t('titles.failure.information_not_verified'),
       heading: t('idv.failure.sessions.heading'),
+      current_step: :verify_info,
       options: [
         {
           url: MarketingSite.contact_url,

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -110,10 +110,10 @@ en:
           you_entered: 'You entered:'
       sessions:
         exception: There was an internal error processing your request.
-        fail_html: '<strong>Please try again in %{timeout}.</strong> For your security,
-          we limit the number of times you can attempt to verify personal
-          information online.'
-        heading: We could not find records matching your personal information.
+        fail_html: 'For your security, we limit the number of times you can attempt to
+          verify personal information online. <strong>Try again in
+          %{timeout}.</strong>'
+        heading: We couldn’t find records matching your personal information
         warning: Please check the information you entered and try again. Common mistakes
           are an incorrect Social Security number or ZIP Code.
       setup:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -118,11 +118,10 @@ es:
           you_entered: 'Ud. entregó:'
       sessions:
         exception: Hubo un error interno al procesar su solicitud.
-        fail_html: '<strong>Por favor, inténtelo de nuevo en %{timeout}.</strong> Por su
-          seguridad, limitamos el número de veces que puede intentar verificar
-          la información personal en línea.'
-        heading: No hemos podido encontrar registros que coincidan con su información
-          personal.
+        fail_html: 'Por su seguridad, limitamos el número de veces que puede intentar
+          verificar la información personal en línea. <strong>Inténtelo de nuevo
+          en %{timeout}.</strong>'
+        heading: No encontramos registros que coincidan con sus datos personales
         warning: Por favor, verifique la información que ingresó y vuelva a intentarlo.
           Los errores más comunes suelen producirse al ingresar un Número de
           Seguridad Social o un Código Postal incorrecto.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -125,7 +125,7 @@ fr:
         fail_html: 'Pour votre sécurité, nous limitons le nombre de fois où vous pouvez
           tenter de vérifier des informations personnelles en ligne.
           <strong>Réessayer dans %{timeout}.</strong>'
-        heading: Nous ne trouvons pas de données qui correspondent à vos informations
+        heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations personnelles
           téléphoniques.
         warning: Veuillez vérifier les informations que vous avez saisies et réessayer.
           Les erreurs les plus courantes sont un numéro de sécurité sociale ou

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -125,8 +125,8 @@ fr:
         fail_html: 'Pour votre sécurité, nous limitons le nombre de fois où vous pouvez
           tenter de vérifier des informations personnelles en ligne.
           <strong>Réessayer dans %{timeout}.</strong>'
-        heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations personnelles
-          téléphoniques.
+        heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations
+          personnelles téléphoniques.
         warning: Veuillez vérifier les informations que vous avez saisies et réessayer.
           Les erreurs les plus courantes sont un numéro de sécurité sociale ou
           un code postal incorrect.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -122,9 +122,9 @@ fr:
           you_entered: 'Tu as soumis:'
       sessions:
         exception: Une erreur interne s’est produite lors du traitement de votre demande.
-        fail_html: '<strong>Veuillez réessayer dans %{timeout}.</strong> Pour votre
-          sécurité, nous limitons le nombre de fois où vous pouvez tenter de
-          vérifier des informations personnelles en ligne.'
+        fail_html: 'Pour votre sécurité, nous limitons le nombre de fois où vous pouvez
+          tenter de vérifier des informations personnelles en ligne.
+          <strong>Réessayer dans %{timeout}.</strong>'
         heading: Nous ne trouvons pas de données qui correspondent à vos informations
           téléphoniques.
         warning: Veuillez vérifier les informations que vous avez saisies et réessayer.

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -199,6 +199,14 @@ describe Idv::SessionErrorsController do
         expect(assigns(:expires_at)).to be_kind_of(Time)
       end
 
+      it 'assigns sp_name' do
+        decorated_session = double
+        allow(decorated_session).to receive(:sp_name).and_return('Example SP')
+        allow(controller).to receive(:decorated_session).and_return(decorated_session)
+        get action
+        expect(assigns(:sp_name)).to eql('Example SP')
+      end
+
       it 'logs an event with attempts remaining' do
         expect(@analytics).to receive(:track_event).with(
           'IdV: session error visited',

--- a/spec/views/idv/session_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/failure.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'idv/session_errors/failure.html.erb' do
-  let(:sp_name) { 'Example SP' }
+  let(:sp_name) { nil }
   let(:timeout_hours) { 6 }
 
   around do |ex|
@@ -9,20 +9,15 @@ describe 'idv/session_errors/failure.html.erb' do
   end
 
   before do
-    decorated_session = instance_double(ServiceProviderSessionDecorator, sp_name: sp_name)
-    allow(view).to receive(:decorated_session).and_return(decorated_session)
     allow(IdentityConfig.store).to receive(:idv_attempt_window_in_hours).and_return(timeout_hours)
 
     @expires_at = Time.zone.now + timeout_hours.hours
+    @sp_name = sp_name
 
     render
   end
 
   it 'renders a list of troubleshooting options' do
-    expect(rendered).to have_link(
-      t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-      href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'failure'),
-    )
     expect(rendered).to have_link(
       t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
       href: MarketingSite.contact_url,
@@ -38,5 +33,27 @@ describe 'idv/session_errors/failure.html.erb' do
         ),
       ),
     )
+  end
+
+  it 'links back to the failure_to_proof URL' do
+    expect(rendered).to have_link(
+      t('idv.failure.exit.without_sp'),
+      href: return_to_sp_failure_to_proof_path(step: 'verify_id', location: 'failure'),
+    )
+  end
+
+  context 'with an associated service provider' do
+    let(:sp_name) { 'Example SP' }
+
+    it 'links back to the SP failure_to_proof URL' do
+      expect(rendered).to have_link(
+        t(
+          'idv.failure.exit.with_sp',
+          sp_name: sp_name,
+          app_name: 'Login.gov',
+        ),
+        href: return_to_sp_failure_to_proof_path(step: 'verify_id', location: 'failure'),
+      )
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9295](https://cm-jira.usa.gov/browse/LG-9295)

## 🛠 Summary of changes

Tweaks to the rate limit error screen shown on the "Verify your information" step of IdV. Includes:

- Updated heading
- Tweaked body copy
- More prominent "exit" link

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

### With SP

![with-sp-en-BEFORE](https://user-images.githubusercontent.com/364697/236053328-6f5afb32-bfa1-4fd8-9e5f-7c1296654567.png)


### Without SP

![without-sp-en-BEFORE](https://user-images.githubusercontent.com/364697/236053387-cf46088e-90b8-408f-bedc-0470c18e0ce5.png)

</details>

<details>
<summary>After:</summary>

### With SP

![with-sp-en-AFTER](https://user-images.githubusercontent.com/364697/236303905-dbf09acd-446a-421b-bffc-28e10d2ec53f.png)


### Without SP


![without-sp-en-AFTER](https://user-images.githubusercontent.com/364697/236303933-08a4fb4e-292e-429a-98d9-9a69a1494449.png)


</details>
