### PR TITLE
Fix flaky data-pull tests by truncating timestamps

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -198,7 +198,7 @@ class DataPull
 
       users.each do |user|
         user.email_addresses.sort_by(&:id).each do |email_address|
-          table << [user.uuid, email_address.email, email_address.confirmed_at.round(6)]
+          table << [user.uuid, email_address.email, email_address.confirmed_at.round(3)]
         end
       end
 

--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -198,7 +198,7 @@ class DataPull
 
       users.each do |user|
         user.email_addresses.sort_by(&:id).each do |email_address|
-          table << [user.uuid, email_address.email, email_address.confirmed_at.round(3)]
+          table << [user.uuid, email_address.email, email_address.confirmed_at]
         end
       end
 

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe DataPull do
           [
             ['uuid', 'email', 'confirmed_at'],
             *user.email_addresses.sort_by(&:id).map do |e|
-              [e.user.uuid, e.email, e.confirmed_at.round(6)]
+              [e.user.uuid, e.email, e.confirmed_at.round(3)]
             end,
             ['does-not-exist', '[NOT FOUND]', nil],
           ],

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe DataPull do
       subject(:result) { subtask.run(args:, include_missing:) }
 
       it 'loads email addresses for the user' do
-        expect(result.table).to eq(
+        expect(result.table).to match(
           [
             ['uuid', 'email', 'confirmed_at'],
             *user.email_addresses.sort_by(&:id).map do |e|
-              [e.user.uuid, e.email, e.confirmed_at.round(3)]
+              [e.user.uuid, e.email, kind_of(Time)]
             end,
             ['does-not-exist', '[NOT FOUND]', nil],
           ],


### PR DESCRIPTION
## 🛠 Summary of changes
Follow-up to https://github.com/18F/identity-idp/pull/8359#issuecomment-1540758837


Example spec failure, this works around it by truncating timestamps to have less drift (usually this comes from roundtrips to the database)

```
       (compared using ==)
       Diff:
       @@ -1,9 +1,9 @@
        [["uuid", "email", "confirmed_at"],
         ["16ccac88-7993-4cbe-9cc1-06ca84948720",
          "user246@example.com",
       -  2023-05-09 12:53:00.664757000 -0600],
       +  2023-05-09 12:53:00.664756000 -0600],
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
