### PR TITLE
LG-9975 hybrid handoff redirects

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -54,7 +54,11 @@ module Idv
     def confirm_upload_step_complete
       return if flow_session[:flow_path].present?
 
-      redirect_to idv_doc_auth_url
+      if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
+        redirect_to idv_hybrid_handoff_url
+      else
+        redirect_to idv_doc_auth_url
+      end
     end
 
     def confirm_document_capture_needed

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -9,6 +9,7 @@ module Idv
     before_action :confirm_two_factor_authenticated
     before_action :render_404_if_hybrid_handoff_controller_disabled
     before_action :confirm_agreement_step_complete
+    before_action :confirm_hybrid_handoff_needed, only: :show
 
     def show
       flow_session[:flow_path] = 'standard'
@@ -210,6 +211,16 @@ module Idv
       return if flow_session['Idv::Steps::AgreementStep']
 
       redirect_to idv_doc_auth_url
+    end
+
+    def confirm_hybrid_handoff_needed
+      return if !flow_session[:flow_path]
+
+      if flow_session[:flow_path] == 'standard'
+        redirect_to idv_document_capture_url
+      elsif flow_session[:flow_path] == 'hybrid'
+        redirect_to idv_link_sent_url
+      end
     end
 
     def formatted_destination_phone

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -62,6 +62,9 @@ module Idv
       if !failure_reason
         flow_session[:flow_path] = 'hybrid'
         redirect_to idv_link_sent_url
+
+        # for the 50/50 state
+        flow_session['Idv::Steps::UploadStep'] = true
       else
         redirect_to idv_hybrid_handoff_url
       end
@@ -118,11 +121,13 @@ module Idv
       flow_session[:flow_path] = 'standard'
       redirect_to idv_document_capture_url
 
+      # for the 50/50 state
+      flow_session['Idv::Steps::UploadStep'] = true
+
       response = form_response(destination: :document_capture)
       analytics.idv_doc_auth_upload_submitted(
         **analytics_arguments.merge(response.to_h),
       )
-      response
     end
 
     def extra_view_variables

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -65,6 +65,7 @@ module Idv
         redirect_to idv_link_sent_url
       else
         redirect_to idv_hybrid_handoff_url
+        flow_session[:flow_path] = nil
       end
 
       analytics.idv_doc_auth_upload_submitted(
@@ -193,6 +194,7 @@ module Idv
 
       failure(message)
       redirect_to idv_hybrid_handoff_url
+      flow_session[:flow_path] = nil
     end
 
     # copied from Flow::Failure module

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -162,14 +162,6 @@ module Idv
       }.merge(**acuant_sdk_ab_test_analytics_args)
     end
 
-    def mark_link_sent_step_complete
-      flow_session['Idv::Steps::LinkSentStep'] = true
-    end
-
-    def mark_upload_step_complete
-      flow_session['Idv::Steps::UploadStep'] = true
-    end
-
     def form_response(destination:)
       FormResponse.new(
         success: true,

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -80,6 +80,7 @@ module Idv
     def render_document_capture_cancelled
       if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
         redirect_to idv_hybrid_handoff_url
+        flow_session[:flow_path] = nil
       else
         mark_upload_step_incomplete
         redirect_to idv_doc_auth_url # was idv_url, why?

--- a/app/services/idv/actions/cancel_link_sent_action.rb
+++ b/app/services/idv/actions/cancel_link_sent_action.rb
@@ -8,6 +8,7 @@ module Idv
       def call
         if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
           redirect_to idv_hybrid_handoff_url
+          flow_session[:flow_path] = nil
         else
           mark_step_incomplete(:upload)
         end

--- a/app/services/idv/actions/redo_document_capture_action.rb
+++ b/app/services/idv/actions/redo_document_capture_action.rb
@@ -11,6 +11,7 @@ module Idv
           redirect_to idv_document_capture_url
         elsif IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
           redirect_to idv_hybrid_handoff_url
+          flow_session[:flow_path] = nil
         else
           mark_step_incomplete(:upload)
         end

--- a/app/services/idv/steps/agreement_step.rb
+++ b/app/services/idv/steps/agreement_step.rb
@@ -16,6 +16,7 @@ module Idv
 
         if flow_session[:skip_upload_step]
           redirect_to idv_document_capture_url
+          flow_session[:flow_path] = 'standard'
         else
           redirect_to idv_hybrid_handoff_url
         end
@@ -30,9 +31,6 @@ module Idv
       def skip_to_capture
         # See: Idv::DocAuthController#update_if_skipping_upload
         flow_session[:skip_upload_step] = true
-        if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
-          flow_session[:flow_path] = 'standard'
-        end
       end
 
       def consent_form_params

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -7,7 +7,7 @@ describe Idv::DocumentCaptureController do
     { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
       :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
       :flow_path => 'standard',
-      'Idv::Steps::UploadStep' => true }
+    }
   end
 
   let(:user) { create(:user) }
