### PR TITLE
LG-9299: Add Cancel Link to Phone Error Page

### DIFF
--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -59,4 +59,4 @@
         </div>
       <% end %>
 <% end %>
-<%= render('idv/doc_auth/cancel') %>
+<%= render('idv/doc_auth/cancel', step: 'phone') %>

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -51,11 +51,11 @@
 
         <div class="margin-y-5">
           <%= render ButtonComponent.new(
-              action: ->(**tag_options, &block) { link_to idv_gpo_path, **tag_options, &block },
-              big: true,
-              wide: true,
-              outline: true,
-          ).with_content(t('idv.failure.phone.warning.gpo.button')) %>
+                action: ->(**tag_options, &block) { link_to idv_gpo_path, **tag_options, &block },
+                big: true,
+                wide: true,
+                outline: true,
+              ).with_content(t('idv.failure.phone.warning.gpo.button')) %>
         </div>
       <% end %>
 <% end %>

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -4,16 +4,6 @@
       title: t('titles.failure.phone_verification'),
       heading: t('idv.failure.phone.warning.heading'),
       current_step: :verify_phone_or_address,
-      options: [
-        decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path(
-            step: 'phone',
-            location: local_assigns.fetch(:name, 'warning'),
-          ),
-          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-          new_tab: true,
-        },
-      ].select(&:present?),
     ) do %>
 
       <% if @phone %>
@@ -61,11 +51,12 @@
 
         <div class="margin-y-5">
           <%= render ButtonComponent.new(
-                action: ->(**tag_options, &block) { link_to idv_gpo_path, **tag_options, &block },
-                big: true,
-                wide: true,
-                outline: true,
-              ).with_content(t('idv.failure.phone.warning.gpo.button')) %>
+              action: ->(**tag_options, &block) { link_to idv_gpo_path, **tag_options, &block },
+              big: true,
+              wide: true,
+              outline: true,
+          ).with_content(t('idv.failure.phone.warning.gpo.button')) %>
         </div>
       <% end %>
-    <% end %>
+<% end %>
+<%= render('idv/doc_auth/cancel') %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -103,9 +103,8 @@ en:
             how_long_it_takes: This typically takes 3 - 7 business days.
           heading: We couldn’t match you to this number
           learn_more_link: 'Learn more about what phone number to use'
-          next_steps_html: 'Please try again with <strong>another</strong> number that you
-            use often and have used for a long time. This can be a work or home
-            number.'
+          next_steps_html: 'Try <strong>another</strong> number that you use often and
+            have used for a long time. This can be a work or home number.'
           try_again_button: 'Try another number'
           you_entered: 'You entered:'
       sessions:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -111,9 +111,8 @@ es:
             how_long_it_takes: Suele tardar entre 3 y 7 días laborables.
           heading: No pudimos asociarlo a este número
           learn_more_link: 'Más información sobre qué número de teléfono usar'
-          next_steps_html: 'Vuelva a intentarlo con <strong>otro número</strong> que
-            utilice a menudo y desde hace tiempo. Puede ser un número del
-            trabajo o particular.'
+          next_steps_html: 'Pruebe con <strong>otro</strong> número que utilice a menudo y
+            desde hace tiempo.. Puede ser un número del trabajo o particular.'
           try_again_button: 'Intente con otro número'
           you_entered: 'Ud. entregó:'
       sessions:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -115,9 +115,9 @@ fr:
             how_long_it_takes: Cette procédure prend typiquement 3 à 7 jours ouvrables.
           heading: Nous n’avons pas pu vous associer à ce numéro
           learn_more_link: 'Apprenez-en plus sur quel numéro de téléphone utiliser'
