### PR TITLE
Fix handling for missing SP logo

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -43,7 +43,7 @@ class ServiceProviderSessionDecorator
     logo = sp_logo
     ActionController::Base.helpers.image_path("sp-logos/#{logo}")
   rescue Propshaft::MissingAssetError
-    nil
+    ''
   end
 
   def new_session_heading

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe ServiceProviderSessionDecorator do
           service_provider_request: ServiceProviderRequestProxy.new,
         )
 
-        expect(subject.sp_logo_url).is_a? String
+        expect(subject.sp_logo_url).to be_kind_of(String)
       end
     end
   end

--- a/spec/views/shared/_nav_branded.html.erb_spec.rb
+++ b/spec/views/shared/_nav_branded.html.erb_spec.rb
@@ -72,4 +72,21 @@ describe 'shared/_nav_branded.html.erb' do
       expect(rendered).to have_css("img[alt*='No logo no problem']")
     end
   end
+
+  context 'service provider has a poorly configured logo' do
+    before do
+      sp = build_stubbed(:service_provider, logo: 'abc')
+      decorated_session = ServiceProviderSessionDecorator.new(
+        sp:,
+        view_context:,
+        sp_session: {},
+        service_provider_request: nil,
+      )
+      allow(view).to receive(:decorated_session).and_return(decorated_session)
+    end
+
+    it 'does not raise an exception' do
+      expect { render }.not_to raise_exception
+    end
+  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an error which can happen if the logo associated with a service provider cannot be resolved.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1684269870234819

The problems are:

- The error handler was added in #8387, where previously the method always returned from `image_path`. The logic of `image_path` always returns a string, even if not found ([source](https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/actionview/lib/action_view/helpers/asset_url_helper.rb#L190)), but we returned `nil` instead in the error handler.
- Spec coverage was lacking:
   - We thought we were testing for a string return value, but there was a bug in the assertion (see `.is_a?` change)
   - We had no spec coverage for this scenario in the `_nav_branded.html.erb` specs, which is where the error was happening