### PR TITLE
Remove legacy session timeout polling behavior

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,13 +10,11 @@ module Users
 
     rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_signin
 
-    skip_before_action :session_expires_at, only: %i[active keepalive]
     skip_before_action :require_no_authentication, only: [:new]
     before_action :store_sp_metadata_in_session, only: [:new]
     before_action :check_user_needs_redirect, only: [:new]
     before_action :apply_secure_headers_override, only: [:new, :create]
     before_action :clear_session_bad_password_count_if_window_expired, only: [:create]
-    after_action :add_csrf_token_header_to_response, only: [:keepalive]
 
     def new
       override_csp_for_google_analytics
@@ -48,31 +46,6 @@ module Users
         success: true,
       )
       super
-    end
-
-    def active
-      session[:pinged_at] = now
-      Rails.logger.debug(alive?: alive?, expires_at: expires_at)
-      render json: { live: alive?, timeout: expires_at }
-    end
-
-    def keepalive
-      session[:session_expires_at] = now + Devise.timeout_in if alive?
-      analytics.session_kept_alive if alive?
-
-      render json: { live: alive?, timeout: expires_at }
-    end
-
-    def timeout
-      analytics.session_timed_out
-      request_id = sp_session[:request_id]
-      sign_out
-      flash[:info] = t(
-        'notices.session_timedout',
-        app_name: APP_NAME,
-        minutes: IdentityConfig.store.session_timeout_in_minutes,
-      )
-      redirect_to root_url(request_id: request_id)
     end
 
     private
@@ -143,22 +116,8 @@ module Users
       redirect_to next_url_after_valid_authentication
     end
 
-    def now
-      @now ||= Time.zone.now
-    end
-
-    def expires_at
-      session[:session_expires_at]&.to_datetime || (now - 1)
-    end
-
     def browser_is_ie11?
       BrowserCache.parse(request.user_agent).ie?(11)
-    end
-
-    def alive?
-      return false unless session && expires_at
-      session_alive = expires_at > now
-      current_user.present? && session_alive
     end
 
     def track_authentication_attempt(email)

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -11,10 +11,6 @@ module SessionTimeoutWarningHelper
     IdentityConfig.store.session_timeout_warning_seconds
   end
 
-  def expires_at
-    session[:session_expires_at]&.to_datetime || Time.zone.now - 1
-  end
-
   def timeout_refresh_path
     UriService.add_params(
       request.original_fullpath,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,8 +84,6 @@ Rails.application.routes.draw do
       post '/' => 'users/sessions#create', as: :user_session
       get '/logout' => 'users/sessions#destroy', as: :destroy_user_session
       delete '/logout' => 'users/sessions#destroy'
-      get '/active' => 'users/sessions#active'
-      post '/sessions/keepalive' => 'users/sessions#keepalive'
 
       get '/login/piv_cac' => 'users/piv_cac_login#new'
       get '/login/piv_cac_error' => 'users/piv_cac_login#error'
@@ -138,7 +136,6 @@ Rails.application.routes.draw do
 
       get '/reauthn' => 'mfa_confirmation#new', as: :user_password_confirm
       post '/reauthn' => 'mfa_confirmation#create', as: :reauthn_user_password
-      get '/timeout' => 'users/sessions#timeout'
     end
 
     if IdentityConfig.store.enable_test_routes

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -1,26 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe SessionTimeoutWarningHelper do
-  describe '#expires_at' do
-    around do |ex|
-      freeze_time { ex.run }
-    end
-
-    it 'returns time before now' do
-      expect(helper.expires_at).to be < Time.zone.now
-    end
-
-    context 'with session expiration' do
-      before do
-        allow(helper).to receive(:session).and_return(session_expires_at: Time.zone.now + 1)
-      end
-
-      it 'returns time remaining in user session' do
-        expect(helper.expires_at).to be > Time.zone.now
-      end
-    end
-  end
-
   describe '#timeout_refresh_path' do
     let(:http_host) { 'example.com' }
     before do


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the session timeout polling behavior which was replaced in #7966, but kept for initial deploy to handle mixed deploy state.

~As such, this should not be merged until #7966 is live in production.~ **Edit:** #7966 is now live in production.

## 📜 Testing Plan

Repeat Testing Plan from #7966.