### PR TITLE
Fix Rubocop namespace warning

### DIFF
--- a/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts.rb
+++ b/app/services/db/monthly_sp_auth_count/total_monthly_auth_counts.rb
@@ -3,10 +3,10 @@ module Db
     class TotalMonthlyAuthCounts
       # @return [Array<Hash>]
       def self.call
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         oldest = ::SpReturnLog.where.not(returned_at: nil).first&.returned_at&.to_date&.beginning_of_month
         newest = ::SpReturnLog.where.not(returned_at: nil).last&.returned_at&.to_date&.end_of_month
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
 
         return [] if !oldest || !newest
 


### PR DESCRIPTION
## 🛠 Summary of changes

When running `rubocop`, there is a warning that we are using the wrong namespace when enabling/disabling `LineLength`. It looks to have been changed quite awhile ago in `0.78.0` (2019-12-18).

This PR fixes it.

```
$ rubocop
app/services/db/monthly_sp_auth_count/total_monthly_auth_counts.rb: Metrics/LineLength has the wrong namespace - should be Layout
app/services/db/monthly_sp_auth_count/total_monthly_auth_counts.rb: Metrics/LineLength has the wrong namespace - should be Layout
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
