### PR TITLE
LG-9767 add span to groups that allows sr to read out dob before date components

### DIFF
--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -20,7 +20,12 @@
             <%= p.input(
                   :month,
                   pattern: '(1[0-2])|(0?[1-9])',
-                  wrapper_html: { class: 'usa-form-group usa-form-group--month margin-bottom-0' },
+                  wrapper_html: {
+                    aria: {
+                      labelledby: [ "memorable-date-month-span-#{unique_id}" ],
+                    },
+                    class: 'usa-form-group usa-form-group--month margin-bottom-0',
+                  },
                   label: t('components.memorable_date.month'),
                   label_html: {
                     class: 'usa-label',
@@ -44,6 +49,9 @@
                   required:,
                 ) %>
           <% end %>
+          <span id=<%= "memorable-date-month-span-#{unique_id}" %> class="display-none">
+            <%= t('in_person_proofing.form.state_id.dob') %>
+          </span>
           <span id=<%= "memorable-date-month-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.month') %>
           </span>
@@ -53,7 +61,13 @@
           <%= p.input(
                 :day,
                 pattern: '(3[01])|([12][0-9])|(0?[1-9])',
-                wrapper_html: { class: 'usa-form-group usa-form-group--day margin-bottom-0' },
+                wrapper_html: {
+                  aria: {
+                    labelledby: [
+                      "memorable-date-day-span-#{unique_id}",
+                    ],
+                  },
+                  class: 'usa-form-group usa-form-group--day margin-bottom-0' },
                 label: t('components.memorable_date.day'),
                 label_html: {
                   class: 'usa-label',
@@ -77,6 +91,9 @@
                 required:,
               ) %>
           <% end %>
+          <span id=<%= "memorable-date-day-span-#{unique_id}" %> class="display-none">
+            <%= t('in_person_proofing.form.state_id.dob') %>
+          </span>
           <span id=<%= "memorable-date-day-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.day') %>
           </span>
@@ -86,7 +103,12 @@
           <%= p.input(
                 :year,
                 pattern: '\d{4}',
-                wrapper_html: { class: 'usa-form-group usa-form-group--year margin-bottom-0' },
+                wrapper_html: {
+                  aria: {
+                    labelledby: [ "memorable-date-year-span-#{unique_id}" ],
+                  },
+                  class: 'usa-form-group usa-form-group--year margin-bottom-0',
+                },
                 label: t('components.memorable_date.year'),
                 label_html: {
                   class: 'usa-label',
@@ -110,6 +132,9 @@
                 required:,
               ) %>
           <% end %>
+          <span id=<%= "memorable-date-year-span-#{unique_id}" %> class="display-none">
+            <%= t('in_person_proofing.form.state_id.dob') %>
+          </span>
           <span id=<%= "memorable-date-year-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.year') %>
           </span>

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -1,4 +1,4 @@
-<label class="usa-label">
+<label class="usa-label" id="dob-label">
     <%= label %>
 </label>
 <div id="validated-field-hint-<%= unique_id %>" class="usa-hint">
@@ -21,9 +21,7 @@
                   :month,
                   pattern: '(1[0-2])|(0?[1-9])',
                   wrapper_html: {
-                    aria: {
-                      labelledby: [ "memorable-date-month-span-#{unique_id}" ],
-                    },
+                    aria: { labelledby: [ "dob-label" ] },
                     class: 'usa-form-group usa-form-group--month margin-bottom-0',
                   },
                   label: t('components.memorable_date.month'),
@@ -49,9 +47,6 @@
                   required:,
                 ) %>
           <% end %>
-          <span id=<%= "memorable-date-month-span-#{unique_id}" %> class="display-none">
-            <%= t('in_person_proofing.form.state_id.dob') %>
-          </span>
           <span id=<%= "memorable-date-month-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.month') %>
           </span>
@@ -62,12 +57,9 @@
                 :day,
                 pattern: '(3[01])|([12][0-9])|(0?[1-9])',
                 wrapper_html: {
-                  aria: {
-                    labelledby: [
-                      "memorable-date-day-span-#{unique_id}",
-                    ],
-                  },
-                  class: 'usa-form-group usa-form-group--day margin-bottom-0' },
+                  aria: { labelledby: [ "dob-label" ] },
+                  class: 'usa-form-group usa-form-group--day margin-bottom-0',
+                },
                 label: t('components.memorable_date.day'),
                 label_html: {
                   class: 'usa-label',
@@ -91,9 +83,6 @@
                 required:,
               ) %>
           <% end %>
-          <span id=<%= "memorable-date-day-span-#{unique_id}" %> class="display-none">
-            <%= t('in_person_proofing.form.state_id.dob') %>
-          </span>
           <span id=<%= "memorable-date-day-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.day') %>
           </span>
@@ -104,9 +93,7 @@
                 :year,
                 pattern: '\d{4}',
                 wrapper_html: {
-                  aria: {
-                    labelledby: [ "memorable-date-year-span-#{unique_id}" ],
-                  },
+                  aria: { labelledby: [ "dob-label" ] },
                   class: 'usa-form-group usa-form-group--year margin-bottom-0',
                 },
                 label: t('components.memorable_date.year'),
@@ -132,9 +119,6 @@
                 required:,
               ) %>
           <% end %>
