### PR TITLE
LG-9633: make backup code download available in mobile

### DIFF
--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -28,13 +28,13 @@
     <% end %>
   </div>
   <div class="margin-top-1">
-      <%= render ClickObserverComponent.new(event_name: 'Multi-Factor Authentication: download backup code') do %>
-        <%= render DownloadButtonComponent.new(
-              file_data: @codes.join("\n"),
-              file_name: 'backup_codes.txt',
-              outline: true,
-            ) %>
-      <% end %>
+    <%= render ClickObserverComponent.new(event_name: 'Multi-Factor Authentication: download backup code') do %>
+      <%= render DownloadButtonComponent.new(
+            file_data: @codes.join("\n"),
+            file_name: 'backup_codes.txt',
+            outline: true,
+          ) %>
+    <% end %>
     <%= render PrintButtonComponent.new(
           icon: :print,
           outline: true,

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -28,7 +28,6 @@
     <% end %>
   </div>
   <div class="margin-top-1">
-    <% if desktop_device? %>
       <%= render ClickObserverComponent.new(event_name: 'Multi-Factor Authentication: download backup code') do %>
         <%= render DownloadButtonComponent.new(
               file_data: @codes.join("\n"),
@@ -36,7 +35,6 @@
               outline: true,
             ) %>
       <% end %>
-    <% end %>
     <%= render PrintButtonComponent.new(
           icon: :print,
           outline: true,

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -22,14 +22,14 @@ feature 'sign up with backup code' do
     expect(user.backup_code_configurations.count).to eq(10)
   end
 
-  it 'does not show download button on a mobile device' do
+  it 'does show download button on a mobile device' do
     allow(BrowserCache).to receive(:parse).and_return(mobile_device)
 
     sign_up_and_set_password
 
     select_2fa_option('backup_code')
 
-    expect(page).to_not have_link(t('components.download_button.label'))
+    expect(page).to have_link(t('components.download_button.label'))
   end
 
   it 'works for each code and refreshes the codes on the last one' do

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -22,16 +22,6 @@ feature 'sign up with backup code' do
     expect(user.backup_code_configurations.count).to eq(10)
   end
 
-  it 'does show download button on a mobile device' do
-    allow(BrowserCache).to receive(:parse).and_return(mobile_device)
-
-    sign_up_and_set_password
-
-    select_2fa_option('backup_code')
-
-    expect(page).to have_link(t('components.download_button.label'))
-  end
-
   it 'works for each code and refreshes the codes on the last one' do
     user = create(:user, :fully_registered, :with_authentication_app)
 


### PR DESCRIPTION
## 🎫 Ticket
[LG-9633: Show Backup code download button for mobile users](https://cm-jira.usa.gov/browse/LG-9633)

## 🛠 Summary of changes

Mobile users are able to see the download button. 

## 👀 Screenshots

An example of this now in mobile mode is below. 
![Screen Shot 2023-05-17 at 10 45 43 AM](https://github.com/18F/identity-idp/assets/23225522/b431dd9c-1f0c-4381-93e8-9dbe97d9098b)
