### PR TITLE
LG-9648 success banner on Enter Password screen

### DIFF
--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -38,7 +38,7 @@ module Idv
       if gpo_mail_service.mail_spammed?
         flash_now[:error] = t('idv.errors.mail_limit_reached')
       elsif idv_session.phone_confirmed?
-        flash_now[:success] = t('idv.messages.review.info_verified')
+        flash_now[:success] = t('idv.messages.review.phone_verified')
       end
     end
 

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -38,7 +38,7 @@ module Idv
       if gpo_mail_service.mail_spammed?
         flash_now[:error] = t('idv.errors.mail_limit_reached')
       else
-        flash_now[:success] = flash_message_content
+        flash_now[:success] = t('idv.messages.review.info_verified')
       end
     end
 
@@ -74,15 +74,6 @@ module Idv
 
     def address_verification_method
       user_session.dig('idv', 'address_verification_mechanism')
-    end
-
-    def flash_message_content
-      if idv_session.address_verification_mechanism != 'gpo'
-        phone_of_record_msg = ActionController::Base.helpers.content_tag(
-          :strong, t('idv.messages.phone.phone_of_record')
-        )
-        t('idv.messages.review.info_verified_html', phone_message: phone_of_record_msg)
-      end
     end
 
     def init_profile

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -37,7 +37,7 @@ module Idv
       flash_now = flash.now
       if gpo_mail_service.mail_spammed?
         flash_now[:error] = t('idv.errors.mail_limit_reached')
-      else
+      elsif idv_session.phone_confirmed?
         flash_now[:success] = t('idv.messages.review.info_verified')
       end
     end

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -195,7 +195,7 @@ en:
           - Your primary number (the one you use the most often)
       return_to_profile: '‹ Return to your %{app_name} profile'
       review:
-        info_verified: We verified your phone number
+        phone_verified: We verified your phone number
         intro: Your verified information
       select_verification_with_sp: To protect you from identity fraud, we will contact
         you to confirm that this %{sp_name} account is legitimate.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -195,7 +195,7 @@ en:
           - Your primary number (the one you use the most often)
       return_to_profile: '‹ Return to your %{app_name} profile'
       review:
-        info_verified_html: We found records matching your %{phone_message}
+        info_verified: We verified your phone number
         intro: Your verified information
       select_verification_with_sp: To protect you from identity fraud, we will contact
         you to confirm that this %{sp_name} account is legitimate.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -195,8 +195,8 @@ en:
           - Your primary number (the one you use the most often)
       return_to_profile: '‹ Return to your %{app_name} profile'
       review:
-        phone_verified: We verified your phone number
         intro: Your verified information
+        phone_verified: We verified your phone number
       select_verification_with_sp: To protect you from identity fraud, we will contact
         you to confirm that this %{sp_name} account is legitimate.
       select_verification_without_sp: To protect you from identity fraud, we will

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -207,7 +207,7 @@ es:
           - Su número principal (el que utiliza con más frecuencia)
       return_to_profile: '‹ Volver a tu perfil de %{app_name}'
       review:
-        info_verified_html: Encontramos registros que coinciden con su %{phone_message}
+        info_verified: Verificamos su número de teléfono
         intro: Su información verificada
       select_verification_with_sp: Para protegerlo de robo de identidad, no puede
         utilizar su cuenta en %{sp_name} hasta que la active ingresando un

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -207,8 +207,8 @@ es:
           - Su número principal (el que utiliza con más frecuencia)
       return_to_profile: '‹ Volver a tu perfil de %{app_name}'
       review:
-        phone_verified: Verificamos su número de teléfono
         intro: Su información verificada
+        phone_verified: Verificamos su número de teléfono
       select_verification_with_sp: Para protegerlo de robo de identidad, no puede
         utilizar su cuenta en %{sp_name} hasta que la active ingresando un
         código único.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -207,7 +207,7 @@ es:
           - Su número principal (el que utiliza con más frecuencia)
       return_to_profile: '‹ Volver a tu perfil de %{app_name}'
       review:
-        info_verified: Verificamos su número de teléfono
+        phone_verified: Verificamos su número de teléfono
         intro: Su información verificada
       select_verification_with_sp: Para protegerlo de robo de identidad, no puede
         utilizar su cuenta en %{sp_name} hasta que la active ingresando un

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -217,8 +217,7 @@ fr:
           - Votre numéro principal (celui que vous utilisez le plus souvent)
       return_to_profile: '‹ Revenir à votre profil %{app_name}'
       review:
-        info_verified_html: Nous avons trouvé des données qui correspondent à votre
-          %{phone_message}
+        info_verified: Nous avons vérifié votre numéro de téléphone
         intro: Vos informations vérifiées
       select_verification_with_sp: Afin de vous protéger des fraudes d’identité, vous
         ne pouvez pas utiliser votre compte au %{sp_name} tant que vous ne

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -217,8 +217,8 @@ fr:
           - Votre numéro principal (celui que vous utilisez le plus souvent)
       return_to_profile: '‹ Revenir à votre profil %{app_name}'
       review:
-        phone_verified: Nous avons vérifié votre numéro de téléphone
         intro: Vos informations vérifiées
+        phone_verified: Nous avons vérifié votre numéro de téléphone
       select_verification_with_sp: Afin de vous protéger des fraudes d’identité, vous
         ne pouvez pas utiliser votre compte au %{sp_name} tant que vous ne
         l’aurez pas activé en entrant votre code à usage unique.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -217,7 +217,7 @@ fr:
           - Votre numéro principal (celui que vous utilisez le plus souvent)
       return_to_profile: '‹ Revenir à votre profil %{app_name}'
       review:
-        info_verified: Nous avons vérifié votre numéro de téléphone
+        phone_verified: Nous avons vérifié votre numéro de téléphone
         intro: Vos informations vérifiées
       select_verification_with_sp: Afin de vous protéger des fraudes d’identité, vous
         ne pouvez pas utiliser votre compte au %{sp_name} tant que vous ne

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -155,7 +155,7 @@ describe Idv::ReviewController do
         get :new
 
         expect(flash.now[:success]).to eq(
-          t('idv.messages.review.info_verified'),
+          t('idv.messages.review.phone_verified'),
         )
       end
 

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -159,6 +159,17 @@ describe Idv::ReviewController do
         )
       end
 
+      context 'user is in gpo flow' do
+        it 'does not display success message' do
+          idv_session.vendor_phone_confirmation = false
+          idv_session.address_verification_mechanism = 'gpo'
+
+          get :new
+
+          expect(flash.now[:success]).to be_nil
+        end
+      end
+
       it 'updates the doc auth log for the user for the encrypt view event' do
         unstub_analytics
         doc_auth_log = DocAuthLog.create(user_id: user.id)

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -155,13 +155,7 @@ describe Idv::ReviewController do
         get :new
 
         expect(flash.now[:success]).to eq(
-          t(
-            'idv.messages.review.info_verified_html',
-            phone_message: ActionController::Base.helpers.content_tag(
-              :strong,
-              t('idv.messages.phone.phone_of_record'),
-            ),
-          ),
+          t('idv.messages.review.info_verified'),
         )
       end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9648](https://cm-jira.usa.gov/browse/LG-9648)

## 🛠 Summary of changes

Clearer wording for phone verification success banner on Enter Password screen, and don't show it for users waiting to verify via US mail.

## 👀 Screenshots

<details>
<summary>After:</summary>
  
![Enter password english](https://user-images.githubusercontent.com/2381438/236951058-4b675c7c-85fd-47e7-8d9e-222fdb51e897.png)![Enter password spanish](https://user-images.githubusercontent.com/2381438/236951057-0f2ab184-d217-439f-a9b7-ff33d85e42af.png)![Enter password french](https://user-images.githubusercontent.com/2381438/236951052-8ce8976d-18b2-4658-83b9-a978e3406535.png)
</details>
