### PR TITLE
LG-9298 Warning screen for “Verify your information” should include a way for a user to cancel and return to SP

### DIFF
--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -12,5 +12,5 @@
 <% end %>
 
 <%= render PageFooterComponent.new do %>
-  <%= link_to cancel_link_text, idv_cancel_path %>
+  <%= link_to t('links.cancel'), idv_cancel_path %>
 <% end %>

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -4,7 +4,7 @@
   <% c.header { t('idv.warning.sessions.heading') } %>
 
   <p><%= t('idv.failure.sessions.warning') %></p>
-  <p><strong><%= t('idv.warning.attempts', count: 1) %></strong></p>
+  <p><strong><%= t('idv.warning.attempts', count: @remaining_attempts) %></strong></p>
 
   <% c.action_button(
        action: ->(**tag_options, &block) { link_to(@try_again_path, **tag_options, &block) },

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -1,34 +1,16 @@
 <% title t('titles.failure.information_not_verified') %>
 
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
-  <% c.header { t('idv.failure.sessions.heading') } %>
+  <% c.header { t('idv.warning.sessions.heading') } %>
 
   <p><%= t('idv.failure.sessions.warning') %></p>
-  <p><strong><%= t('idv.failure.attempts', count: @remaining_attempts) %></strong></p>
+  <p><strong><%= t('idv.warning.attempts', count: 1) %></strong></p>
 
   <% c.action_button(
        action: ->(**tag_options, &block) { link_to(@try_again_path, **tag_options, &block) },
      ) { t('idv.forgot_password.try_again') } %>
+<% end %>
 
-  <% c.troubleshooting_options do |tc| %>
-    <% tc.header { t('components.troubleshooting_options.default_heading') } %>
-    <% if user_session&.dig(:'idv/doc_auth', :had_barcode_read_failure) %>
-      <% tc.option(
-           url: idv_doc_auth_step_path(step: :redo_document_capture),
-           action: FormLinkComponent.method(:new),
-           method: :put,
-         ).with_content(t('idv.troubleshooting.options.add_new_photos')) %>
-    <% end %>
-    <% if decorated_session.sp_name %>
-      <% tc.option(
-           url: return_to_sp_failure_to_proof_path(
-             step: 'verify_info',
-             location: request.params[:action],
-           ),
-           new_tab: true,
-         ).with_content(
-           t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-         ) %>
-    <% end %>
-  <% end %>
+<%= render PageFooterComponent.new do %>
+  <%= link_to cancel_link_text, idv_cancel_path %>
 <% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -105,12 +105,6 @@ ignore_unused:
   - 'idv.failure.attempts.other'
   - 'idv.failure.attempts.other_variant_a_html'
   - 'idv.failure.attempts.other_variant_b_html'
-  - 'idv.warning.attempts.one'
-  - 'idv.warning.attempts.one_variant_a_html'
-  - 'idv.warning.attempts.one_variant_b_html'
-  - 'idv.warning.attempts.other'
-  - 'idv.warning.attempts.other_variant_a_html'
-  - 'idv.warning.attempts.other_variant_b_html'
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:
 #   all:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -105,6 +105,12 @@ ignore_unused:
   - 'idv.failure.attempts.other'
   - 'idv.failure.attempts.other_variant_a_html'
   - 'idv.failure.attempts.other_variant_b_html'
+  - 'idv.warning.attempts.one'
+  - 'idv.warning.attempts.one_variant_a_html'
+  - 'idv.warning.attempts.one_variant_b_html'
+  - 'idv.warning.attempts.other'
+  - 'idv.warning.attempts.other_variant_a_html'
+  - 'idv.warning.attempts.other_variant_b_html'
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:
 #   all:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -254,14 +254,7 @@ en:
     warning:
       attempts:
         one: For security reasons, you have one attempt remaining.
-        one_variant_a_html: For security reasons, you have <strong>one attempt<strong> remaining.
-        one_variant_b_html: Try taking new pictures. For security reasons, you have
-          <strong>one attempt<strong> remaining.
         other: For security reasons, you have %{count} attempts remaining.
-        other_variant_a_html: For security reasons, you have <strong>%{count}
-          attempts<strong> remaining.
-        other_variant_b_html: Try taking new pictures. For security reasons, you have
-          <strong>%{count} attempts<strong>.
       sessions:
         heading: We couldn’t find records matching your personal information
     welcome:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -252,6 +252,20 @@ en:
       status_page_link: 'Get updates on our status page'
       technical_difficulties: Unfortunately, we are having technical difficulties and
         cannot verify your identity at this time.
+    warning:
+      attempts:
+        one: For security reasons, you have one attempt remaining.
+        one_variant_a_html: For security reasons, you have <strong>one attempt<strong>
+          remaining.
+        one_variant_b_html: Try taking new pictures. For security reasons, you have
+          <strong>one attempt<strong> remaining.
+        other: For security reasons, you have %{count} attempts remaining.
+        other_variant_a_html: For security reasons, you have <strong>%{count}
+          attempts<strong> remaining.
+        other_variant_b_html: Try taking new pictures. For security reasons, you have
+          <strong>%{count} attempts<strong>.
+      sessions:
+        heading: We couldn't find records matching your personal information.
     welcome:
       no_js_header: You must enable JavaScript to verify your identity.
       no_js_intro: '%{sp_name} needs you to verify your identity. You need to enable

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -255,8 +255,7 @@ en:
     warning:
       attempts:
         one: For security reasons, you have one attempt remaining.
-        one_variant_a_html: For security reasons, you have <strong>one attempt<strong>
-          remaining.
+        one_variant_a_html: For security reasons, you have <strong>one attempt<strong> remaining.
         one_variant_b_html: Try taking new pictures. For security reasons, you have
           <strong>one attempt<strong> remaining.
         other: For security reasons, you have %{count} attempts remaining.
@@ -265,7 +264,7 @@ en:
         other_variant_b_html: Try taking new pictures. For security reasons, you have
           <strong>%{count} attempts<strong>.
       sessions:
-        heading: We couldn't find records matching your personal information.
+        heading: We couldn’t find records matching your personal information.
     welcome:
       no_js_header: You must enable JavaScript to verify your identity.
       no_js_intro: '%{sp_name} needs you to verify your identity. You need to enable

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -230,7 +230,6 @@ en:
         need_assistance: 'Need immediate assistance? Here’s how to get help:'
         still_having_trouble: Still having trouble?
       options:
-        add_new_photos: Add new photos of your state‑issued ID
         contact_support: Contact %{app_name} Support
         doc_capture_tips: More tips for adding photos of your ID
         get_help_at_sp: Get help at %{sp_name}

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -264,7 +264,7 @@ en:
         other_variant_b_html: Try taking new pictures. For security reasons, you have
           <strong>%{count} attempts<strong>.
       sessions:
-        heading: We couldn’t find records matching your personal information.
+        heading: We couldn’t find records matching your personal information
     welcome:
       no_js_header: You must enable JavaScript to verify your identity.
       no_js_intro: '%{sp_name} needs you to verify your identity. You need to enable

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -270,13 +270,7 @@ es:
     warning:
       attempts:
         one: Por motivos de seguridad, le quedan un intento.
-        one_variant_a_html: Por motivos de seguridad, le quedan <strong>un intento</strong>.
-        one_variant_b_html: Intente tomar nuevas fotografías. Por motivos de seguridad,
-          le quedan <strong>un intento</strong>.
         other: Por motivos de seguridad, le quedan %{count} intentos.
-        other_variant_a_html: Por motivos de seguridad, le quedan <strong>%{count} intentos</strong>.
-        other_variant_b_html: Intente tomar nuevas fotografías. Por motivos de
-          seguridad, le quedan <strong>%{count} intentos</strong>.
       sessions:
         heading: No encontramos registros que coincidan con sus datos personales
     welcome:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -268,6 +268,21 @@ es:
       status_page_link: 'Consulte las actualizaciones en nuestra página de estado'
       technical_difficulties: Lamentablemente, debido a problemas técnicos por nuestra
         parte, tal vez no podamos verificar su identidad en estos momentos.
+    warning:
+      attempts:
+        one: Por motivos de seguridad, le quedan un intento.
+        one_variant_a_html: Por motivos de seguridad, le quedan <strong>un
+          intento</strong>.
+        one_variant_b_html: Intente tomar nuevas fotografías. Por motivos de seguridad,
+          le quedan <strong>un intento</strong>.
+        other: Por motivos de seguridad, le quedan %{count} intentos.
+        other_variant_a_html: Por motivos de seguridad, le quedan <strong>%{count}
+          intentos</strong>.
+        other_variant_b_html: Intente tomar nuevas fotografías. Por motivos de
+          seguridad, le quedan <strong>%{count} intentos</strong>.
+      sessions:
+        heading: No hemos podido encontrar registros que coincidan con su información
+          personal.
     welcome:
       no_js_header: Debe habilitar JavaScript para verificar su identidad.
       no_js_intro: '%{sp_name} requiere que usted verifique su identidad. Debe

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -243,7 +243,6 @@ es:
         need_assistance: '¿Necesita ayuda inmediata? Así es como puede obtener ayuda:'
         still_having_trouble: '¿Sigue teniendo dificultades?'
       options:
-        add_new_photos: Añada nuevas fotos de su ID emitido por el estado
         contact_support: Póngase en contacto con el servicio de asistencia de %{app_name}
         doc_capture_tips: Más consejos para agregar fotos de su identificación
         get_help_at_sp: Obtenga ayuda en %{sp_name}

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -279,8 +279,7 @@ es:
         other_variant_b_html: Intente tomar nuevas fotografías. Por motivos de
           seguridad, le quedan <strong>%{count} intentos</strong>.
       sessions:
-        heading: No hemos podido encontrar registros que coincidan con su información
-          personal.
+        heading: No encontramos registros que coincidan con sus datos personales
     welcome:
       no_js_header: Debe habilitar JavaScript para verificar su identidad.
       no_js_intro: '%{sp_name} requiere que usted verifique su identidad. Debe

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -271,13 +271,11 @@ es:
     warning:
       attempts:
         one: Por motivos de seguridad, le quedan un intento.
-        one_variant_a_html: Por motivos de seguridad, le quedan <strong>un
-          intento</strong>.
+        one_variant_a_html: Por motivos de seguridad, le quedan <strong>un intento</strong>.
         one_variant_b_html: Intente tomar nuevas fotografías. Por motivos de seguridad,
           le quedan <strong>un intento</strong>.
         other: Por motivos de seguridad, le quedan %{count} intentos.
-        other_variant_a_html: Por motivos de seguridad, le quedan <strong>%{count}
-          intentos</strong>.
+        other_variant_a_html: Por motivos de seguridad, le quedan <strong>%{count} intentos</strong>.
         other_variant_b_html: Intente tomar nuevas fotografías. Por motivos de
           seguridad, le quedan <strong>%{count} intentos</strong>.
       sessions:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -283,15 +283,7 @@ fr:
     warning:
       attempts:
         one: Pour des raisons de sécurité, il vous reste une tentative.
-        one_variant_a_html: Pour des raisons de sécurité, il vous reste <strong>une
-          tentative</strong>.
-        one_variant_b_html: Essayez de prendre de nouvelles photos. Pour des raisons de
-          sécurité, il vous reste <strong>une tentative</strong>.
         other: Pour des raisons de sécurité, il vous reste %{count} tentatives.
-        other_variant_a_html: Pour des raisons de sécurité, il vous reste
-          <strong>%{count} tentatives</strong>.
-        other_variant_b_html: Essayez de prendre de nouvelles photos. Pour des raisons
-          de sécurité, il vous reste <strong>%{count} tentatives</strong>.
       sessions:
         heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations
           personnelles

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -295,8 +295,8 @@ fr:
         other_variant_b_html: Essayez de prendre de nouvelles photos. Pour des raisons
           de sécurité, il vous reste <strong>%{count} tentatives</strong>.
       sessions:
-        heading: Nous ne trouvons pas de données qui correspondent à vos informations
-          téléphoniques.
+        heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations
+          personnelles
     welcome:
       no_js_header: Vous devez activer JavaScript pour vérifier votre identité.
       no_js_intro: '%{sp_name} a besoin de vous pour vérifier votre identité. Vous

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -282,6 +282,21 @@ fr:
       status_page_link: 'Obtenez des mises à jour sur notre page de statut'
       technical_difficulties: Malheureusement, nous rencontrons des difficultés
         techniques et ne pouvons pas vérifier votre identité pour le moment.
+    warning:
+      attempts:
+        one: Pour des raisons de sécurité, il vous reste une tentative.
+        one_variant_a_html: Pour des raisons de sécurité, il vous reste <strong>une
+          tentative</strong>.
+        one_variant_b_html: Essayez de prendre de nouvelles photos. Pour des raisons de
+          sécurité, il vous reste <strong>une tentative</strong>.
+        other: Pour des raisons de sécurité, il vous reste %{count} tentatives.
+        other_variant_a_html: Pour des raisons de sécurité, il vous reste
+          <strong>%{count} tentatives</strong>.
+        other_variant_b_html: Essayez de prendre de nouvelles photos. Pour des raisons
+          de sécurité, il vous reste <strong>%{count} tentatives</strong>.
+      sessions:
+        heading: Nous ne trouvons pas de données qui correspondent à vos informations
+          téléphoniques.
     welcome:
       no_js_header: Vous devez activer JavaScript pour vérifier votre identité.
       no_js_intro: '%{sp_name} a besoin de vous pour vérifier votre identité. Vous

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -257,8 +257,6 @@ fr:
           obtenir de l’aide:'
         still_having_trouble: Vous rencontrez toujours des difficultés?
       options:
-        add_new_photos: Ajoutez de nouvelles photos de votre carte d’identité délivrée
-          par l’État.
         contact_support: Contacter le service d’assistance de %{app_name}
         doc_capture_tips: Plus de conseils pour ajouter des photos de votre carte d’identité
         get_help_at_sp: Demandez de l’aide à %{sp_name}

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -41,17 +41,17 @@ feature 'doc auth redo document capture action', js: true do
       expect(page).not_to have_css('[role="status"]')
     end
 
-    it 'shows a troubleshooting option to allow the user to return to upload new images' do
+    it 'shows a troubleshooting option to allow the user to cancel and return to SP' do
       click_idv_continue
 
       expect(page).to have_link(
-        t('idv.troubleshooting.options.add_new_photos'),
-        href: idv_doc_auth_step_path(step: :redo_document_capture),
+        t('links.cancel'),
+        href: idv_cancel_path,
       )
 
-      click_link t('idv.troubleshooting.options.add_new_photos')
+      click_link t('links.cancel')
 
-      expect(current_path).to eq(idv_doc_auth_upload_step)
+      expect(current_path).to eq(idv_cancel_path)
     end
 
     context 'on mobile', driver: :headless_chrome_mobile do

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -166,18 +166,21 @@ feature 'doc auth verify_info step', :js do
 
   context 'resolution throttling' do
     let(:max_resolution_attempts) { 3 }
-    # proof_ssn_max_attempts is 10, vs 5 for resolution, so it doesn't get triggered
-    it 'throttles resolution and continues when it expires' do
+    before(:each) do
       allow(IdentityConfig.store).to receive(:idv_max_attempts).
         and_return(max_resolution_attempts)
-
-      expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited).at_least(1).times.
-        with({ throttle_context: 'single-session' })
 
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_ssn_step
       fill_out_ssn_form_with_ssn_that_fails_resolution
       click_idv_continue
