### PR TITLE
Remove deactivation_reason in Profile#remove_gpo_deactivation_reason

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -73,9 +73,8 @@ class Profile < ApplicationRecord
 
   def remove_gpo_deactivation_reason
     update!(gpo_verification_pending_at: nil)
-    if deactivation_reason == 'gpo_verification_pending'
-      update!(deactivation_reason: nil)
-    end
+
+    update!(deactivation_reason: nil) if deactivation_reason == 'gpo_verification_pending'
   end
 
   def activate_after_passing_review

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -73,6 +73,9 @@ class Profile < ApplicationRecord
 
   def remove_gpo_deactivation_reason
     update!(gpo_verification_pending_at: nil)
+    if deactivation_reason == 'gpo_verification_pending'
+      update!(deactivation_reason: nil)
+    end
   end
 
   def activate_after_passing_review

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -7,6 +7,7 @@ feature 'idv gpo otp verification step' do
   let(:profile) do
     create(
       :profile,
+      deactivation_reason: 3,
       gpo_verification_pending_at: 2.days.ago,
       pii: { ssn: '123-45-6789', dob: '1970-01-01' },
       fraud_review_pending_at: fraud_review_pending_timestamp,


### PR DESCRIPTION
Because otherwise we get a 500 when entering a gpo code and trying to activate the profile.

This is a followup to #8432 which raises an exception if the profile has a deactivation reason when activation is attempted.

We found that the feature test for gpo code activation did not break because the test data does not match the current data model as we change over from deactivation reason to gpo_verification_pending_at.
