### PR TITLE
Remove the backup code logic from the verify profile concern

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include VerifyProfileConcern
+  include BackupCodeReminderConcern
   include LocaleHelper
   include VerifySpAttributesConcern
   include EffectiveUser
@@ -238,7 +239,10 @@ class ApplicationController < ActionController::Base
   end
 
   def signed_in_url
-    user_fully_authenticated? ? account_or_verify_profile_url : user_two_factor_authentication_url
+    return user_two_factor_authentication_url unless user_fully_authenticated?
+    return account_or_verify_profile_url if profile_needs_verification?
+    return backup_code_reminder_url if user_needs_backup_code_reminder?
+    account_url
   end
 
   def after_mfa_setup_path

--- a/app/controllers/concerns/backup_code_reminder_concern.rb
+++ b/app/controllers/concerns/backup_code_reminder_concern.rb
@@ -1,0 +1,14 @@
+module BackupCodeReminderConcern
+  def user_needs_backup_code_reminder?
+    user_backup_codes_configured? && user_last_signed_in_more_than_5_months_ago?
+  end
+
+  def user_backup_codes_configured?
+    MfaContext.new(current_user).backup_code_configurations.present?
+  end
+
+  def user_last_signed_in_more_than_5_months_ago?
+    second_last_signed_in_at = current_user.second_last_signed_in_at
+    second_last_signed_in_at && second_last_signed_in_at < 5.months.ago
+  end
+end

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -4,21 +4,7 @@ module VerifyProfileConcern
   def account_or_verify_profile_url
     return reactivate_account_url if user_needs_to_reactivate_account?
     return idv_gpo_verify_url if profile_needs_verification?
-    return backup_code_reminder_url if user_needs_backup_code_reminder?
     account_url
-  end
-
-  def user_needs_backup_code_reminder?
-    user_backup_codes_configured? && user_last_signed_in_more_than_5_months_ago?
-  end
-
-  def user_backup_codes_configured?
-    MfaContext.new(current_user).backup_code_configurations.present?
-  end
-
-  def user_last_signed_in_more_than_5_months_ago?
-    second_last_signed_in_at = current_user.second_last_signed_in_at
-    second_last_signed_in_at && second_last_signed_in_at < 5.months.ago
   end
 
   def profile_needs_verification?


### PR DESCRIPTION
The verify profile concern is intened to redirect users with profiles that need additional work to verify or unlock to the appropriate place. The backup code reminder logic got mixed into this which causes a little confusion and indirection. This commit moves that logic into its own concern.
