### PR TITLE
Remove step indicator concern from idv sessions error

### DIFF
--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -1,6 +1,5 @@
 module Idv
   class SessionErrorsController < ApplicationController
-    include StepIndicatorConcern
     include IdvSession
     include EffectiveUser
 

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -1,7 +1,6 @@
 <%= render(
       'idv/shared/error',
       heading: t('errors.doc_auth.throttled_heading'),
-      current_step: :verify_id,
       options: [
         {
           url: MarketingSite.contact_url,

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -98,6 +98,20 @@ shared_examples_for 'an idv session errors controller action' do
       get action
     end
   end
+
+  context 'the user is in the hybrid flow' do
+    render_views
+    let(:effective_user) { create(:user) }
+
+    before do
+      session[:doc_capture_user_id] = effective_user.id
+    end
+
+    it 'renders the error template' do
+      get action
+      expect(response).to render_template(template)
+    end
+  end
 end
 
 describe Idv::SessionErrorsController do


### PR DESCRIPTION
## 🛠 Summary of changes

Intends to address a bug in https://github.com/18F/identity-idp/pull/8291 where users viewing a rate limit error would see a 500 error because the step indicator concern relies on session data that doesn't exist when a user is in the hybrid flow

[Slack discussion](https://gsa-tts.slack.com/archives/C0NGESUN5/p1683225941919019?thread_ts=1683224465.791789&cid=C0NGESUN5)

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
