### PR TITLE
LG-9371 Add flow_path back to upload submitted analytics

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -70,8 +70,9 @@ module Idv
         flow_session[:flow_path] = nil
       end
 
-      analytics_args = analytics_arguments.merge(telephony_form_response.to_h)
-      analytics.idv_doc_auth_upload_submitted(**analytics_args)
+      analytics.idv_doc_auth_upload_submitted(
+        **analytics_arguments.merge(telephony_form_response.to_h),
+      )
     end
 
     def send_link
@@ -125,8 +126,11 @@ module Idv
       # for the 50/50 state
       flow_session['Idv::Steps::UploadStep'] = true
 
-      analytics_args = analytics_arguments.merge(form_response(destination: :document_capture).to_h)
-      analytics.idv_doc_auth_upload_submitted(**analytics_args)
+      analytics.idv_doc_auth_upload_submitted(
+        **analytics_arguments.merge(
+          form_response(destination: :document_capture).to_h,
+        ),
+      )
     end
 
     def extra_view_variables

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -45,6 +45,7 @@ module Idv
       return throttled_failure if throttle.throttled?
       idv_session.phone_for_mobile_flow = params[:doc_auth][:phone]
       flow_session[:phone_for_mobile_flow] = idv_session.phone_for_mobile_flow
+      flow_session[:flow_path] = 'hybrid'
       telephony_result = send_link
       telephony_form_response = build_telephony_form_response(telephony_result)
 
@@ -60,17 +61,16 @@ module Idv
       )
 
       if !failure_reason
-        flow_session[:flow_path] = 'hybrid'
         redirect_to idv_link_sent_url
 
         # for the 50/50 state
         flow_session['Idv::Steps::UploadStep'] = true
       else
         redirect_to idv_hybrid_handoff_url
+        flow_session[:flow_path] = nil
       end
 
-      analytics_args = analytics_arguments.merge(form_response(destination: :link_sent).to_h)
-      analytics_args[:flow_path] = flow_session[:flow_path]
+      analytics_args = analytics_arguments.merge(telephony_form_response.to_h)
       analytics.idv_doc_auth_upload_submitted(**analytics_args)
     end
 
@@ -103,6 +103,7 @@ module Idv
         extra: {
           telephony_response: telephony_result.to_h,
           destination: :link_sent,
+          flow_path: flow_session[:flow_path],
         },
       )
     end
@@ -125,7 +126,6 @@ module Idv
       flow_session['Idv::Steps::UploadStep'] = true
 
       analytics_args = analytics_arguments.merge(form_response(destination: :document_capture).to_h)
-      analytics_args[:flow_path] = flow_session[:flow_path]
       analytics.idv_doc_auth_upload_submitted(**analytics_args)
     end
 
@@ -172,6 +172,7 @@ module Idv
         extra: {
           destination: destination,
           skip_upload_step: mobile_device?,
+          flow_path: flow_session[:flow_path],
         },
       )
     end

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -124,10 +124,9 @@ module Idv
       # for the 50/50 state
       flow_session['Idv::Steps::UploadStep'] = true
 
-      response = form_response(destination: :document_capture)
-      analytics.idv_doc_auth_upload_submitted(
-        **analytics_arguments.merge(response.to_h),
-      )
+      analytics_args = analytics_arguments.merge(form_response(destination: :document_capture).to_h)
+      analytics_args[:flow_path] = flow_session[:flow_path]
+      analytics.idv_doc_auth_upload_submitted(**analytics_args)
     end
 
     def extra_view_variables

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -96,29 +96,46 @@ describe Idv::HybridHandoffController do
 
   describe '#update' do
     let(:analytics_name) { 'IdV: doc auth upload submitted' }
-    let(:analytics_args) do
-      { success: true,
-        errors: {},
-        destination: :link_sent,
-        flow_path: 'hybrid',
-        step: 'upload',
-        analytics_id: 'Doc Auth',
-        irs_reproofing: false,
-        skip_upload_step: false }
+
+    context 'hybrid flow' do
+      let(:analytics_args) do
+        { success: true,
+          errors: { message: nil },
+          analytics_id: 'Doc Auth',
+          destination: :link_sent,
+          flow_path: 'hybrid',
+          irs_reproofing: false,
+          step: 'upload',
+          telephony_response: { errors: {},
+                                message_id: 'fake-message-id',
+                                request_id: 'fake-message-request-id',
+                                success: true } }
+      end
+
+      it 'sends analytics_submitted event for hybrid' do
+        put :update, params: { doc_auth: { phone: '202-555-5555' } }
+
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      end
     end
 
-    it 'sends analytics_submitted event for hybrid' do
-      put :update, params: { doc_auth: { phone: '202-555-5555' } }
+    context 'desktop flow' do
+      let(:analytics_args) do
+        { success: true,
+          errors: {},
+          destination: :document_capture,
+          flow_path: 'standard',
+          step: 'upload',
+          analytics_id: 'Doc Auth',
+          irs_reproofing: false,
+          skip_upload_step: false }
+      end
 
-      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
-    end
+      it 'sends analytics_submitted event for desktop' do
+        put :update, params: { type: 'desktop' }
 
-    it 'sends analytics_submitted event for desktop' do
-      put :update, params: { type: 'desktop' }
-
-      analytics_args[:flow_path] = 'standard'
-      analytics_args[:destination] = :document_capture
-      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      end
     end
   end
 end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -107,9 +107,17 @@ describe Idv::HybridHandoffController do
         skip_upload_step: false }
     end
 
-    it 'sends analytics_submitted event' do
+    it 'sends analytics_submitted event for hybrid' do
       put :update, params: { doc_auth: { phone: '202-555-5555' } }
 
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+    end
+
+    it 'sends analytics_submitted event for desktop' do
+      put :update, params: { type: 'desktop' }
+
+      analytics_args[:flow_path] = 'standard'
+      analytics_args[:destination] = :document_capture
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
   end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -101,11 +101,11 @@ describe Idv::HybridHandoffController do
       let(:analytics_args) do
         { success: true,
           errors: { message: nil },
-          analytics_id: 'Doc Auth',
           destination: :link_sent,
           flow_path: 'hybrid',
-          irs_reproofing: false,
           step: 'upload',
+          analytics_id: 'Doc Auth',
+          irs_reproofing: false,
           telephony_response: { errors: {},
                                 message_id: 'fake-message-id',
                                 request_id: 'fake-message-request-id',


### PR DESCRIPTION
In HybridHandoffController, analytics are sent separately from hybrid and standard code paths, and there were no specs on the standard path. Add flow_path back in on the standard path.

Use the telephony_form_response for analytics on the hybrid path. I checked in events.log for UploadStep, and that's what it does.