### PR TITLE
Deploy RC 283 to Prod

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -240,7 +240,8 @@ class ApplicationController < ActionController::Base
 
   def signed_in_url
     return user_two_factor_authentication_url unless user_fully_authenticated?
-    return account_or_verify_profile_url if profile_needs_verification?
+    return reactivate_account_url if user_needs_to_reactivate_account?
+    return url_for_pending_profile_reason if user_has_pending_profile?
     return backup_code_reminder_url if user_needs_backup_code_reminder?
     account_url
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include VerifyProfileConcern
+  include BackupCodeReminderConcern
   include LocaleHelper
   include VerifySpAttributesConcern
   include EffectiveUser
@@ -238,7 +239,10 @@ class ApplicationController < ActionController::Base
   end
 
   def signed_in_url
-    user_fully_authenticated? ? account_or_verify_profile_url : user_two_factor_authentication_url
+    return user_two_factor_authentication_url unless user_fully_authenticated?
+    return account_or_verify_profile_url if profile_needs_verification?
+    return backup_code_reminder_url if user_needs_backup_code_reminder?
+    account_url
   end
 
   def after_mfa_setup_path

--- a/app/controllers/concerns/backup_code_reminder_concern.rb
+++ b/app/controllers/concerns/backup_code_reminder_concern.rb
@@ -1,0 +1,14 @@
+module BackupCodeReminderConcern
+  def user_needs_backup_code_reminder?
+    user_backup_codes_configured? && user_last_signed_in_more_than_5_months_ago?
+  end
+
+  def user_backup_codes_configured?
+    MfaContext.new(current_user).backup_code_configurations.present?
+  end
+
+  def user_last_signed_in_more_than_5_months_ago?
+    second_last_signed_in_at = current_user.second_last_signed_in_at
+    second_last_signed_in_at && second_last_signed_in_at < 5.months.ago
+  end
+end

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -1,0 +1,79 @@
+module Idv
+  module DocumentCaptureConcern
+    extend ActiveSupport::Concern
+
+    def save_proofing_components(user)
+      return unless user
+
+      doc_auth_vendor = DocAuthRouter.doc_auth_vendor(
+        discriminator: document_capture_session_uuid,
+        analytics: analytics,
+      )
+
+      component_attributes = {
+        document_check: doc_auth_vendor,
+        document_type: 'state_id',
+      }
+      ProofingComponent.create_or_find_by(user: user).update(component_attributes)
+    end
+
+    def successful_response
+      FormResponse.new(success: true)
+    end
+
+    # copied from Flow::Failure module
+    def failure(message, extra = nil)
+      flow_session[:error_message] = message if defined?(flow_session)
+      form_response_params = { success: false, errors: { message: message } }
+      form_response_params[:extra] = extra unless extra.nil?
+      FormResponse.new(**form_response_params)
+    end
+
+    # @param [DocAuth::Response,
+    #   DocumentCaptureSessionAsyncResult,
+    #   DocumentCaptureSessionResult] response
+    def extract_pii_from_doc(user, response, store_in_session: false)
+      pii_from_doc = response.pii_from_doc.merge(
+        uuid: user.uuid,
+        phone: user.phone_configurations.take&.phone,
+        uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
+      )
+
+      if defined?(flow_session) # hybrid mobile does not have flow_session
+        flow_session[:had_barcode_read_failure] = response.attention_with_barcode?
+        if store_in_session
+          flow_session[:pii_from_doc] ||= {}
+          flow_session[:pii_from_doc].merge!(pii_from_doc)
+          idv_session.clear_applicant!
+        end
+      end
+
+      track_document_issuing_state(user, pii_from_doc[:state])
+    end
+
+    def in_person_cta_variant_testing_variables
+      bucket = AbTests::IN_PERSON_CTA.bucket(document_capture_session_uuid)
+      session[:in_person_cta_variant] = bucket
+      {
+        in_person_cta_variant_testing_enabled:
+        IdentityConfig.store.in_person_cta_variant_testing_enabled,
+        in_person_cta_variant_active: bucket,
+      }
+    end
+
+    def stored_result
+      return @stored_result if defined?(@stored_result)
+      @stored_result = document_capture_session&.load_result
+    end
+
+    private
+
+    def track_document_issuing_state(user, state)
+      return unless IdentityConfig.store.state_tracking_enabled && state
+      doc_auth_log = DocAuthLog.find_by(user_id: user.id)
+      return unless doc_auth_log
+      doc_auth_log.state = state
+      doc_auth_log.save!
+    end
+  end
+end

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -1,15 +1,15 @@
 module VerifyProfileConcern
   private
 
-  def account_or_verify_profile_url
-    return reactivate_account_url if user_needs_to_reactivate_account?
-    return idv_gpo_verify_url if profile_needs_verification?
-    account_url
+  def url_for_pending_profile_reason
+    return idv_gpo_verify_url if current_user.gpo_verification_pending_profile?
+    return idv_in_person_ready_to_verify_url if current_user.in_person_pending_profile?
+    return idv_please_call_url if current_user.fraud_review_pending?
+    idv_not_verified_url if current_user.fraud_rejection?
   end
 
-  def profile_needs_verification?
+  def user_has_pending_profile?
     return false if current_user.blank?
