### PR TITLE
LG-9369 Improve LinkSent before action

### DIFF
--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -43,9 +43,13 @@ module Idv
     private
 
     def confirm_upload_step_complete
-      return if flow_session['Idv::Steps::UploadStep']
+      return if flow_session[:flow_path] == 'hybrid'
 
-      redirect_to idv_doc_auth_url
+      if flow_session[:flow_path] == 'standard'
+        redirect_to idv_document_capture_url
+      else
+        redirect_to idv_doc_auth_url
+      end
     end
 
     def confirm_document_capture_needed

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -99,7 +99,7 @@ module Idv
       def bypass_send_link_steps
         mark_step_complete(:link_sent)
 
-        flow_session[:flow_path] = @flow.flow_path
+        flow_session[:flow_path] = 'standard'
         redirect_to idv_document_capture_url
 
         form_response(destination: :document_capture)

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -7,8 +7,7 @@ describe Idv::LinkSentController do
     { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
       :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
       :flow_path => 'hybrid',
-      :phone_for_mobile_flow => '201-555-1212',
-      'Idv::Steps::UploadStep' => true }
+      :phone_for_mobile_flow => '201-555-1212' }
   end
 
   let(:user) { create(:user) }
@@ -80,12 +79,24 @@ describe Idv::LinkSentController do
     end
 
     context 'upload step is not complete' do
-      it 'redirects to idv_doc_auth_url' do
-        flow_session['Idv::Steps::UploadStep'] = nil
+      context 'no flow_path' do
+        it 'redirects to idv_doc_auth_url' do
+          flow_session[:flow_path] = nil
 
-        get :show
+          get :show
 
-        expect(response).to redirect_to(idv_doc_auth_url)
+          expect(response).to redirect_to(idv_doc_auth_url)
+        end
+      end
+
+      context 'flow_path is standard' do
+        it 'redirects to idv_document_capture_url' do
+          flow_session[:flow_path] = 'standard'
+
+          get :show
+
+          expect(response).to redirect_to(idv_document_capture_url)
+        end
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9369](https://cm-jira.usa.gov/browse/LG-9369)

## 🛠 Summary of changes
In LinkSentController before action, if flow_path is standard, redirect to DocumentCapture. If flow_path is not set, redirect to FSM (UploadStep). This makes it viable to set the final_url of the remaining DocAuthFlow to idv_link_sent_url, since users will be redirected to DocumentCapture if needed.
