### PR TITLE
Remove 404 action from HybridHandoff controller

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -7,7 +7,6 @@ module Idv
     include StepUtilitiesConcern
 
     before_action :confirm_two_factor_authenticated
-    before_action :render_404_if_hybrid_handoff_controller_disabled
     before_action :confirm_agreement_step_complete
     before_action :confirm_hybrid_handoff_needed, only: :show
 
@@ -204,10 +203,6 @@ module Idv
       form_response_params = { success: false, errors: { message: message } }
       form_response_params[:extra] = extra unless extra.nil?
       FormResponse.new(**form_response_params)
-    end
-
-    def render_404_if_hybrid_handoff_controller_disabled
-      render_not_found unless IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
     end
 
     def confirm_agreement_step_complete


### PR DESCRIPTION
changelog: User-Facing Improvements, Identity Verification, Remove 404 on hybrid handoff

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[Remove 404 action from HybridHandoff controller
](https://cm-jira.usa.gov/browse/LG-9786)

## 🛠 Summary of changes

Removes `before_action` and method that renders a 404 based on hybrid handoff controller enabled.

- [x] Blocked by checking all the edge cases for HybridHandoffController. Latest PR #8528 will be merged today, so this one can be merged too and we can test in int prior to turning the feature flag on.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
