### PR TITLE
LG-9271 StepIndicatorConcern uses effective user instead of current user to ensure user during hybrid flow

### DIFF
--- a/app/controllers/concerns/idv/step_indicator_concern.rb
+++ b/app/controllers/concerns/idv/step_indicator_concern.rb
@@ -31,7 +31,7 @@ module Idv
     def gpo_address_verification?
       # Proofing component values are (currently) never reset between proofing attempts, hence why
       # this refers to the session address verification mechanism and not the proofing component.
-      !!current_user.pending_profile || idv_session.address_verification_mechanism == 'gpo'
+      !!effective_user.pending_profile || idv_session.address_verification_mechanism == 'gpo'
     end
 
     def proofing_components_as_hash
@@ -39,10 +39,10 @@ module Idv
       # are set during identity verification. These values are recorded to the profile at creation,
       # including for a pending profile.
       @proofing_components_as_hash ||= begin
-        if current_user.pending_profile
-          current_user.pending_profile.proofing_components
+        if effective_user.pending_profile
+          effective_user.pending_profile.proofing_components
         else
-          ProofingComponent.find_by(user: current_user).as_json
+          ProofingComponent.find_by(user: effective_user).as_json
         end
       end.to_h
     end

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class SessionErrorsController < ApplicationController
+    include StepIndicatorConcern
     include IdvSession
     include EffectiveUser
 

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -122,6 +122,7 @@ describe Idv::SessionErrorsController do
   before do
     allow(idv_session).to receive(:verify_info_step_complete?).
       and_return(verify_info_step_complete)
+    allow(idv_session).to receive(:address_verification_mechanism).and_return(nil)
     allow(controller).to receive(:idv_session).and_return(idv_session)
     stub_sign_in(user) if user
     stub_analytics


### PR DESCRIPTION
## 🎫 Ticket
[LG-9721](https://cm-jira.usa.gov/browse/LG-9721)

## 🛠 Summary of changes
To ensure a user exists when seeking the ProofingComponent, the StepIndicatorConcern uses the effective_user because the current_user could be nil during the document_capture step on the hybrid flow.

## Background information
https://gsa-tts.slack.com/archives/C0NGESUN5/p1683224465791789


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
