### PR TITLE
LG-9741 Confirm no pending GPO or in person enrollment before actions in IdvStepConcern

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -6,6 +6,17 @@ module IdvStepConcern
   included do
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
+    before_action :confirm_no_pending_profile
+    before_action :confirm_no_pending_in_person_enrollment
+  end
+
+  def confirm_no_pending_profile
+    redirect_to idv_gpo_verify_url if current_user.pending_profile_requires_verification?
+  end
+
+  def confirm_no_pending_in_person_enrollment
+    return if !IdentityConfig.store.in_person_proofing_enabled
+    redirect_to idv_in_person_ready_to_verify_url if current_user.pending_in_person_enrollment
   end
 
   def flow_session

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -6,11 +6,11 @@ module IdvStepConcern
   included do
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
-    before_action :confirm_no_pending_profile
+    before_action :confirm_no_pending_gpo_profile
     before_action :confirm_no_pending_in_person_enrollment
   end
 
-  def confirm_no_pending_profile
+  def confirm_no_pending_gpo_profile
     redirect_to idv_gpo_verify_url if current_user.pending_profile_requires_verification?
   end
 

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -163,4 +163,42 @@ describe 'IdvStepConcern' do
       end
     end
   end
+
+  describe '#confirm_no_pending_in_person_enrollment' do
+    controller Idv::StepController do
+      before_action :confirm_no_pending_in_person_enrollment
+    end
+
+    before(:each) do
+      sign_in(user)
+      allow(subject).to receive(:current_user).and_return(user)
+      routes.draw do
+        get 'show' => 'idv/step#show'
+      end
+    end
+
+    context 'without pending in person enrollment' do
+      it 'does not redirect' do
+        get :show
+
+        expect(response.body).to eq 'Hello'
+        expect(response).to_not redirect_to idv_in_person_ready_to_verify_url
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'with pending in person enrollment' do
+      let(:user) { create(:user, :with_pending_in_person_enrollment, :fully_registered) }
+
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      end
+
+      it 'redirects to in person ready to verify page' do
+        get :show
+
+        expect(response).to redirect_to idv_in_person_ready_to_verify_url
+      end
+    end
+  end
 end

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -201,4 +201,42 @@ describe 'IdvStepConcern' do
       end
     end
   end
+
+  describe '#confirm_no_pending_gpo_profile' do
+    controller Idv::StepController do
+      before_action :confirm_no_pending_gpo_profile
+    end
+
+    before(:each) do
+      sign_in(user)
+      allow(subject).to receive(:current_user).and_return(user)
+      routes.draw do
+        get 'show' => 'idv/step#show'
+      end
+    end
+
+    context 'without pending gpo profile' do
+      it 'does not redirect' do
+        get :show
+
+        expect(response.body).to eq 'Hello'
+        expect(response).to_not redirect_to idv_in_person_ready_to_verify_url
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'with pending gpo profile' do
+      let(:user) { create(:user, :with_pending_gpo_profile, :fully_registered) }
+
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      end
+
+      it 'redirects to enter your code page' do
+        get :show
+
+        expect(response).to redirect_to idv_gpo_verify_url
+      end
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -203,6 +203,19 @@ FactoryBot.define do
       end
     end
 
+    trait :with_pending_gpo_profile do
+      after :build do |user|
+        profile = create(:profile, :with_pii, user: user)
+        profile.gpo_verification_pending_at = 1.day.ago
+        # This sets the deactivation_reason to enum value :gpo_verification_pending
+        profile.gpo_verification_pending!
+        gpo_code = create(:gpo_confirmation_code)
+        profile.gpo_confirmation_codes << gpo_code
+        device = create(:device, user: user)
+        create(:event, user: user, device: device, event_type: :gpo_mail_sent)
+      end
+    end
+
     trait :proofed_with_gpo do
       proofed
       after :build do |user|

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -243,6 +243,14 @@ RSpec.describe 'In Person Proofing', js: true do
     sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_welcome_step
     expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
+
+    # confirm that user cannot visit other IdV pages before completing in-person proofing
+    visit idv_doc_auth_agreement_step
+    expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
+    visit idv_ssn_url
+    expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
+    visit idv_verify_info_url
+    expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
   end
 
   it 'allows the user to cancel and start over from the beginning', allow_browser_log: true do

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -33,6 +33,14 @@ feature 'idv gpo step', :js do
       expect_user_to_be_unverified(user)
       expect(page).to have_content(t('idv.titles.come_back_later'))
       expect(page).to have_current_path(idv_come_back_later_path)
+
+      # Confirm that user cannot visit other IdV pages while unverified
+      visit idv_doc_auth_agreement_step
+      expect(page).to have_current_path(idv_gpo_verify_path)
+      visit idv_ssn_url
+      expect(page).to have_current_path(idv_gpo_verify_path)
+      visit idv_verify_info_url
+      expect(page).to have_current_path(idv_gpo_verify_path)
     end
 
     context 'too much time has passed' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-9741](https://cm-jira.usa.gov/browse/LG-9741)

## 🛠 Summary of changes

Ensure that users waiting for a letter or in person verification see the correct page when entering Identity Verification. Add before actions to IdvStepConcern, which is included in all the post-FSM controllers. These before actions already existed in doc_auth_controller, where they apply to steps inside the FSM.

Now with added concern and feature specs. Note that the feature specs pass even when the new before actions are commented out because doc_auth_controller still has our backs. These before actions will be needed as we pull more steps out of the FSM.
