### PR TITLE
Make the confirrm start over change backwards compatible

### DIFF
--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -45,7 +45,11 @@
   <%= link_to t('idv.messages.gpo.resend'), idv_gpo_path, class: 'display-block margin-bottom-2' %>
 <% end %>
 
-<%= link_to t('idv.messages.clear_and_start_over'), idv_confirm_start_over_path %>
+<%= button_to(
+      idv_session_path(step: 'gpo_verify', location: 'clear_and_start_over'),
+      method: :delete,
+      class: 'usa-button usa-button--unstyled',
+    ) { t('idv.messages.clear_and_start_over') } %>
 
 <div class="margin-top-2 padding-top-2 border-top border-primary-light">
   <%= link_to t('forms.verify_profile.return_to_profile'), account_path %>

--- a/spec/features/idv/confirm_start_over_spec.rb
+++ b/spec/features/idv/confirm_start_over_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'idv gpo confirm start over', js: true do
+xfeature 'idv gpo confirm start over', js: true do
   include IdvStepHelper
   include DocAuthHelper
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -419,7 +419,6 @@ RSpec.describe 'In Person Proofing', js: true do
       click_idv_continue
       click_on t('account.index.verification.reactivate_button')
       click_on t('idv.messages.clear_and_start_over')
-      click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_welcome_step)
     end

--- a/spec/support/idv_examples/clearing_and_restarting.rb
+++ b/spec/support/idv_examples/clearing_and_restarting.rb
@@ -1,7 +1,6 @@
 shared_examples 'clearing and restarting idv' do
   it 'allows the user to retry verification with phone', js: true do
     click_on t('idv.messages.clear_and_start_over')
-    click_idv_continue
 
     expect(user.reload.pending_profile?).to eq(false)
 
@@ -16,7 +15,6 @@ shared_examples 'clearing and restarting idv' do
 
   it 'allows the user to retry verification with gpo', js: true do
     click_on t('idv.messages.clear_and_start_over')
-    click_idv_continue
 
     expect(user.reload.pending_profile?).to eq(false)
 
@@ -41,7 +39,6 @@ shared_examples 'clearing and restarting idv' do
 
   it 'deletes decrypted PII from the session and does not display it on the account page' do
     click_on t('idv.messages.clear_and_start_over')
-    click_idv_continue
 
     visit account_path
 


### PR DESCRIPTION
Previous commits introduced a new screen for confirming you want to cancel IdV. Unfortunately this is not backwards compatible with the 50/50 state. The proper way to deploy this is:

1. Add the new page at an accessible route
2. Start redirecting users to the new route
3. Tear down any code that supported the old approach

This commit winds everything back to step 1 by making the new functionality available but not redirecting users to the new page.

Note that this particular change does not need step 3 since there actually is not an old route to remove. This adds an interstitial page that contains a form to make a request to a route that users are already using.
