### PR TITLE
Updating how gpo pending is set in dummy profile

### DIFF
--- a/spec/features/idv/confirm_start_over_spec.rb
+++ b/spec/features/idv/confirm_start_over_spec.rb
@@ -8,10 +8,10 @@ feature 'idv gpo confirm start over', js: true do
   let(:profile) do
     create(
       :profile,
-      deactivation_reason: :gpo_verification_pending,
       pii: { ssn: '123-45-6789', dob: '1970-01-01' },
       fraud_review_pending_at: nil,
       fraud_rejection_at: nil,
+      gpo_verification_pending_at: 1.day.ago,
     )
   end
   let(:gpo_confirmation_code) do


### PR DESCRIPTION
This PR fixes a test failure that was introduced to main from a recent merged PR. The issue was to do with how user profiles for GPO pending states are now determined (using a timestamp). CI did not catch this because the PR branch was not rebased on main prior to merge, and there were no other conflicts.
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
