### PR TITLE
LG-9535 Read from new gpo column

### DIFF
--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -43,7 +43,7 @@ module Idv
     end
 
     def cancel_verification_attempt_if_pending_profile
-      return if current_user.profiles.gpo_verification_pending.blank?
+      return if !current_user.pending_profile?
       Idv::CancelVerificationAttempt.new(user: current_user).call
     end
 

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -22,6 +22,7 @@ class GpoVerifyForm
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
       elsif fraud_check_failed? && threatmetrix_enabled?
+        pending_profile&.remove_gpo_deactivation_reason
         deactivate_for_fraud_review
       else
         activate_profile
@@ -55,7 +56,6 @@ class GpoVerifyForm
 
   def deactivate_for_fraud_review
     pending_profile&.deactivate_for_fraud_review
-    pending_profile&.update!(deactivation_reason: nil, verified_at: Time.zone.now)
   end
 
   def validate_otp_not_expired
@@ -94,6 +94,7 @@ class GpoVerifyForm
   end
 
   def activate_profile
-    user.pending_profile&.activate_after_gpo_verification
+    pending_profile&.remove_gpo_deactivation_reason
+    pending_profile&.activate
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -58,9 +58,8 @@ class Profile < ApplicationRecord
   end
   # rubocop:enable Rails/SkipsModelValidations
 
-  def activate_after_gpo_verification
+  def remove_gpo_deactivation_reason
     update!(gpo_verification_pending_at: nil)
-    activate
   end
 
   def activate_after_passing_review

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,7 +102,15 @@ class User < ApplicationRecord
     pending_profile.present?
   end
 
+  def gpo_verification_pending_profile?
+    gpo_verification_pending_profile.present?
+  end
+
   def pending_profile
+    gpo_verification_pending_profile
+  end
+
+  def gpo_verification_pending_profile
     profiles.where.not(gpo_verification_pending_at: nil).order(created_at: :desc).first
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,7 +103,7 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    profiles.gpo_verification_pending.order(created_at: :desc).first
+    profiles.where.not(gpo_verification_pending_at: nil).order(created_at: :desc).first
   end
 
   def fraud_review_eligible?

--- a/app/services/idv/cancel_verification_attempt.rb
+++ b/app/services/idv/cancel_verification_attempt.rb
@@ -7,11 +7,14 @@ module Idv
     end
 
     def call
-      user.profiles.gpo_verification_pending.each do |profile|
-        profile.update!(
-          active: false,
-          deactivation_reason: :verification_cancelled,
-        )
+      user.profiles.each do |profile|
+        if profile.gpo_verification_pending?
+          profile.update!(
+            active: false,
+            deactivation_reason: :verification_cancelled,
+            gpo_verification_pending_at: nil,
+          )
+        end
       end
     end
   end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -63,7 +63,7 @@ describe AccountsController do
         user = create(
           :user,
           :fully_registered,
-          profiles: [build(:profile, deactivation_reason: :gpo_verification_pending)],
+          profiles: [build(:profile, gpo_verification_pending_at: 1.day.ago)],
         )
 
         sign_in user

--- a/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
+++ b/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
       end
 
       context 'with a pending profile' do
-        let(:profile) { create(:profile, deactivation_reason: :gpo_verification_pending) }
+        let(:profile) { create(:profile, gpo_verification_pending_at: 1.day.ago) }
 
         it 'returns doc auth gpo steps' do
           expect(steps).to eq doc_auth_step_indicator_steps_gpo
@@ -90,7 +90,7 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
         let(:profile) do
           create(
             :profile,
-            deactivation_reason: :gpo_verification_pending,
+            gpo_verification_pending_at: 1.day.ago,
             proofing_components: { 'document_check' => Idp::Constants::Vendors::USPS },
           )
         end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -75,7 +75,7 @@ describe Idv::SessionsController do
       let(:user) do
         create(
           :user,
-          profiles: [create(:profile, deactivation_reason: :gpo_verification_pending)],
+          profiles: [create(:profile, gpo_verification_pending_at: 1.day.ago)],
         )
       end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -351,7 +351,7 @@ describe Users::SessionsController, devise: true do
         user = create(:user, :fully_registered)
         create(
           :profile,
-          deactivation_reason: :gpo_verification_pending,
+          gpo_verification_pending_at: 1.day.ago,
           user: user, pii: { ssn: '1234' }
         )
 
