### PR TITLE
LG-8319: Re-add the secondary ID instructions to web page and email

### DIFF
--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -40,6 +40,17 @@
     <% c.item(heading: t('in_person_proofing.process.state_id.heading')) do %>
       <p><%= t('in_person_proofing.process.state_id.info') %></p>
     <% end %>
+    <% if @presenter.needs_proof_of_address? %>
+      <% c.item(heading: t('in_person_proofing.process.proof_of_address.heading')) do %>
+        <p class="margin-bottom-105"><%= t('in_person_proofing.process.proof_of_address.info') %></p>
+        <ul class="usa-list margin-y-105">
+          <% t('in_person_proofing.process.proof_of_address.acceptable_proof').each do |proof| %>
+            <li><%= proof %></li>
+          <% end %>
+        </ul>
+        <p><%= t('in_person_proofing.process.proof_of_address.physical_or_digital_copy') %></p>
+      <% end %>
+    <% end %>
   <% end %>
   <p class="margin-bottom-0">
     <%= t('in_person_proofing.body.barcode.questions') %>

--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -47,6 +47,21 @@
         <p class="margin-bottom-105"><%= t('in_person_proofing.process.state_id.info') %></p>
       </td>
     </tr>
+    <% if @presenter.needs_proof_of_address? %>
+      <tr>
+        <td><div class="process-list__circle">4</div></td>
+        <td>
+          <h3 class="font-heading-md text-bold"><%= t('in_person_proofing.process.proof_of_address.heading') %></h3>
+          <p class="margin-bottom-105"><%= t('in_person_proofing.process.proof_of_address.info') %></p>
+          <ul class="usa-list margin-y-105">
+            <% t('in_person_proofing.process.proof_of_address.acceptable_proof').each do |proof| %>
+              <li><%= proof %></li>
+            <% end %>
+          </ul>
+          <p><%= t('in_person_proofing.process.proof_of_address.physical_or_digital_copy') %></p>
+        </td>
+      </tr>
+    <% end %>
   </table>
   <p class="margin-bottom-0">
     <%= t('in_person_proofing.body.barcode.questions') %>

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -152,6 +152,18 @@ en:
         heading: Show your %{app_name} barcode
         info: The retail associate needs to scan your barcode at the top of this page.
           You can print this page or show it on your mobile device.
+      proof_of_address:
+        acceptable_proof:
+          - Lease, Mortgage, or Deed of Trust
+          - Voter Registration
+          - Vehicle Registration Card
+          - Home or Vehicle Insurance Policy
+        heading: Proof of your current address
+        info: 'You need a proof of address if your current address is different than the
+          address on your ID. Acceptable forms of proof of address are:'
+        physical_or_digital_copy: You can bring a physical copy or show a digital copy
+          of the document. You cannot show a photo or screenshot of the
+          document.
       state_id:
         heading: Show your State Driver’s License or State Non-Driver’s Identification
           Card

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -167,6 +167,19 @@ es:
         info: El empleado deberá escanear el código de barras que aparece en la parte
           superior de esta página. Puede imprimir esta página o mostrarla en su
           dispositivo móvil.
+      proof_of_address:
+        acceptable_proof:
+          - Arrendamiento, hipoteca o escritura de fideicomiso
+          - Registro de votantes
+          - Tarjeta de registro del vehículo
+          - Póliza de seguro del hogar o del vehículo
+        heading: Prueba de su dirección actual
+        info: 'Necesita un justificante de domicilio si su dirección actual es diferente
+          a la que figura en su cédula de identidad. Los comprobantes de
+          domicilio aceptables son:'
+        physical_or_digital_copy: Puede traer una copia física o mostrar una copia
+          digital del documento. No puede mostrar una foto o una captura de
+          pantalla del documento.
       state_id:
         heading: Muestre su licencia de conducir estatal o su tarjeta de identificación
           estatal de no conductor

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -169,6 +169,19 @@ fr:
         heading: Montrez votre code-barres %{app_name}
         info: Le vendeur doit scanner votre code-barres en haut de cette page. Vous
           pouvez imprimer cette page ou la montrer sur votre appareil mobile.
