### PR TITLE
Remove handle_valid_otp method

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -74,7 +74,6 @@ module RememberDeviceConcern
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics(cookie_created_at: remember_device_cookie.created_at)
     redirect_to after_otp_verification_confirmation_url unless reauthn?
-    reset_otp_session_data
   end
 
   def handle_valid_remember_device_analytics(cookie_created_at:)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -93,24 +93,9 @@ module TwoFactorAuthenticatableMethods
     ).call
   end
 
-  def handle_valid_otp(next_url:, auth_method: nil)
-    handle_valid_otp_for_context(auth_method: auth_method)
-    handle_remember_device
-    next_url ||= after_otp_verification_confirmation_url
-    redirect_to next_url
-  end
-
   def handle_remember_device
     save_user_opted_remember_device_pref
     save_remember_device_preference
-  end
-
-  def handle_valid_otp_for_context(auth_method:)
-    if UserSessionContext.authentication_or_reauthentication_context?(context)
-      handle_valid_verification_for_authentication_context(auth_method: auth_method)
-    elsif UserSessionContext.confirmation_context?(context)
-      handle_valid_verification_for_confirmation_context(auth_method: auth_method)
-    end
   end
 
   # Method will be renamed in the next refactor.

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -97,7 +97,6 @@ module TwoFactorAuthenticatableMethods
     handle_valid_otp_for_context(auth_method: auth_method)
     handle_remember_device
     next_url ||= after_otp_verification_confirmation_url
-    reset_otp_session_data
     redirect_to next_url
   end
 
@@ -171,6 +170,7 @@ module TwoFactorAuthenticatableMethods
   def handle_valid_verification_for_confirmation_context(auth_method:)
     user_session[:auth_method] = auth_method
     mark_user_session_authenticated(:valid_2fa_confirmation)
+    reset_otp_session_data
     reset_second_factor_attempts_count
   end
 
@@ -179,6 +179,7 @@ module TwoFactorAuthenticatableMethods
     mark_user_session_authenticated(:valid_2fa)
     create_user_event(:sign_in_after_2fa)
 
+    reset_otp_session_data
     reset_second_factor_attempts_count
   end
 

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -155,7 +155,6 @@ module TwoFactorAuthenticatableMethods
   def handle_valid_verification_for_confirmation_context(auth_method:)
     user_session[:auth_method] = auth_method
     mark_user_session_authenticated(:valid_2fa_confirmation)
-    reset_otp_session_data
     reset_second_factor_attempts_count
   end
 
@@ -164,17 +163,11 @@ module TwoFactorAuthenticatableMethods
     mark_user_session_authenticated(:valid_2fa)
     create_user_event(:sign_in_after_2fa)
 
-    reset_otp_session_data
     reset_second_factor_attempts_count
   end
 
   def reset_second_factor_attempts_count
     UpdateUser.new(user: current_user, attributes: { second_factor_attempts_count: 0 }).call
-  end
-
-  def reset_otp_session_data
-    user_session.delete(:unconfirmed_phone)
-    user_session[:context] = 'authentication'
   end
 
   def after_otp_verification_confirmation_url

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -77,7 +77,6 @@ module TwoFactorAuthentication
 
     def handle_valid_backup_code
       redirect_to after_otp_verification_confirmation_url
-      reset_otp_session_data
     end
 
     def check_sp_required_mfa

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -30,6 +30,7 @@ module TwoFactorAuthentication
         end
 
         handle_remember_device
+        reset_otp_session_data
         redirect_to after_otp_verification_confirmation_url
       else
         handle_invalid_otp(context: context, type: 'otp')
@@ -257,6 +258,11 @@ module TwoFactorAuthentication
 
     def direct_otp_code
       current_user.direct_otp if FeatureManagement.prefill_otp_codes?
+    end
+
+    def reset_otp_session_data
+      user_session.delete(:unconfirmed_phone)
+      user_session[:context] = 'authentication'
     end
   end
 end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -24,7 +24,9 @@ module TwoFactorAuthentication
         if UserSessionContext.confirmation_context?(context)
           handle_valid_confirmation_otp
         else
