### PR TITLE
LG-9641 GPO Resend Confirm Interstitial

### DIFF
--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -2,14 +2,16 @@
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: step_indicator_steps,
-        current_step: @step_indicator_current_step,
-        locale_scope: 'idv',
-        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-      ) %>
+      steps: step_indicator_steps,
+      current_step: @step_indicator_current_step,
+      locale_scope: 'idv',
+      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+  ) %>
 <% end %>
 
-<% unless @presenter.resend_requested? %>
+<% if @presenter.resend_requested? %>
+  <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-2') %>
+<% else %>
   <%= render AlertComponent.new(message: t('idv.messages.gpo.info_alert'), class: 'margin-bottom-4') %>
 <% end %>
 

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -9,14 +9,25 @@
       ) %>
 <% end %>
 
-<%= render AlertComponent.new(message: t('idv.messages.gpo.info_alert'), class: 'margin-bottom-4') %>
+<% unless @presenter.resend_requested? %>
+  <%= render AlertComponent.new(message: t('idv.messages.gpo.info_alert'), class: 'margin-bottom-4') %>
+<% end %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.title) %>
 
-<p>
-  <%= t('idv.messages.gpo.address_on_file_html') %>
-  <%= t('idv.messages.gpo.timeframe_html') %>
-</p>
+<% if @presenter.resend_requested? %>
+  <p>
+    <%= t('idv.messages.gpo.resend_timeframe') %>
+  </p>
+  <p>
+    <%= t('idv.messages.gpo.resend_code_warning') %>
+  </p>
+<% else %>  
+  <p>
+    <%= t('idv.messages.gpo.address_on_file_html') %>
+    <%= t('idv.messages.gpo.timeframe_html') %>
+  </p>
+<% end %>
 
 <div class="margin-top-6 margin-bottom-5">
   <%= button_to @presenter.button,

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -10,21 +10,18 @@
 <% end %>
 
 <% if @presenter.resend_requested? %>
-  <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-2') %>
+  <%= render StatusPageComponent.new(status: :warning) do |c| %>
+    <% c.with_header { @presenter.title } %>
+    <p>
+      <%= t('idv.messages.gpo.resend_timeframe') %>
+    </p>
+    <p>
+      <%= t('idv.messages.gpo.resend_code_warning') %>
+    </p>
+  <% end %>
 <% else %>
   <%= render AlertComponent.new(message: t('idv.messages.gpo.info_alert'), class: 'margin-bottom-4') %>
-<% end %>
-
-<%= render PageHeadingComponent.new.with_content(@presenter.title) %>
-
-<% if @presenter.resend_requested? %>
-  <p>
-    <%= t('idv.messages.gpo.resend_timeframe') %>
-  </p>
-  <p>
-    <%= t('idv.messages.gpo.resend_code_warning') %>
-  </p>
-<% else %>  
+  <%= render PageHeadingComponent.new.with_content(@presenter.title) %>
   <p>
     <%= t('idv.messages.gpo.address_on_file_html') %>
     <%= t('idv.messages.gpo.timeframe_html') %>

--- a/app/views/idv/gpo/index.html.erb
+++ b/app/views/idv/gpo/index.html.erb
@@ -2,11 +2,11 @@
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-      steps: step_indicator_steps,
-      current_step: @step_indicator_current_step,
-      locale_scope: 'idv',
-      class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
-  ) %>
+        steps: step_indicator_steps,
+        current_step: @step_indicator_current_step,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      ) %>
 <% end %>
 
 <% if @presenter.resend_requested? %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -200,8 +200,10 @@ en:
         info_alert: You’ll need to wait until your letter is delivered to finish
           verifying your identity.
         resend: Send me another letter
+        resend_code_warning: If you request a new letter now, the one-time code from
+          your current letter will remain valid for a limited time. You may
+          still use the one-time code from either letter.
         resend_timeframe: Letters typically take 3 to 7 business days to arrive.
