### PR TITLE
Upgrade ViewComponent dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'jsbundling-rails', '~> 1.0.0'
 gem 'jwe'
 gem 'jwt'
 gem 'lograge', '>= 0.11.2'
-gem 'lookbook', '~> 1.5.3', require: false
+gem 'lookbook', '~> 2.0.0', require: false
 gem 'lru_redux'
 gem 'msgpack', '~> 1.6'
 gem 'maxminddb'
@@ -68,7 +68,7 @@ gem 'subprocess', require: false
 gem 'terminal-table', require: false
 gem 'uglifier', '~> 4.2'
 gem 'valid_email', '>= 0.1.3'
-gem 'view_component', '~> 2.82.0'
+gem 'view_component', '~> 3.0.0'
 gem 'webauthn', '~> 2.5.2'
 gem 'xmldsig', '~> 0.6'
 gem 'xmlenc', '~> 0.7', '>= 0.7.1'

--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,6 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'irb'
   gem 'letter_opener', '~> 1.8'
-  gem 'listen'
   gem 'octokit', '>= 4.25.0'
   gem 'rack-mini-profiler', '>= 1.1.3', require: false
   gem 'rails-erd', '>= 1.6.0'
@@ -99,6 +98,7 @@ group :development, :test do
   gem 'erb_lint', '~> 0.3.0', require: false
   gem 'i18n-tasks', '~> 1.0'
   gem 'knapsack'
+  gem 'listen'
   gem 'nokogiri', '~> 1.14.0'
   gem 'pg_query', require: false
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,17 +375,16 @@ GEM
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lookbook (1.5.3)
-      actioncable
+    lookbook (2.0.3)
       activemodel
       css_parser
       htmlbeautifier (~> 1.3)
       htmlentities (~> 4.3.4)
-      listen (~> 3.0)
+      marcel (~> 1.0)
       railties (>= 5.0)
       redcarpet (~> 3.5)
       rouge (>= 3.26, < 5.0)
-      view_component (> 2.0, < 4)
+      view_component (>= 2.0)
       yard (~> 0.9.25)
       zeitwerk (~> 2.5)
     lru_redux (1.1.0)
@@ -549,7 +548,7 @@ GEM
     retries (0.0.5)
     rexml (3.2.5)
     rotp (6.2.0)
