### PR TITLE
Check for a deactivation reason before activating a profile

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -370,7 +370,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       passed: true,
       reason: 'Successful status update',
     )
-    enrollment.profile.activate
+    enrollment.profile.activate_after_passing_in_person
     enrollment.update(
       status: :passed,
       proofed_at: proofed_at,

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -76,7 +76,7 @@ class Profile < ApplicationRecord
   end
 
   def has_deactivation_reason?
-    has_fraud_deactivation_reason? || gpo_verification_pending?
+    deactivation_reason.present? || has_fraud_deactivation_reason? || gpo_verification_pending?
   end
 
   def has_fraud_deactivation_reason?

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -71,6 +71,13 @@ class Profile < ApplicationRecord
     activate
   end
 
+  def activate_after_passing_in_person
+    update!(
+      deactivation_reason: nil,
+    )
+    activate
+  end
+
   def deactivate(reason)
     update!(active: false, deactivation_reason: reason)
   end

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -53,6 +53,16 @@ describe 'review_profile' do
         expect(stdout.string).to include('Error: Could not find user with that UUID')
       end
     end
+
+    context 'when the user has cancelled verification' do
+      it 'does not activate the profile' do
+        user.profiles.first.update!(gpo_verification_pending_at: user.created_at)
+
+        invoke_task
+
+        expect(user.reload.profiles.first.active).to eq(false)
+      end
+    end
   end
 
   describe 'users:review:reject' do

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -57,7 +57,7 @@ module SpAuthHelper
     # Mark IPP as passed
     enrollment = user.in_person_enrollments.last
     expect(enrollment).to_not be_nil
-    enrollment.profile.activate
+    enrollment.profile.activate_after_passing_in_person
     enrollment.update(status: :passed)
 
     visit_idp_from_sp_with_ial2(sp)


### PR DESCRIPTION
We should not be activating profiles that have a deactivation reason. The logic for that looks like it got mixed up when we were doing the fraud review work. Specifically the code to check for a deactivation reason does not actually look at the deactivation reason column anymore.

This commit addresses the above.
