### PR TITLE
LG-7184: Add analytics to security & privacy link on welcome and agreement steps

### DIFF
--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -33,7 +33,7 @@
   <p class="margin-top-2">
     <%= new_tab_link_to(
           t('doc_auth.instructions.learn_more'),
-          MarketingSite.security_and_privacy_practices_url,
+          policy_redirect_url(flow: :idv, step: :agreement, location: :consent),
         ) %>
   </p>
   <div class="margin-top-4">

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -97,7 +97,7 @@
     <p>
       <%= new_tab_link_to(
             t('doc_auth.instructions.learn_more'),
-            MarketingSite.security_and_privacy_practices_url,
+            policy_redirect_url(flow: :idv, step: :welcome, location: :footer),
           ) %>
     </p>
 

--- a/spec/views/idv/doc_auth/agreement.html.erb_spec.rb
+++ b/spec/views/idv/doc_auth/agreement.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'idv/doc_auth/agreement' do
+  let(:flow_session) { {} }
+
+  before do
+    allow(view).to receive(:flow_session).and_return(flow_session)
+    allow(view).to receive(:user_signing_up?).and_return(false)
+    allow(view).to receive(:url_for).and_wrap_original do |method, *args, &block|
+      method.call(*args, &block)
+    rescue
+      ''
+    end
+    render
+  end
+
+  it 'renders a link to the privacy & security page' do
+    expect(rendered).to have_link(
+      t('doc_auth.instructions.learn_more'),
+      href: policy_redirect_url(flow: :idv, step: :agreement, location: :consent),
+    )
+  end
+end

--- a/spec/views/idv/doc_auth/welcome.html.erb_spec.rb
+++ b/spec/views/idv/doc_auth/welcome.html.erb_spec.rb
@@ -12,8 +12,12 @@ describe 'idv/doc_auth/welcome.html.erb' do
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
     allow(view).to receive(:flow_session).and_return(flow_session)
     allow(view).to receive(:user_fully_authenticated?).and_return(user_fully_authenticated)
-    allow(view).to receive(:url_for).and_return('https://www.example.com/')
     allow(view).to receive(:user_signing_up?).and_return(false)
+    allow(view).to receive(:url_for).and_wrap_original do |method, *args, &block|
+      method.call(*args, &block)
+    rescue
+      ''
+    end
   end
 
   context 'in doc auth with an authenticated user' do
@@ -101,5 +105,13 @@ describe 'idv/doc_auth/welcome.html.erb' do
         t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
       )
     end
+  end
+
+  it 'renders a link to the privacy & security page' do
+    render template: 'idv/doc_auth/welcome'
+    expect(rendered).to have_link(
+      t('doc_auth.instructions.learn_more'),
+      href: policy_redirect_url(flow: :idv, step: :welcome, location: :footer),
+    )
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-7184](https://cm-jira.usa.gov/browse/LG-7184)

## 🛠 Summary of changes

Updates the "Learn more about our privacy and security measures" links on the welcome and agreements steps of IDV to run through our `RedirectController` to start collecting analytics.

