### PR TITLE
Adds make tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 	brakeman \
 	build_artifact \
 	check \
+	clobber_db \
+	clobber_assets \
+	clobber_logs \
 	docker_setup \
 	download_acuant_sdk \
 	fast_setup \
@@ -34,6 +37,7 @@ ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 	optimize_assets \
 	optimize_svg \
 	run \
+	tidy \
 	update \
 	urn \
 	README.md \
@@ -268,3 +272,25 @@ README.md: docs/ ## Generates README.md based on the contents of the docs direct
 
 download_acuant_sdk: ## Downloads the most recent Acuant SDK release from Github
 	@scripts/download_acuant_sdk.sh
+
+clobber_db:  ## resets the database for make setup
+	bin/rake db:create
+	bin/rake db:environment:set
+	bin/rake db:reset
+	bin/rake db:environment:set
+	bin/rake dev:prime
+
+clobber_assets:  ## removes assets
+	bin/rake assets:clobber
+	RAILS_ENV=test bin/rake assets:clobber
+
+clobber_logs:  ## purges logs
+	rm -f log/*
+	rm -rf tmp/cache/*
+	rm -rf tmp/encrypted_doc_storage
+	rm -rf tmp/letter_opener
+	rm -rf tmp/mails
+
+## Remove assets and logs, and unused gems, but leave DB alone
+tidy: clobber_assets clobber_logs
+	bundle clean

--- a/Makefile
+++ b/Makefile
@@ -291,5 +291,5 @@ clobber_logs: ## Purges logs and tmp/
 	rm -rf tmp/letter_opener
 	rm -rf tmp/mails
 
-tidy: clobber_assets clobber_logs ## Remove assets and logs, and unused gems, but leave DB alone
+tidy: clobber_assets clobber_logs ## Remove assets, logs, and unused gems, but leave DB alone
 	bundle clean

--- a/Makefile
+++ b/Makefile
@@ -273,24 +273,23 @@ README.md: docs/ ## Generates README.md based on the contents of the docs direct
 download_acuant_sdk: ## Downloads the most recent Acuant SDK release from Github
 	@scripts/download_acuant_sdk.sh
 
-clobber_db:  ## resets the database for make setup
+clobber_db: ## Resets the database for make setup
 	bin/rake db:create
 	bin/rake db:environment:set
 	bin/rake db:reset
 	bin/rake db:environment:set
 	bin/rake dev:prime
 
-clobber_assets:  ## removes assets
+clobber_assets: ## Removes (clobbers) assets
 	bin/rake assets:clobber
 	RAILS_ENV=test bin/rake assets:clobber
 
-clobber_logs:  ## purges logs
+clobber_logs: ## Purges logs and tmp/
 	rm -f log/*
 	rm -rf tmp/cache/*
 	rm -rf tmp/encrypted_doc_storage
 	rm -rf tmp/letter_opener
 	rm -rf tmp/mails
 
-## Remove assets and logs, and unused gems, but leave DB alone
-tidy: clobber_assets clobber_logs
+tidy: clobber_assets clobber_logs ## Remove assets and logs, and unused gems, but leave DB alone
 	bundle clean

--- a/bin/setup
+++ b/bin/setup
@@ -56,22 +56,13 @@ Dir.chdir APP_ROOT do
   run "yarn install"
 
   puts "\n== Preparing database =="
-  run 'bin/rake db:create'
-  run 'bin/rake db:environment:set'
-  run 'bin/rake db:reset'
-  run 'bin/rake db:environment:set'
-  run 'bin/rake dev:prime'
+  run 'make clobber_db'
 
   puts "\n== Cleaning up old assets =="
-  run "bin/rake assets:clobber"
-  run "RAILS_ENV=test bin/rake assets:clobber"
+  run "make clobber_assets"
 
   puts "\n== Removing old logs and tempfiles =="
-  run "rm -f log/*"
-  run "rm -rf tmp/cache"
-  run "rm -rf tmp/encrypted_doc_storage"
-  run "rm -rf tmp/letter_opener"
-  run "rm -rf tmp/mails"
+  run "make clobber_logs"
 
   puts "\n== Restarting application server =="
   run "mkdir -p tmp"


### PR DESCRIPTION
Do people like this? This is a little bit of a ragecoded thing.

I realized my identity-idp clone was using over 4GB of disk space. The bulk of the ridiculous stuff was:
- More than 1GB of test Attempts API log files, a unique one-off I cleaned up
- 1.6 GB of vendor/bundle/ stuff
- 700MB of logs

I wanted something like `make tidy` to exist, but it was somewhat duplicative of what `make setup` does. I don't like running `make setup` often because it's kind of heavy-handed and I don't want to mess with my DB. So I moved the relevant parts into individual Makefile targets.

This is purely a "I want this to exist" thing, so if it's contentious I'm fine withdrawing it.