### PR TITLE
request: Omit CSRF token for non-validated requests

### DIFF
--- a/app/javascript/packages/request/index.ts
+++ b/app/javascript/packages/request/index.ts
@@ -54,6 +54,17 @@ class CSRF {
   }
 }
 
+/**
+ * Returns true if the request associated with the given options would require a valid CSRF token,
+ * or false otherwise.
+ *
+ * @param options Request options
+ *
+ * @return Whether the request would require a CSRF token
+ */
+const isCSRFValidatedRequest = (options: RequestOptions) =>
+  !!options.method && !['GET', 'HEAD'].includes(options.method.toUpperCase());
+
 export async function request<Response = any>(
   url,
   options?: Partial<RequestOptions> & { read?: true },
@@ -67,7 +78,7 @@ export async function request(url: string, options: Partial<RequestOptions> = {}
   let { body, headers } = fetchOptions;
   headers = new Headers(headers);
 
-  if (csrf) {
+  if (csrf && isCSRFValidatedRequest(fetchOptions)) {
     const csrfToken = typeof csrf === 'boolean' ? CSRF.token : csrf();
 
     if (csrfToken) {


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the `request` utility to avoid including the CSRF token if it is not necessary for the request.

See related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1685476447724009

## 📜 Testing Plan

- `yarn test`
- Verify that session timeout polling requests complete successfully

It's easier to test the latter by setting a very low session timeout in local `config/application.yml`:

```yml
session_timeout_in_minutes: 1
```