### PR TITLE
LG-9848: Add analytics to onbeforeunload

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -22,6 +22,8 @@ class FrontendLogController < ApplicationController
     'IdV: user clicked sp link on ready to verify page' => :idv_in_person_ready_to_verify_sp_link_clicked,
     'IdV: user clicked what to bring link on ready to verify page' => :idv_in_person_ready_to_verify_what_to_bring_link_clicked,
     'IdV: consent checkbox toggled' => :idv_consent_checkbox_toggled,
+    'User prompted before navigation' => :user_prompted_before_navigation,
+    'User prompted before navigation and still on page' => :user_prompted_before_navigation_and_still_on_page,
   }.transform_values { |method| AnalyticsEvents.instance_method(method) }.freeze
   # rubocop:enable Layout/LineLength
 

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -45,9 +45,7 @@ export class DocumentCapturePolling {
 
   pollAttempts = 0;
 
-  promptOnNavigateBound = false;
-
-  cleanUpPromptOnNavigate = () => {};
+  cleanUpPromptOnNavigate: (() => void) | undefined;
 
   constructor({
     elements,
@@ -75,12 +73,14 @@ export class DocumentCapturePolling {
    * @param {boolean} shouldPrompt Whether to bind or unbind page unload behavior.
    */
   bindPromptOnNavigate(shouldPrompt) {
-    if (shouldPrompt && !this.promptOnNavigateBound) {
+    const isAlreadyBound = !!this.cleanUpPromptOnNavigate;
+
+    if (shouldPrompt && !isAlreadyBound) {
       this.cleanUpPromptOnNavigate = promptOnNavigate();
-      this.promptOnNavigateBound = true;
-    } else if (!shouldPrompt) {
-      this.cleanUpPromptOnNavigate();
-      this.promptOnNavigateBound = false;
+    } else if (!shouldPrompt && isAlreadyBound) {
+      const cleanUp = this.cleanUpPromptOnNavigate ?? (() => {});
+      this.cleanUpPromptOnNavigate = undefined;
+      cleanUp();
     }
   }
 

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -6,6 +6,8 @@ export const MAX_DOC_CAPTURE_POLL_ATTEMPTS = Math.floor(
   DOC_CAPTURE_TIMEOUT / DOC_CAPTURE_POLL_INTERVAL,
 );
 
+const STILL_ON_PAGE_INTERVAL = 5000;
+
 interface DocumentCapturePollingElements {
   form: HTMLFormElement;
 
@@ -44,6 +46,8 @@ export class DocumentCapturePolling {
 
   pollAttempts = 0;
 
+  stillOnPageTimer: NodeJS.Timeout | undefined;
+
   constructor({
     elements,
     statusEndpoint,
@@ -74,6 +78,17 @@ export class DocumentCapturePolling {
       ? (event) => {
           event.preventDefault();
           event.returnValue = '';
+
+          this.trackEvent('IdV: Doc capture polling onbeforeunload');
+
+          if (this.stillOnPageTimer) {
+            clearTimeout(this.stillOnPageTimer);
+          }
+
+          this.stillOnPageTimer = setTimeout(() => {
+            this.trackEvent('IdV: Doc capture polling onbeforeunload still on page');
+            this.stillOnPageTimer = undefined;
+          }, STILL_ON_PAGE_INTERVAL);
         }
       : null;
   }

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -94,7 +94,6 @@ export class DocumentCapturePolling {
       isThrottled: result === ResultType.THROTTLED,
     });
     this.bindPromptOnNavigate(false);
-
     if (redirect) {
       window.location.href = redirect;
     } else {

--- a/app/javascript/packages/form-steps/prompt-on-navigate.ts
+++ b/app/javascript/packages/form-steps/prompt-on-navigate.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect } from 'react';
+import { promptOnNavigate } from '@18f/identity-prompt-on-navigate';
 
 /**
  * While mounted, prompts the user to confirm navigation.
@@ -7,17 +8,7 @@ function PromptOnNavigate() {
   // Use `useLayoutEffect` to guarantee that event unbinding occurs synchronously.
   //
   // See: https://reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing
-  useLayoutEffect(() => {
-    function onBeforeUnload(event) {
-      event.preventDefault();
-      event.returnValue = '';
-    }
-
-    window.onbeforeunload = onBeforeUnload;
-    return () => {
-      window.onbeforeunload = null;
-    };
-  });
+  useLayoutEffect(promptOnNavigate);
 
   return null;
 }

--- a/app/javascript/packages/prompt-on-navigate/README.md
+++ b/app/javascript/packages/prompt-on-navigate/README.md
@@ -16,13 +16,13 @@ cleanUp();
 
 ## Analytics
 
-By default, `promptOnNavigate` will call `trackEvent` to log a `Prompt on navigate` event when the onbeforeunload handler is called. It will then log `Prompt on navigate: user still on page` events at 5, 15, and 30 seconds after the onbeforeunload handler is called (the `seconds` property on the event will contain the number of seconds since the initial prompt).
+By default, `promptOnNavigate` will call `trackEvent` to log a `User prompted before navigation` event when the onbeforeunload handler is called. It will then log `User prompted before navigation and still on page` events at 5, 15, and 30 seconds after the onbeforeunload handler is called (the `seconds` property on the event will contain the number of seconds since the initial prompt).
 
 You can customize these intervals by passing a `stillOnPageIntervalsInSeconds` option:
 
 ```js
 promptOnNavigate({
-  // Log a 'Prompt on navigate: user still on page' event 7 and 11 seconds after the initial prompt.
+  // Log a 'User prompted before navigation and still on page' event 7 and 11 seconds after the initial prompt.
   stillOnPageIntervalsInSeconds: [7, 11],
 });
 ```

--- a/app/javascript/packages/prompt-on-navigate/README.md
+++ b/app/javascript/packages/prompt-on-navigate/README.md
@@ -1,0 +1,28 @@
+# `@18f/identity-prompt-on-navigate`
+
+Configures an `onbeforeunload` event handler such that the browser will prompt the user before they reload or navigate away from the page.
+
+## Usage
+
+```js
+import { promptOnNavigate } from "@18f/identity-prompt-on-navigate";
+
+// Set the onbeforeunload event handler.
+const cleanUp = promptOnNavigate();
+
+// ...some time later, call cleanUp() to restore any previous onbeforeunload handler and cancel any pending timers (this is important).
+cleanUp();
+```
+
+## Analytics
+
+By default, `promptOnNavigate` will call `trackEvent` to log a `Prompt on navigate` event when the onbeforeunload handler is called. It will then log `Prompt on navigate: user still on page` events at 5, 15, and 30 seconds after the onbeforeunload handler is called (the `seconds` property on the event will contain the number of seconds since the initial prompt).
+
+You can customize these intervals by passing a `stillOnPageIntervalsInSeconds` option:
+
+```js
+promptOnNavigate({
+  // Log a 'Prompt on navigate: user still on page' event 7 and 11 seconds after the initial prompt.
+  stillOnPageIntervalsInSeconds: [7, 11],
+});
+```

--- a/app/javascript/packages/prompt-on-navigate/index.spec.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.spec.ts
@@ -1,6 +1,6 @@
-import { promptOnNavigate } from '.';
 import { useSandbox } from '@18f/identity-test-helpers';
 import * as analytics from '@18f/identity-analytics';
+import { promptOnNavigate } from '.';
 
 describe('promptOnNavigate', () => {
   const sandbox = useSandbox({ useFakeTimers: true });

--- a/app/javascript/packages/prompt-on-navigate/index.spec.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.spec.ts
@@ -1,0 +1,96 @@
+import { promptOnNavigate } from '.';
+import { useSandbox } from '@18f/identity-test-helpers';
+import * as analytics from '@18f/identity-analytics';
+
+describe('promptOnNavigate', () => {
+  const sandbox = useSandbox({ useFakeTimers: true });
+
+  it('prompts on navigate', () => {
+    promptOnNavigate();
+
+    const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).to.be.true();
+    expect(event.returnValue).to.be.false();
+  });
+
+  it('logs an event', () => {
+    const trackEvent = sandbox.spy(analytics, 'trackEvent');
+
+    promptOnNavigate();
+
+    const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
+    window.dispatchEvent(event);
+
+    expect(trackEvent).to.have.been.calledOnceWith('Prompt before navigate');
+  });
+
+  it('logs a second event when the user stays on the page', () => {
+    const trackEvent = sandbox.spy(analytics, 'trackEvent');
+
+    promptOnNavigate();
+
+    const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
+
+    window.dispatchEvent(event);
+
+    expect(trackEvent).to.have.been.calledOnceWith('Prompt before navigate');
+    trackEvent.resetHistory();
+
+    sandbox.clock.tick(2000);
+    expect(trackEvent).not.to.have.been.called();
+
+    sandbox.clock.tick(6000);
+    expect(trackEvent).to.have.been.calledWith('Prompt before navigate user still on page', {
+      interval: 7500,
+    });
+  });
+
+  it('cleans up after itself', () => {
+    window.onbeforeunload = null;
+
+    const cleanup = promptOnNavigate();
+
+    expect(window.onbeforeunload).not.to.be.null();
+
+    cleanup();
+
+    expect(window.onbeforeunload).to.be.null();
+  });
+
+  it("does not clean up someone else's handler", () => {
+    const clean = promptOnNavigate();
+    const custom = () => {};
+    window.onbeforeunload = custom;
+    clean();
+    expect(window.onbeforeunload).to.eql(custom);
+  });
+
+  it('does not fire second analytics event after cleanup', () => {
+    const trackEvent = sandbox.spy(analytics, 'trackEvent');
+
+    const cleanup = promptOnNavigate();
+
+    const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
+    window.dispatchEvent(event);
+
+    expect(trackEvent).to.have.been.calledOnceWith('Prompt before navigate');
+    trackEvent.resetHistory();
+
+    sandbox.clock.tick(2000);
+    expect(trackEvent).not.to.have.been.called();
+
+    cleanup();
+
+    sandbox.clock.tick(10000);
+    expect(trackEvent).not.to.have.been.called();
+  });
+
+  it('does not throw if you call cleanup a bunch', () => {
+    const cleanup = promptOnNavigate();
+    for (let i = 0; i < 10; i++) {
+      cleanup();
+    }
+  });
+});

--- a/app/javascript/packages/prompt-on-navigate/index.spec.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.spec.ts
@@ -1,6 +1,6 @@
 import { useSandbox } from '@18f/identity-test-helpers';
 import * as analytics from '@18f/identity-analytics';
-import { promptOnNavigate } from '.';
+import { PROMPT_EVENT, STILL_ON_PAGE_EVENT, promptOnNavigate } from '.';
 
 describe('promptOnNavigate', () => {
   const sandbox = useSandbox({ useFakeTimers: true });
@@ -23,7 +23,7 @@ describe('promptOnNavigate', () => {
     const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith('Prompt on navigate');
+    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT);
   });
 
   it('logs a second event when the user stays on the page for 5s', () => {
@@ -35,14 +35,14 @@ describe('promptOnNavigate', () => {
 
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith('Prompt on navigate');
+    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT);
     trackEvent.resetHistory();
 
     sandbox.clock.tick(2000);
     expect(trackEvent).not.to.have.been.called();
 
     sandbox.clock.tick(3000);
-    expect(trackEvent).to.have.been.calledWith('Prompt on navigate: user still on page', {
+    expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
       seconds: 5,
     });
   });
@@ -56,7 +56,7 @@ describe('promptOnNavigate', () => {
 
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith('Prompt on navigate');
+    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT);
     trackEvent.resetHistory();
 
     sandbox.clock.tick(5000);
@@ -64,7 +64,7 @@ describe('promptOnNavigate', () => {
     trackEvent.resetHistory();
 
     sandbox.clock.tick(10000);
-    expect(trackEvent).to.have.been.calledWith('Prompt on navigate: user still on page', {
+    expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
       seconds: 15,
     });
   });
@@ -90,7 +90,7 @@ describe('promptOnNavigate', () => {
     trackEvent.resetHistory();
 
     sandbox.clock.tick(15000);
-    expect(trackEvent).to.have.been.calledWith('Prompt on navigate: user still on page', {
+    expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
       seconds: 30,
     });
   });
@@ -123,7 +123,7 @@ describe('promptOnNavigate', () => {
     const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith('Prompt on navigate');
+    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT);
     trackEvent.resetHistory();
 
     sandbox.clock.tick(2000);

--- a/app/javascript/packages/prompt-on-navigate/index.spec.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.spec.ts
@@ -23,10 +23,10 @@ describe('promptOnNavigate', () => {
     const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith('Prompt before navigate');
+    expect(trackEvent).to.have.been.calledOnceWith('Prompt on navigate');
   });
 
-  it('logs a second event when the user stays on the page', () => {
+  it('logs a second event when the user stays on the page for 5s', () => {
     const trackEvent = sandbox.spy(analytics, 'trackEvent');
 
     promptOnNavigate();
@@ -35,15 +35,63 @@ describe('promptOnNavigate', () => {
 
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith('Prompt before navigate');
+    expect(trackEvent).to.have.been.calledOnceWith('Prompt on navigate');
     trackEvent.resetHistory();
 
     sandbox.clock.tick(2000);
     expect(trackEvent).not.to.have.been.called();
 
-    sandbox.clock.tick(6000);
-    expect(trackEvent).to.have.been.calledWith('Prompt before navigate user still on page', {
-      interval: 7500,
+    sandbox.clock.tick(3000);
+    expect(trackEvent).to.have.been.calledWith('Prompt on navigate: user still on page', {
+      seconds: 5,
+    });
+  });
+
+  it('logs a third event when the user stays on the page for 15s', () => {
+    const trackEvent = sandbox.spy(analytics, 'trackEvent');
+
+    promptOnNavigate();
+
+    const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
+
+    window.dispatchEvent(event);
+
+    expect(trackEvent).to.have.been.calledOnceWith('Prompt on navigate');
+    trackEvent.resetHistory();
+
+    sandbox.clock.tick(5000);
+    expect(trackEvent).to.have.been.called();
+    trackEvent.resetHistory();
+
+    sandbox.clock.tick(10000);
+    expect(trackEvent).to.have.been.calledWith('Prompt on navigate: user still on page', {
+      seconds: 15,
+    });
+  });
+
+  it('logs a fourth event when the user stays on the page for 30s', () => {
+    const trackEvent = sandbox.spy(analytics, 'trackEvent');
+
+    promptOnNavigate();
+
+    const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
+
+    window.dispatchEvent(event);
+
+    expect(trackEvent).to.have.been.called();
+    trackEvent.resetHistory();
+
+    sandbox.clock.tick(5000);
+    expect(trackEvent).to.have.been.called();
+    trackEvent.resetHistory();
+
+    sandbox.clock.tick(10000);
+    expect(trackEvent).to.have.been.called();
+    trackEvent.resetHistory();
+
+    sandbox.clock.tick(15000);
+    expect(trackEvent).to.have.been.calledWith('Prompt on navigate: user still on page', {
+      seconds: 30,
     });
   });
 
@@ -75,7 +123,7 @@ describe('promptOnNavigate', () => {
     const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith('Prompt before navigate');
+    expect(trackEvent).to.have.been.calledOnceWith('Prompt on navigate');
     trackEvent.resetHistory();
 
     sandbox.clock.tick(2000);

--- a/app/javascript/packages/prompt-on-navigate/index.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.ts
@@ -8,8 +8,9 @@ const defaults = {
   stillOnPageIntervalsInSeconds: [5, 15, 30],
 };
 
-const PROMPT_EVENT = 'User prompted before navigation';
-const STILL_ON_PAGE_EVENT = 'User prompted before navigation and still on page';
+export const PROMPT_EVENT = 'User prompted before navigation';
+
+export const STILL_ON_PAGE_EVENT = 'User prompted before navigation and still on page';
 
 /**
  * Configures the window.onbeforeunload handler such that the user will be prompted before

--- a/app/javascript/packages/prompt-on-navigate/index.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.ts
@@ -15,7 +15,7 @@ const defaults = {
  * @returns {() => void} A function that, when called, will "clean up" -- restore the prior onbeforeunload handler and cancel any pending timeouts.
  */
 export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): () => void {
-  let stillOnPageTimer: NodeJS.Timeout | undefined;
+  let stillOnPageTimer: number | undefined;
 
   function handleBeforeUnload(ev: BeforeUnloadEvent) {
     ev.preventDefault();
@@ -40,7 +40,7 @@ export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): (
       const offsetFromNow = interval - elapsed;
       elapsed = interval;
 
-      stillOnPageTimer = setTimeout(() => {
+      stillOnPageTimer = window.setTimeout(() => {
         trackEvent('Prompt on navigate: user still on page', {
           seconds: elapsed,
         });
@@ -59,7 +59,7 @@ export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): (
       window.onbeforeunload = prevHandler;
     }
     if (stillOnPageTimer) {
-      clearTimeout(stillOnPageTimer);
+      window.clearTimeout(stillOnPageTimer);
       stillOnPageTimer = undefined;
     }
   };

--- a/app/javascript/packages/prompt-on-navigate/index.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.ts
@@ -8,8 +8,8 @@ const defaults = {
   stillOnPageIntervalsInSeconds: [5, 15, 30],
 };
 
-const PROMPT_EVENT = 'Prompt on navigate';
-const STILL_ON_PAGE_EVENT = 'Prompt on navigate: user still on page';
+const PROMPT_EVENT = 'User prompted before navigation';
+const STILL_ON_PAGE_EVENT = 'User prompted before navigation and still on page';
 
 /**
  * Configures the window.onbeforeunload handler such that the user will be prompted before

--- a/app/javascript/packages/prompt-on-navigate/index.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.ts
@@ -8,6 +8,9 @@ const defaults = {
   stillOnPageIntervalsInSeconds: [5, 15, 30],
 };
 
+const PROMPT_EVENT = 'Prompt on navigate';
+const STILL_ON_PAGE_EVENT = 'Prompt on navigate: user still on page';
+
 /**
  * Configures the window.onbeforeunload handler such that the user will be prompted before
  * reloading or navigating away
@@ -21,7 +24,7 @@ export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): (
     ev.preventDefault();
     ev.returnValue = '';
 
-    trackEvent('Prompt on navigate');
+    trackEvent(PROMPT_EVENT);
 
     const stillOnPageIntervalsInSeconds = [...options.stillOnPageIntervalsInSeconds];
     let elapsed = 0;
@@ -41,7 +44,7 @@ export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): (
       elapsed = interval;
 
       stillOnPageTimer = window.setTimeout(() => {
-        trackEvent('Prompt on navigate: user still on page', {
+        trackEvent(STILL_ON_PAGE_EVENT, {
           seconds: elapsed,
         });
         scheduleNextStillOnPagePing();

--- a/app/javascript/packages/prompt-on-navigate/index.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.ts
@@ -1,0 +1,59 @@
+import { trackEvent } from '@18f/identity-analytics';
+
+export type PromptBeforeNavigateOptions = {
+  stillOnPageInterval: number;
+  // trackEvent: (eventName: string, attributes?: Record<string, unknown>) => void;
+};
+
+const defaults = {
+  stillOnPageInterval: 7500,
+  // trackEvent: analytics.trackEvent,
+};
+
+/**
+ * Configures the window.onbeforeunload handler such that the user will be prompted before
+ * reloading or navigating away
+ * @param options {PromptBeforeNavigateOptions}
+ * @returns {() => void} A function that, when called, will "clean up" -- restore the prior onbeforeunload handler and cancel any pending timeouts.
+ */
+export function promptOnNavigate(
+  options: Partial<PromptBeforeNavigateOptions> = defaults,
+): () => void {
+  const { stillOnPageInterval } = {
+    ...defaults,
+    ...options,
+  };
+
+  let stillOnPageTimer: NodeJS.Timeout | undefined;
+
+  function handleBeforeUnload(ev: BeforeUnloadEvent) {
+    ev.preventDefault();
+    ev.returnValue = '';
+
+    trackEvent('Prompt before navigate');
+
+    if (stillOnPageTimer) {
+      clearTimeout(stillOnPageTimer);
+    }
+
+    stillOnPageTimer = setTimeout(() => {
+      stillOnPageTimer = undefined;
+      trackEvent('Prompt before navigate user still on page', {
+        interval: stillOnPageInterval,
+      });
+    }, options.stillOnPageInterval);
+  }
+
+  const prevHandler = window.onbeforeunload;
+  window.onbeforeunload = handleBeforeUnload;
+
+  return () => {
+    if (window.onbeforeunload === handleBeforeUnload) {
+      window.onbeforeunload = prevHandler;
+    }
+    if (stillOnPageTimer) {
+      clearTimeout(stillOnPageTimer);
+      stillOnPageTimer = undefined;
+    }
+  };
+}

--- a/app/javascript/packages/prompt-on-navigate/index.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.ts
@@ -1,47 +1,54 @@
 import { trackEvent } from '@18f/identity-analytics';
 
-export type PromptBeforeNavigateOptions = {
-  stillOnPageInterval: number;
-  // trackEvent: (eventName: string, attributes?: Record<string, unknown>) => void;
+export type PromptOnNavigateOptions = {
+  stillOnPageIntervalsInSeconds: number[];
 };
 
 const defaults = {
-  stillOnPageInterval: 7500,
-  // trackEvent: analytics.trackEvent,
+  stillOnPageIntervalsInSeconds: [5, 15, 30],
 };
 
 /**
  * Configures the window.onbeforeunload handler such that the user will be prompted before
  * reloading or navigating away
- * @param options {PromptBeforeNavigateOptions}
+ * @param options {PromptOnNavigateOptions}
  * @returns {() => void} A function that, when called, will "clean up" -- restore the prior onbeforeunload handler and cancel any pending timeouts.
  */
-export function promptOnNavigate(
-  options: Partial<PromptBeforeNavigateOptions> = defaults,
-): () => void {
-  const { stillOnPageInterval } = {
-    ...defaults,
-    ...options,
-  };
-
+export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): () => void {
   let stillOnPageTimer: NodeJS.Timeout | undefined;
 
   function handleBeforeUnload(ev: BeforeUnloadEvent) {
     ev.preventDefault();
     ev.returnValue = '';
 
-    trackEvent('Prompt before navigate');
+    trackEvent('Prompt on navigate');
 
-    if (stillOnPageTimer) {
-      clearTimeout(stillOnPageTimer);
+    const stillOnPageIntervalsInSeconds = [...options.stillOnPageIntervalsInSeconds];
+    let elapsed = 0;
+
+    function scheduleNextStillOnPagePing() {
+      const interval = stillOnPageIntervalsInSeconds.shift();
+      if (interval === undefined) {
+        return;
+      }
+
+      if (stillOnPageTimer) {
+        clearTimeout(stillOnPageTimer);
+        stillOnPageTimer = undefined;
+      }
+
+      const offsetFromNow = interval - elapsed;
+      elapsed = interval;
+
+      stillOnPageTimer = setTimeout(() => {
+        trackEvent('Prompt on navigate: user still on page', {
+          seconds: elapsed,
+        });
+        scheduleNextStillOnPagePing();
+      }, offsetFromNow * 1000);
     }
 
-    stillOnPageTimer = setTimeout(() => {
-      stillOnPageTimer = undefined;
-      trackEvent('Prompt before navigate user still on page', {
-        interval: stillOnPageInterval,
-      });
-    }, options.stillOnPageInterval);
+    scheduleNextStillOnPagePing();
   }
 
   const prevHandler = window.onbeforeunload;

--- a/app/javascript/packages/prompt-on-navigate/package.json
+++ b/app/javascript/packages/prompt-on-navigate/package.json
@@ -1,9 +1,5 @@
 {
-    "name": "@18f/identity-prompt-on-navigate",
-    "version": "1.0.0",
-    "private": true,
-    "peerDependencies": {
-      "react": "*"
-    }
-  }
-  
+  "name": "@18f/identity-prompt-on-navigate",
+  "version": "1.0.0",
+  "private": true
+}

--- a/app/javascript/packages/prompt-on-navigate/package.json
+++ b/app/javascript/packages/prompt-on-navigate/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "@18f/identity-prompt-on-navigate",
+    "version": "1.0.0",
+    "private": true,
+    "peerDependencies": {
+      "react": "*"
+    }
+  }
+  

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3581,6 +3581,25 @@ module AnalyticsEvents
     )
   end
 
+  # User was shown an "Are you sure you want to navigate away from this page?" message from their
+  # browser (via onbeforeunload). (This is a frontend event.)
+  def user_prompted_before_navigation
+    track_event(
+      'User prompted before navigation',
+    )
+  end
+
+  # User was shown an "Are you sure you want to navigate away from this page?" prompt via
+  # onbeforeunload and was still on the page <seconds> later. (This is a frontend event.)
+  # @param [Integer] seconds Amount of time user has been on page since prompt.
+  def user_prompted_before_navigation_and_still_on_page(seconds:, **extra)
+    track_event(
+      'User prompted before navigation and still on page',
+      seconds: seconds,
+      **extra,
+    )
+  end
+
   # @param [Boolean] success
   # @param [Hash] errors
   # @param [String] sign_up_mfa_priority_bucket

--- a/spec/javascript/packages/document-capture-polling/index-spec.js
+++ b/spec/javascript/packages/document-capture-polling/index-spec.js
@@ -44,6 +44,10 @@ describe('DocumentCapturePolling', () => {
     subject.bind();
   });
 
+  afterEach(() => {
+    subject.bindPromptOnNavigate(false);
+  });
+
   it('hides form', () => {
     expect(screen.getByText('Submit').closest('.display-none')).to.be.ok();
   });


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-9848](https://cm-jira.usa.gov/browse/LG-9848)

## 🛠 Summary of changes

Team Ada is considering removing some `onbeforeunload` prompts (the ones that say "If you navigate away from this page, your data may not be saved" or something to that effect) from the IdV flow on the grounds that they are annoying. But before we do that, we want actual data about how they are used and if they are doing their job.

- How often do users encounter these prompts?
- Do the prompts keep users on the page?

To that end, this PR refactors `onbeforeunload` code out into its own package and adds some analytics calls:

* `User prompted before navigation` fires when the `onbeforeunload` event handler is called
* `User prompted before navigation and still on page` fires at 5s, 15s, and 30s after to indicate the user stayed on the page
