### PR TITLE
Swap identity-react-i18n for identity-i18n

### DIFF
--- a/app/javascript/packages/address-search/index.tsx
+++ b/app/javascript/packages/address-search/index.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@18f/identity-components';
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useI18n } from '@18f/identity-react-i18n';
+import { t } from '@18f/identity-i18n';
 import { request } from '@18f/identity-request';
 import ValidatedField from '@18f/identity-validated-field/validated-field';
 import SpinnerButton, { SpinnerButtonRefHandle } from '@18f/identity-spinner-button/spinner-button';
@@ -104,7 +104,6 @@ function useUspsLocations() {
   // raw text input that is set when user clicks search
   const [addressQuery, setAddressQuery] = useState('');
   const validatedFieldRef = useRef<HTMLFormElement>(null);
-  const { t } = useI18n();
   const handleAddressSearch = useCallback((event, unvalidatedAddressInput) => {
     event.preventDefault();
     validatedFieldRef.current?.setCustomValidity('');
@@ -179,7 +178,6 @@ function AddressSearch({
   onError = () => undefined,
   disabled = false,
 }: AddressSearchProps) {
-  const { t } = useI18n();
   const spinnerButtonRef = useRef<SpinnerButtonRefHandle>(null);
   const [textInput, setTextInput] = useState('');
   const {


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-9978)

## 🛠 Summary of changes

Changes the i18n package for the address-search component.

Before, it was using an i18n wrapper package that enables the use of a React Context.

Now, it is using a lower-level i18n package that simply leverages the window object, which will make usage of it more straightforward outside of the context of identity-idp, specifically identity-site.

Note that these two i18n packages appear to be used interchangeably throughout. I am open to pushback on this! Currently, I'm spot-checking the level of effect to simply use the Context pattern inside the identity-site.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Automated tests
- [ ] Spot check locally translations as normally

