### PR TITLE
Allow configuring shortcodes for international country codes (LG-9839)

### DIFF
--- a/config/initializers/telephony.rb
+++ b/config/initializers/telephony.rb
@@ -22,6 +22,7 @@ Telephony.config do |c|
     c.pinpoint.add_sms_config do |sms|
       sms.application_id = sms_json_config['application_id']
       sms.region = sms_json_config['region']
+      sms.country_code_shortcodes = sms_json_config['country_code_shortcodes'] || {}
       sms.shortcode = sms_json_config['shortcode']
       sms.country_code_longcode_pool = sms_json_config['country_code_longcode_pool'] || {}
       sms.credential_role_arn = sms_json_config['credential_role_arn']

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -15,6 +15,13 @@ module Telephony
       raise 'missing sms configuration block' unless block_given?
       sms = PinpointSmsConfiguration.new(region: 'us-west-2')
       yield sms
+
+      shortcode_country_codes = Set.new(sms.country_code_shortcodes&.keys&.map(&:to_s) || [])
+      longcode_country_codes = Set.new(sms.country_code_longcode_pool&.keys&.map(&:to_s) || [])
+      if shortcode_country_codes.intersect?(longcode_country_codes)
+        raise 'cannot configure a country code for both longcodes and a shortcode'
+      end
+
       sms_configs << sms
       sms
     end
@@ -42,6 +49,7 @@ module Telephony
   PinpointSmsConfiguration = Struct.new(
     :application_id,
     :shortcode,
+    :country_code_shortcodes,
     :country_code_longcode_pool,
     *PINPOINT_CONFIGURATION_NAMES,
     keyword_init: true,

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -16,8 +16,8 @@ module Telephony
       sms = PinpointSmsConfiguration.new(region: 'us-west-2')
       yield sms
 
-      shortcode_country_codes = Set.new(sms.country_code_shortcodes&.keys&.map(&:to_s) || [])
-      longcode_country_codes = Set.new(sms.country_code_longcode_pool&.keys&.map(&:to_s) || [])
+      shortcode_country_codes = sms.country_code_shortcodes&.keys || []
+      longcode_country_codes = sms.country_code_longcode_pool&.keys || []
       if shortcode_country_codes.intersect?(longcode_country_codes)
         raise 'cannot configure a country code for both longcodes and a shortcode'
       end

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -139,6 +139,8 @@ module Telephony
       def origination_number(country_code, sms_config)
         if sms_config.country_code_longcode_pool&.dig(country_code).present?
           sms_config.country_code_longcode_pool[country_code].sample
+        elsif sms_config.country_code_shortcodes&.dig(country_code).present?
+          sms_config.country_code_shortcodes[country_code]
         else
           sms_config.shortcode
         end

--- a/spec/lib/telephony/pinpoint_configuration_spec.rb
+++ b/spec/lib/telephony/pinpoint_configuration_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Telephony::PinpointConfiguration do
+  context '#add_sms_config' do
+    it 'raises if the same country code is used in both longcode and shortcode configuration' do
+      config = Telephony::PinpointConfiguration.new
+      expect do
+        config.add_sms_config do |sms|
+          sms.country_code_shortcodes = { 'PR' => '123456' }
+          sms.country_code_longcode_pool = { 'PR' => ['+1 (939) 456-7890'] }
+        end.to raise_error(
+          'cannot configure a country code for both longcodes and a shortcode',
+        )
+      end
+    end
+  end
+end

--- a/spec/support/shared_contexts/telephony.rb
+++ b/spec/support/shared_contexts/telephony.rb
@@ -15,6 +15,7 @@ def telephony_use_default_config!
       sms.application_id = 'fake-pinpoint-application-id-sms'
       sms.shortcode = '123456'
       sms.country_code_longcode_pool = { 'PR' => ['+19393334444'] }
+      sms.country_code_shortcodes = { 'MX' => '987654' }
     end
 
     c.pinpoint.add_voice_config do |voice|


### PR DESCRIPTION
## 🛠 Summary of changes

Adds support for using specific shortcodes for a given country code.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
