### PR TITLE
LG-7893 add properties to analytics events

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -681,32 +681,224 @@ module AnalyticsEvents
     track_event('IdV: in person proofing residential address submitted', **extra)
   end
 
-  def idv_in_person_proofing_address_submitted(**extra)
-    track_event('IdV: in person proofing address submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean] same_address_as_id
+  # address submitted by user
+  def idv_in_person_proofing_address_submitted(
+    flow_path:,
+    step:,
+    step_count:,
+    analytics_id:,
+    irs_reproofing:,
+    success:,
+    errors:,
+    same_address_as_id:,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing address submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_address_visited(**extra)
-    track_event('IdV: in person proofing address visited', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # address page visited
+  def idv_in_person_proofing_address_visited(
+    flow_path:,
+    step:,
+    step_count:,
+    analytics_id:,
+    irs_reproofing:,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing address visited',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_cancel_update_address(**extra)
-    track_event('IdV: in person proofing cancel_update_address submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean, nil] same_address_as_id
+  # User clicked cancel on update address page
+  def idv_in_person_proofing_cancel_update_address(
+    flow_path:,
+    step:,
+    step_count:,
+    analytics_id:,
+    irs_reproofing:,
+    success:,
+    errors:,
+    same_address_as_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing cancel_update_address submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_cancel_update_state_id(**extra)
-    track_event('IdV: in person proofing cancel_update_state_id submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean] same_address_as_id
+  # User clicked cancel on update state id page
+  def idv_in_person_proofing_cancel_update_state_id(
+    flow_path:,
+    step:,
+    step_count:,
+    analytics_id:,
+    irs_reproofing:,
+    success:,
+    errors:,
+    same_address_as_id:,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing cancel_update_state_id submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_redo_state_id_submitted(**extra)
-    track_event('IdV: in person proofing redo_state_id submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean] same_address_as_id
+  # User submitted state id on redo state id page
+  def idv_in_person_proofing_redo_state_id_submitted(
+    flow_path:,
+    step:,
+    step_count:,
+    analytics_id:,
+    irs_reproofing:,
+    success:,
+    errors:,
+    same_address_as_id:,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing redo_state_id submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_state_id_submitted(**extra)
-    track_event('IdV: in person proofing state_id submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean, nil] same_address_as_id
+  # User submitted state id
+  def idv_in_person_proofing_state_id_submitted(
+    flow_path:,
+    step:,
+    step_count:,
+    analytics_id:,
+    irs_reproofing:,
+    success:,
+    errors:,
+    same_address_as_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing state_id submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_state_id_visited(**extra)
-    track_event('IdV: in person proofing state_id visited', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # State id page visited
+  def idv_in_person_proofing_state_id_visited(
+    flow_path:,
+    step:,
+    step_count:,
+    analytics_id:,
+    irs_reproofing:,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing state_id visited',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      **extra,
+    )
   end
 
   # @param [String] flow_path Document capture path ("hybrid" or "standard")

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -691,14 +691,14 @@ module AnalyticsEvents
   # @param [Boolean] same_address_as_id
   # address submitted by user
   def idv_in_person_proofing_address_submitted(
-    flow_path:,
-    step:,
-    step_count:,
-    analytics_id:,
-    irs_reproofing:,
-    success:,
-    errors:,
-    same_address_as_id:,
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
+    same_address_as_id: nil,
     **extra
   )
     track_event(
@@ -722,11 +722,11 @@ module AnalyticsEvents
   # @param [Boolean] irs_reproofing
   # address page visited
   def idv_in_person_proofing_address_visited(
-    flow_path:,
-    step:,
-    step_count:,
-    analytics_id:,
-    irs_reproofing:,
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
     **extra
   )
     track_event(
@@ -750,13 +750,13 @@ module AnalyticsEvents
   # @param [Boolean, nil] same_address_as_id
   # User clicked cancel on update address page
   def idv_in_person_proofing_cancel_update_address(
-    flow_path:,
-    step:,
-    step_count:,
-    analytics_id:,
-    irs_reproofing:,
-    success:,
-    errors:,
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
     same_address_as_id: nil,
     **extra
   )
@@ -784,14 +784,14 @@ module AnalyticsEvents
   # @param [Boolean] same_address_as_id
   # User clicked cancel on update state id page
   def idv_in_person_proofing_cancel_update_state_id(
-    flow_path:,
-    step:,
-    step_count:,
-    analytics_id:,
-    irs_reproofing:,
-    success:,
-    errors:,
-    same_address_as_id:,
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
+    same_address_as_id: nil,
     **extra
   )
     track_event(
@@ -818,14 +818,14 @@ module AnalyticsEvents
   # @param [Boolean] same_address_as_id
   # User submitted state id on redo state id page
   def idv_in_person_proofing_redo_state_id_submitted(
-    flow_path:,
-    step:,
-    step_count:,
-    analytics_id:,
-    irs_reproofing:,
-    success:,
-    errors:,
-    same_address_as_id:,
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
+    same_address_as_id: nil,
     **extra
   )
     track_event(
@@ -852,13 +852,13 @@ module AnalyticsEvents
   # @param [Boolean, nil] same_address_as_id
   # User submitted state id
   def idv_in_person_proofing_state_id_submitted(
-    flow_path:,
-    step:,
-    step_count:,
-    analytics_id:,
-    irs_reproofing:,
-    success:,
-    errors:,
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
     same_address_as_id: nil,
     **extra
   )
@@ -883,11 +883,11 @@ module AnalyticsEvents
   # @param [Boolean] irs_reproofing
   # State id page visited
   def idv_in_person_proofing_state_id_visited(
-    flow_path:,
-    step:,
-    step_count:,
-    analytics_id:,
-    irs_reproofing:,
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
     **extra
   )
     track_event(

--- a/app/services/idv/flows/in_person_flow.rb
+++ b/app/services/idv/flows/in_person_flow.rb
@@ -58,7 +58,7 @@ module Idv
         extra = {
           pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
         }
-        if @flow_session[:pii_from_user].has_key?(:same_address_as_id)
+        unless @flow_session[:pii_from_user]&.[](:same_address_as_id).nil?
           extra[:same_address_as_id] =
             @flow_session[:pii_from_user][:same_address_as_id].to_s == 'true'
         end

--- a/app/services/idv/flows/in_person_flow.rb
+++ b/app/services/idv/flows/in_person_flow.rb
@@ -55,11 +55,14 @@ module Idv
       end
 
       def extra_analytics_properties
-        return {} if @flow_session[:pii_from_user][:same_address_as_id].nil?
-        {
-          same_address_as_id: @flow_session[:pii_from_user][:same_address_as_id].to_s == 'true',
+        extra = {
           pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
         }
+        if @flow_session[:pii_from_user].has_key?(:same_address_as_id)
+          extra[:same_address_as_id] =
+            @flow_session[:pii_from_user][:same_address_as_id].to_s == 'true'
+        end
+        extra
       end
     end
   end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -92,7 +92,7 @@ feature 'Analytics Regression', js: true do
       'IdV: in person proofing prepare visited' => { flow_path: 'standard' },
       'IdV: in person proofing prepare submitted' => { flow_path: 'standard', in_person_cta_variant: 'in_person_variant_a' },
       'IdV: in person proofing state_id visited' => { step: 'state_id', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false },
-      'IdV: in person proofing state_id submitted' => { success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false, errors: {} },
+      'IdV: in person proofing state_id submitted' => { success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false, errors: {}, same_address_as_id: nil },
       'IdV: in person proofing address visited' => { step: 'address', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false },
       'IdV: in person proofing address submitted' => { success: true, step: 'address', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false, errors: {}, same_address_as_id: true },
       'IdV: doc auth ssn visited' => { analytics_id: 'In Person Proofing', step: 'ssn', flow_path: 'standard', step_count: 1, irs_reproofing: false, same_address_as_id: true },


### PR DESCRIPTION
## 🎫 Ticket

[LG-7893](https://cm-jira.usa.gov/browse/LG-7893)


## 🛠 Summary of changes

This pr adds the appropriate properties to some of the ipp analytics events in order to update the cloud pages handbook documentation on analytics events. The following events should be updated:


idv_in_person_proofing_address_submitted
idv_in_person_proofing_address_visited 
idv_in_person_proofing_cancel_update_address 
idv_in_person_proofing_cancel_update_state_id 
idv_in_person_proofing_redo_state_id_submitted
idv_in_person_proofing_state_id_submitted 
idv_in_person_proofing_state_id_visited



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Log in and go through ipp without DAV enabled, 
- [ ] Arrive at state id form and submit. Confirm you are able to progress through w/o issue.
- [ ] Arrive at address form and submit. Confirm you are able to progress through w/o issue.
- [ ] Continue to verify your info page, click update for state id section then click back button at bottom. Confirm you are able to progress through w/o issue.
- [ ] Continue to verify your info page, click update for address section then click back button at bottom. Confirm you are able to progress through w/o issue.
- [ ] Go to handbook and check that events included in this pr include properties in the[ documentation ](https://handbook.login.gov/articles/analytics-events.html)


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
