### PR TITLE
LG-9813 Prevent user from starting IdV if currently rate-limited

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -32,10 +32,10 @@ module IdvSession
     )
   end
 
-  def idv_attempter_throttled?
+  def idv_attempter_throttled?(throttle_type)
     Throttle.new(
       user: effective_user,
-      throttle_type: :idv_resolution,
+      throttle_type: throttle_type,
     ).throttled?
   end
 

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -60,7 +60,7 @@ module IdvSession
     when :idv_doc_auth
       redirect_to idv_session_errors_throttled_url
     when :proof_address
-      redirect_to idv_phone_errors_failure_url
+      redirect_to idv_phone_errors_failure_url if self.class != Idv::PhoneController
     end
   end
 

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -34,10 +34,10 @@ module IdvSession
 
   def check_throttled_and_redirect
     rate_limited = false
-    %i[idv_resolution idv_doc_auth proof_address].each do |throttled_type|
-      if idv_attempter_throttled?(throttled_type)
-        track_throttled_event(throttled_type)
-        throttled_redirect(throttled_type)
+    %i[idv_resolution idv_doc_auth proof_address].each do |throttle_type|
+      if idv_attempter_throttled?(throttle_type)
+        track_throttled_event(throttle_type)
+        throttled_redirect(throttle_type)
         rate_limited = true
         break
       end
@@ -45,15 +45,15 @@ module IdvSession
     rate_limited
   end
 
-  def track_throttled_event(throttled_type)
+  def track_throttled_event(throttle_type)
     irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
     analytics.throttler_rate_limit_triggered(
-      throttle_type: throttled_type,
+      throttle_type: throttle_type,
     )
   end
 
-  def throttled_redirect(throttled_type)
-    case throttled_type
+  def throttled_redirect(throttle_type)
+    case throttle_type
     when :idv_resolution
       redirect_to idv_session_errors_failure_url
     when :idv_doc_auth

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -46,10 +46,11 @@ module IdvSession
   end
 
   def track_throttled_event(throttle_type)
+    analytics_args = { throttle_type: throttle_type }
+    analytics_args[:step_name] = :phone if throttle_type == :proof_address
+
     irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
-    analytics.throttler_rate_limit_triggered(
-      throttle_type: throttle_type,
-    )
+    analytics.throttler_rate_limit_triggered(**analytics_args)
   end
 
   def throttled_redirect(throttle_type)

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -21,12 +21,7 @@ module IdvStepConcern
   end
 
   def confirm_not_throttled
-    document_capture_throttle = Throttle.new(
-      user: current_user,
-      throttle_type: :idv_doc_auth,
-    )
-
-    redirect_to idv_session_errors_throttled_url if document_capture_throttle.throttled?
+    check_throttled_and_redirect
   end
 
   def flow_session

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -2,11 +2,12 @@ module IdvStepConcern
   extend ActiveSupport::Concern
 
   include IdvSession
+  include RateLimitConcern
 
   included do
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
-    before_action :confirm_not_throttled
+    before_action :confirm_not_rate_limited
     before_action :confirm_no_pending_gpo_profile
     before_action :confirm_no_pending_in_person_enrollment
   end
@@ -20,8 +21,8 @@ module IdvStepConcern
     redirect_to idv_in_person_ready_to_verify_url if current_user.pending_in_person_enrollment
   end
 
-  def confirm_not_throttled
-    check_throttled_and_redirect
+  def confirm_not_rate_limited
+    check_rate_limited_and_redirect
   end
 
   def flow_session

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -6,6 +6,7 @@ module IdvStepConcern
   included do
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
+    before_action :confirm_not_throttled
     before_action :confirm_no_pending_gpo_profile
     before_action :confirm_no_pending_in_person_enrollment
   end
@@ -17,6 +18,17 @@ module IdvStepConcern
   def confirm_no_pending_in_person_enrollment
     return if !IdentityConfig.store.in_person_proofing_enabled
     redirect_to idv_in_person_ready_to_verify_url if current_user.pending_in_person_enrollment
