### PR TITLE
Change the `pending_profile` method to actually return the pending profile

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -11,7 +11,7 @@ module IdvStepConcern
   end
 
   def confirm_no_pending_gpo_profile
-    redirect_to idv_gpo_verify_url if current_user.pending_profile_requires_verification?
+    redirect_to idv_gpo_verify_url if current_user.gpo_verification_pending_profile?
   end
 
   def confirm_no_pending_in_person_enrollment

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -53,7 +53,7 @@ module Idv
     end
 
     def confirm_user_not_pending_gpo_verificaiton
-      return unless current_user.pending_profile_requires_verification?
+      return unless current_user.gpo_verification_pending_profile?
       redirect_to idv_come_back_later_url
     end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -56,6 +56,7 @@ class Profile < ApplicationRecord
       update!(
         active: true,
         activated_at: now,
+        verified_at: now,
       )
     end
     send_push_notifications if is_reproof

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -100,7 +100,6 @@ class Profile < ApplicationRecord
   end
 
   def has_fraud_deactivation_reason?
-    return false if !FeatureManagement.proofing_device_profiling_decisioning_enabled?
     fraud_review_pending? || fraud_rejection?
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,6 +25,10 @@ class Profile < ApplicationRecord
 
   attr_reader :personal_key
 
+  def self.cancelled_profile_deactivation_reasons
+    deactivation_reasons.keys - ['gpo_verificaiton_pending', 'in_person_verification_pending']
+  end
+
   def fraud_review_pending?
     fraud_review_pending_at.present?
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -40,7 +40,7 @@ class Profile < ApplicationRecord
   def pending_reasons
     [
       *(:gpo_verification_pending if gpo_verification_pending?),
-      *(:fraud_check_pending if fraud_review_pending? || fraud_rejection?),
+      *(:fraud_check_pending if has_fraud_deactivation_reason?),
       *(:in_person_verification_pending if in_person_verification_pending?),
     ]
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -37,9 +37,18 @@ class Profile < ApplicationRecord
     gpo_verification_pending_at.present?
   end
 
+  def pending_reasons
+    [
+      *(:gpo_verification_pending if gpo_verification_pending?),
+      *(:fraud_check_pending if fraud_review_pending? || fraud_rejection?),
+      *(:in_person_verification_pending if in_person_verification_pending?),
+    ]
+  end
+
   # rubocop:disable Rails/SkipsModelValidations
   def activate
-    return if has_deactivation_reason?
+    confirm_that_profile_can_be_activated!
+
     now = Time.zone.now
     is_reproof = Profile.find_by(user_id: user_id, active: true)
     transaction do
@@ -47,16 +56,19 @@ class Profile < ApplicationRecord
       update!(
         active: true,
         activated_at: now,
-        deactivation_reason: nil,
-        gpo_verification_pending_at: nil,
-        fraud_review_pending_at: nil,
-        fraud_rejection_at: nil,
-        verified_at: now,
       )
     end
     send_push_notifications if is_reproof
   end
   # rubocop:enable Rails/SkipsModelValidations
+
+  def confirm_that_profile_can_be_activated!
+    if pending_reasons.any?
+      raise "Attempting to activate profile with pending reasons: #{pending_reasons.join(',')}"
+    elsif deactivation_reason.present?
+      raise "Attempting to activate profile with deactivation reason: #{deactivation_reason}"
+    end
+  end
 
   def remove_gpo_deactivation_reason
     update!(gpo_verification_pending_at: nil)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,10 +25,6 @@ class Profile < ApplicationRecord
 
   attr_reader :personal_key
 
-  def self.cancelled_profile_deactivation_reasons
-    deactivation_reasons.keys - ['gpo_verificaiton_pending', 'in_person_verification_pending']
-  end
-
   def fraud_review_pending?
     fraud_review_pending_at.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,7 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    profile = profiles.where(deactivation_reason: :in_person_verification_pending).or(
+    pending = profiles.where(deactivation_reason: :in_person_verification_pending).or(
       profiles.where.not(gpo_verification_pending_at: nil),
     ).or(
       profiles.where.not(fraud_review_pending_at: nil),
@@ -115,10 +115,10 @@ class User < ApplicationRecord
       profiles.where.not(fraud_rejection_at: nil),
     ).order(created_at: :desc).first
 
-    return unless profile.present?
-    return if active_profile.present? && profile.created_at > active_profile.activated_at
+    return unless pending.present?
+    return if active_profile.present? && active_profile.activated_at > pending.created_at
 
-    profile
+    pending
   end
 
   def gpo_verification_pending_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,8 @@ class User < ApplicationRecord
       profiles.where.not(fraud_review_pending_at: nil),
     ).or(
       profiles.where.not(fraud_rejection_at: nil),
+    ).where.not(
+      deactivation_reason: Profile.cancelled_profile_deactivation_reasons,
     ).order(created_at: :desc).first
 
     return unless pending.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,18 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    gpo_verification_pending_profile