@@ -623,7 +623,7 @@ describe Users::SessionsController, devise: true do
       it 'redirects to the verify profile page' do
         profile = create(
           :profile,
-          deactivation_reason: :gpo_verification_pending,
+          gpo_verification_pending_at: 1.day.ago,
           pii: { ssn: '6666', dob: '1920-01-01' },
         )
         user = profile.user

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -7,7 +7,7 @@ feature 'idv gpo otp verification step' do
   let(:profile) do
     create(
       :profile,
-      deactivation_reason: :gpo_verification_pending,
+      gpo_verification_pending_at: 1.day.ago,
       pii: { ssn: '123-45-6789', dob: '1970-01-01' },
       fraud_review_pending_at: fraud_review_pending_timestamp,
       fraud_rejection_at: fraud_rejection_timestamp,

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -7,7 +7,7 @@ feature 'idv gpo otp verification step' do
   let(:profile) do
     create(
       :profile,
-      gpo_verification_pending_at: 1.day.ago,
+      gpo_verification_pending_at: 2.days.ago,
       pii: { ssn: '123-45-6789', dob: '1970-01-01' },
       fraud_review_pending_at: fraud_review_pending_timestamp,
       fraud_rejection_at: fraud_rejection_timestamp,

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -79,7 +79,7 @@ feature 'IAL2 Single Sign On' do
     let(:profile) do
       create(
         :profile,
-        deactivation_reason: :gpo_verification_pending,
+        gpo_verification_pending_at: 1.day.ago,
         pii: { ssn: '6666', dob: '1920-01-01' },
       )
     end

--- a/spec/features/users/password_reset_with_pending_profile_spec.rb
+++ b/spec/features/users/password_reset_with_pending_profile_spec.rb
@@ -8,7 +8,7 @@ feature 'reset password with pending profile' do
   scenario 'password reset email includes warning for pending profile' do
     profile = create(
       :profile,
-      deactivation_reason: :gpo_verification_pending,
+      gpo_verification_pending_at: 1.day.ago,
       pii: { ssn: '666-66-1234', dob: '1920-01-01', phone: '+1 703-555-9999' },
       user: user,
     )

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -9,7 +9,7 @@ feature 'verify profile with OTP' do
   before do
     profile = create(
       :profile,
-      deactivation_reason: :gpo_verification_pending,
+      gpo_verification_pending_at: 1.day.ago,
       pii: { ssn: '666-66-1234', dob: '1920-01-01', phone: '+1 703-555-9999' },
       user: user,
     )

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -14,7 +14,7 @@ describe GpoVerifyForm do
     create(
       :profile,
       user: user,
-      deactivation_reason: :gpo_verification_pending,
+      gpo_verification_pending_at: 1.day.ago,
       proofing_components: proofing_components,
     )
   end
@@ -153,7 +153,7 @@ describe GpoVerifyForm do
           create(
             :profile,
             user: user,
-            deactivation_reason: :gpo_verification_pending,
+            gpo_verification_pending_at: 1.day.ago,
             fraud_review_pending_at: 1.day.ago,
           )
         end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -307,15 +307,15 @@ describe Profile do
     end
   end
 
-  describe '#activate_after_gpo_verification' do
-    it 'activates a profile after gpo verification' do
+  describe '#remove_gpo_deactivation_reason' do
+    it 'removes the gpo_verification_pending_at deactivation reason' do
       profile = create(
         :profile, user: user, active: false,
                   gpo_verification_pending_at: 1.day.ago
       )
-      profile.activate_after_gpo_verification
+      profile.remove_gpo_deactivation_reason
 
-      expect(profile).to be_active
+      expect(profile.gpo_verification_pending?).to be(false)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -462,8 +462,8 @@ RSpec.describe User do
   end
 
   describe '#pending_profile' do
-    context 'when a profile with a gpo_verification_pending deactivation_reason exists' do
-      it 'returns the most recent profile' do
+    context 'when a pending profile exists' do
+      it 'returns with the most recent profile' do
         user = User.new
         _old_profile = create(
           :profile,
@@ -478,6 +478,34 @@ RSpec.describe User do
         )
 
         expect(user.pending_profile).to eq new_profile
+      end
+    end
+
+    context 'when pending profile does not exist' do
+      it 'returns nil' do
+        user = User.new
+        create(
+          :profile,
+          deactivation_reason: :encryption_error,
+          user: user,
+        )
+
+        expect(user.pending_profile).to be_nil
+      end
+    end
+  end
+
+  describe '#gpo_verification_pending_profile' do
+    context 'when a profile with a gpo_verification_pending_at timestamp exists' do
+      it 'returns the profile' do
+        user = User.new
+        profile = create(
+          :profile,
+          gpo_verification_pending_at: Time.zone.now,
+          user: user,
+        )
+
+        expect(user.gpo_verification_pending_profile).to eq profile
       end
     end
 
@@ -496,7 +524,7 @@ RSpec.describe User do
           user: user,
         )
 
-        expect(user.pending_profile).to be_nil
+        expect(user.gpo_verification_pending_profile).to be_nil
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -467,13 +467,13 @@ RSpec.describe User do
         user = User.new
         _old_profile = create(
           :profile,
-          :gpo_verification_pending,
+          gpo_verification_pending_at: 1.day.ago,
           created_at: 1.day.ago,
           user: user,
         )
         new_profile = create(
           :profile,
-          :gpo_verification_pending,
+          gpo_verification_pending_at: Time.zone.now,
           user: user,
         )
 

--- a/spec/presenters/idv/gpo_presenter_spec.rb
+++ b/spec/presenters/idv/gpo_presenter_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Idv::GpoPresenter do
   describe '#fallback_back_path' do
     context 'when the user has a pending profile' do
       it 'returns the verify account path' do
-        create(:profile, user: user, deactivation_reason: :gpo_verification_pending)
+        create(:profile, user: user, gpo_verification_pending_at: 1.day.ago)
         expect(subject.fallback_back_path).to eq('/account/verify')
       end
     end

--- a/spec/services/idv/cancel_verification_attempt_spec.rb
+++ b/spec/services/idv/cancel_verification_attempt_spec.rb
@@ -57,7 +57,7 @@ describe Idv::CancelVerificationAttempt do
       expect(profiles[0].active).to eq(false)
       expect(profiles[0].reload.deactivation_reason).to eq('verification_cancelled')
       expect(other_profile.active).to eq(false)
-      expect(other_profile.reload.gpo_verification_pending_at).to_not eq(nil)
+      expect(other_profile.reload.gpo_verification_pending?).to eq(true)
     end
   end
 end

--- a/spec/services/idv/cancel_verification_attempt_spec.rb
+++ b/spec/services/idv/cancel_verification_attempt_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Idv::CancelVerificationAttempt do
   let(:user) { create(:user, profiles: profiles) }
-  let(:profiles) { [create(:profile, deactivation_reason: :gpo_verification_pending)] }
+  let(:profiles) { [create(:profile, gpo_verification_pending_at: 1.day.ago)] }
 
   subject { described_class.new(user: user) }
 
@@ -18,7 +18,7 @@ describe Idv::CancelVerificationAttempt do
 
   context 'the user has multiple pending profiles' do
     let(:profiles) do
-      super().push(create(:profile, deactivation_reason: :gpo_verification_pending))
+      super().push(create(:profile, gpo_verification_pending_at: 2.days.ago))
     end
 
     it 'deactivates both profiles' do
@@ -50,14 +50,14 @@ describe Idv::CancelVerificationAttempt do
 
   context 'when there are pending profiles for other users' do
     it 'only updates profiles for the specificed user' do
-      other_profile = create(:profile, deactivation_reason: :gpo_verification_pending)
+      other_profile = create(:profile, gpo_verification_pending_at: 1.day.ago)
 
       subject.call
 
       expect(profiles[0].active).to eq(false)
       expect(profiles[0].reload.deactivation_reason).to eq('verification_cancelled')
       expect(other_profile.active).to eq(false)
-      expect(other_profile.reload.deactivation_reason).to eq('gpo_verification_pending')
+      expect(other_profile.reload.gpo_verification_pending_at).to_not eq(nil)
     end
   end
 end

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -19,7 +19,6 @@ shared_examples 'gpo otp verification' do
     else
       expect(profile.active).to be(false)
       expect(profile.fraud_review_pending?).to eq(fraud_review_pending) if fraud_review_pending
-      expect(profile.verified_at).to_not eq(nil) if fraud_review_pending
       expect(profile.deactivation_reason).to eq(nil) if fraud_review_pending
     end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-9535](https://cm-jira.usa.gov/browse/LG-9535)


## 🛠 Summary of changes

We now read from the new `gpo_verification_pending_at` column for deactivation reasons instead of the old enum.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV GPO flow.
- [ ] Confirm that everything is working correctly.



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
