### PR TITLE
LG-9977 Guard IdvStepConcern before_actions for nil current_user

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -13,12 +13,12 @@ module IdvStepConcern
   end
 
   def confirm_no_pending_gpo_profile
-    redirect_to idv_gpo_verify_url if current_user.gpo_verification_pending_profile?
+    redirect_to idv_gpo_verify_url if current_user&.gpo_verification_pending_profile?
   end
 
   def confirm_no_pending_in_person_enrollment
     return if !IdentityConfig.store.in_person_proofing_enabled
-    redirect_to idv_in_person_ready_to_verify_url if current_user.pending_in_person_enrollment
+    redirect_to idv_in_person_ready_to_verify_url if current_user&.pending_in_person_enrollment
   end
 
   def flow_session

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -42,6 +42,10 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
       visit idv_hybrid_mobile_capture_complete_url
       expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
 
+      # Confirm that jumping to LinkSent page does not cause errors
+      visit idv_link_sent_url
+      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -44,7 +44,9 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
 
       # Confirm that jumping to LinkSent page does not cause errors
       visit idv_link_sent_url
-      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+      expect(page).to have_current_path(root_url)
+
+      visit idv_hybrid_mobile_capture_complete_url
 
       attach_and_submit_images
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9977](https://cm-jira.usa.gov/browse/LG-9977)

## 🛠 Summary of changes

Accessing a standard flow page from the hybrid flow was causing 500 errors in these before actions. The user will see that their session expired instead of a 500 error. If they click the browser back button, they successfully go back where they were.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create user, start IdV
- [ ] Choose hybrid flow
- [ ] In separate browser, use `/test/telephony/` to get hybrid flow link and enter hybrid flow
- [ ] On hybrid flow document capture page, navigate to `/verify/link_sent`
- [ ] Expect "Your link has expired" (no 500 error)
- [ ] Expect the back button to resume the hybrid flow document capture
