### PR TITLE
Rename handle_valid_otp_for_authentication_context to handle_valid_verification_for_authentication_context

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -108,7 +108,7 @@ module TwoFactorAuthenticatableMethods
 
   def handle_valid_otp_for_context(auth_method:)
     if UserSessionContext.authentication_or_reauthentication_context?(context)
-      handle_valid_otp_for_authentication_context(auth_method: auth_method)
+      handle_valid_verification_for_authentication_context(auth_method: auth_method)
     elsif UserSessionContext.confirmation_context?(context)
       handle_valid_verification_for_confirmation_context(auth_method: auth_method)
     end
@@ -174,7 +174,7 @@ module TwoFactorAuthenticatableMethods
     reset_second_factor_attempts_count
   end
 
-  def handle_valid_otp_for_authentication_context(auth_method:)
+  def handle_valid_verification_for_authentication_context(auth_method:)
     user_session[:auth_method] = auth_method
     mark_user_session_authenticated(:valid_2fa)
     create_user_event(:sign_in_after_2fa)

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -61,7 +61,7 @@ module TwoFactorAuthentication
 
     def handle_result(result)
       if result.success?
-        handle_valid_otp_for_authentication_context(
+        handle_valid_verification_for_authentication_context(
           auth_method: TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
         )
         return handle_last_code if all_codes_used?

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -89,7 +89,7 @@ module TwoFactorAuthentication
     end
 
     def handle_valid_otp
-      handle_valid_otp_for_authentication_context(
+      handle_valid_verification_for_authentication_context(
         auth_method: TwoFactorAuthenticatable::AuthMethod::PERSONAL_KEY,
       )
       if current_user.identity_verified? || current_user.password_reset_profile.present?

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -50,7 +50,7 @@ module TwoFactorAuthentication
         presented: true,
       )
 
-      handle_valid_otp_for_authentication_context(
+      handle_valid_verification_for_authentication_context(
         auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )
       redirect_to after_otp_verification_confirmation_url

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -40,7 +40,7 @@ module TwoFactorAuthentication
     end
 
     def handle_valid_webauthn
-      handle_valid_otp_for_authentication_context(auth_method: 'webauthn')
+      handle_valid_verification_for_authentication_context(auth_method: 'webauthn')
       handle_remember_device
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data


### PR DESCRIPTION
## 🛠 Summary of changes

This method is used for more than OTPs and brings it in line with the renaming for `handle_valid_verification_for_confirmation_context` in #8431.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