+      proof_of_address:
+        acceptable_proof:
+          - Bail, hypothèque ou acte de fiducie
+          - Inscription sur les listes électorales
+          - Carte d’immatriculation du véhicule
+          - Police d’assurance habitation ou véhicule
+        heading: Preuve de votre adresse actuelle
+        info: 'Vous avez besoin d’un justificatif de domicile si votre adresse actuelle
+          est différente de l’adresse figurant sur votre document d’identité.
+          Les justificatifs d’adresse acceptés sont les suivants:'
+        physical_or_digital_copy: Vous pouvez apporter une copie physique ou montrer une
+          copie numérique du document. Vous ne pouvez pas montrer une photo ou
+          une capture d’écran du document.
       state_id:
         heading: Présentez votre permis de conduire de l’État ou votre carte d’identité
           de non-conducteur de l’État

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -546,6 +546,7 @@ describe UserMailer, type: :mailer do
         current_address_matches_id: current_address_matches_id,
       )
     end
+
     describe '#in_person_ready_to_verify' do
       let(:mail) do
         UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
@@ -555,6 +556,25 @@ describe UserMailer, type: :mailer do
 
       it_behaves_like 'a system email'
       it_behaves_like 'an email that respects user email locale preference'
+
+      context 'double address verification is not enabled' do
+        it 'renders the body' do
+          expect(mail.html_part.body).
+            to have_content(
+              t('in_person_proofing.process.proof_of_address.heading'),
+            )
+        end
+      end
+
+      context 'double address verification is enabled' do
+        let(:capture_secondary_id_enabled) { true }
+        it 'renders the body' do
+          expect(mail.html_part.body).
+            to_not have_content(
+              t('in_person_proofing.process.proof_of_address.heading'),
+            )
+        end
+      end
 
       it 'renders the body' do
         expect(mail.html_part.body).
@@ -576,6 +596,25 @@ describe UserMailer, type: :mailer do
 
       it_behaves_like 'a system email'
       it_behaves_like 'an email that respects user email locale preference'
+
+      context 'double address verification is not enabled' do
+        it 'renders the body' do
+          expect(mail.html_part.body).
+            to have_content(
+              t('in_person_proofing.process.proof_of_address.heading'),
+            )
+        end
+      end
+
+      context 'double address verification is enabled' do
+        let(:capture_secondary_id_enabled) { true }
+        it 'renders the body' do
+          expect(mail.html_part.body).
+            to_not have_content(
+              t('in_person_proofing.process.proof_of_address.heading'),
+            )
+        end
+      end
 
       it 'renders the body' do
         expect(mail.html_part.body).

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -65,6 +65,26 @@ describe 'idv/in_person/ready_to_verify/show.html.erb' do
     )
   end
 
+  context 'with enrollment where current address matches id' do
+    let(:current_address_matches_id) { true }
+
+    it 'renders without proof of address instructions' do
+      render
+
+      expect(rendered).not_to have_content(t('in_person_proofing.process.proof_of_address.heading'))
+    end
+  end
+
+  context 'with enrollment where current address does not match id' do
+    let(:current_address_matches_id) { false }
+
+    it 'renders with proof of address instructions' do
+      render
+
+      expect(rendered).to have_content(t('in_person_proofing.process.proof_of_address.heading'))
+    end
+  end
+
   context 'with enrollment where selected_location_details is present' do
     it 'renders a location' do
       render


### PR DESCRIPTION

## 🎫 Ticket

[LG-8319](https://cm-jira.usa.gov/browse/LG-8319)

## 🛠 Summary of changes

Re-adds the secondary ID instructions to the Ready to Verify page and emails when appropriate. See [this slack thread](https://gsa-tts.slack.com/archives/C04GA9WQ85B/p1683748251597079) for context.