+    profile = profiles.where(deactivation_reason: :in_person_verification_pending).or(
+      profiles.where.not(gpo_verification_pending_at: nil),
+    ).or(
+      profiles.where.not(fraud_review_pending_at: nil),
+    ).or(
+      profiles.where.not(fraud_rejection_at: nil),
+    ).order(created_at: :desc).first
+
+    return unless profile.present?
+    return if active_profile.present? && profile.created_at > active_profile.activated_at
+
+    profile
   end
 
   def gpo_verification_pending_profile
@@ -256,10 +267,7 @@ class User < ApplicationRecord
   end
 
   def pending_profile_requires_verification?
-    return false if pending_profile.blank?
-    return true if identity_not_verified?
-    return false if active_profile_newer_than_pending_profile?
-    true
+    pending_profile.present?
   end
 
   def identity_not_verified?
@@ -274,10 +282,6 @@ class User < ApplicationRecord
     return false unless service_provider&.irs_attempts_api_enabled
     return false unless active_profile.present?
     !active_profile.initiating_service_provider&.irs_attempts_api_enabled
-  end
-
-  def active_profile_newer_than_pending_profile?
-    active_profile.activated_at >= pending_profile.created_at
   end
 
   # This user's most recently activated profile that has also been deactivated

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ApplicationRecord
   end
 
   def gpo_verification_pending_profile
-    profiles.where.not(gpo_verification_pending_at: nil).order(created_at: :desc).first
+    pending_profile if pending_profile&.gpo_verification_pending?
   end
 
   def fraud_review_pending?
@@ -134,13 +134,11 @@ class User < ApplicationRecord
   end
 
   def fraud_review_pending_profile
-    @fraud_review_pending_profile ||=
-      profiles.where.not(fraud_review_pending_at: nil).order(created_at: :desc).first
+    pending_profile if pending_profile&.fraud_review_pending?
   end
 
   def fraud_rejection_profile
-    @fraud_rejection_profile ||=
-      profiles.where.not(fraud_rejection_at: nil).order(created_at: :desc).first
+    pending_profile if pending_profile&.fraud_rejection?
   end
 
   def personal_key_generated_at

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,8 +113,6 @@ class User < ApplicationRecord
       profiles.where.not(fraud_review_pending_at: nil),
     ).or(
       profiles.where.not(fraud_rejection_at: nil),
-    ).where.not(
-      deactivation_reason: Profile.cancelled_profile_deactivation_reasons,
     ).order(created_at: :desc).first
 
     return unless pending.present?

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -35,7 +35,7 @@ class AccountShowPresenter
   end
 
   def show_gpo_partial?
-    user.pending_profile_requires_verification?
+    user.gpo_verification_pending_profile?
   end
 
   def showing_any_partials?

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -58,7 +58,7 @@ describe 'review_profile' do
       it 'does not activate the profile' do
         user.profiles.first.update!(gpo_verification_pending_at: user.created_at)
 
-        invoke_task
+        expect { invoke_task }.to raise_error(RuntimeError)
 
         expect(user.reload.profiles.first.active).to eq(false)
       end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -272,21 +272,21 @@ describe Profile do
 
       it 'does not activate a profile with gpo verification pending' do
         profile.update(gpo_verification_pending_at: 1.day.ago)
-        profile.activate
+        expect { profile.activate }.to raise_error(RuntimeError)
 
         expect(profile).to_not be_active
       end
 
       it 'does not activate a profile if under fraud review' do
         profile.update(fraud_review_pending_at: 1.day.ago)
-        profile.activate
+        expect { profile.activate }.to raise_error(RuntimeError)
 
         expect(profile).to_not be_active
       end
 
       it 'does not activate a profile if rejected for fraud' do
         profile.update(fraud_rejection_at: Time.zone.now - 1.day)
-        profile.activate
+        expect { profile.activate }.to raise_error(RuntimeError)
 
         expect(profile).to_not be_active
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -463,21 +463,26 @@ RSpec.describe User do
 
   describe '#pending_profile' do
     context 'when a pending profile exists' do
