### PR TITLE
Add lint for migrations folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ endif
 	yarn lint:css
 	@echo "--- README.md ---"
 	make lint_readme
+	@echo "--- lint migrations ---"
+	make lint_migrations
 
 lint_erb: ## Lints ERB files
 	bundle exec erblint app/views app/components
@@ -104,6 +106,9 @@ lint_yaml: normalize_yaml ## Lints YAML files
 
 lint_yarn_workspaces: ## Lints Yarn workspace packages
 	scripts/validate-workspaces.js
+
+lint_migrations:
+	scripts/migration_check
 
 lint_gemfile_lock: Gemfile Gemfile.lock ## Lints the Gemfile and its lockfile
 	@bundle check

--- a/scripts/migration_check
+++ b/scripts/migration_check
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -d './db/migrate' ]
+then
+	echo "The ./db/migrate folder should not be used for generating migrations"
+	echo "Use the --database option to specify the database to be used. Example:"
+	echo "rails g migration add_my_database_table --database primary"
+	exit 1
+fi

--- a/scripts/migration_check
+++ b/scripts/migration_check
@@ -4,6 +4,7 @@ if [ -d './db/migrate' ]
 then
 	echo "The ./db/migrate folder should not be used for generating migrations"
 	echo "Use the --database option to specify the database to be used. Example:"
-	echo "rails g migration add_my_database_table --database primary"
+	echo "> rails g migration add_my_database_table --database primary"
+	echo "Then, remove db/migrate"
 	exit 1
 fi


### PR DESCRIPTION
## 🛠 Summary of changes

One of the items in our incident review of [2023-04-13 Unsafe Migration](https://docs.google.com/document/d/1a5Blx8a4MMPbhvOBMRYmzJBpEvMJ8RCiozXB0gDjEnA/edit) was to prevent us from using the default migration folder (as in https://github.com/18F/identity-idp/pull/8175) since it will not be run by the migration script.

I've added https://github.com/18F/identity-idp/commit/fefc13cf434eaaf7c81fb93d518694a2619f644f initially to make sure it fails.

 
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
