### PR TITLE
LG-9515: Refactor capture_secondary_id_enabled

### DIFF
--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -7,6 +7,10 @@ module Idv
 
       private
 
+      def capture_secondary_id_enabled?
+        current_user.establishing_in_person_enrollment.capture_secondary_id_enabled
+      end
+
       def save_proofing_components
         return unless current_user
 

--- a/app/services/idv/steps/in_person/address_step.rb
+++ b/app/services/idv/steps/in_person/address_step.rb
@@ -44,10 +44,6 @@ module Idv
 
         private
 
-        def capture_secondary_id_enabled?
-          current_user.establishing_in_person_enrollment.capture_secondary_id_enabled
-        end
-
         def updating_address?
           flow_session[:pii_from_user].has_key?(:address1)
         end

--- a/app/services/idv/steps/in_person/state_id_step.rb
+++ b/app/services/idv/steps/in_person/state_id_step.rb
@@ -52,10 +52,6 @@ module Idv
 
         private
 
-        def capture_secondary_id_enabled?
-          current_user.establishing_in_person_enrollment.capture_secondary_id_enabled
-        end
-
         def clear_residential_address(pii_from_user)
           pii_from_user.delete(:address1)
           pii_from_user.delete(:address2)

--- a/app/services/idv/steps/in_person/verify_step.rb
+++ b/app/services/idv/steps/in_person/verify_step.rb
@@ -27,10 +27,6 @@ module Idv
 
         private
 
-        def capture_secondary_id_enabled?
-          current_user.establishing_in_person_enrollment.capture_secondary_id_enabled
-        end
-
         def pii
           flow_session[:pii_from_user]
         end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9515](https://cm-jira.usa.gov/browse/LG-9515)

## 🛠 Summary of changes

Refactored the `capture_secondary_id_enabled` method to be defined once

Because these classes all inherit from `DocAuthBaseStep` and define the
method in the exact same way, we can DRY it up by removing the method
from the descendant classes.

## 📜 Testing Plan

### with `capture_secondary_id_enabled`
- [ ] enable `in_person_capture_secondary_id_enabled`
- [ ] follow the flow to the State ID step
- [ ] note that the radio button for same address as id is on the State ID page, as is the initial address entry
- [ ] follow through to the verify page
- [ ] expect that underneath the `Verify your information` heading, you see subheadings of `State-issued ID`, `Residential address`, and `Social Security Number`

### without `capture_secondary_id_enabled`
- [ ] disable `in_person_capture_secondary_id_enabled`
- [ ] follow the flow past the State ID step to the address step
- [ ] note that the radio button for same address as id is on the Address page
- [ ] follow through to the verify page
- [ ] expect the only heading to be `Verify your information`
