### PR TITLE
LG-9726 Use the fraud review checker in the place of fraud_review_eligible

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,10 +114,6 @@ class User < ApplicationRecord
     profiles.where.not(gpo_verification_pending_at: nil).order(created_at: :desc).first
   end
 
-  def fraud_review_eligible?
-    fraud_review_pending_profile&.fraud_review_pending_at&.after?(30.days.ago)
-  end
-
   def fraud_review_pending?
     fraud_review_pending_profile.present?
   end

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -26,7 +26,7 @@ namespace :users do
         next
       end
 
-      if FraudReviewCheccker.new(user).fraud_review_eligible?
+      if FraudReviewChecker.new(user).fraud_review_eligible?
         profile = user.fraud_review_pending_profile
         profile.activate_after_passing_review
 
@@ -73,7 +73,7 @@ namespace :users do
         next
       end
 
-      if FraudReviewCheccker.new(user).fraud_review_eligible?
+      if FraudReviewChecker.new(user).fraud_review_eligible?
         profile = user.fraud_review_pending_profile
 
         profile.reject_for_fraud(notify_user: true)

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -26,7 +26,7 @@ namespace :users do
         next
       end
 
-      if user.fraud_review_eligible?
+      if FraudReviewCheccker.new(user).fraud_review_eligible?
         profile = user.fraud_review_pending_profile
         profile.activate_after_passing_review
 
@@ -73,7 +73,7 @@ namespace :users do
         next
       end
 
-      if user.fraud_review_eligible?
+      if FraudReviewCheccker.new(user).fraud_review_eligible?
         profile = user.fraud_review_pending_profile
 
         profile.reject_for_fraud(notify_user: true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -529,47 +529,6 @@ RSpec.describe User do
     end
   end
 
-  describe '#fraud_review_eligible?' do
-    context 'when fraud_review_pending_at is nil' do
-      it 'returns false' do
-        fraud_review_pending_at = nil
-
-        user = create(:user)
-        user.profiles.create(
-          fraud_review_pending_at: fraud_review_pending_at,
-        )
-
-        expect(user.fraud_review_eligible?).to be_falsey
-      end
-    end
-
-    context 'when verified_at is within 30 days' do
-      it 'returns true' do
-        fraud_review_pending_at = 15.days.ago
-
-        user = create(:user)
-        user.profiles.create(
-          fraud_review_pending_at: fraud_review_pending_at,
-        )
-
-        expect(user.fraud_review_eligible?).to eq true
-      end
-    end
-
-    context 'when verified_at is older than 30 days' do
-      it 'returns false' do
-        fraud_review_pending_at = 45.days.ago
-
-        user = create(:user)
-        user.profiles.create(
-          fraud_review_pending_at: fraud_review_pending_at,
-        )
-
-        expect(user.fraud_review_eligible?).to eq false
-      end
-    end
-  end
-
   describe '#fraud_review_pending?' do
     it 'returns true if fraud review is pending' do
       user = create(:user)


### PR DESCRIPTION
A previous commit (#8397) introduced the `FraudReviewChecker` which includes a method for checking that a user is eligible for fraud review. It did not end up getting used in the rake task where that check is performed. This commit does that and removes the old method from the user model.