+  end
+
+  def confirm_not_throttled
+    document_capture_throttle = Throttle.new(
+      user: current_user,
+      throttle_type: :idv_doc_auth,
+    )
+
+    if document_capture_throttle.throttled?
+      redirect_to idv_session_errors_throttled_url
+    end
   end
 
   def flow_session

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -21,10 +21,6 @@ module IdvStepConcern
     redirect_to idv_in_person_ready_to_verify_url if current_user.pending_in_person_enrollment
   end
 
-  def confirm_not_rate_limited
-    check_rate_limited_and_redirect
-  end
-
   def flow_session
     user_session['idv/doc_auth'] || {}
   end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -26,9 +26,7 @@ module IdvStepConcern
       throttle_type: :idv_doc_auth,
     )
 
-    if document_capture_throttle.throttled?
-      redirect_to idv_session_errors_throttled_url
-    end
+    redirect_to idv_session_errors_throttled_url if document_capture_throttle.throttled?
   end
 
   def flow_session

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -1,7 +1,7 @@
 module RateLimitConcern
   extend ActiveSupport::Concern
 
-  def check_rate_limited_and_redirect
+  def confirm_not_rate_limited
     rate_limited = false
     %i[idv_resolution idv_doc_auth proof_address].each do |throttle_type|
       next if throttle_and_controller_match(throttle_type) && action_name == 'update'

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -4,6 +4,8 @@ module RateLimitConcern
   def check_rate_limited_and_redirect
     rate_limited = false
     %i[idv_resolution idv_doc_auth proof_address].each do |throttle_type|
+      next if throttle_and_controller_match(throttle_type)
+
       if idv_attempter_rate_limited?(throttle_type)
         track_rate_limited_event(throttle_type)
         rate_limited_redirect(throttle_type)
@@ -23,8 +25,6 @@ module RateLimitConcern
   end
 
   def rate_limited_redirect(throttle_type)
-    return if throttle_and_controller_match(throttle_type)
-
     case throttle_type
     when :idv_resolution
       redirect_to idv_session_errors_failure_url

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -23,6 +23,8 @@ module RateLimitConcern
   end
 
   def rate_limited_redirect(throttle_type)
+    return if throttle_and_controller_match(throttle_type)
+
     case throttle_type
     when :idv_resolution
       redirect_to idv_session_errors_failure_url
@@ -30,6 +32,19 @@ module RateLimitConcern
       redirect_to idv_session_errors_throttled_url
     when :proof_address
       redirect_to idv_phone_errors_failure_url if self.class != Idv::PhoneController
+    end
+  end
+
+  def throttle_and_controller_match(throttle_type)
+    case throttle_type
+    when :idv_resolution
+      self.instance_of?(Idv::VerifyInfoController) ||
+        self.instance_of?(Idv::InPerson::VerifyInfoController)
+    when :idv_doc_auth
+      self.instance_of?(Idv::DocumentCaptureController) ||
+        self.instance_of?(Idv::HybridMobile::DocumentCaptureController)
+    when :proof_address
+      self.instance_of?(Idv::PhoneController)
     end
   end
 

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -6,14 +6,20 @@ module RateLimitConcern
     %i[idv_resolution idv_doc_auth proof_address].each do |throttle_type|
       next if throttle_and_controller_match(throttle_type)
 
-      if idv_attempter_rate_limited?(throttle_type)
-        track_rate_limited_event(throttle_type)
-        rate_limited_redirect(throttle_type)
+      if rate_limit_redirect!(throttle_type)
         rate_limited = true
         break
       end
     end
     rate_limited
+  end
+
+  def rate_limit_redirect!(throttle_type)
+    if idv_attempter_rate_limited?(throttle_type)
+      track_rate_limited_event(throttle_type)
+      rate_limited_redirect(throttle_type)
+      return true
+    end
   end
 
   def track_rate_limited_event(throttle_type)

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -4,7 +4,7 @@ module RateLimitConcern
   def check_rate_limited_and_redirect
     rate_limited = false
     %i[idv_resolution idv_doc_auth proof_address].each do |throttle_type|
