### PR TITLE
Consolidate handle remember device method definitions

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -46,11 +46,6 @@ module TwoFactorAuthentication
       reset_otp_session_data
     end
 
-    def handle_remember_device
-      save_user_opted_remember_device_pref
-      save_remember_device_preference
-    end
-
     def handle_invalid_webauthn
       is_platform_auth = params[:platform].to_s == 'true'
       if is_platform_auth

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -84,10 +84,6 @@ module TwoFactorAuthentication
       )
     end
 
-    def user_opted_remember_device_cookie
-      cookies.encrypted[:user_opted_remember_device_preference]
-    end
-
     def save_challenge_in_session
       credential_creation_options = WebAuthn::Credential.options_for_get
       user_session[:webauthn_challenge] = credential_creation_options.challenge.bytes.to_a

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -1,7 +1,7 @@
 module Users
   class BackupCodeSetupController < ApplicationController
+    include TwoFactorAuthenticatableMethods
     include MfaSetupConcern
-    include RememberDeviceConcern
     include SecureHeadersConcern
     include ReauthenticationRequiredConcern
 
@@ -105,10 +105,6 @@ module Users
         user_opted_remember_device_cookie: user_opted_remember_device_cookie,
         remember_device_default: remember_device_default,
       )
-    end
-
-    def user_opted_remember_device_cookie
-      cookies.encrypted[:user_opted_remember_device_preference]
     end
 
     def mark_user_as_fully_authenticated

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -1,5 +1,6 @@
 module Users
   class PhoneSetupController < ApplicationController
+    include TwoFactorAuthenticatableMethods
     include UserAuthenticator
     include PhoneConfirmation
     include MfaSetupConcern
@@ -66,10 +67,6 @@ module Users
 
     def setup_voice_preference?
       params[:otp_delivery_preference].to_s == 'voice'
-    end
-
-    def user_opted_remember_device_cookie
-      cookies.encrypted[:user_opted_remember_device_preference]
     end
 
     def handle_create_success(phone)

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -1,9 +1,7 @@
 module Users
   class TotpSetupController < ApplicationController
     include TwoFactorAuthenticatableMethods
-    include RememberDeviceConcern
     include MfaSetupConcern
-    include RememberDeviceConcern
     include SecureHeadersConcern
     include ReauthenticationRequiredConcern
 
@@ -66,10 +64,6 @@ module Users
         user_opted_remember_device_cookie: user_opted_remember_device_cookie,
         remember_device_default: remember_device_default,
       )
-    end
-
-    def user_opted_remember_device_cookie
-      cookies.encrypted[:user_opted_remember_device_preference]
     end
 
     def sign_up_mfa_selection_order_bucket

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -1,5 +1,6 @@
 module Users
   class TotpSetupController < ApplicationController
+    include TwoFactorAuthenticatableMethods
     include RememberDeviceConcern
     include MfaSetupConcern
     include RememberDeviceConcern
@@ -97,11 +98,6 @@ module Users
       flash[:success] = t('notices.totp_configured')
       user_session.delete(:new_totp_secret)
       redirect_to next_setup_path || after_mfa_setup_path
-    end
-
-    def handle_remember_device
-      save_user_opted_remember_device_pref
-      save_remember_device_preference
     end
 
     def create_events

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -2,7 +2,6 @@ module Users
   class WebauthnSetupController < ApplicationController
     include TwoFactorAuthenticatableMethods
     include MfaSetupConcern
-    include RememberDeviceConcern
     include SecureHeadersConcern
     include ReauthenticationRequiredConcern
 
@@ -107,10 +106,6 @@ module Users
     def sign_up_mfa_selection_order_bucket
       return unless in_multi_mfa_selection_flow?
       @sign_up_mfa_selection_order_bucket = AbTests::SIGN_UP_MFA_SELECTION.bucket(current_user.uuid)
-    end
-
-    def user_opted_remember_device_cookie
-      cookies.encrypted[:user_opted_remember_device_preference]
     end
 
     def flash_error(errors)

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -1,5 +1,6 @@
 module Users
   class WebauthnSetupController < ApplicationController
+    include TwoFactorAuthenticatableMethods
     include MfaSetupConcern
     include RememberDeviceConcern
     include SecureHeadersConcern
@@ -179,11 +180,6 @@ module Users
         in_multi_mfa_selection_flow: in_multi_mfa_selection_flow?,
         sign_up_mfa_selection_order_bucket: sign_up_mfa_selection_order_bucket,
       }
-    end
-
-    def handle_remember_device
-      save_user_opted_remember_device_pref
-      save_remember_device_preference
     end
 
     def process_invalid_webauthn(form)


### PR DESCRIPTION
## 🛠 Summary of changes

We currently define `handle_remember_device` 4 times in the exact same, including in the shared `TwoFactorAuthenticatableMethods` module. The same is true for `user_opted_remember_device_cookie` (but 6 times).

This PR removes the extra definitions and pulls in the shared module so they can share a common definition of these methods.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
