### PR TITLE
Refactor handling of successful two-factor phone confirmation

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -110,7 +110,7 @@ module TwoFactorAuthenticatableMethods
     if UserSessionContext.authentication_or_reauthentication_context?(context)
       handle_valid_otp_for_authentication_context(auth_method: auth_method)
     elsif UserSessionContext.confirmation_context?(context)
-      handle_valid_otp_for_confirmation_context
+      handle_valid_verification_for_confirmation_context
     end
   end
 
@@ -168,13 +168,11 @@ module TwoFactorAuthenticatableMethods
     current_user.increment_second_factor_attempts_count!
   end
 
-  def handle_valid_otp_for_confirmation_context
+  def handle_valid_verification_for_confirmation_context
     user_session[:authn_at] = Time.zone.now
-    assign_phone
     track_mfa_method_added
     @next_mfa_setup_path = next_setup_path
     reset_second_factor_attempts_count
-    flash[:success] = t('notices.phone_confirmed')
   end
 
   def track_mfa_method_added
@@ -192,51 +190,8 @@ module TwoFactorAuthenticatableMethods
     reset_second_factor_attempts_count
   end
 
-  def assign_phone
-    @updating_existing_number = user_session[:phone_id].present?
-
-    if @updating_existing_number && UserSessionContext.confirmation_context?(context)
-      phone_changed
-    else
-      phone_confirmed
-    end
-
-    update_phone_attributes
-  end
-
   def reset_second_factor_attempts_count
     UpdateUser.new(user: current_user, attributes: { second_factor_attempts_count: 0 }).call
-  end
-
-  def phone_changed
-    create_user_event(:phone_changed)
-    send_phone_added_email
-  end
-
-  def phone_confirmed
-    create_user_event(:phone_confirmed)
-    # If the user has MFA configured, then they are not adding a phone during sign up and are
-    # instead adding it outside the sign up flow
-    return unless MfaPolicy.new(current_user).two_factor_enabled?
-    send_phone_added_email
-  end
-
-  def send_phone_added_email
-    _event, disavowal_token = create_user_event_with_disavowal(:phone_added, current_user)
-    current_user.confirmed_email_addresses.each do |email_address|
-      UserMailer.with(user: current_user, email_address: email_address).
-        phone_added(disavowal_token: disavowal_token).deliver_now_or_later
-    end
-  end
-
-  def update_phone_attributes
-    UpdateUser.new(
-      user: current_user,
-      attributes: { phone_id: user_session[:phone_id],
-                    phone: user_session[:unconfirmed_phone],
-                    phone_confirmed_at: Time.zone.now,
-                    otp_make_default_number: selected_otp_make_default_number },
-    ).call
   end
 
   def reset_otp_session_data
@@ -262,10 +217,6 @@ module TwoFactorAuthenticatableMethods
     )
   end
 
-  def direct_otp_code
-    current_user.direct_otp if FeatureManagement.prefill_otp_codes?
-  end
-
   def otp_expiration
     return if current_user.direct_otp_sent_at.blank?
     current_user.direct_otp_sent_at + TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS
@@ -275,33 +226,9 @@ module TwoFactorAuthenticatableMethods
     cookies.encrypted[:user_opted_remember_device_preference]
   end
 
-  def unconfirmed_phone?
-    user_session[:unconfirmed_phone] && UserSessionContext.confirmation_context?(context)
-  end
-
-  def selected_otp_make_default_number
-    params&.dig(:otp_make_default_number)
-  end
-
   def generic_data
     {
       user_opted_remember_device_cookie: user_opted_remember_device_cookie,
     }
-  end
-
-  def display_phone_to_deliver_to
-    if UserSessionContext.authentication_or_reauthentication_context?(context)
-      phone_configuration.masked_phone
-    else
-      user_session[:unconfirmed_phone]
-    end
-  end
-
-  def confirmation_for_add_phone?
-    UserSessionContext.confirmation_context?(context) && user_fully_authenticated?
-  end
-
-  def phone_configuration
-    MfaContext.new(current_user).phone_configuration(user_session[:phone_id])
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

A bit of a followup to #8178 and #8316 (specifically this [comment](https://github.com/18F/identity-idp/pull/8316#pullrequestreview-1408096330)) to start consolidating how we implement `handle_valid_otp`. We have repeated ourselves a few times with methods like `mark_user_as_fully_authenticated`, but there's a significant amount of phone-specific functionality now. This PR starts to separate those, and aims to eventually consolidate into `handle_valid_2FA` or similar since not all 2FAs have an OTP (which makes `handle_valid_otp` kind of misleading).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
