### PR TITLE
LG-9805: SSN input error messaging should be updated

### DIFF
--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -54,7 +54,7 @@ en:
       incorrect_password: The password you entered is not correct.
       mail_limit_reached: You have requested too much mail in the last month.
       pattern_mismatch:
-        ssn: 'Your Social Security number must be entered in as ###-##-####'
+        ssn: 'Enter a nine-digit Social Security number'
         zipcode: Enter a 5 or 9 digit ZIP Code
     failure:
       attempts:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -55,7 +55,7 @@ es:
       incorrect_password: La contraseña que ingresó no es correcta.
       mail_limit_reached: Usted ha solicitado demasiado correo en el último mes.
       pattern_mismatch:
-        ssn: 'Su número de Seguro Social debe ser ingresado como ### - ## - ####'
+        ssn: 'Ingrese un número de Seguro Social de nueve dígitos'
         zipcode: Ingresa un código postal de 5 o 9 dígitos
     failure:
       attempts:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -58,8 +58,7 @@ fr:
       incorrect_password: Le mot de passe que vous avez inscrit est incorrect.
       mail_limit_reached: Vous avez demandé trop de lettres au cours du dernier mois.
       pattern_mismatch:
-        ssn: 'Votre numéro de sécurité sociale doit être inscrit de cette façon :
-          ###-##-####'
+        ssn: 'Entrez un numéro de sécurité sociale à neuf chiffres'
         zipcode: Entrez un code postal à 5 ou 9 chiffres
     failure:
       attempts:


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-9805](https://cm-jira.usa.gov/browse/LG-9805)

## 🛠 Summary of changes
Update the validation error message for the SSN textfield to not display error message with # and hyphens but to say that a nine digit number is required.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots
<details>
<summary>Before:</summary>
<img width="699" alt="LG-9805_before_en" src="https://github.com/18F/identity-idp/assets/1261794/65a390ff-9348-4055-9c78-8a685b62843e">
<img width="635" alt="LG-9805_before_fr" src="https://github.com/18F/identity-idp/assets/1261794/6e7c0394-1bad-454f-a618-218878a8d352">
<img width="750" alt="LG-9805_before_es" src="https://github.com/18F/identity-idp/assets/1261794/2bee047b-1048-4619-a47c-2a85c3826dd1">
</details>

<details>
<summary>After:</summary>
<img width="773" alt="LG-9805_after_es" src="https://github.com/18F/identity-idp/assets/1261794/13e73c1d-5f26-46e0-b988-ed09a39d43e7">
<img width="695" alt="LG-9805_after_fr" src="https://github.com/18F/identity-idp/assets/1261794/16431841-c031-400c-8d42-5d2919dfa0b0">
<img width="789" alt="LG-9805_after_en" src="https://github.com/18F/identity-idp/assets/1261794/e1010400-13dc-4f3c-b338-2664a68e5d22">
</details>
