### PR TITLE
Memoize the `pending_profile` value

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,20 +107,32 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    pending = profiles.where(deactivation_reason: :in_person_verification_pending).or(
-      profiles.where.not(gpo_verification_pending_at: nil),
-    ).or(
-      profiles.where.not(fraud_review_pending_at: nil),
-    ).or(
-      profiles.where.not(fraud_rejection_at: nil),
-    ).order(created_at: :desc).first
+    return @pending_profile if defined?(@pending_profile)
 
-    return unless pending.present?
-    return if pending.password_reset?
-    return if pending.encryption_error? || pending.verification_cancelled?
-    return if active_profile.present? && active_profile.activated_at > pending.created_at
+    @pending_profile = begin
+      pending = profiles.where(deactivation_reason: :in_person_verification_pending).or(
+        profiles.where.not(gpo_verification_pending_at: nil),
+      ).or(
+        profiles.where.not(fraud_review_pending_at: nil),
+      ).or(
+        profiles.where.not(fraud_rejection_at: nil),
+      ).order(created_at: :desc).first
 
-    pending
+      if pending.blank?
+        nil
+      elsif pending.password_reset? || pending.encryption_error? || pending.verification_cancelled?
+        # Profiles that are cancelled for reasons that do not require further verification steps
+        # are not pending profiles
+        nil
+      elsif active_profile.present? && active_profile.activated_at > pending.created_at
+        # If there is an active profile that is older than this pending profile that means the user
+        # has proofed since this profile was created. That profile takes precedence and there is no
+        # pending profile
+        nil
+      else
+        pending
+      end
+    end
   end
 
   def gpo_verification_pending_profile

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -28,7 +28,7 @@ feature 'idv gpo step', :js do
     let(:gpo_confirmation_code) do
       create(
         :gpo_confirmation_code,
-        profile: user.pending_profile,
+        profile: User.find(user.id).pending_profile,
         otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
       )
     end

--- a/spec/support/idv_examples/clearing_and_restarting.rb
+++ b/spec/support/idv_examples/clearing_and_restarting.rb
@@ -35,7 +35,7 @@ shared_examples 'clearing and restarting idv' do
     expect(page).to have_content(t('idv.titles.come_back_later'))
     expect(page).to have_current_path(idv_come_back_later_path)
     expect(user.reload.identity_verified?).to eq(false)
-    expect(user.pending_profile?).to eq(true)
+    expect(User.find(user.id).pending_profile?).to eq(true)
     expect(gpo_confirmation.entry[:address1]).to eq('1 FAKE RD')
   end
 


### PR DESCRIPTION
We made changes to the app to do some of the work for finding a pending profile in a SQL query. We inspect this pending profile value frequently in the course of a request. This commit memoizes the value so we aren't making unnecessary trips to the DB.