-      next if throttle_and_controller_match(throttle_type)
+      next if throttle_and_controller_match(throttle_type) && action_name == 'update'
 
       if rate_limit_redirect!(throttle_type)
         rate_limited = true

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -1,0 +1,42 @@
+module RateLimitConcern
+  extend ActiveSupport::Concern
+
+  def check_rate_limited_and_redirect
+    rate_limited = false
+    %i[idv_resolution idv_doc_auth proof_address].each do |throttle_type|
+      if idv_attempter_rate_limited?(throttle_type)
+        track_rate_limited_event(throttle_type)
+        rate_limited_redirect(throttle_type)
+        rate_limited = true
+        break
+      end
+    end
+    rate_limited
+  end
+
+  def track_rate_limited_event(throttle_type)
+    analytics_args = { throttle_type: throttle_type }
+    analytics_args[:step_name] = :phone if throttle_type == :proof_address
+
+    irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
+    analytics.throttler_rate_limit_triggered(**analytics_args)
+  end
+
+  def rate_limited_redirect(throttle_type)
+    case throttle_type
+    when :idv_resolution
+      redirect_to idv_session_errors_failure_url
+    when :idv_doc_auth
+      redirect_to idv_session_errors_throttled_url
+    when :proof_address
+      redirect_to idv_phone_errors_failure_url if self.class != Idv::PhoneController
+    end
+  end
+
+  def idv_attempter_rate_limited?(throttle_type)
+    Throttle.new(
+      user: effective_user,
+      throttle_type: throttle_type,
+    ).throttled?
+  end
+end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -18,7 +18,7 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('document_capture', :view, true)
 
-      render :show, locals: extra_view_variables if !rate_limit_redirect!(:idv_doc_auth)
+      render :show, locals: extra_view_variables
     end
 
     def update

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -18,9 +18,7 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('document_capture', :view, true)
 
-      if !rate_limit_redirect!(:idv_doc_auth)
-        render :show, locals: extra_view_variables
-      end
+      render :show, locals: extra_view_variables if !rate_limit_redirect!(:idv_doc_auth)
     end
 
     def update

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -5,6 +5,7 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
+    include RateLimitConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_upload_step_complete
@@ -17,7 +18,9 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('document_capture', :view, true)
 
-      render :show, locals: extra_view_variables
+      if !rate_limit_redirect!(:idv_doc_auth)
+        render :show, locals: extra_view_variables
+      end
     end
 
     def update

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -27,37 +27,6 @@ class IdvController < ApplicationController
 
   private
 
-  def check_throttled_and_redirect
-    rate_limited = false
-    %i[idv_resolution idv_doc_auth proof_address].each do |throttled_type|
-      if idv_attempter_throttled?(throttled_type)
-        track_throttled_event(throttled_type)
-        throttled_redirect(throttled_type)
-        rate_limited = true
-        break
-      end
-    end
-    rate_limited
-  end
-
-  def track_throttled_event(throttled_type)
-    irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
-    analytics.throttler_rate_limit_triggered(
-      throttle_type: throttled_type,
-    )
-  end
-
-  def throttled_redirect(throttled_type)
-    case throttled_type
-    when :idv_resolution
-      redirect_to idv_session_errors_failure_url
-    when :idv_doc_auth
-      redirect_to idv_session_errors_throttled_url
-    when :proof_address
-      redirect_to idv_phone_errors_failure_url
-    end
-  end
-
   def verify_identity
     analytics.idv_intro_visit
     redirect_to idv_doc_auth_url

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -13,7 +13,7 @@ class IdvController < ApplicationController
       verify_identity
     elsif active_profile?
       redirect_to idv_activated_url
-    elsif check_throttles_and_redirect
+    elsif check_throttled_and_redirect
       # do nothing
     else
       verify_identity
@@ -27,32 +27,35 @@ class IdvController < ApplicationController
 
   private
 
