### PR TITLE
Configure Stylelint to report needless disables

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,4 +1,5 @@
 {
   "extends": "@18f/identity-stylelint-config",
-  "ignoreFiles": "**/fixtures/**/*"
+  "ignoreFiles": "**/fixtures/**/*",
+  "reportNeedlessDisables": true
 }

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -2,7 +2,6 @@
 
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
-  /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-appearance: none;
   margin: 0;
 }

--- a/app/assets/stylesheets/components/_phone-input.scss
+++ b/app/assets/stylesheets/components/_phone-input.scss
@@ -10,7 +10,6 @@ lg-phone-input {
   .iti__flag {
     background-image: url('/flags.png');
 
-    /* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
     @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
       background-image: url('/flags@2x.png');
     }


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Stylelint configuration to report needless inline configuration for disabling rules, to avoid misleading developers with ineffective configuration.

I considered adding this to the `@18f/identity-stylelint-config` common configuration, but since it's a breaking change, it'd be best to wait to group it with some other breaking change for the package.

## 📜 Testing Plan

1. `yarn lint:css` passes.