+    end
+
+    # proof_ssn_max_attempts is 10, vs 5 for resolution, so it doesn't get triggered
+    it 'throttles resolution and continues when it expires' do
+      expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited).at_least(1).times.
+        with({ throttle_context: 'single-session' })
+
       (max_resolution_attempts - 2).times do
         click_idv_continue
         expect(page).to have_current_path(idv_session_errors_warning_path)
@@ -208,6 +211,11 @@ feature 'doc auth verify_info step', :js do
 
         expect(page).to have_current_path(idv_phone_path)
       end
+    end
+
+    it 'allows user to cancel identify verification' do
+      click_link t('links.cancel')
+      expect(page).to have_current_path(idv_cancel_path(step: 'verify'))
     end
   end
 

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -187,7 +187,7 @@ feature 'doc auth verify_info step', :js do
       # Check that last attempt shows correct warning text
       click_idv_continue
       expect(page).to have_current_path(idv_session_errors_warning_path)
-      expect(page).to have_content(t('idv.failure.attempts.one'))
+      expect(page).to have_content(t('idv.warning.attempts.one'))
       click_try_again
 
       click_idv_continue

--- a/spec/views/idv/session_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/warning.html.erb_spec.rb
@@ -34,11 +34,8 @@ describe 'idv/session_errors/warning.html.erb' do
 
     it 'does not render troubleshooting option to retake photos' do
       expect(rendered).to have_link(t('idv.failure.button.warning'), href: try_again_path)