-    current_user.gpo_verification_pending_profile? ||
-      user_needs_to_reactivate_account?
+    current_user.pending_profile?
   end
 end

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -4,21 +4,7 @@ module VerifyProfileConcern
   def account_or_verify_profile_url
     return reactivate_account_url if user_needs_to_reactivate_account?
     return idv_gpo_verify_url if profile_needs_verification?
-    return backup_code_reminder_url if user_needs_backup_code_reminder?
     account_url
-  end
-
-  def user_needs_backup_code_reminder?
-    user_backup_codes_configured? && user_last_signed_in_more_than_5_months_ago?
-  end
-
-  def user_backup_codes_configured?
-    MfaContext.new(current_user).backup_code_configurations.present?
-  end
-
-  def user_last_signed_in_more_than_5_months_ago?
-    second_last_signed_in_at = current_user.second_last_signed_in_at
-    second_last_signed_in_at && second_last_signed_in_at < 5.months.ago
   end
 
   def profile_needs_verification?

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   class DocumentCaptureController < ApplicationController
     include AcuantConcern
+    include DocumentCaptureConcern
     include IdvSession
     include IdvStepConcern
     include StepIndicatorConcern
@@ -37,7 +38,7 @@ module Idv
 
     def extra_view_variables
       {
-        document_capture_session_uuid: flow_session[:document_capture_session_uuid],
+        document_capture_session_uuid: document_capture_session_uuid,
         flow_path: 'standard',
         sp_name: decorated_session.sp_name,
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
@@ -73,94 +74,16 @@ module Idv
       }.merge(**acuant_sdk_ab_test_analytics_args)
     end
 
-    def in_person_cta_variant_testing_variables
-      bucket = AbTests::IN_PERSON_CTA.bucket(flow_session[:document_capture_session_uuid])
-      session[:in_person_cta_variant] = bucket
-      {
-        in_person_cta_variant_testing_enabled:
-        IdentityConfig.store.in_person_cta_variant_testing_enabled,
-        in_person_cta_variant_active: bucket,
-      }
-    end
-
     def handle_stored_result
       if stored_result&.success?
-        save_proofing_components
-        extract_pii_from_doc(stored_result, store_in_session: !hybrid_flow_mobile?)
+        save_proofing_components(current_user)
+        extract_pii_from_doc(current_user, stored_result, store_in_session: true)
         flash[:success] = t('doc_auth.headings.capture_complete')
         successful_response
       else
         extra = { stored_result_present: stored_result.present? }
         failure(I18n.t('doc_auth.errors.general.network_error'), extra)
       end
-    end
-
-    def stored_result
-      return @stored_result if defined?(@stored_result)
-      @stored_result = document_capture_session&.load_result
-    end
-
-    def save_proofing_components
-      return unless current_user
-
-      doc_auth_vendor = DocAuthRouter.doc_auth_vendor(
-        discriminator: document_capture_session_uuid,
-        analytics: analytics,
-      )
-
-      component_attributes = {
-        document_check: doc_auth_vendor,
-        document_type: 'state_id',
-      }
-      ProofingComponent.create_or_find_by(user: current_user).update(component_attributes)
-    end
-
-    def hybrid_flow_mobile?
-      user_id_from_token.present?
-    end
-
-    def user_id_from_token
-      flow_session[:doc_capture_user_id]
-    end
-
-    # copied from doc_auth_base_step.rb
-    # @param [DocAuth::Response,
-    #   DocumentCaptureSessionAsyncResult,
-    #   DocumentCaptureSessionResult] response
-    def extract_pii_from_doc(response, store_in_session: false)
-      pii_from_doc = response.pii_from_doc.merge(
-        uuid: effective_user.uuid,
-        phone: effective_user.phone_configurations.take&.phone,
-        uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
-      )
-
-      flow_session[:had_barcode_read_failure] = response.attention_with_barcode?
-      if store_in_session
-        flow_session[:pii_from_doc] ||= {}
-        flow_session[:pii_from_doc].merge!(pii_from_doc)
-        idv_session.clear_applicant!
-      end
-      track_document_state(pii_from_doc[:state])
-    end
-
-    def track_document_state(state)
-      return unless IdentityConfig.store.state_tracking_enabled && state
-      doc_auth_log = DocAuthLog.find_by(user_id: current_user.id)
-      return unless doc_auth_log
-      doc_auth_log.state = state
-      doc_auth_log.save!
-    end
-
-    def successful_response
-      FormResponse.new(success: true)
-    end
-
-    # copied from Flow::Failure module
-    def failure(message, extra = nil)
-      flow_session[:error_message] = message
-      form_response_params = { success: false, errors: { message: message } }
-      form_response_params[:extra] = extra unless extra.nil?
-      FormResponse.new(**form_response_params)
     end
   end
 end

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class LinkSentController < ApplicationController
+    include DocumentCaptureConcern
     include IdvSession
     include IdvStepConcern
     include StepIndicatorConcern
@@ -68,52 +69,10 @@ module Idv
     end
 
     def handle_document_verification_success(get_results_response)
-      save_proofing_components
-      extract_pii_from_doc(get_results_response, store_in_session: true)
+      save_proofing_components(current_user)
+      extract_pii_from_doc(current_user, get_results_response, store_in_session: true)
       mark_upload_step_complete
       flow_session[:flow_path] = 'hybrid'
