### PR TITLE
Do not return cancelled or errored profiles from `#pending_profile`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,6 +116,8 @@ class User < ApplicationRecord
     ).order(created_at: :desc).first
 
     return unless pending.present?
+    return if pending.password_reset?
+    return if pending.encryption_error? || pending.verification_cancelled?
     return if active_profile.present? && active_profile.activated_at > pending.created_at
 
     pending

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -498,6 +498,20 @@ RSpec.describe User do
         expect(user.pending_profile).to be_nil
       end
     end
+
+    context 'verification was cancelled for a pending profile' do
+      it 'return nil' do
+        user = User.new
+        create(
+          :profile,
+          gpo_verification_pending_at: Time.zone.now,
+          deactivation_reason: :verification_cancelled,
+          user: user,
+        )
+
+        expect(user.pending_profile).to be_nil
+      end
+    end
   end
 
   describe '#gpo_verification_pending_profile' do


### PR DESCRIPTION
The pending profile will return a profile that is pending GPO confirmation, pending in-person, or pending fraud review.

In the above cases, if a user cancels verification or has an encryption error then their profile is no longer verifiable and is not pending. This commit adds a guard to the `pending_profile` method to return nil in these cases.
=