### PR TITLE
Fix mobile unstyled appearance for clipboard button

### DIFF
--- a/app/components/clipboard_button_component.rb
+++ b/app/components/clipboard_button_component.rb
@@ -1,22 +1,34 @@
-class ClipboardButtonComponent < ButtonComponent
-  attr_reader :clipboard_text, :tag_options
+class ClipboardButtonComponent < BaseComponent
+  attr_reader :clipboard_text, :button_options
 
-  def initialize(clipboard_text:, **tag_options)
-    super(**tag_options, type: :button, icon: :content_copy)
-
+  def initialize(clipboard_text:, **button_options)
     @clipboard_text = clipboard_text
+    @button_options = button_options
   end
 
   def call
     content_tag(
       :'lg-clipboard-button',
-      super,
+      button_content,
       'clipboard-text': clipboard_text,
       'tooltip-text': t('components.clipboard_button.tooltip'),
+      class: css_class,
     )
   end
 
   def content
     t('components.clipboard_button.label')
+  end
+
+  def css_class
+    'clipboard-button--unstyled' if button_options[:unstyled]
+  end
+
+  def button_content
+    render ButtonComponent.new(
+      **button_options,
+      type: :button,
+      icon: :content_copy,
+    ).with_content(content)
   end
 end

--- a/app/components/clipboard_button_component.scss
+++ b/app/components/clipboard_button_component.scss
@@ -12,5 +12,9 @@
 .usa-tooltip {
   @include at-media-max('mobile-lg') {
     display: block;
+
+    .clipboard-button--unstyled & {
+      display: inline;
+    }
   }
 }

--- a/spec/components/clipboard_button_component_spec.rb
+++ b/spec/components/clipboard_button_component_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe ClipboardButtonComponent, type: :component do
   let(:clipboard_text) { 'Copy Text' }
-  let(:tag_options) { {} }
+  let(:button_options) { {} }
 
   subject(:rendered) do
-    render_inline ClipboardButtonComponent.new(clipboard_text:, **tag_options)
+    render_inline ClipboardButtonComponent.new(clipboard_text:, **button_options)
   end
 
   it 'renders with clipboard text as attribute' do
@@ -19,7 +19,7 @@ RSpec.describe ClipboardButtonComponent, type: :component do
   end
 
   context 'with tag options' do
-    let(:tag_options) { { outline: true, data: { foo: 'bar' } } }
+    let(:button_options) { { outline: true, data: { foo: 'bar' } } }
 
     it 'renders button given the tag options' do
       expect(rendered).to have_css('button.usa-button[type="button"][data-foo="bar"]')
@@ -27,6 +27,14 @@ RSpec.describe ClipboardButtonComponent, type: :component do
 
     it 'respects keyword arguments of button component' do
       expect(rendered).to have_css('.usa-button--outline:not([outline])')
+    end
+  end
+
+  context 'with unstyled button' do
+    let(:button_options) { { unstyled: true } }
+
+    it 'renders with modifier class' do
+      expect(rendered).to have_css('lg-clipboard-button.clipboard-button--unstyled')
     end
   end
 end

--- a/spec/components/previews/clipboard_button_component_preview.rb
+++ b/spec/components/previews/clipboard_button_component_preview.rb
@@ -3,11 +3,18 @@ class ClipboardButtonComponentPreview < BaseComponentPreview
   def default
     render(ClipboardButtonComponent.new(clipboard_text: 'Copied Text', class: css_class))
   end
+
+  def unstyled
+    render(
+      ClipboardButtonComponent.new(clipboard_text: 'Copied Text', unstyled: true, class: css_class),
+    )
+  end
   # @!endgroup
 
   # @param clipboard_text text
-  def workbench(clipboard_text: 'Copied Text')
-    render(ClipboardButtonComponent.new(clipboard_text:, class: css_class))
+  # @param unstyled toggle
+  def workbench(clipboard_text: 'Copied Text', unstyled: false)
+    render(ClipboardButtonComponent.new(clipboard_text:, unstyled:, class: css_class))
   end
 
   private


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a bug where the "Copy" button appears incorrect on the Personal Key confirmation screen at small viewport sizes, regressed in #8307 due to a workaround introduced to resolve an [upstream issue with button display at small viewport sizes](https://github.com/uswds/uswds/issues/5273).

The workaround caused all buttons to appear as `display: block`, but since an unstyled button is expected to appear as `display: inline` ([source](https://github.com/18F/identity-idp/blob/b4b2fa7a2ea1c2a301bc6905b0ad650fdc870631/app/assets/stylesheets/components/_btn.scss#L10-L15)), these should be excluded from the workaround.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in or create an account
3. Go to http://localhost:3000/verify
4. Complete identity verification up to personal key screen
5. If on desktop, use devtools screen size emulator to emulate a mobile phone viewport width
6. Observe that "Copy" link appears inline

## 👀 Screenshots

Before|After
---|---
![localhost_3000_verify_personal_key(iPhone XR) (1)](https://github.com/18F/identity-idp/assets/1779930/d7770677-0fab-4077-b39d-c1ca10936cba)|![localhost_3000_verify_personal_key(iPhone XR)](https://github.com/18F/identity-idp/assets/1779930/d457f648-0d72-4c14-8206-5829f6f5671b)

