### PR TITLE
Add ig-request data-pull task

### DIFF
--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -104,6 +104,29 @@ RSpec.describe DataPull do
         expect(JSON.parse(stdout.string)).to be_empty
       end
     end
+
+    describe 'ig-query task' do
+      let(:service_provider) { create(:service_provider) }
+      let(:identity) { IdentityLinker.new(user, service_provider).link_identity }
+
+      let(:argv) do
+        ['ig-request', identity.uuid, '--requesting-issuer', service_provider.issuer]
+      end
+
+      it 'runs the data requests report and prints it as JSON' do
+        data_pull.run
+
+        response = JSON.parse(stdout.string, symbolize_names: true)
+        expect(response.first.keys).to contain_exactly(
+          :user_id,
+          :login_uuid,
+          :requesting_issuer_uuid,
+          :email_addresses,
+          :mfa_configurations,
+          :user_events,
+        )
+      end
+    end
   end
 
   describe DataPull::UuidLookup do
@@ -179,6 +202,34 @@ RSpec.describe DataPull do
         )
 
         expect(result.subtask).to eq('email-lookup')
+        expect(result.uuids).to eq([user.uuid])
+      end
+    end
+  end
+
+  describe DataPull::InspectorGeneralRequest do
+    subject(:subtask) { DataPull::InspectorGeneralRequest.new }
+
+    describe '#run' do
+      let(:user) { create(:user) }
+      let(:service_provider) { create(:service_provider) }
+      let(:identity) { IdentityLinker.new(user, service_provider).link_identity }
+      let(:args) { [user.uuid] }
+
+      subject(:result) { subtask.run(args:, requesting_issuers: [service_provider.issuer]) }
+
+      it 'runs the create users report, has a JSON-only response', aggregate_failures: true do
+        expect(result.table).to be_nil
+        expect(result.json.first.keys).to contain_exactly(
+          :user_id,
+          :login_uuid,
+          :requesting_issuer_uuid,
+          :email_addresses,
+          :mfa_configurations,
+          :user_events,
+        )
+
+        expect(result.subtask).to eq('ig-request')
         expect(result.uuids).to eq([user.uuid])
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Takes advantage of our new `data-pull` infra to allow for pulling data from prod in a batched way.

Once merged, this will let us replace the [first two separate tasks in our guide](https://github.com/18F/identity-security-private/wiki/Responding-to-Inspector-General-(IG)-Data-Requests):

1. (open interactive SSM shell & sudo)
2. `data_requests:lookup_users_by_device`
2. `data_requests:create_users_report`

with one task we can run right from local devops repo:

```
./bin/data-pull ig-request UUID1 UUID2 UUID3 --requesting-issuer "a:b:c:d"
```
and it'll print the JSON right there
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
