### PR TITLE
Use sendBeacon() for frontend analytics

### DIFF
--- a/app/javascript/packages/analytics/index.spec.ts
+++ b/app/javascript/packages/analytics/index.spec.ts
@@ -1,19 +1,33 @@
-import type { SinonStub } from 'sinon';
 import { trackEvent, trackError } from '@18f/identity-analytics';
 import { usePropertyValue, useSandbox } from '@18f/identity-test-helpers';
+import type { SinonStub } from 'sinon';
+
+function blobTextContents(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('loadend', () => {
+      resolve(reader.result as string);
+    });
+    reader.addEventListener('error', reject);
+    reader.readAsText(blob, 'utf-8');
+  });
+}
 
 describe('trackEvent', () => {
   const sandbox = useSandbox();
 
   beforeEach(() => {
     sandbox.stub(global, 'fetch').resolves();
+    sandbox.stub(global.navigator, 'sendBeacon').returns(true);
   });
 
   context('page configuration does not exist', () => {
-    it('does not fetch and resolves to undefined', async () => {
+    it('does not sendBeacon or fetch and resolves to undefined', async () => {
       const result = await trackEvent('name');
 
       expect(result).to.be.undefined();
+
+      expect(global.navigator.sendBeacon).not.to.have.been.called();
       expect(global.fetch).not.to.have.been.called();
     });
   });
@@ -26,44 +40,139 @@ describe('trackEvent', () => {
     });
 
     context('no payload', () => {
-      it('fetches and resolves to undefined', async () => {
+      it('calls sendBeacon and resolves to undefined', async () => {
         const result = await trackEvent('name');
 
         expect(result).to.be.undefined();
-        expect(global.fetch).to.have.been.calledWith(
-          endpoint,
-          sandbox.match({
-            body: '{"event":"name"}',
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-          }),
-        );
+
+        expect(global.navigator.sendBeacon).to.have.been.calledOnce();
+
+        const [actualEndpoint, data] = (global.navigator.sendBeacon as SinonStub).firstCall.args;
+        expect(actualEndpoint).to.eql(endpoint);
+        expect(data).to.have.property('type').eql('application/json');
+
+        expect(await blobTextContents(data)).to.eql('{"event":"name"}');
+      });
+
+      it('does not fall back to fetch', async () => {
+        await trackEvent('name');
+        expect(global.fetch).not.to.have.been.called();
       });
     });
 
     context('payload', () => {
-      it('fetches and resolves to undefined', async () => {
+      it('calls sendBeacon and resolves to undefined', async () => {
         const result = await trackEvent('name', { foo: 'bar' });
 
         expect(result).to.be.undefined();
-        expect(global.fetch).to.have.been.calledWith(
-          endpoint,
-          sandbox.match({
-            body: '{"event":"name","payload":{"foo":"bar"}}',
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-          }),
-        );
+
+        expect(global.navigator.sendBeacon).to.have.been.calledOnce();
+
+        const [actualEndpoint, data] = (global.navigator.sendBeacon as SinonStub).firstCall.args;
+
+        expect(actualEndpoint).to.eql(endpoint);
+        expect(data).to.have.property('type').eql('application/json');
+        expect(await blobTextContents(data)).to.eql('{"event":"name","payload":{"foo":"bar"}}');
+      });
+      it('does not fall back to fetch', async () => {
+        await trackEvent('name', { foo: 'bar' });
+        expect(global.fetch).not.to.have.been.called();
       });
     });
 
-    context('a network error occurs in the request', () => {
+    context('sendBeacon() throws', () => {
       beforeEach(() => {
-        (global.fetch as SinonStub).rejects(new TypeError());
+        global.navigator.sendBeacon = sandbox.stub().throws();
       });
 
-      it('absorbs the error', async () => {
-        await trackEvent('name');
+      context('no payload', () => {
+        it('falls back to fetch and resolves to undefined', async () => {
+          const result = await trackEvent('name');
+
+          expect(result).to.be.undefined();
+          expect(global.fetch).to.have.been.calledWith(
+            endpoint,
+            sandbox.match({
+              body: '{"event":"name"}',
+              headers: { 'Content-Type': 'application/json' },
+              method: 'POST',
+            }),
+          );
+        });
+      });
+
+      context('payload', () => {
+        it('falls back to fetch and resolves to undefined', async () => {
+          const result = await trackEvent('name', { foo: 'bar' });
+
+          expect(result).to.be.undefined();
+          expect(global.fetch).to.have.been.calledWith(
+            endpoint,
+            sandbox.match({
+              body: '{"event":"name","payload":{"foo":"bar"}}',
+              headers: { 'Content-Type': 'application/json' },
+              method: 'POST',
+            }),
+          );
+        });
+      });
+
+      context('a network error occurs in the request', () => {
+        beforeEach(() => {
+          (global.fetch as SinonStub).rejects(new TypeError());
+        });
+
+        it('absorbs the error', async () => {
+          await trackEvent('name');
+        });
+      });
+    });
+
+    context('sendBeacon() returns false', () => {
+      beforeEach(() => {
+        global.navigator.sendBeacon = sandbox.stub().returns(false);
+      });
+
+      context('no payload', () => {
+        it('falls back to fetch and resolves to undefined', async () => {
+          const result = await trackEvent('name');
+
+          expect(result).to.be.undefined();
+          expect(global.fetch).to.have.been.calledWith(
+            endpoint,
+            sandbox.match({
+              body: '{"event":"name"}',
+              headers: { 'Content-Type': 'application/json' },
+              method: 'POST',
+            }),
+          );
+        });
+      });
+
+      context('payload', () => {
+        it('falls back to fetch and resolves to undefined', async () => {
+          const result = await trackEvent('name', { foo: 'bar' });
+
+          expect(result).to.be.undefined();
+          expect(global.fetch).to.have.been.calledWith(
+            endpoint,
+            sandbox.match({
+              body: '{"event":"name","payload":{"foo":"bar"}}',
+              headers: { 'Content-Type': 'application/json' },
+              method: 'POST',
+            }),
+          );
+        });
+      });
+
+      context('a network error occurs in the request', () => {
+        beforeEach(() => {
+          (global.fetch as SinonStub).rejects(new TypeError());
+        });
+
+        it('absorbs the error', async () => {
+          await trackEvent('name');
+        });
       });
     });
   });

--- a/spec/javascript/spec_helper.js
+++ b/spec/javascript/spec_helper.js
@@ -40,6 +40,8 @@ global.window.Response = Response;
 useCleanDOM(dom);
 useConsoleLogSpy();
 
+global.navigator.sendBeacon = () => true;
+
 // Remove after upgrading to React 18
 // See: https://github.com/facebook/react/issues/20756#issuecomment-780945678
 delete global.MessageChannel;


### PR DESCRIPTION
(This is related to work I'm doing for [LG-9848](https://cm-jira.usa.gov/browse/LG-9848).)

sendBeacon() is [an API in modern browsers](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API) that is intended to be used for making “fire and forget” HTTP requests. The primary use is for analytics. 

Frontend code can call `sendBeacon(url, payload)` and the browser will schedule a POST request to be made to the given url with the given payload. sendBeacon synchronously returns a boolean value indicating whether the request was actually enqueued.

The benefits of sendBeacon are:

- Browsers can prioritize analytics requests appropriately and avoid slowing down the user experience
- Browsers can ensure requests made with sendBeacon during page unload actually complete, potentially enabling better analytics on our use of `onbeforeunload` handlers.

Drawbacks of sendBeacon are:

- Timestamps of frontend analytics calls in logs will be slightly more unreliable, since the browser only guarantees it will _eventually_ make these requests. However, these timestamps have never been super reliable, as they’re fundamentally based on an assumption of perfect network connectivity.

- Browser extensions could potentially more easily identify and block analytics calls. This may or may not be a drawback, depending on your perspective. But blocking requests made using sendBeacon`is only slightly easier than blocking fetch requests to `/api/logger`, so we should not worry about this too much.

## More reading

- [caniuse for the beacon API](https://caniuse.com/beacon)
- [Beaconing in Practice](https://calendar.perfplanet.com/2020/beaconing-in-practice/#beaconing-sendbeacon-beacon) article on telemetry exfiltration in general, with good info on `sendBeacon`