### PR TITLE
Test that a fraud rejected user cannot enter the IdV flow

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -227,13 +227,27 @@ FactoryBot.define do
       end
     end
 
-    trait :deactivated_fraud_profile do
+    trait :fraud_review_pending do
       fully_registered
 
       after :build do |user|
         create(
           :profile,
           :fraud_review_pending,
+          :verified,
+          :with_pii,
+          user: user,
+        )
+      end
+    end
+
+    trait :fraud_rejection do
+      fully_registered
+
+      after :build do |user|
+        create(
+          :profile,
+          :fraud_rejection,
           :verified,
           :with_pii,
           user: user,

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'rake'
 
 describe 'review_profile' do
-  let(:user) { create(:user, :deactivated_fraud_profile) }
+  let(:user) { create(:user, :fraud_review_pending) }
   let(:uuid) { user.uuid }
   let(:task_name) { nil }
 


### PR DESCRIPTION
This commit adds a test that tests that a user who went through fraud review and either expired or was explicitly reject cannot enter the IdV flow.

The tests in the codebase prior to this change cover the fraud pending state. The fraud rejection state is slightly different and we track differently.
