### PR TITLE
Upgrade to postgres 14

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
-brew 'postgresql@13'
+brew 'postgresql@14'
 brew 'redis'
 brew 'node@16'
 brew 'yarn'

--- a/bin/setup
+++ b/bin/setup
@@ -62,7 +62,7 @@ Dir.chdir APP_ROOT do
 
   puts "\n== Starting services =="
   run "brew services start redis" if brew_installed
-  run "brew services start postgresql@13" if brew_installed
+  run "brew services start postgresql@14" if brew_installed
 
   puts "\n== Preparing database =="
   run 'make clobber_db'


### PR DESCRIPTION
## 🛠 Summary of changes

In https://github.com/18F/identity-idp/pull/8475, we chose to keep Postgres at version 13 so that it could
[match production](https://github.com/18F/identity-devops/blob/33ba02736b37f3a79c50479892a03c6f3e920041/terraform/app/rds-variables.tf#L82).

However, when trying to continue on the `postgis` work, I found that
when installing `postgis`, `brew` installs 14 anyway, as a dependency of
`postgis`. There doesn't seem to be an easy way to tell Brew not to
install 14, or postgis to use 13 instead. This becomes an issue then
when the app is using 13, but `postgis` is using 14.

I thought it'd be better to change this now than wait for the postgis
work to be ready, as it would potentially stop folks from installing an
extra version of postgres.

There may be another workaround, but after reading [a homebrew issue
about versioning issues with postgres and postgis](https://github.com/Homebrew/homebrew-core/issues/86709), which included
suggestions like [making your own copy of `postgis` and changing its
dependencies](https://github.com/Homebrew/homebrew-core/issues/86709#issuecomment-936462624), it seemed like upgrading `postgres` was a
better solution.

While it will mean dev is on a different version than prod, most folks
have been using 14 or even 15, so we don't expect issues to arise.