### PR TITLE
Change the fraud review logic for fraud review

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -26,11 +26,11 @@ class Profile < ApplicationRecord
   attr_reader :personal_key
 
   def fraud_review_pending?
-    fraud_review_pending_at.present?
+    fraud_review_pending_at.present? && !has_deactivation_reason?
   end
 
   def fraud_rejection?
-    fraud_rejection_at.present?
+    fraud_rejection_at.present? && !has_deactivation_reason?
   end
 
   def gpo_verification_pending?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,13 +123,26 @@ class User < ApplicationRecord
   end
 
   def fraud_review_pending_profile
-    @fraud_review_pending_profile ||=
-      profiles.where.not(fraud_review_pending_at: nil).order(created_at: :desc).first
+    @fraud_review_pending_profile ||= profiles.
+      where.not(
+        fraud_review_pending_at: nil,
+      ).
+      where(
+        deactivation_reason: nil,
+        gpo_verification_pending_at: nil,
+      ).
+      order(created_at: :desc).first
   end
 
   def fraud_rejection_profile
-    @fraud_rejection_profile ||=
-      profiles.where.not(fraud_rejection_at: nil).order(created_at: :desc).first
+    @fraud_rejection_profile ||= profiles.
+      where.not(
+        fraud_rejection_at: nil,
+      ).
+      where(
+        deactivation_reason: nil,
+        gpo_verification_pending_at: nil,
+      ).order(created_at: :desc).first
   end
 
   def personal_key_generated_at


### PR DESCRIPTION
We have been making changes to the way that we manage users in fraud review. Specifically we have been unloading the `deactivation_reason` column and using specific columns each reason a profile could be in review.

This proves problematic in some cases since some of the logic that assumes a single deactivation reason is still in place. Specifically, a user can now be in fraud review or GPO pending state simultaneously, but the logic for changing states does not take that into consideration. As a result the logic for moving users in between states is incomplete. This commit helps to alleviate that by adjust the fraud review profile query to only return a fraud review profile when a user is not in a GPO pending state and their profile has not been deactivate for some other reason.
