### PR TITLE
LG-7184: Add analytics event for consent checkbox toggles

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -21,6 +21,7 @@ class FrontendLogController < ApplicationController
     'IdV: personal key acknowledgment toggled' => :idv_personal_key_acknowledgment_toggled,
     'IdV: user clicked sp link on ready to verify page' => :idv_in_person_ready_to_verify_sp_link_clicked,
     'IdV: user clicked what to bring link on ready to verify page' => :idv_in_person_ready_to_verify_what_to_bring_link_clicked,
+    'IdV: consent checkbox toggled' => :idv_consent_checkbox_toggled,
   }.transform_values { |method| AnalyticsEvents.instance_method(method) }.freeze
   # rubocop:enable Layout/LineLength
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -557,6 +557,17 @@ module AnalyticsEvents
     )
   end
 
+  # The user checked or unchecked the "By checking this box..." checkbox on the idv agreement step.
+  # (This is a frontend event.)
+  # @param [Boolean] checked Whether the user checked the checkbox
+  def idv_consent_checkbox_toggled(checked:, **extra)
+    track_event(
+      'IdV: consent checkbox toggled',
+      checked: checked,
+      **extra,
+    )
+  end
+
   # The user visited the "come back later" page shown during the GPO mailing flow
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   def idv_come_back_later_visit(proofing_components: nil, **extra)

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -23,13 +23,15 @@
       method: 'put',
       html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
     ) do |f| %>
-  <%= render ValidatedFieldComponent.new(
-        form: f,
-        name: :ial2_consent_given,
-        as: :boolean,
-        label: t('doc_auth.instructions.consent', app_name: APP_NAME),
-        required: true,
-      ) %>
+  <%= render ClickObserverComponent.new(event_name: 'Idv: Consent checkbox toggled') do %>
+    <%= render ValidatedFieldComponent.new(
+          form: f,
+          name: :ial2_consent_given,
+          as: :boolean,
+          label: t('doc_auth.instructions.consent', app_name: APP_NAME),
+          required: true,
+        ) %>
+  <% end %>
   <p class="margin-top-2">
     <%= new_tab_link_to(
           t('doc_auth.instructions.learn_more'),

--- a/app/views/idv/doc_auth/agreement.html.erb
+++ b/app/views/idv/doc_auth/agreement.html.erb
@@ -23,7 +23,7 @@
       method: 'put',
       html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
     ) do |f| %>
-  <%= render ClickObserverComponent.new(event_name: 'Idv: Consent checkbox toggled') do %>
+  <%= render ClickObserverComponent.new(event_name: 'IdV: consent checkbox toggled') do %>
     <%= render ValidatedFieldComponent.new(
           form: f,
           name: :ial2_consent_given,

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -14,6 +14,7 @@ feature 'Analytics Regression', js: true do
       'IdV: doc auth welcome visited' => { flow_path: 'standard', step: 'welcome', step_count: 1, acuant_sdk_upgrade_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false },
       'IdV: doc auth welcome submitted' => { success: true, errors: {}, flow_path: 'standard', step: 'welcome', step_count: 1, acuant_sdk_upgrade_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false },
       'IdV: doc auth agreement visited' => { flow_path: 'standard', step: 'agreement', step_count: 1, acuant_sdk_upgrade_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false },
+      'IdV: consent checkbox toggled' => { checked: true },
       'IdV: doc auth agreement submitted' => { success: true, errors: {}, flow_path: 'standard', step: 'agreement', step_count: 1, acuant_sdk_upgrade_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false },
       'IdV: doc auth upload visited' => { flow_path: 'standard', step: 'upload', step_count: 1, acuant_sdk_upgrade_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false },
       'IdV: doc auth upload submitted' => { success: true, errors: {}, destination: :document_capture, flow_path: 'standard', step: 'upload', step_count: 1, acuant_sdk_upgrade_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false, skip_upload_step: false },

--- a/spec/views/idv/doc_auth/agreement.html.erb_spec.rb
+++ b/spec/views/idv/doc_auth/agreement.html.erb_spec.rb
@@ -16,7 +16,7 @@ describe 'idv/doc_auth/agreement' do
 
   it 'includes code to track clicks on the consent checkbox' do
     selector = [
-      'lg-click-observer[event-name="Idv: Consent checkbox toggled"]',
+      'lg-click-observer[event-name="IdV: consent checkbox toggled"]',
       '[name="doc_auth[ial2_consent_given]"]',
     ].join ' '
 

--- a/spec/views/idv/doc_auth/agreement.html.erb_spec.rb
+++ b/spec/views/idv/doc_auth/agreement.html.erb_spec.rb
@@ -14,6 +14,15 @@ describe 'idv/doc_auth/agreement' do
     render
   end
 
+  it 'includes code to track clicks on the consent checkbox' do
+    selector = [
+      'lg-click-observer[event-name="Idv: Consent checkbox toggled"]',
+      '[name="doc_auth[ial2_consent_given]"]',
+    ].join ' '
+
+    expect(rendered).to have_css(selector)
+  end
+
   it 'renders a link to the privacy & security page' do
     expect(rendered).to have_link(
       t('doc_auth.instructions.learn_more'),


### PR DESCRIPTION
## 🎫 Ticket

[LG-7184](https://cm-jira.usa.gov/browse/LG-7184)

## 🛠 Summary of changes

Wrap the consent checkbox on the IdV agreement step in a `ClickObserverComponent` and log an event on toggles. 

The new event will be `IdV: Consent checkbox toggled`.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
