### PR TITLE
Fixes some trivial typos in comments

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2140,7 +2140,7 @@ module AnalyticsEvents
     )
   end
 
-  # User registration has been hadnded off to agency page
+  # User registration has been handed off to agency page
   # @param [Boolean] ial2
   # @param [Integer] ialmax
   # @param [String] service_provider_name
@@ -2241,7 +2241,7 @@ module AnalyticsEvents
   # @param [Hash] errors
   # @param [Boolean] profile_deactivated if the active profile for the account was deactivated
   # (the user will need to use their personal key to reactivate their profile)
-  # The user changed the password for their account via the paswword reset flow
+  # The user changed the password for their account via the password reset flow
   def password_reset_password(success:, errors:, profile_deactivated:, **extra)
     track_event(
       'Password Reset: Password Submitted',
@@ -2615,7 +2615,7 @@ module AnalyticsEvents
     track_event('SP handoff bounced visited')
   end
 
-  # Tracks when a user vists the "This agency no longer uses Login.gov" page.
+  # Tracks when a user visits the "This agency no longer uses Login.gov" page.
   def sp_inactive_visit
     track_event('SP inactive visited')
   end


### PR DESCRIPTION
I came across these while looking for something and they bugged me.

[skip changelog]

## 🎫 Ticket

None, unless this is a mandatory field?