### PR TITLE
LG-6355 Update presenter to skip ial2 data if no data is present

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -127,7 +127,7 @@ class OpenidConnectUserInfoPresenter
 
   def ialmax_session?
     identity.ial == Idp::Constants::IAL_MAX
- end
+  end
 
   def x509_data
     @x509_data ||= begin

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -18,7 +18,7 @@ class OpenidConnectUserInfoPresenter
     }
 
     info[:all_emails] = all_emails_from_sp_identity(identity) if scoper.all_emails_requested?
-    info.merge!(ial2_attributes) if scoper.ial2_scopes_requested?
+    info.merge!(ial2_attributes) if scoper.ial2_scopes_requested? && ial2_data.present?
     info.merge!(x509_attributes) if scoper.x509_scopes_requested?
     info[:verified_at] = verified_at if scoper.verified_at_requested?
     info[:ial] = Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[identity.ial]
@@ -126,8 +126,8 @@ class OpenidConnectUserInfoPresenter
   end
 
   def ialmax_session?
-    identity.ial&.zero?
-  end
+    identity.ial == Idp::Constants::IAL_MAX
+ end
 
   def x509_data
     @x509_data ||= begin


### PR DESCRIPTION

## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-6355

## 🛠 Summary of changes
Fixes bug where server throws a 500 if an unverified user tries to log into a service provider using the OIDC protocol and an IALMax service level. 

