### PR TITLE
LG-9924 Add DB columns for User suspension

### DIFF
--- a/db/primary_migrate/20230601195606_add_columns_for_user_suspension.rb
+++ b/db/primary_migrate/20230601195606_add_columns_for_user_suspension.rb
@@ -1,11 +1,6 @@
 class AddColumnsForUserSuspension < ActiveRecord::Migration[7.0]
-  disable_ddl_transaction!
-
   def change
     add_column :users, :suspended_at, :datetime
     add_column :users, :reinstated_at, :datetime
-
-    add_index :users, :suspended_at, where: 'suspended_at IS NOT NULL', algorithm: :concurrently
-    add_index :users, :reinstated_at, where: 'reinstated_at IS NOT NULL', algorithm: :concurrently
   end
 end

--- a/db/primary_migrate/20230601195606_add_columns_for_user_suspension.rb
+++ b/db/primary_migrate/20230601195606_add_columns_for_user_suspension.rb
@@ -5,7 +5,7 @@ class AddColumnsForUserSuspension < ActiveRecord::Migration[7.0]
     add_column :users, :suspended_at, :datetime
     add_column :users, :reinstated_at, :datetime
 
-    add_index :users, :suspended_at, algorithm: :concurrently
-    add_index :users, :reinstated_at, algorithm: :concurrently
+    add_index :users, :suspended_at, where: 'suspended_at IS NOT NULL', algorithm: :concurrently
+    add_index :users, :reinstated_at, where: 'reinstated_at IS NOT NULL', algorithm: :concurrently
   end
 end

--- a/db/primary_migrate/20230601195606_add_columns_for_user_suspension.rb
+++ b/db/primary_migrate/20230601195606_add_columns_for_user_suspension.rb
@@ -1,0 +1,11 @@
+class AddColumnsForUserSuspension < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :suspended_at, :datetime
+    add_column :users, :reinstated_at, :datetime
+
+    add_index :users, :suspended_at, algorithm: :concurrently
+    add_index :users, :reinstated_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_03_231037) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_01_195606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -590,7 +590,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_03_231037) do
     t.string "email_language", limit: 10
     t.datetime "accepted_terms_at", precision: nil
     t.datetime "encrypted_recovery_code_digest_generated_at", precision: nil
+    t.datetime "suspended_at"
+    t.datetime "reinstated_at"
+    t.index ["reinstated_at"], name: "index_users_on_reinstated_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["suspended_at"], name: "index_users_on_suspended_at"
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -592,9 +592,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_01_195606) do
     t.datetime "encrypted_recovery_code_digest_generated_at", precision: nil
     t.datetime "suspended_at"
     t.datetime "reinstated_at"
-    t.index ["reinstated_at"], name: "index_users_on_reinstated_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["suspended_at"], name: "index_users_on_suspended_at"
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 


### PR DESCRIPTION
As part of our ongoing user suspension work, we are introducing new columns to indicate whether a user is currently suspended or reinstated. This commit implements the necessary changes to add these columns for tracking purposes. It is important to note that writing to these columns should only begin after the migration has been successfully deployed and executed in a production environment.

