### PR TITLE
Documentation: Add details on how to find IP address on macOS

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -158,7 +158,7 @@ The app will start using that Geolite2 file for geolocation after restart.
 
 By default, the application binds to `localhost`. To test on a local network device or within a virtual machine, you can bind to `0.0.0.0` instead, using the following instructions:
 
-1. Determine your computer's network IP address. On macOS, you can find this in the "Network" system settings. From there, select "Wi-Fi or Ethernet" and click "Details". This often takes the format of `192.168.1.x` or `10.0.0.x`.
+1. Determine your computer's network IP address. On macOS, you can find this in the "Network" system settings. From there, select "Wi-Fi" or "Ethernet" and click "Details". This often takes the format of `192.168.1.x` or `10.0.0.x`.
 2. In `config/application.yml`, add `domain_name` and `mailer_domain_name` keys under `development`, like so:
    ```yaml
    development:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -156,9 +156,18 @@ The app will start using that Geolite2 file for geolocation after restart.
 
 ### Testing in a virtual machine
 
-By default, the application binds to `localhost`. To test on a local network device or within a virtual machine, you can bind to `0.0.0.0` instead, using the following instructions:
+By default, the application binds to `localhost`. To test on a local network device or within a virtual machine, you can bind to `0.0.0.0`. Before development, use the following instructions based on your machine's operating system.
 
-1. Determine your computer's network IP address. On macOS, you can find this in the "Network" system settings. From there, select "Wi-Fi" or "Ethernet". This option will change based on how you are connected to the internet. On the next screen, click "Details". This often takes the format of `192.168.1.x` or `10.0.0.x`.
+1. From the "Network" tab on:
+
+* macOS Monterey and below
+Once on "Network" system settings, your IP address is shown under "Status: Connected" label.
+
+* macOS Ventura
+Select "Wi-Fi" or "Ethernet". This option will change based on how you are connected to the internet. From there, click "Details".
+
+* IP addresses often take the format of `192.168.1.x` or `10.0.0.x`.
+
 2. In `config/application.yml`, add `domain_name` and `mailer_domain_name` keys under `development`, like so:
    ```yaml
    development:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -131,7 +131,7 @@ We recommend using [Homebrew](https://brew.sh/), [rbenv](https://github.com/rben
 
 ### Translations
 
-  Login.gov translates the IdP into English, French and Spanish. To help us handle extra newlines and make sure we wrap lines consistently, we have a script that helps format YAML consistently. After importing translations (or making changes to the `*.yml` files with strings, run this for the IdP app:
+  Login.gov translates the IdP into English, French and Spanish. To help us handle extra newlines and make sure we wrap lines consistently, we have a script that helps format YAML consistently. After importing translations (or making changes to the `*.yml` files with strings), run this for the IdP app:
 
   ```
   $ make normalize_yaml
@@ -160,13 +160,15 @@ By default, the application binds to `localhost`. To test on a local network dev
 
 1. From the "Network" tab on:
 
-* macOS Monterey and below
-Once on "Network" system settings, your IP address is shown under "Status: Connected" label.
+  * Monterey and below
 
-* macOS Ventura
-Select "Wi-Fi" or "Ethernet". This option will change based on how you are connected to the internet. From there, click "Details".
+    Once on "Network" system settings, your IP address is shown under "Status: Connected" label.
 
-* IP addresses often take the format of `192.168.1.x` or `10.0.0.x`.
+  * Ventura
+
+    Select "Wi-Fi" or "Ethernet". This option will change based on how you are connected to the internet. From there, click "Details".
+
+    **IP addresses often take the format of `192.168.1.x` or `10.0.0.x`.**
 
 2. In `config/application.yml`, add `domain_name` and `mailer_domain_name` keys under `development`, like so:
    ```yaml

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -158,7 +158,7 @@ The app will start using that Geolite2 file for geolocation after restart.
 
 By default, the application binds to `localhost`. To test on a local network device or within a virtual machine, you can bind to `0.0.0.0` instead, using the following instructions:
 
-1. Determine your computer's network IP address. On macOS, you can find this in the "Network" system settings, shown under the "Status: Connected" label. This often takes the format of `192.168.1.x` or `10.0.0.x`.
+1. Determine your computer's network IP address. On macOS, you can find this in the "Network" system settings. From there, select "Wi-Fi or Ethernet" and click "Details". This often takes the format of `192.168.1.x` or `10.0.0.x`.
 2. In `config/application.yml`, add `domain_name` and `mailer_domain_name` keys under `development`, like so:
    ```yaml
    development:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -158,7 +158,7 @@ The app will start using that Geolite2 file for geolocation after restart.
 
 By default, the application binds to `localhost`. To test on a local network device or within a virtual machine, you can bind to `0.0.0.0` instead, using the following instructions:
 
-1. Determine your computer's network IP address. On macOS, you can find this in the "Network" system settings. From there, select "Wi-Fi" or "Ethernet" and click "Details". This often takes the format of `192.168.1.x` or `10.0.0.x`.
+1. Determine your computer's network IP address. On macOS, you can find this in the "Network" system settings. From there, select "Wi-Fi" or "Ethernet". This option will change based on how you are connected to the internet. On the next screen, click "Details". This often takes the format of `192.168.1.x` or `10.0.0.x`.
 2. In `config/application.yml`, add `domain_name` and `mailer_domain_name` keys under `development`, like so:
    ```yaml
    development:


### PR DESCRIPTION
When trying to find my IP address on my machine, I had to go through some extra steps to get my IP address. I edited it so that it could help someone else.

Test plan: Follow the below instructions
- Go to System Preferences 
- Click "Network"
- Select "Wi-Fi" or "Ethernet". This will change based on the type of connection you are using
- Click "Details"

From here, you should see your IP address. Change the `domain_name` and `mailer_domain_name` as laid out in `local-development.md`. Run `HOST=0.0.0 make run` to access the site.
