### PR TITLE
Refactor handling of successful two-factor phone confirmation

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -170,16 +170,8 @@ module TwoFactorAuthenticatableMethods
 
   def handle_valid_verification_for_confirmation_context
     user_session[:authn_at] = Time.zone.now
-    track_mfa_method_added
     @next_mfa_setup_path = next_setup_path
     reset_second_factor_attempts_count
-  end
-
-  def track_mfa_method_added
-    mfa_user = MfaContext.new(current_user)
-    mfa_count = mfa_user.enabled_mfa_methods_count
-    analytics.multi_factor_auth_added_phone(enabled_mfa_methods_count: mfa_count)
-    Funnel::Registration::AddMfa.call(current_user.id, 'phone', analytics)
   end
 
   def handle_valid_otp_for_authentication_context(auth_method:)

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -32,6 +32,7 @@ module TwoFactorAuthentication
 
     def handle_valid_confirmation_otp
       assign_phone
+      track_mfa_added
       flash[:success] = t('notices.phone_confirmed')
     end
 
@@ -44,6 +45,13 @@ module TwoFactorAuthentication
 
       flash[:error] = t('errors.messages.phone_required')
       redirect_to new_user_session_path
+    end
+
+    def track_mfa_added
+      mfa_user = MfaContext.new(current_user)
+      mfa_count = mfa_user.enabled_mfa_methods_count
+      analytics.multi_factor_auth_added_phone(enabled_mfa_methods_count: mfa_count)
+      Funnel::Registration::AddMfa.call(current_user.id, 'phone', analytics)
     end
 
     def confirm_multiple_factors_enabled

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -48,9 +48,9 @@ module TwoFactorAuthentication
     end
 
     def track_mfa_added
-      mfa_user = MfaContext.new(current_user)
-      mfa_count = mfa_user.enabled_mfa_methods_count
-      analytics.multi_factor_auth_added_phone(enabled_mfa_methods_count: mfa_count)
+      analytics.multi_factor_auth_added_phone(
+        enabled_mfa_methods_count: MfaContext.new(current_user).enabled_mfa_methods_count,
+      )
       Funnel::Registration::AddMfa.call(current_user.id, 'phone', analytics)
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

A small follow-up to #8347 to move some phone-specific functionality out of `TwoFactorAuthenticationMethods`. The path is a little bit circuitous with calling `handle_valid_otp` and a `confirmation` state in `UserSessionContext`, but the `track_mfa_method_added` method defined is only used when confirming a phone. The big clue is that the method name sounds general, but turns out to be specific to confirming a phone.

This PR pulls that method definition into the `OtpVerificationController` and calls it when confirming a phone.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
