### PR TITLE
Two fixes for new LinkSentController

### DIFF
--- a/app/services/idv/actions/redo_document_capture_action.rb
+++ b/app/services/idv/actions/redo_document_capture_action.rb
@@ -8,8 +8,13 @@ module Idv
       def call
         flow_session['redo_document_capture'] = true
         unless flow_session[:skip_upload_step]
-          mark_step_incomplete(:link_sent)
           mark_step_incomplete(:upload)
+
+          if IdentityConfig.store.doc_auth_link_sent_controller_enabled
+            redirect_to idv_document_capture_url
+          else
+            mark_step_incomplete(:link_sent)
+          end
         end
       end
     end

--- a/app/services/idv/actions/redo_document_capture_action.rb
+++ b/app/services/idv/actions/redo_document_capture_action.rb
@@ -7,12 +7,12 @@ module Idv
 
       def call
         flow_session['redo_document_capture'] = true
-        unless flow_session[:skip_upload_step]
+        if flow_session[:skip_upload_step]
+          redirect_to idv_document_capture_url
+        else
           mark_step_incomplete(:upload)
 
-          if IdentityConfig.store.doc_auth_link_sent_controller_enabled
-            redirect_to idv_document_capture_url
-          else
+          if !IdentityConfig.store.doc_auth_link_sent_controller_enabled
             mark_step_incomplete(:link_sent)
           end
         end

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -75,7 +75,8 @@ module Idv
           failure_reason: failure_reason,
         )
 
-        if IdentityConfig.store.doc_auth_link_sent_controller_enabled
+        if !failure_reason &&
+           IdentityConfig.store.doc_auth_link_sent_controller_enabled
           flow_session[:flow_path] = 'hybrid'
           redirect_to idv_link_sent_url
         end
@@ -162,8 +163,6 @@ module Idv
       end
 
       def build_telephony_form_response(telephony_result)
-        flow_session[:error_message] = telephony_result.error&.friendly_message
-
         FormResponse.new(
           success: telephony_result.success?,
           errors: { message: telephony_result.error&.friendly_message },

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -162,6 +162,8 @@ module Idv
       end
 
       def build_telephony_form_response(telephony_result)
+        flow_session[:error_message] = telephony_result.error&.friendly_message
+
         FormResponse.new(
           success: telephony_result.success?,
           errors: { message: telephony_result.error&.friendly_message },

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -4,8 +4,12 @@ feature 'doc auth redo document capture action', js: true do
   include IdvStepHelper
   include DocAuthHelper
 
+  let(:new_controller_enabled) { false }
+
   context 'when barcode scan returns a warning', allow_browser_log: true do
     before do
+      allow(IdentityConfig.store).to receive(:doc_auth_link_sent_controller_enabled).
+        and_return(new_controller_enabled)
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_document_capture_step
       mock_doc_auth_attention_with_barcode
@@ -78,6 +82,26 @@ feature 'doc auth redo document capture action', js: true do
         check t('forms.ssn.show')
         expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
         expect(page).not_to have_css('[role="status"]')
+      end
+    end
+
+    context 'with doc_auth_link_sent_controller_enabled flag enabled',
+            driver: :headless_chrome_mobile do
+      let(:new_controller_enabled) { true }
+
+      it 'goes to document capture' do
+        warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
+
+        expect(page).to have_css(
+          '[role="status"]',
+          text: t(
+            'doc_auth.headings.capture_scan_warning_html',
+            link: warning_link_text,
+          ).tr(' ', ' '),
+        )
+        click_link warning_link_text
+
+        expect(current_path).to eq(idv_document_capture_path)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9369](https://cm-jira.usa.gov/browse/LG-9369)

## 🛠 Summary of changes

Check telephony errors when sending text from "Upload" step before redirecting to LinkSent step.
Also explicitly redirect to idv_document_capture_url when skipping upload in RedoDocumentCaptureAction.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create account, start IdV
- [ ] Enter phone number that will fail, 225-555-1000
- [ ] Confirm that error is displayed 