### PR TITLE
Fix Sign In tabbed A/B variant after LGDS 7

### DIFF
--- a/app/assets/stylesheets/_uswds.scss
+++ b/app/assets/stylesheets/_uswds.scss
@@ -6,6 +6,7 @@
 @forward 'usa-alert';
 @forward 'usa-banner';
 @forward 'usa-button';
+@forward 'usa-button-group';
 @forward 'usa-collection';
 @forward 'usa-form';
 @forward 'usa-header';


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a visual regression introduced in #8093, affecting one of the 3 Sign-In page A/B test variants ("Tabbed"). Fortunately, the design system upgrade has not shipped yet in production, so the bug is not live.

#8093 takes advantage of USWDS' new per-component stylesheet optimization feature, opting in to only the components currently in use. Because of overlapping timeframe of #8093 and #8112 and the fact that the A/B test is not shown in all cases, the "Button Group" component was not included.

I also made another pass at trying to find components potentially in use that are not included, and did not find others.

## 📜 Testing Plan

Easier to test when forcing Tabbed variant 100% of the time, adding this to `config/application.yml`:

```
sign_in_a_b_testing: '{"tabbed":100}'
```

## 👀 Screenshots

Before|After
---|---
![Screen Shot 2023-05-08 at 9 15 16 AM](https://user-images.githubusercontent.com/1779930/236834922-7c25f4bd-ca84-4fb7-a62e-7b4ab3702653.png)|![Screen Shot 2023-05-08 at 9 14 59 AM](https://user-images.githubusercontent.com/1779930/236834931-5e108872-6d6b-4f3e-84b8-9d5bf19252c4.png)