-    rouge (4.1.0)
+    rouge (4.1.1)
     rqrcode (2.1.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
@@ -667,7 +666,7 @@ GEM
       activemodel
       mail (>= 2.6.1)
       simpleidn
-    view_component (2.82.0)
+    view_component (3.0.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -766,7 +765,7 @@ DEPENDENCIES
   letter_opener (~> 1.8)
   listen
   lograge (>= 0.11.2)
-  lookbook (~> 1.5.3)
+  lookbook (~> 2.0.0)
   lru_redux
   maxminddb
   msgpack (~> 1.6)
@@ -826,7 +825,7 @@ DEPENDENCIES
   terminal-table
   uglifier (~> 4.2)
   valid_email (>= 0.1.3)
-  view_component (~> 2.82.0)
+  view_component (~> 3.0.0)
   webauthn (~> 2.5.2)
   webdrivers (~> 5.2.0)
   webmock

--- a/app/components/javascript_required_component.html.erb
+++ b/app/components/javascript_required_component.html.erb
@@ -1,6 +1,6 @@
 <noscript>
   <%= render StatusPageComponent.new(status: :error) do |c| %>
-    <% c.header { header } %>
+    <% c.with_header { header } %>
 
     <% if intro %>
       <p><%= intro %></p>

--- a/app/components/password_confirmation_component.html.erb
+++ b/app/components/password_confirmation_component.html.erb
@@ -3,7 +3,7 @@
         form: form,
         name: :password,
         type: :password,
-        label: default_label,
+        label: t('forms.password'),
         required: true,
         **field_options,
         input_html: field_options[:input_html].to_h.merge(
@@ -16,7 +16,7 @@
         form: form,
         name: :password_confirmation,
         type: :password_confirmation,
-        label: confirmation_label,
+        label: t('components.password_confirmation.confirm_label'),
         required: true,
         **field_options,
         input_html: field_options[:input_html].to_h.merge(
@@ -41,7 +41,7 @@
     for="<%= toggle_id %>"
     class="usa-checkbox__label password-confirmation__toggle-label"
   >
-    <%= toggle_label %>
+    <%= t('components.password_confirmation.toggle_label') %>
   </label>
 
   <%= form.hidden_field :confirmation_enabled, value: true %>

--- a/app/components/password_confirmation_component.rb
+++ b/app/components/password_confirmation_component.rb
@@ -1,24 +1,14 @@
 class PasswordConfirmationComponent < BaseComponent
-  attr_reader :form, :toggle_label, :field_options, :tag_options
+  attr_reader :form, :field_options, :tag_options
 
   def initialize(
     form:,
-    toggle_label: t('components.password_confirmation.toggle_label'),
     field_options: {},
     **tag_options
   )
     @form = form
-    @toggle_label = toggle_label
     @field_options = field_options
     @tag_options = tag_options
-  end
-
-  def default_label
-    t('forms.password')
-  end
-
-  def confirmation_label
-    t('components.password_confirmation.confirm_label')
   end
 
   def toggle_id

--- a/app/components/password_toggle_component.html.erb
+++ b/app/components/password_toggle_component.html.erb
@@ -3,7 +3,7 @@
         form:,
         name: :password,
         type: :password,
-        label: default_label,
+        label: label,
         **field_options,
         input_html: field_options[:input_html].to_h.merge(
           id: input_id,

--- a/app/components/password_toggle_component.rb
+++ b/app/components/password_toggle_component.rb
@@ -1,9 +1,10 @@
 class PasswordToggleComponent < BaseComponent
-  attr_reader :form, :label, :toggle_label, :field_options, :tag_options
+  attr_reader :form, :field_options, :tag_options
 
   def initialize(
     form:,
-    toggle_label: t('components.password_toggle.toggle_label'),
+    label: nil,
+    toggle_label: nil,
     field_options: {},
     **tag_options
   )
@@ -14,8 +15,12 @@ class PasswordToggleComponent < BaseComponent
     @tag_options = tag_options
   end
 
-  def default_label
-    t('components.password_toggle.label')
+  def label
+    @label || t('components.password_toggle.label')
+  end
+
+  def toggle_label
+    @toggle_label || t('components.password_toggle.toggle_label')
   end
 
   def toggle_id

--- a/app/views/account_reset/recovery_options/show.html.erb
+++ b/app/views/account_reset/recovery_options/show.html.erb
@@ -6,11 +6,11 @@
 </p>
 
   <%= render ProcessListComponent.new(class: 'margin-y-3') do |c| %>
-    <%= c.item(heading: t('account_reset.recovery_options.try_method_again')) %>
-    <%= c.item(heading: t('account_reset.recovery_options.use_device')) do %>
+    <%= c.with_item(heading: t('account_reset.recovery_options.try_method_again')) %>
+    <%= c.with_item(heading: t('account_reset.recovery_options.use_device')) do %>
       <p><%= t('account_reset.recovery_options.try_another_device') %></p>
     <% end %>
-    <%= c.item(heading: t('account_reset.recovery_options.check_webauthn_platform')) do %>
+    <%= c.with_item(heading: t('account_reset.recovery_options.check_webauthn_platform')) do %>
       <p><%= t('account_reset.recovery_options.check_webauthn_platform_info', app_name: APP_NAME) %></p>
     <% end %>
   <% end %>

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -1,7 +1,7 @@
 <% title t('titles.idv.cancelled') %>
 
 <%= render StatusPageComponent.new(status: :error) do |c| %>
-  <% c.header { t('idv.cancel.headings.confirmation.hybrid') } %>
+  <% c.with_header { t('idv.cancel.headings.confirmation.hybrid') } %>
 
   <p><%= t('doc_auth.instructions.switch_back') %></p>
   <%= image_tag(asset_url('idv/switch.png'), width: 193, height: 109, alt: t('doc_auth.instructions.switch_back_image')) %>

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -2,17 +2,17 @@
 
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
   <% if @hybrid_session %>
-    <% c.header { t('idv.cancel.headings.prompt.hybrid') } %>
+    <% c.with_header { t('idv.cancel.headings.prompt.hybrid') } %>
 
     <p><%= t('idv.cancel.description.hybrid') %></p>
 
-    <% c.action_button(
+    <% c.with_action_button(
          action: ->(**tag_options, &block) do
            button_to(idv_cancel_path(step: params[:step], location: 'cancel'), **tag_options, &block)
          end,
          method: :delete,
        ).with_content(t('forms.buttons.cancel')) %>
-    <% c.action_button(
+    <% c.with_action_button(
          action: ->(**tag_options, &block) do
            button_to(idv_cancel_path(step: params[:step]), **tag_options, &block)
          end,
@@ -20,7 +20,7 @@
          outline: true,
        ).with_content(t('links.go_back')) %>
   <% else %>
-    <% c.header { t('idv.cancel.headings.prompt.standard') } %>
+    <% c.with_header { t('idv.cancel.headings.prompt.standard') } %>
 
     <h2 class="margin-top-4 margin-bottom-2"><%= t('idv.cancel.headings.start_over') %></h2>
 

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -23,13 +23,13 @@
     <h2><%= t('doc_auth.instructions.welcome') %></h2>
 
     <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
-      <%= c.item(heading: t('doc_auth.instructions.bullet1')) do %>
+      <%= c.with_item(heading: t('doc_auth.instructions.bullet1')) do %>
         <p><%= t('doc_auth.instructions.text1') %></p>
       <% end %>
-      <%= c.item(heading: t('doc_auth.instructions.bullet2')) do %>
+      <%= c.with_item(heading: t('doc_auth.instructions.bullet2')) do %>
         <p><%= t('doc_auth.instructions.text2') %></p>
       <% end %>
-      <%= c.item(heading: t('doc_auth.instructions.bullet3')) do %>
+      <%= c.with_item(heading: t('doc_auth.instructions.bullet3')) do %>
         <ul class="usa-list">
           <% t('doc_auth.instructions.text3_html').each do |bullet_item| %>
             <li><%= bullet_item %></li>

--- a/app/views/idv/forgot_password/new.html.erb
+++ b/app/views/idv/forgot_password/new.html.erb
@@ -1,7 +1,7 @@
 <% title t('titles.idv.reset_password') %>
 
 <%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
-  <% c.header { t('idv.forgot_password.modal_header') } %>
+  <% c.with_header { t('idv.forgot_password.modal_header') } %>
 
   <ul class="usa-list">
     <% t('idv.forgot_password.warnings').each do |warning| %>
@@ -9,13 +9,13 @@
     <% end %>
   </ul>
 
-  <% c.action_button(
+  <% c.with_action_button(
        action: ->(**tag_options, &block) do
          link_to(idv_review_path, **tag_options, &block)
        end,
      ) { t('idv.forgot_password.try_again') } %>
 
-  <% c.action_button(
+  <% c.with_action_button(
        action: ->(**tag_options, &block) do
          button_to(idv_forgot_password_path, method: :post, **tag_options, &block)
        end,

--- a/app/views/idv/gpo_only_warning/show.html.erb
+++ b/app/views/idv/gpo_only_warning/show.html.erb
@@ -6,7 +6,7 @@
     ) %>
 
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
-  <% c.header { t('vendor_outage.alerts.pinpoint.idv.header') } %>
+  <% c.with_header { t('vendor_outage.alerts.pinpoint.idv.header') } %>
   <p>
     <%= t('vendor_outage.alerts.pinpoint.idv.message_html', app_name: APP_NAME, sp_name: current_sp&.friendly_name || APP_NAME) %>
   </p>
@@ -18,7 +18,7 @@
       </li>
     <% end %>
   </ul>
-  <% c.action_button(
+  <% c.with_action_button(
        action: ->(**tag_options, &block) do
          link_to(idv_doc_auth_step_path(step: :welcome), **tag_options, &block)
        end,
@@ -26,7 +26,7 @@
        wide: true,
        class: 'usa-button',
      ).with_content(t('doc_auth.buttons.continue')) %>
-  <% c.action_button(
+  <% c.with_action_button(
        action: ->(**tag_options, &block) do
          link_to(exit_url, **tag_options, &block)
        end,
@@ -35,14 +35,14 @@
        outline: true,
        class: 'usa-button',
      ).with_content(t('links.exit_login', app_name: APP_NAME)) %>
-  <% c.troubleshooting_options do |tc| %>
-    <% tc.header { t('components.troubleshooting_options.default_heading') } %>
-    <% tc.option(
+  <% c.with_troubleshooting_options do |tc| %>
+    <% tc.with_header { t('components.troubleshooting_options.default_heading') } %>
+    <% tc.with_option(
          url: StatusPage.base_url,
          new_tab: true,
        ).with_content(t('vendor_outage.get_updates_on_status_page')) %>
     <% if decorated_session.sp_name %>
-      <% tc.option(
+      <% tc.with_option(
            url: current_sp.return_to_sp_url,
            new_tab: true,
          ).with_content(

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -44,17 +44,17 @@
 <section class="border-1px border-primary-light radius-lg padding-4">
   <h2 class="margin-top-0 margin-bottom-2"><%= t('in_person_proofing.body.barcode.what_to_expect') %></h2>
   <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
-    <% c.item(heading: t('in_person_proofing.process.what_to_do.heading')) do %>
+    <% c.with_item(heading: t('in_person_proofing.process.what_to_do.heading')) do %>
       <p><%= t('in_person_proofing.process.what_to_do.info', app_name: APP_NAME) %></p>
     <% end %>
-    <% c.item(heading: t('in_person_proofing.process.barcode.heading', app_name: APP_NAME)) do %>
+    <% c.with_item(heading: t('in_person_proofing.process.barcode.heading', app_name: APP_NAME)) do %>
       <p class="margin-bottom-105"><%= t('in_person_proofing.process.barcode.info') %></p>
     <% end %>
-    <% c.item(heading: t('in_person_proofing.process.state_id.heading')) do %>
+    <% c.with_item(heading: t('in_person_proofing.process.state_id.heading')) do %>
       <p><%= t('in_person_proofing.process.state_id.info') %></p>
     <% end %>
     <% if @presenter.needs_proof_of_address? %>
-      <% c.item(heading: t('in_person_proofing.process.proof_of_address.heading')) do %>
+      <% c.with_item(heading: t('in_person_proofing.process.proof_of_address.heading')) do %>
         <p class="margin-bottom-105"><%= t('in_person_proofing.process.proof_of_address.info') %></p>
         <ul class="usa-list margin-y-105">
           <% t('in_person_proofing.process.proof_of_address.acceptable_proof').each do |proof| %>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -39,7 +39,7 @@
     <%= link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url, class: 'margin-left-1') %>
   </div>
   <%= render AccordionComponent.new do |c| %>
-    <% c.header { t('idv.messages.review.intro') } %>
+    <% c.with_header { t('idv.messages.review.intro') } %>
     <%= render 'shared/pii_review', pii: @applicant,
                                     phone: PhoneFormatter.format(@applicant[:phone]) %>
   <% end %>

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -1,12 +1,12 @@
 <% title t('titles.failure.information_not_verified') %>
 
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
-  <% c.header { t('idv.warning.sessions.heading') } %>
+  <% c.with_header { t('idv.warning.sessions.heading') } %>
 
   <p><%= t('idv.failure.sessions.warning') %></p>
   <p><strong><%= t('idv.warning.attempts', count: @remaining_attempts) %></strong></p>
 
-  <% c.action_button(
+  <% c.with_action_button(
        action: ->(**tag_options, &block) { link_to(@try_again_path, **tag_options, &block) },
        class: 'margin-bottom-2',
      ) { t('idv.forgot_password.try_again') } %>

--- a/app/views/idv/unavailable/show.html.erb
+++ b/app/views/idv/unavailable/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render StatusPageComponent.new(status: :error) do |c| %>
 
-  <% c.header { t('idv.titles.unavailable') } %>
+  <% c.with_header { t('idv.titles.unavailable') } %>
 
   <p>
     <% if decorated_session.sp_name.present? %>
@@ -27,7 +27,7 @@
         ) %>
   </p>
 
-  <% c.action_button(
+  <% c.with_action_button(
        action: ->(**tag_options, &block) do
          link_to(
            return_to_sp_failure_to_proof_path(location: :unavailable),

--- a/app/views/shared/_password_accordion.html.erb
+++ b/app/views/shared/_password_accordion.html.erb
@@ -1,4 +1,4 @@
 <%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
-  <% c.header { t('instructions.password.help_text_header') } %>
+  <% c.with_header { t('instructions.password.help_text_header') } %>
   <%= simple_format(t('instructions.password.help_text')) %>
 <% end %>

--- a/app/views/shared/_personal_key.html.erb
+++ b/app/views/shared/_personal_key.html.erb
@@ -8,7 +8,7 @@
 </div>
 
 <%= render AccordionComponent.new do |c| %>
-  <% c.header { t('forms.personal_key_partial.explanation.header') } %>
+  <% c.with_header { t('forms.personal_key_partial.explanation.header') } %>
   <% t('forms.personal_key_partial.explanation.text').each do |paragraph| %>
     <p><%= paragraph %></p>
   <% end %>

--- a/app/views/shared/_troubleshooting_options.html.erb
+++ b/app/views/shared/_troubleshooting_options.html.erb
@@ -6,6 +6,6 @@ locals:
 * class: Additional class names to add to wrapper element.
 %>
 <%= render TroubleshootingOptionsComponent.new(class: local_assigns[:class]) do |c| %>
-  <% c.header(heading_level: local_assigns[:heading_tag] || :h2).with_content(heading) %>
-  <% options.each { |option| c.option(**option.except(:text)).with_content(option[:text]) } %>
+  <% c.with_header(heading_level: local_assigns[:heading_tag] || :h2).with_content(heading) %>
+  <% options.each { |option| c.with_option(**option.except(:text)).with_content(option[:text]) } %>
 <% end %>

--- a/app/views/sign_up/cancellations/new.html.erb
+++ b/app/views/sign_up/cancellations/new.html.erb
@@ -1,7 +1,7 @@
 <% title t('headings.cancellations.prompt') %>
 
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
-  <% c.header { t('headings.cancellations.prompt') } %>
+  <% c.with_header { t('headings.cancellations.prompt') } %>
 
   <p>
     <strong><%= t('sign_up.cancel.warning_header') %></strong>
@@ -14,13 +14,13 @@
     <li><%= t('users.delete.bullet_4', app_name: APP_NAME) %></li>
   </ul>
 
-  <% c.action_button(
+  <% c.with_action_button(
        action: ->(**tag_options, &block) do
          button_to(sign_up_destroy_path, method: :delete, **tag_options, &block)
        end,
      ) { t('forms.buttons.cancel') } %>
 
-  <% c.action_button(
+  <% c.with_action_button(
        action: ->(**tag_options, &block) do
          link_to(@presenter.go_back_path, **tag_options, &block)
        end,

--- a/app/views/sign_up/registrations/_required_pii_accordion.html.erb
+++ b/app/views/sign_up/registrations/_required_pii_accordion.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <%= render AccordionComponent.new(class: 'margin-y-2') do |c| %>
-  <% c.header { t('devise.registrations.start.accordion') } %>
+  <% c.with_header { t('devise.registrations.start.accordion') } %>
   <p class="grid-row grid-gutter">
     <%= image_tag(
           asset_url('get-started/email-password.svg'),

--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -1,7 +1,7 @@
 <% title t('titles.account_locked') %>
 
 <%= render StatusPageComponent.new(status: :error, icon: :lock) do |c| %>
-  <% c.header { t('titles.account_locked') } %>
+  <% c.with_header { t('titles.account_locked') } %>
 
   <p><%= presenter.locked_reason %></p>
 
@@ -14,13 +14,13 @@
         ) %>
   </p>
 
-  <% c.troubleshooting_options do |tc| %>
-    <% tc.header { t('components.troubleshooting_options.default_heading') } %>
-    <% tc.option(
+  <% c.with_troubleshooting_options do |tc| %>
+    <% tc.with_header { t('components.troubleshooting_options.default_heading') } %>
+    <% tc.with_option(
          url: MarketingSite.help_url,
          new_tab: true,
        ).with_content(t('two_factor_authentication.read_about_two_factor_authentication')) %>
-    <% tc.option(
+    <% tc.with_option(
          url: MarketingSite.contact_url,
          new_tab: true,
        ).with_content(t('idv.troubleshooting.options.contact_support', app_name: APP_NAME)) %>

--- a/app/views/users/phone_setup/spam_protection.html.erb
+++ b/app/views/users/phone_setup/spam_protection.html.erb
@@ -42,13 +42,13 @@
 <% end %>
 
 <%= render TroubleshootingOptionsComponent.new do |c| %>
-  <% c.header { t('components.troubleshooting_options.default_heading') } %>
+  <% c.with_header { t('components.troubleshooting_options.default_heading') } %>
   <% if local_assigns[:two_factor_options_path].present? %>
-    <% c.option(
+    <% c.with_option(
          url: two_factor_options_path,
        ).with_content(t('two_factor_authentication.login_options_link_text')) %>
   <% end %>
-  <% c.option(
+  <% c.with_option(
        url: help_center_redirect_path(
          category: 'get-started',
          article: 'authentication-options',

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -6,7 +6,7 @@
 
 <%= simple_form_for('', url: submit_new_piv_cac_url) do |f| %>
   <%= render ProcessListComponent.new(connected: true, class: 'margin-y-4') do |c| %>
-    <%= c.item(heading: t('instructions.mfa.piv_cac.step_1')) do %>
+    <%= c.with_item(heading: t('instructions.mfa.piv_cac.step_1')) do %>
       <p>
         <%= t('instructions.mfa.piv_cac.step_1_info') %>
       </p>
@@ -23,8 +23,8 @@
             },
           ) %>
     <% end %>
-    <%= c.item(heading: t('instructions.mfa.piv_cac.step_2')) %>
-    <%= c.item(heading: t('instructions.mfa.piv_cac.step_3')) do %>
+    <%= c.with_item(heading: t('instructions.mfa.piv_cac.step_2')) %>
+    <%= c.with_item(heading: t('instructions.mfa.piv_cac.step_3')) do %>
       <p>
         <%= t('instructions.mfa.piv_cac.step_3_info_html') %>
       </p>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -11,7 +11,7 @@
 
 <%= simple_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
   <%= render ProcessListComponent.new(connected: true, class: 'margin-y-4') do |c| %>
-    <%= c.item(heading: t('forms.totp_setup.totp_step_1')) do %>
+    <%= c.with_item(heading: t('forms.totp_setup.totp_step_1')) do %>
       <p><%= t('forms.totp_setup.totp_step_1a') %></p>
       <%= render ValidatedFieldComponent.new(
             form: f,
@@ -25,8 +25,8 @@
             },
           ) %>
     <% end %>
-    <%= c.item(heading: t('forms.totp_setup.totp_step_2')) %>
-    <%= c.item(heading: t('forms.totp_setup.totp_step_3')) do %>
+    <%= c.with_item(heading: t('forms.totp_setup.totp_step_2')) %>
+    <%= c.with_item(heading: t('forms.totp_setup.totp_step_3')) do %>
       <div class="text-center">
         <%= image_tag @qrcode, size: 240, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
       </div>
@@ -36,7 +36,7 @@
       </code>
       <%= render ClipboardButtonComponent.new(clipboard_text: @code.upcase, outline: true) %>
     <% end %>
-    <%= c.item(heading: t('forms.totp_setup.totp_step_4')) do %>
+    <%= c.with_item(heading: t('forms.totp_setup.totp_step_4')) do %>
       <%= render OneTimeCodeInputComponent.new(
             form: f,
             transport: nil,

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -26,7 +26,7 @@
 
 <div class='margin-top-6'>
   <%= render AccordionComponent.new do |c| %>
-    <% c.header { t('idv.messages.review.intro') } %>
+    <% c.with_header { t('idv.messages.review.intro') } %>
     <%= render 'shared/pii_review', pii: @decrypted_pii, phone: @decrypted_pii[:phone] %>
   <% end %>
 </div>

--- a/spec/components/accordion_component_spec.rb
+++ b/spec/components/accordion_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AccordionComponent, type: :component do
 
   subject(:rendered) do
     render_inline(described_class.new(**options)) do |c|
-      c.header { 'heading' }
+      c.with_header { 'heading' }
       'content'
     end
   end

--- a/spec/components/base_component_spec.rb
+++ b/spec/components/base_component_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe BaseComponent, type: :component do
     end
   end
 
-  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
-  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:view_context) { vc_test_controller.view_context }
 
   before do
     allow_any_instance_of(ApplicationController).to receive(:view_context).and_return(view_context)

--- a/spec/components/captcha_submit_button_component_spec.rb
+++ b/spec/components/captcha_submit_button_component_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CaptchaSubmitButtonComponent, type: :component do
-  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
-  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:view_context) { vc_test_controller.view_context }
   let(:form_object) { NewPhoneForm.new(user: User.new) }
   let(:form) { SimpleForm::FormBuilder.new('', form_object, view_context, {}) }
   let(:content) { 'Button' }

--- a/spec/components/icon_component_spec.rb
+++ b/spec/components/icon_component_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe IconComponent, type: :component do
   it 'renders icon svg' do
     rendered = render_inline IconComponent.new(icon: :print)
 
-    expect(rendered).to have_css(".usa-icon use[href^='#{request.base_url}'][href$='.svg#print']")
+    expect(rendered).to have_css(
+      ".usa-icon use[href^='#{vc_test_request.base_url}'][href$='.svg#print']",
+    )
   end
 
   context 'with invalid icon' do

--- a/spec/components/javascript_required_component_spec.rb
+++ b/spec/components/javascript_required_component_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe JavascriptRequiredComponent, type: :component do
 
   context 'with session which was previously no-js' do
     before do
-      controller.session[NoJsController::SESSION_KEY] = true
+      vc_test_controller.session[NoJsController::SESSION_KEY] = true
     end
 
     it 'renders alert confirming successful enabling of JS' do

--- a/spec/components/memorable_date_component_spec.rb
+++ b/spec/components/memorable_date_component_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe MemorableDateComponent, type: :component do
   include SimpleForm::ActionViewExtensions::FormHelper
 
-  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
-  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:view_context) { vc_test_controller.view_context }
   let(:form_object) { Date.new }
   let(:form_builder) do
     SimpleForm::FormBuilder.new('MemorableDate', form_object, view_context, {})

--- a/spec/components/one_time_code_input_component_spec.rb
+++ b/spec/components/one_time_code_input_component_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe OneTimeCodeInputComponent, type: :component do
   include SimpleForm::ActionViewExtensions::FormHelper
 
-  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
-  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:view_context) { vc_test_controller.view_context }
   let(:form) { SimpleForm::FormBuilder.new('', {}, view_context, {}) }
   let(:options) { {} }
 

--- a/spec/components/password_confirmation_component_spec.rb
+++ b/spec/components/password_confirmation_component_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PasswordConfirmationComponent, type: :component do
-  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
-  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:view_context) { vc_test_controller.view_context }
   let(:form) { SimpleForm::FormBuilder.new('', {}, view_context, {}) }
 
   subject(:rendered) do
@@ -11,5 +10,14 @@ RSpec.describe PasswordConfirmationComponent, type: :component do
 
   it 'renders password fields with expected attributes' do
     expect(rendered).to have_css('[type=password][autocomplete=new-password]', count: 2)
+    expect(rendered).to have_field(t('forms.password'), type: :password)
+    expect(rendered).to have_field(
+      t('components.password_confirmation.confirm_label'),
+      type: :password,
+    )
+    expect(rendered).to have_field(
+      t('components.password_confirmation.toggle_label'),
+      type: :checkbox,
+    )
   end
 end

--- a/spec/components/password_toggle_component_spec.rb
+++ b/spec/components/password_toggle_component_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe PasswordToggleComponent, type: :component do
   include SimpleForm::ActionViewExtensions::FormHelper
 
-  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
-  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:view_context) { vc_test_controller.view_context }
   let(:form) { SimpleForm::FormBuilder.new('', {}, view_context, {}) }
   let(:options) { {} }
 
@@ -21,6 +20,17 @@ RSpec.describe PasswordToggleComponent, type: :component do
 
     expect(input_id).to be_present
     expect(rendered).to have_css("[aria-controls='#{input_id}']")
+  end
+
+  describe '#label' do
+    context 'with custom label' do
+      let(:label) { 'Custom Label' }
+      let(:options) { { label: } }
+
+      it 'renders custom field label' do
+        expect(rendered).to have_field(label, type: :password)
+      end
+    end
   end
 
   describe '#toggle_label' do

--- a/spec/components/phone_input_component_spec.rb
+++ b/spec/components/phone_input_component_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe PhoneInputComponent, type: :component do
   include SimpleForm::ActionViewExtensions::FormHelper
 
-  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
-  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:view_context) { vc_test_controller.view_context }
   let(:user) { build_stubbed(:user) }
   let(:form_object) { NewPhoneForm.new(user:) }
   let(:form_builder) do

--- a/spec/components/previews/accordion_component_preview.rb
+++ b/spec/components/previews/accordion_component_preview.rb
@@ -2,14 +2,14 @@ class AccordionComponentPreview < BaseComponentPreview
   # @!group Preview
   def default
     render(AccordionComponent.new) do |c|
-      c.header { 'Header' }
+      c.with_header { 'Header' }
       'Content'
     end
   end
 
   def unbordered
     render(AccordionComponent.new(bordered: false)) do |c|
-      c.header { 'Header' }
+      c.with_header { 'Header' }
       'Content'
     end
   end
@@ -20,7 +20,7 @@ class AccordionComponentPreview < BaseComponentPreview
   # @param bordered toggle
   def workbench(header: 'Header', content: 'Content', bordered: true)
     render(AccordionComponent.new(bordered:)) do |c|
-      c.header { header }
+      c.with_header { header }
       content
     end
   end

--- a/spec/components/previews/password_confirmation_component_preview.rb
+++ b/spec/components/previews/password_confirmation_component_preview.rb
@@ -7,13 +7,7 @@ class PasswordConfirmationComponentPreview < BaseComponentPreview
   # @!endgroup
 
   # @display form true
-  # @param toggle_label text
-  def workbench(toggle_label: nil)
-    render(
-      PasswordConfirmationComponent.new(
-        form: form_builder,
-        **{ toggle_label: }.compact,
-      ),
-    )
+  def workbench
+    render(PasswordConfirmationComponent.new(form: form_builder))
   end
 end

--- a/spec/components/previews/process_list_component_preview.rb
+++ b/spec/components/previews/process_list_component_preview.rb
@@ -2,29 +2,29 @@ class ProcessListComponentPreview < BaseComponentPreview
   # @!group Preview
   def default
     render(ProcessListComponent.new) do |c|
-      c.item(heading: 'Item 1') { 'Item 1 Content' }
-      c.item(heading: 'Item 2') { 'Item 2 Content' }
+      c.with_item(heading: 'Item 1') { 'Item 1 Content' }
+      c.with_item(heading: 'Item 2') { 'Item 2 Content' }
     end
   end
 
   def connected
     render(ProcessListComponent.new(connected: true)) do |c|
-      c.item(heading: 'Item 1') { 'Item 1 Content' }
-      c.item(heading: 'Item 2') { 'Item 2 Content' }
+      c.with_item(heading: 'Item 1') { 'Item 1 Content' }
+      c.with_item(heading: 'Item 2') { 'Item 2 Content' }
     end
   end
 
   def big
     render(ProcessListComponent.new(big: true)) do |c|
-      c.item(heading: 'Item 1') { 'Item 1 Content' }
-      c.item(heading: 'Item 2') { 'Item 2 Content' }
+      c.with_item(heading: 'Item 1') { 'Item 1 Content' }
+      c.with_item(heading: 'Item 2') { 'Item 2 Content' }
     end
   end
 
   def big_and_connected
     render(ProcessListComponent.new(big: true, connected: true)) do |c|
-      c.item(heading: 'Item 1') { 'Item 1 Content' }
-      c.item(heading: 'Item 2') { 'Item 2 Content' }
+      c.with_item(heading: 'Item 1') { 'Item 1 Content' }
+      c.with_item(heading: 'Item 2') { 'Item 2 Content' }
     end
   end
   # @!endgroup
@@ -33,8 +33,8 @@ class ProcessListComponentPreview < BaseComponentPreview
   # @param big toggle
   def workbench(big: false, connected: false)
     render(ProcessListComponent.new(big:, connected:)) do |c|
-      c.item(heading: 'Item 1') { 'Item 1 Content' }
-      c.item(heading: 'Item 2') { 'Item 2 Content' }
+      c.with_item(heading: 'Item 1') { 'Item 1 Content' }
+      c.with_item(heading: 'Item 2') { 'Item 2 Content' }
     end
   end
 end

--- a/spec/components/previews/troubleshooting_options_component_preview.rb
+++ b/spec/components/previews/troubleshooting_options_component_preview.rb
@@ -2,10 +2,10 @@ class TroubleshootingOptionsComponentPreview < BaseComponentPreview
   # @!group Preview
   def default
     render(TroubleshootingOptionsComponent.new) do |c|
-      c.header { 'Header' }
-      c.option(url: '') { 'Option 1' }
-      c.option(url: '') { 'Option 2' }
-      c.option(url: '', new_tab: true) { 'Option 3 (New Tab)' }
+      c.with_header { 'Header' }
+      c.with_option(url: '') { 'Option 1' }
+      c.with_option(url: '') { 'Option 2' }
+      c.with_option(url: '', new_tab: true) { 'Option 3 (New Tab)' }
     end
   end
   # @!endgroup
@@ -13,10 +13,10 @@ class TroubleshootingOptionsComponentPreview < BaseComponentPreview
   # @param header text
   def workbench(header: 'Header')
     render(TroubleshootingOptionsComponent.new) do |c|
-      c.header { header }
-      c.option(url: '') { 'Option 1' }
-      c.option(url: '') { 'Option 2' }
-      c.option(url: '', new_tab: true) { 'Option 3 (New Tab)' }
+      c.with_header { header }
+      c.with_option(url: '') { 'Option 1' }
+      c.with_option(url: '') { 'Option 2' }
+      c.with_option(url: '', new_tab: true) { 'Option 3 (New Tab)' }
     end
   end
 end

--- a/spec/components/process_list_component_spec.rb
+++ b/spec/components/process_list_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe ProcessListComponent, type: :component do
 
   it 'renders items slot content at default heading level' do
     rendered = render_inline ProcessListComponent.new do |c|
-      c.item(heading: 'Item 1') { 'Item 1 Content' }
-      c.item(heading: 'Item 2') { 'Item 2 Content' }
+      c.with_item(heading: 'Item 1') { 'Item 1 Content' }
+      c.with_item(heading: 'Item 2') { 'Item 2 Content' }
     end
 
     expect(rendered).to have_css('h2.usa-process-list__heading', text: 'Item 1')
@@ -22,7 +22,7 @@ RSpec.describe ProcessListComponent, type: :component do
   context 'custom heading level' do
     it 'renders items slot content at custom heading level' do
       rendered = render_inline ProcessListComponent.new(heading_level: :h3) do |c|
-        c.item(heading: 'Item') { '' }
+        c.with_item(heading: 'Item') { '' }
       end
 
       expect(rendered).to have_css('h3.usa-process-list__heading', text: 'Item')

--- a/spec/components/status_page_component_spec.rb
+++ b/spec/components/status_page_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StatusPageComponent, type: :component do
   include ActionView::Helpers::TagHelper
 
   it 'renders default icon associated with status' do
-    rendered = render_inline(StatusPageComponent.new(status: :warning)) { |c| c.header { '' } }
+    rendered = render_inline(StatusPageComponent.new(status: :warning)) { |c| c.with_header { '' } }
 
     expect(rendered).to have_css(
       "img[alt='#{t('image_description.warning')}'][src*='warning']",
@@ -13,7 +13,7 @@ RSpec.describe StatusPageComponent, type: :component do
 
   it 'renders icon associated with status' do
     rendered = render_inline(StatusPageComponent.new(status: :error, icon: :lock)) do |c|
-      c.header { '' }
+      c.with_header { '' }
     end
 
     expect(rendered).to have_css(
@@ -22,14 +22,14 @@ RSpec.describe StatusPageComponent, type: :component do
   end
 
   it 'renders page heading' do
-    rendered = render_inline(StatusPageComponent.new) { |c| c.header { 'Heading' } }
+    rendered = render_inline(StatusPageComponent.new) { |c| c.with_header { 'Heading' } }
 
     expect(rendered).to have_css('h1', text: 'Heading')
   end
 
   it 'renders block content' do
     rendered = render_inline(StatusPageComponent.new) do |c|
-      c.header { 'Heading' }
+      c.with_header { 'Heading' }
       content_tag(:p, 'Content')
     end
 
@@ -38,7 +38,7 @@ RSpec.describe StatusPageComponent, type: :component do
 
   it 'renders action buttons' do
     rendered = render_inline(StatusPageComponent.new) do |c|
-      c.action_button(outline: true) { 'Cancel' }
+      c.with_action_button(outline: true) { 'Cancel' }
     end
 
     expect(rendered).to have_css(
@@ -49,9 +49,9 @@ RSpec.describe StatusPageComponent, type: :component do
 
   it 'renders troubleshooting options' do
     rendered = render_inline(StatusPageComponent.new) do |c|
-      c.troubleshooting_options do |tc|
-        tc.header { 'Troubleshooting' }
-        tc.option(url: '/', new_tab: true) { 'Option' }
+      c.with_troubleshooting_options do |tc|
+        tc.with_header { 'Troubleshooting' }
+        tc.with_option(url: '/', new_tab: true) { 'Option' }
       end
     end
 

--- a/spec/components/tab_navigation_component_spec.rb
+++ b/spec/components/tab_navigation_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TabNavigationComponent, type: :component do
 
   context 'with link for current request' do
     before do
-      allow(request).to receive(:path).and_return('/first')
+      allow(vc_test_request).to receive(:path).and_return('/first')
     end
 
     it 'renders current link as highlighted' do

--- a/spec/components/troubleshooting_options_component_spec.rb
+++ b/spec/components/troubleshooting_options_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TroubleshootingOptionsComponent, type: :component do
   context 'with options' do
     it 'renders troubleshooting options' do
       rendered = render_inline(TroubleshootingOptionsComponent.new) do |c|
-        c.option(url: '/').with_content('Link Text')
+        c.with_option(url: '/').with_content('Link Text')
       end
 
       expect(rendered).to have_css('.troubleshooting-options')
@@ -24,7 +24,7 @@ RSpec.describe TroubleshootingOptionsComponent, type: :component do
             class: 'my-custom-class',
             data: { foo: 'bar' },
           ),
-        ) { |c| c.option(url: '/').with_content('Link Text') }
+        ) { |c| c.with_option(url: '/').with_content('Link Text') }
 
         expect(rendered).to have_css('.troubleshooting-options.my-custom-class[data-foo="bar"]')
       end
@@ -33,8 +33,8 @@ RSpec.describe TroubleshootingOptionsComponent, type: :component do
     context 'with header' do
       it 'renders header' do
         rendered = render_inline(TroubleshootingOptionsComponent.new) do |c|
-          c.header { 'Heading' }
-          c.option(url: '/')
+          c.with_header { 'Heading' }
+          c.with_option(url: '/')
         end
 
         expect(rendered).to have_css('h2.troubleshooting-options__heading', text: 'Heading')
@@ -43,8 +43,8 @@ RSpec.describe TroubleshootingOptionsComponent, type: :component do
       context 'with custom heading level' do
         it 'renders header' do
           rendered = render_inline(TroubleshootingOptionsComponent.new) do |c|
-            c.header(heading_level: :h3) { 'Heading' }
-            c.option(url: '/')
+            c.with_header(heading_level: :h3) { 'Heading' }
+            c.with_option(url: '/')
           end
 
           expect(rendered).to have_css('h3.troubleshooting-options__heading', text: 'Heading')

--- a/spec/components/validated_field_component_spec.rb
+++ b/spec/components/validated_field_component_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe ValidatedFieldComponent, type: :component do
   include SimpleForm::ActionViewExtensions::FormHelper
 
-  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
-  let(:view_context) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:view_context) { vc_test_controller.view_context }
   let(:form_object) { User.new }
   let(:form_builder) do
     SimpleForm::FormBuilder.new(form_object.model_name.param_key, form_object, view_context, {})


### PR DESCRIPTION
## 🛠 Summary of changes

Upgrades [ViewComponent](https://github.com/ViewComponent/view_component) and [Lookbook](https://github.com/ViewComponent/lookbook) to their latest respective versions, both of which are major upgrades:

- ViewComponent: 2.82.0 ➡️ 3.0.0
- Lookbook: 1.5.3 ➡️ 2.0.3

Notable breaking changes encountered:

- Trying to reference translation helpers in component constructor results in an error (see changes to PasswordToggleComponent)
- `controller` and `request` were removed from spec helpers, and were updated to equivalent `vc_test_controller` and `vc_test_request`.
- Slot API changes result in slot content rendering requiring a `with_` prefix

## 📜 Testing Plan

- Spot check the application and [component previews](http://localhost:3000/components)
- `rspec`