### PR TITLE
LG-9860: Fix platform authenticator reauthentication redirect

### DIFF
--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -14,7 +14,7 @@
 
 <%= simple_form_for(
       '',
-      url: webauthn_setup_path,
+      url: webauthn_setup_path(platform: @platform_authenticator),
       method: :patch,
       html: {
         class: 'margin-top-4 margin-bottom-1',

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -169,6 +169,17 @@ describe 'webauthn management' do
 
         expect(page).to have_current_path webauthn_setup_path(platform: true)
 
+        # Regression: LG-9860: Ensure that the platform URL parameter is maintained through reauthn
+        travel_to (IdentityConfig.store.reauthn_window + 1).seconds.from_now
+        fill_in_nickname_and_click_continue
+        mock_press_button_on_hardware_key_on_setup
+
+        expect(page).to have_current_path login_two_factor_options_path(reauthn: true)
+        click_on t('forms.buttons.continue')
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect(page).to have_current_path webauthn_setup_path(platform: true)
         fill_in_nickname_and_click_continue
         mock_press_button_on_hardware_key_on_setup
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9860](https://cm-jira.usa.gov/browse/LG-9860)

## 🛠 Summary of changes

Fixes an issue where a user who is prompted for reauthentication after submitting platform authenticator setup will be returned to the _Security Key_ setup screen after reauthentication. With these changes, they'll be correctly redirected back to the Face and Touch Unlock setup screen.

## 📜 Testing Plan

Recommend setting a very low reauthentication window in `config/application.yml` to facilitate testing:

```
reauthn_window: 20
```

1. Go to http://localhost:3000/
2. Sign in to an existing account or create an account and then sign in
3. Click "Add Face or Touch Unlock"
4. On the "Use your device" screen, wait 2 minutes, or the amount of seconds for `reauthn_window` if configured
5. Enter a nickname
6. Click "Continue" and complete the browser prompts
7. At this point, you should be prompted for MFA "reauthentication"
8. Complete the reauthentication

**Before:** You are redirected to set up Security Key after reauthentication
**After:** You are redirected to set up Face or Touch Unlock after reauthentication
