### PR TITLE
Remove styles associated with numeric input fields

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -1,11 +1,5 @@
 @use 'uswds-core' as *;
 
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 // ===============================================
 // Pending upstream Login Design System revisions:
 // ===============================================


### PR DESCRIPTION
## 🛠 Summary of changes

Removes styles associated with `[type="number"]` input fields (see [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-outer-spin-button)).

Why?

- To the best of my knowledge, there are no `[type="number"]` fields in the application
- Reduce size of application stylesheet to improve performance
- Improve maintainability by...
   - Eliminating styles where the intended impact is unclear
   - Aligning closer to design system defaults

We could reintroduce in the future if the need arises, but I think it's worth a reevaluation anyways, and we'd want to scope it to specific instances (e.g. via component stylesheet).

Related resources:

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#using_number_inputs
   - >The `number` input type should only be used for incremental numbers, especially when spinbutton incrementing and decrementing are helpful to user experience.
- https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/

## 📜 Testing Plan

There should be no user-facing impact of these changes.