### PR TITLE
LG-9858 GPO Personal Key fix

### DIFF
--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -74,7 +74,7 @@ module Idv
 
     def profile
       return idv_session.profile if idv_session.profile
-      current_user.active_profile
+      current_user.active_or_pending_profile
     end
 
     def generate_personal_key


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-9858](https://cm-jira.usa.gov/browse/LG-9858)


## 🛠 Summary of changes

Users who were going through the verify-by mail flow and had a pending profile due to either fraud_review, or in-person proofing were not reaching the personal key step after they entered in their one-time code. The problem was that our before_action, `:confirm_profile_has_been_created` in the personal_key_controller was only looking at active profiles and not pending profiles also. Since the user is in a new session idv_session did not have the profile.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV flow selecting 'review' on the SSN step, and select verify by mail
- [ ] Grab the one-time code for the GPO flow.
- [ ] Log out and log back in, enter the GPO code.
- [ ] Verify that you reach the personal key page.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