-    end
-
-    def save_proofing_components
-      return unless current_user
-
-      doc_auth_vendor = DocAuthRouter.doc_auth_vendor(
-        discriminator: flow_session[:document_capture_session_uuid],
-        analytics: analytics,
-      )
-
-      component_attributes = {
-        document_check: doc_auth_vendor,
-        document_type: 'state_id',
-      }
-      ProofingComponent.create_or_find_by(user: current_user).update(component_attributes)
-    end
-
-    # @param [DocAuth::Response,
-    #   DocumentCaptureSessionAsyncResult,
-    #   DocumentCaptureSessionResult] response
-    def extract_pii_from_doc(response, store_in_session: false)
-      pii_from_doc = response.pii_from_doc.merge(
-        uuid: effective_user.uuid,
-        phone: effective_user.phone_configurations.take&.phone,
-        uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
-      )
-
-      flow_session[:had_barcode_read_failure] = response.attention_with_barcode?
-      if store_in_session
-        flow_session[:pii_from_doc] ||= {}
-        flow_session[:pii_from_doc].merge!(pii_from_doc)
-        idv_session.clear_applicant!
-      end
-      track_document_state(pii_from_doc[:state])
-    end
-
-    def track_document_state(state)
-      return unless IdentityConfig.store.state_tracking_enabled && state
-      doc_auth_log = DocAuthLog.find_by(user_id: current_user.id)
-      return unless doc_auth_log
-      doc_auth_log.state = state
-      doc_auth_log.save!
     end
 
     def render_document_capture_cancelled
@@ -143,18 +102,6 @@ module Idv
 
     def mark_upload_step_incomplete
       flow_session['Idv::Steps::UploadStep'] = nil
-    end
-
-    def successful_response
-      FormResponse.new(success: true)
-    end
-
-    # copied from Flow::Failure module
-    def failure(message, extra = nil)
-      flow_session[:error_message] = message
-      form_response_params = { success: false, errors: { message: message } }
-      form_response_params[:extra] = extra unless extra.nil?
-      FormResponse.new(**form_response_params)
     end
 
     def extend_timeout_using_meta_refresh

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import type { ComponentType } from 'react';
 import { Provider as MarketingSiteContextProvider } from '../context/marketing-site';
 import InPersonPrepareStep from './in-person-prepare-step';
