### PR TITLE
Add note about deprecation of Docker use in docs

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,6 +1,6 @@
 # Docker
 
-Currently, Docker is not being widely used and is considered deprecated. [See this note about Docker](./local-development.md#installing-with-docker) for more details.
+Currently, Docker is not being widely used and this project's Docker configuration is considered deprecated. [See this note about Docker](./local-development.md#installing-with-docker) for more details.
 
 ## Overview
 

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,5 +1,9 @@
 # Docker
 
+Currently, Docker is not being widely used and is considered deprecated. [See this note about Docker](./local-development.md#installing-with-docker) for more details.
+
+## Overview
+
 We use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds) to build different kinds of containers. They utilise two upstream containers run by the DevOps team, `logindotgov/build` and `logindotgov/base`.
 
 1. `development.Dockerfile` installs development and test tools useful for local development.


### PR DESCRIPTION
## 🛠 Summary of changes

Finding this Docker documentation on its own, without coming to it from the `local-development.md` note about Docker deprecation, can be confusing. The doc gives the appearance Docker is being actively used by the project.

Adding a link to the deprecation explanation so that it is clear.

[See this Slack thread for more details](https://gsa-tts.slack.com/archives/C0NGESUN5/p1684517846543419).