### PR TITLE
LG-9740 Add csp overrides for ThreatMetrix before_action to SsnController

### DIFF
--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -10,6 +10,18 @@ module Idv
 
       return if params[:step] != 'ssn'
 
+      threat_metrix_csp_overrides
+    end
+
+    # Remove this duplication once in_person_controller is no longer in use
+    # for their SSN step
+    def override_csp_for_threat_metrix_no_fsm
+      return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
+
+      threat_metrix_csp_overrides
+    end
+
+    def threat_metrix_csp_overrides
       policy = current_content_security_policy
 
       # ThreatMetrix requires additional Content Security Policy (CSP)

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -5,9 +5,11 @@ module Idv
     include StepIndicatorConcern
     include StepUtilitiesConcern
     include Steps::ThreatMetrixStepHelper
+    include ThreatMetrixConcern
 
     before_action :confirm_verify_info_step_needed
     before_action :confirm_document_capture_complete
+    before_action :override_csp_for_threat_metrix_no_fsm
 
     attr_accessor :error_message
 

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -83,6 +83,27 @@ describe Idv::SsnController do
         expect(response).to redirect_to(idv_doc_auth_url)
       end
     end
+
+    it 'overrides Content Security Policies for ThreatMetrix' do
+      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
+        and_return(:enabled)
+      get :show
+
+      csp = response.request.content_security_policy
+
+      aggregate_failures do
+        expect(csp.directives['script-src']).to include('h.online-metrix.net')
+        expect(csp.directives['script-src']).to include("'unsafe-eval'")
+
+        expect(csp.directives['style-src']).to include("'unsafe-inline'")
+
+        expect(csp.directives['child-src']).to include('h.online-metrix.net')
+
+        expect(csp.directives['connect-src']).to include('h.online-metrix.net')
+
+        expect(csp.directives['img-src']).to include('*.online-metrix.net')
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -34,6 +34,13 @@ describe Idv::SsnController do
         :confirm_document_capture_complete,
       )
     end
+
+    it 'overrides CSPs for ThreatMetrix' do
+      expect(subject).to have_actions(
+        :before,
+        :override_csp_for_threat_metrix_no_fsm,
+      )
+    end
   end
 
   describe '#show' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-9740](https://cm-jira.usa.gov/browse/LG-9740)

## 🛠 Summary of changes

This before action is needed to allow ThreatMetrix to load in browsers that respect Content Security Policies. It was part of the Flow State Machine but not clearly part of the SSN step.

Note: The in_person_controller still uses `override_csp_for_threat_metrix` with the parameter check for the ssn step, so I factored out the main part of the code and made a new method for the remote SsnController. This can be restored to a single method when the in_person FSM SsnStep is removed.

Note2: We need a test that checks that ThreatMetrix is loading without errors, either as part of this PR or as a separate PR.

## 📜 Testing Plan

- [ ] Do IdV process in staging, make sure ThreatMetrix loads without errors at SSN step