-      it 'returns with the most recent profile' do
-        user = User.new
-        _old_profile = create(
+      let(:user) { User.new }
+      let!(:pending) do
+        create(
           :profile,
-          gpo_verification_pending_at: 1.day.ago,
-          created_at: 1.day.ago,
+          gpo_verification_pending_at: 2.days.ago,
+          created_at: 2.days.ago,
           user: user,
         )
-        new_profile = create(
-          :profile,
-          gpo_verification_pending_at: Time.zone.now,
-          user: user,
-        )
+      end
 
-        expect(user.pending_profile).to eq new_profile
+      it 'returns nil if the active profile is newer than the pending profile' do
+        allow(user).to receive(:active_profile).and_return(Profile.new(activated_at: Time.zone.now))
+
+        expect(user.pending_profile).to be_nil
+      end
+
+      it 'returns the profile if the active profile is older than the pending profile' do
+        allow(user).to receive(:active_profile).and_return(Profile.new(activated_at: 3.days.ago))
+
+        expect(user.pending_profile).to eq pending
       end
     end
 
@@ -966,28 +971,6 @@ RSpec.describe User do
     it 'returns true when pending profile exists and identity is not verified' do
       user = User.new
       allow(user).to receive(:pending_profile).and_return('profile')
-      allow(user).to receive(:identity_not_verified?).and_return(true)
-
-      expect(user.pending_profile_requires_verification?).to eq true
-    end
-
-    it 'returns false when active profile is newer than pending profile' do
-      user = User.new
-      allow(user).to receive(:pending_profile).and_return('profile')
-      allow(user).to receive(:identity_not_verified?).and_return(false)
-      allow(user).to receive(:active_profile_newer_than_pending_profile?).
-        and_return(true)
-
-      expect(user.pending_profile_requires_verification?).to eq false
-    end
-
-    it 'returns true when pending profile is newer than active profile' do
-      user = User.new
-
-      allow(user).to receive(:pending_profile).and_return('profile')
-      allow(user).to receive(:identity_not_verified?).and_return(false)
-      allow(user).to receive(:active_profile_newer_than_pending_profile?).
-        and_return(false)
 
       expect(user.pending_profile_requires_verification?).to eq true
     end
@@ -1022,26 +1005,6 @@ RSpec.describe User do
       allow(user).to receive(:active_profile).and_return(nil)
 
       expect(user.identity_verified?).to eq false
-    end
-  end
-
-  describe '#active_profile_newer_than_pending_profile?' do
-    it 'returns true if the active profile is newer than the pending profile' do
-      user = User.new
-      allow(user).to receive(:active_profile).and_return(Profile.new(activated_at: Time.zone.now))
-      allow(user).to receive(:pending_profile).
-        and_return(Profile.new(created_at: 1.day.ago))
-
-      expect(user.active_profile_newer_than_pending_profile?).to eq true
-    end
-
-    it 'returns false if the active profile is older than the pending profile' do
-      user = User.new
-      allow(user).to receive(:active_profile).and_return(Profile.new(activated_at: 1.day.ago))
-      allow(user).to receive(:pending_profile).
-        and_return(Profile.new(created_at: Time.zone.now))
-
-      expect(user.active_profile_newer_than_pending_profile?).to eq false
     end
   end
 

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -44,7 +44,7 @@ describe 'accounts/show.html.erb' do
 
   context 'when the user does not have pending_profile' do
     before do
-      allow(user).to receive(:pending_profile).and_return(false)
+      allow(user).to receive(:pending_profile).and_return(nil)
     end
 
     it 'lacks a pending profile section' do
@@ -58,7 +58,13 @@ describe 'accounts/show.html.erb' do
 
   context 'when current user has pending_profile' do
     before do
-      allow(user).to receive(:pending_profile).and_return(build(:profile))
+      pending = create(
+        :profile,
+        gpo_verification_pending_at: 2.days.ago,
+        created_at: 2.days.ago,
+        user: user,
+      )
+      allow(user).to receive(:pending_profile).and_return(pending)
     end
 
     it 'contains a link to activate profile' do


### PR DESCRIPTION
During the work on the profile state the `pending_profile` method got re-implemented to return the GPO pending profile. This commit changes that method so that is returns the profile that is pending for any reason.

In additional, this commit adds some tooling for managing those pending profiles.
