### PR TITLE
LG-8115: don't require any auth headers for DDP.

### DIFF
--- a/app/services/proofing/lexis_nexis/authenticated_request.rb
+++ b/app/services/proofing/lexis_nexis/authenticated_request.rb
@@ -17,7 +17,7 @@ module Proofing
           conn.post(url, body, headers) do |req|
             req.options.context = { service_name: metric_name }
           end,
-          )
+        )
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
         # NOTE: This is only for when Faraday is using NET::HTTP if the adapter is changed
         # this will have to change to handle timeouts
@@ -45,7 +45,7 @@ module Proofing
           config: config,
           message_body: body,
           path: url_request_path,
-          ).hmac_authorization
+        ).hmac_authorization
       end
     end
   end

--- a/app/services/proofing/lexis_nexis/authenticated_request.rb
+++ b/app/services/proofing/lexis_nexis/authenticated_request.rb
@@ -1,0 +1,52 @@
+module Proofing
+  module LexisNexis
+    class AuthenticatedRequest < Request
+      def send_request
+        conn = Faraday.new do |f|
+          f.request :instrumentation, name: 'request_metric.faraday'
+          unless hmac_auth_enabled?
+            f.request :authorization, :basic, config.username, config.password
+          end
+          f.options.timeout = timeout
+          f.options.read_timeout = timeout
+          f.options.open_timeout = timeout
+          f.options.write_timeout = timeout
+        end
+
+        Response.new(
+          conn.post(url, body, headers) do |req|
+            req.options.context = { service_name: metric_name }
+          end,
+          )
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+        # NOTE: This is only for when Faraday is using NET::HTTP if the adapter is changed
+        # this will have to change to handle timeouts
+        if e.message == 'execution expired'
+          raise ::Proofing::TimeoutError,
+                'LexisNexis timed out waiting for verification response'
+        else
+          message = "Lexis Nexis request raised #{e.class} with the message: #{e.message}"
+          raise LexisNexis::RequestError, message
+        end
+      end
+
+      def build_request_headers
+        headers = super
+        headers['Authorization'] = hmac_authorization if hmac_auth_enabled?
+        headers
+      end
+
+      def hmac_auth_enabled?
+        IdentityConfig.store.lexisnexis_hmac_auth_enabled
+      end
+
+      def hmac_authorization
+        Proofing::LexisNexis::RequestSigner.new(
+          config: config,
+          message_body: body,
+          path: url_request_path,
+          ).hmac_authorization
+      end
+    end
+  end
+end

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -11,7 +11,11 @@ module Proofing
         end
 
         def proof(applicant)
-          response = VerificationRequest.new(config: config, applicant: applicant).send
+          response = VerificationRequest.new(
+            config: config,
+            applicant: applicant,
+            require_auth_headers: false,
+          ).send
           build_result_from_response(response)
         rescue => exception
           NewRelic::Agent.notice_error(exception)

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -11,11 +11,7 @@ module Proofing
         end
 
         def proof(applicant)
-          response = VerificationRequest.new(
-            config: config,
-            applicant: applicant,
-            require_auth_headers: false,
-          ).send
+          response = VerificationRequest.new(config: config, applicant: applicant).send_request
           build_result_from_response(response)
         rescue => exception
           NewRelic::Agent.notice_error(exception)

--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -4,10 +4,6 @@ module Proofing
       class VerificationRequest < Request
         private
 
