### PR TITLE
LG-9959 Fix a bug in which in-person and GPO pending users do not have GPO pending status cleared

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -19,11 +19,11 @@ class GpoVerifyForm
     result = valid?
     threatmetrix_check_failed = fraud_review_checker.fraud_check_failed?
     if result
+      pending_profile&.remove_gpo_deactivation_reason
       if pending_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
       elsif fraud_review_checker.fraud_check_failed? && threatmetrix_enabled?
-        pending_profile&.remove_gpo_deactivation_reason
         deactivate_for_fraud_review
       else
         pending_profile&.update!(

--- a/lib/tasks/fix_in_person_pending_user.rake
+++ b/lib/tasks/fix_in_person_pending_user.rake
@@ -1,0 +1,11 @@
+namespace :profiles do
+  desc 'If a profile is pending in-person and pending GPO remove the GPO pending status'
+  task fix_in_person_and_gpo_pending_user: :environment do
+    enrollments = InPersonEnrollment.pending.joins(:profile).where(
+      'profiles.gpo_verification_pending_at IS NOT NULL',
+    )
+    enrollments.each do |enrollment|
+      enrollment.profile.update!(gpo_verification_pending_at: nil)
+    end
+  end
+end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -135,6 +135,7 @@ describe GpoVerifyForm do
 
           expect(pending_profile).not_to be_active
           expect(pending_profile.deactivation_reason).to eq('in_person_verification_pending')
+          expect(pending_profile.gpo_verification_pending?).to eq(false)
         end
 
         it 'updates establishing in-person enrollment to pending' do


### PR DESCRIPTION
We had a bug where users who are in the GPO pending state did not have that state cleared after entering a successful code and going through in-person proofing. This resulted in an error attempting to activate these users profiles when the enrollments background job runs.

changelog: Improvements, In-person proofing, A bug in which users who were letter and in-person pending did not have their letter pending status cleared after entering a letter code resulting in the user not being proofed after visiting the post office was fixed.
