### PR TITLE
data-pull script: Switch -r flag to be -i

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -130,7 +130,7 @@ class DataPull
         Options:
       EOS
 
-      opts.on('-r=ISSUER', '--requesting-issuer=ISSUER', <<-MSG) do |issuer|
+      opts.on('-i=ISSUER', '--requesting-issuer=ISSUER', <<-MSG) do |issuer|
         requesting issuer (used for ig-request task)
       MSG
         config.requesting_issuers << issuer


### PR DESCRIPTION
**Why**: -r is "eaten" as a shorthand for --reason in the [calling script in the devops repo](https://github.com/18F/identity-devops/blob/eee825f5d8de2b56a7c0f8520224eb71a7eb5b2d/bin/data-pull#L49)


