### PR TITLE
LG-9561: Limit requesting new GPO codes to 30 days after initial request

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -7,6 +7,7 @@ module Idv
     before_action :confirm_idv_needed
     before_action :confirm_user_completed_idv_profile_step
     before_action :confirm_mail_not_spammed
+    before_action :confirm_profile_not_too_old
 
     def index
       @presenter = GpoPresenter.new(current_user, url_options)
@@ -37,6 +38,10 @@ module Idv
     end
 
     private
+
+    def confirm_profile_not_too_old
+      redirect_to idv_path if gpo_mail_service.profile_too_old?
+    end
 
     def step_indicator_current_step
       if resend_requested?

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -16,7 +16,7 @@ module Idv
       @user_can_request_another_gpo_code =
         FeatureManagement.gpo_verification_enabled? &&
         !gpo_mail.mail_spammed? &&
-        !profile_is_too_old
+        !gpo_mail.profile_too_old?
 
       if throttle.throttled?
         render_throttled
@@ -75,12 +75,6 @@ module Idv
       end
 
       enable_personal_key_generation
-    end
-
-    def profile_is_too_old
-      max_age_in_days = IdentityConfig.store.gpo_max_profile_age_to_send_letter_in_days
-      min_creation_date = Time.zone.now - max_age_in_days.days
-      current_user.pending_profile.created_at < min_creation_date
     end
 
     def throttle

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -15,8 +15,8 @@ module Idv
     def profile_too_old?
       return false if !current_user.pending_profile
 
-      max_age_in_days = IdentityConfig.store.gpo_max_profile_age_to_send_letter_in_days
-      min_creation_date = Time.zone.now - max_age_in_days.days
+      min_creation_date = IdentityConfig.store.
+        gpo_max_profile_age_to_send_letter_in_days.days.ago
 
       current_user.pending_profile.created_at < min_creation_date
     end

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -12,6 +12,15 @@ module Idv
       max_events? && updated_within_last_month?
     end
 
+    def profile_too_old?
+      return false if !current_user.pending_profile
+
+      max_age_in_days = IdentityConfig.store.gpo_max_profile_age_to_send_letter_in_days
+      min_creation_date = Time.zone.now - max_age_in_days.days
+
+      current_user.pending_profile.created_at < min_creation_date
+    end
+
     private
 
     attr_reader :current_user

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -41,7 +41,7 @@
   </div>
 <% end %>
 
-<% if FeatureManagement.gpo_verification_enabled? && !@mail_spammed %>
+<% if @user_can_request_another_gpo_code %>
   <%= link_to t('idv.messages.gpo.resend'), idv_gpo_path, class: 'display-block margin-bottom-2' %>
 <% end %>
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -116,6 +116,7 @@ good_job_max_threads: 5
 good_job_queues: 'default:5;low:1;*'
 good_job_queue_select_limit: 5_000
 gpo_designated_receiver_pii: '{}'
+gpo_max_profile_age_to_send_letter_in_days: 30
 hide_phone_mfa_signup: false
 identity_pki_disabled: false
 identity_pki_local_dev: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -193,6 +193,7 @@ class IdentityConfig
     config.add(:good_job_queues, type: :string)
     config.add(:good_job_queue_select_limit, type: :integer)
     config.add(:gpo_designated_receiver_pii, type: :json, options: { symbolize_names: true })
+    config.add(:gpo_max_profile_age_to_send_letter_in_days, type: :integer)
     config.add(:hide_phone_mfa_signup, type: :boolean)
     config.add(:hmac_fingerprinter_key, type: :string)
     config.add(:hmac_fingerprinter_key_queue, type: :json)

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -15,6 +15,7 @@ describe Idv::GpoController do
         :confirm_two_factor_authenticated,
         :confirm_idv_needed,
         :confirm_mail_not_spammed,
+        :confirm_profile_not_too_old,
       )
     end
 
@@ -93,6 +94,34 @@ describe Idv::GpoController do
         get :index
 
         expect(assigns(:step_indicator_current_step)).to eq(:get_a_letter)
+      end
+    end
+
+    context 'user has a pending profile' do
+      let(:profile_created_at) { Time.zone.now }
+      let(:pending_profile) do
+        create(
+          :profile,
+          :with_pii,
+          user: user,
+          created_at: profile_created_at,
+        )
+      end
+      before do
+        allow(user).to receive(:pending_profile).and_return(pending_profile)
+      end
+
+      it 'renders ok' do
+        get :index
+        expect(response).to be_ok
+      end
+
+      context 'but pending profile is too old to send another letter' do
+        let(:profile_created_at) { Time.zone.now - 31.days }
+        it 'redirects back to /verify' do
+          get :index
+          expect(response).to redirect_to(idv_path)
+        end
       end
     end
   end

--- a/spec/views/idv/gpo_verify/index.html.erb_spec.rb
+++ b/spec/views/idv/gpo_verify/index.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe 'idv/gpo_verify/index.html.erb' do
+  let(:user) do
+    create(:user)
+  end
+
+  let(:pii) do
+    {}
+  end
+
+  before do
+    allow(view).to receive(:step_indicator_steps).and_return({})
+    @gpo_verify_form = GpoVerifyForm.new(
+      user: user,
+      pii: pii,
+      otp: '1234',
+    )
+  end
+
+  context 'user is allowed to request another GPO letter' do
+    before do
+      @user_can_request_another_gpo_code = true
+      render
+    end
+    it 'includes the send another letter link' do
+      expect(rendered).to have_link(t('idv.messages.gpo.resend'), href: idv_gpo_path)
+    end
+  end
+  context 'user is NOT allowed to request another GPO letter' do
+    before do
+      @user_can_request_another_gpo_code = false
+      render
+    end
+    it 'does not include the send another letter link' do
+      expect(rendered).not_to have_link(t('idv.messages.gpo.resend'), href: idv_gpo_path)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-9561](https://cm-jira.usa.gov/browse/LG-9561)

## 🛠 Summary of changes

Add a new config, `gpo_max_profile_age_to_send_letter_in_days`, which can be used to limit the amount of time after a profile is first created we allow requesting a GPO letter to verify it. The default value for this config is 30 days, calculated from the `created_at` of the `Profile`.

When the user is outside this window of time, they are no longer offered the option to "Send me another letter" on the GPO verification page--they can either enter the OTP that was already mailed to them or restart the proofing process.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
