### PR TITLE
Remove combined params from mobile upload step url

### DIFF
--- a/app/views/idv/doc_auth/upload.html.erb
+++ b/app/views/idv/doc_auth/upload.html.erb
@@ -30,7 +30,7 @@
     <%= simple_form_for(
           idv_phone_form,
           as: :doc_auth,
-          url: url_for(type: :mobile, combined: true),
+          url: url_for(type: :mobile),
           method: 'PUT',
           html: { autocomplete: 'off' },
         ) do |f| %>

--- a/spec/services/idv/steps/upload_step_spec.rb
+++ b/spec/services/idv/steps/upload_step_spec.rb
@@ -24,7 +24,6 @@ describe Idv::Steps::UploadStep do
       ActionController::Parameters.new(
         {
           doc_auth: { phone: '(201) 555-1212' },
-          combined: true,
         },
       )
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-9830](https://cm-jira.usa.gov/browse/LG-9830)

## 🛠 Summary of changes
Remove the combined parameter for the upload step page url when send link submissions are rate limited.

Before:
example.com/verify/doc_auth/upload?**combined=true**&type=mobile
After:
example.com/verify/doc_auth/upload?type=mobile
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots
<details>
<summary>Before:</summary>
<img width="964" alt="Screen Shot 2023-05-24 at 3 51 24 PM" src="https://github.com/18F/identity-idp/assets/1261794/476ea6aa-378c-4bfd-8a4b-00c7c4d7ae93">
</details>

<details>
<summary>After:</summary>
<img width="1138" alt="Screen Shot 2023-05-24 at 3 53 06 PM" src="https://github.com/18F/identity-idp/assets/1261794/a5b28dc1-a9a3-4451-a17b-73d0349fa563">
</details>
