### PR TITLE
LG-9531: Change title separate from dash to bar

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -17,7 +17,7 @@
 
   <%= content_tag(
         'title',
-        content_for?(:title) ? raw("#{yield(:title)} - #{APP_NAME}") : APP_NAME,
+        content_for?(:title) ? raw("#{yield(:title)} | #{APP_NAME}") : APP_NAME,
       ) %>
 
   <%= javascript_tag(nonce: true) do %>
@@ -74,7 +74,7 @@
         local_assigns[:user_main_tag] == false ? 'div' : 'main',
         class: 'site-wrap bg-primary-lighter',
         id: local_assigns[:user_main_tag] == false ? nil : 'main-content',
-      ) do %>  
+      ) do %>
     <% if @is_on_home_page && @sign_in_a_b_test_bucket == :banner %>
       <div class="grid-container padding-y-2 card tablet:margin-bottom-1">
         <%= render 'shared/create_account_banner' %>

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -73,7 +73,7 @@ describe 'layouts/application.html.erb' do
         render
 
         doc = Nokogiri::HTML(rendered)
-        expect(doc.at_css('title').text).to include("Something with 'single quotes' - Login.gov")
+        expect(doc.at_css('title').text).to eq("Something with 'single quotes' | #{APP_NAME}")
       end
 
       it 'properly works with > in the title tag' do
@@ -82,7 +82,7 @@ describe 'layouts/application.html.erb' do
         render
 
         doc = Nokogiri::HTML(rendered)
-        expect(doc.at_css('title').text).to include('Symbols <> - Login.gov')
+        expect(doc.at_css('title').text).to eq("Symbols <> | #{APP_NAME}")
       end
     end
 
@@ -91,7 +91,7 @@ describe 'layouts/application.html.erb' do
         render
 
         doc = Nokogiri::HTML(rendered)
-        expect(doc.at_css('title').text).to include('Login.gov')
+        expect(doc.at_css('title').text).to eq(APP_NAME)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9531](https://cm-jira.usa.gov/browse/LG-9531)

## 🛠 Summary of changes

Changes the separator in the `<title>` from a dash ("-") to a bar ("|").

**Why?**

- For consistency with [Login.gov](https://login.gov/) ([source](https://github.com/18F/identity-site/blob/0e3bb36cb7c257ebf539f31fe8cae4d7cf39f8b9/_includes/meta.html#L23))
- For (marginally) improved accessibility ([related article](https://www.standards-schmandards.com/index.html%3Fp=15.html))

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Observe text in browser tab

## 👀 Screenshots

Before|After
---|---
![Screen Shot 2023-05-10 at 10 23 01 AM](https://github.com/18F/identity-idp/assets/1779930/9cadd428-4fe0-47db-b93a-baae2e82d18b)|![image](https://github.com/18F/identity-idp/assets/1779930/fad664f8-7a13-4567-a0a8-35f881064ae3)
