### PR TITLE
Fix mobile navigation to prevent horizontal scroll

### DIFF
--- a/app/javascript/packages/components/full-screen.spec.tsx
+++ b/app/javascript/packages/components/full-screen.spec.tsx
@@ -49,7 +49,7 @@ describe('FullScreen', () => {
   it('renders with a close button', () => {
     const { getByLabelText } = render(<FullScreen>Content</FullScreen>);
 
-    const button = getByLabelText('users.personal_key.close');
+    const button = getByLabelText('account.navigation.close');
 
     expect(button.nodeName).to.equal('BUTTON');
   });
@@ -62,7 +62,7 @@ describe('FullScreen', () => {
         </FullScreen>,
       );
 
-      const button = queryByLabelText('users.personal_key.close');
+      const button = queryByLabelText('account.navigation.close');
 
       expect(button).to.not.exist();
     });
@@ -131,7 +131,7 @@ describe('FullScreen', () => {
 
     await delay(); // focus-trap delays initial focus by default
     expect(document.activeElement).to.equal(
-      getByRole('button', { name: 'users.personal_key.close' }),
+      getByRole('button', { name: 'account.navigation.close' }),
     );
   });
 
@@ -147,7 +147,7 @@ describe('FullScreen', () => {
       <FullScreen onRequestClose={onRequestClose}>Content</FullScreen>,
     );
 
-    const button = getByLabelText('users.personal_key.close');
+    const button = getByLabelText('account.navigation.close');
     fireEvent.click(button);
 
     expect(onRequestClose.calledOnce).to.be.true();
@@ -177,7 +177,7 @@ describe('FullScreen', () => {
   it('traps focus', (done) => {
     const { baseElement, getByLabelText } = render(<FullScreen>Content</FullScreen>);
 
-    const button = getByLabelText('users.personal_key.close');
+    const button = getByLabelText('account.navigation.close');
 
     const event = new window.KeyboardEvent('keydown', {
       key: 'Tab',
@@ -201,7 +201,7 @@ describe('FullScreen', () => {
     const { getByLabelText, rerender } = render(<FullScreen>Content</FullScreen>);
     rerender(<FullScreen onRequestClose={onRequestClose}>Content</FullScreen>);
 
-    const button = getByLabelText('users.personal_key.close');
+    const button = getByLabelText('account.navigation.close');
 
     const event = new window.KeyboardEvent('keydown', {
       key: 'Escape',

--- a/app/javascript/packages/components/full-screen.tsx
+++ b/app/javascript/packages/components/full-screen.tsx
@@ -111,7 +111,7 @@ function FullScreen(
       {!hideCloseButton && (
         <button
           type="button"
-          aria-label={t('users.personal_key.close')}
+          aria-label={t('account.navigation.close')}
           onClick={onRequestClose}
           className="full-screen__close-button usa-button padding-2 margin-2"
         >

--- a/app/views/accounts/_mobile_nav.html.erb
+++ b/app/views/accounts/_mobile_nav.html.erb
@@ -1,7 +1,9 @@
 <nav class="usa-nav tablet:display-none sidenav-mobile" aria-label="<%= t('account.navigation.landmark_label') %>">
   <div class="usa-nav__inner">
     <button class="usa-nav__close">
-      <span class="usa-sr-only">Close</span>
+      <span class="usa-sr-only">
+        <%= t('account.navigation.close') %>
+      </span>
     </button>
     <ul class="usa-nav__primary usa-accordion">
       <% NavigationPresenter.new(user: current_user, url_options: url_options).navigation_items.each do |nav_item| %>

--- a/app/views/accounts/_mobile_nav.html.erb
+++ b/app/views/accounts/_mobile_nav.html.erb
@@ -1,8 +1,8 @@
 <nav class="usa-nav tablet:display-none sidenav-mobile" aria-label="<%= t('account.navigation.landmark_label') %>">
-  <button class="usa-nav__close">
-    <span class="usa-sr-only">Close</span>
-  </button>
   <div class="usa-nav__inner">
+    <button class="usa-nav__close">
+      <span class="usa-sr-only">Close</span>
+    </button>
     <ul class="usa-nav__primary usa-accordion">
       <% NavigationPresenter.new(user: current_user, url_options: url_options).navigation_items.each do |nav_item| %>
         <li class="usa-nav__primary-item">

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -83,6 +83,7 @@ en:
       add_phone_number: Add phone number
       add_platform_authenticator: Add Face or Touch Unlock
       add_security_key: Add security key
+      close: Close
       connected_accounts: Your connected accounts
       customer_support: Customer support
       delete_account: Delete account

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -84,6 +84,7 @@ es:
       add_phone_number: Agregar el número de teléfono
       add_platform_authenticator: Agregar desbloqueo facial o táctil
       add_security_key: Agregar llave de seguridad
+      close: Cerrar
       connected_accounts: Tus cuentas conectadas
       customer_support: Atención al cliente
       delete_account: Borrar cuenta

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -89,6 +89,7 @@ fr:
       add_phone_number: Ajouter un numéro de téléphone
       add_platform_authenticator: Ajouter déverouillage facial ou déverrouillage par empreinte digitale
       add_security_key: Ajouter une clé de sécurité
+      close: Fermer
       connected_accounts: Vos comptes connectés
       customer_support: Service client
       delete_account: Supprimer le compte

--- a/config/locales/users/en.yml
+++ b/config/locales/users/en.yml
@@ -22,7 +22,6 @@ en:
       accessible_labels:
         code_example: A personal key example with 16 characters
         preview: Personal key preview
-      close: Close
       confirmation_error: You’ve entered an incorrect personal key.
       generated_on_html: Your personal key was generated on %{date}
     phones:

--- a/config/locales/users/es.yml
+++ b/config/locales/users/es.yml
@@ -23,7 +23,6 @@ es:
       accessible_labels:
         code_example: Un ejemplo de clave personal con 16 caracteres
         preview: Vista previa de la clave personal
-      close: Cerrar
       confirmation_error: Ha ingresado una clave personal incorrecta.
       generated_on_html: Tu clave personal fue generada el %{date}
     phones:

--- a/config/locales/users/fr.yml
+++ b/config/locales/users/fr.yml
@@ -25,7 +25,6 @@ fr:
       accessible_labels:
         code_example: Un exemple de code personnel à 16 caractères
         preview: Aperçu du code personnel
-      close: Fermer
       confirmation_error: Vous avez entré un clé personnelle erronée.
       generated_on_html: Votre clé personnelle a été générée le %{date}
     phones:

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -951,10 +951,10 @@ describe('document-capture/components/acuant-capture', () => {
 
     const placeholder = getByLabelText('Image');
     await userEvent.click(placeholder);
-    await userEvent.click(getByLabelText('users.personal_key.close'));
+    await userEvent.click(getByLabelText('account.navigation.close'));
     const button = getByText('doc_auth.buttons.take_picture');
     await userEvent.click(button);
-    await userEvent.click(getByLabelText('users.personal_key.close'));
+    await userEvent.click(getByLabelText('account.navigation.close'));
     const upload = getByText('Upload');
     fireEvent.click(upload);
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where the mobile navigation on the account dashboard unintentionally allows horizontal scroll, when only vertical scrolling is expected. This is due to the markup not aligning to the [documented code](https://designsystem.digital.gov/components/header/#component-code-3) for the component.

## 👀 Screenshots

**Before:**

https://user-images.githubusercontent.com/1779930/236556106-ca376802-be58-43eb-808d-152540473f44.MP4

**After:**

https://user-images.githubusercontent.com/1779930/236556116-73c28e12-68ae-4a48-9830-44fc6dc1e87c.MP4

