### PR TITLE
Use the verify profile concern to sort through all of the reasons a user may be pending

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -240,7 +240,8 @@ class ApplicationController < ActionController::Base
 
   def signed_in_url
     return user_two_factor_authentication_url unless user_fully_authenticated?
-    return account_or_verify_profile_url if profile_needs_verification?
+    return reactivate_account_url if user_needs_to_reactivate_account?
+    return url_for_pending_profile_reason if user_has_pending_profile?
     return backup_code_reminder_url if user_needs_backup_code_reminder?
     account_url
   end

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -1,15 +1,15 @@
 module VerifyProfileConcern
   private
 
-  def account_or_verify_profile_url
-    return reactivate_account_url if user_needs_to_reactivate_account?
-    return idv_gpo_verify_url if profile_needs_verification?
-    account_url
+  def url_for_pending_profile_reason
+    return idv_gpo_verify_url if current_user.gpo_verification_pending_profile?
+    return idv_in_person_ready_to_verify_url if current_user.in_person_pending_profile?
+    return idv_please_call_url if current_user.fraud_review_pending?
+    idv_not_verified_url if current_user.fraud_rejection?
   end
 
-  def profile_needs_verification?
+  def user_has_pending_profile?
     return false if current_user.blank?
-    current_user.gpo_verification_pending_profile? ||
-      user_needs_to_reactivate_account?
+    current_user.pending_profile?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,6 +143,14 @@ class User < ApplicationRecord
     pending_profile if pending_profile&.fraud_rejection?
   end
 
+  def in_person_pending_profile?
+    in_person_pending_profile.present?
+  end
+
+  def in_person_pending_profile
+    pending_profile if pending_profile&.in_person_verification_pending?
+  end
+
   def personal_key_generated_at
     encrypted_recovery_code_digest_generated_at ||
       active_profile&.verified_at ||

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2073,7 +2073,7 @@ describe SamlIdpController do
 
         stub_analytics
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
-        allow(controller).to receive(:profile_needs_verification?).and_return(true)
+        allow(controller).to receive(:user_has_pending_profile?).and_return(true)
 
         analytics_hash = {
           success: true,


### PR DESCRIPTION
We have made changes to the `pending_profile` concept in the IdP. Previously a profile was pending if the user was waiting on GPO verification. We have added more out of band flows which result in more pending reasons:

1. GPO Verification
2. Fraud review
3. In-person proofing

This logic got spread throughout the codebase in ways that were often kind of tough to follow. This led to lots of bugs trying to send the user to the right place to finish proofing.

This commit collects that logic in the `VerifyProfileConcern`. This was chosen because this is where much of the logic for the GPO confirmation flow lived already.
