### PR TITLE
LG-9596: Stop logging AAMVA timeout errors to NewRelic

### DIFF
--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -36,7 +36,7 @@ module Proofing
         )
         build_result_from_response(response)
       rescue => exception
-        NewRelic::Agent.notice_error(exception)
+        NewRelic::Agent.notice_error(exception) unless exception.is_a? Proofing::TimeoutError
         Proofing::StateIdResult.new(
           success: false, errors: {}, exception: exception, vendor_name: 'aamva:state_id',
           transaction_id: nil, verified_attributes: []


### PR DESCRIPTION
Continue to log any other errors.

## 🎫 Ticket

[LG-9596](https://cm-jira.usa.gov/browse/LG-9596)

## 🛠 Summary of changes

If the exception raised in the processing of an AAMVA request is a TimeoutError, don't log it to NewRelic.