-        resend_code_warning: If you request a new letter now, the one-time code from your current letter will remain valid for a limited time. You may still use the one-time code from either letter.
         timeframe_html: Letters are sent the next business day via USPS First Class Mail
           and <strong>typically take 3 to 7 business days to arrive</strong>.
       otp_delivery_method_description: If you entered a landline above, please select “Phone call” below.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -200,6 +200,8 @@ en:
         info_alert: You’ll need to wait until your letter is delivered to finish
           verifying your identity.
         resend: Send me another letter
+        resend_timeframe: Letters typically take 3 to 7 business days to arrive.
+        resend_code_warning: If you request a new letter now, the one-time code from your current letter will remain valid for a limited time. You may still use the one-time code from either letter.
         timeframe_html: Letters are sent the next business day via USPS First Class Mail
           and <strong>typically take 3 to 7 business days to arrive</strong>.
       otp_delivery_method_description: If you entered a landline above, please select “Phone call” below.
@@ -237,7 +239,7 @@ en:
       activated: Your identity has already been verified
       come_back_later: Your letter is on the way
       mail:
-        resend: Want another letter?
+        resend: Send another letter?
         verify: Want a letter?
       otp_delivery_method: How should we send a code?
       review: Review and submit

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -212,6 +212,8 @@ es:
         info_alert: Tendrá que esperar a que su carta sea entregada para terminar de
           verificar su identidad.
         resend: Envíeme otra carta
+        resend_timeframe: Las cartas suelen tardar entre 3 y 7 días hábiles en llegar.
+        resend_code_warning: Si solicitas una nueva carta ahora, el código de una sola vez de tu carta actual seguirá siendo válido durante un tiempo limitado. Puedes seguir utilizando el código de una sola vez de cualquiera de las dos cartas.
         timeframe_html: Las cartas se envían al día siguiente por First Class Mail de
           USPS y <strong>suelen tardar entre 3 y 7 días hábiles en
           llegar</strong>.
@@ -252,7 +254,7 @@ es:
       activated: Ya se verificó tu identidad.
       come_back_later: Su carta está en camino
       mail:
-        resend: '¿Desea otra carta?'
+        resend: '¿Enviar otra carta?'
         verify: '¿Desea una carta?'
       otp_delivery_method: '¿Cómo debemos enviar un código?'
       review: Revise y envíe

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -212,8 +212,11 @@ es:
         info_alert: Tendrá que esperar a que su carta sea entregada para terminar de
           verificar su identidad.
         resend: Envíeme otra carta
+        resend_code_warning: Si solicitas una nueva carta ahora, el código de una sola
+          vez de tu carta actual seguirá siendo válido durante un tiempo
+          limitado. Puedes seguir utilizando el código de una sola vez de
+          cualquiera de las dos cartas.
         resend_timeframe: Las cartas suelen tardar entre 3 y 7 días hábiles en llegar.
-        resend_code_warning: Si solicitas una nueva carta ahora, el código de una sola vez de tu carta actual seguirá siendo válido durante un tiempo limitado. Puedes seguir utilizando el código de una sola vez de cualquiera de las dos cartas.
         timeframe_html: Las cartas se envían al día siguiente por First Class Mail de
           USPS y <strong>suelen tardar entre 3 y 7 días hábiles en
           llegar</strong>.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -225,6 +225,8 @@ fr:
         info_alert: Vous devrez attendre la livraison de votre lettre pour compléter la
           vérification de votre identité.
         resend: Envoyez-moi une autre lettre
+        resend_timeframe: Les lettres mettent généralement entre trois et sept jours ouvrables pour arriver.
+        resend_code_warning: Si vous demandez une nouvelle lettre maintenant, le code à usage unique de votre lettre actuelle restera valable pendant une période limitée. Vous pouvez toujours utiliser le code à usage unique de l'une ou l'autre lettre.
         timeframe_html: Les lettres sont envoyées les jours ouvrables par courriel de
           première classe de USPS et <strong>prennent généralement entre trois à
           sept jours ouvrables pour être reçues</strong>.
@@ -268,7 +270,7 @@ fr:
       activated: Votre identité a déjà été vérifiée
       come_back_later: Votre lettre est en route
       mail:
-        resend: Vous voulez une autre lettre?
+        resend: Envoyer une autre lettre?
         verify: Vous voulez une lettre?
       otp_delivery_method: Comment envoyer un code?
       review: Réviser et soumettre

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -225,8 +225,12 @@ fr:
         info_alert: Vous devrez attendre la livraison de votre lettre pour compléter la
           vérification de votre identité.
         resend: Envoyez-moi une autre lettre
-        resend_timeframe: Les lettres mettent généralement entre trois et sept jours ouvrables pour arriver.
-        resend_code_warning: Si vous demandez une nouvelle lettre maintenant, le code à usage unique de votre lettre actuelle restera valable pendant une période limitée. Vous pouvez toujours utiliser le code à usage unique de l'une ou l'autre lettre.
+        resend_code_warning: Si vous demandez une nouvelle lettre maintenant, le code à
+          usage unique de votre lettre actuelle restera valable pendant une
+          période limitée. Vous pouvez toujours utiliser le code à usage unique
+          de l’une ou l’autre lettre.
+        resend_timeframe: Les lettres mettent généralement entre trois et sept jours
+          ouvrables pour arriver.
         timeframe_html: Les lettres sont envoyées les jours ouvrables par courriel de
           première classe de USPS et <strong>prennent généralement entre trois à
           sept jours ouvrables pour être reçues</strong>.

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -43,7 +43,7 @@ feature 'idv gpo step', :js do
       expect(page).to have_content(t('idv.messages.gpo.resend_code_warning'))
       expect(page).to have_content(t('idv.buttons.mail.resend'))
       expect(page).to_not have_content(t('idv.messages.gpo.info_alert'))
-      
+
       expect { click_on t('idv.buttons.mail.resend') }.
         to change { GpoConfirmation.count }.from(1).to(2)
       expect_user_to_be_unverified(user)

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -36,9 +36,18 @@ feature 'idv gpo step', :js do
     it 'allows the user to resend a letter and redirects to the come back later step' do
       complete_idv_and_return_to_gpo_step
 
+      # Confirm that we show the correct content on
+      # the GPO page for users requesting re-send
+      expect(page).to have_content(t('idv.titles.mail.resend'))
+      expect(page).to have_content(t('idv.messages.gpo.resend_timeframe'))
+      expect(page).to have_content(t('idv.messages.gpo.resend_code_warning'))
+      expect(page).to have_content(t('idv.buttons.mail.resend'))
+      expect(page).to_not have_content(t('idv.messages.gpo.info_alert'))
+      
       expect { click_on t('idv.buttons.mail.resend') }.
         to change { GpoConfirmation.count }.from(1).to(2)
       expect_user_to_be_unverified(user)
+
       expect(page).to have_content(t('idv.titles.come_back_later'))
       expect(page).to have_current_path(idv_come_back_later_path)
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-9641](https://cm-jira.usa.gov/browse/LG-9641)



## 🛠 Summary of changes

Instead of creating a "true" new page (controller, view, tests, etc), we found that re-using the current GPO page (ie the "Want a letter?" page) with a presenter that checks whether or not the user already has a letter pending proved sufficient.



## 📜 Testing Plan

- [ ] Complete IDV up until the phone verification page
- [ ] Select the GPO option and send the letter
- [ ] On the account page, click the enter your code link
- [ ] On the Welcome back page, click the link to send another letter
- [ ] You should see the "Send another letter?" variant specified in this ticket
- [ ] Click the back link, you should be on the welcome back page again
- [ ] Re-click the send another letter link, you should arrive back on the Send another letter variant
- [ ] Click the button to re-send a letter
- [ ] GPO should work as normal


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>English:</summary>
  
![Screen Shot 2023-06-01 at 4 28 00 PM](https://github.com/18F/identity-idp/assets/105373963/c1c6b534-2481-4330-8037-93add3cc7640)


</details>

<details>
<summary>Spanish:</summary>
  
![Screen Shot 2023-06-01 at 4 28 09 PM](https://github.com/18F/identity-idp/assets/105373963/9ed67cd9-36c4-4484-ba89-31db73a2510d)

</details>
  
<details>
<summary>French:</summary>
  
![Screen Shot 2023-06-01 at 4 28 16 PM](https://github.com/18F/identity-idp/assets/105373963/df0e059c-2164-42c1-a1eb-27a2fffb7bf8)


</details>

