### PR TITLE
Sort analytics events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 	help \
 	lint \
 	lint_analytics_events \
+	lint_analytics_events_sorted \
 	lint_tracker_events \
 	lint_country_dialing_codes \
 	lint_erb \
@@ -75,6 +76,7 @@ endif
 	@echo "--- analytics_events ---"
 	make lint_analytics_events
 	make lint_tracker_events
+	make lint_analytics_events_sorted
 	@echo "--- brakeman ---"
 	bundle exec brakeman
 	@echo "--- bundler-audit ---"
@@ -101,6 +103,7 @@ endif
 	make lint_readme
 	@echo "--- lint migrations ---"
 	make lint_migrations
+
 
 lint_erb: ## Lints ERB files
 	bundle exec erblint app/views app/components
@@ -246,6 +249,10 @@ analytics_events: public/api/_analytics-events.json ## Generates a JSON file tha
 
 lint_analytics_events: .yardoc ## Checks that all methods on AnalyticsEvents are documented
 	bundle exec ruby lib/analytics_events_documenter.rb --class-name="AnalyticsEvents" --check $<
+
+lint_analytics_events_sorted:
+	@test "$(shell grep '^  def ' app/services/analytics_events.rb)" = "$(shell grep '^  def ' app/services/analytics_events.rb | sort)" \
+		|| (echo 'Error: methods in analytics_events.rb are not sorted alphabetically' && exit 1)
 
 lint_tracker_events: .yardoc ## Checks that all methods on AnalyticsEvents are documented
 	bundle exec ruby lib/analytics_events_documenter.rb --class-name="IrsAttemptsApi::TrackerEvents" --check --skip-extra-params $<

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -11,15 +11,15 @@
 #                 ||     ||
 
 module AnalyticsEvents
+  # When a user visits the page to delete their account
+  def account_delete_visited
+    track_event('Account Delete visited')
+  end
+
   # @param [Boolean] success
   # When a user submits a form to delete their account
   def account_delete_submitted(success:, **extra)
     track_event('Account Delete submitted', success: success, **extra)
-  end
-
-  # When a user visits the page to delete their account
-  def account_delete_visited
-    track_event('Account Delete visited')
   end
 
   # @param [String] request_came_from the controller/action the request came from

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -11,15 +11,15 @@
 #                 ||     ||
 
 module AnalyticsEvents
-  # When a user visits the page to delete their account
-  def account_delete_visited
-    track_event('Account Delete visited')
-  end
-
   # @param [Boolean] success
   # When a user submits a form to delete their account
   def account_delete_submitted(success:, **extra)
     track_event('Account Delete submitted', success: success, **extra)
+  end
+
+  # When a user visits the page to delete their account
+  def account_delete_visited
+    track_event('Account Delete visited')
   end
 
   # @param [String] request_came_from the controller/action the request came from

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+#  ______________________________________
+# / Adding something new in here? Please \
+# \ keep methods sorted alphabetically.  /
+#  --------------------------------------
+#         \   ^__^
+#          \  (oo)\_______
+#             (__)\       )\/\
+#                 ||----w |
+#                 ||     ||
+
 module AnalyticsEvents
   # @param [Boolean] success
   # When a user submits a form to delete their account

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2242,7 +2242,6 @@ module AnalyticsEvents
                                     phone_type:,
                                     types:,
                                     **extra)
-
     track_event(
       'Multi-Factor Authentication: phone setup',
       success: success,
@@ -2412,7 +2411,6 @@ module AnalyticsEvents
       ialmax: nil,
       **extra
     )
-
     track_event(
       'User registration: agency handoff visited',
       ial2: ial2,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 module AnalyticsEvents
+  # @param [Boolean] success
+  # When a user submits a form to delete their account
+  def account_delete_submitted(success:, **extra)
+    track_event('Account Delete submitted', success: success, **extra)
+  end
+
+  # When a user visits the page to delete their account
+  def account_delete_visited
+    track_event('Account Delete visited')
+  end
+
+  # @param [String] request_came_from the controller/action the request came from
+  # When a user deletes their account
+  def account_deletion(request_came_from:, **extra)
+    track_event('Account Deletion Requested', request_came_from: request_came_from, **extra)
+  end
+
   # @identity.idp.previous_event_name Account Reset
   # @param [String] user_id
   # @param [String, nil] message_id from AWS Pinpoint API
@@ -15,6 +32,19 @@ module AnalyticsEvents
         request_id: request_id,
         **extra,
       }.compact,
+    )
+  end
+
+  # @identity.idp.previous_event_name Account Reset
+  # @param [String] user_id
+  # @param [Hash] errors
+  # Validates the token used for cancelling an account reset
+  def account_reset_cancel_token_validation(user_id:, errors: nil, **extra)
+    track_event(
+      'Account Reset: cancel token validation',
+      user_id: user_id,
+      errors: errors,
+      **extra,
     )
   end
 
@@ -43,6 +73,31 @@ module AnalyticsEvents
       errors: errors,
       **extra,
     )
+  end
+
+  # @identity.idp.previous_event_name Account Reset
+  # @param [String] user_id
+  # @param [Hash] errors
+  # Validates the granted token for account reset
+  def account_reset_granted_token_validation(user_id: nil, errors: nil, **extra)
+    track_event(
+      'Account Reset: granted token validation',
+      user_id: user_id,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # @identity.idp.previous_event_name Account Reset
+  # @param [Integer] count number of email notifications sent
+  # Account reset was performed, logs the number of email notifications sent
+  def account_reset_notifications(count:, **extra)
+    track_event('Account Reset: notifications', count: count, **extra)
+  end
+
+  # Tracks users visiting the recovery options page
+  def account_reset_recovery_options_visit
+    track_event('Account Reset: Recovery Options Visited')
   end
 
   # @identity.idp.previous_event_name Account Reset
@@ -79,59 +134,9 @@ module AnalyticsEvents
     )
   end
 
