### PR TITLE
LG-9828: add mva_timeout? method to AAMVA proofer result

### DIFF
--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -19,8 +19,6 @@ module Proofing
         ],
       )
 
-      MVA_TIMEOUT_EXCEPTION = 'ExceptionId: 0047'.freeze
-
       attr_reader :config
 
       # Instance methods
@@ -111,7 +109,7 @@ module Proofing
       end
 
       def mva_timeout?(error_message)
-        error_message.include? MVA_TIMEOUT_EXCEPTION
+        error_message.include? Proofing::StateIdResult::MVA_TIMEOUT_EXCEPTION
       end
     end
   end

--- a/app/services/proofing/aamva/response/verification_response.rb
+++ b/app/services/proofing/aamva/response/verification_response.rb
@@ -25,8 +25,6 @@ module Proofing
           first_name
         ].freeze
 
-        MVA_TIMEOUT_EXCEPTION = 'ExceptionId: 0047'.freeze
-
         attr_reader :verification_results, :transaction_locator_id
 
         def initialize(http_response)
@@ -112,10 +110,6 @@ module Proofing
 
         def rexml_document
           return @rexml_document ||= REXML::Document.new(http_response.body)
-        end
-
-        def mva_timeout?(error_message)
-          error_message.include? MVA_TIMEOUT_EXCEPTION
         end
       end
     end

--- a/app/services/proofing/state_id_result.rb
+++ b/app/services/proofing/state_id_result.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 module Proofing
   class StateIdResult
-    MVA_TIMEOUT_EXCEPTION = 'ExceptionId: 0047'.freeze
+    MVA_UNAVAILABLE = 'ExceptionId: 0001'
+    MVA_SYSTEM_ERROR = 'ExceptionId: 0002'
+    MVA_TIMEOUT_EXCEPTION = 'ExceptionId: 0047'
 
     attr_reader :errors,
                 :exception,
@@ -33,8 +37,20 @@ module Proofing
       exception.is_a?(Proofing::TimeoutError)
     end
 
+    def mva_unavailable?
+      exception&.message&.include? MVA_UNAVAILABLE
+    end
+
+    def mva_system_error?
+      exception&.message&.include? MVA_SYSTEM_ERROR
+    end
+
     def mva_timeout?
       exception&.message&.include? MVA_TIMEOUT_EXCEPTION
+    end
+
+    def mva_exception?
+      mva_unavailable? || mva_system_error? || mva_timeout?
     end
 
     def to_h

--- a/app/services/proofing/state_id_result.rb
+++ b/app/services/proofing/state_id_result.rb
@@ -1,5 +1,7 @@
 module Proofing
   class StateIdResult
+    MVA_TIMEOUT_EXCEPTION = 'ExceptionId: 0047'.freeze
+
     attr_reader :errors,
                 :exception,
                 :success,
@@ -29,6 +31,10 @@ module Proofing
 
     def timed_out?
       exception.is_a?(Proofing::TimeoutError)
+    end
+
+    def mva_timeout?
+      exception&.message&.include? MVA_TIMEOUT_EXCEPTION
     end
 
     def to_h

--- a/spec/services/proofing/aamva/proofer_spec.rb
+++ b/spec/services/proofing/aamva/proofer_spec.rb
@@ -145,6 +145,7 @@ describe Proofing::Aamva::Proofer do
 
         expect(result.success?).to eq(false)
         expect(result.exception).to eq(exception)
+        expect(result.mva_timeout?).to eq(false)
       end
 
       context 'the exception is a timeout error' do
@@ -157,13 +158,14 @@ describe Proofing::Aamva::Proofer do
 
           expect(result.success?).to eq(false)
           expect(result.exception).to eq(exception)
+          expect(result.mva_timeout?).to eq(false)
         end
       end
 
       context 'the exception is a verification error due to MVA timeout' do
         let(:exception) do
           Proofing::Aamva::VerificationError.new(
-            "DLDV VSS - ExceptionId: 0047, ExceptionText: MVA did not respond in a timely fashion",
+            'DLDV VSS - ExceptionId: 0047, ExceptionText: MVA did not respond in a timely fashion',
           )
         end
 
@@ -174,6 +176,7 @@ describe Proofing::Aamva::Proofer do
 
           expect(result.success?).to eq(false)
           expect(result.exception).to eq(exception)
+          expect(result.mva_timeout?).to eq(true)
         end
       end
     end

--- a/spec/services/proofing/aamva/proofer_spec.rb
+++ b/spec/services/proofing/aamva/proofer_spec.rb
@@ -145,7 +145,7 @@ describe Proofing::Aamva::Proofer do
 
         expect(result.success?).to eq(false)
         expect(result.exception).to eq(exception)
-        expect(result.mva_timeout?).to eq(false)
+        expect(result.mva_exception?).to eq(false)
       end
 
       context 'the exception is a timeout error' do
