### PR TITLE
Add flag to pause enrollment expiration

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -163,13 +163,7 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     if response_message == IPP_INCOMPLETE_ERROR_MESSAGE
       # Customer has not been to post office for IPP
-      enrollment_outcomes[:enrollments_in_progress] += 1
-      analytics(user: enrollment.user).
-        idv_in_person_usps_proofing_results_job_enrollment_incomplete(
-          **enrollment_analytics_attributes(enrollment, complete: false),
-          response_message: response_message,
-        )
-      enrollment.update(status_check_completed_at: Time.zone.now)
+      handle_incomplete_status_update(enrollment, response_message)
     elsif response_message&.match(IPP_EXPIRED_ERROR_MESSAGE)
       handle_expired_status_update(enrollment, err.response, response_message)
     elsif response_message == IPP_INVALID_ENROLLMENT_CODE_MESSAGE % enrollment.enrollment_code
@@ -272,6 +266,16 @@ class GetUspsProofingResultsJob < ApplicationJob
       **email_analytics_attributes(enrollment),
       email_type: 'Failed unsupported ID type',
     )
+  end
+
+  def handle_incomplete_status_update(enrollment, response_message)
+    enrollment_outcomes[:enrollments_in_progress] += 1
+    analytics(user: enrollment.user).
+      idv_in_person_usps_proofing_results_job_enrollment_incomplete(
+        **enrollment_analytics_attributes(enrollment, complete: false),
+        response_message: response_message,
+      )
+    enrollment.update(status_check_completed_at: Time.zone.now)
   end
 
   def handle_expired_status_update(enrollment, response, response_message)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -142,6 +142,7 @@ in_person_enrollment_validity_in_days: 30
 in_person_results_delay_in_hours: 1
 in_person_completion_survey_url: 'https://login.gov'
 in_person_verify_info_controller_enabled: false
+in_person_stop_expiring_enrollments: false
 include_slo_in_saml_metadata: false
 irs_attempt_api_audience: 'https://irs.gov'
 irs_attempt_api_auth_tokens: ''

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -221,6 +221,7 @@ class IdentityConfig
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:in_person_completion_survey_url, type: :string)
     config.add(:in_person_verify_info_controller_enabled, type: :boolean)
+    config.add(:in_person_stop_expiring_enrollments, type: :boolean)
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:irs_attempt_api_audience)
     config.add(:irs_attempt_api_auth_tokens, type: :comma_separated_string_list)

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -782,6 +782,27 @@ RSpec.describe GetUspsProofingResultsJob do
               ),
             )
           end
+
+          context 'when the in_person_stop_expiring_enrollments flag is true' do
+            before do
+              allow(IdentityConfig.store).to(
+                receive(:in_person_stop_expiring_enrollments).and_return(true),
+              )
+            end
+
+            it 'treats the enrollment as incomplete' do
+              job.perform(Time.zone.now)
+
+              expect(pending_enrollment.status).to eq('pending')
+              # we pass the expiration message to analytics
+              expect(job_analytics).to have_logged_event(
+                'GetUspsProofingResultsJob: Enrollment incomplete',
+                hash_including(
+                  response_message: 'More than 30 days have passed since opt-in to IPP',
+                ),
+              )
+            end
+          end
         end
 
         context 'when an enrollment expires unexpectedly' do

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -1015,6 +1015,13 @@ RSpec.describe GetUspsProofingResultsJob do
             expect(job_analytics).not_to have_logged_event(
               'GetUspsProofingResultsJob: Enrollment status updated',
             )
+
+            expect(job_analytics).to have_logged_event(
+              'GetUspsProofingResultsJob: Enrollment incomplete',
+              hash_including(
+                response_message: 'Customer has not been to a post office to complete IPP',
+              ),
+            )
           end
         end
 


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-9901](https://cm-jira.usa.gov/browse/LG-9901)

## 🛠 Summary of changes

Adds `in_person_stop_expiring_enrollments ` feature flag; when `true`, the `GetUspsProofingResultsJob` will treat expired enrollments as incomplete.

