### PR TITLE
LG-9477 log nontransliterable chars

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -666,8 +666,10 @@ module AnalyticsEvents
 
   # @param [String] nontransliterable_characters
   # Nontransliterable characters submitted by user
-  def idv_in_person_proofing_nontransliterable_characters_submitted(nontransliterable_characters:,
-                                                                    **extra)
+  def idv_in_person_proofing_nontransliterable_characters_submitted(
+    nontransliterable_characters:,
+    **extra
+  )
     track_event(
       'IdV: in person proofing characters submitted could not be transliterated',
       nontransliterable_characters: nontransliterable_characters,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -664,6 +664,17 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String] nontransliterable_characters
+  # Nontransliterable characters submitted by user
+  def idv_in_person_proofing_nontransliterable_characters_submitted(nontransliterable_characters:,
+                                                                    **extra)
+    track_event(
+      'IdV: in person proofing characters submitted could not be transliterated',
+      nontransliterable_characters: nontransliterable_characters,
+      **extra,
+    )
+  end
+
   def idv_in_person_proofing_residential_address_submitted(**extra)
     track_event('IdV: in person proofing residential address submitted', **extra)
   end

--- a/app/services/usps_in_person_proofing/transliterable_validator.rb
+++ b/app/services/usps_in_person_proofing/transliterable_validator.rb
@@ -52,9 +52,8 @@ module UspsInPersonProofing
       end
 
       if nontransliterable_chars.present?
-        nontransliterable_chars = nontransliterable_chars.sort
         analytics.idv_in_person_proofing_nontransliterable_characters_submitted(
-          nontransliterable_characters: nontransliterable_chars,
+          nontransliterable_characters: nontransliterable_chars.sort,
         )
       end
     end

--- a/app/services/usps_in_person_proofing/transliterable_validator.rb
+++ b/app/services/usps_in_person_proofing/transliterable_validator.rb
@@ -32,7 +32,7 @@ module UspsInPersonProofing
     # @param [ActiveModel::Validations] record
     def validate(record)
       return unless IdentityConfig.store.usps_ipp_transliteration_enabled
-
+      nontransliterable_chars = []
       @fields.each do |field|
         next unless record.respond_to?(field)
 
@@ -42,11 +42,18 @@ module UspsInPersonProofing
         invalid_chars = get_invalid_chars(value)
         next unless invalid_chars.present?
 
+        nontransliterable_chars += invalid_chars
+
         record.errors.add(
           field,
           :nontransliterable_field,
           message: get_error_message(invalid_chars),
         )
+      end
+
+      if nontransliterable_chars.present?
+        nontransliterable_chars = nontransliterable_chars.sort.uniq
+        log_nontransliterable_characters(nontransliterable_chars)
       end
     end
 
@@ -86,6 +93,16 @@ module UspsInPersonProofing
 
       # Create sorted list of unique unsupported characters
       (result.unsupported_chars + additional_chars).sort.uniq
+    end
+
+    def analytics(user: AnonymousUser.new)
+      Analytics.new(user: user, request: nil, session: {}, sp: nil)
+    end
+
+    def log_nontransliterable_characters(result)
+      analytics.idv_in_person_proofing_nontransliterable_characters_submitted(
+        nontransliterable_characters: result,
+      )
     end
   end
 end

--- a/app/services/usps_in_person_proofing/transliterable_validator.rb
+++ b/app/services/usps_in_person_proofing/transliterable_validator.rb
@@ -32,7 +32,7 @@ module UspsInPersonProofing
     # @param [ActiveModel::Validations] record
     def validate(record)
       return unless IdentityConfig.store.usps_ipp_transliteration_enabled
-      nontransliterable_chars = []
+      nontransliterable_chars = Set.new
       @fields.each do |field|
         next unless record.respond_to?(field)
 
@@ -52,8 +52,10 @@ module UspsInPersonProofing
       end
 
       if nontransliterable_chars.present?
-        nontransliterable_chars = nontransliterable_chars.sort.uniq
-        log_nontransliterable_characters(nontransliterable_chars)
+        nontransliterable_chars = nontransliterable_chars.sort
+        analytics.idv_in_person_proofing_nontransliterable_characters_submitted(
+          nontransliterable_characters: nontransliterable_chars,
+        )
       end
     end
 
@@ -97,12 +99,6 @@ module UspsInPersonProofing
 
     def analytics(user: AnonymousUser.new)
       Analytics.new(user: user, request: nil, session: {}, sp: nil)
-    end
-
-    def log_nontransliterable_characters(result)
-      analytics.idv_in_person_proofing_nontransliterable_characters_submitted(
-        nontransliterable_characters: result,
-      )
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9477](https://cm-jira.usa.gov/browse/LG-9477)


## 🛠 Summary of changes

Add an analytics event that logs nontransliterable characters that a user submits. An event will be logged for each group of fields where nontransliterable characters are present. The characters are sorted and duplicates are removed. 



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Walk through ipp and arrive at state id form
- [ ] Make sure name input includes characters that will be rejected ex: `F1r$t N@m3`
- [ ] Make sure address input includes characters that will be rejected ex: `100 M@!n $t`
- [ ] Submit form
- [ ] Make sure `events.log` logged event w/ the rejected characters
- [ ] Correct errors and advance to address form
- [ ] Make sure address input includes characters that will be rejected ex: `100 M@!n $t`
- [ ] Submit form
- [ ] Make sure `events.log` logged event w/ the rejected characters

