### PR TITLE
LG-9714 - Remove feature flag for password confirmation

### DIFF
--- a/app/components/password_confirmation_component.html.erb
+++ b/app/components/password_confirmation_component.html.erb
@@ -43,6 +43,4 @@
   >
     <%= t('components.password_confirmation.toggle_label') %>
   </label>
-
-  <%= form.hidden_field :confirmation_enabled, value: true %>
 <% end %>

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -50,8 +50,7 @@ module SignUp
 
     def permitted_params
       params.require(:password_form).permit(
-        :confirmation_token, :password, :password_confirmation,
-        :confirmation_enabled
+        :confirmation_token, :password, :password_confirmation
       )
     end
 

--- a/app/forms/password_form.rb
+++ b/app/forms/password_form.rb
@@ -11,7 +11,6 @@ class PasswordForm
     @password = params[:password]
     @password_confirmation = params[:password_confirmation]
     @request_id = params.fetch(:request_id, '')
-    @confirmation_enabled = params[:confirmation_enabled].presence
 
     FormResponse.new(success: valid?, errors: errors, extra: extra_analytics_attributes)
   end

--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -2,7 +2,7 @@ module FormPasswordValidator
   extend ActiveSupport::Concern
 
   included do
-    attr_accessor :password, :password_confirmation, :validate_confirmation, :confirmation_enabled
+    attr_accessor :password, :password_confirmation, :validate_confirmation
     attr_reader :user
 
     validates :password,
@@ -11,7 +11,7 @@ module FormPasswordValidator
     validates :password_confirmation,
               presence: true,
               length: { in: Devise.password_length },
-              if: -> { confirmation_enabled && validate_confirmation }
+              if: -> { validate_confirmation }
 
     validate :password_graphemes_length, :strong_password, :not_pwned, :passwords_match
   end
@@ -54,7 +54,7 @@ module FormPasswordValidator
   end
 
   def passwords_match
-    return unless confirmation_enabled && validate_confirmation
+    return unless validate_confirmation
 
     if password != password_confirmation
       errors.add(

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -21,7 +21,6 @@ describe PasswordForm, type: :model do
       {
         password: password,
         password_confirmation: password_confirmation,
-        confirmation_enabled: true,
       }
     end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9714](https://cm-jira.usa.gov/browse/LG-9714)


## 🛠 Summary of changes

This code removes something like a "feature flag" for the password confirmation feature that was implemented to ensure backwards compatibility across servers. Now that the servers are running the new code, the "feature flag" can be removed.


## 📜 Testing Plan

The easiest way to test that everything is working as expected is to sign up and create a new account. After submitting the "Create a strong password" form validations should be performed and it should be possible to create an account.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