-  # @identity.idp.previous_event_name Account Reset
-  # @param [String] user_id
-  # @param [Hash] errors
-  # Validates the token used for cancelling an account reset
-  def account_reset_cancel_token_validation(user_id:, errors: nil, **extra)
-    track_event(
-      'Account Reset: cancel token validation',
-      user_id: user_id,
-      errors: errors,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name Account Reset
-  # @param [String] user_id
-  # @param [Hash] errors
-  # Validates the granted token for account reset
-  def account_reset_granted_token_validation(user_id: nil, errors: nil, **extra)
-    track_event(
-      'Account Reset: granted token validation',
-      user_id: user_id,
-      errors: errors,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name Account Reset
-  # @param [Integer] count number of email notifications sent
-  # Account reset was performed, logs the number of email notifications sent
-  def account_reset_notifications(count:, **extra)
-    track_event('Account Reset: notifications', count: count, **extra)
-  end
-
   # User visited the account deletion and reset page
   def account_reset_visit
     track_event('Account deletion and reset visited')
-  end
-
-  # @param [Boolean] success
-  # When a user submits a form to delete their account
-  def account_delete_submitted(success:, **extra)
-    track_event('Account Delete submitted', success: success, **extra)
-  end
-
-  # When a user visits the page to delete their account
-  def account_delete_visited
-    track_event('Account Delete visited')
-  end
-
-  # @param [String] request_came_from the controller/action the request came from
-  # When a user deletes their account
-  def account_deletion(request_came_from:, **extra)
-    track_event('Account Deletion Requested', request_came_from: request_came_from, **extra)
   end
 
   # When a user views the account page
@@ -144,6 +149,25 @@ module AnalyticsEvents
   # A user has clicked the confirmation link in an email
   def add_email_confirmation(user_id:, success: nil, **extra)
     track_event('Add Email: Email Confirmation', user_id: user_id, success: success, **extra)
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # Tracks request for adding new emails to an account
+  def add_email_request(success:, errors:, **extra)
+    track_event(
+      'Add Email Requested',
+      success: success,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # Tracks When users visit the add phone page
+  def add_phone_setup_visit
+    track_event(
+      'Phone Setup Visited',
+    )
   end
 
   # When a user views the "you are already signed in with the following email" screen
@@ -220,6 +244,27 @@ module AnalyticsEvents
     track_event('Broken Personal Key: Regenerated')
   end
 
+  # Tracks users going back or cancelling acoount recovery
+  def cancel_account_reset_recovery
+    track_event('Account Reset: Cancel Account Recovery Options')
+  end
+
+  # @param [String] redirect_url URL user was directed to
+  # @param [String, nil] step which step
+  # @param [String, nil] location which part of a step, if applicable
+  # @param ["idv", String, nil] flow which flow
+  # User was redirected to the login.gov contact page
+  def contact_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
+    track_event(
+      'Contact Page Redirect',
+      redirect_url: redirect_url,
+      step: step,
+      location: location,
+      flow: flow,
+      **extra,
+    )
+  end
+
   # @param [String, nil] error error message
   # @param [String, nil] uuid document capture session uuid
   # @param [String, nil] result_id document capture session result id
@@ -280,22 +325,12 @@ module AnalyticsEvents
 
   # @param [Boolean] success
   # @param [Hash] errors
-  # Tracks request for adding new emails to an account
-  def add_email_request(success:, errors:, **extra)
+  # Tracks if Email Language is updated
+  def email_language_updated(success:, errors:, **extra)
     track_event(
-      'Add Email Requested',
+      'Email Language: Updated',
       success: success,
       errors: errors,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # Tracks request for resending confirmation for new emails to an account
-  def resend_add_email_request(success:, **extra)
-    track_event(
-      'Resend Add Email Requested',
-      success: success,
       **extra,
     )
   end
@@ -305,14 +340,14 @@ module AnalyticsEvents
     track_event('Email Language: Visited')
   end
 
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # Tracks if Email Language is updated
-  def email_language_updated(success:, errors:, **extra)
+  # Logs after an email is sent
+  # @param [String] action type of email being sent
+  # @param [String, nil] ses_message_id AWS SES Message ID
+  def email_sent(action:, ses_message_id:, **extra)
     track_event(
-      'Email Language: Updated',
-      success: success,
-      errors: errors,
+      'Email Sent',
+      action: action,
+      ses_message_id: ses_message_id,
       **extra,
     )
   end
@@ -489,53 +524,29 @@ module AnalyticsEvents
     track_event('IdV: address visited')
   end
 
-  # @param [String] step the step that the user was on when they clicked cancel
-  # @param [String] request_came_from the controller and action from the
-  #   source such as "users/sessions#new"
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # The user clicked cancel during IDV (presented with an option to go back or confirm)
-  def idv_cancellation_visited(
-    step:,
-    request_came_from:,
-    proofing_components: nil,
+  # Tracks if request to get address candidates from ArcGIS fails
+  # @param [String] exception_class
+  # @param [String] exception_message
+  # @param [Boolean] response_body_present
+  # @param [Hash] response_body
+  # @param [Integer] response_status_code
+  def idv_arcgis_request_failure(
+    exception_class:,
+    exception_message:,
+    response_body_present:,
+    response_body:,
+    response_status_code:,
     **extra
   )
     track_event(
-      'IdV: cancellation visited',
-      step: step,
-      request_came_from: request_came_from,
-      proofing_components: proofing_components,
+      'Request ArcGIS Address Candidates: request failed',
+      exception_class: exception_class,
+      exception_message: exception_message,
+      response_body_present: response_body_present,
+      response_body: response_body,
+      response_status_code: response_status_code,
       **extra,
     )
-  end
-
-  # @param [Integer] failed_capture_attempts Number of failed Acuant SDK attempts
-  # @param [Integer] failed_submission_attempts Number of failed Acuant doc submissions
-  # @param [String] field Image form field
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
-  # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
-  # camera, on mobile devices.
-  def idv_native_camera_forced(
-    failed_capture_attempts:,
-    failed_submission_attempts:,
-    field:,
-    flow_path:,
-    **extra
-  )
-    track_event(
-      'IdV: Native camera forced after failed attempts',
-      failed_capture_attempts: failed_capture_attempts,
-      failed_submission_attempts: failed_submission_attempts,
-      field: field,
-      flow_path: flow_path,
-      **extra,
-    )
-  end
-
-  # The user visited the gpo confirm cancellation screen
-  def idv_gpo_confirm_start_over_visited
-    track_event('IdV: gpo confirm start over visited')
   end
 
   # @param [String] step the step that the user was on when they clicked cancel
@@ -562,13 +573,22 @@ module AnalyticsEvents
     )
   end
 
-  # The user checked or unchecked the "By checking this box..." checkbox on the idv agreement step.
-  # (This is a frontend event.)
-  # @param [Boolean] checked Whether the user checked the checkbox
-  def idv_consent_checkbox_toggled(checked:, **extra)
+  # @param [String] step the step that the user was on when they clicked cancel
+  # @param [String] request_came_from the controller and action from the
+  #   source such as "users/sessions#new"
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # The user clicked cancel during IDV (presented with an option to go back or confirm)
+  def idv_cancellation_visited(
+    step:,
+    request_came_from:,
+    proofing_components: nil,
+    **extra
+  )
     track_event(
-      'IdV: consent checkbox toggled',
-      checked: checked,
+      'IdV: cancellation visited',
+      step: step,
+      request_came_from: request_came_from,
+      proofing_components: proofing_components,
       **extra,
     )
   end
@@ -583,13 +603,424 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # @param [String] in_person_cta_variant Variant testing bucket label
-  # The user clicked the troubleshooting option to start in-person proofing
-  def idv_verify_in_person_troubleshooting_option_clicked(flow_path:, in_person_cta_variant:,
-                                                          **extra)
+  # The user checked or unchecked the "By checking this box..." checkbox on the idv agreement step.
+  # (This is a frontend event.)
+  # @param [Boolean] checked Whether the user checked the checkbox
+  def idv_consent_checkbox_toggled(checked:, **extra)
     track_event(
-      'IdV: verify in person troubleshooting option clicked',
+      'IdV: consent checkbox toggled',
+      checked: checked,
+      **extra,
+    )
+  end
+
+  # User has consented to share information with document upload and may
+  # view the "hybrid handoff" step next unless "skip_upload" param is true
+  def idv_doc_auth_agreement_submitted(**extra)
+    track_event('IdV: doc auth agreement submitted', **extra)
+  end
+
+  def idv_doc_auth_agreement_visited(**extra)
+    track_event('IdV: doc auth agreement visited', **extra)
+  end
+
+  def idv_doc_auth_cancel_link_sent_submitted(**extra)
+    track_event('IdV: doc auth cancel_link_sent submitted', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing cancel_update_ssn submitted
+  def idv_doc_auth_cancel_update_ssn_submitted(**extra)
+    track_event('IdV: doc auth cancel_update_ssn submitted', **extra)
+  end
+
+  def idv_doc_auth_capture_complete_visited(**extra)
+    track_event('IdV: doc auth capture_complete visited', **extra)
+  end
+
+  def idv_doc_auth_document_capture_submitted(**extra)
+    track_event('IdV: doc auth document_capture submitted', **extra)
+  end
+
+  def idv_doc_auth_document_capture_visited(**extra)
+    track_event('IdV: doc auth document_capture visited', **extra)
+  end
+
+  # @param [String] step_name which step the user was on
+  # @param [Integer] remaining_attempts how many attempts the user has left before we throttle them
+  # The user visited an error page due to an encountering an exception talking to a proofing vendor
+  def idv_doc_auth_exception_visited(step_name:, remaining_attempts:, **extra)
+    track_event(
+      'IdV: doc auth exception visited',
+      step_name: step_name,
+      remaining_attempts: remaining_attempts,
+      **extra,
+    )
+  end
+
+  # @identity.idp.previous_event_name IdV: doc auth send_link submitted
+  def idv_doc_auth_link_sent_submitted(**extra)
+    track_event('IdV: doc auth link_sent submitted', **extra)
+  end
+
+  def idv_doc_auth_link_sent_visited(**extra)
+    track_event('IdV: doc auth link_sent visited', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing optional verify_wait submitted
+  def idv_doc_auth_optional_verify_wait_submitted(**extra)
+    track_event('IdV: doc auth optional verify_wait submitted', **extra)
+  end
+
+  def idv_doc_auth_randomizer_defaulted
+    track_event(
+      'IdV: doc_auth random vendor error',
+      error: 'document_capture_session_uuid_key missing',
+    )
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing redo_address submitted
+  def idv_doc_auth_redo_address_submitted(**extra)
+    track_event('IdV: doc auth redo_address submitted', **extra)
+  end
+
+  def idv_doc_auth_redo_document_capture_submitted(**extra)
+    track_event('IdV: doc auth redo_document_capture submitted', **extra)
+  end
+
+  def idv_doc_auth_redo_ssn_submitted(**extra)
+    track_event('IdV: doc auth redo_ssn submitted', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing ssn submitted
+  def idv_doc_auth_ssn_submitted(**extra)
+    track_event('IdV: doc auth ssn submitted', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing ssn visited
+  def idv_doc_auth_ssn_visited(**extra)
+    track_event('IdV: doc auth ssn visited', **extra)
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Integer] attempts
+  # @param [Integer] remaining_attempts
+  # @param [String] user_id
+  # @param [String] flow_path
+  # The document capture image uploaded was locally validated during the IDV process
+  def idv_doc_auth_submitted_image_upload_form(
+    success:,
+    errors:,
+    remaining_attempts:,
+    flow_path:,
+    attempts: nil,
+    user_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth image upload form submitted',
+      success: success,
+      errors: errors,
+      attempts: attempts,
+      remaining_attempts: remaining_attempts,
+      user_id: user_id,
+      flow_path: flow_path,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] exception
+  # @param [Boolean] billed
+  # @param [String] doc_auth_result
+  # @param [String] state
+  # @param [String] state_id_type
+  # @param [Boolean] async
+  # @param [Integer] attempts
+  # @param [Integer] remaining_attempts
+  # @param [Hash] client_image_metrics
+  # @param [String] flow_path
+  # The document capture image was uploaded to vendor during the IDV process
+  def idv_doc_auth_submitted_image_upload_vendor(
+    success:,
+    errors:,
+    exception:,
+    state:,
+    state_id_type:,
+    async:, attempts:,
+    remaining_attempts:,
+    client_image_metrics:,
+    flow_path:,
+    billed: nil,
+    doc_auth_result: nil,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth image upload vendor submitted',
+      success: success,
+      errors: errors,
+      exception: exception,
+      billed: billed,
+      doc_auth_result: doc_auth_result,
+      state: state,
+      state_id_type: state_id_type,
+      async: async,
+      attempts: attempts,
+      remaining_attempts: remaining_attempts,
+      client_image_metrics: client_image_metrics,
+      flow_path: flow_path,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] user_id
+  # @param [Integer] remaining_attempts
+  # @param [Hash] pii_like_keypaths
+  # @param [String] flow_path
+  # The PII that came back from the document capture vendor was validated
+  def idv_doc_auth_submitted_pii_validation(
+    success:,
+    errors:,
+    remaining_attempts:,
+    pii_like_keypaths:,
+    flow_path:,
+    user_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth image upload vendor pii validation',
+      success: success,
+      errors: errors,
+      user_id: user_id,
+      remaining_attempts: remaining_attempts,
+      pii_like_keypaths: pii_like_keypaths,
+      flow_path: flow_path,
+      **extra,
+    )
+  end
+
+  # The "hybrid handoff" step: Desktop user has submitted their choice to
+  # either continue via desktop ("document_capture" destination) or switch
+  # to mobile phone ("send_link" destination) to perform document upload.
+  # Mobile users still log this event but with skip_upload_step = true
+  def idv_doc_auth_upload_submitted(**extra)
+    track_event('IdV: doc auth upload submitted', **extra)
+  end
+
+  # Desktop user has reached the above "hybrid handoff" view
+  def idv_doc_auth_upload_visited(**extra)
+    track_event('IdV: doc auth upload visited', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: doc auth optional verify_wait submitted
+  def idv_doc_auth_verify_proofing_results(**extra)
+    track_event('IdV: doc auth verify proofing results', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing verify submitted
+  def idv_doc_auth_verify_submitted(**extra)
+    track_event('IdV: doc auth verify submitted', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing verify visited
+  def idv_doc_auth_verify_visited(**extra)
+    track_event('IdV: doc auth verify visited', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing verify_wait visited
+  def idv_doc_auth_verify_wait_step_visited(**extra)
+    track_event('IdV: doc auth verify_wait visited', **extra)
+  end
+
+  # @param [String] step_name
+  # @param [Integer] remaining_attempts
+  # The user was sent to a warning page during the IDV flow
+  def idv_doc_auth_warning_visited(
+    step_name:,
+    remaining_attempts:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth warning visited',
+      step_name: step_name,
+      remaining_attempts: remaining_attempts,
+      **extra,
+    )
+  end
+
+  def idv_doc_auth_welcome_submitted(**extra)
+    track_event('IdV: doc auth welcome submitted', **extra)
+  end
+
+  def idv_doc_auth_welcome_visited(**extra)
+    track_event('IdV: doc auth welcome visited', **extra)
+  end
+
+  # @param [Boolean] success
+  # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
+  # @param [Boolean] fraud_review_pending Profile is under review for fraud
+  # @param [Boolean] fraud_rejection Profile is rejected due to fraud
+  # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verificaiton
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # Tracks the last step of IDV, indicates the user successfully proofed
+  def idv_final(
+    success:,
+    fraud_review_pending:,
+    fraud_rejection:,
+    gpo_verification_pending:,
+    deactivation_reason: nil,
+    proofing_components: nil,
+    **extra
+  )
+    track_event(
+      'IdV: final resolution',
+      success: success,
+      fraud_review_pending: fraud_review_pending,
+      fraud_rejection: fraud_rejection,
+      gpo_verification_pending: gpo_verification_pending,
+      deactivation_reason: deactivation_reason,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # User visited forgot password page
+  def idv_forgot_password(proofing_components: nil, **extra)
+    track_event(
+      'IdV: forgot password visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # User confirmed forgot password
+  def idv_forgot_password_confirmed(proofing_components: nil, **extra)
+    track_event(
+      'IdV: forgot password confirmed',
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [DateTime] enqueued_at
+  # @param [Boolean] resend
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # GPO letter was enqueued and the time at which it was enqueued
+  def idv_gpo_address_letter_enqueued(enqueued_at:, resend:, proofing_components: nil, **extra)
+    track_event(
+      'IdV: USPS address letter enqueued',
+      enqueued_at: enqueued_at,
+      resend: resend,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] resend
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # GPO letter was requested
+  def idv_gpo_address_letter_requested(resend:, proofing_components: nil, **extra)
+    track_event(
+      'IdV: USPS address letter requested',
+      resend: resend,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] letter_already_sent
+  # GPO address visited
+  def idv_gpo_address_visited(
+    letter_already_sent:,
+    **extra
+  )
+    track_event(
+      'IdV: USPS address visited',
+      letter_already_sent: letter_already_sent,
+      **extra,
+    )
+  end
+
+  # The user visited the gpo confirm cancellation screen
+  def idv_gpo_confirm_start_over_visited
+    track_event('IdV: gpo confirm start over visited')
+  end
+
+  # @identity.idp.previous_event_name Account verification submitted
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Hash] pii_like_keypaths
+  # GPO verification submitted
+  def idv_gpo_verification_submitted(
+    success:,
+    errors:,
+    pii_like_keypaths:,
+    **extra
+  )
+    track_event(
+      'IdV: GPO verification submitted',
+      success: success,
+      errors: errors,
+      pii_like_keypaths: pii_like_keypaths,
+      **extra,
+    )
+  end
+
+  # @identity.idp.previous_event_name Account verification visited
+  # GPO verification visited
+  def idv_gpo_verification_visited
+    track_event('IdV: GPO verification visited')
+  end
+
+  # Tracks emails that are initiated during InPerson::EmailReminderJob
+  # @param [String] email_type early or late
+  # @param [String] enrollment_id
+  def idv_in_person_email_reminder_job_email_initiated(
+    email_type:,
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      'InPerson::EmailReminderJob: Reminder email initiated',
+      email_type: email_type,
+      enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
+
+  # Tracks exceptions that are raised when running InPerson::EmailReminderJob
+  # @param [String] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  def idv_in_person_email_reminder_job_exception(
+    enrollment_id:,
+    exception_class: nil,
+    exception_message: nil,
+    **extra
+  )
+    track_event(
+      'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
+  # @param [String] selected_location Selected in-person location
+  # @param [String] in_person_cta_variant Variant testing bucket label
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The user submitted the in person proofing location step
+  def idv_in_person_location_submitted(selected_location:, in_person_cta_variant:, flow_path:,
+                                       **extra)
+    track_event(
+      'IdV: in person proofing location submitted',
+      selected_location: selected_location,
       flow_path: flow_path,
       in_person_cta_variant: in_person_cta_variant,
       **extra,
@@ -604,6 +1035,31 @@ module AnalyticsEvents
       'IdV: in person proofing location visited',
       flow_path: flow_path,
       in_person_cta_variant: in_person_cta_variant,
+      **extra,
+    )
+  end
+
+  # Tracks if request to get USPS in-person proofing locations fails
+  # @param [String] exception_class
+  # @param [String] exception_message
+  # @param [Boolean] response_body_present
+  # @param [Hash] response_body
+  # @param [Integer] response_status_code
+  def idv_in_person_locations_request_failure(
+    exception_class:,
+    exception_message:,
+    response_body_present:,
+    response_body:,
+    response_status_code:,
+    **extra
+  )
+    track_event(
+      'Request USPS IPP locations: request failed',
+      exception_class: exception_class,
+      exception_message: exception_message,
+      response_body_present: response_body_present,
+      response_body: response_body,
+      response_status_code: response_status_code,
       **extra,
     )
   end
@@ -636,27 +1092,6 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] selected_location Selected in-person location
-  # @param [String] in_person_cta_variant Variant testing bucket label
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The user submitted the in person proofing location step
-  def idv_in_person_location_submitted(selected_location:, in_person_cta_variant:, flow_path:,
-                                       **extra)
-    track_event(
-      'IdV: in person proofing location submitted',
-      selected_location: selected_location,
-      flow_path: flow_path,
-      in_person_cta_variant: in_person_cta_variant,
-      **extra,
-    )
-  end
-
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The user visited the in person proofing prepare step
-  def idv_in_person_prepare_visited(flow_path:, **extra)
-    track_event('IdV: in person proofing prepare visited', flow_path: flow_path, **extra)
-  end
-
   # @param [String] flow_path Document capture path ("hybrid" or "standard")
   # @param [String] in_person_cta_variant Variant testing bucket label
   # The user submitted the in person proofing prepare step
@@ -669,21 +1104,10 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] nontransliterable_characters
-  # Nontransliterable characters submitted by user
-  def idv_in_person_proofing_nontransliterable_characters_submitted(
-    nontransliterable_characters:,
-    **extra
-  )
-    track_event(
-      'IdV: in person proofing characters submitted could not be transliterated',
-      nontransliterable_characters: nontransliterable_characters,
-      **extra,
-    )
-  end
-
-  def idv_in_person_proofing_residential_address_submitted(**extra)
-    track_event('IdV: in person proofing residential address submitted', **extra)
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The user visited the in person proofing prepare step
+  def idv_in_person_prepare_visited(flow_path:, **extra)
+    track_event('IdV: in person proofing prepare visited', flow_path: flow_path, **extra)
   end
 
   # @param [String] flow_path
@@ -813,6 +1237,75 @@ module AnalyticsEvents
     )
   end
 
+  # A job to check USPS notifications about in-person enrollment status updates has completed
+  # @param [Integer] fetched_items items fetched
+  # @param [Integer] processed_items items fetched and processed
+  # @param [Integer] deleted_items items fetched, processed, and then deleted from the queue
+  # @param [Integer] valid_items items that could be successfully used to update a record
+  # @param [Integer] invalid_items items that couldn't be used to update a record
+  # @param [Integer] incomplete_items fetched items not processed nor deleted from the queue
+  # @param [Integer] deletion_failed_items processed items that we failed to delete
+  def idv_in_person_proofing_enrollments_ready_for_status_check_job_completed(
+    fetched_items:,
+    processed_items:,
+    deleted_items:,
+    valid_items:,
+    invalid_items:,
+    incomplete_items:,
+    deletion_failed_items:,
+    **extra
+  )
+    track_event(
+      'InPersonEnrollmentsReadyForStatusCheckJob: Job completed',
+      fetched_items:,
+      processed_items:,
+      deleted_items:,
+      valid_items:,
+      invalid_items:,
+      incomplete_items:,
+      deletion_failed_items:,
+      **extra,
+    )
+  end
+
+  # A job to check USPS notifications about in-person enrollment status updates
+  # has encountered an error
+  # @param [String] exception_class
+  # @param [String] exception_message
+  def idv_in_person_proofing_enrollments_ready_for_status_check_job_ingestion_error(
+    exception_class:,
+    exception_message:,
+    **extra
+  )
+    track_event(
+      'InPersonEnrollmentsReadyForStatusCheckJob: Ingestion error',
+      exception_class:,
+      exception_message:,
+      **extra,
+    )
+  end
+
+  # A job to check USPS notifications about in-person enrollment status updates has started
+  def idv_in_person_proofing_enrollments_ready_for_status_check_job_started(**extra)
+    track_event(
+      'InPersonEnrollmentsReadyForStatusCheckJob: Job started',
+      **extra,
+    )
+  end
+
+  # @param [String] nontransliterable_characters
+  # Nontransliterable characters submitted by user
+  def idv_in_person_proofing_nontransliterable_characters_submitted(
+    nontransliterable_characters:,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing characters submitted could not be transliterated',
+      nontransliterable_characters: nontransliterable_characters,
+      **extra,
+    )
+  end
+
   # @param [String] flow_path
   # @param [String] step
   # @param [Integer] step_count
@@ -845,6 +1338,10 @@ module AnalyticsEvents
       same_address_as_id: same_address_as_id,
       **extra,
     )
+  end
+
+  def idv_in_person_proofing_residential_address_submitted(**extra)
+    track_event('IdV: in person proofing residential address submitted', **extra)
   end
 
   # @param [String] flow_path
@@ -906,16 +1403,12 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The user visited the in person proofing switch_back step
-  def idv_in_person_switch_back_visited(flow_path:, **extra)
-    track_event('IdV: in person proofing switch_back visited', flow_path: flow_path, **extra)
-  end
-
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The user submitted the in person proofing switch_back step
-  def idv_in_person_switch_back_submitted(flow_path:, **extra)
-    track_event('IdV: in person proofing switch_back submitted', flow_path: flow_path, **extra)
+  # The user clicked the sp link on the "ready to verify" page
+  def idv_in_person_ready_to_verify_sp_link_clicked(**extra)
+    track_event(
+      'IdV: user clicked sp link on ready to verify page',
+      **extra,
+    )
   end
 
   # @param [String] in_person_cta_variant Variant testing bucket label
@@ -931,14 +1424,6 @@ module AnalyticsEvents
     )
   end
 
-  # The user clicked the sp link on the "ready to verify" page
-  def idv_in_person_ready_to_verify_sp_link_clicked(**extra)
-    track_event(
-      'IdV: user clicked sp link on ready to verify page',
-      **extra,
-    )
-  end
-
   # The user clicked the what to bring link on the "ready to verify" page
   def idv_in_person_ready_to_verify_what_to_bring_link_clicked(**extra)
     track_event(
@@ -947,390 +1432,287 @@ module AnalyticsEvents
     )
   end
 
-  # A job to check USPS notifications about in-person enrollment status updates has started
-  def idv_in_person_proofing_enrollments_ready_for_status_check_job_started(**extra)
-    track_event(
-      'InPersonEnrollmentsReadyForStatusCheckJob: Job started',
-      **extra,
-    )
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The user submitted the in person proofing switch_back step
+  def idv_in_person_switch_back_submitted(flow_path:, **extra)
+    track_event('IdV: in person proofing switch_back submitted', flow_path: flow_path, **extra)
   end
 
-  # A job to check USPS notifications about in-person enrollment status updates has completed
-  # @param [Integer] fetched_items items fetched
-  # @param [Integer] processed_items items fetched and processed
-  # @param [Integer] deleted_items items fetched, processed, and then deleted from the queue
-  # @param [Integer] valid_items items that could be successfully used to update a record
-  # @param [Integer] invalid_items items that couldn't be used to update a record
-  # @param [Integer] incomplete_items fetched items not processed nor deleted from the queue
-  # @param [Integer] deletion_failed_items processed items that we failed to delete
-  def idv_in_person_proofing_enrollments_ready_for_status_check_job_completed(
-    fetched_items:,
-    processed_items:,
-    deleted_items:,
-    valid_items:,
-    invalid_items:,
-    incomplete_items:,
-    deletion_failed_items:,
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The user visited the in person proofing switch_back step
+  def idv_in_person_switch_back_visited(flow_path:, **extra)
+    track_event('IdV: in person proofing switch_back visited', flow_path: flow_path, **extra)
+  end
+
+  # GetUspsProofingResultsJob has completed. Includes counts of various outcomes encountered
+  # @param [Float] duration_seconds number of minutes the job was running
+  # @param [Integer] enrollments_checked number of enrollments eligible for status check
+  # @param [Integer] enrollments_errored number of enrollments for which we encountered an error
+  # @param [Integer] enrollments_expired number of enrollments which expired
+  # @param [Integer] enrollments_failed number of enrollments which failed identity proofing
+  # @param [Integer] enrollments_in_progress number of enrollments which did not have any change
+  # @param [Integer] enrollments_passed number of enrollments which passed identity proofing
+  def idv_in_person_usps_proofing_results_job_completed(
+    duration_seconds:,
+    enrollments_checked:,
+    enrollments_errored:,
+    enrollments_expired:,
+    enrollments_failed:,
+    enrollments_in_progress:,
+    enrollments_passed:,
     **extra
   )
     track_event(
-      'InPersonEnrollmentsReadyForStatusCheckJob: Job completed',
-      fetched_items:,
-      processed_items:,
-      deleted_items:,
-      valid_items:,
-      invalid_items:,
-      incomplete_items:,
-      deletion_failed_items:,
+      'GetUspsProofingResultsJob: Job completed',
+      duration_seconds: duration_seconds,
+      enrollments_checked: enrollments_checked,
+      enrollments_errored: enrollments_errored,
+      enrollments_expired: enrollments_expired,
+      enrollments_failed: enrollments_failed,
+      enrollments_in_progress: enrollments_in_progress,
+      enrollments_passed: enrollments_passed,
       **extra,
     )
   end
 
-  # A job to check USPS notifications about in-person enrollment status updates
-  # has encountered an error
+  # Tracks exceptions that are raised when initiating deadline email in GetUspsProofingResultsJob
+  # @param [String] enrollment_id
   # @param [String] exception_class
   # @param [String] exception_message
-  def idv_in_person_proofing_enrollments_ready_for_status_check_job_ingestion_error(
+  def idv_in_person_usps_proofing_results_job_deadline_passed_email_exception(
+    enrollment_id:,
+    exception_class: nil,
+    exception_message: nil,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Exception raised when attempting to send deadline passed email',
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
+  # Tracks deadline email initiated during GetUspsProofingResultsJob
+  # @param [String] enrollment_id
+  def idv_in_person_usps_proofing_results_job_deadline_passed_email_initiated(
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: deadline passed email initiated',
+      enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
+
+  # Tracks emails that are initiated during GetUspsProofingResultsJob
+  # @param [String] email_type success, failed or failed fraud
+  def idv_in_person_usps_proofing_results_job_email_initiated(
+    email_type:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Success or failure email initiated',
+      email_type: email_type,
+      **extra,
+    )
+  end
+
+  # Tracks incomplete enrollments checked via the USPS API
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [Float] minutes_since_established
+  # @param [String] response_message
+  def idv_in_person_usps_proofing_results_job_enrollment_incomplete(
+    enrollment_code:,
+    enrollment_id:,
+    minutes_since_established:,
+    response_message:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Enrollment incomplete',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      minutes_since_established: minutes_since_established,
+      response_message: response_message,
+      **extra,
+    )
+  end
+
+  # Tracks individual enrollments that are updated during GetUspsProofingResultsJob
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [Float] minutes_since_established
+  # @param [Boolean] fraud_suspected
+  # @param [Boolean] passed did this enrollment pass or fail?
+  # @param [String] reason why did this enrollment pass or fail?
+  def idv_in_person_usps_proofing_results_job_enrollment_updated(
+    enrollment_code:,
+    enrollment_id:,
+    minutes_since_established:,
+    fraud_suspected:,
+    passed:,
+    reason:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Enrollment status updated',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      minutes_since_established: minutes_since_established,
+      fraud_suspected: fraud_suspected,
+      passed: passed,
+      reason: reason,
+      **extra,
+    )
+  end
+
+  # Tracks exceptions that are raised when running GetUspsProofingResultsJob
+  # @param [String] reason why was the exception raised?
+  # @param [String] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  # @param [String] enrollment_code
+  # @param [Float] minutes_since_established
+  # @param [Float] minutes_since_last_status_check
+  # @param [Float] minutes_since_last_status_update
+  # @param [Float] minutes_to_completion
+  # @param [Boolean] fraud_suspected
+  # @param [String] primary_id_type
+  # @param [String] secondary_id_type
+  # @param [String] failure_reason
+  # @param [String] transaction_end_date_time
+  # @param [String] transaction_start_date_time
+  # @param [String] status
+  # @param [String] assurance_level
+  # @param [String] proofing_post_office
+  # @param [String] proofing_city
+  # @param [String] proofing_state
+  # @param [String] scan_count
+  # @param [String] response_message
+  # @param [Integer] response_status_code
+  def idv_in_person_usps_proofing_results_job_exception(
+    reason:,
+    enrollment_id:,
+    minutes_since_established:,
+    exception_class: nil,
+    exception_message: nil,
+    enrollment_code: nil,
+    minutes_since_last_status_check: nil,
+    minutes_since_last_status_update: nil,
+    minutes_to_completion: nil,
+    fraud_suspected: nil,
+    primary_id_type: nil,
+    secondary_id_type: nil,
+    failure_reason: nil,
+    transaction_end_date_time: nil,
+    transaction_start_date_time: nil,
+    status: nil,
+    assurance_level: nil,
+    proofing_post_office: nil,
+    proofing_city: nil,
+    proofing_state: nil,
+    scan_count: nil,
+    response_message: nil,
+    response_status_code: nil,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Exception raised',
+      reason: reason,
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      enrollment_code: enrollment_code,
+      minutes_since_established: minutes_since_established,
+      minutes_since_last_status_check: minutes_since_last_status_check,
+      minutes_since_last_status_update: minutes_since_last_status_update,
+      minutes_to_completion: minutes_to_completion,
+      fraud_suspected: fraud_suspected,
+      primary_id_type: primary_id_type,
+      secondary_id_type: secondary_id_type,
+      failure_reason: failure_reason,
+      transaction_end_date_time: transaction_end_date_time,
+      transaction_start_date_time: transaction_start_date_time,
+      status: status,
+      assurance_level: assurance_level,
+      proofing_post_office: proofing_post_office,
+      proofing_city: proofing_city,
+      proofing_state: proofing_state,
+      scan_count: scan_count,
+      response_message: response_message,
+      response_status_code: response_status_code,
+      **extra,
+    )
+  end
+
+  # GetUspsProofingResultsJob is beginning. Includes some metadata about what the job will do
+  # @param [Integer] enrollments_count number of enrollments eligible for status check
+  # @param [Integer] reprocess_delay_minutes minimum delay since last status check
+  def idv_in_person_usps_proofing_results_job_started(
+    enrollments_count:,
+    reprocess_delay_minutes:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Job started',
+      enrollments_count: enrollments_count,
+      reprocess_delay_minutes: reprocess_delay_minutes,
+      **extra,
+    )
+  end
+
+  # Tracks unexpected responses from the USPS API
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [Float] minutes_since_established
+  # @param [String] response_message
+  # @param [String] reason why was this error unexpected?
+  def idv_in_person_usps_proofing_results_job_unexpected_response(
+    enrollment_code:,
+    enrollment_id:,
+    minutes_since_established:,
+    response_message:,
+    reason:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Unexpected response received',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      minutes_since_established: minutes_since_established,
+      response_message: response_message,
+      reason: reason,
+      **extra,
+    )
+  end
+
+  # Tracks if USPS in-person proofing enrollment request fails
+  # @param [String] context
+  # @param [String] reason
+  # @param [Integer] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  def idv_in_person_usps_request_enroll_exception(
+    context:,
+    reason:,
+    enrollment_id:,
     exception_class:,
     exception_message:,
     **extra
   )
     track_event(
-      'InPersonEnrollmentsReadyForStatusCheckJob: Ingestion error',
-      exception_class:,
-      exception_message:,
+      'USPS IPPaaS enrollment failed',
+      context: context,
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      reason: reason,
       **extra,
     )
-  end
-
-  # User has consented to share information with document upload and may
-  # view the "hybrid handoff" step next unless "skip_upload" param is true
-  def idv_doc_auth_agreement_submitted(**extra)
-    track_event('IdV: doc auth agreement submitted', **extra)
-  end
-
-  def idv_doc_auth_agreement_visited(**extra)
-    track_event('IdV: doc auth agreement visited', **extra)
-  end
-
-  def idv_doc_auth_cancel_link_sent_submitted(**extra)
-    track_event('IdV: doc auth cancel_link_sent submitted', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing cancel_update_ssn submitted
-  def idv_doc_auth_cancel_update_ssn_submitted(**extra)
-    track_event('IdV: doc auth cancel_update_ssn submitted', **extra)
-  end
-
-  def idv_doc_auth_capture_complete_visited(**extra)
-    track_event('IdV: doc auth capture_complete visited', **extra)
-  end
-
-  def idv_doc_auth_document_capture_visited(**extra)
-    track_event('IdV: doc auth document_capture visited', **extra)
-  end
-
-  def idv_doc_auth_document_capture_submitted(**extra)
-    track_event('IdV: doc auth document_capture submitted', **extra)
-  end
-
-  # @param [String] step_name which step the user was on
-  # @param [Integer] remaining_attempts how many attempts the user has left before we throttle them
-  # The user visited an error page due to an encountering an exception talking to a proofing vendor
-  def idv_doc_auth_exception_visited(step_name:, remaining_attempts:, **extra)
-    track_event(
-      'IdV: doc auth exception visited',
-      step_name: step_name,
-      remaining_attempts: remaining_attempts,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name IdV: doc auth send_link submitted
-  def idv_doc_auth_link_sent_submitted(**extra)
-    track_event('IdV: doc auth link_sent submitted', **extra)
-  end
-
-  def idv_doc_auth_link_sent_visited(**extra)
-    track_event('IdV: doc auth link_sent visited', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing optional verify_wait submitted
-  def idv_doc_auth_optional_verify_wait_submitted(**extra)
-    track_event('IdV: doc auth optional verify_wait submitted', **extra)
-  end
-
-  def idv_doc_auth_redo_document_capture_submitted(**extra)
-    track_event('IdV: doc auth redo_document_capture submitted', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing ssn submitted
-  def idv_doc_auth_ssn_submitted(**extra)
-    track_event('IdV: doc auth ssn submitted', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing ssn visited
-  def idv_doc_auth_ssn_visited(**extra)
-    track_event('IdV: doc auth ssn visited', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing redo_address submitted
-  def idv_doc_auth_redo_address_submitted(**extra)
-    track_event('IdV: doc auth redo_address submitted', **extra)
-  end
-
-  def idv_doc_auth_redo_ssn_submitted(**extra)
-    track_event('IdV: doc auth redo_ssn submitted', **extra)
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [Integer] attempts
-  # @param [Integer] remaining_attempts
-  # @param [String] user_id
-  # @param [String] flow_path
-  # The document capture image uploaded was locally validated during the IDV process
-  def idv_doc_auth_submitted_image_upload_form(
-    success:,
-    errors:,
-    remaining_attempts:,
-    flow_path:,
-    attempts: nil,
-    user_id: nil,
-    **extra
-  )
-    track_event(
-      'IdV: doc auth image upload form submitted',
-      success: success,
-      errors: errors,
-      attempts: attempts,
-      remaining_attempts: remaining_attempts,
-      user_id: user_id,
-      flow_path: flow_path,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [String] exception
-  # @param [Boolean] billed
-  # @param [String] doc_auth_result
-  # @param [String] state
-  # @param [String] state_id_type
-  # @param [Boolean] async
-  # @param [Integer] attempts
-  # @param [Integer] remaining_attempts
-  # @param [Hash] client_image_metrics
-  # @param [String] flow_path
-  # The document capture image was uploaded to vendor during the IDV process
-  def idv_doc_auth_submitted_image_upload_vendor(
-    success:,
-    errors:,
-    exception:,
-    state:,
-    state_id_type:,
-    async:, attempts:,
-    remaining_attempts:,
-    client_image_metrics:,
-    flow_path:,
-    billed: nil,
-    doc_auth_result: nil,
-    **extra
-  )
-    track_event(
-      'IdV: doc auth image upload vendor submitted',
-      success: success,
-      errors: errors,
-      exception: exception,
-      billed: billed,
-      doc_auth_result: doc_auth_result,
-      state: state,
-      state_id_type: state_id_type,
-      async: async,
-      attempts: attempts,
-      remaining_attempts: remaining_attempts,
-      client_image_metrics: client_image_metrics,
-      flow_path: flow_path,
-      **extra,
-    )
-  end
-
-  def idv_doc_auth_randomizer_defaulted
-    track_event(
-      'IdV: doc_auth random vendor error',
-      error: 'document_capture_session_uuid_key missing',
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [String] user_id
-  # @param [Integer] remaining_attempts
-  # @param [Hash] pii_like_keypaths
-  # @param [String] flow_path
-  # The PII that came back from the document capture vendor was validated
-  def idv_doc_auth_submitted_pii_validation(
-    success:,
-    errors:,
-    remaining_attempts:,
-    pii_like_keypaths:,
-    flow_path:,
-    user_id: nil,
-    **extra
-  )
-    track_event(
-      'IdV: doc auth image upload vendor pii validation',
-      success: success,
-      errors: errors,
-      user_id: user_id,
-      remaining_attempts: remaining_attempts,
-      pii_like_keypaths: pii_like_keypaths,
-      flow_path: flow_path,
-      **extra,
-    )
-  end
-
-  # The "hybrid handoff" step: Desktop user has submitted their choice to
-  # either continue via desktop ("document_capture" destination) or switch
-  # to mobile phone ("send_link" destination) to perform document upload.
-  # Mobile users still log this event but with skip_upload_step = true
-  def idv_doc_auth_upload_submitted(**extra)
-    track_event('IdV: doc auth upload submitted', **extra)
-  end
-
-  # Desktop user has reached the above "hybrid handoff" view
-  def idv_doc_auth_upload_visited(**extra)
-    track_event('IdV: doc auth upload visited', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing verify submitted
-  def idv_doc_auth_verify_submitted(**extra)
-    track_event('IdV: doc auth verify submitted', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing verify visited
-  def idv_doc_auth_verify_visited(**extra)
-    track_event('IdV: doc auth verify visited', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: doc auth optional verify_wait submitted
-  def idv_doc_auth_verify_proofing_results(**extra)
-    track_event('IdV: doc auth verify proofing results', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing verify_wait visited
-  def idv_doc_auth_verify_wait_step_visited(**extra)
-    track_event('IdV: doc auth verify_wait visited', **extra)
-  end
-
-  # @param [String] step_name
-  # @param [Integer] remaining_attempts
-  # The user was sent to a warning page during the IDV flow
-  def idv_doc_auth_warning_visited(
-    step_name:,
-    remaining_attempts:,
-    **extra
-  )
-    track_event(
-      'IdV: doc auth warning visited',
-      step_name: step_name,
-      remaining_attempts: remaining_attempts,
-      **extra,
-    )
-  end
-
-  def idv_doc_auth_welcome_submitted(**extra)
-    track_event('IdV: doc auth welcome submitted', **extra)
-  end
-
-  def idv_doc_auth_welcome_visited(**extra)
-    track_event('IdV: doc auth welcome visited', **extra)
-  end
-
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # User visited forgot password page
-  def idv_forgot_password(proofing_components: nil, **extra)
-    track_event(
-      'IdV: forgot password visited',
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # User confirmed forgot password
-  def idv_forgot_password_confirmed(proofing_components: nil, **extra)
-    track_event(
-      'IdV: forgot password confirmed',
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [DateTime] enqueued_at
-  # @param [Boolean] resend
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # GPO letter was enqueued and the time at which it was enqueued
-  def idv_gpo_address_letter_enqueued(enqueued_at:, resend:, proofing_components: nil, **extra)
-    track_event(
-      'IdV: USPS address letter enqueued',
-      enqueued_at: enqueued_at,
-      resend: resend,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] resend
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # GPO letter was requested
-  def idv_gpo_address_letter_requested(resend:, proofing_components: nil, **extra)
-    track_event(
-      'IdV: USPS address letter requested',
-      resend: resend,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] letter_already_sent
-  # GPO address visited
-  def idv_gpo_address_visited(
-    letter_already_sent:,
-    **extra
-  )
-    track_event(
-      'IdV: USPS address visited',
-      letter_already_sent: letter_already_sent,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name Account verification submitted
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [Hash] pii_like_keypaths
-  # GPO verification submitted
-  def idv_gpo_verification_submitted(
-    success:,
-    errors:,
-    pii_like_keypaths:,
-    **extra
-  )
-    track_event(
-      'IdV: GPO verification submitted',
-      success: success,
-      errors: errors,
-      pii_like_keypaths: pii_like_keypaths,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name Account verification visited
-  # GPO verification visited
-  def idv_gpo_verification_visited
-    track_event('IdV: GPO verification visited')
   end
 
   # User visits IdV
@@ -1338,39 +1720,77 @@ module AnalyticsEvents
     track_event('IdV: intro visited')
   end
 
-  # @param [Boolean] success
-  # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
-  # @param [Boolean] fraud_review_pending Profile is under review for fraud
-  # @param [Boolean] fraud_rejection Profile is rejected due to fraud
-  # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verificaiton
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # Tracks the last step of IDV, indicates the user successfully proofed
-  def idv_final(
-    success:,
-    fraud_review_pending:,
-    fraud_rejection:,
-    gpo_verification_pending:,
-    deactivation_reason: nil,
-    proofing_components: nil,
+  # Tracks whether the user's device appears to be mobile device with a camera attached.
+  # @param [Boolean] is_camera_capable_mobile Whether we think the device _could_ have a camera.
+  # @param [Boolean,nil] camera_present Whether the user's device _actually_ has a camera available.
+  # @param [Integer,nil] grace_time Extra time allowed for browser to report camera availability.
+  # @param [Integer,nil] duration Time taken for browser to report camera availability.
+  def idv_mobile_device_and_camera_check(
+    is_camera_capable_mobile:,
+    camera_present: nil,
+    grace_time: nil,
+    duration: nil,
     **extra
   )
     track_event(
-      'IdV: final resolution',
-      success: success,
-      fraud_review_pending: fraud_review_pending,
-      fraud_rejection: fraud_rejection,
-      gpo_verification_pending: gpo_verification_pending,
-      deactivation_reason: deactivation_reason,
+      'IdV: Mobile device and camera check',
+      is_camera_capable_mobile: is_camera_capable_mobile,
+      camera_present: camera_present,
+      grace_time: grace_time,
+      duration: duration,
+      **extra,
+    )
+  end
+
+  # @param [Integer] failed_capture_attempts Number of failed Acuant SDK attempts
+  # @param [Integer] failed_submission_attempts Number of failed Acuant doc submissions
+  # @param [String] field Image form field
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
+  # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
+  # camera, on mobile devices.
+  def idv_native_camera_forced(
+    failed_capture_attempts:,
+    failed_submission_attempts:,
+    field:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: Native camera forced after failed attempts',
+      failed_capture_attempts: failed_capture_attempts,
+      failed_submission_attempts: failed_submission_attempts,
+      field: field,
+      flow_path: flow_path,
+      **extra,
+    )
+  end
+
+  # Tracks when user reaches verify errors due to being rejected due to fraud
+  def idv_not_verified_visited
+    track_event('IdV: Not verified visited')
+  end
+
+  # Tracks if a user clicks the 'acknowledge' checkbox during personal
+  # key creation
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [boolean] checked whether the user checked or un-checked
+  #                  the box with this click
+  def idv_personal_key_acknowledgment_toggled(checked:, proofing_components:, **extra)
+    track_event(
+      'IdV: personal key acknowledgment toggled',
+      checked: checked,
       proofing_components: proofing_components,
       **extra,
     )
   end
 
+  # A user has downloaded their personal key. This event is no longer emitted.
+  # @identity.idp.previous_event_name IdV: download personal key
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # User visited IDV personal key page
-  def idv_personal_key_visited(proofing_components: nil, **extra)
+  def idv_personal_key_downloaded(proofing_components: nil, **extra)
     track_event(
-      'IdV: personal key visited',
+      'IdV: personal key downloaded',
       proofing_components: proofing_components,
       **extra,
     )
@@ -1398,17 +1818,11 @@ module AnalyticsEvents
     )
   end
 
-  # A user has downloaded their backup codes
-  def multi_factor_auth_backup_code_download
-    track_event('Multi-Factor Authentication: download backup code')
-  end
-
-  # A user has downloaded their personal key. This event is no longer emitted.
-  # @identity.idp.previous_event_name IdV: download personal key
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  def idv_personal_key_downloaded(proofing_components: nil, **extra)
+  # User visited IDV personal key page
+  def idv_personal_key_visited(proofing_components: nil, **extra)
     track_event(
-      'IdV: personal key downloaded',
+      'IdV: personal key visited',
       proofing_components: proofing_components,
       **extra,
     )
@@ -1542,25 +1956,6 @@ module AnalyticsEvents
 
   # @param [Boolean] success
   # @param [Hash] errors
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # The vendor finished the process of confirming the users phone
-  def idv_phone_confirmation_vendor_submitted(
-    success:,
-    errors:,
-    proofing_components: nil,
-    **extra
-  )
-    track_event(
-      'IdV: phone confirmation vendor',
-      success: success,
-      errors: errors,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] errors
   # @param [Boolean] code_expired if the one-time code expired
   # @param [Boolean] code_matches
   # @param [Integer] second_factor_attempts_count number of attempts to confirm this phone
@@ -1600,6 +1995,25 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # The vendor finished the process of confirming the users phone
+  def idv_phone_confirmation_vendor_submitted(
+    success:,
+    errors:,
+    proofing_components: nil,
+    **extra
+  )
+    track_event(
+      'IdV: phone confirmation vendor',
+      success: success,
+      errors: errors,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
   # @param ['warning','jobfail','failure'] type
   # @param [Time] throttle_expires_at when the throttle expires
   # @param [Integer] remaining_attempts number of attempts remaining
@@ -1621,6 +2035,16 @@ module AnalyticsEvents
         remaining_attempts: remaining_attempts,
         **extra,
       }.compact,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # User visited idv phone of record
+  def idv_phone_of_record_visited(proofing_components: nil, **extra)
+    track_event(
+      'IdV: phone of record visited',
+      proofing_components: proofing_components,
+      **extra,
     )
   end
 
@@ -1651,16 +2075,6 @@ module AnalyticsEvents
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # User visited idv phone of record
-  def idv_phone_of_record_visited(proofing_components: nil, **extra)
-    track_event(
-      'IdV: phone of record visited',
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User visited idv phone OTP delivery selection
   def idv_phone_otp_delivery_selection_visit(proofing_components: nil, **extra)
     track_event(
@@ -1677,6 +2091,17 @@ module AnalyticsEvents
     track_event(
       'IdV: use different phone number',
       step: step,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @identity.idp.previous_event_name IdV: Verify setup errors visited
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # Tracks when the user reaches the verify please call page after failing proofing
+  def idv_please_call_visited(proofing_components: nil, **extra)
+    track_event(
+      'IdV: Verify please call visited',
       proofing_components: proofing_components,
       **extra,
     )
@@ -1736,6 +2161,22 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when the user visits one of the the session error pages.
+  # @param [String] type
+  # @param [Integer,nil] attempts_remaining
+  def idv_session_error_visited(
+    type:,
+    attempts_remaining: nil,
+    **extra
+  )
+    track_event(
+      'IdV: session error visited',
+      type: type,
+      attempts_remaining: attempts_remaining,
+      **extra,
+    )
+  end
+
   # @param [String] step
   # @param [String] location
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
@@ -1751,6 +2192,19 @@ module AnalyticsEvents
       step: step,
       location: location,
       proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param [String] in_person_cta_variant Variant testing bucket label
+  # The user clicked the troubleshooting option to start in-person proofing
+  def idv_verify_in_person_troubleshooting_option_clicked(flow_path:, in_person_cta_variant:,
+                                                          **extra)
+    track_event(
+      'IdV: verify in person troubleshooting option clicked',
+      flow_path: flow_path,
+      in_person_cta_variant: in_person_cta_variant,
       **extra,
     )
   end
@@ -1771,21 +2225,20 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] controller
-  # @param [String] referer
-  # @param [Boolean] user_signed_in
-  # Redirect was almost sent to an invalid external host unexpectedly
-  def unsafe_redirect_error(
-    controller:,
-    referer:,
-    user_signed_in: nil,
+  # @param [String] event_type
+  # @param [Integer] unencrypted_payload_num_bytes size of payload as JSON data
+  # @param [Boolean] recorded if the full event was recorded or not
+  def irs_attempts_api_event_metadata(
+    event_type:,
+    unencrypted_payload_num_bytes:,
+    recorded:,
     **extra
   )
     track_event(
-      'Unsafe Redirect',
-      controller: controller,
-      referer: referer,
-      user_signed_in: user_signed_in,
+      'IRS Attempt API: Event metadata',
+      event_type: event_type,
+      unencrypted_payload_num_bytes: unencrypted_payload_num_bytes,
+      recorded: recorded,
       **extra,
     )
   end
@@ -1808,24 +2261,6 @@ module AnalyticsEvents
       authenticated: authenticated,
       elapsed_time: elapsed_time,
       success: success,
-      **extra,
-    )
-  end
-
-  # @param [String] event_type
-  # @param [Integer] unencrypted_payload_num_bytes size of payload as JSON data
-  # @param [Boolean] recorded if the full event was recorded or not
-  def irs_attempts_api_event_metadata(
-    event_type:,
-    unencrypted_payload_num_bytes:,
-    recorded:,
-    **extra
-  )
-    track_event(
-      'IRS Attempt API: Event metadata',
-      event_type: event_type,
-      unencrypted_payload_num_bytes: unencrypted_payload_num_bytes,
-      recorded: recorded,
       **extra,
     )
   end
@@ -1856,126 +2291,6 @@ module AnalyticsEvents
   )
     track_event(
       'Logout Initiated',
-      success: success,
-      client_id: client_id,
-      client_id_parameter_present: client_id_parameter_present,
-      id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
-      error_details: error_details,
-      sp_initiated: sp_initiated,
-      oidc: oidc,
-      saml_request_valid: saml_request_valid,
-      method: method,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [String] client_id
-  # @param [Boolean] client_id_parameter_present
-  # @param [Boolean] id_token_hint_parameter_present
-  # @param [Boolean] sp_initiated
-  # @param [Boolean] oidc
-  # @param [Boolean] saml_request_valid
-  # @param [Hash] errors
-  # @param [Hash] error_details
-  # @param [String] method
-  # OIDC Logout Requested
-  def oidc_logout_requested(
-    success: nil,
-    client_id: nil,
-    sp_initiated: nil,
-    oidc: nil,
-    client_id_parameter_present: nil,
-    id_token_hint_parameter_present: nil,
-    saml_request_valid: nil,
-    errors: nil,
-    error_details: nil,
-    method: nil,
-    **extra
-  )
-    track_event(
-      'OIDC Logout Requested',
-      success: success,
-      client_id: client_id,
-      client_id_parameter_present: client_id_parameter_present,
-      id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
-      error_details: error_details,
-      sp_initiated: sp_initiated,
-      oidc: oidc,
-      saml_request_valid: saml_request_valid,
-      method: method,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [String] client_id
-  # @param [Boolean] client_id_parameter_present
-  # @param [Boolean] id_token_hint_parameter_present
-  # @param [Boolean] sp_initiated
-  # @param [Boolean] oidc
-  # @param [Boolean] saml_request_valid
-  # @param [Hash] errors
-  # @param [Hash] error_details
-  # @param [String] method
-  # OIDC Logout Visited
-  def oidc_logout_visited(
-    success: nil,
-    client_id: nil,
-    sp_initiated: nil,
-    oidc: nil,
-    client_id_parameter_present: nil,
-    id_token_hint_parameter_present: nil,
-    saml_request_valid: nil,
-    errors: nil,
-    error_details: nil,
-    method: nil,
-    **extra
-  )
-    track_event(
-      'OIDC Logout Page Visited',
-      success: success,
-      client_id: client_id,
-      client_id_parameter_present: client_id_parameter_present,
-      id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
-      error_details: error_details,
-      sp_initiated: sp_initiated,
-      oidc: oidc,
-      saml_request_valid: saml_request_valid,
-      method: method,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [String] client_id
-  # @param [Boolean] client_id_parameter_present
-  # @param [Boolean] id_token_hint_parameter_present
-  # @param [Boolean] sp_initiated
-  # @param [Boolean] oidc
-  # @param [Boolean] saml_request_valid
-  # @param [Hash] errors
-  # @param [Hash] error_details
-  # @param [String] method
-  # OIDC Logout Submitted
-  def oidc_logout_submitted(
-    success: nil,
-    client_id: nil,
-    sp_initiated: nil,
-    oidc: nil,
-    client_id_parameter_present: nil,
-    id_token_hint_parameter_present: nil,
-    saml_request_valid: nil,
-    errors: nil,
-    error_details: nil,
-    method: nil,
-    **extra
-  )
-    track_event(
-      'OIDC Logout Submitted',
       success: success,
       client_id: client_id,
       client_id_parameter_present: client_id_parameter_present,
@@ -2098,6 +2413,11 @@ module AnalyticsEvents
     )
   end
 
+  # A user has downloaded their backup codes
+  def multi_factor_auth_backup_code_download
+    track_event('Multi-Factor Authentication: download backup code')
+  end
+
   # Tracks when the user visits the backup code confirmation setup page
   # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
   def multi_factor_auth_enter_backup_code_confirmation_visit(
@@ -2118,6 +2438,28 @@ module AnalyticsEvents
     track_event(
       'Multi-Factor Authentication: enter backup code visited',
       context: context,
+      **extra,
+    )
+  end
+
+  # @param [String] context
+  # @param [String] multi_factor_auth_method
+  # @param [Boolean] confirmation_for_add_phone
+  # @param [Integer] phone_configuration_id
+  # Multi-Factor Authentication enter OTP visited
+  def multi_factor_auth_enter_otp_visit(
+    context:,
+    multi_factor_auth_method:,
+    confirmation_for_add_phone:,
+    phone_configuration_id:,
+    **extra
+  )
+    track_event(
+      'Multi-Factor Authentication: enter OTP visited',
+      context: context,
+      multi_factor_auth_method: multi_factor_auth_method,
+      confirmation_for_add_phone: confirmation_for_add_phone,
+      phone_configuration_id: phone_configuration_id,
       **extra,
     )
   end
@@ -2147,28 +2489,6 @@ module AnalyticsEvents
       context: context,
       multi_factor_auth_method: multi_factor_auth_method,
       piv_cac_configuration_id: piv_cac_configuration_id,
-      **extra,
-    )
-  end
-
-  # @param [String] context
-  # @param [String] multi_factor_auth_method
-  # @param [Boolean] confirmation_for_add_phone
-  # @param [Integer] phone_configuration_id
-  # Multi-Factor Authentication enter OTP visited
-  def multi_factor_auth_enter_otp_visit(
-    context:,
-    multi_factor_auth_method:,
-    confirmation_for_add_phone:,
-    phone_configuration_id:,
-    **extra
-  )
-    track_event(
-      'Multi-Factor Authentication: enter OTP visited',
-      context: context,
-      multi_factor_auth_method: multi_factor_auth_method,
-      confirmation_for_add_phone: confirmation_for_add_phone,
-      phone_configuration_id: phone_configuration_id,
       **extra,
     )
   end
@@ -2203,6 +2523,11 @@ module AnalyticsEvents
   # Max multi factor auth attempts met
   def multi_factor_auth_max_attempts
     track_event('Multi-Factor Authentication: max attempts reached')
+  end
+
+  # Max multi factor max otp sends reached
+  def multi_factor_auth_max_sends
+    track_event('Multi-Factor Authentication: max otp sends reached')
   end
 
   # Multi factor selected from auth options list
@@ -2256,11 +2581,6 @@ module AnalyticsEvents
     )
   end
 
-  # Max multi factor max otp sends reached
-  def multi_factor_auth_max_sends
-    track_event('Multi-Factor Authentication: max otp sends reached')
-  end
-
   # Tracks when a user sets up a multi factor auth method
   # @param [Boolean] success Whether authenticator setup was successful
   # @param [Hash] errors Authenticator setup error reasons, if unsuccessful
@@ -2282,6 +2602,126 @@ module AnalyticsEvents
       multi_factor_auth_method: multi_factor_auth_method,
       in_multi_mfa_selection_flow: in_multi_mfa_selection_flow,
       enabled_mfa_methods_count: enabled_mfa_methods_count,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Requested
+  def oidc_logout_requested(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Requested',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Submitted
+  def oidc_logout_submitted(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Submitted',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Visited
+  def oidc_logout_visited(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Page Visited',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
       **extra,
     )
   end
@@ -2344,86 +2784,6 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when user is redirected to OTP expired page
-  # @param [String] otp_sent_at
-  # @param [String] otp_expiration
-  def otp_expired_visited(otp_sent_at:, otp_expiration:, **extra)
-    track_event(
-      'OTP Expired Page Visited',
-      otp_sent_at: otp_sent_at,
-      otp_expiration: otp_expiration,
-      **extra,
-    )
-  end
-
-  # Tracks if otp phone validation failed
-  # @identity.idp.previous_event_name Twilio Phone Validation Failed
-  # @param [String] error
-  # @param [String] context
-  # @param [String] country
-  def otp_phone_validation_failed(error:, context:, country:, **extra)
-    track_event(
-      'Vendor Phone Validation failed',
-      error: error,
-      context: context,
-      country: country,
-      **extra,
-    )
-  end
-
-  # User has been marked as authenticated
-  # @param [String] authentication_type
-  def user_marked_authed(authentication_type:, **extra)
-    track_event(
-      'User marked authenticated',
-      authentication_type: authentication_type,
-      **extra,
-    )
-  end
-
-  # User has attempted to access an action that requires re-authenticating
-  # @param [String] auth_method
-  # @param [String] authenticated_at
-  def user_2fa_reauthentication_required(auth_method:, authenticated_at:, **extra)
-    track_event(
-      'User 2FA Reauthentication Required',
-      auth_method: auth_method,
-      authenticated_at: authenticated_at,
-      **extra,
-    )
-  end
-
-  # User registration has been handed off to agency page
-  # @param [Boolean] ial2
-  # @param [Integer] ialmax
-  # @param [String] service_provider_name
-  # @param [String] page_occurence
-  # @param [String] needs_completion_screen_reason
-  # @param [Array] sp_request_requested_attributes
-  # @param [Array] sp_session_requested_attributes
-  def user_registration_agency_handoff_page_visit(
-      ial2:,
-      service_provider_name:,
-      page_occurence:,
-      needs_completion_screen_reason:,
-      sp_session_requested_attributes:,
-      sp_request_requested_attributes: nil,
-      ialmax: nil,
-      **extra
-    )
-    track_event(
-      'User registration: agency handoff visited',
-      ial2: ial2,
-      ialmax: ialmax,
-      service_provider_name: service_provider_name,
-      page_occurence: page_occurence,
-      needs_completion_screen_reason: needs_completion_screen_reason,
-      sp_request_requested_attributes: sp_request_requested_attributes,
-      sp_session_requested_attributes: sp_session_requested_attributes,
-      **extra,
-    )
-  end
-
   # Tracks when user makes an otp delivery selection
   # @param [String] otp_delivery_preference (sms or voice)
   # @param [Boolean] resend
@@ -2448,6 +2808,33 @@ module AnalyticsEvents
       area_code: area_code,
       context: context,
       pii_like_keypaths: pii_like_keypaths,
+      **extra,
+    )
+  end
+
+  # Tracks when user is redirected to OTP expired page
+  # @param [String] otp_sent_at
+  # @param [String] otp_expiration
+  def otp_expired_visited(otp_sent_at:, otp_expiration:, **extra)
+    track_event(
+      'OTP Expired Page Visited',
+      otp_sent_at: otp_sent_at,
+      otp_expiration: otp_expiration,
+      **extra,
+    )
+  end
+
+  # Tracks if otp phone validation failed
+  # @identity.idp.previous_event_name Twilio Phone Validation Failed
+  # @param [String] error
+  # @param [String] context
+  # @param [String] country
+  def otp_phone_validation_failed(error:, context:, country:, **extra)
+    track_event(
+      'Vendor Phone Validation failed',
+      error: error,
+      context: context,
+      country: country,
       **extra,
     )
   end
@@ -2502,11 +2889,6 @@ module AnalyticsEvents
       profile_deactivated: profile_deactivated,
       **extra,
     )
-  end
-
-  # User has visited the page that lets them confirm if they want a new personal key
-  def profile_personal_key_visit
-    track_event('Profile: Visited new personal key')
   end
 
   # @param [Boolean] success
@@ -2645,6 +3027,22 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String] redirect_url URL user was directed to
+  # @param [String, nil] step which step
+  # @param [String, nil] location which part of a step, if applicable
+  # @param ["idv", String, nil] flow which flow
+  # User was redirected to the login.gov policy page
+  def policy_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
+    track_event(
+      'Policy Page Redirect',
+      redirect_url: redirect_url,
+      step: step,
+      location: location,
+      flow: flow,
+      **extra,
+    )
+  end
+
   # @param [String] error
   # Tracks if a Profile encryption is invalid
   def profile_encryption_invalid(error:, **extra)
@@ -2671,6 +3069,11 @@ module AnalyticsEvents
       sms_message_ids: sms_message_ids,
       **extra,
     )
+  end
+
+  # User has visited the page that lets them confirm if they want a new personal key
+  def profile_personal_key_visit
+    track_event('Profile: Visited new personal key')
   end
 
   # @identity.idp.previous_event_name Proofing Address Timeout
@@ -2734,6 +3137,22 @@ module AnalyticsEvents
     )
   end
 
+  # Service provider completed remote logout
+  # @param [String] service_provider
+  # @param [String] user_id
+  def remote_logout_completed(
+    service_provider:,
+    user_id:,
+    **extra
+  )
+    track_event(
+      'Remote Logout completed',
+      service_provider: service_provider,
+      user_id: user_id,
+      **extra,
+    )
+  end
+
   # Service provider initiated remote logout
   # @param [String] service_provider
   # @param [Boolean] saml_request_valid
@@ -2750,18 +3169,12 @@ module AnalyticsEvents
     )
   end
 
-  # Service provider completed remote logout
-  # @param [String] service_provider
-  # @param [String] user_id
-  def remote_logout_completed(
-    service_provider:,
-    user_id:,
-    **extra
-  )
+  # @param [Boolean] success
+  # Tracks request for resending confirmation for new emails to an account
+  def resend_add_email_request(success:, **extra)
     track_event(
-      'Remote Logout completed',
-      service_provider: service_provider,
-      user_id: user_id,
+      'Resend Add Email Requested',
+      success: success,
       **extra,
     )
   end
@@ -2823,11 +3236,6 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when rules of use is visited
-  def rules_of_use_visit
-    track_event('Rules of Use Visited')
-  end
-
   # Tracks when rules of use is submitted with a success or failure
   # @param [Boolean] success
   # @param [Hash] errors
@@ -2840,113 +3248,9 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when security event is received
-  # @param [Boolean] success
-  # @param [String] error_code
-  # @param [Hash] errors
-  # @param [String] jti
-  # @param [String] user_id
-  # @param [String] client_id
-  def security_event_received(
-    success:,
-    error_code: nil,
-    errors: nil,
-    jti: nil,
-    user_id: nil,
-    client_id: nil,
-    **extra
-  )
-    track_event(
-      'RISC: Security event received',
-      success: success,
-      error_code: error_code,
-      errors: errors,
-      jti: jti,
-      user_id: user_id,
-      client_id: client_id,
-      **extra,
-    )
-  end
-
-  # Tracks when a user is bounced back from the service provider due to an integration issue.
-  def sp_handoff_bounced_detected
-    track_event('SP handoff bounced detected')
-  end
-
-  # Tracks when a user visits the bounced page.
-  def sp_handoff_bounced_visit
-    track_event('SP handoff bounced visited')
-  end
-
-  # Tracks when a user visits the "This agency no longer uses Login.gov" page.
-  def sp_inactive_visit
-    track_event('SP inactive visited')
-  end
-
-  # Tracks when a user is redirected back to the service provider
-  # @param [Integer] ial
-  # @param [Integer] billed_ial
-  def sp_redirect_initiated(ial:, billed_ial:, **extra)
-    track_event(
-      'SP redirect initiated',
-      ial: ial,
-      billed_ial: billed_ial,
-      **extra,
-    )
-  end
-
-  # Tracks when a user triggered a rate limit throttle
-  # @param [String] throttle_type
-  def throttler_rate_limit_triggered(throttle_type:, **extra)
-    track_event(
-      'Throttler Rate Limit Triggered',
-      throttle_type: throttle_type,
-      **extra,
-    )
-  end
-
-  # Tracks when a user visits TOTP device setup
-  # @param [Boolean] user_signed_up
-  # @param [Boolean] totp_secret_present
-  # @param [Integer] enabled_mfa_methods_count
-  def totp_setup_visit(
-    user_signed_up:,
-    totp_secret_present:,
-    enabled_mfa_methods_count:,
-    **extra
-  )
-    track_event(
-      'TOTP Setup Visited',
-      user_signed_up: user_signed_up,
-      totp_secret_present: totp_secret_present,
-      enabled_mfa_methods_count: enabled_mfa_methods_count,
-      **extra,
-    )
-  end
-
-  # Tracks when a user disabled a TOTP device
-  def totp_user_disabled
-    track_event('TOTP: User Disabled')
-  end
-
-  # Tracks when service provider consent is revoked
-  # @param [String] issuer issuer of the service provider consent to be revoked
-  def sp_revoke_consent_revoked(issuer:, **extra)
-    track_event(
-      'SP Revoke Consent: Revoked',
-      issuer: issuer,
-      **extra,
-    )
-  end
-
-  # Tracks when the page to revoke consent (unlink from) a service provider visited
-  # @param [String] issuer which issuer
-  def sp_revoke_consent_visited(issuer:, **extra)
-    track_event(
-      'SP Revoke Consent: Visited',
-      issuer: issuer,
-      **extra,
-    )
+  # Tracks when rules of use is visited
+  def rules_of_use_visit
+    track_event('Rules of Use Visited')
   end
 
   # Record SAML authentication payload Hash
@@ -3001,6 +3305,34 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when security event is received
+  # @param [Boolean] success
+  # @param [String] error_code
+  # @param [Hash] errors
+  # @param [String] jti
+  # @param [String] user_id
+  # @param [String] client_id
+  def security_event_received(
+    success:,
+    error_code: nil,
+    errors: nil,
+    jti: nil,
+    user_id: nil,
+    client_id: nil,
+    **extra
+  )
+    track_event(
+      'RISC: Security event received',
+      success: success,
+      error_code: error_code,
+      errors: errors,
+      jti: jti,
+      user_id: user_id,
+      client_id: client_id,
+      **extra,
+    )
+  end
+
   # tracks if the session is kept alive
   def session_kept_alive
     track_event('Session Kept Alive')
@@ -3014,6 +3346,12 @@ module AnalyticsEvents
   # tracks when a user's session is timed out
   def session_total_duration_timeout
     track_event('User Maximum Session Length Exceeded')
+  end
+
+  # Tracks if a user clicks the "Show Password button"
+  # @param [String] path URL path where the click occurred
+  def show_password_button_clicked(path:, **extra)
+    track_event('Show Password Button Clicked', path: path, **extra)
   end
 
   # @param [String] flash
@@ -3071,6 +3409,53 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when a user is bounced back from the service provider due to an integration issue.
+  def sp_handoff_bounced_detected
+    track_event('SP handoff bounced detected')
+  end
+
+  # Tracks when a user visits the bounced page.
+  def sp_handoff_bounced_visit
+    track_event('SP handoff bounced visited')
+  end
+
+  # Tracks when a user visits the "This agency no longer uses Login.gov" page.
+  def sp_inactive_visit
+    track_event('SP inactive visited')
+  end
+
+  # Tracks when a user is redirected back to the service provider
+  # @param [Integer] ial
+  # @param [Integer] billed_ial
+  def sp_redirect_initiated(ial:, billed_ial:, **extra)
+    track_event(
+      'SP redirect initiated',
+      ial: ial,
+      billed_ial: billed_ial,
+      **extra,
+    )
+  end
+
+  # Tracks when service provider consent is revoked
+  # @param [String] issuer issuer of the service provider consent to be revoked
+  def sp_revoke_consent_revoked(issuer:, **extra)
+    track_event(
+      'SP Revoke Consent: Revoked',
+      issuer: issuer,
+      **extra,
+    )
+  end
+
+  # Tracks when the page to revoke consent (unlink from) a service provider visited
+  # @param [String] issuer which issuer
+  def sp_revoke_consent_visited(issuer:, **extra)
+    track_event(
+      'SP Revoke Consent: Visited',
+      issuer: issuer,
+      **extra,
+    )
+  end
+
   # @param [String] area_code
   # @param [String] country_code
   # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
@@ -3111,10 +3496,78 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks When users visit the add phone page
-  def add_phone_setup_visit
+  # Tracks when a user triggered a rate limit throttle
+  # @param [String] throttle_type
+  def throttler_rate_limit_triggered(throttle_type:, **extra)
     track_event(
-      'Phone Setup Visited',
+      'Throttler Rate Limit Triggered',
+      throttle_type: throttle_type,
+      **extra,
+    )
+  end
+
+  # Tracks when a user visits TOTP device setup
+  # @param [Boolean] user_signed_up
+  # @param [Boolean] totp_secret_present
+  # @param [Integer] enabled_mfa_methods_count
+  def totp_setup_visit(
+    user_signed_up:,
+    totp_secret_present:,
+    enabled_mfa_methods_count:,
+    **extra
+  )
+    track_event(
+      'TOTP Setup Visited',
+      user_signed_up: user_signed_up,
+      totp_secret_present: totp_secret_present,
+      enabled_mfa_methods_count: enabled_mfa_methods_count,
+      **extra,
+    )
+  end
+
+  # Tracks when a user disabled a TOTP device
+  def totp_user_disabled
+    track_event('TOTP: User Disabled')
+  end
+
+  # @param [String] controller
+  # @param [String] referer
+  # @param [Boolean] user_signed_in
+  # Redirect was almost sent to an invalid external host unexpectedly
+  def unsafe_redirect_error(
+    controller:,
+    referer:,
+    user_signed_in: nil,
+    **extra
+  )
+    track_event(
+      'Unsafe Redirect',
+      controller: controller,
+      referer: referer,
+      user_signed_in: user_signed_in,
+      **extra,
+    )
+  end
+
+  # User has attempted to access an action that requires re-authenticating
+  # @param [String] auth_method
+  # @param [String] authenticated_at
+  def user_2fa_reauthentication_required(auth_method:, authenticated_at:, **extra)
+    track_event(
+      'User 2FA Reauthentication Required',
+      auth_method: auth_method,
+      authenticated_at: authenticated_at,
+      **extra,
+    )
+  end
+
+  # User has been marked as authenticated
+  # @param [String] authentication_type
+  def user_marked_authed(authentication_type:, **extra)
+    track_event(
+      'User marked authenticated',
+      authentication_type: authentication_type,
+      **extra,
     )
   end
 
@@ -3177,68 +3630,6 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] mfa_method
-  # Tracks when the the user fully registered by submitting their first MFA method into the system
-  def user_registration_user_fully_registered(
-    mfa_method:,
-    **extra
-  )
-    track_event(
-      'User Registration: User Fully Registered',
-      {
-        mfa_method: mfa_method,
-        **extra,
-      }.compact,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] mfa_method_counts
-  # @param [Integer] enabled_mfa_methods_count
-  # @param [Hash] pii_like_keypaths
-  # Tracks when a user has completed MFA setup
-  def user_registration_mfa_setup_complete(
-    success:,
-    mfa_method_counts:,
-    enabled_mfa_methods_count:,
-    pii_like_keypaths:,
-    **extra
-  )
-    track_event(
-      'User Registration: MFA Setup Complete',
-      {
-        success: success,
-        mfa_method_counts: mfa_method_counts,
-        enabled_mfa_methods_count: enabled_mfa_methods_count,
-        pii_like_keypaths: pii_like_keypaths,
-        **extra,
-      }.compact,
-    )
-  end
-
-  # Tracks when user's piv cac is disabled
-  def user_registration_piv_cac_disabled
-    track_event('User Registration: piv cac disabled')
-  end
-
-  # Tracks when user's piv cac setup
-  def user_registration_piv_cac_setup_visit(**extra)
-    track_event(
-      'User Registration: piv cac setup visited',
-      **extra,
-    )
-  end
-
-  # Tracks when user visits Suggest Another MFA Page
-  def user_registration_suggest_another_mfa_notice_visited
-    track_event('User Registration: Suggest Another MFA Notice visited')
-  end
-
-  # Tracks when user skips Suggest Another MFA Page
-  def user_registration_suggest_another_mfa_notice_skipped
-    track_event('User Registration: Suggest Another MFA Notice Skipped')
-  end
-
   # Tracks when user visits MFA selection page
   # @param [String] sign_up_mfa_priority_bucket
   def user_registration_2fa_setup_visit(sign_up_mfa_priority_bucket:, **extra)
@@ -3249,70 +3640,33 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Hash] vendor_status
-  # @param [String,nil] redirect_from
-  # Tracks when vendor has outage
-  def vendor_outage(
-    vendor_status:,
-    redirect_from: nil,
-    **extra
-  )
-    track_event(
-      'Vendor Outage',
-      redirect_from: redirect_from,
-      vendor_status: vendor_status,
-      **extra,
+  # User registration has been handed off to agency page
+  # @param [Boolean] ial2
+  # @param [Integer] ialmax
+  # @param [String] service_provider_name
+  # @param [String] page_occurence
+  # @param [String] needs_completion_screen_reason
+  # @param [Array] sp_request_requested_attributes
+  # @param [Array] sp_session_requested_attributes
+  def user_registration_agency_handoff_page_visit(
+      ial2:,
+      service_provider_name:,
+      page_occurence:,
+      needs_completion_screen_reason:,
+      sp_session_requested_attributes:,
+      sp_request_requested_attributes: nil,
+      ialmax: nil,
+      **extra
     )
-  end
-
-  # @param [Boolean] success
-  # @param [Integer] mfa_method_counts
-  # Tracks when WebAuthn is deleted
-  def webauthn_deleted(success:, mfa_method_counts:, pii_like_keypaths:, **extra)
     track_event(
-      'WebAuthn Deleted',
-      success: success,
-      mfa_method_counts: mfa_method_counts,
-      pii_like_keypaths: pii_like_keypaths,
-      **extra,
-    )
-  end
-
-  # @param [Hash] platform_authenticator
-  # @param [Hash] errors
-  # @param [Integer] enabled_mfa_methods_count
-  # @param [Boolean] success
-  # Tracks when WebAuthn setup is visited
-  def webauthn_setup_visit(platform_authenticator:, errors:, enabled_mfa_methods_count:, success:,
-                           **extra)
-    track_event(
-      'WebAuthn Setup Visited',
-      platform_authenticator: platform_authenticator,
-      errors: errors,
-      enabled_mfa_methods_count: enabled_mfa_methods_count,
-      success: success,
-      **extra,
-    )
-  end
-
-  # Tracks when user visits enter email page
-  # @param [String] sign_in_a_b_test_bucket
-  # @param [Boolean] from_sign_in
-  def user_registration_enter_email_visit(sign_in_a_b_test_bucket:, from_sign_in:, **extra)
-    track_event(
-      'User Registration: enter email visited',
-      sign_in_a_b_test_bucket:,
-      from_sign_in:,
-      **extra,
-    )
-  end
-
-  # @param [Integer] enabled_mfa_methods_count
-  # Tracks when user visits the phone setup step during registration
-  def user_registration_phone_setup_visit(enabled_mfa_methods_count:, **extra)
-    track_event(
-      'User Registration: phone setup visited',
-      enabled_mfa_methods_count: enabled_mfa_methods_count,
+      'User registration: agency handoff visited',
+      ial2: ial2,
+      ialmax: ialmax,
+      service_provider_name: service_provider_name,
+      page_occurence: page_occurence,
+      needs_completion_screen_reason: needs_completion_screen_reason,
+      sp_request_requested_attributes: sp_request_requested_attributes,
+      sp_session_requested_attributes: sp_session_requested_attributes,
       **extra,
     )
   end
@@ -3413,91 +3767,87 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks if request to get address candidates from ArcGIS fails
-  # @param [String] exception_class
-  # @param [String] exception_message
-  # @param [Boolean] response_body_present
-  # @param [Hash] response_body
-  # @param [Integer] response_status_code
-  def idv_arcgis_request_failure(
-    exception_class:,
-    exception_message:,
-    response_body_present:,
-    response_body:,
-    response_status_code:,
-    **extra
-  )
+  # Tracks when user visits enter email page
+  # @param [String] sign_in_a_b_test_bucket
+  # @param [Boolean] from_sign_in
+  def user_registration_enter_email_visit(sign_in_a_b_test_bucket:, from_sign_in:, **extra)
     track_event(
-      'Request ArcGIS Address Candidates: request failed',
-      exception_class: exception_class,
-      exception_message: exception_message,
-      response_body_present: response_body_present,
-      response_body: response_body,
-      response_status_code: response_status_code,
+      'User Registration: enter email visited',
+      sign_in_a_b_test_bucket:,
+      from_sign_in:,
       **extra,
     )
   end
 
-  # Tracks whether the user's device appears to be mobile device with a camera attached.
-  # @param [Boolean] is_camera_capable_mobile Whether we think the device _could_ have a camera.
-  # @param [Boolean,nil] camera_present Whether the user's device _actually_ has a camera available.
-  # @param [Integer,nil] grace_time Extra time allowed for browser to report camera availability.
-  # @param [Integer,nil] duration Time taken for browser to report camera availability.
-  def idv_mobile_device_and_camera_check(
-    is_camera_capable_mobile:,
-    camera_present: nil,
-    grace_time: nil,
-    duration: nil,
+  # @param [Boolean] success
+  # @param [Hash] mfa_method_counts
+  # @param [Integer] enabled_mfa_methods_count
+  # @param [Hash] pii_like_keypaths
+  # Tracks when a user has completed MFA setup
+  def user_registration_mfa_setup_complete(
+    success:,
+    mfa_method_counts:,
+    enabled_mfa_methods_count:,
+    pii_like_keypaths:,
     **extra
   )
     track_event(
-      'IdV: Mobile device and camera check',
-      is_camera_capable_mobile: is_camera_capable_mobile,
-      camera_present: camera_present,
-      grace_time: grace_time,
-      duration: duration,
+      'User Registration: MFA Setup Complete',
+      {
+        success: success,
+        mfa_method_counts: mfa_method_counts,
+        enabled_mfa_methods_count: enabled_mfa_methods_count,
+        pii_like_keypaths: pii_like_keypaths,
+        **extra,
+      }.compact,
+    )
+  end
+
+  # @param [Integer] enabled_mfa_methods_count
+  # Tracks when user visits the phone setup step during registration
+  def user_registration_phone_setup_visit(enabled_mfa_methods_count:, **extra)
+    track_event(
+      'User Registration: phone setup visited',
+      enabled_mfa_methods_count: enabled_mfa_methods_count,
       **extra,
     )
   end
 
-  # Tracks when the user visits one of the the session error pages.
-  # @param [String] type
-  # @param [Integer,nil] attempts_remaining
-  def idv_session_error_visited(
-    type:,
-    attempts_remaining: nil,
-    **extra
-  )
+  # Tracks when user's piv cac is disabled
+  def user_registration_piv_cac_disabled
+    track_event('User Registration: piv cac disabled')
+  end
+
+  # Tracks when user's piv cac setup
+  def user_registration_piv_cac_setup_visit(**extra)
     track_event(
-      'IdV: session error visited',
-      type: type,
-      attempts_remaining: attempts_remaining,
+      'User Registration: piv cac setup visited',
       **extra,
     )
   end
 
-  # Tracks if request to get USPS in-person proofing locations fails
-  # @param [String] exception_class
-  # @param [String] exception_message
-  # @param [Boolean] response_body_present
-  # @param [Hash] response_body
-  # @param [Integer] response_status_code
-  def idv_in_person_locations_request_failure(
-    exception_class:,
-    exception_message:,
-    response_body_present:,
-    response_body:,
-    response_status_code:,
+  # Tracks when user skips Suggest Another MFA Page
+  def user_registration_suggest_another_mfa_notice_skipped
+    track_event('User Registration: Suggest Another MFA Notice Skipped')
+  end
+
+  # Tracks when user visits Suggest Another MFA Page
+  def user_registration_suggest_another_mfa_notice_visited
+    track_event('User Registration: Suggest Another MFA Notice visited')
+  end
+
+  # @param [String] mfa_method
+  # Tracks when the the user fully registered by submitting their first MFA method into the system
+  def user_registration_user_fully_registered(
+    mfa_method:,
     **extra
   )
     track_event(
-      'Request USPS IPP locations: request failed',
-      exception_class: exception_class,
-      exception_message: exception_message,
-      response_body_present: response_body_present,
-      response_body: response_body,
-      response_status_code: response_status_code,
-      **extra,
+      'User Registration: User Fully Registered',
+      {
+        mfa_method: mfa_method,
+        **extra,
+      }.compact,
     )
   end
 
@@ -3520,398 +3870,48 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks if USPS in-person proofing enrollment request fails
-  # @param [String] context
-  # @param [String] reason
-  # @param [Integer] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  def idv_in_person_usps_request_enroll_exception(
-    context:,
-    reason:,
-    enrollment_id:,
-    exception_class:,
-    exception_message:,
+  # @param [Hash] vendor_status
+  # @param [String,nil] redirect_from
+  # Tracks when vendor has outage
+  def vendor_outage(
+    vendor_status:,
+    redirect_from: nil,
     **extra
   )
     track_event(
-      'USPS IPPaaS enrollment failed',
-      context: context,
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      reason: reason,
+      'Vendor Outage',
+      redirect_from: redirect_from,
+      vendor_status: vendor_status,
       **extra,
     )
   end
 
-  # GetUspsProofingResultsJob is beginning. Includes some metadata about what the job will do
-  # @param [Integer] enrollments_count number of enrollments eligible for status check
-  # @param [Integer] reprocess_delay_minutes minimum delay since last status check
-  def idv_in_person_usps_proofing_results_job_started(
-    enrollments_count:,
-    reprocess_delay_minutes:,
-    **extra
-  )
+  # @param [Boolean] success
+  # @param [Integer] mfa_method_counts
+  # Tracks when WebAuthn is deleted
+  def webauthn_deleted(success:, mfa_method_counts:, pii_like_keypaths:, **extra)
     track_event(
-      'GetUspsProofingResultsJob: Job started',
-      enrollments_count: enrollments_count,
-      reprocess_delay_minutes: reprocess_delay_minutes,
+      'WebAuthn Deleted',
+      success: success,
+      mfa_method_counts: mfa_method_counts,
+      pii_like_keypaths: pii_like_keypaths,
       **extra,
     )
   end
 
-  # GetUspsProofingResultsJob has completed. Includes counts of various outcomes encountered
-  # @param [Float] duration_seconds number of minutes the job was running
-  # @param [Integer] enrollments_checked number of enrollments eligible for status check
-  # @param [Integer] enrollments_errored number of enrollments for which we encountered an error
-  # @param [Integer] enrollments_expired number of enrollments which expired
-  # @param [Integer] enrollments_failed number of enrollments which failed identity proofing
-  # @param [Integer] enrollments_in_progress number of enrollments which did not have any change
-  # @param [Integer] enrollments_passed number of enrollments which passed identity proofing
-  def idv_in_person_usps_proofing_results_job_completed(
-    duration_seconds:,
-    enrollments_checked:,
-    enrollments_errored:,
-    enrollments_expired:,
-    enrollments_failed:,
-    enrollments_in_progress:,
-    enrollments_passed:,
-    **extra
-  )
+  # @param [Hash] platform_authenticator
+  # @param [Hash] errors
+  # @param [Integer] enabled_mfa_methods_count
+  # @param [Boolean] success
+  # Tracks when WebAuthn setup is visited
+  def webauthn_setup_visit(platform_authenticator:, errors:, enabled_mfa_methods_count:, success:,
+                           **extra)
     track_event(
-      'GetUspsProofingResultsJob: Job completed',
-      duration_seconds: duration_seconds,
-      enrollments_checked: enrollments_checked,
-      enrollments_errored: enrollments_errored,
-      enrollments_expired: enrollments_expired,
-      enrollments_failed: enrollments_failed,
-      enrollments_in_progress: enrollments_in_progress,
-      enrollments_passed: enrollments_passed,
-      **extra,
-    )
-  end
-
-  # Tracks exceptions that are raised when running GetUspsProofingResultsJob
-  # @param [String] reason why was the exception raised?
-  # @param [String] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  # @param [String] enrollment_code
-  # @param [Float] minutes_since_established
-  # @param [Float] minutes_since_last_status_check
-  # @param [Float] minutes_since_last_status_update
-  # @param [Float] minutes_to_completion
-  # @param [Boolean] fraud_suspected
-  # @param [String] primary_id_type
-  # @param [String] secondary_id_type
-  # @param [String] failure_reason
-  # @param [String] transaction_end_date_time
-  # @param [String] transaction_start_date_time
-  # @param [String] status
-  # @param [String] assurance_level
-  # @param [String] proofing_post_office
-  # @param [String] proofing_city
-  # @param [String] proofing_state
-  # @param [String] scan_count
-  # @param [String] response_message
-  # @param [Integer] response_status_code
-  def idv_in_person_usps_proofing_results_job_exception(
-    reason:,
-    enrollment_id:,
-    minutes_since_established:,
-    exception_class: nil,
-    exception_message: nil,
-    enrollment_code: nil,
-    minutes_since_last_status_check: nil,
-    minutes_since_last_status_update: nil,
-    minutes_to_completion: nil,
-    fraud_suspected: nil,
-    primary_id_type: nil,
-    secondary_id_type: nil,
-    failure_reason: nil,
-    transaction_end_date_time: nil,
-    transaction_start_date_time: nil,
-    status: nil,
-    assurance_level: nil,
-    proofing_post_office: nil,
-    proofing_city: nil,
-    proofing_state: nil,
-    scan_count: nil,
-    response_message: nil,
-    response_status_code: nil,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Exception raised',
-      reason: reason,
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      enrollment_code: enrollment_code,
-      minutes_since_established: minutes_since_established,
-      minutes_since_last_status_check: minutes_since_last_status_check,
-      minutes_since_last_status_update: minutes_since_last_status_update,
-      minutes_to_completion: minutes_to_completion,
-      fraud_suspected: fraud_suspected,
-      primary_id_type: primary_id_type,
-      secondary_id_type: secondary_id_type,
-      failure_reason: failure_reason,
-      transaction_end_date_time: transaction_end_date_time,
-      transaction_start_date_time: transaction_start_date_time,
-      status: status,
-      assurance_level: assurance_level,
-      proofing_post_office: proofing_post_office,
-      proofing_city: proofing_city,
-      proofing_state: proofing_state,
-      scan_count: scan_count,
-      response_message: response_message,
-      response_status_code: response_status_code,
-      **extra,
-    )
-  end
-
-  # Tracks deadline email initiated during GetUspsProofingResultsJob
-  # @param [String] enrollment_id
-  def idv_in_person_usps_proofing_results_job_deadline_passed_email_initiated(
-    enrollment_id:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: deadline passed email initiated',
-      enrollment_id: enrollment_id,
-      **extra,
-    )
-  end
-
-  # Tracks exceptions that are raised when initiating deadline email in GetUspsProofingResultsJob
-  # @param [String] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  def idv_in_person_usps_proofing_results_job_deadline_passed_email_exception(
-    enrollment_id:,
-    exception_class: nil,
-    exception_message: nil,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Exception raised when attempting to send deadline passed email',
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      **extra,
-    )
-  end
-
-  # Tracks exceptions that are raised when running InPerson::EmailReminderJob
-  # @param [String] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  def idv_in_person_email_reminder_job_exception(
-    enrollment_id:,
-    exception_class: nil,
-    exception_message: nil,
-    **extra
-  )
-    track_event(
-      'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      **extra,
-    )
-  end
-
-  # Tracks individual enrollments that are updated during GetUspsProofingResultsJob
-  # @param [String] enrollment_code
-  # @param [String] enrollment_id
-  # @param [Float] minutes_since_established
-  # @param [Boolean] fraud_suspected
-  # @param [Boolean] passed did this enrollment pass or fail?
-  # @param [String] reason why did this enrollment pass or fail?
-  def idv_in_person_usps_proofing_results_job_enrollment_updated(
-    enrollment_code:,
-    enrollment_id:,
-    minutes_since_established:,
-    fraud_suspected:,
-    passed:,
-    reason:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Enrollment status updated',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      minutes_since_established: minutes_since_established,
-      fraud_suspected: fraud_suspected,
-      passed: passed,
-      reason: reason,
-      **extra,
-    )
-  end
-
-  # Tracks emails that are initiated during GetUspsProofingResultsJob
-  # @param [String] email_type success, failed or failed fraud
-  def idv_in_person_usps_proofing_results_job_email_initiated(
-    email_type:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Success or failure email initiated',
-      email_type: email_type,
-      **extra,
-    )
-  end
-
-  # Tracks emails that are initiated during InPerson::EmailReminderJob
-  # @param [String] email_type early or late
-  # @param [String] enrollment_id
-  def idv_in_person_email_reminder_job_email_initiated(
-    email_type:,
-    enrollment_id:,
-    **extra
-  )
-    track_event(
-      'InPerson::EmailReminderJob: Reminder email initiated',
-      email_type: email_type,
-      enrollment_id: enrollment_id,
-      **extra,
-    )
-  end
-
-  # Tracks incomplete enrollments checked via the USPS API
-  # @param [String] enrollment_code
-  # @param [String] enrollment_id
-  # @param [Float] minutes_since_established
-  # @param [String] response_message
-  def idv_in_person_usps_proofing_results_job_enrollment_incomplete(
-    enrollment_code:,
-    enrollment_id:,
-    minutes_since_established:,
-    response_message:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Enrollment incomplete',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      minutes_since_established: minutes_since_established,
-      response_message: response_message,
-      **extra,
-    )
-  end
-
-  # Tracks unexpected responses from the USPS API
-  # @param [String] enrollment_code
-  # @param [String] enrollment_id
-  # @param [Float] minutes_since_established
-  # @param [String] response_message
-  # @param [String] reason why was this error unexpected?
-  def idv_in_person_usps_proofing_results_job_unexpected_response(
-    enrollment_code:,
-    enrollment_id:,
-    minutes_since_established:,
-    response_message:,
-    reason:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Unexpected response received',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      minutes_since_established: minutes_since_established,
-      response_message: response_message,
-      reason: reason,
-      **extra,
-    )
-  end
-
-  # Tracks users visiting the recovery options page
-  def account_reset_recovery_options_visit
-    track_event('Account Reset: Recovery Options Visited')
-  end
-
-  # Tracks users going back or cancelling acoount recovery
-  def cancel_account_reset_recovery
-    track_event('Account Reset: Cancel Account Recovery Options')
-  end
-
-  # @identity.idp.previous_event_name IdV: Verify setup errors visited
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # Tracks when the user reaches the verify please call page after failing proofing
-  def idv_please_call_visited(proofing_components: nil, **extra)
-    track_event(
-      'IdV: Verify please call visited',
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # Tracks when user reaches verify errors due to being rejected due to fraud
-  def idv_not_verified_visited
-    track_event('IdV: Not verified visited')
-  end
-
-  # @param [String] redirect_url URL user was directed to
-  # @param [String, nil] step which step
-  # @param [String, nil] location which part of a step, if applicable
-  # @param ["idv", String, nil] flow which flow
-  # User was redirected to the login.gov contact page
-  def contact_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
-    track_event(
-      'Contact Page Redirect',
-      redirect_url: redirect_url,
-      step: step,
-      location: location,
-      flow: flow,
-      **extra,
-    )
-  end
-
-  # @param [String] redirect_url URL user was directed to
-  # @param [String, nil] step which step
-  # @param [String, nil] location which part of a step, if applicable
-  # @param ["idv", String, nil] flow which flow
-  # User was redirected to the login.gov policy page
-  def policy_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
-    track_event(
-      'Policy Page Redirect',
-      redirect_url: redirect_url,
-      step: step,
-      location: location,
-      flow: flow,
-      **extra,
-    )
-  end
-
-  # Tracks if a user clicks the "Show Password button"
-  # @param [String] path URL path where the click occurred
-  def show_password_button_clicked(path:, **extra)
-    track_event('Show Password Button Clicked', path: path, **extra)
-  end
-
-  # Tracks if a user clicks the 'acknowledge' checkbox during personal
-  # key creation
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # @param [boolean] checked whether the user checked or un-checked
-  #                  the box with this click
-  def idv_personal_key_acknowledgment_toggled(checked:, proofing_components:, **extra)
-    track_event(
-      'IdV: personal key acknowledgment toggled',
-      checked: checked,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # Logs after an email is sent
-  # @param [String] action type of email being sent
-  # @param [String, nil] ses_message_id AWS SES Message ID
-  def email_sent(action:, ses_message_id:, **extra)
-    track_event(
-      'Email Sent',
-      action: action,
-      ses_message_id: ses_message_id,
+      'WebAuthn Setup Visited',
+      platform_authenticator: platform_authenticator,
+      errors: errors,
+      enabled_mfa_methods_count: enabled_mfa_methods_count,
+      success: success,
       **extra,
     )
   end


### PR DESCRIPTION
`analytics_events.rb` is almost 4000 lines long, and the methods in it are not sorted alphabetically. This bugs me, so I sorted them and added a step to `make lint` that will error out if they're not kept sorted.

Does it make sense that I want to be able to scroll through this 4000 line file rather than just use the search function of my text editor? No, it does not. Is this a transparent attempt to juice my commit stats? Possibly. Is there a better way to do this, like with rubocop or something? Probably!

## Testing

1. Add a new method to `analytics_events.rb`, but purposefully DO NOT put it in the correct alphabetical position
2. Run `make lint_analytics_events_sorted` and get yelled at
3. Put your new method in the correct place
4. Run `make lint_analytics_events_sorted` again and don't get yelled at

**This is a noisy PR and likely to cause problems for people who have outstanding changes to `analytics_events.rb`. For this I apologize.**