-  def check_throttles_and_redirect
-    rate_limited = true
-
-    if idv_attempter_throttled?(:idv_resolution) # rate limited at verify info step
-      irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
-      analytics.throttler_rate_limit_triggered(
-        throttle_type: :idv_resolution,
-      )
-      redirect_to idv_session_errors_failure_url
-    elsif idv_attempter_throttled?(:idv_doc_auth) # rate limited at document capture step
-      irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
-      analytics.throttler_rate_limit_triggered(
-        throttle_type: :idv_doc_auth,
-      )
-      redirect_to idv_session_errors_throttled_url
-    elsif idv_attempter_throttled?(:proof_address) # Rate limited at phone step
-      irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
-      analytics.throttler_rate_limit_triggered(
-        throttle_type: :proof_address,
-      )
-      redirect_to idv_phone_errors_failure_url
-    else
-      rate_limited = false
+  def check_throttled_and_redirect
+    rate_limited = false
+    %i(idv_resolution idv_doc_auth proof_address).each do |throttled_type|
+      if idv_attempter_throttled?(throttled_type)
+        track_throttled_event(throttled_type)
+        throttled_redirect(throttled_type)
+        rate_limited = true
+        break
+      end
     end
+    rate_limited
+  end
 
-    return rate_limited
+  def track_throttled_event(throttled_type)
+    irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
+    analytics.throttler_rate_limit_triggered(
+      throttle_type: throttled_type,
+    )
+  end
+
+  def throttled_redirect(throttled_type)
+    case throttled_type
+    when :idv_resolution
+      redirect_to idv_session_errors_failure_url
+    when :idv_doc_auth
+      redirect_to idv_session_errors_throttled_url
+    when :proof_address
+      redirect_to idv_phone_errors_failure_url
+    end
   end
 
   def verify_identity

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -2,6 +2,7 @@ class IdvController < ApplicationController
   include IdvSession
   include AccountReactivationConcern
   include FraudReviewConcern
+  include RateLimitConcern
 
   before_action :confirm_two_factor_authenticated
   before_action :profile_needs_reactivation?, only: [:index]
@@ -13,7 +14,7 @@ class IdvController < ApplicationController
       verify_identity
     elsif active_profile?
       redirect_to idv_activated_url
-    elsif check_throttled_and_redirect
+    elsif check_rate_limited_and_redirect
       # do nothing
     else
       verify_identity

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -7,6 +7,7 @@ class IdvController < ApplicationController
   before_action :confirm_two_factor_authenticated
   before_action :profile_needs_reactivation?, only: [:index]
   before_action :handle_fraud
+  before_action :confirm_not_rate_limited
 
   def index
     if decorated_session.requested_more_recent_verification? ||
@@ -14,8 +15,6 @@ class IdvController < ApplicationController
       verify_identity
     elsif active_profile?
       redirect_to idv_activated_url
-    elsif check_rate_limited_and_redirect
-      # do nothing
     else
       verify_identity
     end

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -29,7 +29,7 @@ class IdvController < ApplicationController
 
   def check_throttled_and_redirect
     rate_limited = false
-    %i(idv_resolution idv_doc_auth proof_address).each do |throttled_type|
+    %i[idv_resolution idv_doc_auth proof_address].each do |throttled_type|
       if idv_attempter_throttled?(throttled_type)
         track_throttled_event(throttled_type)
         throttled_redirect(throttled_type)

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -13,12 +13,24 @@ class IdvController < ApplicationController
       verify_identity
     elsif active_profile?
       redirect_to idv_activated_url
-    elsif idv_attempter_throttled?
+    elsif idv_attempter_throttled?(:idv_resolution) # rate limited at verify info step
       irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
       analytics.throttler_rate_limit_triggered(
         throttle_type: :idv_resolution,
       )
       redirect_to idv_session_errors_failure_url
+    elsif idv_attempter_throttled?(:idv_doc_auth) # rate limited at document capture step
+      irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
+      analytics.throttler_rate_limit_triggered(
+        throttle_type: :idv_doc_auth,
+      )
+      redirect_to idv_session_errors_throttled_url
+    elsif idv_attempter_throttled?(:proof_address) # Rate limited at phone step
+      irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
+      analytics.throttler_rate_limit_triggered(
+        throttle_type: :proof_address,
+      )
+      redirect_to idv_phone_errors_failure_url
     else
       verify_identity
     end

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -236,9 +236,9 @@ describe 'IdvStepConcern' do
     end
   end
 