@@ -18,9 +18,6 @@ describe Idv::DocumentCaptureController do
       app_id: '123',
     )
   end
-
-  let(:default_sdk_version) { IdentityConfig.store.idv_acuant_sdk_version_default }
-  let(:alternate_sdk_version) { IdentityConfig.store.idv_acuant_sdk_version_alternate }
 
   before do
     allow(subject).to receive(:flow_session).and_return(flow_session)

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -6,8 +6,7 @@ describe Idv::DocumentCaptureController do
   let(:flow_session) do
     { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
       :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
-      :flow_path => 'standard',
-    }
+      :flow_path => 'standard' }
   end
 
   let(:user) { create(:user) }

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -28,6 +28,13 @@ describe Idv::HybridHandoffController do
         :confirm_agreement_step_complete,
       )
     end
+
+    it 'checks that hybrid_handoff is needed' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_hybrid_handoff_needed,
+      )
+    end
   end
 
   describe '#show' do
@@ -66,6 +73,24 @@ describe Idv::HybridHandoffController do
         get :show
 
         expect(response).to redirect_to(idv_doc_auth_url)
+      end
+    end
+
+    context 'hybrid_handoff already visited' do
+      it 'redirects to document_capture in standard flow' do
+        subject.user_session['idv/doc_auth'][:flow_path] = 'standard'
+
+        get :show
+
+        expect(response).to redirect_to(idv_document_capture_url)
+      end
+
+      it 'redirects to link_sent in hybrid flow' do
+        subject.user_session['idv/doc_auth'][:flow_path] = 'hybrid'
+
+        get :show
+
+        expect(response).to redirect_to(idv_link_sent_url)
       end
     end
   end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -40,8 +40,7 @@ describe Idv::HybridHandoffController do
   describe '#show' do
     let(:analytics_name) { 'IdV: doc auth upload visited' }
     let(:analytics_args) do
-      { flow_path: 'standard',
-        step: 'upload',
+      { step: 'upload',
         analytics_id: 'Doc Auth',
         irs_reproofing: false }
     end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -35,7 +35,7 @@ feature 'doc auth document capture step', :js do
     end
 
     it 'shows the new DocumentCapture page for desktop standard flow' do
-      expect(page).to have_current_path(idv_document_capture_url)
+      expect(page).to have_current_path(idv_document_capture_path)
 
       expect(page).to have_content(t('doc_auth.headings.document_capture').tr(' ', ' '))
       expect(page).to have_content(t('step_indicator.flows.idv.verify_id'))
@@ -48,6 +48,12 @@ feature 'doc auth document capture step', :js do
         irs_reproofing: false,
         acuant_sdk_upgrade_ab_test_bucket: :default,
       )
+
+      # it redirects here if trying to move earlier in the flow
+      visit(idv_doc_auth_agreement_step)
+      expect(page).to have_current_path(idv_document_capture_path)
+      visit(idv_doc_auth_upload_step)
+      expect(page).to have_current_path(idv_document_capture_path)
     end
 
     it 'logs return to sp link click' do

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'doc auth upload step' do
+feature 'doc auth hybrid_handoff step' do
   include IdvStepHelper
   include DocAuthHelper
   include ActionView::Helpers::DateHelper
@@ -19,14 +19,14 @@ feature 'doc auth upload step' do
     allow(IdentityConfig.store).to receive(:doc_auth_hybrid_handoff_controller_enabled).
       and_return(new_controller_enabled)
     allow_any_instance_of(Idv::HybridHandoffController).to receive(:mobile_device?).and_return(true)
