### PR TITLE
LG-9872: Add missing interpolation value for personal key alert

### DIFF
--- a/lib/telephony/alert_sender.rb
+++ b/lib/telephony/alert_sender.rb
@@ -40,7 +40,7 @@ module Telephony
     end
 
     def send_personal_key_sign_in_notice(to:, country_code:)
-      message = I18n.t('telephony.personal_key_sign_in_notice')
+      message = I18n.t('telephony.personal_key_sign_in_notice', app_name: APP_NAME)
       response = adapter.send(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
       response

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -9,15 +9,16 @@ feature 'Signing in via one-time use personal key' do
     raw_key = PersonalKeyGenerator.new(user).create
     old_key = user.reload.encrypted_recovery_code_digest
 
-    expect(Telephony).to receive(:send_personal_key_sign_in_notice).
-      with(to: '+1 (202) 345-6789', country_code: 'US')
-
     sign_in_before_2fa(user)
     choose_another_security_option('personal_key')
     enter_personal_key(personal_key: raw_key)
     click_submit_default
     expect(user.reload.encrypted_recovery_code_digest).to_not eq old_key
     expect(current_path).to eq account_path
+
+    last_message = Telephony::Test::Message.messages.last
+    expect(last_message.body).to eq t('telephony.personal_key_sign_in_notice', app_name: APP_NAME)
+    expect(last_message.to).to eq user.phone_configurations.take.phone
 
     expect_delivered_email_count(1)
     expect_delivered_email(

--- a/spec/lib/telephony/alert_sender_spec.rb
+++ b/spec/lib/telephony/alert_sender_spec.rb
@@ -117,7 +117,9 @@ RSpec.describe Telephony::AlertSender do
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
-      expect(last_message.body).to eq(I18n.t('telephony.personal_key_sign_in_notice'))
+      expect(last_message.body).to eq(
+        t('telephony.personal_key_sign_in_notice', app_name: APP_NAME),
+      )
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -15,8 +15,11 @@ describe Event do
 
   it 'has a translation for every event type' do
     missing_translations = Event.event_types.keys.select do |event_type|
-      translation = I18n.t("event_types.#{event_type}", raise: true)
-      translation.empty?
+      I18n.t(
+        "event_types.#{event_type}",
+        raise: true,
+        ignore_test_helper_missing_interpolation: true,
+      ).empty?
     rescue I18n::MissingTranslationData
       true
     end

--- a/spec/support/i18n_helper.rb
+++ b/spec/support/i18n_helper.rb
@@ -2,14 +2,10 @@ module I18n
   class << self
     prepend(
       Module.new do
-        def t(...)
-          result = super(...)
-
-          if result.include?('%{')
-            raise "Unexpected missing interpolation in translated string: #{result}"
-          end
-
-          result
+        def t(*args, ignore_test_helper_missing_interpolation: false, **kwargs)
+          result = super(*args, **kwargs)
+          return result if ignore_test_helper_missing_interpolation || !result.include?('%{')
+          raise "Missing interpolation in translated string: #{result}"
         end
       end,
     )

--- a/spec/support/i18n_helper.rb
+++ b/spec/support/i18n_helper.rb
@@ -1,0 +1,17 @@
+module I18n
+  class << self
+    prepend(
+      Module.new do
+        def t(...)
+          result = super(...)
+
+          if result.include?('%{')
+            raise "Unexpected missing interpolation in translated string: #{result}"
+          end
+
+          result
+        end
+      end,
+    )
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9872](https://cm-jira.usa.gov/browse/LG-9872)

Fixes #8443

## 🛠 Summary of changes

Fixes the notification sent when signing in using Personal Key as the multi-factor authentication method, which previously included the literal `%{app_name}` rather than "Login.gov".

As a proactive step to try to identify these sorts of issues sooner, the changes also include a monkeypatch to the `I18n.t` method when tests are run, raising an exception if the result of the translation includes a lingering interpolation variable.

## 📜 Testing Plan

(Note that this is difficult to test in deployed environments because it relates to a legacy behavior where "personal key" was supported as an MFA method without an existing identity-verified account)

1. Go to http://localhost:3000/
2. Create an account
3. Once account creation is complete, go to http://localhost:3000/verify
4. Complete identity verification
5. Download or make a copy of the personal key
6. When returned to the account dashboard, click "Forget browsers" in the sidebar and confirm
7. Sign out
8. In your terminal, open a Rails console with rails console
9. Delete the identity verified profile by entering `User.find_with_email('<email here>').profiles.delete_all` (substitute "`<email here>`" with your chosen email)
10. Sign in
11. When prompted for MFA, click "Choose another authentication method"
12. Click "Personal key"
13. Click "Continue"
14. Enter the personal key you copied from the identity verification process
15. Click "Submit"
16. Go to http://localhost:3000/test/telephony
17. Observe that the sent message includes "Login.gov", not "%{app_name}"