### PR TITLE
LG-10014 [Bugfix] Password Reset Activates Any Profile

### DIFF
--- a/app/forms/verify_password_form.rb
+++ b/app/forms/verify_password_form.rb
@@ -34,8 +34,7 @@ class VerifyPasswordForm
 
   def reencrypt_pii
     personal_key = profile.encrypt_pii(decrypted_pii, password)
-    profile.update(deactivation_reason: nil, active: true)
-    profile.save!
+    profile.activate_after_password_reset
     personal_key
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -92,6 +92,13 @@ class Profile < ApplicationRecord
     activate
   end
 
+  def activate_after_password_reset
+    update!(
+      deactivation_reason: nil,
+    )
+    activate
+  end
+
   def deactivate(reason)
     update!(active: false, deactivation_reason: reason)
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -93,10 +93,12 @@ class Profile < ApplicationRecord
   end
 
   def activate_after_password_reset
-    update!(
-      deactivation_reason: nil,
-    )
-    activate
+    if password_reset?
+      update!(
+        deactivation_reason: nil,
+      )
+      activate
+    end
   end
 
   def deactivate(reason)

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -345,6 +345,20 @@ describe Profile do
 
       expect { profile.activate_after_password_reset }.to raise_error
     end
+
+    it 'does not activate a profile with non password_reset deactivation_reason' do
+      profile = create(
+        :profile,
+        user: user,
+        active: false,
+        deactivation_reason: :encryption_error,
+      )
+
+      profile.activate_after_password_reset
+
+      expect(profile.active).to eq false
+      expect(profile.deactivation_reason).to_not eq nil
+    end
   end
 
   describe '#activate_after_passing_review' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -319,6 +319,34 @@ describe Profile do
     end
   end
 
+  describe '#activate_after_password_reset' do
+    it 'activates a profile after password reset' do
+      profile = create(
+        :profile,
+        user: user,
+        active: false,
+        deactivation_reason: :password_reset,
+      )
+
+      profile.activate_after_password_reset
+
+      expect(profile.active).to eq true
+      expect(profile.deactivation_reason).to eq nil
+    end
+
+    it 'does not activate a profile if it has a pending reason' do
+      profile = create(
+        :profile,
+        user: user,
+        active: false,
+        deactivation_reason: :password_reset,
+        fraud_review_pending_at: 1.day.ago,
+      )
+
+      expect { profile.activate_after_password_reset }.to raise_error
+    end
+  end
+
   describe '#activate_after_passing_review' do
     it 'activates a profile if it passes fraud review' do
       profile = create(


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-10014](https://cm-jira.usa.gov/browse/LG-10014)


## 🛠 Summary of changes

Previously, any password reactivation was manually setting the profile to `active` in the database. This is a problem if the profile also has fraud and/or gpo pending. These changes include a new helper that uses the existing `activate` method which does the appropriate checks for all pending/deactivation reasons first.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