-          handle_valid_otp_for_authentication_context(auth_method: params[:otp_delivery_preference])
+          handle_valid_verification_for_authentication_context(
+            auth_method: params[:otp_delivery_preference],
+          )
         end
 
         handle_remember_device

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -21,8 +21,14 @@ module TwoFactorAuthentication
       result = otp_verification_form.submit
       post_analytics(result)
       if result.success?
-        handle_valid_confirmation_otp if UserSessionContext.confirmation_context?(context)
-        handle_valid_otp(next_url: nil, auth_method: params[:otp_delivery_preference])
+        if UserSessionContext.confirmation_context?(context)
+          handle_valid_confirmation_otp
+        else
+          handle_valid_otp_for_authentication_context(auth_method: params[:otp_delivery_preference])
+        end
+
+        handle_remember_device
+        redirect_to after_otp_verification_confirmation_url
       else
         handle_invalid_otp(context: context, type: 'otp')
       end
@@ -34,6 +40,9 @@ module TwoFactorAuthentication
       assign_phone
       track_mfa_added
       @next_mfa_setup_path = next_setup_path
+      handle_valid_verification_for_confirmation_context(
+        auth_method: params[:otp_delivery_preference],
+      )
       flash[:success] = t('notices.phone_confirmed')
     end
 

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -99,7 +99,6 @@ module TwoFactorAuthentication
       else
         redirect_to authentication_methods_setup_url
       end
-      reset_otp_session_data
     end
   end
 end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -54,7 +54,6 @@ module TwoFactorAuthentication
         auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )
       redirect_to after_otp_verification_confirmation_url
-      reset_otp_session_data
     end
 
     def handle_invalid_piv_cac

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -23,7 +23,7 @@ module TwoFactorAuthentication
       irs_attempts_api_tracker.mfa_login_totp(success: result.success?)
 
       if result.success?
-        handle_valid_otp(next_url: nil, auth_method: 'authenticator')
+        handle_valid_otp(next_url: nil, auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP)
       else
         handle_invalid_otp(context: context, type: 'totp')
       end

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -23,7 +23,11 @@ module TwoFactorAuthentication
       irs_attempts_api_tracker.mfa_login_totp(success: result.success?)
 
       if result.success?
-        handle_valid_otp(next_url: nil, auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP)
+        handle_valid_otp_for_authentication_context(
+          auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,
+        )
+        handle_remember_device
+        redirect_to after_otp_verification_confirmation_url
       else
         handle_invalid_otp(context: context, type: 'totp')
       end

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -23,7 +23,7 @@ module TwoFactorAuthentication
       irs_attempts_api_tracker.mfa_login_totp(success: result.success?)
 
       if result.success?