-  describe '#confirm_not_throttled' do
+  describe '#confirm_not_rate_limited' do
     controller Idv::StepController do
-      before_action :confirm_not_throttled
+      before_action :confirm_not_rate_limited
     end
 
     before(:each) do

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -250,18 +250,17 @@ describe 'IdvStepConcern' do
     end
 
     context 'user is not throttled' do
+      let(:user) { create(:user, :fully_registered) }
+
       it 'does not redirect' do
         get :show
 
         expect(response.body).to eq 'Hello'
-        expect(response).to_not redirect_to idv_gpo_verify_url
         expect(response.status).to eq 200
       end
     end
 
     context 'with idv_doc_auth throttle (DocumentCapture)' do
-      let(:user) { create(:user, :fully_registered) }
-
       it 'redirects to idv_doc_auth throttled error page' do
         throttle = Throttle.new(user: user, throttle_type: :idv_doc_auth)
         throttle.increment_to_throttled!
@@ -269,6 +268,28 @@ describe 'IdvStepConcern' do
         get :show
 
         expect(response).to redirect_to idv_session_errors_throttled_url
+      end
+    end
+
+    context 'with idv_resolution throttle (VerifyInfo)' do
+      it 'redirects to idv_resolution throttled error page' do
+        throttle = Throttle.new(user: user, throttle_type: :idv_resolution)
+        throttle.increment_to_throttled!
+
+        get :show
+
+        expect(response).to redirect_to idv_session_errors_failure_url
+      end
+    end
+
+    context 'with proof_address throttle (PhoneStep)' do
+      it 'redirects to proof_address throttled error page' do
+        throttle = Throttle.new(user: user, throttle_type: :proof_address)
+        throttle.increment_to_throttled!
+
+        get :show
+
+        expect(response).to redirect_to idv_phone_errors_failure_url
       end
     end
   end

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -16,6 +16,15 @@ describe 'IdvStepConcern' do
     end
   end
 
+  describe 'before_actions' do
+    it 'includes confirm_not_rate_limited before_action' do
+      expect(Idv::StepController).to have_actions(
+        :before,
+        :confirm_not_rate_limited,
+      )
+    end
+  end
+
   describe '#confirm_idv_needed' do
     controller Idv::StepController do
       before_action :confirm_idv_needed
@@ -233,29 +242,6 @@ describe 'IdvStepConcern' do
 
         expect(response).to redirect_to idv_gpo_verify_url
       end
-    end
-  end
-
-  describe '#confirm_not_rate_limited' do
-    controller Idv::StepController do
-      before_action :confirm_not_rate_limited
-    end
-
-    before do
-      sign_in(user)
-      allow(subject).to receive(:current_user).and_return(user)
-
-      routes.draw do
-        get 'show' => 'idv/step#show'
-      end
-    end
-
-    it 'calls check_rate_limited_and_redirect' do
-      allow(controller).to receive(:check_rate_limited_and_redirect)
-
-      get :show
-
-      expect(controller).to have_received(:check_rate_limited_and_redirect)
     end
   end
 end

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -220,17 +220,13 @@ describe 'IdvStepConcern' do
         get :show
 
         expect(response.body).to eq 'Hello'
-        expect(response).to_not redirect_to idv_in_person_ready_to_verify_url
+        expect(response).to_not redirect_to idv_gpo_verify_url
         expect(response.status).to eq 200
       end
     end
 
     context 'with pending gpo profile' do
       let(:user) { create(:user, :with_pending_gpo_profile, :fully_registered) }
-
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-      end
 
       it 'redirects to enter your code page' do
         get :show

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -241,56 +241,21 @@ describe 'IdvStepConcern' do
       before_action :confirm_not_rate_limited
     end
 
-    before(:each) do
+    before do
       sign_in(user)
       allow(subject).to receive(:current_user).and_return(user)
+
       routes.draw do
         get 'show' => 'idv/step#show'
       end
     end
 
-    context 'user is not throttled' do
-      let(:user) { create(:user, :fully_registered) }
+    it 'calls check_rate_limited_and_redirect' do
+      allow(controller).to receive(:check_rate_limited_and_redirect)
 