@@ -158,11 +158,53 @@ describe Proofing::Aamva::Proofer do
 
           expect(result.success?).to eq(false)
           expect(result.exception).to eq(exception)
-          expect(result.mva_timeout?).to eq(false)
+          expect(result.mva_exception?).to eq(false)
         end
       end
 
-      context 'the exception is a verification error due to MVA timeout' do
+      context 'the exception is a verification error due to the MVA being unavailable' do
+        let(:exception) do
+          Proofing::Aamva::VerificationError.new(
+            'DLDV VSS - ExceptionId: 0001, ExceptionText: MVA system is unavailable',
+          )
+        end
+
+        it 'logs to NewRelic' do
+          expect(NewRelic::Agent).to receive(:notice_error)
+
+          result = subject.proof(state_id_data)
+
+          expect(result.success?).to eq(false)
+          expect(result.exception).to eq(exception)
+          expect(result.mva_unavailable?).to eq(true)
+          expect(result.mva_system_error?).to eq(false)
+          expect(result.mva_timeout?).to eq(false)
+          expect(result.mva_exception?).to eq(true)
+        end
+      end
+
+      context 'the exception is a verification error due to a MVA system error' do
+        let(:exception) do
+          Proofing::Aamva::VerificationError.new(
+            'DLDV VSS - ExceptionId: 0002, ExceptionText: MVA system error',
+          )
+        end
+
+        it 'logs to NewRelic' do
+          expect(NewRelic::Agent).to receive(:notice_error)
+
+          result = subject.proof(state_id_data)
+
+          expect(result.success?).to eq(false)
+          expect(result.exception).to eq(exception)
+          expect(result.mva_unavailable?).to eq(false)
+          expect(result.mva_system_error?).to eq(true)
+          expect(result.mva_timeout?).to eq(false)
+          expect(result.mva_exception?).to eq(true)
+        end
+      end
+
+      context 'the exception is a verification error due to a MVA timeout' do
         let(:exception) do
           Proofing::Aamva::VerificationError.new(
             'DLDV VSS - ExceptionId: 0047, ExceptionText: MVA did not respond in a timely fashion',
@@ -176,7 +218,10 @@ describe Proofing::Aamva::Proofer do
 
           expect(result.success?).to eq(false)
           expect(result.exception).to eq(exception)
+          expect(result.mva_unavailable?).to eq(false)
+          expect(result.mva_system_error?).to eq(false)
           expect(result.mva_timeout?).to eq(true)
+          expect(result.mva_exception?).to eq(true)
         end
       end
     end

--- a/spec/services/proofing/aamva/proofer_spec.rb
+++ b/spec/services/proofing/aamva/proofer_spec.rb
@@ -159,6 +159,23 @@ describe Proofing::Aamva::Proofer do
           expect(result.exception).to eq(exception)
         end
       end
+
+      context 'the exception is a verification error due to MVA timeout' do
+        let(:exception) do
+          Proofing::Aamva::VerificationError.new(
+            "DLDV VSS - ExceptionId: 0047, ExceptionText: MVA did not respond in a timely fashion",
+          )
+        end
+
+        it 'does not log to NewRelic' do
+          expect(NewRelic::Agent).not_to receive(:notice_error)
+
+          result = subject.proof(state_id_data)
+
+          expect(result.success?).to eq(false)
+          expect(result.exception).to eq(exception)
+        end
+      end
     end
   end
 end

--- a/spec/services/proofing/aamva/verification_client_spec.rb
+++ b/spec/services/proofing/aamva/verification_client_spec.rb
@@ -107,7 +107,7 @@ describe Proofing::Aamva::VerificationClient do
         it 'throws an exception about the MVA timeout' do
           expect { response }.to raise_error(
             Proofing::Aamva::VerificationError,
-            /#{Proofing::Aamva::Response::VerificationResponse::MVA_TIMEOUT_EXCEPTION}/o,
+            /#{Proofing::StateIdResult::MVA_TIMEOUT_EXCEPTION}/o,
           )
         end
 
@@ -133,7 +133,7 @@ describe Proofing::Aamva::VerificationClient do
         it 'throws an exception about the MVA timeout' do
           expect { response }.to raise_error(
             Proofing::Aamva::VerificationError,
-            /#{Proofing::Aamva::Response::VerificationResponse::MVA_TIMEOUT_EXCEPTION}/o,
+            /#{Proofing::StateIdResult::MVA_TIMEOUT_EXCEPTION}/o,
           )
         end
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9828](https://cm-jira.usa.gov/browse/LG-9828)

## 🛠 Summary of changes

Includes `Proofing::StateIdResult#mva_timeout?` to allow checking for MVA timeouts (as opposed to AAMVA timeouts).

BONUS: stop sending VerificationErrors to NewRelic if caused by a MVA timeout