-        def initialize(config:, applicant:)
-          super(config: config, applicant: applicant, require_auth_headers: false)
-        end
-
         def build_request_body
           {
             api_key: config.api_key,

--- a/app/services/proofing/lexis_nexis/ddp/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/verification_request.rb
@@ -4,6 +4,10 @@ module Proofing
       class VerificationRequest < Request
         private
 
+        def initialize(config:, applicant:)
+          super(config: config, applicant: applicant, require_auth_headers: false)
+        end
+
         def build_request_body
           {
             api_key: config.api_key,

--- a/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/proofer.rb
@@ -9,7 +9,7 @@ module Proofing
         end
 
         def proof(applicant)
-          response = VerificationRequest.new(config: config, applicant: applicant).send
+          response = VerificationRequest.new(config: config, applicant: applicant).send_request
           build_result_from_response(response)
         rescue => exception
           NewRelic::Agent.notice_error(exception)

--- a/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
@@ -1,7 +1,7 @@
 module Proofing
   module LexisNexis
     module InstantVerify
-      class VerificationRequest < Request
+      class VerificationRequest < AuthenticatedRequest
         private
 
         def build_request_body

--- a/app/services/proofing/lexis_nexis/phone_finder/proofer.rb
+++ b/app/services/proofing/lexis_nexis/phone_finder/proofer.rb
@@ -9,7 +9,7 @@ module Proofing
         end
 
         def proof(applicant)
-          response = VerificationRequest.new(config: config, applicant: applicant).send
+          response = VerificationRequest.new(config: config, applicant: applicant).send_request
           build_result_from_response(response)
         rescue => exception
           NewRelic::Agent.notice_error(exception)

--- a/app/services/proofing/lexis_nexis/phone_finder/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/phone_finder/verification_request.rb
@@ -1,7 +1,7 @@
 module Proofing
   module LexisNexis
     module PhoneFinder
-      class VerificationRequest < Request
+      class VerificationRequest < AuthenticatedRequest
         private
 
         def build_request_body

--- a/app/services/proofing/lexis_nexis/request.rb
+++ b/app/services/proofing/lexis_nexis/request.rb
@@ -14,7 +14,7 @@ module Proofing
         @url = build_request_url
       end
 
-      def send
+      def send_request
         conn = Faraday.new do |f|
           f.request :instrumentation, name: 'request_metric.faraday'
           if require_auth_headers? && !hmac_auth_enabled?

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -43,7 +43,7 @@ describe Proofing::LexisNexis::Ddp::Proofer do
           verification_request.url,
         ).to_timeout
 
-        expect { verification_request.send }.to raise_error(
+        expect { verification_request.send_request }.to raise_error(
           Proofing::TimeoutError,
           'LexisNexis timed out waiting for verification response',
         )
@@ -64,7 +64,7 @@ describe Proofing::LexisNexis::Ddp::Proofer do
             status: 200,
           )
 
-        verification_request.send
+        verification_request.send_request
 
         expect(request).to have_been_requested.once
       end

--- a/spec/services/proofing/lexis_nexis/ddp/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/verification_request_spec.rb
@@ -57,4 +57,14 @@ describe Proofing::LexisNexis::Ddp::VerificationRequest do
       expect(subject.url).to eq('https://example.com/api/session-query')
     end
   end
+
+  describe '#build_request_headers' do
+    before do
+      allow(IdentityConfig.store).to receive(:lexisnexis_hmac_auth_enabled).and_return(true)
+    end
+
+    it 'does not include an Authorization header' do
+      expect(subject.send(:build_request_headers)['Authorization']).to be_nil
+    end
+  end
 end

--- a/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
@@ -71,4 +71,31 @@ describe Proofing::LexisNexis::InstantVerify::VerificationRequest do
       expect(subject.url).to eq('https://example.com/restws/identity/v2/test_account/gsa2.chk32.test.wf/conversation')
     end
   end
+
+  describe '#build_request_headers' do
+    context 'HMAC Auth disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:lexisnexis_hmac_auth_enabled).and_return(false)
+      end
+
+      it 'does not include a HMAC Authorization header' do
+        expect(subject.send(:build_request_headers)['Authorization']).to be_nil
+      end
+    end
+
+    context 'HMAC Auth enabled' do
+      let(:token) do
+        'HMAC-SHA256 keyid=HMAC-KEY-ID ts=timestamp nonce=nonce bodyHash=base64digest signature=sig'
+      end
+
+      before do
+        allow(IdentityConfig.store).to receive(:lexisnexis_hmac_auth_enabled).and_return(true)
+        allow(subject).to receive(:hmac_authorization).and_return(token)
+      end
+
+      it 'includes an Authorization header with the HMAC token' do
+        expect(subject.send(:build_request_headers)['Authorization']).to eq(token)
+      end
+    end
+  end
 end

--- a/spec/services/proofing/lexis_nexis/phone_finder/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/phone_finder/verification_request_spec.rb
@@ -43,4 +43,31 @@ describe Proofing::LexisNexis::PhoneFinder::VerificationRequest do
       )
     end
   end
