### PR TITLE
Use the presence of the flow path in the session as a proxy for upload step completion

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -50,7 +50,7 @@ module Idv
     private
 
     def confirm_upload_step_complete
-      return if flow_session['Idv::Steps::UploadStep']
+      return if flow_session[:flow_path].present?
 
       redirect_to idv_doc_auth_url
     end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -85,7 +85,7 @@ describe Idv::DocumentCaptureController do
 
     context 'upload step is not complete' do
       it 'redirects to idv_doc_auth_url' do
-        flow_session['Idv::Steps::UploadStep'] = nil
+        flow_session.delete(:flow_path)
 
         get :show
 


### PR DESCRIPTION
The document capture controller no longer uses the FSM. It does, however, check that the upload step in the flow state machine is complete. Prior to this commit it checks that the step is marked complete in the flow session. This means that we need to continue marking the step complete in an eventual upload step replacement.

This commit changes the way that we check that the step is complete to look that the `flow_path` has been set. This brings the upload step completion in line with the new link sent controller.
