### PR TITLE
Switch to using AWS Public ECR for Redis and PostgreSQL images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,9 +126,9 @@ specs:
     POSTGRES_HOST_AUTH_METHOD: trust
     RAILS_ENV: test
   services:
-    - name: postgres:13.9
+    - name: public.ecr.aws/docker/library/postgres:13.9
       alias: db-postgres
-    - name: redis:7.0
+    - name: public.ecr.aws/docker/library/redis:7.0
       alias: db-redis
   artifacts:
     expire_in: 31d

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,9 +126,9 @@ specs:
     POSTGRES_HOST_AUTH_METHOD: trust
     RAILS_ENV: test
   services:
-    - name: ${ECR_REGISTRY}/ecr-public/docker/library/postgres:13.9
+    - name: "${ECR_REGISTRY}/ecr-public/docker/library/postgres:13.9"
       alias: db-postgres
-    - name: ${ECR_REGISTRY}/ecr-public/docker/library/redis:7.0
+    - name: "${ECR_REGISTRY}/ecr-public/docker/library/redis:7.0"
       alias: db-redis
   artifacts:
     expire_in: 31d

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,9 +126,9 @@ specs:
     POSTGRES_HOST_AUTH_METHOD: trust
     RAILS_ENV: test
   services:
-    - name: public.ecr.aws/docker/library/postgres:13.9
+    - name: ${ECR_REGISTRY}/ecr-public/docker/library/postgres:13.9
       alias: db-postgres
-    - name: public.ecr.aws/docker/library/redis:7.0
+    - name: ${ECR_REGISTRY}/ecr-public/docker/library/redis:7.0
       alias: db-redis
   artifacts:
     expire_in: 31d


### PR DESCRIPTION
## 🛠 Summary of changes

Uses AWS ECR for CI containers instead of fetching from Docker Hub.
