### PR TITLE
Remove after_otp_verification_confirmation_url

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -73,7 +73,7 @@ module RememberDeviceConcern
     user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics(cookie_created_at: remember_device_cookie.created_at)
-    redirect_to after_otp_verification_confirmation_url unless reauthn?
+    redirect_to after_sign_in_path_for(current_user) unless reauthn?
   end
 
   def handle_valid_remember_device_analytics(cookie_created_at:)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -67,7 +67,7 @@ module TwoFactorAuthenticatableMethods
     return if remember_device_expired_for_sp?
     return if service_provider_mfa_policy.user_needs_sp_auth_method_verification?
 
-    redirect_to after_otp_verification_confirmation_url
+    redirect_to after_sign_in_path_for(current_user)
   end
 
   def check_sp_required_mfa_bypass(auth_method:)
@@ -168,12 +168,6 @@ module TwoFactorAuthenticatableMethods
 
   def reset_second_factor_attempts_count
     UpdateUser.new(user: current_user, attributes: { second_factor_attempts_count: 0 }).call
-  end
-
-  def after_otp_verification_confirmation_url
-    return @next_mfa_setup_path if @next_mfa_setup_path
-    return account_url if @updating_existing_number
-    after_sign_in_path_for(current_user)
   end
 
   def mark_user_session_authenticated(authentication_type)

--- a/app/controllers/password_capture_controller.rb
+++ b/app/controllers/password_capture_controller.rb
@@ -39,7 +39,7 @@ class PasswordCaptureController < ApplicationController
     cache_active_profile(password)
     session[:password_attempts] = 0
     user_session[:current_password_required] = false
-    redirect_to after_otp_verification_confirmation_url
+    redirect_to after_sign_in_path_for(current_user)
   end
 
   def handle_invalid_password

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -76,7 +76,7 @@ module TwoFactorAuthentication
     end
 
     def handle_valid_backup_code
-      redirect_to after_otp_verification_confirmation_url
+      redirect_to after_sign_in_path_for(current_user)
     end
 
     def check_sp_required_mfa

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -29,7 +29,7 @@ module TwoFactorAuthentication
           handle_valid_verification_for_authentication_context(
             auth_method: params[:otp_delivery_preference],
           )
-          redirect_to after_otp_verification_confirmation_url
+          redirect_to after_sign_in_path_for(current_user)
         end
 
         reset_otp_session_data
@@ -211,9 +211,7 @@ module TwoFactorAuthentication
     end
 
     def assign_phone
-      @updating_existing_number = user_session[:phone_id].present?
-
-      if @updating_existing_number
+      if user_session[:phone_id].present?
         phone_changed
       else
         phone_confirmed

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -211,13 +211,17 @@ module TwoFactorAuthentication
     end
 
     def assign_phone
-      if user_session[:phone_id].present?
+      if updating_existing_number?
         phone_changed
       else
         phone_confirmed
       end
 
       update_phone_attributes
+    end
+
+    def updating_existing_number?
+      user_session[:phone_id].present?
     end
 
     def update_phone_attributes

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -53,7 +53,7 @@ module TwoFactorAuthentication
       handle_valid_verification_for_authentication_context(
         auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )
-      redirect_to after_otp_verification_confirmation_url
+      redirect_to after_sign_in_path_for(current_user)
     end
 
     def handle_invalid_piv_cac

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -27,7 +27,7 @@ module TwoFactorAuthentication
           auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,
         )
         handle_remember_device
-        redirect_to after_otp_verification_confirmation_url
+        redirect_to after_sign_in_path_for(current_user)
       else
         handle_invalid_otp(context: context, type: 'totp')
       end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -50,7 +50,7 @@ module TwoFactorAuthentication
         )
       end
       handle_remember_device
-      redirect_to after_otp_verification_confirmation_url
+      redirect_to after_sign_in_path_for(current_user)
     end
 
     def handle_invalid_webauthn

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -84,7 +84,7 @@ module Users
       if ial_context.ial2_requested?
         capture_password_url
       else
-        after_otp_verification_confirmation_url
+        after_sign_in_path_for(current_user)
       end
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

A little bit of cleanup following #8392. The `after_otp_verification_confirmation_url` function only behaves differently in the `OtpVerificationController` when in the confirmation context due to the prior work. The `@next_mfa_setup_path` and `@updating_existing_number` instance variables are only set there, which is what results in the different behavior.

This PR removes those instance variables and replaces the `after_otp_verification_confirmation_url` with the default `after_sign_in_path_for(current_user)` in the other controllers that used it. This should not result in a change in behavior and hopefully results in a little bit less abstraction.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
