### PR TITLE
Return to VerifyInfo when attempting to navigate to earlier pages

### DIFF
--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -9,6 +9,7 @@ module Idv
 
     before_action :confirm_verify_info_step_needed
     before_action :confirm_document_capture_complete
+    before_action :confirm_repeat_ssn, only: :show
     before_action :override_csp_for_threat_metrix_no_fsm
 
     attr_accessor :error_message
@@ -49,6 +50,13 @@ module Idv
     end
 
     private
+
+    def confirm_repeat_ssn
+      return if !pii_from_doc[:ssn]
+      return if request.referer == idv_verify_info_url
+
+      redirect_to idv_verify_info_url
+    end
 
     def next_url
       if pii_from_doc[:state] == 'PR'

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -32,13 +32,10 @@ feature 'doc auth redo document capture action', js: true do
       DocAuth::Mock::DocAuthMockClient.reset!
       attach_and_submit_images
 
-      expect(current_path).to eq(idv_ssn_path)
-      fill_out_ssn_form_with_ssn_that_fails_resolution
-      click_on t('forms.buttons.submit.update')
       expect(current_path).to eq(idv_verify_info_path)
       check t('forms.ssn.show')
       expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
-      expect(page).not_to have_css('[role="status"]')
+      expect(page).to have_css('[role="status"]')  # We verified your ID
     end
 
     it 'shows a troubleshooting option to allow the user to cancel and return to SP' do
@@ -71,13 +68,10 @@ feature 'doc auth redo document capture action', js: true do
         DocAuth::Mock::DocAuthMockClient.reset!
         attach_and_submit_images
 
-        expect(current_path).to eq(idv_ssn_path)
-        fill_out_ssn_form_with_ssn_that_fails_resolution
-        click_on t('forms.buttons.submit.update')
         expect(current_path).to eq(idv_verify_info_path)
         check t('forms.ssn.show')
         expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
-        expect(page).not_to have_css('[role="status"]')
+        expect(page).to have_css('[role="status"]') # We verified your ID
       end
     end
   end

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -51,6 +51,10 @@ feature 'doc auth verify_info step', :js do
     check t('forms.ssn.show')
     expect(page).not_to have_text(DocAuthHelper::GOOD_SSN_MASKED)
     expect(page).to have_text(DocAuthHelper::GOOD_SSN)
+
+    # navigating to earlier pages returns here
+    visit(idv_document_capture_url)
+    expect(page).to have_current_path(idv_verify_info_path)
   end
 
   it 'allows the user to enter in a new address and displays updated info' do


### PR DESCRIPTION
When navigating to earlier pages from VerifyInfo, users previously landed on the SSN page because it allows updates from VerifyInfo and it was not checking the referer. Now check the referer and redirect as appropriate.

This came up in testing for HybridHandoffController, but is not directly related to it.

Test plan:
- Create account, start IdV
- In DocumentCapture, upload a yaml for barcode read error (I can provide)
- Choose to Continue
- Enter 'valid' SSN (900-....)
- In VerifyInfo, click on the link in the banner to redo document capture
- Upload valid yaml or any photo
- Expect to be redirected to VerifyInfo with "We verified your ID" success banner
- Visit `/verify/hybrid_handoff` url
- Expect to stay on VerifyInfo page