### PR TITLE
Brewfile for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ Vagrantfile
 
 package-lock.json
 browsers.json
+Brewfile.lock.json
 
 saml_*.txt
 saml_*.shr

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,6 @@
+brew 'postgresql@13'
+brew 'redis'
+brew 'node@16'
+brew 'yarn'
+brew 'openssl@1.1'
+cask 'chromedriver'

--- a/bin/setup
+++ b/bin/setup
@@ -50,10 +50,19 @@ Dir.chdir APP_ROOT do
   run "cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt"
 
   puts "\n== Installing dependencies =="
+  brew_installed = system "brew -v 2>&1"
+  run "brew bundle" if brew_installed
   run "gem install bundler --conservative"
   run 'gem install foreman --conservative && gem update foreman'
   run "bundle check || bundle install --without deploy production"
   run "yarn install"
+
+  puts "\n== Stopping running services to ensure clean start =="
+  run "brew services stop --all"
+
+  puts "\n== Starting services =="
+  run "brew services start redis" if brew_installed
+  run "brew services start postgresql@13" if brew_installed
 
   puts "\n== Preparing database =="
   run 'make clobber_db'

--- a/bin/setup
+++ b/bin/setup
@@ -58,7 +58,7 @@ Dir.chdir APP_ROOT do
   run "yarn install"
 
   puts "\n== Stopping running services to ensure clean start =="
-  run "brew services stop --all"
+  run "brew services stop --all" if brew_installed
 
   puts "\n== Starting services =="
   run "brew services start redis" if brew_installed

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -44,7 +44,7 @@ If not using macOS:
     $ make setup
     ```
 
-    This command copies sample configuration files, installs required gems and brew packages (if using macOS), and sets up the database. Check out our Makefile commands to learn more about what this command does: https://github.com/18F/identity-idp/blob/main/Makefile
+    This command copies sample configuration files, installs required gems and brew packages (if using macOS), and sets up the database. Check out our [Makefile commands](../Makefile) to learn more about what this command does.
 
 1. Now that you have you have everything installed, you can run the following command to start your local server:
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -7,51 +7,52 @@ This installation method is meant for those who are familiar with setting up loc
 We recommend using [Homebrew](https://brew.sh/), [rbenv](https://github.com/rbenv/rbenv), [nvm](https://github.com/nvm-sh/nvm) or other version management tooling to install the below dependencies; while we don't anticipate changing these frequently, this will ensure that you will be able to easily switch to different versions as needed.
 
 ### Dependencies
+
+Installing the packages differs slightly if you're on a macOS or a different OS.
+
+If using macOS:
+
+1. Install [rbenv](https://github.com/rbenv/rbenv) (lets you install and switch between different versions of Ruby)
+1. Install Ruby. Choose the version [in the `.ruby-version` file](../.ruby-version)
+1. Skip to the [set up local environment section](#set-up-local-environment). Your other dependencies will be installed in that step.
+
+If not using macOS:
+
 1. To start, make sure you have the following dependencies installed and a working development environment:
 
-- Ruby ~> 3.2.0
-- [PostgreSQL](http://www.postgresql.org/download/)
-- [Redis 7+](http://redis.io/)
-- [Node.js v16](https://nodejs.org)
-- [Yarn](https://yarnpkg.com/en/)
-- [chromedriver](https://formulae.brew.sh/cask/chromedriver)
+    - [rbenv](https://github.com/rbenv/rbenv) (lets you install and switch between different versions of Ruby)
+    - Ruby. Choose the version [in the `.ruby-version` file](../.ruby-version)
+    - [PostgreSQL](http://www.postgresql.org/download/)
+    - [Redis 7+](http://redis.io/)
+    - [Node.js v16](https://nodejs.org)
+    - [Yarn](https://yarnpkg.com/en/)
+    - [chromedriver](https://formulae.brew.sh/cask/chromedriver)
 
-2. You will need to install openssl version 1.1:
+1. You will need to install openssl version 1.1:
 
-- Run `brew install openssl@1.1`
+    - Run `brew install openssl@1.1`
 
-3. Test that you have Postgres and Redis running.
+1. Test that you have Postgres and Redis running.
 
-  For example, if you've installed with Homebrew, you can start the services like this:
+1. Continue to the [set up local environment section](#set-up-local-environment).
 
-  ```
-  $ brew services start redis
-  $ brew services start postgresql
-  ```
+### Set up local environment
 
-  To confirm the services are running properly, run:
-  ```
-  $ brew services list
-  ```
+1. Run the following command to set up your local environment:
 
-4. Run the following command to set up your local environment:
+    ```
+    $ make setup
+    ```
 
-  ```
-  $ make setup
-  ```
+    This command copies sample configuration files, installs required gems and brew packages (if using macOS), and sets up the database. Check out our Makefile commands to learn more about what this command does: https://github.com/18F/identity-idp/blob/main/Makefile
 
-  This command copies sample configuration files, installs required gems
-  and sets up the database. Check out our Makefile commands to learn more about what this command does: https://github.com/18F/identity-idp/blob/main/Makefile
+1. Now that you have you have everything installed, you can run the following command to start your local server:
 
-  Note: If you didn't explicitly install `openssl@1.1` in Step 2 above and you use a M1 Mac, you may see an error on this step. Homebrew works differently on a M1 Mac, so specifying the version is necessary for the make script to work, but may still work on x86.
+    ```
+    $ make run
+    ```
 
-5. Now that you have you have everything installed, you can run the following command to start your local server:
-
-  ```
-  $ make run
-  ```
-
-  You should now be able to go to open up your favorite browser, go to `localhost:3000` and see your local development environment running.
+    You should now be able to go to open up your favorite browser, go to `localhost:3000` and see your local development environment running.
 
 ### Running tests locally
 


### PR DESCRIPTION
## 🛠 Summary of changes

We're looking at adding a dependency soon, which could cause some issues
with local development for folks if they didn't know they need to
manually install it. We thought adding a `Brewfile` and having the setup
script run `brew bundle` would help mitigate the difficulties of that
change. There's a bonus in that it's self documenting too!

It would also:

- make initial setup for new developers much more straightforward
- make future changes to dependencies easier to manage
- prevents a mixture of dependencies installed in different ways (for
instance, I think when I initially set things up I ended up with one
version of postgres downloaded manually from the doc-linked site, and
another via homebrew)

Notes:

- As pointed out by @pauldoomgov, we use [postgres@13 in production](https://github.com/18F/identity-devops/blob/33ba02736b37f3a79c50479892a03c6f3e920041/terraform/app/rds-variables.tf#L82),
so it would be good to encourage use of 13 locally. The method I chose
to try and enforce this was using `brew services stop --all` before
starting the services we want (where I specify 13).
- I tried various combinations of having these dependencies installed /
uninstalled before running `make setup` and the script seems to still
work. But I don't have a machine without MacOS to test on to make sure
it works for everyone.
- While making relevant doc changes, I also fixed up some syntax for
readability / easy re-ordering of steps