### PR TITLE
LG-9369 Fix new link_sent page back link

### DIFF
--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -57,4 +57,4 @@
   <%= javascript_packs_tag_once 'doc-capture-polling' %>
 <% end %>
 
-<%= render 'idv/shared/back', action: 'cancel_link_sent', class: 'link-sent-back-link', step_url: :idv_doc_auth_url %>
+<%= render 'idv/shared/back', action: 'cancel_link_sent', class: 'link-sent-back-link', step_url: :idv_doc_auth_step_url %>

--- a/spec/features/idv/actions/cancel_link_sent_action_spec.rb
+++ b/spec/features/idv/actions/cancel_link_sent_action_spec.rb
@@ -4,7 +4,11 @@ feature 'doc auth cancel link sent action' do
   include IdvStepHelper
   include DocAuthHelper
 
+  let(:new_controller_enabled) { false }
+
   before do
+    allow(IdentityConfig.store).to receive(:doc_auth_link_sent_controller_enabled).
+      and_return(new_controller_enabled)
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_link_sent_step
   end
@@ -13,5 +17,16 @@ feature 'doc auth cancel link sent action' do
     click_doc_auth_back_link
 
     expect(page).to have_current_path(idv_doc_auth_upload_step)
+  end
+
+  context 'new SendLink controller is enabled' do
+    let(:new_controller_enabled) { true }
+
+    it 'returns to link sent step', :js do
+      expect(page).to have_current_path(idv_link_sent_path)
+      click_doc_auth_back_link
+
+      expect(page).to have_current_path(idv_doc_auth_upload_step)
+    end
   end
 end


### PR DESCRIPTION
The Back link at the bottom of the new LinkSent page was getting a 404. Needed to set its step_url parameter to idv_doc_auth_step_url instead of idv_doc_auth_url

Also add a feature test for the cancel link sent action with the feature flag enabled.

