### PR TITLE
Bugfix: Updating GPO confirm cancel route path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,7 +392,7 @@ Rails.application.routes.draw do
 
     get '/account/verify' => 'idv/gpo_verify#index', as: :idv_gpo_verify
     post '/account/verify' => 'idv/gpo_verify#create'
-    get '/account/confirm_start_over' => 'idv/confirm_start_over#index', as: :idv_confirm_start_over
+    get '/account/verify/confirm_start_over' => 'idv/confirm_start_over#index', as: :idv_confirm_start_over
     if FeatureManagement.gpo_verification_enabled?
       scope '/verify', module: 'idv', as: 'idv' do
         get '/usps' => 'gpo#index', as: :gpo


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

## 🛠 Summary of changes
With #8393 we introduced a new interstitial screen with its own route, which should be under the GPO namespace. I made a mistake and forgot to include `/verify/` in the path (which for the moment indicates the GPO namespace). This PR rectifies the oversight. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