-    complete_doc_auth_steps_before_upload_step
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ApplicationController).to receive(:irs_attempts_api_tracker).
       and_return(fake_attempts_tracker)
   end
 
-  context 'on a desktop device', js: true do
+  context 'on a desktop device' do
     before do
+      complete_doc_auth_steps_before_upload_step
       allow_any_instance_of(
         Idv::HybridHandoffController,
       ).to receive(
@@ -56,7 +56,7 @@ feature 'doc auth upload step' do
       )
     end
 
-    it "defaults phone to user's 2fa phone number" do
+    it "defaults phone to user's 2fa phone number", :js do
       field = page.find_field(t('two_factor_authentication.phone_label'))
       expect(field.value).to eq('(202) 555-1212')
     end
@@ -75,7 +75,7 @@ feature 'doc auth upload step' do
       )
     end
 
-    it 'proceeds to the next page with valid info' do
+    it 'proceeds to the next page with valid info', :js do
       expect(fake_attempts_tracker).to receive(
         :idv_phone_upload_link_sent,
       ).with(
@@ -96,7 +96,7 @@ feature 'doc auth upload step' do
       expect(page).to have_current_path(idv_link_sent_path)
     end
 
-    it 'does not proceed to the next page with invalid info' do
+    it 'does not proceed to the next page with invalid info', :js do
       fill_in :doc_auth_phone, with: ''
       click_send_link
 

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -31,7 +31,7 @@ feature 'doc auth hybrid_handoff step' do
     visit(idv_hybrid_handoff_url)
     expect(page).to have_current_path(idv_doc_auth_agreement_step)
     complete_agreement_step
-    expect(page).to have_current_path(idv_hybrid_handoff_step)
+    expect(page).to have_current_path(idv_hybrid_handoff_path)
   end
 
   context 'on a desktop device' do

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -24,6 +24,16 @@ feature 'doc auth hybrid_handoff step' do
       and_return(fake_attempts_tracker)
   end
 
+  it 'does not skip ahead in standard desktop flow' do
+    visit(idv_hybrid_handoff_url)
+    expect(page).to have_current_path(idv_doc_auth_welcome_step)
+    complete_welcome_step
+    visit(idv_hybrid_handoff_url)
+    expect(page).to have_current_path(idv_doc_auth_agreement_step)
+    complete_agreement_step
+    expect(page).to have_current_path(idv_hybrid_handoff_step)
+  end
+
   context 'on a desktop device' do
     before do
       complete_doc_auth_steps_before_upload_step
@@ -54,6 +64,9 @@ feature 'doc auth hybrid_handoff step' do
         'IdV: doc auth upload submitted',
         hash_including(step: 'upload', destination: :document_capture),
       )
+
+      visit(idv_hybrid_handoff_url)
+      expect(page).to have_current_path(idv_document_capture_path)
     end
 
     it "defaults phone to user's 2fa phone number", :js do
@@ -73,6 +86,9 @@ feature 'doc auth hybrid_handoff step' do
         'IdV: doc auth upload submitted',
         hash_including(step: 'upload', destination: :link_sent),
       )
+
+      visit(idv_hybrid_handoff_url)
+      expect(page).to have_current_path(idv_link_sent_path)
     end
 
     it 'proceeds to the next page with valid info', :js do

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -45,8 +45,7 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
       # Confirm that jumping to LinkSent page does not cause errors
       visit idv_link_sent_url
       expect(page).to have_current_path(root_url)
-
-      visit idv_hybrid_mobile_capture_complete_url
+      visit idv_hybrid_mobile_document_capture_url
 
       attach_and_submit_images
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9975](https://cm-jira.usa.gov/browse/LG-9975)

## 🛠 Summary of changes

We eventually want the hybrid handoff step to be reentrant. For now, replicate the behavior of the FSM and redirect the user if the step is already complete. Use flow_path to indicate whether the step is complete.

Note: There are some complications because the analytics expect flow_path to be set on :show. We may want to just change that expectation and not set flow_path on show, which would simplify this PR considerably.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->
