### PR TITLE
Improve one-time code pattern enforcement, prefix handling

### DIFF
--- a/app/components/one_time_code_input_component.html.erb
+++ b/app/components/one_time_code_input_component.html.erb
@@ -10,7 +10,7 @@
         input_html: {
           **field_options[:input_html].to_h,
           value:,
-          maxlength:,
+          maxlength: input_maxlength,
           autofocus: autofocus?,
           class: input_css_class,
           pattern: input_pattern,

--- a/app/components/one_time_code_input_component.rb
+++ b/app/components/one_time_code_input_component.rb
@@ -13,6 +13,9 @@ class OneTimeCodeInputComponent < BaseComponent
   alias_method :numeric?, :numeric
   alias_method :autofocus?, :autofocus
 
+  # @see https://tc39.es/ecma262/#prod-SyntaxCharacter
+  JS_REGEXP_SYNTAX_CHARACTER = Regexp.union(%w[^ $ \ . * + ? ( ) [ ] { } |])
+
   # @param [FormBuilder] form Form builder instance.
   # @param [Symbol] name Field name. Defaults to `:code`.
   # @param [String] value Field value. Defaults to empty.
@@ -66,7 +69,7 @@ class OneTimeCodeInputComponent < BaseComponent
   end
 
   def input_pattern_prefix
-    "#{Regexp.escape(optional_prefix)}?" if optional_prefix.present?
+    "#{regexp_escape_for_js(optional_prefix)}?" if optional_prefix.present?
   end
 
   def input_pattern_character_set
@@ -87,5 +90,11 @@ class OneTimeCodeInputComponent < BaseComponent
 
   def input_css_class
     [*field_options.dig(:input_html, :class), 'one-time-code-input__input']
+  end
+
+  def regexp_escape_for_js(string)
+    # `Regexp.escape` escapes more characters than what is considered "special" for JavaScript
+    # regular expressions. Browsers may log errors for unexpected escaping of characters.
+    string.gsub(JS_REGEXP_SYNTAX_CHARACTER) { |c| Regexp.escape(c) }
   end
 end

--- a/app/components/one_time_code_input_component.rb
+++ b/app/components/one_time_code_input_component.rb
@@ -2,7 +2,8 @@ class OneTimeCodeInputComponent < BaseComponent
   attr_reader :form,
               :name,
               :value,
-              :maxlength,
+              :code_length,
+              :optional_prefix,
               :autofocus,
               :transport,
               :numeric,
@@ -15,8 +16,9 @@ class OneTimeCodeInputComponent < BaseComponent
   # @param [FormBuilder] form Form builder instance.
   # @param [Symbol] name Field name. Defaults to `:code`.
   # @param [String] value Field value. Defaults to empty.
-  # @param [Integer] maxlength Sets maxlength for the field. Defaults to
+  # @param [Integer] code_length Expected code length. Defaults to
   # TwoFactorAuthenticatable::DIRECT_OTP_LENGTH
+  # @param [String] optional_prefix Optional prefix to allow before code
   # @param [Boolean] autofocus Whether the input should be focused on page load. Defaults to
   # `false`.
   # @param [String] transport WebOTP transport method. Defaults to 'sms'.
@@ -27,7 +29,8 @@ class OneTimeCodeInputComponent < BaseComponent
     form:,
     name: :code,
     value: nil,
-    maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH + 1, # to allow for leading '#'
+    code_length: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
+    optional_prefix: '',
     autofocus: false,
     transport: 'sms',
     numeric: true,
@@ -37,7 +40,8 @@ class OneTimeCodeInputComponent < BaseComponent
     @form = form
     @name = name
     @value = value
-    @maxlength = maxlength
+    @code_length = code_length
+    @optional_prefix = optional_prefix
     @autofocus = autofocus
     @transport = transport
     @numeric = numeric
@@ -53,11 +57,23 @@ class OneTimeCodeInputComponent < BaseComponent
     end
   end
 
+  def input_maxlength
+    optional_prefix.size + code_length
+  end
+
   def input_pattern
+    "#{input_pattern_prefix}#{input_pattern_character_set}{#{code_length}}"
+  end
+
+  def input_pattern_prefix
+    "#{Regexp.escape(optional_prefix)}?" if optional_prefix.present?
+  end
+
+  def input_pattern_character_set
     if numeric?
-      '#?[0-9]*'
+      '[0-9]'
     else
-      '#?[a-zA-Z0-9]*'
+      '[a-z0-9]'
     end
   end
 

--- a/app/components/one_time_code_input_component.rb
+++ b/app/components/one_time_code_input_component.rb
@@ -76,7 +76,7 @@ class OneTimeCodeInputComponent < BaseComponent
     if numeric?
       '[0-9]'
     else
-      '[a-z0-9]'
+      '[a-zA-Z0-9]'
     end
   end
 

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -21,7 +21,8 @@
         value: @code,
         numeric: false,
         autofocus: true,
-        maxlength: TwoFactorAuthenticatable::PROOFING_DIRECT_OTP_LENGTH + 1,
+        code_length: TwoFactorAuthenticatable::PROOFING_DIRECT_OTP_LENGTH,
+        optional_prefix: '#',
         class: 'margin-bottom-5',
       ) %>
   <%= f.submit t('forms.buttons.submit.default'), class: 'margin-bottom-5' %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -25,7 +25,13 @@
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>
-  <%= render OneTimeCodeInputComponent.new(form: f, autofocus: true, value: @presenter.code_value) %>
+  <%= render OneTimeCodeInputComponent.new(
+        form: f,
+        autofocus: true,
+        value: @presenter.code_value,
+        code_length: TwoFactorAuthenticatable::OTP_LENGTH,
+        optional_prefix: '#',
+      ) %>
   <%= f.input(
         :remember_device,
         as: :boolean,

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -29,7 +29,6 @@
         form: f,
         autofocus: true,
         value: @presenter.code_value,
-        code_length: TwoFactorAuthenticatable::OTP_LENGTH,
         optional_prefix: '#',
       ) %>
   <%= f.input(

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -11,7 +11,7 @@
         value: @code,
         autofocus: true,
         transport: nil,
-        maxlength: TwoFactorAuthenticatable::OTP_LENGTH,
+        code_length: TwoFactorAuthenticatable::OTP_LENGTH,
       ) %>
   <%= f.input(
         :remember_device,

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -40,7 +40,7 @@
       <%= render OneTimeCodeInputComponent.new(
             form: f,
             transport: nil,
-            maxlength: TwoFactorAuthenticatable::OTP_LENGTH,
+            code_length: TwoFactorAuthenticatable::OTP_LENGTH,
             field_options: {
               label: false,
               input_html: {

--- a/spec/components/one_time_code_input_component_spec.rb
+++ b/spec/components/one_time_code_input_component_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
 
   subject(:rendered) { render_inline OneTimeCodeInputComponent.new(form:, **options) }
 
+  before do
+    stub_const('TwoFactorAuthenticatable::DIRECT_OTP_LENGTH', 6)
+  end
+
   describe 'name' do
     context 'no name given' do
       it 'renders default name "code"' do
@@ -30,6 +34,10 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
       it 'renders input mode "numeric"' do
         expect(rendered).to have_selector('[inputmode="numeric"]')
       end
+
+      it 'renders input pattern' do
+        expect(rendered).to have_css('[pattern="[0-9]{6}"]')
+      end
     end
 
     context 'numeric is false' do
@@ -37,6 +45,10 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
 
       it 'renders input mode "text"' do
         expect(rendered).to have_selector('[inputmode="text"]')
+      end
+
+      it 'renders input pattern' do
+        expect(rendered).to have_css('[pattern="[a-z0-9]{6}"]')
       end
     end
   end
@@ -107,22 +119,50 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
     end
   end
 
-  describe 'maxlength' do
-    context 'no maxlength given' do
-      it 'renders input maxlength DIRECT_OTP_LENGTH + 1' do
-        expect(rendered).to have_selector(
-          "[maxlength=\"#{TwoFactorAuthenticatable::DIRECT_OTP_LENGTH + 1}\"]",
-        )
+  describe 'code_length' do
+    context 'without code_length' do
+      it 'renders input default maxlength' do
+        expect(rendered).to have_css('[maxlength="6"]')
+      end
+
+      it 'renders input pattern' do
+        expect(rendered).to have_css('[pattern="[0-9]{6}"]')
       end
     end
 
-    context 'maxlength given' do
-      let(:options) { { maxlength: 10 } }
+    context 'with code_length' do
+      let(:options) { { code_length: 10 } }
 
-      it 'renders input given maxlength' do
-        expect(rendered).to have_selector(
-          '[maxlength="10"]',
-        )
+      it 'renders input maxlength based on given code_length' do
+        expect(rendered).to have_css('[maxlength="10"]')
+      end
+
+      it 'renders input pattern' do
+        expect(rendered).to have_css('[pattern="[0-9]{10}"]')
+      end
+    end
+  end
+
+  describe 'optional_prefix' do
+    context 'without optional_prefix' do
+      it 'renders input default maxlength' do
+        expect(rendered).to have_css('[maxlength="6"]')
+      end
+
+      it 'renders input pattern' do
+        expect(rendered).to have_css('[pattern="[0-9]{6}"]')
+      end
+    end
+
+    context 'with optional_prefix given' do
+      let(:options) { { optional_prefix: '$' } }
+
+      it 'renders input maxlength based on given optional_prefix' do
+        expect(rendered).to have_css('[maxlength="7"]')
+      end
+
+      it 'renders input pattern' do
+        expect(rendered).to have_css('[pattern="\\\$?[0-9]{6}"]')
       end
     end
   end

--- a/spec/components/one_time_code_input_component_spec.rb
+++ b/spec/components/one_time_code_input_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
       end
 
       it 'renders input pattern' do
-        expect(rendered).to have_css('[pattern="[a-z0-9]{6}"]')
+        expect(rendered).to have_css('[pattern="[a-zA-Z0-9]{6}"]')
       end
     end
   end

--- a/spec/components/one_time_code_input_component_spec.rb
+++ b/spec/components/one_time_code_input_component_spec.rb
@@ -164,6 +164,14 @@ RSpec.describe OneTimeCodeInputComponent, type: :component do
       it 'renders input pattern' do
         expect(rendered).to have_css('[pattern="\\\$?[0-9]{6}"]')
       end
+
+      context 'with prefix which would be escaped in ruby but unescaped in javascript' do
+        let(:options) { { optional_prefix: '#' } }
+
+        it 'renders input pattern without escaping' do
+          expect(rendered).to have_css('[pattern="#?[0-9]{6}"]')
+        end
+      end
     end
   end
 end

--- a/spec/components/previews/one_time_code_input_component_preview.rb
+++ b/spec/components/previews/one_time_code_input_component_preview.rb
@@ -8,11 +8,16 @@ class OneTimeCodeInputComponentPreview < BaseComponentPreview
   def alphanumeric
     render(OneTimeCodeInputComponent.new(form: form_builder, numeric: false))
   end
+
+  def with_optional_prefix
+    render(OneTimeCodeInputComponent.new(form: form_builder, numeric: false, optional_prefix: '#'))
+  end
   # @!endgroup
 
   # @display form true
   # @param numeric toggle
-  def workbench(numeric: true)
-    render(OneTimeCodeInputComponent.new(form: form_builder, numeric:))
+  # @param optional_prefix text
+  def workbench(numeric: true, optional_prefix: '')
+    render(OneTimeCodeInputComponent.new(form: form_builder, numeric:, optional_prefix:))
   end
 end

--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -37,7 +37,7 @@ feature 'phone otp rate limiting', :js do
       complete_idv_steps_before_phone_otp_verification_step(user)
 
       max_attempts.times do
-        fill_in('code', with: 'wrong')
+        fill_in('code', with: 'badbad')
         click_button t('forms.buttons.submit.default')
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Improves `OneTimeCodeInputComponent`'s pattern and prefix handling:

- Enforces code length in pattern
   - Previously, you could enter 5 digits for an OTP and it was considered valid
- Makes prefix behavior opt-in, since this requires special back-end handling
   - Previously, TOTP code fields allowed the `#` prefix, but it was not valid, and prevented entering the full code due to `maxlength` restriction

## 📜 Testing Plan

Run included spec revisions:

- `rspec spec/components/one_time_code_input_component_spec.rb`
- `rspec spec/features/two_factor_authentication/sign_in_spec.rb:268`

Verify no regressions in OTP entry.