-          <span id=<%= "memorable-date-year-span-#{unique_id}" %> class="display-none">
-            <%= t('in_person_proofing.form.state_id.dob') %>
-          </span>
           <span id=<%= "memorable-date-year-hint-#{unique_id}" %> class="display-none">
             <%= t('in_person_proofing.form.state_id.date_hint.year') %>
           </span>

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -1,4 +1,4 @@
-<label class="usa-label" id="dob-label">
+<label class="usa-label" id="memorable-date-label-<%= unique_id %>">
     <%= label %>
 </label>
 <div id="validated-field-hint-<%= unique_id %>" class="usa-hint">
@@ -21,7 +21,7 @@
                   :month,
                   pattern: '(1[0-2])|(0?[1-9])',
                   wrapper_html: {
-                    aria: { labelledby: [ "dob-label" ] },
+                    aria: { labelledby: ["memorable-date-label-#{unique_id}"] },
                     class: 'usa-form-group usa-form-group--month margin-bottom-0',
                   },
                   label: t('components.memorable_date.month'),
@@ -57,7 +57,7 @@
                 :day,
                 pattern: '(3[01])|([12][0-9])|(0?[1-9])',
                 wrapper_html: {
-                  aria: { labelledby: [ "dob-label" ] },
+                  aria: { labelledby: ["memorable-date-label-#{unique_id}"] },
                   class: 'usa-form-group usa-form-group--day margin-bottom-0',
                 },
                 label: t('components.memorable_date.day'),
@@ -93,7 +93,7 @@
                 :year,
                 pattern: '\d{4}',
                 wrapper_html: {
-                  aria: { labelledby: [ "dob-label" ] },
+                  aria: { labelledby: ["memorable-date-label-#{unique_id}"] },
                   class: 'usa-form-group usa-form-group--year margin-bottom-0',
                 },
                 label: t('components.memorable_date.year'),

--- a/spec/components/memorable_date_component_spec.rb
+++ b/spec/components/memorable_date_component_spec.rb
@@ -63,8 +63,13 @@ RSpec.describe MemorableDateComponent, type: :component do
     expect(rendered).to have_css('input[aria-labelledby*="memorable-date-year-hint"]')
   end
 
+  it 'renders wrapper html with reference to label' do
+    expect(rendered).to have_css('div[aria-labelledby*="memorable-date-label"]', count: 3)
+  end
+
   it 'sets the label' do
     expect(rendered).to have_css('.usa-label', text: label)
+    expect(rendered).to have_css('label[id*="memorable-date-label"]')
   end
 
   it 'sets the hint' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-9767](https://cm-jira.usa.gov/browse/LG-9767)


## 🛠 Summary of changes

Adds span to memorable date component groups so that a screen reader reads out "Date of birth" before the month, day and year group.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through ipp flow and arrive at state id form
- [ ]  Enable screen reader
- [ ] Ensure "date of birth" is read out before month, day and year groupd


