### PR TITLE
LG-9709: Add autocomplete attribute to password fields

### DIFF
--- a/app/components/password_confirmation_component.html.erb
+++ b/app/components/password_confirmation_component.html.erb
@@ -8,6 +8,7 @@
         **field_options,
         input_html: field_options[:input_html].to_h.merge(
           id: input_id,
+          autocomplete: 'new-password',
           class: ['password-confirmation__input', *field_options.dig(:input_html, :class)],
         ),
       ) %>
@@ -20,6 +21,7 @@
         **field_options,
         input_html: field_options[:input_html].to_h.merge(
           id: input_confirmation_id,
+          autocomplete: 'new-password',
           class: ['password-confirmation__input-confirmation', *field_options.dig(:input_html, :class)],
         ),
         wrapper_html: field_options[:wrapper_html].to_h.merge(
@@ -28,7 +30,7 @@
         error_messages: {
           valueMissing: t('components.password_confirmation.errors.empty'),
         },
-      ) %>      
+      ) %>
   <input
     id="<%= toggle_id %>"
     type="checkbox"

--- a/app/components/password_confirmation_component.scss
+++ b/app/components/password_confirmation_component.scss
@@ -1,0 +1,3 @@
+lg-password-confirmation {
+  display: block;
+}

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -17,6 +17,9 @@
         field_options: {
           label: t('forms.passwords.edit.labels.password'),
           required: true,
+          input_html: {
+            autocomplete: 'new-password',
+          },
         },
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -46,9 +46,11 @@
   <%= render PasswordToggleComponent.new(
         form: f,
         class: 'margin-bottom-4',
-        field_options: { required: true },
-        input_html: {
-          autocomplete: 'current-password',
+        field_options: {
+          required: true,
+          input_html: {
+            autocomplete: 'current-password',
+          },
         },
       ) %>
   <%= f.submit t('links.next'), full_width: true, wide: false %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -47,6 +47,9 @@
         form: f,
         class: 'margin-bottom-4',
         field_options: { required: true },
+        input_html: {
+          autocomplete: 'current-password',
+        },
       ) %>
   <%= f.submit t('links.next'), full_width: true, wide: false %>
   <% if @sign_in_a_b_test_bucket == :default %>

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -15,6 +15,9 @@
           field_options: {
             label: t('forms.passwords.edit.labels.password'),
             required: true,
+            input_html: {
+              autocomplete: 'new-password',
+            },
           },
         ) %>
     <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -30,6 +30,9 @@
         field_options: {
           label: t('idv.form.password'),
           required: true,
+          input_html: {
+            autocomplete: 'current-password',
+          },
         },
       ) %>
   <div class="text-right margin-top-neg-4 margin-bottom-4">

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -12,7 +12,15 @@
       url: reauthn_user_password_path,
       html: { autocomplete: 'off', method: 'post', class: 'margin-top-4' },
     ) do |f| %>
-  <%= render PasswordToggleComponent.new(form: f, field_options: { required: true }) %>
+  <%= render PasswordToggleComponent.new(
+        form: f,
+        field_options: {
+          required: true,
+          input_html: {
+            autocomplete: 'current-password',
+          },
+        },
+      ) %>
   <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>
 <% end %>
 <%= render 'shared/cancel', link: account_path %>

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -28,6 +28,9 @@
           name: :password,
           label: t('idv.form.password'),
           required: true,
+          input_html: {
+            autocomplete: 'current-password',
+          },
         },
       ) %>
 

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -17,7 +17,10 @@
           name: :password,
           label: t('forms.passwords.edit.labels.password'),
           required: true,
-          input_html: { aria: { describedby: 'password-description' } },
+          input_html: {
+            aria: { describedby: 'password-description' },
+            autocomplete: 'new-password',
+          },
         },
       ) %>
   <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -16,6 +16,9 @@
           name: :password,
           label: t('idv.form.password'),
           required: true,
+          input_html: {
+            autocomplete: 'current-password',
+          },
         },
       ) %>
   <%= f.submit t('forms.buttons.continue'), class: 'margin-top-5' %>

--- a/spec/components/password_confirmation_component_spec.rb
+++ b/spec/components/password_confirmation_component_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe PasswordConfirmationComponent, type: :component do
+  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
+  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:form) { SimpleForm::FormBuilder.new('', {}, view_context, {}) }
+
+  subject(:rendered) do
+    render_inline PasswordConfirmationComponent.new(form:)
+  end
+
+  it 'renders password fields with expected attributes' do
+    expect(rendered).to have_css('[type=password][autocomplete=new-password]', count: 2)
+  end
+end

--- a/spec/components/previews/password_confirmation_component_preview.rb
+++ b/spec/components/previews/password_confirmation_component_preview.rb
@@ -1,0 +1,19 @@
+class PasswordConfirmationComponentPreview < BaseComponentPreview
+  # @!group Preview
+  # @display form true
+  def default
+    render(PasswordConfirmationComponent.new(form: form_builder))
+  end
+  # @!endgroup
+
+  # @display form true
+  # @param toggle_label text
+  def workbench(toggle_label: nil)
+    render(
+      PasswordConfirmationComponent.new(
+        form: form_builder,
+        **{ toggle_label: }.compact,
+      ),
+    )
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9709](https://cm-jira.usa.gov/browse/LG-9709)

## 🛠 Summary of changes

Adds `autocomplete` attributes to every password field in the application, set to either `new-password` or `current-password` based on context of the field's usage.

Related resources:

- https://web.dev/sign-in-form-best-practices/#new-password
- https://web.dev/sign-in-form-best-practices/#current-password
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#sect14
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#sect15

The practical impact of this can be improved autofill options offered by the browser. See screenshots for an example.

## 📜 Testing Plan

- Verify that autocomplete still works as expected in your browser for affected password fields.

## 👀 Screenshots

Example showing effect of `[autocomplete=new-password]` in Chrome:

Before|After
---|---
![Screen Shot 2023-05-23 at 1 31 20 PM](https://github.com/18F/identity-idp/assets/1779930/1713dd54-4f95-467b-8a3d-a1d9215e91de)|![Screen Shot 2023-05-23 at 1 31 31 PM](https://github.com/18F/identity-idp/assets/1779930/c2184cbc-0dc5-48c6-a740-c5caa70db960)