+
+  describe '#build_request_headers' do
+    context 'HMAC Auth disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:lexisnexis_hmac_auth_enabled).and_return(false)
+      end
+
+      it 'does not include a HMAC Authorization header' do
+        expect(subject.send(:build_request_headers)['Authorization']).to be_nil
+      end
+    end
+
+    context 'HMAC Auth enabled' do
+      let(:token) do
+        'HMAC-SHA256 keyid=HMAC-KEY-ID ts=timestamp nonce=nonce bodyHash=base64digest signature=sig'
+      end
+
+      before do
+        allow(IdentityConfig.store).to receive(:lexisnexis_hmac_auth_enabled).and_return(true)
+        allow(subject).to receive(:hmac_authorization).and_return(token)
+      end
+
+      it 'includes an Authorization header with the HMAC token' do
+        expect(subject.send(:build_request_headers)['Authorization']).to eq(token)
+      end
+    end
+  end
 end

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -9,6 +9,8 @@ module LexisNexisFixtures
         account_id: 'test_account',
         username: 'test_username',
         password: 'test_password',
+        hmac_key_id: 'test_hmac_key_id',
+        hmac_secret_key: 'test_hmac_secret_key',
         instant_verify_workflow: 'gsa2.chk32.test.wf',
         phone_finder_workflow: 'customers.gsa2.phonefinder.workflow',
       )

--- a/spec/support/shared_examples/lexis_nexis.rb
+++ b/spec/support/shared_examples/lexis_nexis.rb
@@ -14,7 +14,7 @@ shared_examples 'a lexisnexis rdp proofer' do
     allow(response).to receive(:transaction_reason_code).and_return('123abc')
     allow(response).to receive(:product_list).and_return([])
 
-    allow(verification_request).to receive(:send).and_return(response)
+    allow(verification_request).to receive(:send_request).and_return(response)
     allow(verification_request.class).to receive(:new).
       with(applicant: applicant, config: kind_of(Proofing::LexisNexis::Config)).
       and_return(verification_request)
@@ -60,7 +60,7 @@ shared_examples 'a lexisnexis request' do |basic_auth: true|
     end
   end
 
-  describe '#send' do
+  describe '#send_request' do
     if basic_auth
       it 'includes the basic auth header' do
         credentials = Base64.strict_encode64('test_username:test_password')
@@ -69,7 +69,7 @@ shared_examples 'a lexisnexis request' do |basic_auth: true|
         stub_request(:post, subject.url).
           to_return(status: 200, body: response_body)
 
-        subject.send
+        subject.send_request
 
         expect(a_request(:post, subject.url).with(headers: { 'Authorization' => expected_value })).
           to have_been_requested
@@ -80,7 +80,7 @@ shared_examples 'a lexisnexis request' do |basic_auth: true|
       stub_request(:post, subject.url).
         to_return(status: 200, body: response_body)
 
-      ln_response = subject.send
+      ln_response = subject.send_request
       expect(ln_response).to be_a(Proofing::LexisNexis::Response)
       expect(ln_response.response.status).to eq 200
       expect(ln_response.response.body).to eq response_body


### PR DESCRIPTION
## 🎫 Ticket

[LG-8115](https://cm-jira.usa.gov/browse/LG-8115)

## 🛠 Summary of changes

The ThreatMetrix DDP API does not require any auth headers (basic or hmac) so let's stop sending them.