### PR TITLE
LG-9371 skip hybrid handoff in agreement step

### DIFF
--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -78,8 +78,12 @@ module Idv
     end
 
     def render_document_capture_cancelled
-      mark_upload_step_incomplete
-      redirect_to idv_doc_auth_url # was idv_url, why?
+      if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
+        redirect_to idv_hybrid_handoff_url
+      else
+        mark_upload_step_incomplete
+        redirect_to idv_doc_auth_url # was idv_url, why?
+      end
       failure(I18n.t('errors.doc_auth.document_capture_cancelled'))
     end
 

--- a/app/services/idv/steps/agreement_step.rb
+++ b/app/services/idv/steps/agreement_step.rb
@@ -12,7 +12,11 @@ module Idv
       end
 
       def call
-        if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
+        return if !IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
+
+        if flow_session[:skip_upload_step]
+          redirect_to idv_document_capture_url
+        else
           redirect_to idv_hybrid_handoff_url
         end
       end
@@ -26,6 +30,9 @@ module Idv
       def skip_to_capture
         # See: Idv::DocAuthController#update_if_skipping_upload
         flow_session[:skip_upload_step] = true
+        if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
+          flow_session[:flow_path] = 'standard'
+        end
       end
 
       def consent_form_params

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -148,19 +148,32 @@ describe Idv::LinkSentController do
 
       context 'document capture session canceled' do
         let(:session_canceled_at) { Time.zone.now }
+        let(:error_message) { t('errors.doc_auth.document_capture_cancelled') }
 
-        it 'redirects to doc_auth page' do
-          error_message = t('errors.doc_auth.document_capture_cancelled')
+        before do
           expect(FormResponse).to receive(:new).with(
             { success: false,
               errors: { message: error_message } },
           )
+        end
 
+        it 'redirects to doc_auth page' do
           put :update
 
           expect(response).to redirect_to(idv_doc_auth_url)
           expect(flow_session[:error_message]).to eq(error_message)
           expect(flow_session['Idv::Steps::UploadStep']).to be_nil
+        end
+
+        context 'doc_auth_hybrid_handoff_controller_enabled is true' do
+          it 'redirects to hybrid_handoff page' do
+            allow(IdentityConfig.store).to receive(:doc_auth_hybrid_handoff_controller_enabled).
+              and_return(true)
+
+            put :update
+
+            expect(response).to redirect_to(idv_hybrid_handoff_url)
+          end
         end
       end
 

--- a/spec/features/idv/doc_auth/agreement_step_spec.rb
+++ b/spec/features/idv/doc_auth/agreement_step_spec.rb
@@ -89,6 +89,23 @@ feature 'doc auth welcome step' do
     end
   end
 
+  context 'doc_auth_hybrid_handoff_controller_enabled flag is true' do
+    context 'skipping upload step', :js, driver: :headless_chrome_mobile do
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_hybrid_handoff_controller_enabled).
+          and_return(true)
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_agreement_step
+        complete_agreement_step
+      end
+
+      it 'progresses to document capture' do
+        expect(page).to have_current_path(idv_document_capture_url)
+      end
+    end
+  end
+
+
   context 'during the acuant maintenance window' do
     let(:start) { Time.zone.parse('2020-01-01T00:00:00Z') }
     let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }


### PR DESCRIPTION
## 🎫 Ticket

[LG-9371](https://cm-jira.usa.gov/browse/LG-9371)

## 🛠 Summary of changes

Two changes when `doc_auth_hybrid_handoff_controller_enabled` flag is true
In AgreementStep, redirect to `idv_document_capture_url` instead of `idv_hybrid_handoff_url` if `:skip_upload_step` is true.
In LinkSentStep, redirect to `idv_hybrid_handoff_url` if document capture is canceled.