-          next_steps_html: 'Veuillez réessayer avec <strong>un autre numéro</strong> que
-            vous utilisez souvent et depuis longtemps. Il peut s’agir d’un
-            numéro professionnel ou personnel.'
+          next_steps_html: 'Essayez <strtong>un autre<strong> numéro que vous utilisez
+            souvent et depuis longtemps. Il peut s’agir d’un numéro
+            professionnel ou personnel.'
           try_again_button: 'Essayez un autre numéro'
           you_entered: 'Tu as soumis:'
       sessions:

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -148,6 +148,16 @@ feature 'idv phone step', :js do
       expect(page).to have_content('+1 703-555-5555')
     end
 
+    it 'goes to the cancel page when cancel link is clicked', js: true do
+      start_idv_from_sp
+      complete_idv_steps_before_phone_step
+      fill_out_phone_form_fail
+      click_idv_send_security_code
+      click_on t('links.cancel')
+
+      expect(page).to have_current_path(idv_cancel_path)
+    end
+
     it 'links to verify by mail, from which user can return back to the warning screen' do
       start_idv_from_sp
       complete_idv_steps_before_phone_step

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -155,7 +155,7 @@ feature 'idv phone step', :js do
       click_idv_send_security_code
       click_on t('links.cancel')
 
-      expect(page).to have_current_path(idv_cancel_path)
+      expect(page).to have_current_path(idv_cancel_path(step: 'phone'))
     end
 
     it 'links to verify by mail, from which user can return back to the warning screen' do

--- a/spec/views/idv/phone_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/warning.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'idv/phone_errors/warning.html.erb' do
+  include Devise::Test::ControllerHelpers
+
   let(:sp_name) { 'Example SP' }
   let(:remaining_attempts) { 5 }
   let(:gpo_letter_available) { false }
@@ -61,13 +63,6 @@ describe 'idv/phone_errors/warning.html.erb' do
     )
   end
 
-  it 'renders a list of troubleshooting options' do
-    expect(rendered).to have_link(
-      t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-      href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'warning'),
-    )
-  end
-
   context 'no sp' do
     let(:sp_name) { nil }
     it 'does not prompt user to get help at sp' do
@@ -79,12 +74,6 @@ describe 'idv/phone_errors/warning.html.erb' do
   end
 
   context 'gpo verification disabled' do
-    it 'renders a list of troubleshooting options' do
-      expect(rendered).to have_link(
-        t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
-        href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'warning'),
-      )
-    end
     it 'does not render link to gpo flow' do
       expect(rendered).not_to have_link(
         t('idv.troubleshooting.options.verify_by_mail'),


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-9299](https://cm-jira.usa.gov/browse/LG-9299)


## 🛠 Summary of changes

As a user undergoing IDV who is unsuccessful at the Verify your personal details step, I want to have a clear way to cancel identity verification and return to the requesting SP.

- Remove “Get help at [Partner Agency]” link
- Add “Cancel” experience


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
  
<summary>Before:</summary>
  
![127 0 0 1_57521_es_verify_phone_errors_warning](https://user-images.githubusercontent.com/105373963/236851316-cdb42c22-72ea-4c2b-b15c-21d29dc5d326.png)
![127 0 0 1_57521_fr_verify_phone_errors_warning](https://user-images.githubusercontent.com/105373963/236851328-e6391e15-ff66-4a37-ab4a-09848ed2d664.png)
![127 0 0 1_57521_verify_phone_errors_warning](https://user-images.githubusercontent.com/105373963/236851332-1aa07e93-d7f7-4d2d-ba0d-1b0cd4416ed6.png)

</details>

<details>
  
<summary>After:</summary>
  
![127 0 0 1_55899_verify_phone_errors_warning](https://user-images.githubusercontent.com/105373963/236851364-742a8dcb-8162-4541-a28b-8cad1431ecad.png)
![127 0 0 1_55899_es_verify_phone_errors_warning](https://user-images.githubusercontent.com/105373963/236851370-fc8dc8a6-f614-4477-b4fb-12900f89fec1.png)
![127 0 0 1_55899_fr_verify_phone_errors_warning](https://user-images.githubusercontent.com/105373963/236851371-0c35a4cd-34a5-47d5-9320-9141ccfdbabc.png)

</details>

