### PR TITLE
LG-5725 IALMax requests ial2 info if user is verified

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -47,13 +47,21 @@ module SignUp
         current_sp: current_sp,
         decrypted_pii: pii,
         requested_attributes: decorated_session.requested_attributes.map(&:to_sym),
-        ial2_requested: sp_session[:ial2] || sp_session[:ialmax],
+        ial2_requested: !!ial2_requested?,
         completion_context: needs_completion_screen_reason,
       )
     end
 
     def ial2?
       sp_session[:ial2]
+    end
+
+    def ial_max?
+      sp_session[:ialmax]
+    end
+
+    def ial2_requested?
+      ial2? || (ial_max? && current_user.identity_verified?)
     end
 
     def return_to_account

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -89,7 +89,10 @@ module Users
     end
 
     def ial_context
-      @ial_context ||= IalContext.new(ial: sp_session_ial, service_provider: current_sp)
+      @ial_context ||= IalContext.new(
+        ial: sp_session_ial, service_provider: current_sp,
+        user: piv_cac_login_form.user
+      )
     end
 
     def process_invalid_submission

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -57,11 +57,19 @@ class IdTokenBuilder
   def acr
     ial = identity.ial
     case ial
-    when Idp::Constants::IAL_MAX then Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
+    when Idp::Constants::IAL_MAX then determine_ial_max_acr
     when Idp::Constants::IAL1 then Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
     when Idp::Constants::IAL2 then Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
     else
       raise "Unknown ial #{ial}"
+    end
+  end
+
+  def determine_ial_max_acr
+    if identity.user.identity_verified?
+      Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+    else
+      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket
https://cm-jira.usa.gov/browse/LG-5725

## 🛠 Summary of changes
This change: 
* ensures if a service provider is using IALMax that a user sees the IAL1 completion screen if they are not verified
* Adds the user to the IalContext for PivCac users so it can be determined if they are verified
* Updates the ACR return values to return the IAL2 or IAL1 acr_value depending on if the user is verified or not