-      it 'does not redirect' do
-        get :show
+      get :show
 
-        expect(response.body).to eq 'Hello'
-        expect(response.status).to eq 200
-      end
-    end
-
-    context 'with idv_doc_auth throttle (DocumentCapture)' do
-      it 'redirects to idv_doc_auth throttled error page' do
-        throttle = Throttle.new(user: user, throttle_type: :idv_doc_auth)
-        throttle.increment_to_throttled!
-
-        get :show
-
-        expect(response).to redirect_to idv_session_errors_throttled_url
-      end
-    end
-
-    context 'with idv_resolution throttle (VerifyInfo)' do
-      it 'redirects to idv_resolution throttled error page' do
-        throttle = Throttle.new(user: user, throttle_type: :idv_resolution)
-        throttle.increment_to_throttled!
-
-        get :show
-
-        expect(response).to redirect_to idv_session_errors_failure_url
-      end
-    end
-
-    context 'with proof_address throttle (PhoneStep)' do
-      it 'redirects to proof_address throttled error page' do
-        throttle = Throttle.new(user: user, throttle_type: :proof_address)
-        throttle.increment_to_throttled!
-
-        get :show
-
-        expect(response).to redirect_to idv_phone_errors_failure_url
-      end
+      expect(controller).to have_received(:check_rate_limited_and_redirect)
     end
   end
 end

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -69,5 +69,17 @@ describe 'RateLimitConcern' do
         expect(response).to redirect_to idv_phone_errors_failure_url
       end
     end
+
+    context 'including controller and throttle match' do
+      it 'does not redirect' do
+        allow(Idv::StepController).to receive(:throttle_and_controller_match).
+          and_return(true)
+
+        get :show
+
+        expect(response.body).to eq 'Hello'
+        expect(response.status).to eq 200
+      end
+    end
   end
 end

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe 'RateLimitConcern' do
+  let(:user) { create(:user, :fully_registered, email: 'old_email@example.com') }
+
+  module Idv
+    class StepController < ApplicationController
+      include RateLimitConcern
+
+      def show
+        render plain: 'Hello'
+      end
+    end
+  end
+
+  describe '#check_rate_limited_and_redirect' do
+    controller Idv::StepController do
+      before_action :check_rate_limited_and_redirect
+    end
+
+    before(:each) do
+      sign_in(user)
+      allow(subject).to receive(:current_user).and_return(user)
+      routes.draw do
+        get 'show' => 'idv/step#show'
+      end
+    end
+
+    context 'user is not throttled' do
+      let(:user) { create(:user, :fully_registered) }
+
+      it 'does not redirect' do
+        get :show
+
+        expect(response.body).to eq 'Hello'
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'with idv_doc_auth throttle (DocumentCapture)' do
+      it 'redirects to idv_doc_auth throttled error page' do
+        throttle = Throttle.new(user: user, throttle_type: :idv_doc_auth)
+        throttle.increment_to_throttled!
+
+        get :show
+
+        expect(response).to redirect_to idv_session_errors_throttled_url
+      end
+    end
+
+    context 'with idv_resolution throttle (VerifyInfo)' do
+      it 'redirects to idv_resolution throttled error page' do
+        throttle = Throttle.new(user: user, throttle_type: :idv_resolution)
+        throttle.increment_to_throttled!
+
+        get :show
+
+        expect(response).to redirect_to idv_session_errors_failure_url
+      end
+    end
+
+    context 'with proof_address throttle (PhoneStep)' do
+      it 'redirects to proof_address throttled error page' do
+        throttle = Throttle.new(user: user, throttle_type: :proof_address)
+        throttle.increment_to_throttled!
+
+        get :show
+
+        expect(response).to redirect_to idv_phone_errors_failure_url
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -17,9 +17,9 @@ describe 'RateLimitConcern' do
     end
   end
 
-  describe '#check_rate_limited_and_redirect' do
+  describe '#confirm_not_rate_limited' do
     controller Idv::StepController do