+import { InPersonContext } from '../context';
 
 describe('InPersonPrepareStep', () => {
   const DEFAULT_PROPS = { toPreviousStep() {}, value: {} };
@@ -15,6 +16,29 @@ describe('InPersonPrepareStep', () => {
         name: 'in_person_proofing.body.prepare.privacy_disclaimer_link links.new_tab',
       }),
     ).not.to.exist();
+  });
+
+  context('USPS outage message', () => {
+    it('renders a warning when the flag is enabled', () => {
+      const { queryByText } = render(
+        <InPersonContext.Provider value={{ inPersonUspsOutageMessageEnabled: true }}>
+          <InPersonPrepareStep {...DEFAULT_PROPS} />
+        </InPersonContext.Provider>,
+      );
+      expect(
+        queryByText('idv.failure.exceptions.usps_outage_error_message.post_cta.title'),
+      ).to.exist();
+    });
+    it('does not render a warning when the flag is disabled', () => {
+      const { queryByText } = render(
+        <InPersonContext.Provider value={{ inPersonUspsOutageMessageEnabled: false }}>
+          <InPersonPrepareStep {...DEFAULT_PROPS} />
+        </InPersonContext.Provider>,
+      );
+      expect(
+        queryByText('idv.failure.exceptions.usps_outage_error_message.post_cta.title'),
+      ).not.to.exist();
+    });
   });
 
   context('with marketing site context URL', () => {

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react';
-import { Alert, Link, PageHeading, ProcessList, ProcessListItem } from '@18f/identity-components';
+import { Link, PageHeading, ProcessList, ProcessListItem } from '@18f/identity-components';
 import { getConfigValue } from '@18f/identity-config';
 import { useI18n } from '@18f/identity-react-i18n';
 import { FormStepsButton } from '@18f/identity-form-steps';
@@ -9,13 +9,15 @@ import AnalyticsContext from '../context/analytics';
 import BackButton from './back-button';
 import InPersonTroubleshootingOptions from './in-person-troubleshooting-options';
 import { InPersonContext } from '../context';
+import InPersonUspsOutageAlert from './in-person-usps-outage-alert';
 
 function InPersonPrepareStep({ toPreviousStep }) {
   const { t } = useI18n();
   const { flowPath } = useContext(UploadContext);
   const { setSubmitEventMetadata } = useContext(AnalyticsContext);
   const { securityAndPrivacyHowItWorksURL } = useContext(MarketingSiteContext);
-  const { inPersonURL, inPersonCtaVariantActive } = useContext(InPersonContext);
+  const { inPersonURL, inPersonCtaVariantActive, inPersonUspsOutageMessageEnabled } =
+    useContext(InPersonContext);
 
   useEffect(() => {
     setSubmitEventMetadata({ in_person_cta_variant: inPersonCtaVariantActive });
@@ -23,19 +25,7 @@ function InPersonPrepareStep({ toPreviousStep }) {
 
   return (
     <>
-      <Alert type="warning" className="margin-bottom-4">
-        <>
-          <strong>
-            {t('idv.failure.exceptions.post_office_outage_error_message.post_cta.title')}
-          </strong>
-          <br />
-          <br />
-          {t('idv.failure.exceptions.post_office_outage_error_message.post_cta.body', {
-            app_name: getConfigValue('appName'),
-          })}
-          <br />
-        </>
-      </Alert>
+      {inPersonUspsOutageMessageEnabled && <InPersonUspsOutageAlert />}
 
       <PageHeading>{t('in_person_proofing.headings.prepare')}</PageHeading>
 

--- a/app/javascript/packages/document-capture/components/in-person-usps-outage-alert.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-usps-outage-alert.spec.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import InPersonUspsOutageAlert from './in-person-usps-outage-alert';
+
+describe('InPersonUspsOutageAlert', () => {
+  let getByText;
+  beforeEach(() => {
+    getByText = render(<InPersonUspsOutageAlert />).getByText;
+  });
+
+  it('renders the title', () => {
+    expect(getByText('idv.failure.exceptions.usps_outage_error_message.post_cta.title')).to.exist();
+  });
+
+  it('renders the body', () => {
+    expect(getByText('idv.failure.exceptions.usps_outage_error_message.post_cta.body')).to.exist();
+  });
+});

--- a/app/javascript/packages/document-capture/components/in-person-usps-outage-alert.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-usps-outage-alert.tsx
@@ -1,0 +1,21 @@
+import { t } from '@18f/identity-i18n';
+import { Alert } from '@18f/identity-components';
+import { getConfigValue } from '@18f/identity-config';
+
+function InPersonUspsOutageAlert() {
+  return (
+    <Alert type="warning" className="margin-bottom-4">
+      <>
+        <strong>{t('idv.failure.exceptions.usps_outage_error_message.post_cta.title')}</strong>
+        <br />
+        <br />
+        {t('idv.failure.exceptions.usps_outage_error_message.post_cta.body', {
+          app_name: getConfigValue('appName'),
+        })}
+        <br />
+      </>
+    </Alert>
+  );
+}
+
+export default InPersonUspsOutageAlert;

--- a/app/javascript/packages/document-capture/context/in-person.ts
+++ b/app/javascript/packages/document-capture/context/in-person.ts
@@ -15,11 +15,17 @@ export interface InPersonContextProps {
    * URL to in-person proofing alternative flow, if enabled.
    */
   inPersonURL?: string;
+
+  /**
+   * Whether the message indicating a USPS outage should be displayed
+   */
+  inPersonUspsOutageMessageEnabled: boolean;
 }
 
 const InPersonContext = createContext<InPersonContextProps>({
   inPersonCtaVariantTestingEnabled: false,
   inPersonCtaVariantActive: '',
+  inPersonUspsOutageMessageEnabled: false,
 });
 
 InPersonContext.displayName = 'InPersonContext';

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -115,6 +115,7 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
     securityAndPrivacyHowItWorksUrl: securityAndPrivacyHowItWorksURL,
     inPersonCtaVariantTestingEnabled,
     inPersonCtaVariantActive,
+    inPersonUspsOutageMessageEnabled,
   } = appRoot.dataset as DOMStringMap & AppRootData;
 
   const App = composeComponents(
@@ -127,6 +128,7 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
           inPersonCtaVariantTestingEnabled: inPersonCtaVariantTestingEnabled === true,
           inPersonCtaVariantActive,
           inPersonURL,
+          inPersonUspsOutageMessageEnabled: inPersonUspsOutageMessageEnabled === 'true',
         },
       },
     ],

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -163,15 +163,14 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     if response_message == IPP_INCOMPLETE_ERROR_MESSAGE
       # Customer has not been to post office for IPP
-      enrollment_outcomes[:enrollments_in_progress] += 1
-      analytics(user: enrollment.user).
-        idv_in_person_usps_proofing_results_job_enrollment_incomplete(
-          **enrollment_analytics_attributes(enrollment, complete: false),
-          response_message: response_message,
-        )
-      enrollment.update(status_check_completed_at: Time.zone.now)
+      handle_incomplete_status_update(enrollment, response_message)
     elsif response_message&.match(IPP_EXPIRED_ERROR_MESSAGE)
-      handle_expired_status_update(enrollment, err.response, response_message)
+      # If we're blocking expirations, treat this enrollment as incomplete
+      if IdentityConfig.store.in_person_stop_expiring_enrollments.blank?
+        handle_expired_status_update(enrollment, err.response, response_message)
+      else
+        handle_incomplete_status_update(enrollment, response_message)
+      end
     elsif response_message == IPP_INVALID_ENROLLMENT_CODE_MESSAGE % enrollment.enrollment_code
       handle_unexpected_response(enrollment, response_message, reason: 'Invalid enrollment code')
     elsif response_message == IPP_INVALID_APPLICANT_MESSAGE % enrollment.unique_id
@@ -272,6 +271,16 @@ class GetUspsProofingResultsJob < ApplicationJob
       **email_analytics_attributes(enrollment),
       email_type: 'Failed unsupported ID type',
     )
+  end
+
+  def handle_incomplete_status_update(enrollment, response_message)
+    enrollment_outcomes[:enrollments_in_progress] += 1
+    analytics(user: enrollment.user).
+      idv_in_person_usps_proofing_results_job_enrollment_incomplete(
+        **enrollment_analytics_attributes(enrollment, complete: false),
+        response_message: response_message,
+      )
+    enrollment.update(status_check_completed_at: Time.zone.now)
   end
 
   def handle_expired_status_update(enrollment, response, response_message)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,6 +143,14 @@ class User < ApplicationRecord
     pending_profile if pending_profile&.fraud_rejection?
   end
 
+  def in_person_pending_profile?
+    in_person_pending_profile.present?
+  end
+
+  def in_person_pending_profile
+    pending_profile if pending_profile&.in_person_verification_pending?
+  end
+
   def personal_key_generated_at
     encrypted_recovery_code_digest_generated_at ||
       active_profile&.verified_at ||

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,20 +107,32 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    pending = profiles.where(deactivation_reason: :in_person_verification_pending).or(
-      profiles.where.not(gpo_verification_pending_at: nil),
-    ).or(
-      profiles.where.not(fraud_review_pending_at: nil),
-    ).or(
-      profiles.where.not(fraud_rejection_at: nil),
-    ).order(created_at: :desc).first
+    return @pending_profile if defined?(@pending_profile)
 
-    return unless pending.present?
-    return if pending.password_reset?
-    return if pending.encryption_error? || pending.verification_cancelled?
-    return if active_profile.present? && active_profile.activated_at > pending.created_at
+    @pending_profile = begin
+      pending = profiles.where(deactivation_reason: :in_person_verification_pending).or(
+        profiles.where.not(gpo_verification_pending_at: nil),
+      ).or(
+        profiles.where.not(fraud_review_pending_at: nil),
+      ).or(
+        profiles.where.not(fraud_rejection_at: nil),
+      ).order(created_at: :desc).first
 
-    pending
+      if pending.blank?
+        nil
+      elsif pending.password_reset? || pending.encryption_error? || pending.verification_cancelled?
+        # Profiles that are cancelled for reasons that do not require further verification steps
+        # are not pending profiles
+        nil
+      elsif active_profile.present? && active_profile.activated_at > pending.created_at
+        # If there is an active profile that is older than this pending profile that means the user
+        # has proofed since this profile was created. That profile takes precedence and there is no
+        # pending profile
+        nil
+      else
+        pending
+      end
+    end
   end
 
   def gpo_verification_pending_profile

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -108,6 +108,10 @@ class CompletionsPresenter
     end
   end
 
+  def image_alt
+    I18n.t('sign_up.completed.smiling_image_alt')
+  end
+
   def pii
     displayable_attribute_keys.index_with do |attribute_name|
       displayable_pii[attribute_name]

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -46,6 +46,10 @@ module Idv
         sp_return_url_resolver.homepage_url if service_provider
       end
 
+      def usps_outage_message_enabled
+        IdentityConfig.store.in_person_usps_outage_message_enabled
+      end
+
       private
 
       attr_reader :enrollment

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -686,32 +686,224 @@ module AnalyticsEvents
     track_event('IdV: in person proofing residential address submitted', **extra)
   end
 
-  def idv_in_person_proofing_address_submitted(**extra)
-    track_event('IdV: in person proofing address submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean] same_address_as_id
+  # address submitted by user
+  def idv_in_person_proofing_address_submitted(
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
+    same_address_as_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing address submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_address_visited(**extra)
-    track_event('IdV: in person proofing address visited', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # address page visited
+  def idv_in_person_proofing_address_visited(
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing address visited',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_cancel_update_address(**extra)
-    track_event('IdV: in person proofing cancel_update_address submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean, nil] same_address_as_id
+  # User clicked cancel on update address page
+  def idv_in_person_proofing_cancel_update_address(
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
+    same_address_as_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing cancel_update_address submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_cancel_update_state_id(**extra)
-    track_event('IdV: in person proofing cancel_update_state_id submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean] same_address_as_id
+  # User clicked cancel on update state id page
+  def idv_in_person_proofing_cancel_update_state_id(
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
+    same_address_as_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing cancel_update_state_id submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_redo_state_id_submitted(**extra)
-    track_event('IdV: in person proofing redo_state_id submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean] same_address_as_id
+  # User submitted state id on redo state id page
+  def idv_in_person_proofing_redo_state_id_submitted(
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
+    same_address_as_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing redo_state_id submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_state_id_submitted(**extra)
-    track_event('IdV: in person proofing state_id submitted', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Boolean, nil] same_address_as_id
+  # User submitted state id
+  def idv_in_person_proofing_state_id_submitted(
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    success: nil,
+    errors: nil,
+    same_address_as_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing state_id submitted',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      success: success,
+      errors: errors,
+      same_address_as_id: same_address_as_id,
+      **extra,
+    )
   end
 
-  def idv_in_person_proofing_state_id_visited(**extra)
-    track_event('IdV: in person proofing state_id visited', **extra)
+  # @param [String] flow_path
+  # @param [String] step
+  # @param [Integer] step_count
+  # @param [String] analytics_id
+  # @param [Boolean] irs_reproofing
+  # State id page visited
+  def idv_in_person_proofing_state_id_visited(
+    flow_path: nil,
+    step: nil,
+    step_count: nil,
+    analytics_id: nil,
+    irs_reproofing: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing state_id visited',
+      flow_path: flow_path,
+      step: step,
+      step_count: step_count,
+      analytics_id: analytics_id,
+      irs_reproofing: irs_reproofing,
+      **extra,
+    )
   end
 
   # @param [String] flow_path Document capture path ("hybrid" or "standard")

--- a/app/services/idv/flows/in_person_flow.rb
+++ b/app/services/idv/flows/in_person_flow.rb
@@ -55,11 +55,14 @@ module Idv
       end
 
       def extra_analytics_properties
-        return {} if @flow_session[:pii_from_user][:same_address_as_id].nil?
-        {
-          same_address_as_id: @flow_session[:pii_from_user][:same_address_as_id].to_s == 'true',
+        extra = {
           pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
         }
+        unless @flow_session[:pii_from_user]&.[](:same_address_as_id).nil?
+          extra[:same_address_as_id] =
+            @flow_session[:pii_from_user][:same_address_as_id].to_s == 'true'
+        end
+        extra
       end
     end
   end

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -9,16 +9,18 @@
       ) %>
 <% end %>
 
-<%= render AlertComponent.new(type: :warning, class: 'margin-bottom-4', text_tag: 'div') do %>
-  <strong><%= t('idv.failure.exceptions.post_office_outage_error_message.ready_to_verify.title') %></strong>
-  <br/>
-  <br/>
-  <%= t('idv.failure.exceptions.post_office_outage_error_message.ready_to_verify.body') %>
-  <br/>
-  <br/>
-  <%= t('idv.failure.exceptions.post_office_outage_error_message.ready_to_verify.contact_html', app_name: APP_NAME, help_url: MarketingSite.contact_url) %>
-  <br/>
-  <br/>
+<% if @presenter.usps_outage_message_enabled %>
+  <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-4', text_tag: 'div') do %>
+    <strong><%= t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.title') %></strong>
+    <br/>
+    <br/>
+    <%= t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.body') %>
+    <br/>
+    <br/>
+    <%= t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.contact_html', app_name: APP_NAME, help_url: MarketingSite.contact_url) %>
+    <br/>
+    <br/>
+  <% end %>
 <% end %>
 
 <%= render PageHeadingComponent.new(class: 'text-center') do %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -32,6 +32,7 @@
       security_and_privacy_how_it_works_url: MarketingSite.security_and_privacy_how_it_works_url,
       in_person_cta_variant_testing_enabled: IdentityConfig.store.in_person_cta_variant_testing_enabled,
       in_person_cta_variant_active: in_person_cta_variant_active,
+      in_person_usps_outage_message_enabled: IdentityConfig.store.in_person_usps_outage_message_enabled,
     } %>
   <%= simple_form_for(
         :doc_auth,

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -1,6 +1,6 @@
 <% title @presenter.heading %>
 <div class="text-center">
-  <%= image_tag asset_url(@presenter.image_name), width: 140, alt: '', class: 'margin-bottom-2' %>
+  <%= image_tag asset_url(@presenter.image_name), width: 140, alt: @presenter.image_alt, class: 'margin-bottom-2' %>
 </div>
 
 <%= render PageHeadingComponent.new(class: 'tablet:margin-right-1 tablet:margin-left-1 text-center') do %>

--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -1,22 +1,23 @@
+<% if @presenter.usps_outage_message_enabled %>
 <table class="warning-alert margin-y-4">
   <tr>
     <td width="16">
       <%= image_tag('email/warning.png', width: 16, height: 16, alt: '') %>
     </td>
     <td>
-      <strong><%= t('idv.failure.exceptions.post_office_outage_error_message.ready_to_verify.title') %></strong>
+      <strong><%= t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.title') %></strong>
       <br />
       <br />
-      <%= t('idv.failure.exceptions.post_office_outage_error_message.ready_to_verify.body') %>
+      <%= t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.body') %>
       <br />
       <br />
-      <%= t('idv.failure.exceptions.post_office_outage_error_message.ready_to_verify.contact_html', app_name: APP_NAME, help_url: MarketingSite.contact_url) %>
+      <%= t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.contact_html', app_name: APP_NAME, help_url: MarketingSite.contact_url) %>
       <br />
       <br />
     </td>
   </tr>
 </table>
-
+<% end %>
 <div class="text-center">
   <%= render 'idv/shared/mini_logo', filename: 'logo.png' %>
   <%= render BarcodeComponent.new(

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -142,6 +142,7 @@ in_person_enrollment_validity_in_days: 30
 in_person_results_delay_in_hours: 1
 in_person_completion_survey_url: 'https://login.gov'
 in_person_verify_info_controller_enabled: false
+in_person_stop_expiring_enrollments: false
 include_slo_in_saml_metadata: false
 irs_attempt_api_audience: 'https://irs.gov'
 irs_attempt_api_auth_tokens: ''

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -141,6 +141,7 @@ in_person_proofing_enabled: false
 in_person_enrollment_validity_in_days: 30
 in_person_results_delay_in_hours: 1
 in_person_completion_survey_url: 'https://login.gov'
+in_person_usps_outage_message_enabled: false
 in_person_verify_info_controller_enabled: false
 in_person_stop_expiring_enrollments: false
 include_slo_in_saml_metadata: false

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -75,7 +75,11 @@ en:
       exceptions:
         internal_error: There was an internal error processing your request. Please try again.
         link: please contact us
-        post_office_outage_error_message:
+        post_office_search_error: We are having technical difficulties at the moment.
+          Try searching for a Post Office again. If this issue continues, come
+          back later.
+        text_html: Please try again. If you keep getting these errors, %{link}.
+        usps_outage_error_message:
           post_cta:
             body: In the meantime, you can still begin the in-person verification process on
               %{app_name} and then visit a Post Office. If you urgently need
@@ -91,10 +95,6 @@ en:
               verification results by Thursday, June 1.
             title: We’re working on a technical issue. Your identity verification results
               may not be emailed to you until Tuesday, May 30.
-        post_office_search_error: We are having technical difficulties at the moment.
-          Try searching for a Post Office again. If this issue continues, come
-          back later.
-        text_html: Please try again. If you keep getting these errors, %{link}.
       exit:
         with_sp: Exit %{app_name} and return to %{sp_name}
         without_sp: Exit identity verification and go to your account page

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -80,7 +80,11 @@ es:
         internal_error: Se produjo un error interno al procesar tu solicitud. Por favor,
           inténtalo de nuevo.
         link: contáctanos
-        post_office_outage_error_message:
+        post_office_search_error: En este momento, estamos teniendo problemas técnicos.
+          Trate de buscar de nuevo una oficina de correos. Si el problema
+          continúa, regrese más tarde.
+        text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
+        usps_outage_error_message:
           post_cta:
             body: Mientras tanto, todavía puedes iniciar el proceso de verificación
               presencial en %{app_name} y luego acudir a una oficina de correos.
@@ -99,10 +103,6 @@ es:
             title: Estamos resolviendo un problema técnico. Es probable que los resultados
               de tu verificación de identidad se te envíen por correo
               electrónico hasta el martes, May 30.
-        post_office_search_error: En este momento, estamos teniendo problemas técnicos.
-          Trate de buscar de nuevo una oficina de correos. Si el problema
-          continúa, regrese más tarde.
-        text_html: Inténtalo de nuevo. Si sigues recibiendo estos errores, %{link}.
       exit:
         with_sp: Salir de %{app_name} y volver a %{sp_name}
         without_sp: Salir de la verificación de identidad e ir a la página de su cuenta

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -84,7 +84,11 @@ fr:
         internal_error: Une erreur interne s’est produite lors du traitement de votre
           demande. Veuillez réessayer.
         link: contactez-nous
-        post_office_outage_error_message:
+        post_office_search_error: Nous connaissons des difficultés techniques en ce
+          moment. Essayez de chercher à nouveau un bureau de poste. Si le
+          problème persiste, revenez plus tard.
+        text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
+        usps_outage_error_message:
           post_cta:
             body: En attendant, vous pouvez toujours commencer la procédure de vérification
               en personne sur %{app_name} et vous pouvez visiter un bureau de
@@ -105,10 +109,6 @@ fr:
             title: Nous travaillons sur un problème technique. Il se peut que les résultats
               de votre vérification d’identité ne vous soient pas envoyés par
               courrier électronique avant le mardi, May 30.
-        post_office_search_error: Nous connaissons des difficultés techniques en ce
-          moment. Essayez de chercher à nouveau un bureau de poste. Si le
-          problème persiste, revenez plus tard.
-        text_html: Veuillez réessayer. Si vous continuez à recevoir ces erreurs, %{link}
       exit:
         with_sp: Quittez %{app_name} et retournez à %{sp_name}
         without_sp: Quittez la vérification d’identité et accédez à la page de votre compte

--- a/config/locales/sign_up/en.yml
+++ b/config/locales/sign_up/en.yml
@@ -5,4 +5,6 @@ en:
     cancel:
       success: Your account has been deleted. We did not save your information.
       warning_header: 'If you cancel now:'
+    completed:
+      smiling_image_alt: A smiling person with a green checkmark indicating success
     terms: I read and accept the %{app_name}

--- a/config/locales/sign_up/es.yml
+++ b/config/locales/sign_up/es.yml
@@ -5,4 +5,6 @@ es:
     cancel:
       success: Su cuenta ha sido eliminada. No guardamos su información.
       warning_header: 'Si cancela ahora:'
+    completed:
+      smiling_image_alt: Una persona sonriente con una marca de verificación verde de éxito
     terms: He leído y acepto el %{app_name}

--- a/config/locales/sign_up/fr.yml
+++ b/config/locales/sign_up/fr.yml
@@ -5,4 +5,6 @@ fr:
     cancel:
       success: Le dossier contenant votre information a été effacé
       warning_header: 'Si vous annulez maintenant:'
+    completed:
+      smiling_image_alt: Une personne souriante avec une coche verte indiquant la réussite
     terms: J’ai lu et j’accepte le %{app_name}

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -220,6 +220,7 @@ class IdentityConfig
     config.add(:in_person_enrollment_validity_in_days, type: :integer)
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:in_person_completion_survey_url, type: :string)
+    config.add(:in_person_usps_outage_message_enabled, type: :boolean)
     config.add(:in_person_verify_info_controller_enabled, type: :boolean)
     config.add(:in_person_stop_expiring_enrollments, type: :boolean)
     config.add(:include_slo_in_saml_metadata, type: :boolean)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -221,6 +221,7 @@ class IdentityConfig
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:in_person_completion_survey_url, type: :string)
     config.add(:in_person_verify_info_controller_enabled, type: :boolean)
+    config.add(:in_person_stop_expiring_enrollments, type: :boolean)
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:irs_attempt_api_audience)
     config.add(:irs_attempt_api_auth_tokens, type: :comma_separated_string_list)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2073,7 +2073,7 @@ describe SamlIdpController do
 
         stub_analytics
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
-        allow(controller).to receive(:profile_needs_verification?).and_return(true)
+        allow(controller).to receive(:user_has_pending_profile?).and_return(true)
 
         analytics_hash = {
           success: true,

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -92,7 +92,7 @@ feature 'Analytics Regression', js: true do
       'IdV: in person proofing prepare visited' => { flow_path: 'standard' },
       'IdV: in person proofing prepare submitted' => { flow_path: 'standard', in_person_cta_variant: 'in_person_variant_a' },
       'IdV: in person proofing state_id visited' => { step: 'state_id', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false },
-      'IdV: in person proofing state_id submitted' => { success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false, errors: {} },
+      'IdV: in person proofing state_id submitted' => { success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false, errors: {}, same_address_as_id: nil },
       'IdV: in person proofing address visited' => { step: 'address', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false },
       'IdV: in person proofing address submitted' => { success: true, step: 'address', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing', irs_reproofing: false, errors: {}, same_address_as_id: true },
       'IdV: doc auth ssn visited' => { analytics_id: 'In Person Proofing', step: 'ssn', flow_path: 'standard', step_count: 1, irs_reproofing: false, same_address_as_id: true },

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -28,7 +28,7 @@ feature 'idv gpo step', :js do
     let(:gpo_confirmation_code) do
       create(
         :gpo_confirmation_code,
-        profile: user.pending_profile,
+        profile: User.find(user.id).pending_profile,
         otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
       )
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -576,6 +576,27 @@ describe UserMailer, type: :mailer do
         end
       end
 
+      context 'USPS outage message' do
+        it 'renders a warning when the flag is enabled' do
+          allow(IdentityConfig.store).to receive(:in_person_usps_outage_message_enabled).
+            and_return(true)
+
+          expect(mail.html_part.body).
+            to have_content(
+              t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.title'),
+            )
+        end
+        it 'does not renders a warning when the flag is disabled' do
+          allow(IdentityConfig.store).to receive(:in_person_usps_outage_message_enabled).
+            and_return(false)
+
+          expect(mail.html_part.body).
+            to_not have_content(
+              t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.title'),
+            )
+        end
+      end
+
       it 'renders the body' do
         expect(mail.html_part.body).
           to have_content(

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -164,6 +164,12 @@ describe CompletionsPresenter do
     end
   end
 
+  describe '#image_alt' do
+    it 'returns image alt test' do
+      expect(presenter.image_alt).to eq(I18n.t('sign_up.completed.smiling_image_alt'))
+    end
+  end
+
   describe '#intro' do
     describe 'ial1' do
       context 'consent has expired since the last sign in' do

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -159,6 +159,21 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
     end
   end
 
+  describe '#usps_outage_message_enabled' do
+    subject(:usps_outage_message_enabled) { presenter.usps_outage_message_enabled }
+    it 'returns true when the flag is enabled' do
+      allow(IdentityConfig.store).to receive(:in_person_usps_outage_message_enabled).
+        and_return(true).once
+      expect(usps_outage_message_enabled).to be(true)
+    end
+
+    it 'returns false when the flag is disabled' do
+      allow(IdentityConfig.store).to receive(:in_person_usps_outage_message_enabled).
+        and_return(false).once
+      expect(usps_outage_message_enabled).to be(false)
+    end
+  end
+
   describe '#barcode_image_url' do
     subject(:barcode_image_url) { presenter.barcode_image_url }
 

--- a/spec/support/idv_examples/clearing_and_restarting.rb
+++ b/spec/support/idv_examples/clearing_and_restarting.rb
@@ -35,7 +35,7 @@ shared_examples 'clearing and restarting idv' do
     expect(page).to have_content(t('idv.titles.come_back_later'))
     expect(page).to have_current_path(idv_come_back_later_path)
     expect(user.reload.identity_verified?).to eq(false)
-    expect(user.pending_profile?).to eq(true)
+    expect(User.find(user.id).pending_profile?).to eq(true)
     expect(gpo_confirmation.entry[:address1]).to eq('1 FAKE RD')
   end
 

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -102,4 +102,31 @@ describe 'idv/in_person/ready_to_verify/show.html.erb' do
       expect(rendered).not_to have_content(t('in_person_proofing.body.barcode.retail_hours'))
     end
   end
+
+  context 'USPS outage message flag' do
+    before(:each) do
+    end
+
+    it 'renders the USPS outage alert when flag is enabled' do
+      allow(IdentityConfig.store).to receive(:in_person_usps_outage_message_enabled).
+        and_return(true)
+
+      render
+
+      expect(rendered).to have_content(
+        t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.title'),
+      )
+    end
+
+    it 'does not render the USPS outage alert when flag is disabled' do
+      allow(IdentityConfig.store).to receive(:in_person_usps_outage_message_enabled).
+        and_return(false)
+
+      render
+
+      expect(rendered).not_to have_content(
+        t('idv.failure.exceptions.usps_outage_error_message.ready_to_verify.title'),
+      )
+    end
+  end
 end


### PR DESCRIPTION
## User-Facing Improvements
- Registration: Update image alt text for accessibility ([#8445](https://github.com/18F/identity-idp/pull/8445))

## Internal
- Analytics events: Update ipp analytics events to include properties in order to update documentation ([#8399](https://github.com/18F/identity-idp/pull/8399))
- In-Person Proofing: Allow disabling the proofing delay warning without code deploy ([#8476](https://github.com/18F/identity-idp/pull/8476))
- In-person proofing: Add feature flag to ignore enrollment expirations ([#8474](https://github.com/18F/identity-idp/pull/8474))