### PR TITLE
LG-9710: Add hidden field to associate password with email

### DIFF
--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -11,12 +11,13 @@
       method: :post,
       html: { autocomplete: 'off' },
     ) do |f| %>
-    <%= render PasswordConfirmationComponent.new(
-          form: f,
-          field_options: {
-            input_html: { aria: { describedby: 'password-description' } },
-          },
-        ) %>
+  <%= text_field_tag('username', @email_address.email, hidden: true, autocomplete: 'username') %>
+  <%= render PasswordConfirmationComponent.new(
+        form: f,
+        field_options: {
+          input_html: { aria: { describedby: 'password-description' } },
+        },
+      ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>
   <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>

--- a/spec/components/javascript_required_component_spec.rb
+++ b/spec/components/javascript_required_component_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe JavascriptRequiredComponent, type: :component do
   end
 
   it 'loads css resource for setting session key in JavaScript-disabled environments' do
-    expect(rendered).to have_css('noscript link') do |node|
-      node[:href] == no_js_detect_css_path
-    end
+    expect(rendered).to have_css("noscript link[href='#{no_js_detect_css_path}']")
   end
 
   context 'with intro' do

--- a/spec/views/sign_up/passwords/new.html.erb_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.erb_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 describe 'sign_up/passwords/new.html.erb' do
+  let(:user) { build_stubbed(:user) }
+
   before do
-    user = build_stubbed(:user)
     allow(view).to receive(:current_user).and_return(nil)
     allow(view).to receive(:params).and_return(confirmation_token: 123)
     allow(view).to receive(:request_id).and_return(nil)
 
+    @email_address = user.email_addresses.first
     @password_form = PasswordForm.new(user)
 
     render
@@ -26,6 +28,17 @@ describe 'sign_up/passwords/new.html.erb' do
         'instructions.password.info.lead_html',
         min_length: Devise.password_length.min,
       ),
+    )
+  end
+
+  it 'includes the user email address as a hidden field' do
+    # Reference:
+    # - https://www.chromium.org/developers/design-documents/create-amazing-password-forms/#use-hidden-fields-for-implicit-information
+    # - https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/
+    expect(user.email).to be_present
+    expect(rendered).to have_css(
+      "input[type='text'][name='username'][value='#{user.email}'][autocomplete='username']",
+      visible: false,
     )
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9710](https://cm-jira.usa.gov/browse/LG-9710)

## 🛠 Summary of changes

Adds a hidden field to the password creation screen, so that browsers or password managers can associate the newly-created password as a full credential including the user's email address.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Click "Create an account"
3. Continue account creation to the password entry screen
4. Enter and confirm a password
5. Submit
6. Observe if/how the browser prompts you to save the password you just created

## 👀 Screenshots

Device|Before|After
---|---|---
Chrome (Desktop)|![chrome-before](https://github.com/18F/identity-idp/assets/1779930/5ad77fdc-da38-4a50-a384-bdb2fa533d7d)|![chrome-after](https://github.com/18F/identity-idp/assets/1779930/f6a78155-b14a-4b2a-a751-f196a5f9c09c)
Chrome (Mobile)|![chrome-mobile-before](https://github.com/18F/identity-idp/assets/1779930/17535bd6-da2b-40cd-b51b-5c0053d93044)|![chrome-mobile-after](https://github.com/18F/identity-idp/assets/1779930/46fb9515-83c6-4fe6-a3da-1e51d91c602f)
Firefox|![firefox-before](https://github.com/18F/identity-idp/assets/1779930/7b28be4e-8177-44e9-9de4-da485f12b72d)|![firefox-after](https://github.com/18F/identity-idp/assets/1779930/4bf00d19-3ede-4637-a964-d81a25c586f3)
Safari (Desktop)|![safari-before](https://github.com/18F/identity-idp/assets/1779930/bd17f64e-d961-44b6-b7a0-aefcc1e4ad12)|![safari-after](https://github.com/18F/identity-idp/assets/1779930/3ded5408-73a5-47a3-8e95-c897b174a771)![safari-after-passwords](https://github.com/18F/identity-idp/assets/1779930/99e31218-3014-43b0-9030-691ea3875aca)
Safari (Mobile)|![safari-mobile-before](https://github.com/18F/identity-idp/assets/1779930/59d767d7-9609-4cdb-97c3-caf140b23c37)|![safari-mobile-after](https://github.com/18F/identity-idp/assets/1779930/83fdccc2-dc44-4782-93c8-3e3bccb227a1)