-      before_action :check_rate_limited_and_redirect
+      before_action :confirm_not_rate_limited
     end
 
     before(:each) do

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -105,10 +105,7 @@ describe Idv::DocumentCaptureController do
     context 'user is rate_limited' do
       it 'redirects to rate limited page' do
         user = create(:user)
-        profile = create(
-          :profile,
-          user: user,
-        )
+
         Throttle.new(throttle_type: :idv_doc_auth, user: user).increment_to_throttled!
         allow(subject).to receive(:current_user).and_return(user)
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -101,6 +101,22 @@ describe Idv::DocumentCaptureController do
         expect(response).to redirect_to(idv_ssn_url)
       end
     end
+
+    context 'user is rate_limited' do
+      it 'redirects to rate limited page' do
+        user = create(:user)
+        profile = create(
+          :profile,
+          user: user,
+        )
+        Throttle.new(throttle_type: :idv_doc_auth, user: user).increment_to_throttled!
+        allow(subject).to receive(:current_user).and_return(user)
+
+        get :show
+
+        expect(response).to redirect_to(idv_session_errors_throttled_url)
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -47,7 +47,7 @@ describe IdvController do
       expect(response).to redirect_to(idv_not_verified_url)
     end
 
-    context 'if number of attempts has been exceeded' do
+    context 'if number of verify_info attempts has been exceeded' do
       before do
         user = create(:user)
         profile = create(
@@ -71,6 +71,44 @@ describe IdvController do
           with({ throttle_context: 'single-session' })
 
         get :index
+      end
+    end
+
+    context 'if number of document capture attempts has been exceeded' do
+      before do
+        user = create(:user)
+        profile = create(
+          :profile,
+          user: user,
+        )
+        Throttle.new(throttle_type: :idv_doc_auth, user: user).increment_to_throttled!
+
+        stub_sign_in(profile.user)
+      end
+
+      it 'redirects to throttled page' do
+        get :index
+
+        expect(response).to redirect_to idv_session_errors_throttled_url
+      end
+    end
+
+    context 'if number of verify phone attempts has been exceeded' do
+      before do
+        user = create(:user)
+        profile = create(
+          :profile,
+          user: user,
+        )
+        Throttle.new(throttle_type: :proof_address, user: user).increment_to_throttled!
+
+        stub_sign_in(profile.user)
+      end
+
+      it 'redirects to throttled page' do
+        get :index
+
+        expect(response).to redirect_to idv_phone_errors_failure_url
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9813](https://cm-jira.usa.gov/browse/LG-9813)

## 🛠 Summary of changes

Add new RateLimitConcern.

Check in IdvController (`/verify`) and IdvStepConcern (steps after Upload/HybridHandoff) if a user is rate-limited, and show them the appropriate error screen. Rate limits can be from DocumentCapture, VerifyInfo, or PhoneStep.

Do not redirect if the current controller is the one that updates that particular rate limit, because the update action may check for success before rate limiting. PhoneController currently checks for success and the other two don't (yet).

Notes: 
- Decided not to add/change a before_action in DocAuthController (FSM) to catch Welcome through Upload/HybridHandoff for the Phone Step rate limit. IdvController will catch most users.
- Can't check the SSN rate limit because it depends on the SSN being entered.

Future work:
- Rename Throttle to RateLimit
- Create a RateLimitChecker that encapsulates knowledge of Controller/RateLimit/RedirectUrl and use it everywhere
- Update DocumentCapture and VerifyInfo to check for success before enforcing a rate limit.

## 📜 Testing Plan

- [ ] Create an account (recommend using text MFA, remember this browser)
- [ ] Start IdV. In the DocumentCapture step, upload a yaml to trigger an error, available for download [here](https://developers.login.gov/testing/).
- [ ] Click Try again online and keep uploading error yamls until rate limited
- [ ] Try to start Idv again. Navigate to `/verify` and `/verify/document_capture`
- [ ] Expect to see rate limit error screen.
- [ ] Log out and back in.
- [ ] Try to start Idv again. Navigate to `/verify` and `/verify/document_capture`
- [ ] Expect to see rate limit error screen.

- [ ] Same as above, with SSN 123-45-6666 to fail VerifyInfo

- [ ] Same as above, with phone # 7035555555 to fail Phone step
