### PR TITLE
Cherry-pick design system form control styles

### DIFF
--- a/app/assets/stylesheets/_uswds-form-controls.scss
+++ b/app/assets/stylesheets/_uswds-form-controls.scss
@@ -1,0 +1,12 @@
+@forward 'usa-checkbox';
+@forward 'usa-error-message';
+@forward 'usa-fieldset';
+@forward 'usa-file-input';
+@forward 'usa-form-group';
+@forward 'usa-hint';
+@forward 'usa-input';
+@forward 'usa-label';
+@forward 'usa-legend';
+@forward 'usa-memorable-date';
+@forward 'usa-radio';
+@forward 'usa-select';

--- a/app/assets/stylesheets/_uswds-form-controls.scss
+++ b/app/assets/stylesheets/_uswds-form-controls.scss
@@ -10,3 +10,4 @@
 @forward 'usa-memorable-date';
 @forward 'usa-radio';
 @forward 'usa-select';
+@forward 'usa-success-message';


### PR DESCRIPTION
## 🛠 Summary of changes

Replaces the [default set of design system form control styles](https://github.com/uswds/uswds/blob/develop/packages/uswds-form-controls/_index.scss) with a subset of those in active use.

Included:

- checkbox
- error-message
- fieldset
- file-input
- form-group
- hint
- input
- label
- legend
- memorable-date
- radio
- select

**Edit:** Included from[ LGDS custom form controls](https://github.com/18F/identity-design-system/blob/main/src/scss/packages/_uswds-form-controls.scss):

- success-message

Excluded:

- character-count
- combo-box
- date-picker
- form
- input-prefix-suffix
- input-mask
- range
- textarea
- time-picker

### Impact

```
NODE_ENV=production yarn build:css && brotli-size app/assets/builds/application.css
```

Before: 29.4kb
After: 27.2kb
Diff: -2.2kb (-7.5%)

## 📜 Testing Plan

- Check the list above: Anything in "excluded" that should be "included" ?