### PR TITLE
Deploy RC 286 to Prod

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
-brew 'postgresql@13'
+brew 'postgresql@14'
 brew 'redis'
 brew 'node@16'
 brew 'yarn'

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 	help \
 	lint \
 	lint_analytics_events \
+	lint_analytics_events_sorted \
 	lint_tracker_events \
 	lint_country_dialing_codes \
 	lint_erb \
@@ -75,6 +76,7 @@ endif
 	@echo "--- analytics_events ---"
 	make lint_analytics_events
 	make lint_tracker_events
+	make lint_analytics_events_sorted
 	@echo "--- brakeman ---"
 	bundle exec brakeman
 	@echo "--- bundler-audit ---"
@@ -101,6 +103,7 @@ endif
 	make lint_readme
 	@echo "--- lint migrations ---"
 	make lint_migrations
+
 
 lint_erb: ## Lints ERB files
 	bundle exec erblint app/views app/components
@@ -246,6 +249,10 @@ analytics_events: public/api/_analytics-events.json ## Generates a JSON file tha
 
 lint_analytics_events: .yardoc ## Checks that all methods on AnalyticsEvents are documented
 	bundle exec ruby lib/analytics_events_documenter.rb --class-name="AnalyticsEvents" --check $<
+
+lint_analytics_events_sorted:
+	@test "$(shell grep '^  def ' app/services/analytics_events.rb)" = "$(shell grep '^  def ' app/services/analytics_events.rb | sort)" \
+		|| (echo 'Error: methods in analytics_events.rb are not sorted alphabetically' && exit 1)
 
 lint_tracker_events: .yardoc ## Checks that all methods on AnalyticsEvents are documented
 	bundle exec ruby lib/analytics_events_documenter.rb --class-name="IrsAttemptsApi::TrackerEvents" --check --skip-extra-params $<

--- a/app/components/memorable_date_component.html.erb
+++ b/app/components/memorable_date_component.html.erb
@@ -35,11 +35,12 @@
                     minLength: 1,
                     maxLength: 2,
                     aria: {
-                      invalid: false,
+                      invalid: has_errors?,
                       labelledby: [
                         "memorable-date-month-label-#{unique_id}",
                         "memorable-date-month-hint-#{unique_id}",
                       ],
+                      describedby: ["validated-field-error-#{unique_id}"],
                     },
                     value: month,
                   },
@@ -71,11 +72,13 @@
                   minLength: 1,
                   maxLength: 2,
                   aria: {
-                    invalid: false,
+                    invalid: has_errors?,
                     labelledby: [
                       "memorable-date-day-label-#{unique_id}",
                       "memorable-date-day-hint-#{unique_id}",
                     ],
+                    describedby: ["validated-field-error-#{unique_id}"],
+
                   },
                   value: day,
                 },
@@ -107,11 +110,12 @@
                   minLength: 4,
                   maxLength: 4,
                   aria: {
-                    invalid: false,
+                    invalid: has_errors?,
                     labelledby: [
                       "memorable-date-year-label-#{unique_id}",
                       "memorable-date-year-hint-#{unique_id}",
                     ],
+                    describedby: ["validated-field-error-#{unique_id}"],
                   },
                   value: year,
                 },
@@ -125,4 +129,8 @@
         </lg-validated-field>
     </div>
   <% end -%>
-<div id="validated-field-error-<%= unique_id %>" class="usa-error-message display-none"></div>
+<div id="validated-field-error-<%= unique_id %>" class="usa-error-message <%= 'display-none' unless has_errors? %>">
+  <% if has_errors? %>
+    <%= error_msg %>
+  <% end %>
+</div>

--- a/app/components/memorable_date_component.rb
+++ b/app/components/memorable_date_component.rb
@@ -122,6 +122,14 @@ class MemorableDateComponent < BaseComponent
     end
   end
 
+  def has_errors?
+    form.object.respond_to?(:errors) && form.object.errors.key?(name)
+  end
+
+  def error_msg
+    form.object.errors[name]&.first
+  end
+
   # Configure default generic error messages for component,
   # then integrate any overrides
   def generate_error_messages(label, min, max, override_error_messages)

--- a/app/controllers/concerns/idv/step_utilities_concern.rb
+++ b/app/controllers/concerns/idv/step_utilities_concern.rb
@@ -4,7 +4,7 @@ module Idv
     include AcuantConcern
 
     def irs_reproofing?
-      effective_user&.reproof_for_irs?(
+      current_user&.reproof_for_irs?(
         service_provider: current_sp,
       ).present?
     end

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -1,16 +1,15 @@
 module IdvSession
   extend ActiveSupport::Concern
-  include EffectiveUser
 
   included do
-    before_action :redirect_unless_effective_user
+    before_action :redirect_unless_idv_session_user
     before_action :redirect_if_sp_context_needed
   end
 
   def confirm_idv_needed
-    return if effective_user.active_profile.blank? ||
+    return if idv_session_user.active_profile.blank? ||
               decorated_session.requested_more_recent_verification? ||
-              effective_user.reproof_for_irs?(service_provider: current_sp)
+              idv_session_user.reproof_for_irs?(service_provider: current_sp)
 
     redirect_to idv_activated_url
   end
@@ -29,20 +28,26 @@ module IdvSession
   def idv_session
     @idv_session ||= Idv::Session.new(
       user_session: user_session,
-      current_user: effective_user,
+      current_user: idv_session_user,
       service_provider: current_sp,
     )
   end
 
-  def redirect_unless_effective_user
-    redirect_to root_url if !effective_user
+  def redirect_unless_idv_session_user
+    redirect_to root_url if !idv_session_user
   end
 
   def redirect_if_sp_context_needed
     return if sp_from_sp_session.present?
     return unless IdentityConfig.store.idv_sp_required
-    return if effective_user.profiles.any?
+    return if idv_session_user.profiles.any?
 
     redirect_to account_url
+  end
+
+  def idv_session_user
+    return User.find_by(id: session[:doc_capture_user_id]) if !current_user && hybrid_session?
+
+    current_user
   end
 end

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -47,8 +47,7 @@ module RateLimitConcern
       self.instance_of?(Idv::VerifyInfoController) ||
         self.instance_of?(Idv::InPerson::VerifyInfoController)
     when :idv_doc_auth
-      self.instance_of?(Idv::DocumentCaptureController) ||
-        self.instance_of?(Idv::HybridMobile::DocumentCaptureController)
+      self.instance_of?(Idv::DocumentCaptureController)
     when :proof_address
       self.instance_of?(Idv::PhoneController)
     end
@@ -56,7 +55,7 @@ module RateLimitConcern
 
   def idv_attempter_rate_limited?(throttle_type)
     Throttle.new(
-      user: effective_user,
+      user: idv_session_user,
       throttle_type: throttle_type,
     ).throttled?
   end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -54,7 +54,11 @@ module Idv
     def confirm_upload_step_complete
       return if flow_session[:flow_path].present?
 
-      redirect_to idv_doc_auth_url
+      if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
+        redirect_to idv_hybrid_handoff_url
+      else
+        redirect_to idv_doc_auth_url
+      end
     end
 
     def confirm_document_capture_needed

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -9,7 +9,9 @@ module Idv
     before_action :confirm_two_factor_authenticated
     before_action :render_404_if_hybrid_handoff_controller_disabled
     before_action :confirm_agreement_step_complete
+    before_action :allow_redo
     before_action :confirm_hybrid_handoff_needed, only: :show
+    before_action :confirm_not_on_mobile
 
     def show
       analytics.idv_doc_auth_upload_visited(**analytics_arguments)
@@ -228,6 +230,16 @@ module Idv
       elsif flow_session[:flow_path] == 'hybrid'
         redirect_to idv_link_sent_url
       end
+    end
+
+    def allow_redo
+      flow_session['redo_document_capture'] = true if params[:redo]
+    end
+
+    def confirm_not_on_mobile
+      return unless mobile_device?
+
+      redirect_to idv_document_capture_url
     end
 
     def formatted_destination_phone

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -45,6 +45,7 @@ module Idv
       return throttled_failure if throttle.throttled?
       idv_session.phone_for_mobile_flow = params[:doc_auth][:phone]
       flow_session[:phone_for_mobile_flow] = idv_session.phone_for_mobile_flow
+      flow_session[:flow_path] = 'hybrid'
       telephony_result = send_link
       telephony_form_response = build_telephony_form_response(telephony_result)
 
@@ -60,18 +61,18 @@ module Idv
       )
 
       if !failure_reason
-        flow_session[:flow_path] = 'hybrid'
         redirect_to idv_link_sent_url
 
         # for the 50/50 state
         flow_session['Idv::Steps::UploadStep'] = true
       else
         redirect_to idv_hybrid_handoff_url
+        flow_session[:flow_path] = nil
       end
 
-      analytics_args = analytics_arguments.merge(form_response(destination: :link_sent).to_h)
-      analytics_args[:flow_path] = flow_session[:flow_path]
-      analytics.idv_doc_auth_upload_submitted(**analytics_args)
+      analytics.idv_doc_auth_upload_submitted(
+        **analytics_arguments.merge(telephony_form_response.to_h),
+      )
     end
 
     def send_link
@@ -103,6 +104,7 @@ module Idv
         extra: {
           telephony_response: telephony_result.to_h,
           destination: :link_sent,
+          flow_path: flow_session[:flow_path],
         },
       )
     end
@@ -124,9 +126,10 @@ module Idv
       # for the 50/50 state
       flow_session['Idv::Steps::UploadStep'] = true
 
-      response = form_response(destination: :document_capture)
       analytics.idv_doc_auth_upload_submitted(
-        **analytics_arguments.merge(response.to_h),
+        **analytics_arguments.merge(
+          form_response(destination: :document_capture).to_h,
+        ),
       )
     end
 
@@ -173,6 +176,7 @@ module Idv
         extra: {
           destination: destination,
           skip_upload_step: mobile_device?,
+          flow_path: flow_session[:flow_path],
         },
       )
     end

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -80,6 +80,7 @@ module Idv
     def render_document_capture_cancelled
       if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
         redirect_to idv_hybrid_handoff_url
+        flow_session[:flow_path] = nil
       else
         mark_upload_step_incomplete
         redirect_to idv_doc_auth_url # was idv_url, why?

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -1,7 +1,6 @@
 module Idv
   class SessionErrorsController < ApplicationController
     include IdvSession
-    include EffectiveUser
     include StepIndicatorConcern
 
     before_action :confirm_two_factor_authenticated_or_user_id_in_session
@@ -15,7 +14,7 @@ module Idv
 
     def warning
       throttle = Throttle.new(
-        user: effective_user,
+        user: idv_session_user,
         throttle_type: :idv_resolution,
       )
 
@@ -29,7 +28,7 @@ module Idv
 
     def failure
       throttle = Throttle.new(
-        user: effective_user,
+        user: idv_session_user,
         throttle_type: :idv_resolution,
       )
       @expires_at = throttle.expires_at
@@ -53,7 +52,7 @@ module Idv
     end
 
     def throttled
-      throttle = Throttle.new(user: effective_user, throttle_type: :idv_doc_auth)
+      throttle = Throttle.new(user: idv_session_user, throttle_type: :idv_doc_auth)
       log_event(based_on_throttle: throttle)
       @expires_at = throttle.expires_at
     end

--- a/app/forms/idv/in_person/address_form.rb
+++ b/app/forms/idv/in_person/address_form.rb
@@ -19,13 +19,14 @@ module Idv
       def submit(params)
         consume_params(params)
 
+        validation_success = valid?
         cleaned_errors = errors.dup
         cleaned_errors.delete(:city, :nontransliterable_field)
         cleaned_errors.delete(:address1, :nontransliterable_field)
         cleaned_errors.delete(:address2, :nontransliterable_field)
 
         FormResponse.new(
-          success: valid?,
+          success: validation_success,
           errors: cleaned_errors,
         )
       end

--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -19,7 +19,7 @@ module Idv
 
     def submit(params)
       consume_params(params)
-
+      validation_success = valid?
       cleaned_errors = errors.dup
       cleaned_errors.delete(:first_name, :nontransliterable_field)
       cleaned_errors.delete(:last_name, :nontransliterable_field)
@@ -28,7 +28,7 @@ module Idv
       cleaned_errors.delete(:identity_doc_address2, :nontransliterable_field)
 
       FormResponse.new(
-        success: valid?,
+        success: validation_success,
         errors: cleaned_errors,
       )
     end

--- a/app/javascript/packages/address-search/index.tsx
+++ b/app/javascript/packages/address-search/index.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@18f/identity-components';
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useI18n } from '@18f/identity-react-i18n';
+import { t } from '@18f/identity-i18n';
 import { request } from '@18f/identity-request';
 import ValidatedField from '@18f/identity-validated-field/validated-field';
 import SpinnerButton, { SpinnerButtonRefHandle } from '@18f/identity-spinner-button/spinner-button';