-        handle_valid_otp_for_authentication_context(
+        handle_valid_verification_for_authentication_context(
           auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,
         )
         handle_remember_device

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -43,7 +43,6 @@ module TwoFactorAuthentication
       handle_valid_verification_for_authentication_context(auth_method: 'webauthn')
       handle_remember_device
       redirect_to after_otp_verification_confirmation_url
-      reset_otp_session_data
     end
 
     def handle_invalid_webauthn

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -103,9 +103,9 @@ module TwoFactorAuthentication
     def analytics_properties
       auth_method = if form&.webauthn_configuration&.platform_authenticator ||
                        params[:platform].to_s == 'true'
-                      'webauthn_platform'
+                      TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM
                     else
-                      'webauthn'
+                      TwoFactorAuthenticatable::AuthMethod::WEBAUTHN
                     end
       {
         context: context,

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -42,11 +42,11 @@ module TwoFactorAuthentication
     def handle_valid_webauthn
       if form.webauthn_configuration.platform_authenticator
         handle_valid_verification_for_authentication_context(
-          auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN,
+          auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM,
         )
       else
         handle_valid_verification_for_authentication_context(
-          auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM,
+          auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN,
         )
       end
       handle_remember_device

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -40,7 +40,15 @@ module TwoFactorAuthentication
     end
 
     def handle_valid_webauthn
-      handle_valid_verification_for_authentication_context(auth_method: 'webauthn')
+      if form.webauthn_configuration.platform_authenticator
+        handle_valid_verification_for_authentication_context(
+          auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN,
+        )
+      else
+        handle_valid_verification_for_authentication_context(
+          auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM,
+        )
+      end
       handle_remember_device
       redirect_to after_otp_verification_confirmation_url
     end

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -74,10 +74,10 @@ module Users
         presented: true,
       )
 
-      handle_valid_otp(
-        next_url: next_step,
+      handle_valid_verification_for_authentication_context(
         auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )
+      redirect_to next_step
     end
 
     def next_step
@@ -104,14 +104,6 @@ module Users
 
     def process_token_with_error
       redirect_to login_piv_cac_error_url(error: piv_cac_login_form.error_type)
-    end
-
-    def mark_user_session_authenticated(authentication_type)
-      user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
-      user_session[:authn_at] = Time.zone.now
-      analytics.user_marked_authed(
-        authentication_type: authentication_type,
-      )
     end
   end
 end

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -41,6 +41,11 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
           with(:mfa_login_backup_code, success: true)
 
         post :create, params: payload
+
+        expect(subject.user_session[:auth_method]).to eq(
+          TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
+        )
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
       end
 
       it 'tracks the valid authentication event when there are exisitng codes' do
@@ -120,6 +125,8 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
 
         expect(response).to render_template(:show)
         expect(flash[:error]).to eq t('two_factor_authentication.invalid_backup_code')
+        expect(subject.user_session[:auth_method]).to eq nil
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end
 
       it 'tracks the max attempts event' do

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -393,6 +393,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
       let(:user) { create(:user, :fully_registered) }
       before do
         sign_in_as_user(user)
+        subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
         subject.user_session[:unconfirmed_phone] = '+1 (703) 555-5555'
         subject.user_session[:context] = 'confirmation'
 
@@ -417,7 +418,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         @previous_phone = MfaContext.new(subject.current_user).phone_configurations.first&.phone
       end
 
-      context 'user has an existing phone number' do
+      context 'user is fully authenticated and has an existing phone number' do
         context 'user enters a valid code' do
           before do
             subject.user_session[:mfa_selections] = ['sms']

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -161,6 +161,11 @@ describe TwoFactorAuthentication::OtpVerificationController do
       it 'displays flash error message' do
         expect(flash[:error]).to eq t('two_factor_authentication.invalid_otp')
       end
+
+      it 'does not set auth_method and requires 2FA' do
+        expect(subject.user_session[:auth_method]).to eq nil
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
+      end
     end
 
     context 'when the user enters an invalid OTP during reauthentication context' do
@@ -278,6 +283,9 @@ describe TwoFactorAuthentication::OtpVerificationController do
           code: subject.current_user.reload.direct_otp,
           otp_delivery_preference: 'sms',
         }
+
+        expect(subject.user_session[:auth_method]).to eq TwoFactorAuthenticatable::AuthMethod::SMS
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
       end
 
       it 'tracks the attempt event with reauthentication parameter true' do

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -67,6 +67,11 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
           with('User marked authenticated', authentication_type: :valid_2fa)
 
         post :create, params: payload
+
+        expect(subject.user_session[:auth_method]).to eq(
+          TwoFactorAuthenticatable::AuthMethod::PERSONAL_KEY,
+        )
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
       end
     end
 
@@ -136,6 +141,9 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         expect(subject).to receive(:handle_invalid_otp).and_call_original
 
         post :create, params: payload
+
+        expect(subject.user_session[:auth_method]).to eq nil
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end
 
       it 're-renders the personal key entry screen' do

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -68,6 +68,10 @@ describe TwoFactorAuthentication::PivCacVerificationController do
 
         get :show, params: { token: 'good-token' }
 
+        expect(subject.user_session[:auth_method]).to eq(
+          TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
+        )
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
         expect(response).to redirect_to account_path
         expect(subject.user_session[:decrypted_x509]).to eq(
           {
@@ -146,6 +150,11 @@ describe TwoFactorAuthentication::PivCacVerificationController do
 
       it 'resets the piv/cac session information' do
         expect(subject.user_session[:decrypted_x509]).to be_nil
+      end
+
+      it 'does not set auth_method and requires 2FA' do
+        expect(subject.user_session[:auth_method]).to eq nil
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end
     end
 

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -91,6 +91,11 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
         )
 
         patch :confirm, params: params
+
+        expect(subject.user_session[:auth_method]).to eq(
+          TwoFactorAuthenticatable::AuthMethod::WEBAUTHN,
+        )
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
       end
 
       it 'tracks a valid platform authenticator submission' do
@@ -117,6 +122,10 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
         )
 
         patch :confirm, params: params
+        expect(subject.user_session[:auth_method]).to eq(
+          TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM,
+        )
+        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
       end
 
       it 'tracks an invalid submission' do
@@ -173,6 +182,8 @@ describe TwoFactorAuthentication::WebauthnVerificationController do
           it 'redirects to webauthn show page' do
             patch :confirm, params: params
             expect(response).to redirect_to login_two_factor_webauthn_url(platform: true)
+            expect(subject.user_session[:auth_method]).to eq nil
+            expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
           end
 
           it 'displays flash error message' do

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -146,14 +146,6 @@ describe Users::PivCacLoginController do
           end
 
           describe 'it handles the otp_context' do
-            it 'sets the otp user_session' do
-              expect(controller.user_session[:auth_method]).
-                to eq TwoFactorAuthenticatable::AuthMethod::PIV_CAC
-
-              expect(controller.user_session[:unconfirmed_phone]).to be nil
-              expect(controller.user_session[:context]).to eq 'authentication'
-            end
-
             it 'tracks the user_marked_authed event' do
               expect(@analytics).to have_received(:track_event).with(
                 'User marked authenticated',

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -4,14 +4,13 @@ module ControllerHelper
   def sign_in_as_user(user = create(:user, :fully_registered, password: VALID_PASSWORD))
     @request.env['devise.mapping'] = Devise.mappings[:user]
     sign_in user
+    controller.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = true
     user
   end
 
   def sign_in_before_2fa(user = create(:user, :fully_registered))
     sign_in_as_user(user)
     controller.current_user.create_direct_otp
-    allow(controller).to receive(:user_fully_authenticated?).and_return(false)
-    allow(controller).to receive(:signed_in_url).and_return(account_url)
   end
 
   def stub_sign_in(user = build(:user, password: VALID_PASSWORD))
@@ -32,6 +31,7 @@ module ControllerHelper
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
     allow(controller).to receive(:signed_in_url).and_return(account_url)
+    controller.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = true
   end
 
   def stub_idv_steps_before_verify_step(user)


### PR DESCRIPTION
## 🛠 Summary of changes

Following up in what is hopefully the last series of changes for this (see #8347, #8316, #8315, #8037, #8031). Currently, the session "confirmation context" is only used by phone OTP verification, so this PR splits that specific functionality out of the shared concern and into the controller. With that, we can call `handle_valid_verification_for_confirmation_context`/`handle_valid_verification_for_authentication_context` explicitly within the 2FA controller depending on whether it is a setup controller or verification controller.

Some of the existing 2FA controllers also implemented their own version of `mark_user_as_fully_authenticated` to set values in the session, and this PR consolidates the behavior into the shared concern and has all of the controllers use that via `handle_valid_`.


`handle_remember_device` is not used in every authentication as we do not always present that option, so that part is left to each controller for now.

`handle_valid_otp` also had some logic for redirecting that was only used in one controller, so the redirect behavior was also moved back into each controller individually and called explicitly.

With these changes, we should be able to make consistent assumptions about which 2FA method was used for authentication. It will hopefully create the space to do things like keep track of verifications vs. confirmations and individual timestamps for each in the future. That will allow us to be a bit more fine-grained in terms of when we request a user to authenticate with a PIV/CAC or phishing-resistant method when an SP requests it.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
