### PR TITLE
Try absolute path for Propshaft assets

### DIFF
--- a/app/assets/stylesheets/_required.scss
+++ b/app/assets/stylesheets/_required.scss
@@ -1,7 +1,7 @@
 @use 'uswds-core' with (
   $theme-body-font-size: 'sm',
-  $theme-font-path: '.',
-  $theme-image-path: '.',
+  $theme-font-path: '',
+  $theme-image-path: '',
   $theme-global-border-box-sizing: true,
   $theme-global-link-styles: true,
   $theme-grid-container-max-width: 'tablet-lg',

--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -6,7 +6,7 @@
   font-weight: bold;
 
   &::before {
-    background-image: url('alert/info-white.svg');
+    background-image: url('/alert/info-white.svg');
   }
 }
 

--- a/app/assets/stylesheets/components/_icon.scss
+++ b/app/assets/stylesheets/components/_icon.scss
@@ -28,7 +28,7 @@ $icon-min-padding: 2px;
 
   &-success {
     &::before {
-      background-image: url('alert/success.svg');
+      background-image: url('/alert/success.svg');
       content: '';
       display: block;
       height: $h4;

--- a/app/assets/stylesheets/components/_language-picker.scss
+++ b/app/assets/stylesheets/components/_language-picker.scss
@@ -66,10 +66,10 @@
     }
 
     &::after {
-      background-image: url(angle-arrow-up.svg);
+      background-image: url('/angle-arrow-up.svg');
 
       @include at-media('tablet') {
-        background-image: url(angle-arrow-up-white.svg);
+        background-image: url('/angle-arrow-up-white.svg');
       }
     }
   }
@@ -79,7 +79,7 @@
     color: color('white');
 
     &::after {
-      background-image: url(angle-arrow-down-white.svg);
+      background-image: url('/angle-arrow-down-white.svg');
     }
   }
 }

--- a/app/assets/stylesheets/components/_list.scss
+++ b/app/assets/stylesheets/components/_list.scss
@@ -3,7 +3,7 @@
     padding: 1rem 1rem 1rem 0;
 
     &::before {
-      background-image: url('alert/success.svg');
+      background-image: url('/alert/success.svg');
       background-repeat: no-repeat;
       content: '';
       display: inline-block;

--- a/app/assets/stylesheets/components/_personal-key.scss
+++ b/app/assets/stylesheets/components/_personal-key.scss
@@ -2,7 +2,7 @@
 
 .personal-key-block {
   @include u-padding-y(2);
-  background-image: url('personal-key/pkey-block.svg');
+  background-image: url('/personal-key/pkey-block.svg');
   background-position: center;
   background-repeat: no-repeat;
 
@@ -28,7 +28,7 @@
 
 .bg-personal-key {
   height: 145px;
-  background-image: url('personal-key/shield.svg');
+  background-image: url('/personal-key/shield.svg');
   background-position: center;
   background-repeat: no-repeat;
   background-size: 145px 145px;

--- a/app/assets/stylesheets/components/_phone-input.scss
+++ b/app/assets/stylesheets/components/_phone-input.scss
@@ -8,11 +8,11 @@ lg-phone-input {
   }
 
   .iti__flag {
-    background-image: url('flags.png');
+    background-image: url('/flags.png');
 
     /* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
     @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-      background-image: url('flags@2x.png');
+      background-image: url('/flags@2x.png');
     }
   }
 

--- a/app/assets/stylesheets/components/_step-indicator.scss
+++ b/app/assets/stylesheets/components/_step-indicator.scss
@@ -109,7 +109,7 @@ lg-step-indicator {
 
 .step-indicator__step--complete::before {
   background-color: color('white');
-  background-image: url('alert/success.svg');
+  background-image: url('/alert/success.svg');
 }
 
 .step-indicator__step:not(:last-child)::after {


### PR DESCRIPTION
## 🛠 Summary of changes

Changes `url(...)` to reference assets using absolute (slash-prefixed) paths, in hopes of fixing issues observed in deployed environments, and following related migration guidance:

>[...]Propshaft assumes all paths are relative to the path of the file it’s processing. Since it was processing a css file inside the theme folder, it will also look for hero.jpg in the same folder.
>
>By adding a / at the start of the path we are telling Propshaft to consider this path as an absolute path.

https://github.com/rails/propshaft/blob/main/UPGRADING.md#3-migrate-from-sprockets-to-propshaft

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Observe ⬇️ caret image next to "Here's how you know in banner"