### PR TITLE
Fix NoMethodError on unexpected response from USPS API

### DIFF
--- a/app/services/usps_in_person_proofing/response/request_enroll_response.rb
+++ b/app/services/usps_in_person_proofing/response/request_enroll_response.rb
@@ -15,7 +15,7 @@ module UspsInPersonProofing
 
       def parse_response
         unless body.is_a?(Hash)
-          raise StandardError.new("Expected a hash but got a #{body.class.class_name}")
+          raise StandardError.new("Expected a hash but got a #{body.class.name}")
         end
 
         unless body['enrollmentCode']

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -495,6 +495,26 @@ describe Idv::ReviewController do
             end
           end
 
+          context 'when the USPS response is not a hash' do
+            let(:stub_usps_response) do
+              stub_request_enroll_non_hash_response
+            end
+
+            it 'logs an error message' do
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+              expect(@analytics).to have_logged_event(
+                'USPS IPPaaS enrollment failed',
+                context: 'authentication',
+                enrollment_id: enrollment.id,
+                exception_class: 'UspsInPersonProofing::Exception::RequestEnrollException',
+                exception_message: 'Expected a hash but got a NilClass',
+                original_exception_class: 'StandardError',
+                reason: 'Request exception',
+              )
+            end
+          end
+
           context 'when the USPS response is missing an enrollment code' do
             let(:stub_usps_response) do
               stub_request_enroll_invalid_response

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -93,6 +93,14 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_enroll_non_hash_response
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant}).to_return(
+      status: 200,
+      body: nil,
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_expired_proofing_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
       **request_expired_proofing_results_args,


### PR DESCRIPTION
## 🛠 Summary of changes

[We encountered](https://gsa-tts.slack.com/archives/C043ZSQ3NUV/p1685153467001539) a case where a `NoMethodError` was being raised upon receiving a response from USPS API in an unexpected format. The error came from a case where we were using `[variable].class.class_name` instead of `[variable].class.name`.

`class_name` is a method [provided by the yard gem](https://rubydoc.info/gems/yard/YARD/Parser/Ruby/ClassNode#class_name-instance_method) that apparently is not available in production.