### PR TITLE
Add BadgeComponent for design system badges

### DIFF
--- a/app/assets/stylesheets/_uswds.scss
+++ b/app/assets/stylesheets/_uswds.scss
@@ -24,6 +24,5 @@
 @forward 'usa-skipnav';
 @forward 'usa-step-indicator';
 @forward 'usa-tag';
-@forward 'usa-verification-badge';
 @forward 'uswds-form-controls';
 @forward 'uswds-utilities';

--- a/app/components/badge_component.html.erb
+++ b/app/components/badge_component.html.erb
@@ -1,0 +1,4 @@
+<%= content_tag('div', **tag_options, class: ['lg-verification-badge', *tag_options[:class]]) do %>
+  <%= image_tag(asset_path("alerts/#{icon}.svg"), size: 16, alt: '') %>
+  <%= content %>
+<% end %>

--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -1,0 +1,14 @@
+class BadgeComponent < BaseComponent
+  ICONS = %i[
+    unphishable
+    success
+  ].to_set.freeze
+
+  attr_reader :icon, :tag_options
+
+  def initialize(icon:, **tag_options)
+    raise ArgumentError, "invalid icon #{icon}, expected one of #{ICONS}" if !ICONS.include?(icon)
+    @icon = icon
+    @tag_options = tag_options
+  end
+end

--- a/app/components/badge_component.scss
+++ b/app/components/badge_component.scss
@@ -1,0 +1,1 @@
+@forward 'usa-verification-badge';

--- a/app/views/accounts/_unphishable_badge.html.erb
+++ b/app/views/accounts/_unphishable_badge.html.erb
@@ -1,9 +1,1 @@
-<div class="lg-verification-badge">
-  <%= image_tag(
-        asset_path('alerts/unphishable.svg'),
-        size: 16,
-        class: 'text-middle',
-        alt: '',
-      ) %>
-  <%= t('headings.account.unphishable') %>
-</div>
+<%= render BadgeComponent.new(icon: :unphishable).with_content(t('headings.account.unphishable')) %>

--- a/app/views/accounts/_verified_account_badge.html.erb
+++ b/app/views/accounts/_verified_account_badge.html.erb
@@ -1,9 +1,1 @@
-<div class="lg-verification-badge">
-  <%= image_tag(
-        asset_path('alerts/success.svg'),
-        size: 16,
-        class: 'text-middle',
-        alt: '',
-      ) %>
-  <%= t('headings.account.verified_account') %>
-</div>
+<%= render BadgeComponent.new(icon: :success).with_content(t('headings.account.verified_account')) %>

--- a/spec/components/badge_component_spec.rb
+++ b/spec/components/badge_component_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe BadgeComponent, type: :component do
+  let(:icon) {}
+  let(:content) { 'Content' }
+  let(:options) { { icon: } }
+
+  subject(:rendered) do
+    render_inline BadgeComponent.new(**options).with_content(content)
+  end
+
+  context 'without icon' do
+    let(:icon) { nil }
+
+    it 'raises an exception' do
+      expect { rendered }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'with invalid icon' do
+    let(:icon) { :invalid }
+
+    it 'raises an exception' do
+      expect { rendered }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'with valid icon' do
+    let(:icon) { :success }
+
+    it 'renders badge with icon and content' do
+      expect(rendered).to have_css('.lg-verification-badge')
+      expect(rendered).to have_css('img[src^="/assets/alerts/success-"]')
+      expect(rendered).to have_content(content)
+    end
+
+    context 'with extra tag options' do
+      let(:options) { super().merge(class: 'example-class', data: { foo: 'bar' }) }
+
+      it 'renders badge with extra tag options on wrapper element' do
+        expect(rendered).to have_css('.lg-verification-badge.example-class[data-foo="bar"]')
+      end
+    end
+  end
+end

--- a/spec/components/previews/badge_component_preview.rb
+++ b/spec/components/previews/badge_component_preview.rb
@@ -1,0 +1,13 @@
+class BadgeComponentPreview < BaseComponentPreview
+  # @!group Preview
+  def default
+    render(BadgeComponent.new(icon: :success).with_content('Verified Account'))
+  end
+  # @!endgroup
+
+  # @param icon select [success,unphishable]
+  # @param content text
+  def workbench(icon: :success, content: 'Verified Account')
+    render(BadgeComponent.new(icon: icon&.to_sym).with_content(content))
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Supports future work [LG-9953](https://cm-jira.usa.gov/browse/LG-9953) and implementation for [LG-8872](https://cm-jira.usa.gov/browse/LG-8872).

## 🛠 Summary of changes

Refactors badge UI partials as view component.

**Why?**

* Support future usage and options planned between [LG-9953](https://cm-jira.usa.gov/browse/LG-9953) and implementation for [LG-8872](https://cm-jira.usa.gov/browse/LG-8872)
* Improve coverage of component preview demonstrating available components
* Reduce chance for human error with ad hoc implementations
* Improve performance in critical paths by reducing size of main application stylesheet

## 📜 Testing Plan

Confirm existing usage:

1. Go to http://localhost:3000
2. Set up an account with an unphishable MFA (security key, face & touch unlock, PIV)
3. Once on account dashboard, observe no regressions in display of "Unphishable" badge

Confirm component preview:

1. Go to http://localhost:3000/components/inspect/badge/preview