@@ -104,7 +104,6 @@ function useUspsLocations() {
   // raw text input that is set when user clicks search
   const [addressQuery, setAddressQuery] = useState('');
   const validatedFieldRef = useRef<HTMLFormElement>(null);
-  const { t } = useI18n();
   const handleAddressSearch = useCallback((event, unvalidatedAddressInput) => {
     event.preventDefault();
     validatedFieldRef.current?.setCustomValidity('');
@@ -179,7 +178,6 @@ function AddressSearch({
   onError = () => undefined,
   disabled = false,
 }: AddressSearchProps) {
-  const { t } = useI18n();
   const spinnerButtonRef = useRef<SpinnerButtonRefHandle>(null);
   const [textInput, setTextInput] = useState('');
   const {

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1,6 +1,33 @@
 # frozen_string_literal: true
 
+#  ______________________________________
+# / Adding something new in here? Please \
+# \ keep methods sorted alphabetically.  /
+#  --------------------------------------
+#         \   ^__^
+#          \  (oo)\_______
+#             (__)\       )\/\
+#                 ||----w |
+#                 ||     ||
+
 module AnalyticsEvents
+  # @param [Boolean] success
+  # When a user submits a form to delete their account
+  def account_delete_submitted(success:, **extra)
+    track_event('Account Delete submitted', success: success, **extra)
+  end
+
+  # When a user visits the page to delete their account
+  def account_delete_visited
+    track_event('Account Delete visited')
+  end
+
+  # @param [String] request_came_from the controller/action the request came from
+  # When a user deletes their account
+  def account_deletion(request_came_from:, **extra)
+    track_event('Account Deletion Requested', request_came_from: request_came_from, **extra)
+  end
+
   # @identity.idp.previous_event_name Account Reset
   # @param [String] user_id
   # @param [String, nil] message_id from AWS Pinpoint API
@@ -15,6 +42,19 @@ module AnalyticsEvents
         request_id: request_id,
         **extra,
       }.compact,
+    )
+  end
+
+  # @identity.idp.previous_event_name Account Reset
+  # @param [String] user_id
+  # @param [Hash] errors
+  # Validates the token used for cancelling an account reset
+  def account_reset_cancel_token_validation(user_id:, errors: nil, **extra)
+    track_event(
+      'Account Reset: cancel token validation',
+      user_id: user_id,
+      errors: errors,
+      **extra,
     )
   end
 
@@ -43,6 +83,31 @@ module AnalyticsEvents
       errors: errors,
       **extra,
     )
+  end
+
+  # @identity.idp.previous_event_name Account Reset
+  # @param [String] user_id
+  # @param [Hash] errors
+  # Validates the granted token for account reset
+  def account_reset_granted_token_validation(user_id: nil, errors: nil, **extra)
+    track_event(
+      'Account Reset: granted token validation',
+      user_id: user_id,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # @identity.idp.previous_event_name Account Reset
+  # @param [Integer] count number of email notifications sent
+  # Account reset was performed, logs the number of email notifications sent
+  def account_reset_notifications(count:, **extra)
+    track_event('Account Reset: notifications', count: count, **extra)
+  end
+
+  # Tracks users visiting the recovery options page
+  def account_reset_recovery_options_visit
+    track_event('Account Reset: Recovery Options Visited')
   end
 
   # @identity.idp.previous_event_name Account Reset
@@ -79,59 +144,9 @@ module AnalyticsEvents
     )
   end
 
-  # @identity.idp.previous_event_name Account Reset
-  # @param [String] user_id
-  # @param [Hash] errors
-  # Validates the token used for cancelling an account reset
-  def account_reset_cancel_token_validation(user_id:, errors: nil, **extra)
-    track_event(
-      'Account Reset: cancel token validation',
-      user_id: user_id,
-      errors: errors,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name Account Reset
-  # @param [String] user_id
-  # @param [Hash] errors
-  # Validates the granted token for account reset
-  def account_reset_granted_token_validation(user_id: nil, errors: nil, **extra)
-    track_event(
-      'Account Reset: granted token validation',
-      user_id: user_id,
-      errors: errors,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name Account Reset
-  # @param [Integer] count number of email notifications sent
-  # Account reset was performed, logs the number of email notifications sent
-  def account_reset_notifications(count:, **extra)
-    track_event('Account Reset: notifications', count: count, **extra)
-  end
-
   # User visited the account deletion and reset page
   def account_reset_visit
     track_event('Account deletion and reset visited')
-  end
-
-  # @param [Boolean] success
-  # When a user submits a form to delete their account
-  def account_delete_submitted(success:, **extra)
-    track_event('Account Delete submitted', success: success, **extra)
-  end
-
-  # When a user visits the page to delete their account
-  def account_delete_visited
-    track_event('Account Delete visited')
-  end
-
-  # @param [String] request_came_from the controller/action the request came from
-  # When a user deletes their account
-  def account_deletion(request_came_from:, **extra)
-    track_event('Account Deletion Requested', request_came_from: request_came_from, **extra)
   end
 
   # When a user views the account page
@@ -144,6 +159,25 @@ module AnalyticsEvents
   # A user has clicked the confirmation link in an email
   def add_email_confirmation(user_id:, success: nil, **extra)
     track_event('Add Email: Email Confirmation', user_id: user_id, success: success, **extra)
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # Tracks request for adding new emails to an account
+  def add_email_request(success:, errors:, **extra)
+    track_event(
+      'Add Email Requested',
+      success: success,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # Tracks When users visit the add phone page
+  def add_phone_setup_visit
+    track_event(
+      'Phone Setup Visited',
+    )
   end
 
   # When a user views the "you are already signed in with the following email" screen
@@ -220,6 +254,27 @@ module AnalyticsEvents
     track_event('Broken Personal Key: Regenerated')
   end
 
+  # Tracks users going back or cancelling acoount recovery
+  def cancel_account_reset_recovery
+    track_event('Account Reset: Cancel Account Recovery Options')
+  end
+
+  # @param [String] redirect_url URL user was directed to
+  # @param [String, nil] step which step
+  # @param [String, nil] location which part of a step, if applicable
+  # @param ["idv", String, nil] flow which flow
+  # User was redirected to the login.gov contact page
+  def contact_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
+    track_event(
+      'Contact Page Redirect',
+      redirect_url: redirect_url,
+      step: step,
+      location: location,
+      flow: flow,
+      **extra,
+    )
+  end
+
   # @param [String, nil] error error message
   # @param [String, nil] uuid document capture session uuid
   # @param [String, nil] result_id document capture session result id
@@ -280,22 +335,12 @@ module AnalyticsEvents
 
   # @param [Boolean] success
   # @param [Hash] errors
-  # Tracks request for adding new emails to an account
-  def add_email_request(success:, errors:, **extra)
+  # Tracks if Email Language is updated
+  def email_language_updated(success:, errors:, **extra)
     track_event(
-      'Add Email Requested',
+      'Email Language: Updated',
       success: success,
       errors: errors,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # Tracks request for resending confirmation for new emails to an account
-  def resend_add_email_request(success:, **extra)
-    track_event(
-      'Resend Add Email Requested',
-      success: success,
       **extra,
     )
   end
@@ -305,14 +350,14 @@ module AnalyticsEvents
     track_event('Email Language: Visited')
   end
 
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # Tracks if Email Language is updated
-  def email_language_updated(success:, errors:, **extra)
+  # Logs after an email is sent
+  # @param [String] action type of email being sent
+  # @param [String, nil] ses_message_id AWS SES Message ID
+  def email_sent(action:, ses_message_id:, **extra)
     track_event(
-      'Email Language: Updated',
-      success: success,
-      errors: errors,
+      'Email Sent',
+      action: action,
+      ses_message_id: ses_message_id,
       **extra,
     )
   end
@@ -489,53 +534,29 @@ module AnalyticsEvents
     track_event('IdV: address visited')
   end
 
-  # @param [String] step the step that the user was on when they clicked cancel
-  # @param [String] request_came_from the controller and action from the
-  #   source such as "users/sessions#new"
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # The user clicked cancel during IDV (presented with an option to go back or confirm)
-  def idv_cancellation_visited(
-    step:,
-    request_came_from:,
-    proofing_components: nil,
+  # Tracks if request to get address candidates from ArcGIS fails
+  # @param [String] exception_class
+  # @param [String] exception_message
+  # @param [Boolean] response_body_present
+  # @param [Hash] response_body
+  # @param [Integer] response_status_code
+  def idv_arcgis_request_failure(
+    exception_class:,
+    exception_message:,
+    response_body_present:,
+    response_body:,
+    response_status_code:,
     **extra
   )
     track_event(
-      'IdV: cancellation visited',
-      step: step,
-      request_came_from: request_came_from,
-      proofing_components: proofing_components,
+      'Request ArcGIS Address Candidates: request failed',
+      exception_class: exception_class,
+      exception_message: exception_message,
+      response_body_present: response_body_present,
+      response_body: response_body,
+      response_status_code: response_status_code,
       **extra,
     )
-  end
-
-  # @param [Integer] failed_capture_attempts Number of failed Acuant SDK attempts
-  # @param [Integer] failed_submission_attempts Number of failed Acuant doc submissions
-  # @param [String] field Image form field
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
-  # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
-  # camera, on mobile devices.
-  def idv_native_camera_forced(
-    failed_capture_attempts:,
-    failed_submission_attempts:,
-    field:,
-    flow_path:,
-    **extra
-  )
-    track_event(
-      'IdV: Native camera forced after failed attempts',
-      failed_capture_attempts: failed_capture_attempts,
-      failed_submission_attempts: failed_submission_attempts,
-      field: field,
-      flow_path: flow_path,
-      **extra,
-    )
-  end
-
-  # The user visited the gpo confirm cancellation screen
-  def idv_gpo_confirm_start_over_visited
-    track_event('IdV: gpo confirm start over visited')
   end
 
   # @param [String] step the step that the user was on when they clicked cancel
@@ -562,13 +583,22 @@ module AnalyticsEvents
     )
   end
 
-  # The user checked or unchecked the "By checking this box..." checkbox on the idv agreement step.
-  # (This is a frontend event.)
-  # @param [Boolean] checked Whether the user checked the checkbox
-  def idv_consent_checkbox_toggled(checked:, **extra)
+  # @param [String] step the step that the user was on when they clicked cancel
+  # @param [String] request_came_from the controller and action from the
+  #   source such as "users/sessions#new"
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # The user clicked cancel during IDV (presented with an option to go back or confirm)
+  def idv_cancellation_visited(
+    step:,
+    request_came_from:,
+    proofing_components: nil,
+    **extra
+  )
     track_event(
-      'IdV: consent checkbox toggled',
-      checked: checked,
+      'IdV: cancellation visited',
+      step: step,
+      request_came_from: request_came_from,
+      proofing_components: proofing_components,
       **extra,
     )
   end
@@ -583,13 +613,424 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # @param [String] in_person_cta_variant Variant testing bucket label
-  # The user clicked the troubleshooting option to start in-person proofing
-  def idv_verify_in_person_troubleshooting_option_clicked(flow_path:, in_person_cta_variant:,
-                                                          **extra)
+  # The user checked or unchecked the "By checking this box..." checkbox on the idv agreement step.
+  # (This is a frontend event.)
+  # @param [Boolean] checked Whether the user checked the checkbox
+  def idv_consent_checkbox_toggled(checked:, **extra)
     track_event(
-      'IdV: verify in person troubleshooting option clicked',
+      'IdV: consent checkbox toggled',
+      checked: checked,
+      **extra,
+    )
+  end
+
+  # User has consented to share information with document upload and may
+  # view the "hybrid handoff" step next unless "skip_upload" param is true
+  def idv_doc_auth_agreement_submitted(**extra)
+    track_event('IdV: doc auth agreement submitted', **extra)
+  end
+
+  def idv_doc_auth_agreement_visited(**extra)
+    track_event('IdV: doc auth agreement visited', **extra)
+  end
+
+  def idv_doc_auth_cancel_link_sent_submitted(**extra)
+    track_event('IdV: doc auth cancel_link_sent submitted', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing cancel_update_ssn submitted
+  def idv_doc_auth_cancel_update_ssn_submitted(**extra)
+    track_event('IdV: doc auth cancel_update_ssn submitted', **extra)
+  end
+
+  def idv_doc_auth_capture_complete_visited(**extra)
+    track_event('IdV: doc auth capture_complete visited', **extra)
+  end
+
+  def idv_doc_auth_document_capture_submitted(**extra)
+    track_event('IdV: doc auth document_capture submitted', **extra)
+  end
+
+  def idv_doc_auth_document_capture_visited(**extra)
+    track_event('IdV: doc auth document_capture visited', **extra)
+  end
+
+  # @param [String] step_name which step the user was on
+  # @param [Integer] remaining_attempts how many attempts the user has left before we throttle them
+  # The user visited an error page due to an encountering an exception talking to a proofing vendor
+  def idv_doc_auth_exception_visited(step_name:, remaining_attempts:, **extra)
+    track_event(
+      'IdV: doc auth exception visited',
+      step_name: step_name,
+      remaining_attempts: remaining_attempts,
+      **extra,
+    )
+  end
+
+  # @identity.idp.previous_event_name IdV: doc auth send_link submitted
+  def idv_doc_auth_link_sent_submitted(**extra)
+    track_event('IdV: doc auth link_sent submitted', **extra)
+  end
+
+  def idv_doc_auth_link_sent_visited(**extra)
+    track_event('IdV: doc auth link_sent visited', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing optional verify_wait submitted
+  def idv_doc_auth_optional_verify_wait_submitted(**extra)
+    track_event('IdV: doc auth optional verify_wait submitted', **extra)
+  end
+
+  def idv_doc_auth_randomizer_defaulted
+    track_event(
+      'IdV: doc_auth random vendor error',
+      error: 'document_capture_session_uuid_key missing',
+    )
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing redo_address submitted
+  def idv_doc_auth_redo_address_submitted(**extra)
+    track_event('IdV: doc auth redo_address submitted', **extra)
+  end
+
+  def idv_doc_auth_redo_document_capture_submitted(**extra)
+    track_event('IdV: doc auth redo_document_capture submitted', **extra)
+  end
+
+  def idv_doc_auth_redo_ssn_submitted(**extra)
+    track_event('IdV: doc auth redo_ssn submitted', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing ssn submitted
+  def idv_doc_auth_ssn_submitted(**extra)
+    track_event('IdV: doc auth ssn submitted', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing ssn visited
+  def idv_doc_auth_ssn_visited(**extra)
+    track_event('IdV: doc auth ssn visited', **extra)
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Integer] attempts
+  # @param [Integer] remaining_attempts
+  # @param [String] user_id
+  # @param [String] flow_path
+  # The document capture image uploaded was locally validated during the IDV process
+  def idv_doc_auth_submitted_image_upload_form(
+    success:,
+    errors:,
+    remaining_attempts:,
+    flow_path:,
+    attempts: nil,
+    user_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth image upload form submitted',
+      success: success,
+      errors: errors,
+      attempts: attempts,
+      remaining_attempts: remaining_attempts,
+      user_id: user_id,
+      flow_path: flow_path,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] exception
+  # @param [Boolean] billed
+  # @param [String] doc_auth_result
+  # @param [String] state
+  # @param [String] state_id_type
+  # @param [Boolean] async
+  # @param [Integer] attempts
+  # @param [Integer] remaining_attempts
+  # @param [Hash] client_image_metrics
+  # @param [String] flow_path
+  # The document capture image was uploaded to vendor during the IDV process
+  def idv_doc_auth_submitted_image_upload_vendor(
+    success:,
+    errors:,
+    exception:,
+    state:,
+    state_id_type:,
+    async:, attempts:,
+    remaining_attempts:,
+    client_image_metrics:,
+    flow_path:,
+    billed: nil,
+    doc_auth_result: nil,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth image upload vendor submitted',
+      success: success,
+      errors: errors,
+      exception: exception,
+      billed: billed,
+      doc_auth_result: doc_auth_result,
+      state: state,
+      state_id_type: state_id_type,
+      async: async,
+      attempts: attempts,
+      remaining_attempts: remaining_attempts,
+      client_image_metrics: client_image_metrics,
+      flow_path: flow_path,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] user_id
+  # @param [Integer] remaining_attempts
+  # @param [Hash] pii_like_keypaths
+  # @param [String] flow_path
+  # The PII that came back from the document capture vendor was validated
+  def idv_doc_auth_submitted_pii_validation(
+    success:,
+    errors:,
+    remaining_attempts:,
+    pii_like_keypaths:,
+    flow_path:,
+    user_id: nil,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth image upload vendor pii validation',
+      success: success,
+      errors: errors,
+      user_id: user_id,
+      remaining_attempts: remaining_attempts,
+      pii_like_keypaths: pii_like_keypaths,
+      flow_path: flow_path,
+      **extra,
+    )
+  end
+
+  # The "hybrid handoff" step: Desktop user has submitted their choice to
+  # either continue via desktop ("document_capture" destination) or switch
+  # to mobile phone ("send_link" destination) to perform document upload.
+  # Mobile users still log this event but with skip_upload_step = true
+  def idv_doc_auth_upload_submitted(**extra)
+    track_event('IdV: doc auth upload submitted', **extra)
+  end
+
+  # Desktop user has reached the above "hybrid handoff" view
+  def idv_doc_auth_upload_visited(**extra)
+    track_event('IdV: doc auth upload visited', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: doc auth optional verify_wait submitted
+  def idv_doc_auth_verify_proofing_results(**extra)
+    track_event('IdV: doc auth verify proofing results', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing verify submitted
+  def idv_doc_auth_verify_submitted(**extra)
+    track_event('IdV: doc auth verify submitted', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing verify visited
+  def idv_doc_auth_verify_visited(**extra)
+    track_event('IdV: doc auth verify visited', **extra)
+  end
+
+  # @identity.idp.previous_event_name IdV: in person proofing verify_wait visited
+  def idv_doc_auth_verify_wait_step_visited(**extra)
+    track_event('IdV: doc auth verify_wait visited', **extra)
+  end
+
+  # @param [String] step_name
+  # @param [Integer] remaining_attempts
+  # The user was sent to a warning page during the IDV flow
+  def idv_doc_auth_warning_visited(
+    step_name:,
+    remaining_attempts:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth warning visited',
+      step_name: step_name,
+      remaining_attempts: remaining_attempts,
+      **extra,
+    )
+  end
+
+  def idv_doc_auth_welcome_submitted(**extra)
+    track_event('IdV: doc auth welcome submitted', **extra)
+  end
+
+  def idv_doc_auth_welcome_visited(**extra)
+    track_event('IdV: doc auth welcome visited', **extra)
+  end
+
+  # @param [Boolean] success
+  # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
+  # @param [Boolean] fraud_review_pending Profile is under review for fraud
+  # @param [Boolean] fraud_rejection Profile is rejected due to fraud
+  # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verificaiton
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # Tracks the last step of IDV, indicates the user successfully proofed
+  def idv_final(
+    success:,
+    fraud_review_pending:,
+    fraud_rejection:,
+    gpo_verification_pending:,
+    deactivation_reason: nil,
+    proofing_components: nil,
+    **extra
+  )
+    track_event(
+      'IdV: final resolution',
+      success: success,
+      fraud_review_pending: fraud_review_pending,
+      fraud_rejection: fraud_rejection,
+      gpo_verification_pending: gpo_verification_pending,
+      deactivation_reason: deactivation_reason,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # User visited forgot password page
+  def idv_forgot_password(proofing_components: nil, **extra)
+    track_event(
+      'IdV: forgot password visited',
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # User confirmed forgot password
+  def idv_forgot_password_confirmed(proofing_components: nil, **extra)
+    track_event(
+      'IdV: forgot password confirmed',
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [DateTime] enqueued_at
+  # @param [Boolean] resend
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # GPO letter was enqueued and the time at which it was enqueued
+  def idv_gpo_address_letter_enqueued(enqueued_at:, resend:, proofing_components: nil, **extra)
+    track_event(
+      'IdV: USPS address letter enqueued',
+      enqueued_at: enqueued_at,
+      resend: resend,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] resend
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # GPO letter was requested
+  def idv_gpo_address_letter_requested(resend:, proofing_components: nil, **extra)
+    track_event(
+      'IdV: USPS address letter requested',
+      resend: resend,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] letter_already_sent
+  # GPO address visited
+  def idv_gpo_address_visited(
+    letter_already_sent:,
+    **extra
+  )
+    track_event(
+      'IdV: USPS address visited',
+      letter_already_sent: letter_already_sent,
+      **extra,
+    )
+  end
+
+  # The user visited the gpo confirm cancellation screen
+  def idv_gpo_confirm_start_over_visited
+    track_event('IdV: gpo confirm start over visited')
+  end
+
+  # @identity.idp.previous_event_name Account verification submitted
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Hash] pii_like_keypaths
+  # GPO verification submitted
+  def idv_gpo_verification_submitted(
+    success:,
+    errors:,
+    pii_like_keypaths:,
+    **extra
+  )
+    track_event(
+      'IdV: GPO verification submitted',
+      success: success,
+      errors: errors,
+      pii_like_keypaths: pii_like_keypaths,
+      **extra,
+    )
+  end
+
+  # @identity.idp.previous_event_name Account verification visited
+  # GPO verification visited
+  def idv_gpo_verification_visited
+    track_event('IdV: GPO verification visited')
+  end
+
+  # Tracks emails that are initiated during InPerson::EmailReminderJob
+  # @param [String] email_type early or late
+  # @param [String] enrollment_id
+  def idv_in_person_email_reminder_job_email_initiated(
+    email_type:,
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      'InPerson::EmailReminderJob: Reminder email initiated',
+      email_type: email_type,
+      enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
+
+  # Tracks exceptions that are raised when running InPerson::EmailReminderJob
+  # @param [String] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  def idv_in_person_email_reminder_job_exception(
+    enrollment_id:,
+    exception_class: nil,
+    exception_message: nil,
+    **extra
+  )
+    track_event(
+      'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
+  # @param [String] selected_location Selected in-person location
+  # @param [String] in_person_cta_variant Variant testing bucket label
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The user submitted the in person proofing location step
+  def idv_in_person_location_submitted(selected_location:, in_person_cta_variant:, flow_path:,
+                                       **extra)
+    track_event(
+      'IdV: in person proofing location submitted',
+      selected_location: selected_location,
       flow_path: flow_path,
       in_person_cta_variant: in_person_cta_variant,
       **extra,
@@ -604,6 +1045,31 @@ module AnalyticsEvents
       'IdV: in person proofing location visited',
       flow_path: flow_path,
       in_person_cta_variant: in_person_cta_variant,
+      **extra,
+    )
+  end
+
+  # Tracks if request to get USPS in-person proofing locations fails
+  # @param [String] exception_class
+  # @param [String] exception_message
+  # @param [Boolean] response_body_present
+  # @param [Hash] response_body
+  # @param [Integer] response_status_code
+  def idv_in_person_locations_request_failure(
+    exception_class:,
+    exception_message:,
+    response_body_present:,
+    response_body:,
+    response_status_code:,
+    **extra
+  )
+    track_event(
+      'Request USPS IPP locations: request failed',
+      exception_class: exception_class,
+      exception_message: exception_message,
+      response_body_present: response_body_present,
+      response_body: response_body,
+      response_status_code: response_status_code,
       **extra,
     )
   end
@@ -636,27 +1102,6 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] selected_location Selected in-person location
-  # @param [String] in_person_cta_variant Variant testing bucket label
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The user submitted the in person proofing location step
-  def idv_in_person_location_submitted(selected_location:, in_person_cta_variant:, flow_path:,
-                                       **extra)
-    track_event(
-      'IdV: in person proofing location submitted',
-      selected_location: selected_location,
-      flow_path: flow_path,
-      in_person_cta_variant: in_person_cta_variant,
-      **extra,
-    )
-  end
-
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The user visited the in person proofing prepare step
-  def idv_in_person_prepare_visited(flow_path:, **extra)
-    track_event('IdV: in person proofing prepare visited', flow_path: flow_path, **extra)
-  end
-
   # @param [String] flow_path Document capture path ("hybrid" or "standard")
   # @param [String] in_person_cta_variant Variant testing bucket label
   # The user submitted the in person proofing prepare step
@@ -669,21 +1114,10 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] nontransliterable_characters
-  # Nontransliterable characters submitted by user
-  def idv_in_person_proofing_nontransliterable_characters_submitted(
-    nontransliterable_characters:,
-    **extra
-  )
-    track_event(
-      'IdV: in person proofing characters submitted could not be transliterated',
-      nontransliterable_characters: nontransliterable_characters,
-      **extra,
-    )
-  end
-
-  def idv_in_person_proofing_residential_address_submitted(**extra)
-    track_event('IdV: in person proofing residential address submitted', **extra)
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The user visited the in person proofing prepare step
+  def idv_in_person_prepare_visited(flow_path:, **extra)
+    track_event('IdV: in person proofing prepare visited', flow_path: flow_path, **extra)
   end
 
   # @param [String] flow_path
@@ -813,6 +1247,75 @@ module AnalyticsEvents
     )
   end
 
+  # A job to check USPS notifications about in-person enrollment status updates has completed
+  # @param [Integer] fetched_items items fetched
+  # @param [Integer] processed_items items fetched and processed
+  # @param [Integer] deleted_items items fetched, processed, and then deleted from the queue
+  # @param [Integer] valid_items items that could be successfully used to update a record
+  # @param [Integer] invalid_items items that couldn't be used to update a record
+  # @param [Integer] incomplete_items fetched items not processed nor deleted from the queue
+  # @param [Integer] deletion_failed_items processed items that we failed to delete
+  def idv_in_person_proofing_enrollments_ready_for_status_check_job_completed(
+    fetched_items:,
+    processed_items:,
+    deleted_items:,
+    valid_items:,
+    invalid_items:,
+    incomplete_items:,
+    deletion_failed_items:,
+    **extra
+  )
+    track_event(
+      'InPersonEnrollmentsReadyForStatusCheckJob: Job completed',
+      fetched_items:,
+      processed_items:,
+      deleted_items:,
+      valid_items:,
+      invalid_items:,
+      incomplete_items:,
+      deletion_failed_items:,
+      **extra,
+    )
+  end
+
+  # A job to check USPS notifications about in-person enrollment status updates
+  # has encountered an error
+  # @param [String] exception_class
+  # @param [String] exception_message
+  def idv_in_person_proofing_enrollments_ready_for_status_check_job_ingestion_error(
+    exception_class:,
+    exception_message:,
+    **extra
+  )
+    track_event(
+      'InPersonEnrollmentsReadyForStatusCheckJob: Ingestion error',
+      exception_class:,
+      exception_message:,
+      **extra,
+    )
+  end
+
+  # A job to check USPS notifications about in-person enrollment status updates has started
+  def idv_in_person_proofing_enrollments_ready_for_status_check_job_started(**extra)
+    track_event(
+      'InPersonEnrollmentsReadyForStatusCheckJob: Job started',
+      **extra,
+    )
+  end
+
+  # @param [String] nontransliterable_characters
+  # Nontransliterable characters submitted by user
+  def idv_in_person_proofing_nontransliterable_characters_submitted(
+    nontransliterable_characters:,
+    **extra
+  )
+    track_event(
+      'IdV: in person proofing characters submitted could not be transliterated',
+      nontransliterable_characters: nontransliterable_characters,
+      **extra,
+    )
+  end
+
   # @param [String] flow_path
   # @param [String] step
   # @param [Integer] step_count
@@ -845,6 +1348,10 @@ module AnalyticsEvents
       same_address_as_id: same_address_as_id,
       **extra,
     )
+  end
+
+  def idv_in_person_proofing_residential_address_submitted(**extra)
+    track_event('IdV: in person proofing residential address submitted', **extra)
   end
 
   # @param [String] flow_path
@@ -906,16 +1413,12 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The user visited the in person proofing switch_back step
-  def idv_in_person_switch_back_visited(flow_path:, **extra)
-    track_event('IdV: in person proofing switch_back visited', flow_path: flow_path, **extra)
-  end
-
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
-  # The user submitted the in person proofing switch_back step
-  def idv_in_person_switch_back_submitted(flow_path:, **extra)
-    track_event('IdV: in person proofing switch_back submitted', flow_path: flow_path, **extra)
+  # The user clicked the sp link on the "ready to verify" page
+  def idv_in_person_ready_to_verify_sp_link_clicked(**extra)
+    track_event(
+      'IdV: user clicked sp link on ready to verify page',
+      **extra,
+    )
   end
 
   # @param [String] in_person_cta_variant Variant testing bucket label
@@ -931,14 +1434,6 @@ module AnalyticsEvents
     )
   end
 
-  # The user clicked the sp link on the "ready to verify" page
-  def idv_in_person_ready_to_verify_sp_link_clicked(**extra)
-    track_event(
-      'IdV: user clicked sp link on ready to verify page',
-      **extra,
-    )
-  end
-
   # The user clicked the what to bring link on the "ready to verify" page
   def idv_in_person_ready_to_verify_what_to_bring_link_clicked(**extra)
     track_event(
@@ -947,390 +1442,287 @@ module AnalyticsEvents
     )
   end
 
-  # A job to check USPS notifications about in-person enrollment status updates has started
-  def idv_in_person_proofing_enrollments_ready_for_status_check_job_started(**extra)
-    track_event(
-      'InPersonEnrollmentsReadyForStatusCheckJob: Job started',
-      **extra,
-    )
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The user submitted the in person proofing switch_back step
+  def idv_in_person_switch_back_submitted(flow_path:, **extra)
+    track_event('IdV: in person proofing switch_back submitted', flow_path: flow_path, **extra)
   end
 
-  # A job to check USPS notifications about in-person enrollment status updates has completed
-  # @param [Integer] fetched_items items fetched
-  # @param [Integer] processed_items items fetched and processed
-  # @param [Integer] deleted_items items fetched, processed, and then deleted from the queue
-  # @param [Integer] valid_items items that could be successfully used to update a record
-  # @param [Integer] invalid_items items that couldn't be used to update a record
-  # @param [Integer] incomplete_items fetched items not processed nor deleted from the queue
-  # @param [Integer] deletion_failed_items processed items that we failed to delete
-  def idv_in_person_proofing_enrollments_ready_for_status_check_job_completed(
-    fetched_items:,
-    processed_items:,
-    deleted_items:,
-    valid_items:,
-    invalid_items:,
-    incomplete_items:,
-    deletion_failed_items:,
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The user visited the in person proofing switch_back step
+  def idv_in_person_switch_back_visited(flow_path:, **extra)
+    track_event('IdV: in person proofing switch_back visited', flow_path: flow_path, **extra)
+  end
+
+  # GetUspsProofingResultsJob has completed. Includes counts of various outcomes encountered
+  # @param [Float] duration_seconds number of minutes the job was running
+  # @param [Integer] enrollments_checked number of enrollments eligible for status check
+  # @param [Integer] enrollments_errored number of enrollments for which we encountered an error
+  # @param [Integer] enrollments_expired number of enrollments which expired
+  # @param [Integer] enrollments_failed number of enrollments which failed identity proofing
+  # @param [Integer] enrollments_in_progress number of enrollments which did not have any change
+  # @param [Integer] enrollments_passed number of enrollments which passed identity proofing
+  def idv_in_person_usps_proofing_results_job_completed(
+    duration_seconds:,
+    enrollments_checked:,
+    enrollments_errored:,
+    enrollments_expired:,
+    enrollments_failed:,
+    enrollments_in_progress:,
+    enrollments_passed:,
     **extra
   )
     track_event(
-      'InPersonEnrollmentsReadyForStatusCheckJob: Job completed',
-      fetched_items:,
-      processed_items:,
-      deleted_items:,
-      valid_items:,
-      invalid_items:,
-      incomplete_items:,
-      deletion_failed_items:,
+      'GetUspsProofingResultsJob: Job completed',
+      duration_seconds: duration_seconds,
+      enrollments_checked: enrollments_checked,
+      enrollments_errored: enrollments_errored,
+      enrollments_expired: enrollments_expired,
+      enrollments_failed: enrollments_failed,
+      enrollments_in_progress: enrollments_in_progress,
+      enrollments_passed: enrollments_passed,
       **extra,
     )
   end
 
-  # A job to check USPS notifications about in-person enrollment status updates
-  # has encountered an error
+  # Tracks exceptions that are raised when initiating deadline email in GetUspsProofingResultsJob
+  # @param [String] enrollment_id
   # @param [String] exception_class
   # @param [String] exception_message
-  def idv_in_person_proofing_enrollments_ready_for_status_check_job_ingestion_error(
+  def idv_in_person_usps_proofing_results_job_deadline_passed_email_exception(
+    enrollment_id:,
+    exception_class: nil,
+    exception_message: nil,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Exception raised when attempting to send deadline passed email',
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
+  # Tracks deadline email initiated during GetUspsProofingResultsJob
+  # @param [String] enrollment_id
+  def idv_in_person_usps_proofing_results_job_deadline_passed_email_initiated(
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: deadline passed email initiated',
+      enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
+
+  # Tracks emails that are initiated during GetUspsProofingResultsJob
+  # @param [String] email_type success, failed or failed fraud
+  def idv_in_person_usps_proofing_results_job_email_initiated(
+    email_type:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Success or failure email initiated',
+      email_type: email_type,
+      **extra,
+    )
+  end
+
+  # Tracks incomplete enrollments checked via the USPS API
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [Float] minutes_since_established
+  # @param [String] response_message
+  def idv_in_person_usps_proofing_results_job_enrollment_incomplete(
+    enrollment_code:,
+    enrollment_id:,
+    minutes_since_established:,
+    response_message:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Enrollment incomplete',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      minutes_since_established: minutes_since_established,
+      response_message: response_message,
+      **extra,
+    )
+  end
+
+  # Tracks individual enrollments that are updated during GetUspsProofingResultsJob
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [Float] minutes_since_established
+  # @param [Boolean] fraud_suspected
+  # @param [Boolean] passed did this enrollment pass or fail?
+  # @param [String] reason why did this enrollment pass or fail?
+  def idv_in_person_usps_proofing_results_job_enrollment_updated(
+    enrollment_code:,
+    enrollment_id:,
+    minutes_since_established:,
+    fraud_suspected:,
+    passed:,
+    reason:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Enrollment status updated',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      minutes_since_established: minutes_since_established,
+      fraud_suspected: fraud_suspected,
+      passed: passed,
+      reason: reason,
+      **extra,
+    )
+  end
+
+  # Tracks exceptions that are raised when running GetUspsProofingResultsJob
+  # @param [String] reason why was the exception raised?
+  # @param [String] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  # @param [String] enrollment_code
+  # @param [Float] minutes_since_established
+  # @param [Float] minutes_since_last_status_check
+  # @param [Float] minutes_since_last_status_update
+  # @param [Float] minutes_to_completion
+  # @param [Boolean] fraud_suspected
+  # @param [String] primary_id_type
+  # @param [String] secondary_id_type
+  # @param [String] failure_reason
+  # @param [String] transaction_end_date_time
+  # @param [String] transaction_start_date_time
+  # @param [String] status
+  # @param [String] assurance_level
+  # @param [String] proofing_post_office
+  # @param [String] proofing_city
+  # @param [String] proofing_state
+  # @param [String] scan_count
+  # @param [String] response_message
+  # @param [Integer] response_status_code
+  def idv_in_person_usps_proofing_results_job_exception(
+    reason:,
+    enrollment_id:,
+    minutes_since_established:,
+    exception_class: nil,
+    exception_message: nil,
+    enrollment_code: nil,
+    minutes_since_last_status_check: nil,
+    minutes_since_last_status_update: nil,
+    minutes_to_completion: nil,
+    fraud_suspected: nil,
+    primary_id_type: nil,
+    secondary_id_type: nil,
+    failure_reason: nil,
+    transaction_end_date_time: nil,
+    transaction_start_date_time: nil,
+    status: nil,
+    assurance_level: nil,
+    proofing_post_office: nil,
+    proofing_city: nil,
+    proofing_state: nil,
+    scan_count: nil,
+    response_message: nil,
+    response_status_code: nil,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Exception raised',
+      reason: reason,
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      enrollment_code: enrollment_code,
+      minutes_since_established: minutes_since_established,
+      minutes_since_last_status_check: minutes_since_last_status_check,
+      minutes_since_last_status_update: minutes_since_last_status_update,
+      minutes_to_completion: minutes_to_completion,
+      fraud_suspected: fraud_suspected,
+      primary_id_type: primary_id_type,
+      secondary_id_type: secondary_id_type,
+      failure_reason: failure_reason,
+      transaction_end_date_time: transaction_end_date_time,
+      transaction_start_date_time: transaction_start_date_time,
+      status: status,
+      assurance_level: assurance_level,
+      proofing_post_office: proofing_post_office,
+      proofing_city: proofing_city,
+      proofing_state: proofing_state,
+      scan_count: scan_count,
+      response_message: response_message,
+      response_status_code: response_status_code,
+      **extra,
+    )
+  end
+
+  # GetUspsProofingResultsJob is beginning. Includes some metadata about what the job will do
+  # @param [Integer] enrollments_count number of enrollments eligible for status check
+  # @param [Integer] reprocess_delay_minutes minimum delay since last status check
+  def idv_in_person_usps_proofing_results_job_started(
+    enrollments_count:,
+    reprocess_delay_minutes:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Job started',
+      enrollments_count: enrollments_count,
+      reprocess_delay_minutes: reprocess_delay_minutes,
+      **extra,
+    )
+  end
+
+  # Tracks unexpected responses from the USPS API
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [Float] minutes_since_established
+  # @param [String] response_message
+  # @param [String] reason why was this error unexpected?
+  def idv_in_person_usps_proofing_results_job_unexpected_response(
+    enrollment_code:,
+    enrollment_id:,
+    minutes_since_established:,
+    response_message:,
+    reason:,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Unexpected response received',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      minutes_since_established: minutes_since_established,
+      response_message: response_message,
+      reason: reason,
+      **extra,
+    )
+  end
+
+  # Tracks if USPS in-person proofing enrollment request fails
+  # @param [String] context
+  # @param [String] reason
+  # @param [Integer] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  def idv_in_person_usps_request_enroll_exception(
+    context:,
+    reason:,
+    enrollment_id:,
     exception_class:,
     exception_message:,
     **extra
   )
     track_event(
-      'InPersonEnrollmentsReadyForStatusCheckJob: Ingestion error',
-      exception_class:,
-      exception_message:,
+      'USPS IPPaaS enrollment failed',
+      context: context,
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      reason: reason,
       **extra,
     )
-  end
-
-  # User has consented to share information with document upload and may
-  # view the "hybrid handoff" step next unless "skip_upload" param is true
-  def idv_doc_auth_agreement_submitted(**extra)
-    track_event('IdV: doc auth agreement submitted', **extra)
-  end
-
-  def idv_doc_auth_agreement_visited(**extra)
-    track_event('IdV: doc auth agreement visited', **extra)
-  end
-
-  def idv_doc_auth_cancel_link_sent_submitted(**extra)
-    track_event('IdV: doc auth cancel_link_sent submitted', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing cancel_update_ssn submitted
-  def idv_doc_auth_cancel_update_ssn_submitted(**extra)
-    track_event('IdV: doc auth cancel_update_ssn submitted', **extra)
-  end
-
-  def idv_doc_auth_capture_complete_visited(**extra)
-    track_event('IdV: doc auth capture_complete visited', **extra)
-  end
-
-  def idv_doc_auth_document_capture_visited(**extra)
-    track_event('IdV: doc auth document_capture visited', **extra)
-  end
-
-  def idv_doc_auth_document_capture_submitted(**extra)
-    track_event('IdV: doc auth document_capture submitted', **extra)
-  end
-
-  # @param [String] step_name which step the user was on
-  # @param [Integer] remaining_attempts how many attempts the user has left before we throttle them
-  # The user visited an error page due to an encountering an exception talking to a proofing vendor
-  def idv_doc_auth_exception_visited(step_name:, remaining_attempts:, **extra)
-    track_event(
-      'IdV: doc auth exception visited',
-      step_name: step_name,
-      remaining_attempts: remaining_attempts,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name IdV: doc auth send_link submitted
-  def idv_doc_auth_link_sent_submitted(**extra)
-    track_event('IdV: doc auth link_sent submitted', **extra)
-  end
-
-  def idv_doc_auth_link_sent_visited(**extra)
-    track_event('IdV: doc auth link_sent visited', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing optional verify_wait submitted
-  def idv_doc_auth_optional_verify_wait_submitted(**extra)
-    track_event('IdV: doc auth optional verify_wait submitted', **extra)
-  end
-
-  def idv_doc_auth_redo_document_capture_submitted(**extra)
-    track_event('IdV: doc auth redo_document_capture submitted', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing ssn submitted
-  def idv_doc_auth_ssn_submitted(**extra)
-    track_event('IdV: doc auth ssn submitted', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing ssn visited
-  def idv_doc_auth_ssn_visited(**extra)
-    track_event('IdV: doc auth ssn visited', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing redo_address submitted
-  def idv_doc_auth_redo_address_submitted(**extra)
-    track_event('IdV: doc auth redo_address submitted', **extra)
-  end
-
-  def idv_doc_auth_redo_ssn_submitted(**extra)
-    track_event('IdV: doc auth redo_ssn submitted', **extra)
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [Integer] attempts
-  # @param [Integer] remaining_attempts
-  # @param [String] user_id
-  # @param [String] flow_path
-  # The document capture image uploaded was locally validated during the IDV process
-  def idv_doc_auth_submitted_image_upload_form(
-    success:,
-    errors:,
-    remaining_attempts:,
-    flow_path:,
-    attempts: nil,
-    user_id: nil,
-    **extra
-  )
-    track_event(
-      'IdV: doc auth image upload form submitted',
-      success: success,
-      errors: errors,
-      attempts: attempts,
-      remaining_attempts: remaining_attempts,
-      user_id: user_id,
-      flow_path: flow_path,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [String] exception
-  # @param [Boolean] billed
-  # @param [String] doc_auth_result
-  # @param [String] state
-  # @param [String] state_id_type
-  # @param [Boolean] async
-  # @param [Integer] attempts
-  # @param [Integer] remaining_attempts
-  # @param [Hash] client_image_metrics
-  # @param [String] flow_path
-  # The document capture image was uploaded to vendor during the IDV process
-  def idv_doc_auth_submitted_image_upload_vendor(
-    success:,
-    errors:,
-    exception:,
-    state:,
-    state_id_type:,
-    async:, attempts:,
-    remaining_attempts:,
-    client_image_metrics:,
-    flow_path:,
-    billed: nil,
-    doc_auth_result: nil,
-    **extra
-  )
-    track_event(
-      'IdV: doc auth image upload vendor submitted',
-      success: success,
-      errors: errors,
-      exception: exception,
-      billed: billed,
-      doc_auth_result: doc_auth_result,
-      state: state,
-      state_id_type: state_id_type,
-      async: async,
-      attempts: attempts,
-      remaining_attempts: remaining_attempts,
-      client_image_metrics: client_image_metrics,
-      flow_path: flow_path,
-      **extra,
-    )
-  end
-
-  def idv_doc_auth_randomizer_defaulted
-    track_event(
-      'IdV: doc_auth random vendor error',
-      error: 'document_capture_session_uuid_key missing',
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [String] user_id
-  # @param [Integer] remaining_attempts
-  # @param [Hash] pii_like_keypaths
-  # @param [String] flow_path
-  # The PII that came back from the document capture vendor was validated
-  def idv_doc_auth_submitted_pii_validation(
-    success:,
-    errors:,
-    remaining_attempts:,
-    pii_like_keypaths:,
-    flow_path:,
-    user_id: nil,
-    **extra
-  )
-    track_event(
-      'IdV: doc auth image upload vendor pii validation',
-      success: success,
-      errors: errors,
-      user_id: user_id,
-      remaining_attempts: remaining_attempts,
-      pii_like_keypaths: pii_like_keypaths,
-      flow_path: flow_path,
-      **extra,
-    )
-  end
-
-  # The "hybrid handoff" step: Desktop user has submitted their choice to
-  # either continue via desktop ("document_capture" destination) or switch
-  # to mobile phone ("send_link" destination) to perform document upload.
-  # Mobile users still log this event but with skip_upload_step = true
-  def idv_doc_auth_upload_submitted(**extra)
-    track_event('IdV: doc auth upload submitted', **extra)
-  end
-
-  # Desktop user has reached the above "hybrid handoff" view
-  def idv_doc_auth_upload_visited(**extra)
-    track_event('IdV: doc auth upload visited', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing verify submitted
-  def idv_doc_auth_verify_submitted(**extra)
-    track_event('IdV: doc auth verify submitted', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing verify visited
-  def idv_doc_auth_verify_visited(**extra)
-    track_event('IdV: doc auth verify visited', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: doc auth optional verify_wait submitted
-  def idv_doc_auth_verify_proofing_results(**extra)
-    track_event('IdV: doc auth verify proofing results', **extra)
-  end
-
-  # @identity.idp.previous_event_name IdV: in person proofing verify_wait visited
-  def idv_doc_auth_verify_wait_step_visited(**extra)
-    track_event('IdV: doc auth verify_wait visited', **extra)
-  end
-
-  # @param [String] step_name
-  # @param [Integer] remaining_attempts
-  # The user was sent to a warning page during the IDV flow
-  def idv_doc_auth_warning_visited(
-    step_name:,
-    remaining_attempts:,
-    **extra
-  )
-    track_event(
-      'IdV: doc auth warning visited',
-      step_name: step_name,
-      remaining_attempts: remaining_attempts,
-      **extra,
-    )
-  end
-
-  def idv_doc_auth_welcome_submitted(**extra)
-    track_event('IdV: doc auth welcome submitted', **extra)
-  end
-
-  def idv_doc_auth_welcome_visited(**extra)
-    track_event('IdV: doc auth welcome visited', **extra)
-  end
-
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # User visited forgot password page
-  def idv_forgot_password(proofing_components: nil, **extra)
-    track_event(
-      'IdV: forgot password visited',
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # User confirmed forgot password
-  def idv_forgot_password_confirmed(proofing_components: nil, **extra)
-    track_event(
-      'IdV: forgot password confirmed',
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [DateTime] enqueued_at
-  # @param [Boolean] resend
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # GPO letter was enqueued and the time at which it was enqueued
-  def idv_gpo_address_letter_enqueued(enqueued_at:, resend:, proofing_components: nil, **extra)
-    track_event(
-      'IdV: USPS address letter enqueued',
-      enqueued_at: enqueued_at,
-      resend: resend,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] resend
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # GPO letter was requested
-  def idv_gpo_address_letter_requested(resend:, proofing_components: nil, **extra)
-    track_event(
-      'IdV: USPS address letter requested',
-      resend: resend,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] letter_already_sent
-  # GPO address visited
-  def idv_gpo_address_visited(
-    letter_already_sent:,
-    **extra
-  )
-    track_event(
-      'IdV: USPS address visited',
-      letter_already_sent: letter_already_sent,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name Account verification submitted
-  # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [Hash] pii_like_keypaths
-  # GPO verification submitted
-  def idv_gpo_verification_submitted(
-    success:,
-    errors:,
-    pii_like_keypaths:,
-    **extra
-  )
-    track_event(
-      'IdV: GPO verification submitted',
-      success: success,
-      errors: errors,
-      pii_like_keypaths: pii_like_keypaths,
-      **extra,
-    )
-  end
-
-  # @identity.idp.previous_event_name Account verification visited
-  # GPO verification visited
-  def idv_gpo_verification_visited
-    track_event('IdV: GPO verification visited')
   end
 
   # User visits IdV
@@ -1338,39 +1730,77 @@ module AnalyticsEvents
     track_event('IdV: intro visited')
   end
 
-  # @param [Boolean] success
-  # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
-  # @param [Boolean] fraud_review_pending Profile is under review for fraud
-  # @param [Boolean] fraud_rejection Profile is rejected due to fraud
-  # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verificaiton
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # Tracks the last step of IDV, indicates the user successfully proofed
-  def idv_final(
-    success:,
-    fraud_review_pending:,
-    fraud_rejection:,
-    gpo_verification_pending:,
-    deactivation_reason: nil,
-    proofing_components: nil,
+  # Tracks whether the user's device appears to be mobile device with a camera attached.
+  # @param [Boolean] is_camera_capable_mobile Whether we think the device _could_ have a camera.
+  # @param [Boolean,nil] camera_present Whether the user's device _actually_ has a camera available.
+  # @param [Integer,nil] grace_time Extra time allowed for browser to report camera availability.
+  # @param [Integer,nil] duration Time taken for browser to report camera availability.
+  def idv_mobile_device_and_camera_check(
+    is_camera_capable_mobile:,
+    camera_present: nil,
+    grace_time: nil,
+    duration: nil,
     **extra
   )
     track_event(
-      'IdV: final resolution',
-      success: success,
-      fraud_review_pending: fraud_review_pending,
-      fraud_rejection: fraud_rejection,
-      gpo_verification_pending: gpo_verification_pending,
-      deactivation_reason: deactivation_reason,
+      'IdV: Mobile device and camera check',
+      is_camera_capable_mobile: is_camera_capable_mobile,
+      camera_present: camera_present,
+      grace_time: grace_time,
+      duration: duration,
+      **extra,
+    )
+  end
+
+  # @param [Integer] failed_capture_attempts Number of failed Acuant SDK attempts
+  # @param [Integer] failed_submission_attempts Number of failed Acuant doc submissions
+  # @param [String] field Image form field
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
+  # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
+  # camera, on mobile devices.
+  def idv_native_camera_forced(
+    failed_capture_attempts:,
+    failed_submission_attempts:,
+    field:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: Native camera forced after failed attempts',
+      failed_capture_attempts: failed_capture_attempts,
+      failed_submission_attempts: failed_submission_attempts,
+      field: field,
+      flow_path: flow_path,
+      **extra,
+    )
+  end
+
+  # Tracks when user reaches verify errors due to being rejected due to fraud
+  def idv_not_verified_visited
+    track_event('IdV: Not verified visited')
+  end
+
+  # Tracks if a user clicks the 'acknowledge' checkbox during personal
+  # key creation
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [boolean] checked whether the user checked or un-checked
+  #                  the box with this click
+  def idv_personal_key_acknowledgment_toggled(checked:, proofing_components:, **extra)
+    track_event(
+      'IdV: personal key acknowledgment toggled',
+      checked: checked,
       proofing_components: proofing_components,
       **extra,
     )
   end
 
+  # A user has downloaded their personal key. This event is no longer emitted.
+  # @identity.idp.previous_event_name IdV: download personal key
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # User visited IDV personal key page
-  def idv_personal_key_visited(proofing_components: nil, **extra)
+  def idv_personal_key_downloaded(proofing_components: nil, **extra)
     track_event(
-      'IdV: personal key visited',
+      'IdV: personal key downloaded',
       proofing_components: proofing_components,
       **extra,
     )
@@ -1398,17 +1828,11 @@ module AnalyticsEvents
     )
   end
 
-  # A user has downloaded their backup codes
-  def multi_factor_auth_backup_code_download
-    track_event('Multi-Factor Authentication: download backup code')
-  end
-
-  # A user has downloaded their personal key. This event is no longer emitted.
-  # @identity.idp.previous_event_name IdV: download personal key
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  def idv_personal_key_downloaded(proofing_components: nil, **extra)
+  # User visited IDV personal key page
+  def idv_personal_key_visited(proofing_components: nil, **extra)
     track_event(
-      'IdV: personal key downloaded',
+      'IdV: personal key visited',
       proofing_components: proofing_components,
       **extra,
     )
@@ -1542,25 +1966,6 @@ module AnalyticsEvents
 
   # @param [Boolean] success
   # @param [Hash] errors
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # The vendor finished the process of confirming the users phone
-  def idv_phone_confirmation_vendor_submitted(
-    success:,
-    errors:,
-    proofing_components: nil,
-    **extra
-  )
-    track_event(
-      'IdV: phone confirmation vendor',
-      success: success,
-      errors: errors,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] errors
   # @param [Boolean] code_expired if the one-time code expired
   # @param [Boolean] code_matches
   # @param [Integer] second_factor_attempts_count number of attempts to confirm this phone
@@ -1600,6 +2005,25 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # The vendor finished the process of confirming the users phone
+  def idv_phone_confirmation_vendor_submitted(
+    success:,
+    errors:,
+    proofing_components: nil,
+    **extra
+  )
+    track_event(
+      'IdV: phone confirmation vendor',
+      success: success,
+      errors: errors,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
   # @param ['warning','jobfail','failure'] type
   # @param [Time] throttle_expires_at when the throttle expires
   # @param [Integer] remaining_attempts number of attempts remaining
@@ -1621,6 +2045,16 @@ module AnalyticsEvents
         remaining_attempts: remaining_attempts,
         **extra,
       }.compact,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # User visited idv phone of record
+  def idv_phone_of_record_visited(proofing_components: nil, **extra)
+    track_event(
+      'IdV: phone of record visited',
+      proofing_components: proofing_components,
+      **extra,
     )
   end
 
@@ -1651,16 +2085,6 @@ module AnalyticsEvents
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # User visited idv phone of record
-  def idv_phone_of_record_visited(proofing_components: nil, **extra)
-    track_event(
-      'IdV: phone of record visited',
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # User visited idv phone OTP delivery selection
   def idv_phone_otp_delivery_selection_visit(proofing_components: nil, **extra)
     track_event(
@@ -1677,6 +2101,17 @@ module AnalyticsEvents
     track_event(
       'IdV: use different phone number',
       step: step,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @identity.idp.previous_event_name IdV: Verify setup errors visited
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # Tracks when the user reaches the verify please call page after failing proofing
+  def idv_please_call_visited(proofing_components: nil, **extra)
+    track_event(
+      'IdV: Verify please call visited',
       proofing_components: proofing_components,
       **extra,
     )
@@ -1736,6 +2171,22 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when the user visits one of the the session error pages.
+  # @param [String] type
+  # @param [Integer,nil] attempts_remaining
+  def idv_session_error_visited(
+    type:,
+    attempts_remaining: nil,
+    **extra
+  )
+    track_event(
+      'IdV: session error visited',
+      type: type,
+      attempts_remaining: attempts_remaining,
+      **extra,
+    )
+  end
+
   # @param [String] step
   # @param [String] location
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
@@ -1751,6 +2202,19 @@ module AnalyticsEvents
       step: step,
       location: location,
       proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param [String] in_person_cta_variant Variant testing bucket label
+  # The user clicked the troubleshooting option to start in-person proofing
+  def idv_verify_in_person_troubleshooting_option_clicked(flow_path:, in_person_cta_variant:,
+                                                          **extra)
+    track_event(
+      'IdV: verify in person troubleshooting option clicked',
+      flow_path: flow_path,
+      in_person_cta_variant: in_person_cta_variant,
       **extra,
     )
   end
@@ -1771,21 +2235,20 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] controller
-  # @param [String] referer
-  # @param [Boolean] user_signed_in
-  # Redirect was almost sent to an invalid external host unexpectedly
-  def unsafe_redirect_error(
-    controller:,
-    referer:,
-    user_signed_in: nil,
+  # @param [String] event_type
+  # @param [Integer] unencrypted_payload_num_bytes size of payload as JSON data
+  # @param [Boolean] recorded if the full event was recorded or not
+  def irs_attempts_api_event_metadata(
+    event_type:,
+    unencrypted_payload_num_bytes:,
+    recorded:,
     **extra
   )
     track_event(
-      'Unsafe Redirect',
-      controller: controller,
-      referer: referer,
-      user_signed_in: user_signed_in,
+      'IRS Attempt API: Event metadata',
+      event_type: event_type,
+      unencrypted_payload_num_bytes: unencrypted_payload_num_bytes,
+      recorded: recorded,
       **extra,
     )
   end
@@ -1808,24 +2271,6 @@ module AnalyticsEvents
       authenticated: authenticated,
       elapsed_time: elapsed_time,
       success: success,
-      **extra,
-    )
-  end
-
-  # @param [String] event_type
-  # @param [Integer] unencrypted_payload_num_bytes size of payload as JSON data
-  # @param [Boolean] recorded if the full event was recorded or not
-  def irs_attempts_api_event_metadata(
-    event_type:,
-    unencrypted_payload_num_bytes:,
-    recorded:,
-    **extra
-  )
-    track_event(
-      'IRS Attempt API: Event metadata',
-      event_type: event_type,
-      unencrypted_payload_num_bytes: unencrypted_payload_num_bytes,
-      recorded: recorded,
       **extra,
     )
   end
@@ -1856,126 +2301,6 @@ module AnalyticsEvents
   )
     track_event(
       'Logout Initiated',
-      success: success,
-      client_id: client_id,
-      client_id_parameter_present: client_id_parameter_present,
-      id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
-      error_details: error_details,
-      sp_initiated: sp_initiated,
-      oidc: oidc,
-      saml_request_valid: saml_request_valid,
-      method: method,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [String] client_id
-  # @param [Boolean] client_id_parameter_present
-  # @param [Boolean] id_token_hint_parameter_present
-  # @param [Boolean] sp_initiated
-  # @param [Boolean] oidc
-  # @param [Boolean] saml_request_valid
-  # @param [Hash] errors
-  # @param [Hash] error_details
-  # @param [String] method
-  # OIDC Logout Requested
-  def oidc_logout_requested(
-    success: nil,
-    client_id: nil,
-    sp_initiated: nil,
-    oidc: nil,
-    client_id_parameter_present: nil,
-    id_token_hint_parameter_present: nil,
-    saml_request_valid: nil,
-    errors: nil,
-    error_details: nil,
-    method: nil,
-    **extra
-  )
-    track_event(
-      'OIDC Logout Requested',
-      success: success,
-      client_id: client_id,
-      client_id_parameter_present: client_id_parameter_present,
-      id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
-      error_details: error_details,
-      sp_initiated: sp_initiated,
-      oidc: oidc,
-      saml_request_valid: saml_request_valid,
-      method: method,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [String] client_id
-  # @param [Boolean] client_id_parameter_present
-  # @param [Boolean] id_token_hint_parameter_present
-  # @param [Boolean] sp_initiated
-  # @param [Boolean] oidc
-  # @param [Boolean] saml_request_valid
-  # @param [Hash] errors
-  # @param [Hash] error_details
-  # @param [String] method
-  # OIDC Logout Visited
-  def oidc_logout_visited(
-    success: nil,
-    client_id: nil,
-    sp_initiated: nil,
-    oidc: nil,
-    client_id_parameter_present: nil,
-    id_token_hint_parameter_present: nil,
-    saml_request_valid: nil,
-    errors: nil,
-    error_details: nil,
-    method: nil,
-    **extra
-  )
-    track_event(
-      'OIDC Logout Page Visited',
-      success: success,
-      client_id: client_id,
-      client_id_parameter_present: client_id_parameter_present,
-      id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
-      error_details: error_details,
-      sp_initiated: sp_initiated,
-      oidc: oidc,
-      saml_request_valid: saml_request_valid,
-      method: method,
-      **extra,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [String] client_id
-  # @param [Boolean] client_id_parameter_present
-  # @param [Boolean] id_token_hint_parameter_present
-  # @param [Boolean] sp_initiated
-  # @param [Boolean] oidc
-  # @param [Boolean] saml_request_valid
-  # @param [Hash] errors
-  # @param [Hash] error_details
-  # @param [String] method
-  # OIDC Logout Submitted
-  def oidc_logout_submitted(
-    success: nil,
-    client_id: nil,
-    sp_initiated: nil,
-    oidc: nil,
-    client_id_parameter_present: nil,
-    id_token_hint_parameter_present: nil,
-    saml_request_valid: nil,
-    errors: nil,
-    error_details: nil,
-    method: nil,
-    **extra
-  )
-    track_event(
-      'OIDC Logout Submitted',
       success: success,
       client_id: client_id,
       client_id_parameter_present: client_id_parameter_present,
@@ -2098,6 +2423,11 @@ module AnalyticsEvents
     )
   end
 
+  # A user has downloaded their backup codes
+  def multi_factor_auth_backup_code_download
+    track_event('Multi-Factor Authentication: download backup code')
+  end
+
   # Tracks when the user visits the backup code confirmation setup page
   # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
   def multi_factor_auth_enter_backup_code_confirmation_visit(
@@ -2118,6 +2448,28 @@ module AnalyticsEvents
     track_event(
       'Multi-Factor Authentication: enter backup code visited',
       context: context,
+      **extra,
+    )
+  end
+
+  # @param [String] context
+  # @param [String] multi_factor_auth_method
+  # @param [Boolean] confirmation_for_add_phone
+  # @param [Integer] phone_configuration_id
+  # Multi-Factor Authentication enter OTP visited
+  def multi_factor_auth_enter_otp_visit(
+    context:,
+    multi_factor_auth_method:,
+    confirmation_for_add_phone:,
+    phone_configuration_id:,
+    **extra
+  )
+    track_event(
+      'Multi-Factor Authentication: enter OTP visited',
+      context: context,
+      multi_factor_auth_method: multi_factor_auth_method,
+      confirmation_for_add_phone: confirmation_for_add_phone,
+      phone_configuration_id: phone_configuration_id,
       **extra,
     )
   end
@@ -2147,28 +2499,6 @@ module AnalyticsEvents
       context: context,
       multi_factor_auth_method: multi_factor_auth_method,
       piv_cac_configuration_id: piv_cac_configuration_id,
-      **extra,
-    )
-  end
-
-  # @param [String] context
-  # @param [String] multi_factor_auth_method
-  # @param [Boolean] confirmation_for_add_phone
-  # @param [Integer] phone_configuration_id
-  # Multi-Factor Authentication enter OTP visited
-  def multi_factor_auth_enter_otp_visit(
-    context:,
-    multi_factor_auth_method:,
-    confirmation_for_add_phone:,
-    phone_configuration_id:,
-    **extra
-  )
-    track_event(
-      'Multi-Factor Authentication: enter OTP visited',
-      context: context,
-      multi_factor_auth_method: multi_factor_auth_method,
-      confirmation_for_add_phone: confirmation_for_add_phone,
-      phone_configuration_id: phone_configuration_id,
       **extra,
     )
   end
@@ -2203,6 +2533,11 @@ module AnalyticsEvents
   # Max multi factor auth attempts met
   def multi_factor_auth_max_attempts
     track_event('Multi-Factor Authentication: max attempts reached')
+  end
+
+  # Max multi factor max otp sends reached
+  def multi_factor_auth_max_sends
+    track_event('Multi-Factor Authentication: max otp sends reached')
   end
 
   # Multi factor selected from auth options list
@@ -2242,7 +2577,6 @@ module AnalyticsEvents
                                     phone_type:,
                                     types:,
                                     **extra)
-
     track_event(
       'Multi-Factor Authentication: phone setup',
       success: success,
@@ -2255,11 +2589,6 @@ module AnalyticsEvents
       types: types,
       **extra,
     )
-  end
-
-  # Max multi factor max otp sends reached
-  def multi_factor_auth_max_sends
-    track_event('Multi-Factor Authentication: max otp sends reached')
   end
 
   # Tracks when a user sets up a multi factor auth method
@@ -2283,6 +2612,126 @@ module AnalyticsEvents
       multi_factor_auth_method: multi_factor_auth_method,
       in_multi_mfa_selection_flow: in_multi_mfa_selection_flow,
       enabled_mfa_methods_count: enabled_mfa_methods_count,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Requested
+  def oidc_logout_requested(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Requested',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Submitted
+  def oidc_logout_submitted(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Submitted',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [String] client_id
+  # @param [Boolean] client_id_parameter_present
+  # @param [Boolean] id_token_hint_parameter_present
+  # @param [Boolean] sp_initiated
+  # @param [Boolean] oidc
+  # @param [Boolean] saml_request_valid
+  # @param [Hash] errors
+  # @param [Hash] error_details
+  # @param [String] method
+  # OIDC Logout Visited
+  def oidc_logout_visited(
+    success: nil,
+    client_id: nil,
+    sp_initiated: nil,
+    oidc: nil,
+    client_id_parameter_present: nil,
+    id_token_hint_parameter_present: nil,
+    saml_request_valid: nil,
+    errors: nil,
+    error_details: nil,
+    method: nil,
+    **extra
+  )
+    track_event(
+      'OIDC Logout Page Visited',
+      success: success,
+      client_id: client_id,
+      client_id_parameter_present: client_id_parameter_present,
+      id_token_hint_parameter_present: id_token_hint_parameter_present,
+      errors: errors,
+      error_details: error_details,
+      sp_initiated: sp_initiated,
+      oidc: oidc,
+      saml_request_valid: saml_request_valid,
+      method: method,
       **extra,
     )
   end
@@ -2345,87 +2794,6 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when user is redirected to OTP expired page
-  # @param [String] otp_sent_at
-  # @param [String] otp_expiration
-  def otp_expired_visited(otp_sent_at:, otp_expiration:, **extra)
-    track_event(
-      'OTP Expired Page Visited',
-      otp_sent_at: otp_sent_at,
-      otp_expiration: otp_expiration,
-      **extra,
-    )
-  end
-
-  # Tracks if otp phone validation failed
-  # @identity.idp.previous_event_name Twilio Phone Validation Failed
-  # @param [String] error
-  # @param [String] context
-  # @param [String] country
-  def otp_phone_validation_failed(error:, context:, country:, **extra)
-    track_event(
-      'Vendor Phone Validation failed',
-      error: error,
-      context: context,
-      country: country,
-      **extra,
-    )
-  end
-
-  # User has been marked as authenticated
-  # @param [String] authentication_type
-  def user_marked_authed(authentication_type:, **extra)
-    track_event(
-      'User marked authenticated',
-      authentication_type: authentication_type,
-      **extra,
-    )
-  end
-
-  # User has attempted to access an action that requires re-authenticating
-  # @param [String] auth_method
-  # @param [String] authenticated_at
-  def user_2fa_reauthentication_required(auth_method:, authenticated_at:, **extra)
-    track_event(
-      'User 2FA Reauthentication Required',
-      auth_method: auth_method,
-      authenticated_at: authenticated_at,
-      **extra,
-    )
-  end
-
-  # User registration has been handed off to agency page
-  # @param [Boolean] ial2
-  # @param [Integer] ialmax
-  # @param [String] service_provider_name
-  # @param [String] page_occurence
-  # @param [String] needs_completion_screen_reason
-  # @param [Array] sp_request_requested_attributes
-  # @param [Array] sp_session_requested_attributes
-  def user_registration_agency_handoff_page_visit(
-      ial2:,
-      service_provider_name:,
-      page_occurence:,
-      needs_completion_screen_reason:,
-      sp_session_requested_attributes:,
-      sp_request_requested_attributes: nil,
-      ialmax: nil,
-      **extra
-    )
-
-    track_event(
-      'User registration: agency handoff visited',
-      ial2: ial2,
-      ialmax: ialmax,
-      service_provider_name: service_provider_name,
-      page_occurence: page_occurence,
-      needs_completion_screen_reason: needs_completion_screen_reason,
-      sp_request_requested_attributes: sp_request_requested_attributes,
-      sp_session_requested_attributes: sp_session_requested_attributes,
-      **extra,
-    )
-  end
-
   # Tracks when user makes an otp delivery selection
   # @param [String] otp_delivery_preference (sms or voice)
   # @param [Boolean] resend
@@ -2450,6 +2818,33 @@ module AnalyticsEvents
       area_code: area_code,
       context: context,
       pii_like_keypaths: pii_like_keypaths,
+      **extra,
+    )
+  end
+
+  # Tracks when user is redirected to OTP expired page
+  # @param [String] otp_sent_at
+  # @param [String] otp_expiration
+  def otp_expired_visited(otp_sent_at:, otp_expiration:, **extra)
+    track_event(
+      'OTP Expired Page Visited',
+      otp_sent_at: otp_sent_at,
+      otp_expiration: otp_expiration,
+      **extra,
+    )
+  end
+
+  # Tracks if otp phone validation failed
+  # @identity.idp.previous_event_name Twilio Phone Validation Failed
+  # @param [String] error
+  # @param [String] context
+  # @param [String] country
+  def otp_phone_validation_failed(error:, context:, country:, **extra)
+    track_event(
+      'Vendor Phone Validation failed',
+      error: error,
+      context: context,
+      country: country,
       **extra,
     )
   end
@@ -2504,11 +2899,6 @@ module AnalyticsEvents
       profile_deactivated: profile_deactivated,
       **extra,
     )
-  end
-
-  # User has visited the page that lets them confirm if they want a new personal key
-  def profile_personal_key_visit
-    track_event('Profile: Visited new personal key')
   end
 
   # @param [Boolean] success
@@ -2647,6 +3037,22 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String] redirect_url URL user was directed to
+  # @param [String, nil] step which step
+  # @param [String, nil] location which part of a step, if applicable
+  # @param ["idv", String, nil] flow which flow
+  # User was redirected to the login.gov policy page
+  def policy_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
+    track_event(
+      'Policy Page Redirect',
+      redirect_url: redirect_url,
+      step: step,
+      location: location,
+      flow: flow,
+      **extra,
+    )
+  end
+
   # @param [String] error
   # Tracks if a Profile encryption is invalid
   def profile_encryption_invalid(error:, **extra)
@@ -2673,6 +3079,11 @@ module AnalyticsEvents
       sms_message_ids: sms_message_ids,
       **extra,
     )
+  end
+
+  # User has visited the page that lets them confirm if they want a new personal key
+  def profile_personal_key_visit
+    track_event('Profile: Visited new personal key')
   end
 
   # @identity.idp.previous_event_name Proofing Address Timeout
@@ -2736,6 +3147,22 @@ module AnalyticsEvents
     )
   end
 
+  # Service provider completed remote logout
+  # @param [String] service_provider
+  # @param [String] user_id
+  def remote_logout_completed(
+    service_provider:,
+    user_id:,
+    **extra
+  )
+    track_event(
+      'Remote Logout completed',
+      service_provider: service_provider,
+      user_id: user_id,
+      **extra,
+    )
+  end
+
   # Service provider initiated remote logout
   # @param [String] service_provider
   # @param [Boolean] saml_request_valid
@@ -2752,18 +3179,12 @@ module AnalyticsEvents
     )
   end
 
-  # Service provider completed remote logout
-  # @param [String] service_provider
-  # @param [String] user_id
-  def remote_logout_completed(
-    service_provider:,
-    user_id:,
-    **extra
-  )
+  # @param [Boolean] success
+  # Tracks request for resending confirmation for new emails to an account
+  def resend_add_email_request(success:, **extra)
     track_event(
-      'Remote Logout completed',
-      service_provider: service_provider,
-      user_id: user_id,
+      'Resend Add Email Requested',
+      success: success,
       **extra,
     )
   end
@@ -2825,11 +3246,6 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when rules of use is visited
-  def rules_of_use_visit
-    track_event('Rules of Use Visited')
-  end
-
   # Tracks when rules of use is submitted with a success or failure
   # @param [Boolean] success
   # @param [Hash] errors
@@ -2842,113 +3258,9 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when security event is received
-  # @param [Boolean] success
-  # @param [String] error_code
-  # @param [Hash] errors
-  # @param [String] jti
-  # @param [String] user_id
-  # @param [String] client_id
-  def security_event_received(
-    success:,
-    error_code: nil,
-    errors: nil,
-    jti: nil,
-    user_id: nil,
-    client_id: nil,
-    **extra
-  )
-    track_event(
-      'RISC: Security event received',
-      success: success,
-      error_code: error_code,
-      errors: errors,
-      jti: jti,
-      user_id: user_id,
-      client_id: client_id,
-      **extra,
-    )
-  end
-
-  # Tracks when a user is bounced back from the service provider due to an integration issue.
-  def sp_handoff_bounced_detected
-    track_event('SP handoff bounced detected')
-  end
-
-  # Tracks when a user visits the bounced page.
-  def sp_handoff_bounced_visit
-    track_event('SP handoff bounced visited')
-  end
-
-  # Tracks when a user visits the "This agency no longer uses Login.gov" page.
-  def sp_inactive_visit
-    track_event('SP inactive visited')
-  end
-
-  # Tracks when a user is redirected back to the service provider
-  # @param [Integer] ial
-  # @param [Integer] billed_ial
-  def sp_redirect_initiated(ial:, billed_ial:, **extra)
-    track_event(
-      'SP redirect initiated',
-      ial: ial,
-      billed_ial: billed_ial,
-      **extra,
-    )
-  end
-
-  # Tracks when a user triggered a rate limit throttle
-  # @param [String] throttle_type
-  def throttler_rate_limit_triggered(throttle_type:, **extra)
-    track_event(
-      'Throttler Rate Limit Triggered',
-      throttle_type: throttle_type,
-      **extra,
-    )
-  end
-
-  # Tracks when a user visits TOTP device setup
-  # @param [Boolean] user_signed_up
-  # @param [Boolean] totp_secret_present
-  # @param [Integer] enabled_mfa_methods_count
-  def totp_setup_visit(
-    user_signed_up:,
-    totp_secret_present:,
-    enabled_mfa_methods_count:,
-    **extra
-  )
-    track_event(
-      'TOTP Setup Visited',
-      user_signed_up: user_signed_up,
-      totp_secret_present: totp_secret_present,
-      enabled_mfa_methods_count: enabled_mfa_methods_count,
-      **extra,
-    )
-  end
-
-  # Tracks when a user disabled a TOTP device
-  def totp_user_disabled
-    track_event('TOTP: User Disabled')
-  end
-
-  # Tracks when service provider consent is revoked
-  # @param [String] issuer issuer of the service provider consent to be revoked
-  def sp_revoke_consent_revoked(issuer:, **extra)
-    track_event(
-      'SP Revoke Consent: Revoked',
-      issuer: issuer,
-      **extra,
-    )
-  end
-
-  # Tracks when the page to revoke consent (unlink from) a service provider visited
-  # @param [String] issuer which issuer
-  def sp_revoke_consent_visited(issuer:, **extra)
-    track_event(
-      'SP Revoke Consent: Visited',
-      issuer: issuer,
-      **extra,
-    )
+  # Tracks when rules of use is visited
+  def rules_of_use_visit
+    track_event('Rules of Use Visited')
   end
 
   # Record SAML authentication payload Hash
@@ -3003,6 +3315,34 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when security event is received
+  # @param [Boolean] success
+  # @param [String] error_code
+  # @param [Hash] errors
+  # @param [String] jti
+  # @param [String] user_id
+  # @param [String] client_id
+  def security_event_received(
+    success:,
+    error_code: nil,
+    errors: nil,
+    jti: nil,
+    user_id: nil,
+    client_id: nil,
+    **extra
+  )
+    track_event(
+      'RISC: Security event received',
+      success: success,
+      error_code: error_code,
+      errors: errors,
+      jti: jti,
+      user_id: user_id,
+      client_id: client_id,
+      **extra,
+    )
+  end
+
   # tracks if the session is kept alive
   def session_kept_alive
     track_event('Session Kept Alive')
@@ -3016,6 +3356,12 @@ module AnalyticsEvents
   # tracks when a user's session is timed out
   def session_total_duration_timeout
     track_event('User Maximum Session Length Exceeded')
+  end
+
+  # Tracks if a user clicks the "Show Password button"
+  # @param [String] path URL path where the click occurred
+  def show_password_button_clicked(path:, **extra)
+    track_event('Show Password Button Clicked', path: path, **extra)
   end
 
   # @param [String] flash
@@ -3073,6 +3419,53 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when a user is bounced back from the service provider due to an integration issue.
+  def sp_handoff_bounced_detected
+    track_event('SP handoff bounced detected')
+  end
+
+  # Tracks when a user visits the bounced page.
+  def sp_handoff_bounced_visit
+    track_event('SP handoff bounced visited')
+  end
+
+  # Tracks when a user visits the "This agency no longer uses Login.gov" page.
+  def sp_inactive_visit
+    track_event('SP inactive visited')
+  end
+
+  # Tracks when a user is redirected back to the service provider
+  # @param [Integer] ial
+  # @param [Integer] billed_ial
+  def sp_redirect_initiated(ial:, billed_ial:, **extra)
+    track_event(
+      'SP redirect initiated',
+      ial: ial,
+      billed_ial: billed_ial,
+      **extra,
+    )
+  end
+
+  # Tracks when service provider consent is revoked
+  # @param [String] issuer issuer of the service provider consent to be revoked
+  def sp_revoke_consent_revoked(issuer:, **extra)
+    track_event(
+      'SP Revoke Consent: Revoked',
+      issuer: issuer,
+      **extra,
+    )
+  end
+
+  # Tracks when the page to revoke consent (unlink from) a service provider visited
+  # @param [String] issuer which issuer
+  def sp_revoke_consent_visited(issuer:, **extra)
+    track_event(
+      'SP Revoke Consent: Visited',
+      issuer: issuer,
+      **extra,
+    )
+  end
+
   # @param [String] area_code
   # @param [String] country_code
   # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
@@ -3113,10 +3506,78 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks When users visit the add phone page
-  def add_phone_setup_visit
+  # Tracks when a user triggered a rate limit throttle
+  # @param [String] throttle_type
+  def throttler_rate_limit_triggered(throttle_type:, **extra)
     track_event(
-      'Phone Setup Visited',
+      'Throttler Rate Limit Triggered',
+      throttle_type: throttle_type,
+      **extra,
+    )
+  end
+
+  # Tracks when a user visits TOTP device setup
+  # @param [Boolean] user_signed_up
+  # @param [Boolean] totp_secret_present
+  # @param [Integer] enabled_mfa_methods_count
+  def totp_setup_visit(
+    user_signed_up:,
+    totp_secret_present:,
+    enabled_mfa_methods_count:,
+    **extra
+  )
+    track_event(
+      'TOTP Setup Visited',
+      user_signed_up: user_signed_up,
+      totp_secret_present: totp_secret_present,
+      enabled_mfa_methods_count: enabled_mfa_methods_count,
+      **extra,
+    )
+  end
+
+  # Tracks when a user disabled a TOTP device
+  def totp_user_disabled
+    track_event('TOTP: User Disabled')
+  end
+
+  # @param [String] controller
+  # @param [String] referer
+  # @param [Boolean] user_signed_in
+  # Redirect was almost sent to an invalid external host unexpectedly
+  def unsafe_redirect_error(
+    controller:,
+    referer:,
+    user_signed_in: nil,
+    **extra
+  )
+    track_event(
+      'Unsafe Redirect',
+      controller: controller,
+      referer: referer,
+      user_signed_in: user_signed_in,
+      **extra,
+    )
+  end
+
+  # User has attempted to access an action that requires re-authenticating
+  # @param [String] auth_method
+  # @param [String] authenticated_at
+  def user_2fa_reauthentication_required(auth_method:, authenticated_at:, **extra)
+    track_event(
+      'User 2FA Reauthentication Required',
+      auth_method: auth_method,
+      authenticated_at: authenticated_at,
+      **extra,
+    )
+  end
+
+  # User has been marked as authenticated
+  # @param [String] authentication_type
+  def user_marked_authed(authentication_type:, **extra)
+    track_event(
+      'User marked authenticated',
+      authentication_type: authentication_type,
+      **extra,
     )
   end
 
@@ -3179,68 +3640,6 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] mfa_method
-  # Tracks when the the user fully registered by submitting their first MFA method into the system
-  def user_registration_user_fully_registered(
-    mfa_method:,
-    **extra
-  )
-    track_event(
-      'User Registration: User Fully Registered',
-      {
-        mfa_method: mfa_method,
-        **extra,
-      }.compact,
-    )
-  end
-
-  # @param [Boolean] success
-  # @param [Hash] mfa_method_counts
-  # @param [Integer] enabled_mfa_methods_count
-  # @param [Hash] pii_like_keypaths
-  # Tracks when a user has completed MFA setup
-  def user_registration_mfa_setup_complete(
-    success:,
-    mfa_method_counts:,
-    enabled_mfa_methods_count:,
-    pii_like_keypaths:,
-    **extra
-  )
-    track_event(
-      'User Registration: MFA Setup Complete',
-      {
-        success: success,
-        mfa_method_counts: mfa_method_counts,
-        enabled_mfa_methods_count: enabled_mfa_methods_count,
-        pii_like_keypaths: pii_like_keypaths,
-        **extra,
-      }.compact,
-    )
-  end
-
-  # Tracks when user's piv cac is disabled
-  def user_registration_piv_cac_disabled
-    track_event('User Registration: piv cac disabled')
-  end
-
-  # Tracks when user's piv cac setup
-  def user_registration_piv_cac_setup_visit(**extra)
-    track_event(
-      'User Registration: piv cac setup visited',
-      **extra,
-    )
-  end
-
-  # Tracks when user visits Suggest Another MFA Page
-  def user_registration_suggest_another_mfa_notice_visited
-    track_event('User Registration: Suggest Another MFA Notice visited')
-  end
-
-  # Tracks when user skips Suggest Another MFA Page
-  def user_registration_suggest_another_mfa_notice_skipped
-    track_event('User Registration: Suggest Another MFA Notice Skipped')
-  end
-
   # Tracks when user visits MFA selection page
   # @param [String] sign_up_mfa_priority_bucket
   def user_registration_2fa_setup_visit(sign_up_mfa_priority_bucket:, **extra)
@@ -3251,70 +3650,33 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Hash] vendor_status
-  # @param [String,nil] redirect_from
-  # Tracks when vendor has outage
-  def vendor_outage(
-    vendor_status:,
-    redirect_from: nil,
-    **extra
-  )
-    track_event(
-      'Vendor Outage',
-      redirect_from: redirect_from,
-      vendor_status: vendor_status,
-      **extra,
+  # User registration has been handed off to agency page
+  # @param [Boolean] ial2
+  # @param [Integer] ialmax
+  # @param [String] service_provider_name
+  # @param [String] page_occurence
+  # @param [String] needs_completion_screen_reason
+  # @param [Array] sp_request_requested_attributes
+  # @param [Array] sp_session_requested_attributes
+  def user_registration_agency_handoff_page_visit(
+      ial2:,
+      service_provider_name:,
+      page_occurence:,
+      needs_completion_screen_reason:,
+      sp_session_requested_attributes:,
+      sp_request_requested_attributes: nil,
+      ialmax: nil,
+      **extra
     )
-  end
-
-  # @param [Boolean] success
-  # @param [Integer] mfa_method_counts
-  # Tracks when WebAuthn is deleted
-  def webauthn_deleted(success:, mfa_method_counts:, pii_like_keypaths:, **extra)
     track_event(
-      'WebAuthn Deleted',
-      success: success,
-      mfa_method_counts: mfa_method_counts,
-      pii_like_keypaths: pii_like_keypaths,
-      **extra,
-    )
-  end
-
-  # @param [Hash] platform_authenticator
-  # @param [Hash] errors
-  # @param [Integer] enabled_mfa_methods_count
-  # @param [Boolean] success
-  # Tracks when WebAuthn setup is visited
-  def webauthn_setup_visit(platform_authenticator:, errors:, enabled_mfa_methods_count:, success:,
-                           **extra)
-    track_event(
-      'WebAuthn Setup Visited',
-      platform_authenticator: platform_authenticator,
-      errors: errors,
-      enabled_mfa_methods_count: enabled_mfa_methods_count,
-      success: success,
-      **extra,
-    )
-  end
-
-  # Tracks when user visits enter email page
-  # @param [String] sign_in_a_b_test_bucket
-  # @param [Boolean] from_sign_in
-  def user_registration_enter_email_visit(sign_in_a_b_test_bucket:, from_sign_in:, **extra)
-    track_event(
-      'User Registration: enter email visited',
-      sign_in_a_b_test_bucket:,
-      from_sign_in:,
-      **extra,
-    )
-  end
-
-  # @param [Integer] enabled_mfa_methods_count
-  # Tracks when user visits the phone setup step during registration
-  def user_registration_phone_setup_visit(enabled_mfa_methods_count:, **extra)
-    track_event(
-      'User Registration: phone setup visited',
-      enabled_mfa_methods_count: enabled_mfa_methods_count,
+      'User registration: agency handoff visited',
+      ial2: ial2,
+      ialmax: ialmax,
+      service_provider_name: service_provider_name,
+      page_occurence: page_occurence,
+      needs_completion_screen_reason: needs_completion_screen_reason,
+      sp_request_requested_attributes: sp_request_requested_attributes,
+      sp_session_requested_attributes: sp_session_requested_attributes,
       **extra,
     )
   end
@@ -3415,91 +3777,87 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks if request to get address candidates from ArcGIS fails
-  # @param [String] exception_class
-  # @param [String] exception_message
-  # @param [Boolean] response_body_present
-  # @param [Hash] response_body
-  # @param [Integer] response_status_code
-  def idv_arcgis_request_failure(
-    exception_class:,
-    exception_message:,
-    response_body_present:,
-    response_body:,
-    response_status_code:,
-    **extra
-  )
+  # Tracks when user visits enter email page
+  # @param [String] sign_in_a_b_test_bucket
+  # @param [Boolean] from_sign_in
+  def user_registration_enter_email_visit(sign_in_a_b_test_bucket:, from_sign_in:, **extra)
     track_event(
-      'Request ArcGIS Address Candidates: request failed',
-      exception_class: exception_class,
-      exception_message: exception_message,
-      response_body_present: response_body_present,
-      response_body: response_body,
-      response_status_code: response_status_code,
+      'User Registration: enter email visited',
+      sign_in_a_b_test_bucket:,
+      from_sign_in:,
       **extra,
     )
   end
 
-  # Tracks whether the user's device appears to be mobile device with a camera attached.
-  # @param [Boolean] is_camera_capable_mobile Whether we think the device _could_ have a camera.
-  # @param [Boolean,nil] camera_present Whether the user's device _actually_ has a camera available.
-  # @param [Integer,nil] grace_time Extra time allowed for browser to report camera availability.
-  # @param [Integer,nil] duration Time taken for browser to report camera availability.
-  def idv_mobile_device_and_camera_check(
-    is_camera_capable_mobile:,
-    camera_present: nil,
-    grace_time: nil,
-    duration: nil,
+  # @param [Boolean] success
+  # @param [Hash] mfa_method_counts
+  # @param [Integer] enabled_mfa_methods_count
+  # @param [Hash] pii_like_keypaths
+  # Tracks when a user has completed MFA setup
+  def user_registration_mfa_setup_complete(
+    success:,
+    mfa_method_counts:,
+    enabled_mfa_methods_count:,
+    pii_like_keypaths:,
     **extra
   )
     track_event(
-      'IdV: Mobile device and camera check',
-      is_camera_capable_mobile: is_camera_capable_mobile,
-      camera_present: camera_present,
-      grace_time: grace_time,
-      duration: duration,
+      'User Registration: MFA Setup Complete',
+      {
+        success: success,
+        mfa_method_counts: mfa_method_counts,
+        enabled_mfa_methods_count: enabled_mfa_methods_count,
+        pii_like_keypaths: pii_like_keypaths,
+        **extra,
+      }.compact,
+    )
+  end
+
+  # @param [Integer] enabled_mfa_methods_count
+  # Tracks when user visits the phone setup step during registration
+  def user_registration_phone_setup_visit(enabled_mfa_methods_count:, **extra)
+    track_event(
+      'User Registration: phone setup visited',
+      enabled_mfa_methods_count: enabled_mfa_methods_count,
       **extra,
     )
   end
 
-  # Tracks when the user visits one of the the session error pages.
-  # @param [String] type
-  # @param [Integer,nil] attempts_remaining
-  def idv_session_error_visited(
-    type:,
-    attempts_remaining: nil,
-    **extra
-  )
+  # Tracks when user's piv cac is disabled
+  def user_registration_piv_cac_disabled
+    track_event('User Registration: piv cac disabled')
+  end
+
+  # Tracks when user's piv cac setup
+  def user_registration_piv_cac_setup_visit(**extra)
     track_event(
-      'IdV: session error visited',
-      type: type,
-      attempts_remaining: attempts_remaining,
+      'User Registration: piv cac setup visited',
       **extra,
     )
   end
 
-  # Tracks if request to get USPS in-person proofing locations fails
-  # @param [String] exception_class
-  # @param [String] exception_message
-  # @param [Boolean] response_body_present
-  # @param [Hash] response_body
-  # @param [Integer] response_status_code
-  def idv_in_person_locations_request_failure(
-    exception_class:,
-    exception_message:,
-    response_body_present:,
-    response_body:,
-    response_status_code:,
+  # Tracks when user skips Suggest Another MFA Page
+  def user_registration_suggest_another_mfa_notice_skipped
+    track_event('User Registration: Suggest Another MFA Notice Skipped')
+  end
+
+  # Tracks when user visits Suggest Another MFA Page
+  def user_registration_suggest_another_mfa_notice_visited
+    track_event('User Registration: Suggest Another MFA Notice visited')
+  end
+
+  # @param [String] mfa_method
+  # Tracks when the the user fully registered by submitting their first MFA method into the system
+  def user_registration_user_fully_registered(
+    mfa_method:,
     **extra
   )
     track_event(
-      'Request USPS IPP locations: request failed',
-      exception_class: exception_class,
-      exception_message: exception_message,
-      response_body_present: response_body_present,
-      response_body: response_body,
-      response_status_code: response_status_code,
-      **extra,
+      'User Registration: User Fully Registered',
+      {
+        mfa_method: mfa_method,
+        **extra,
+      }.compact,
     )
   end
 
@@ -3522,398 +3880,48 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks if USPS in-person proofing enrollment request fails
-  # @param [String] context
-  # @param [String] reason
-  # @param [Integer] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  def idv_in_person_usps_request_enroll_exception(
-    context:,
-    reason:,
-    enrollment_id:,
-    exception_class:,
-    exception_message:,
+  # @param [Hash] vendor_status
+  # @param [String,nil] redirect_from
+  # Tracks when vendor has outage
+  def vendor_outage(
+    vendor_status:,
+    redirect_from: nil,
     **extra
   )
     track_event(
-      'USPS IPPaaS enrollment failed',
-      context: context,
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      reason: reason,
+      'Vendor Outage',
+      redirect_from: redirect_from,
+      vendor_status: vendor_status,
       **extra,
     )
   end
 
-  # GetUspsProofingResultsJob is beginning. Includes some metadata about what the job will do
-  # @param [Integer] enrollments_count number of enrollments eligible for status check
-  # @param [Integer] reprocess_delay_minutes minimum delay since last status check
-  def idv_in_person_usps_proofing_results_job_started(
-    enrollments_count:,
-    reprocess_delay_minutes:,
-    **extra
-  )
+  # @param [Boolean] success
+  # @param [Integer] mfa_method_counts
+  # Tracks when WebAuthn is deleted
+  def webauthn_deleted(success:, mfa_method_counts:, pii_like_keypaths:, **extra)
     track_event(
-      'GetUspsProofingResultsJob: Job started',
-      enrollments_count: enrollments_count,
-      reprocess_delay_minutes: reprocess_delay_minutes,
+      'WebAuthn Deleted',
+      success: success,
+      mfa_method_counts: mfa_method_counts,
+      pii_like_keypaths: pii_like_keypaths,
       **extra,
     )
   end
 
-  # GetUspsProofingResultsJob has completed. Includes counts of various outcomes encountered
-  # @param [Float] duration_seconds number of minutes the job was running
-  # @param [Integer] enrollments_checked number of enrollments eligible for status check
-  # @param [Integer] enrollments_errored number of enrollments for which we encountered an error
-  # @param [Integer] enrollments_expired number of enrollments which expired
-  # @param [Integer] enrollments_failed number of enrollments which failed identity proofing
-  # @param [Integer] enrollments_in_progress number of enrollments which did not have any change
-  # @param [Integer] enrollments_passed number of enrollments which passed identity proofing
-  def idv_in_person_usps_proofing_results_job_completed(
-    duration_seconds:,
-    enrollments_checked:,
-    enrollments_errored:,
-    enrollments_expired:,
-    enrollments_failed:,
-    enrollments_in_progress:,
-    enrollments_passed:,
-    **extra
-  )
+  # @param [Hash] platform_authenticator
+  # @param [Hash] errors
+  # @param [Integer] enabled_mfa_methods_count
+  # @param [Boolean] success
+  # Tracks when WebAuthn setup is visited
+  def webauthn_setup_visit(platform_authenticator:, errors:, enabled_mfa_methods_count:, success:,
+                           **extra)
     track_event(
-      'GetUspsProofingResultsJob: Job completed',
-      duration_seconds: duration_seconds,
-      enrollments_checked: enrollments_checked,
-      enrollments_errored: enrollments_errored,
-      enrollments_expired: enrollments_expired,
-      enrollments_failed: enrollments_failed,
-      enrollments_in_progress: enrollments_in_progress,
-      enrollments_passed: enrollments_passed,
-      **extra,
-    )
-  end
-
-  # Tracks exceptions that are raised when running GetUspsProofingResultsJob
-  # @param [String] reason why was the exception raised?
-  # @param [String] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  # @param [String] enrollment_code
-  # @param [Float] minutes_since_established
-  # @param [Float] minutes_since_last_status_check
-  # @param [Float] minutes_since_last_status_update
-  # @param [Float] minutes_to_completion
-  # @param [Boolean] fraud_suspected
-  # @param [String] primary_id_type
-  # @param [String] secondary_id_type
-  # @param [String] failure_reason
-  # @param [String] transaction_end_date_time
-  # @param [String] transaction_start_date_time
-  # @param [String] status
-  # @param [String] assurance_level
-  # @param [String] proofing_post_office
-  # @param [String] proofing_city
-  # @param [String] proofing_state
-  # @param [String] scan_count
-  # @param [String] response_message
-  # @param [Integer] response_status_code
-  def idv_in_person_usps_proofing_results_job_exception(
-    reason:,
-    enrollment_id:,
-    minutes_since_established:,
-    exception_class: nil,
-    exception_message: nil,
-    enrollment_code: nil,
-    minutes_since_last_status_check: nil,
-    minutes_since_last_status_update: nil,
-    minutes_to_completion: nil,
-    fraud_suspected: nil,
-    primary_id_type: nil,
-    secondary_id_type: nil,
-    failure_reason: nil,
-    transaction_end_date_time: nil,
-    transaction_start_date_time: nil,
-    status: nil,
-    assurance_level: nil,
-    proofing_post_office: nil,
-    proofing_city: nil,
-    proofing_state: nil,
-    scan_count: nil,
-    response_message: nil,
-    response_status_code: nil,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Exception raised',
-      reason: reason,
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      enrollment_code: enrollment_code,
-      minutes_since_established: minutes_since_established,
-      minutes_since_last_status_check: minutes_since_last_status_check,
-      minutes_since_last_status_update: minutes_since_last_status_update,
-      minutes_to_completion: minutes_to_completion,
-      fraud_suspected: fraud_suspected,
-      primary_id_type: primary_id_type,
-      secondary_id_type: secondary_id_type,
-      failure_reason: failure_reason,
-      transaction_end_date_time: transaction_end_date_time,
-      transaction_start_date_time: transaction_start_date_time,
-      status: status,
-      assurance_level: assurance_level,
-      proofing_post_office: proofing_post_office,
-      proofing_city: proofing_city,
-      proofing_state: proofing_state,
-      scan_count: scan_count,
-      response_message: response_message,
-      response_status_code: response_status_code,
-      **extra,
-    )
-  end
-
-  # Tracks deadline email initiated during GetUspsProofingResultsJob
-  # @param [String] enrollment_id
-  def idv_in_person_usps_proofing_results_job_deadline_passed_email_initiated(
-    enrollment_id:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: deadline passed email initiated',
-      enrollment_id: enrollment_id,
-      **extra,
-    )
-  end
-
-  # Tracks exceptions that are raised when initiating deadline email in GetUspsProofingResultsJob
-  # @param [String] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  def idv_in_person_usps_proofing_results_job_deadline_passed_email_exception(
-    enrollment_id:,
-    exception_class: nil,
-    exception_message: nil,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Exception raised when attempting to send deadline passed email',
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      **extra,
-    )
-  end
-
-  # Tracks exceptions that are raised when running InPerson::EmailReminderJob
-  # @param [String] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  def idv_in_person_email_reminder_job_exception(
-    enrollment_id:,
-    exception_class: nil,
-    exception_message: nil,
-    **extra
-  )
-    track_event(
-      'InPerson::EmailReminderJob: Exception raised when attempting to send reminder email',
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      **extra,
-    )
-  end
-
-  # Tracks individual enrollments that are updated during GetUspsProofingResultsJob
-  # @param [String] enrollment_code
-  # @param [String] enrollment_id
-  # @param [Float] minutes_since_established
-  # @param [Boolean] fraud_suspected
-  # @param [Boolean] passed did this enrollment pass or fail?
-  # @param [String] reason why did this enrollment pass or fail?
-  def idv_in_person_usps_proofing_results_job_enrollment_updated(
-    enrollment_code:,
-    enrollment_id:,
-    minutes_since_established:,
-    fraud_suspected:,
-    passed:,
-    reason:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Enrollment status updated',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      minutes_since_established: minutes_since_established,
-      fraud_suspected: fraud_suspected,
-      passed: passed,
-      reason: reason,
-      **extra,
-    )
-  end
-
-  # Tracks emails that are initiated during GetUspsProofingResultsJob
-  # @param [String] email_type success, failed or failed fraud
-  def idv_in_person_usps_proofing_results_job_email_initiated(
-    email_type:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Success or failure email initiated',
-      email_type: email_type,
-      **extra,
-    )
-  end
-
-  # Tracks emails that are initiated during InPerson::EmailReminderJob
-  # @param [String] email_type early or late
-  # @param [String] enrollment_id
-  def idv_in_person_email_reminder_job_email_initiated(
-    email_type:,
-    enrollment_id:,
-    **extra
-  )
-    track_event(
-      'InPerson::EmailReminderJob: Reminder email initiated',
-      email_type: email_type,
-      enrollment_id: enrollment_id,
-      **extra,
-    )
-  end
-
-  # Tracks incomplete enrollments checked via the USPS API
-  # @param [String] enrollment_code
-  # @param [String] enrollment_id
-  # @param [Float] minutes_since_established
-  # @param [String] response_message
-  def idv_in_person_usps_proofing_results_job_enrollment_incomplete(
-    enrollment_code:,
-    enrollment_id:,
-    minutes_since_established:,
-    response_message:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Enrollment incomplete',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      minutes_since_established: minutes_since_established,
-      response_message: response_message,
-      **extra,
-    )
-  end
-
-  # Tracks unexpected responses from the USPS API
-  # @param [String] enrollment_code
-  # @param [String] enrollment_id
-  # @param [Float] minutes_since_established
-  # @param [String] response_message
-  # @param [String] reason why was this error unexpected?
-  def idv_in_person_usps_proofing_results_job_unexpected_response(
-    enrollment_code:,
-    enrollment_id:,
-    minutes_since_established:,
-    response_message:,
-    reason:,
-    **extra
-  )
-    track_event(
-      'GetUspsProofingResultsJob: Unexpected response received',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      minutes_since_established: minutes_since_established,
-      response_message: response_message,
-      reason: reason,
-      **extra,
-    )
-  end
-
-  # Tracks users visiting the recovery options page
-  def account_reset_recovery_options_visit
-    track_event('Account Reset: Recovery Options Visited')
-  end
-
-  # Tracks users going back or cancelling acoount recovery
-  def cancel_account_reset_recovery
-    track_event('Account Reset: Cancel Account Recovery Options')
-  end
-
-  # @identity.idp.previous_event_name IdV: Verify setup errors visited
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # Tracks when the user reaches the verify please call page after failing proofing
-  def idv_please_call_visited(proofing_components: nil, **extra)
-    track_event(
-      'IdV: Verify please call visited',
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # Tracks when user reaches verify errors due to being rejected due to fraud
-  def idv_not_verified_visited
-    track_event('IdV: Not verified visited')
-  end
-
-  # @param [String] redirect_url URL user was directed to
-  # @param [String, nil] step which step
-  # @param [String, nil] location which part of a step, if applicable
-  # @param ["idv", String, nil] flow which flow
-  # User was redirected to the login.gov contact page
-  def contact_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
-    track_event(
-      'Contact Page Redirect',
-      redirect_url: redirect_url,
-      step: step,
-      location: location,
-      flow: flow,
-      **extra,
-    )
-  end
-
-  # @param [String] redirect_url URL user was directed to
-  # @param [String, nil] step which step
-  # @param [String, nil] location which part of a step, if applicable
-  # @param ["idv", String, nil] flow which flow
-  # User was redirected to the login.gov policy page
-  def policy_redirect(redirect_url:, step: nil, location: nil, flow: nil, **extra)
-    track_event(
-      'Policy Page Redirect',
-      redirect_url: redirect_url,
-      step: step,
-      location: location,
-      flow: flow,
-      **extra,
-    )
-  end
-
-  # Tracks if a user clicks the "Show Password button"
-  # @param [String] path URL path where the click occurred
-  def show_password_button_clicked(path:, **extra)
-    track_event('Show Password Button Clicked', path: path, **extra)
-  end
-
-  # Tracks if a user clicks the 'acknowledge' checkbox during personal
-  # key creation
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # @param [boolean] checked whether the user checked or un-checked
-  #                  the box with this click
-  def idv_personal_key_acknowledgment_toggled(checked:, proofing_components:, **extra)
-    track_event(
-      'IdV: personal key acknowledgment toggled',
-      checked: checked,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # Logs after an email is sent
-  # @param [String] action type of email being sent
-  # @param [String, nil] ses_message_id AWS SES Message ID
-  def email_sent(action:, ses_message_id:, **extra)
-    track_event(
-      'Email Sent',
-      action: action,
-      ses_message_id: ses_message_id,
+      'WebAuthn Setup Visited',
+      platform_authenticator: platform_authenticator,
+      errors: errors,
+      enabled_mfa_methods_count: enabled_mfa_methods_count,
+      success: success,
       **extra,
     )
   end

--- a/app/services/idv/actions/cancel_link_sent_action.rb
+++ b/app/services/idv/actions/cancel_link_sent_action.rb
@@ -8,6 +8,7 @@ module Idv
       def call
         if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
           redirect_to idv_hybrid_handoff_url
+          flow_session[:flow_path] = nil
         else
           mark_step_incomplete(:upload)
         end

--- a/app/services/idv/actions/redo_document_capture_action.rb
+++ b/app/services/idv/actions/redo_document_capture_action.rb
@@ -11,6 +11,7 @@ module Idv
           redirect_to idv_document_capture_url
         elsif IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
           redirect_to idv_hybrid_handoff_url
+          flow_session[:flow_path] = nil
         else
           mark_step_incomplete(:upload)
         end

--- a/app/services/idv/steps/agreement_step.rb
+++ b/app/services/idv/steps/agreement_step.rb
@@ -16,6 +16,7 @@ module Idv
 
         if flow_session[:skip_upload_step]
           redirect_to idv_document_capture_url
+          flow_session[:flow_path] = 'standard'
         else
           redirect_to idv_hybrid_handoff_url
         end
@@ -30,9 +31,6 @@ module Idv
       def skip_to_capture
         # See: Idv::DocAuthController#update_if_skipping_upload
         flow_session[:skip_upload_step] = true
-        if IdentityConfig.store.doc_auth_hybrid_handoff_controller_enabled
-          flow_session[:flow_path] = 'standard'
-        end
       end
 
       def consent_form_params

--- a/app/services/usps_in_person_proofing/date_validator.rb
+++ b/app/services/usps_in_person_proofing/date_validator.rb
@@ -1,0 +1,37 @@
+module UspsInPersonProofing
+  # Validator that can be attached to a form or other model
+  # to verify that specific supported fields are comparable to other dates.
+  # Since it's a subclass of ComparisonValidator, it share the same options.
+  # == Example
+  #
+  #   validates_with UspsInPersonProofing::DateValidator,
+  #     attributes: [:dob],
+  #     message: "error",
+  #     less_than_or_equal_to: ->(_rec) {
+  #         Time.zone.today - IdentityConfig.store.idv_min_age_years.years
+  #     }
+  #     ....
+  #
+  class DateValidator < ActiveModel::Validations::ComparisonValidator
+    private
+
+    def prepare_value_for_validation(value, _record, _attr_name)
+      val_to_date(value)
+    rescue
+      nil
+    end
+
+    # @param [String,Date,#to_hash] param
+    # @return [Date]
+    # It's caller's responsibility to ensure the param contains required entries
+    def val_to_date(param)
+      case param
+      when String, Date
+        DateParser.parse_legacy(param)
+      else
+        h = param.to_hash.with_indifferent_access
+        Date.new(h[:year].to_i, h[:month].to_i, h[:day].to_i)
+      end
+    end
+  end
+end

--- a/app/validators/idv/form_state_id_validator.rb
+++ b/app/validators/idv/form_state_id_validator.rb
@@ -2,6 +2,7 @@ module Idv
   module FormStateIdValidator
     extend ActiveSupport::Concern
 
+    # rubocop:disable Metrics/BlockLength
     included do
       validates :first_name,
                 :last_name,
@@ -29,6 +30,17 @@ module Idv
                          char_list: invalid_chars.join(', '),
                        )
                      end
+      # rubocop:disable Layout/LineLength
+      validates_with UspsInPersonProofing::DateValidator,
+                     attributes: [:dob], less_than_or_equal_to: ->(_rec) {
+                       Time.zone.today - IdentityConfig.store.idv_min_age_years.years
+                     },
+                     message: I18n.t(
+                       'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
+                       app_name: APP_NAME,
+                     )
+      # rubocop:enable Layout/LineLength
     end
+    # rubocop:enable Metrics/BlockLength
   end
 end

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -26,11 +26,10 @@ locals:
       ) do %>
     <%= t(
           'doc_auth.headings.capture_scan_warning_html',
-          link: render(
-            FormLinkComponent.new(
-              href: idv_doc_auth_step_path(step: :redo_document_capture),
-              method: :put,
-            ).with_content(t('doc_auth.headings.capture_scan_warning_link')),
+          link_to(
+            t('doc_auth.headings.capture_scan_warning_link'),
+            idv_hybrid_handoff_url,
+            'aria-label': t('doc_auth.headings.capture_scan_warning_link'),
           ),
         ) %>
   <% end %>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -26,11 +26,10 @@ locals:
       ) do %>
     <%= t(
           'doc_auth.headings.capture_scan_warning_html',
-          link: render(
-            FormLinkComponent.new(
-              href: idv_doc_auth_step_path(step: :redo_document_capture),
-              method: :put,
-            ).with_content(t('doc_auth.headings.capture_scan_warning_link')),
+          link: link_to(
+            t('doc_auth.headings.capture_scan_warning_link'),
+            idv_hybrid_handoff_url(redo: true),
+            'aria-label': t('doc_auth.headings.capture_scan_warning_link'),
           ),
         ) %>
   <% end %>

--- a/bin/setup
+++ b/bin/setup
@@ -62,7 +62,7 @@ Dir.chdir APP_ROOT do
 
   puts "\n== Starting services =="
   run "brew services start redis" if brew_installed
-  run "brew services start postgresql@13" if brew_installed
+  run "brew services start postgresql@14" if brew_installed
 
   puts "\n== Preparing database =="
   run 'make clobber_db'

--- a/spec/components/memorable_date_component_spec.rb
+++ b/spec/components/memorable_date_component_spec.rb
@@ -278,4 +278,17 @@ RSpec.describe MemorableDateComponent, type: :component do
       MemorableDateComponent.extract_date_param('abcd'),
     ).to be_nil
   end
+
+  context 'backend validation error message' do
+    let(:backend_error) { 'backend error' }
+    it 'renders a visible error message element' do
+      allow(form_builder.object).to receive(:errors).and_return(
+        {
+          name => [backend_error],
+        },
+      )
+      expect(rendered).not_to have_css('.usa-error-message.display-none')
+      expect(rendered.css('.usa-error-message')).to have_text(backend_error)
+    end
+  end
 end

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -6,6 +6,7 @@ describe 'RateLimitConcern' do
   module Idv
     class StepController < ApplicationController
       include RateLimitConcern
+      include IdvSession
 
       def show
         render plain: 'Hello'

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -6,8 +6,7 @@ describe Idv::DocumentCaptureController do
   let(:flow_session) do
     { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
       :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0',
-      :flow_path => 'standard',
-      'Idv::Steps::UploadStep' => true }
+      :flow_path => 'standard' }
   end
 
   let(:user) { create(:user) }
@@ -18,9 +17,6 @@ describe Idv::DocumentCaptureController do
       app_id: '123',
     )
   end
-
-  let(:default_sdk_version) { IdentityConfig.store.idv_acuant_sdk_version_default }
-  let(:alternate_sdk_version) { IdentityConfig.store.idv_acuant_sdk_version_alternate }
 
   before do
     allow(subject).to receive(:flow_session).and_return(flow_session)

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -102,6 +102,13 @@ describe Idv::DocumentCaptureController do
       end
     end
 
+    it 'does not use effective user outside of analytics_user in ApplicationControler' do
+      allow(subject).to receive(:analytics_user).and_return(subject.current_user)
+      expect(subject).not_to receive(:effective_user)
+
+      get :show
+    end
+
     context 'user is rate_limited' do
       it 'redirects to rate limited page' do
         user = create(:user)

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -28,13 +28,19 @@ describe Idv::HybridHandoffController do
         :confirm_agreement_step_complete,
       )
     end
+
+    it 'checks that hybrid_handoff is needed' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_hybrid_handoff_needed,
+      )
+    end
   end
 
   describe '#show' do
     let(:analytics_name) { 'IdV: doc auth upload visited' }
     let(:analytics_args) do
-      { flow_path: 'standard',
-        step: 'upload',
+      { step: 'upload',
         analytics_id: 'Doc Auth',
         irs_reproofing: false }
     end
@@ -66,6 +72,24 @@ describe Idv::HybridHandoffController do
         get :show
 
         expect(response).to redirect_to(idv_doc_auth_url)
+      end
+    end
+
+    context 'hybrid_handoff already visited' do
+      it 'redirects to document_capture in standard flow' do
+        subject.user_session['idv/doc_auth'][:flow_path] = 'standard'
+
+        get :show
+
+        expect(response).to redirect_to(idv_document_capture_url)
+      end
+
+      it 'redirects to link_sent in hybrid flow' do
+        subject.user_session['idv/doc_auth'][:flow_path] = 'hybrid'
+
+        get :show
+
+        expect(response).to redirect_to(idv_link_sent_url)
       end
     end
   end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -35,6 +35,13 @@ describe Idv::HybridHandoffController do
         :confirm_hybrid_handoff_needed,
       )
     end
+
+    it 'checks that the user is not on mobile' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_not_on_mobile,
+      )
+    end
   end
 
   describe '#show' do
@@ -90,6 +97,16 @@ describe Idv::HybridHandoffController do
         get :show
 
         expect(response).to redirect_to(idv_link_sent_url)
+      end
+    end
+
+    context 'user is on mobile' do
+      it 'redirects to document capture' do
+        subject.user_session['idv/doc_auth'][:skip_upload_step] = true
+
+        get :show
+
+        expect(response).to redirect_to(idv_document_capture_url)
       end
     end
   end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -96,21 +96,46 @@ describe Idv::HybridHandoffController do
 
   describe '#update' do
     let(:analytics_name) { 'IdV: doc auth upload submitted' }
-    let(:analytics_args) do
-      { success: true,
-        errors: {},
-        destination: :link_sent,
-        flow_path: 'hybrid',
-        step: 'upload',
-        analytics_id: 'Doc Auth',
-        irs_reproofing: false,
-        skip_upload_step: false }
+
+    context 'hybrid flow' do
+      let(:analytics_args) do
+        { success: true,
+          errors: { message: nil },
+          destination: :link_sent,
+          flow_path: 'hybrid',
+          step: 'upload',
+          analytics_id: 'Doc Auth',
+          irs_reproofing: false,
+          telephony_response: { errors: {},
+                                message_id: 'fake-message-id',
+                                request_id: 'fake-message-request-id',
+                                success: true } }
+      end
+
+      it 'sends analytics_submitted event for hybrid' do
+        put :update, params: { doc_auth: { phone: '202-555-5555' } }
+
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      end
     end
 
-    it 'sends analytics_submitted event' do
-      put :update, params: { doc_auth: { phone: '202-555-5555' } }
+    context 'desktop flow' do
+      let(:analytics_args) do
+        { success: true,
+          errors: {},
+          destination: :document_capture,
+          flow_path: 'standard',
+          step: 'upload',
+          analytics_id: 'Doc Auth',
+          irs_reproofing: false,
+          skip_upload_step: false }
+      end
 
-      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      it 'sends analytics_submitted event for desktop' do
+        put :update, params: { type: 'desktop' }
+
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      end
     end
   end
 end

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 feature 'doc auth redo document capture action', js: true do
   include IdvStepHelper
   include DocAuthHelper
+  before do
+    allow(IdentityConfig.store).
+      to receive(:doc_auth_hybrid_handoff_controller_enabled).
+      and_return(true)
+  end
 
   context 'when barcode scan returns a warning', allow_browser_log: true do
     before do
@@ -27,7 +32,7 @@ feature 'doc auth redo document capture action', js: true do
       )
       click_link warning_link_text
 
-      expect(current_path).to eq(idv_doc_auth_upload_step)
+      expect(current_path).to eq(idv_hybrid_handoff_path)
       complete_upload_step
       DocAuth::Mock::DocAuthMockClient.reset!
       attach_and_submit_images
@@ -67,7 +72,7 @@ feature 'doc auth redo document capture action', js: true do
         )
         click_link warning_link_text
 
-        expect(current_path).to eq(idv_document_capture_path)
+        expect(current_path).to eq(idv_document_capture_path) # /verify/ssn
         DocAuth::Mock::DocAuthMockClient.reset!
         attach_and_submit_images
 

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -35,7 +35,7 @@ feature 'doc auth document capture step', :js do
     end
 
     it 'shows the new DocumentCapture page for desktop standard flow' do
-      expect(page).to have_current_path(idv_document_capture_url)
+      expect(page).to have_current_path(idv_document_capture_path)
 
       expect(page).to have_content(t('doc_auth.headings.document_capture').tr(' ', ' '))
       expect(page).to have_content(t('step_indicator.flows.idv.verify_id'))
@@ -48,6 +48,12 @@ feature 'doc auth document capture step', :js do
         irs_reproofing: false,
         acuant_sdk_upgrade_ab_test_bucket: :default,
       )
+
+      # it redirects here if trying to move earlier in the flow
+      visit(idv_doc_auth_agreement_step)
+      expect(page).to have_current_path(idv_document_capture_path)
+      visit(idv_doc_auth_upload_step)
+      expect(page).to have_current_path(idv_document_capture_path)
     end
 
     it 'logs return to sp link click' do

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'doc auth upload step' do
+feature 'doc auth hybrid_handoff step' do
   include IdvStepHelper
   include DocAuthHelper
   include ActionView::Helpers::DateHelper
@@ -19,14 +19,24 @@ feature 'doc auth upload step' do
     allow(IdentityConfig.store).to receive(:doc_auth_hybrid_handoff_controller_enabled).
       and_return(new_controller_enabled)
     allow_any_instance_of(Idv::HybridHandoffController).to receive(:mobile_device?).and_return(true)
-    complete_doc_auth_steps_before_upload_step
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ApplicationController).to receive(:irs_attempts_api_tracker).
       and_return(fake_attempts_tracker)
   end
 
-  context 'on a desktop device', js: true do
+  it 'does not skip ahead in standard desktop flow' do
+    visit(idv_hybrid_handoff_url)
+    expect(page).to have_current_path(idv_doc_auth_welcome_step)
+    complete_welcome_step
+    visit(idv_hybrid_handoff_url)
+    expect(page).to have_current_path(idv_doc_auth_agreement_step)
+    complete_agreement_step
+    expect(page).to have_current_path(idv_hybrid_handoff_path)
+  end
+
+  context 'on a desktop device' do
     before do
+      complete_doc_auth_steps_before_upload_step
       allow_any_instance_of(
         Idv::HybridHandoffController,
       ).to receive(
@@ -54,9 +64,12 @@ feature 'doc auth upload step' do
         'IdV: doc auth upload submitted',
         hash_including(step: 'upload', destination: :document_capture),
       )
+
+      visit(idv_hybrid_handoff_url)
+      expect(page).to have_current_path(idv_document_capture_path)
     end
 
-    it "defaults phone to user's 2fa phone number" do
+    it "defaults phone to user's 2fa phone number", :js do
       field = page.find_field(t('two_factor_authentication.phone_label'))
       expect(field.value).to eq('(202) 555-1212')
     end
@@ -73,9 +86,12 @@ feature 'doc auth upload step' do
         'IdV: doc auth upload submitted',
         hash_including(step: 'upload', destination: :link_sent),
       )
+
+      visit(idv_hybrid_handoff_url)
+      expect(page).to have_current_path(idv_link_sent_path)
     end
 
-    it 'proceeds to the next page with valid info' do
+    it 'proceeds to the next page with valid info', :js do
       expect(fake_attempts_tracker).to receive(
         :idv_phone_upload_link_sent,
       ).with(
@@ -96,7 +112,7 @@ feature 'doc auth upload step' do
       expect(page).to have_current_path(idv_link_sent_path)
     end
 
-    it 'does not proceed to the next page with invalid info' do
+    it 'does not proceed to the next page with invalid info', :js do
       fill_in :doc_auth_phone, with: ''
       click_send_link
 

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -15,13 +15,14 @@ feature 'doc auth hybrid_handoff step' do
   end
 
   before do
-    sign_in_and_2fa_user
     allow(IdentityConfig.store).to receive(:doc_auth_hybrid_handoff_controller_enabled).
       and_return(new_controller_enabled)
-    allow_any_instance_of(Idv::HybridHandoffController).to receive(:mobile_device?).and_return(true)
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ApplicationController).to receive(:irs_attempts_api_tracker).
       and_return(fake_attempts_tracker)
+
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_upload_step
   end
 
   it 'does not skip ahead in standard desktop flow' do
@@ -37,11 +38,6 @@ feature 'doc auth hybrid_handoff step' do
   context 'on a desktop device' do
     before do
       complete_doc_auth_steps_before_upload_step
-      allow_any_instance_of(
-        Idv::HybridHandoffController,
-      ).to receive(
-        :mobile_device?,
-      ).and_return(false)
     end
 
     it 'displays with the expected content' do

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -45,8 +45,7 @@ describe 'Hybrid Flow', :allow_net_connect_on_start do
       # Confirm that jumping to LinkSent page does not cause errors
       visit idv_link_sent_url
       expect(page).to have_current_path(root_url)
-
-      visit idv_hybrid_mobile_capture_complete_url
+      visit idv_hybrid_mobile_document_capture_url
 
       attach_and_submit_images
 

--- a/spec/forms/idv/in_person/address_form_spec.rb
+++ b/spec/forms/idv/in_person/address_form_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+describe Idv::InPerson::AddressForm do
+  let(:pii) { Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS }
+  context 'test validation for transliteration after form submission' do
+    let(:good_params) do
+      {
+        address1: Faker::Address.street_address,
+        address2: Faker::Address.secondary_address,
+        zipcode: Faker::Address.zip_code,
+        state: Faker::Address.state_abbr,
+        city: Faker::Address.city,
+      }
+    end
+    let(:invalid_char) { '$' }
+    let(:bad_params) do
+      {
+        address1: invalid_char + Faker::Address.street_address,
+        address2: invalid_char + Faker::Address.secondary_address + invalid_char,
+        zipcode: Faker::Address.zip_code,
+        state: Faker::Address.state_abbr,
+        city: invalid_char + Faker::Address.city,
+      }
+    end
+    context 'when usps_ipp_transliteration_enabled is false' do
+      let(:subject) { described_class.new(capture_secondary_id_enabled: true) }
+      before(:each) do
+        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(false)
+      end
+      it 'submit success with good params' do
+        good_params[:same_address_as_id] = true
+        result = subject.submit(good_params)
+        expect(subject.errors.empty?).to be(true)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to be(true)
+      end
+
+      it 'submit success with good params' do
+        good_params[:same_address_as_id] = false
+        result = subject.submit(good_params)
+        expect(subject.errors.empty?).to be(true)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to be(true)
+      end
+
+      it 'submit success with bad params' do
+        bad_params[:same_address_as_id] = false
+        result = subject.submit(bad_params)
+        expect(subject.errors.empty?).to be(true)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to be(true)
+      end
+    end
+    context 'when usps_ipp_transliteration_enabled is enabled ' do
+      let(:subject) { described_class.new(capture_secondary_id_enabled: true) }
+      before(:each) do
+        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(true)
+      end
+      it 'submit success with good params' do
+        good_params[:same_address_as_id] = true
+        result = subject.submit(good_params)
+        expect(subject.errors.empty?).to be(true)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to be(true)
+      end
+      it 'submit failure with bad params' do
+        bad_params[:same_address_as_id] = false
+        result = subject.submit(bad_params)
+        expect(subject.errors.empty?).to be(false)
+        expect(subject.errors.to_hash).to include(:address1, :address2, :city)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to be(false)
+        expect(result.errors.empty?).to be(true)
+      end
+    end
+    context 'when usps_ipp_transliteration_enabled is enabled and validate on other field' do
+      before(:each) do
+        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(true)
+      end
+      context 'when capture_secondary_id_enabled is true' do
+        let(:subject) { described_class.new(capture_secondary_id_enabled: true) }
+        it 'submit with missing same_address_as_id should be successful' do
+          missing_required_params = good_params.except(:same_address_as_id)
+          result = subject.submit(missing_required_params)
+          expect(subject.errors.empty?).to be(true)
+          expect(result).to be_kind_of(FormResponse)
+          expect(result.success?).to be(true)
+        end
+      end
+      context 'when capture_secondary_id_enabled is false' do
+        let(:subject) { described_class.new(capture_secondary_id_enabled: false) }
+        it 'submit with missing same_address_as_id will fail' do
+          missing_required_params = good_params.except(:same_address_as_id)
+          result = subject.submit(missing_required_params)
+          expect(subject.errors.empty?).to be(false)
+          expect(result).to be_kind_of(FormResponse)
+          expect(result.success?).to be(false)
+          expect(result.errors.keys).to include(:same_address_as_id)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/idv/state_id_form_spec.rb
+++ b/spec/forms/idv/state_id_form_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+describe Idv::StateIdForm do
+  let(:subject) { Idv::StateIdForm.new(pii) }
+  let(:valid_dob) do
+    valid_d = Time.zone.today - IdentityConfig.store.idv_min_age_years.years - 1.day
+    ActionController::Parameters.new(
+      {
+        year: valid_d.year,
+        month: valid_d.month,
+        day: valid_d.mday,
+      },
+    ).permit(:year, :month, :day)
+  end
+  let(:too_young_dob) do
+    (Time.zone.today - IdentityConfig.store.idv_min_age_years.years + 1.day).to_s
+  end
+  let(:good_params) do
+    {
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      dob: valid_dob,
+      identity_doc_address1: Faker::Address.street_address,
+      identity_doc_address2: Faker::Address.secondary_address,
+      identity_doc_zipcode: Faker::Address.zip_code,
+      identity_doc_address_state: Faker::Address.state_abbr,
+      same_address_as_id: 'true',
+      state_id_jurisdiction: 'AL',
+      state_id_number: Faker::IDNumber.valid,
+    }
+  end
+  let(:dob_min_age_name_error_params) do
+    {
+      first_name: Faker::Name.first_name + invalid_char,
+      last_name: Faker::Name.last_name,
+      dob: too_young_dob,
+      identity_doc_address1: Faker::Address.street_address,
+      identity_doc_address2: Faker::Address.secondary_address,
+      identity_doc_zipcode: Faker::Address.zip_code,
+      identity_doc_address_state: Faker::Address.state_abbr,
+      same_address_as_id: 'true',
+      state_id_jurisdiction: 'AL',
+      state_id_number: Faker::IDNumber.valid,
+    }
+  end
+  let(:invalid_char) { '1' }
+  let(:name_error_params) do
+    {
+      first_name: Faker::Name.first_name + invalid_char,
+      last_name: Faker::Name.last_name,
+      dob: valid_dob,
+      identity_doc_address1: Faker::Address.street_address,
+      identity_doc_address2: Faker::Address.secondary_address,
+      identity_doc_zipcode: Faker::Address.zip_code,
+      identity_doc_address_state: Faker::Address.state_abbr,
+      same_address_as_id: 'true',
+      state_id_jurisdiction: 'AL',
+      state_id_number: Faker::IDNumber.valid,
+    }
+  end
+  let(:pii) { nil }
+  describe '#submit' do
+    context 'when the form is valid' do
+      it 'returns a successful form response' do
+        result = subject.submit(good_params)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(true)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context 'when there is an error with name' do
+      it 'returns a single name error when name is wrong' do
+        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(true)
+        result = subject.submit(name_error_params)
+        expect(subject.errors.empty?).to be(false)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(subject.errors[:first_name]).to eq [
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: [invalid_char].join(', '),
+          ),
+        ]
+        expect(result.errors.empty?).to be(true)
+      end
+      it 'returns both name and dob error when both fields are invalid' do
+        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(true)
+        result = subject.submit(dob_min_age_name_error_params)
+        expect(subject.errors.empty?).to be(false)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(subject.errors[:first_name]).to eq [
+          I18n.t(
+            'in_person_proofing.form.state_id.errors.unsupported_chars',
+            char_list: [invalid_char].join(', '),
+          ),
+        ]
+        expect(subject.errors[:dob]).to eq [
+          I18n.t(
+            'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
+            app_name: APP_NAME,
+          ),
+        ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Internal
- Analytics: Sort analytics_events.rb and enforce sorting in CI ([#8519](https://github.com/18F/identity-idp/pull/8519))
- Application dependencies: Upgrade postgres to version 14 ([#8518](https://github.com/18F/identity-idp/pull/8518))
- In-Person Proofing: Add DOB validation for minimal age. ([#8501](https://github.com/18F/identity-idp/pull/8501))
- In-Person Proofing: Use Rails-like i18n wrapper instead (#9165) (#8522) ([#9165](https://github.com/18F/identity-idp/pull/9165))
- Refactoring: IdVSession to concern to use current_user by default ([#8505](https://github.com/18F/identity-idp/pull/8505))
- Refactoring: Replace FSM RedoDocumentCaptureAction