-      expect(rendered).to_not have_content(t('components.troubleshooting_options.default_heading'))
-      expect(rendered).to_not have_link(
-        t('idv.troubleshooting.options.add_new_photos'),
-        href: idv_doc_auth_step_path(step: :redo_document_capture),
-      )
+      expect(rendered).to have_text(t('idv.warning.attempts', count: remaining_attempts))
+      expect(rendered).to have_link(t('links.cancel'), href: idv_cancel_path)
     end
   end
 end

--- a/spec/views/idv/session_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/warning.html.erb_spec.rb
@@ -22,35 +22,11 @@ describe 'idv/session_errors/warning.html.erb' do
   end
 
   it 'shows remaining attempts' do
-    expect(rendered).to have_text(t('idv.failure.attempts', count: remaining_attempts))
+    expect(rendered).to have_text(t('idv.warning.attempts', count: remaining_attempts))
   end
 
-  it 'does not display troubleshooting options' do
-    expect(rendered).not_to have_content(t('components.troubleshooting_options.default_heading'))
-  end
-
-  context 'with an associated service provider' do
-    let(:sp_name) { 'Example SP' }
-
-    it 'renders troubleshooting option to get help at service provider' do
-      expect(rendered).to have_content(t('components.troubleshooting_options.default_heading'))
-      expect(rendered).to have_link(
-        t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'warning'),
-      )
-    end
-  end
-
-  context 'with a flow session which had a barcode attention document capture result' do
-    let(:user_session) { { 'idv/doc_auth': { had_barcode_read_failure: true } } }
-
-    it 'renders troubleshooting option to retake photos' do
-      expect(rendered).to have_content(t('components.troubleshooting_options.default_heading'))
-      expect(rendered).to have_link(
-        t('idv.troubleshooting.options.add_new_photos'),
-        href: idv_doc_auth_step_path(step: :redo_document_capture),
-      )
-    end
+  it 'shows a cancel link' do
+    expect(rendered).to have_link(t('links.cancel'), href: idv_cancel_path)
   end
 
   context 'with a nil user_session' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-9298](https://cm-jira.usa.gov/browse/LG-9298)

## 🛠 Summary of changes

- Tweaked heading _could not_ -> _couldn't_
- removed troubleshooting section
-  Removed _to add your ID online_ from the remaining attempts warning message
- added cancel link

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="675" alt="LG-9298-before" src="https://user-images.githubusercontent.com/1261794/236555867-21cd5a66-4d90-4d76-bd78-bd1df88d0c8d.png">
<img width="644" alt="LG-9298-before-es" src="https://user-images.githubusercontent.com/1261794/236561633-3d33c980-b797-476f-8a69-cd86a5ffc8d5.png">
<img width="648" alt="LG-9298-before-fr" src="https://user-images.githubusercontent.com/1261794/236561646-7313a0d9-689b-4e66-bc3e-80f8c17c96c8.png">
</details>
<details>
<summary>After:</summary>
<img width="589" alt="LG-9298-after" src="https://user-images.githubusercontent.com/1261794/236564756-2abcd565-47a7-44f6-91d3-dda93a4788ad.png">
<img width="585" alt="LG-9298-after-es" src="https://user-images.githubusercontent.com/1261794/236564775-bbaae97c-f906-42ec-b932-73dd29c08995.png">
<img width="611" alt="LG-9298-after-fr" src="https://user-images.githubusercontent.com/1261794/236564795-2df3bddd-0fb1-4fd6-bc51-2bbea89e29a0.png">


</details>
