### PR TITLE
Re-enabled the confirm start over screen

### DIFF
--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -45,11 +45,7 @@
   <%= link_to t('idv.messages.gpo.resend'), idv_gpo_path, class: 'display-block margin-bottom-2' %>
 <% end %>
 
-<%= button_to(
-      idv_session_path(step: 'gpo_verify', location: 'clear_and_start_over'),
-      method: :delete,
-      class: 'usa-button usa-button--unstyled',
-    ) { t('idv.messages.clear_and_start_over') } %>
+<%= link_to t('idv.messages.clear_and_start_over'), idv_confirm_start_over_path %>
 
 <div class="margin-top-2 padding-top-2 border-top border-primary-light">
   <%= link_to t('forms.verify_profile.return_to_profile'), account_path %>

--- a/spec/features/idv/confirm_start_over_spec.rb
+++ b/spec/features/idv/confirm_start_over_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-xfeature 'idv gpo confirm start over', js: true do
+feature 'idv gpo confirm start over', js: true do
   include IdvStepHelper
   include DocAuthHelper
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -419,6 +419,7 @@ RSpec.describe 'In Person Proofing', js: true do
       click_idv_continue
       click_on t('account.index.verification.reactivate_button')
       click_on t('idv.messages.clear_and_start_over')
+      click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_welcome_step)
     end

--- a/spec/support/idv_examples/clearing_and_restarting.rb
+++ b/spec/support/idv_examples/clearing_and_restarting.rb
@@ -1,6 +1,7 @@
 shared_examples 'clearing and restarting idv' do
   it 'allows the user to retry verification with phone', js: true do
     click_on t('idv.messages.clear_and_start_over')
+    click_idv_continue
 
     expect(user.reload.pending_profile?).to eq(false)
 
@@ -15,6 +16,7 @@ shared_examples 'clearing and restarting idv' do
 
   it 'allows the user to retry verification with gpo', js: true do
     click_on t('idv.messages.clear_and_start_over')
+    click_idv_continue
 
     expect(user.reload.pending_profile?).to eq(false)
 
@@ -39,6 +41,7 @@ shared_examples 'clearing and restarting idv' do
 
   it 'deletes decrypted PII from the session and does not display it on the account page' do
     click_on t('idv.messages.clear_and_start_over')
+    click_idv_continue
 
     visit account_path
 


### PR DESCRIPTION
In #8448 I removed the link to the confirm start over screen to maintain backwards compatibility. Now that that change is deployed to production we can start directing users to the new screen. This commit makes that change.
