### PR TITLE
Add support for reading configuration from system environment variables

### DIFF
--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -15,7 +15,7 @@ class IdentityConfig
     # database_host: ['env', 'DATABASE_HOST']
     # To use a string value directly, you can specify a string explicitly:
     # database_host: 'localhost'
-    system_environment_or_string: proc do |value|
+    string: proc do |value|
       if value.is_a?(Array) && value.length == 2 && value.first == 'env'
         ENV.fetch(value[1])
       elsif value.is_a?(String)
@@ -24,7 +24,6 @@ class IdentityConfig
         raise 'invalid system environment configuration value'
       end
     end,
-    string: proc { |value| value.to_s },
     symbol: proc { |value| value.to_sym },
     comma_separated_string_list: proc do |value|
       value.split(',')

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -10,6 +10,20 @@ class IdentityConfig
   end
 
   CONVERTERS = {
+    # Allows loading a string configuration from a system environment variable
+    # ex: To read DATABASE_HOST from system environment for the database_host key
+    # database_host: ['env', 'DATABASE_HOST']
+    # To use a string value directly, you can specify a string explicitly:
+    # database_host: 'localhost'
+    system_environment_or_string: proc do |value|
+      if value.is_a?(Array) && value.length == 2 && value.first == 'env'
+        ENV.fetch(value[1])
+      elsif value.is_a?(String)
+        value
+      else
+        raise 'invalid system environment configuration value'
+      end
+    end,
     string: proc { |value| value.to_s },
     symbol: proc { |value| value.to_sym },
     comma_separated_string_list: proc do |value|


### PR DESCRIPTION
## 🛠 Summary of changes

As we continue our work on building quickly-deployed review applications, we have the need to read config in via environment variables at boot time.

Assumptions:

- We will be expanding the scope of reading config from environment variables, including different data types
- Configuration via files as we do now will continue to be the primary form of config for the foreseeable future
- No new configuration data types will be introduced

The short implementation in this PR is my proposal to allow a given configuration key to opt-in to specifying an environment variable per-environment. Currently this is only targeted at review environment applications, and we will likely want a fuller evaluation of the options for setting and loading configuration if the scope expands in the future. This implementation is quite small, and since review applications are short-lived, the backwards compatibility of this is not critical. If our configuration needs change drastically, review applications will hopefully not be a huge lift to transition.

### Alternatives:

#### Hardcode the variable used as an option
ex:
```ruby
    config.add(:database_host, type: :string, options: { environment_variable: "DATABASE_HOST" })
```

I'm not sure I like this since a deployed environment may end up using an environment variable unexpectedly if the variable is set and does not allow for opting-in to this behavior.

#### Something Else?

???

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
