### PR TITLE
Add monthly proofing report (LG-10005)

### DIFF
--- a/lib/reporting/command_line_options.rb
+++ b/lib/reporting/command_line_options.rb
@@ -4,7 +4,7 @@ module Reporting
   class CommandLineOptions
     # rubocop:disable Rails/Exit
     # @return [Hash]
-    def parse!(argv, out: STDOUT)
+    def parse!(argv, out: STDOUT, require_issuer: true)
       date = nil
       issuer = nil
       verbose = false
@@ -89,7 +89,7 @@ module Reporting
 
       parser.parse!(argv)
 
-      if !date || !issuer
+      if !date || (require_issuer && !issuer)
         out.puts parser
         exit 1
       else

--- a/lib/reporting/monthly_proofing_report.rb
+++ b/lib/reporting/monthly_proofing_report.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'csv'
+begin
+  require 'reporting/cloudwatch_client'
+  require 'reporting/cloudwatch_query_quoting'
+  require 'reporting/command_line_options'
+rescue LoadError => e
+  warn 'could not load paths, try running with "bundle exec rails runner"'
+  raise e
+end
+
+module Reporting
+  class MonthlyProofingReport
+    include Reporting::CloudwatchQueryQuoting
+
+    attr_reader :issuer, :time_range
+
+    module Events
+      IDV_DOC_AUTH_IMAGE_UPLOAD = 'IdV: doc auth image upload vendor submitted'
+      IDV_GPO_ADDRESS_LETTER_REQUESTED = 'IdV: USPS address letter requested'
+      USPS_IPP_ENROLLMENT_CREATED = 'USPS IPPaaS enrollment created'
+      IDV_FINAL_RESOLUTION = 'IdV: final resolution'
+      GPO_VERIFICATION_SUBMITTED = 'IdV: GPO verification submitted'
+      USPS_ENROLLMENT_STATUS_UPDATED = 'GetUspsProofingResultsJob: Enrollment status updated'
+
+      def self.all_events
+        constants.map { |c| const_get(c) }
+      end
+    end
+
+    # @param [String] isssuer
+    # @param [Range<Time>] date
+    def initialize(
+      issuer:,
+      time_range:,
+      verbose: false,
+      progress: false,
+      slice: 3.hours,
+      threads: 5
+    )
+      @issuer = issuer
+      @time_range = time_range
+      @verbose = verbose
+      @progress = progress
+      @slice = slice
+      @threads = threads
+    end
+
+    def verbose?
+      @verbose
+    end
+
+    def progress?
+      @progress
+    end
+
+    def to_csv
+      CSV.generate do |csv|
+        csv << ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"]
+        csv << ['Report Generated', Date.today.to_s] # rubocop:disable Rails/Date
+        csv << ['Issuer', issuer]
+        csv << []
+        csv << ['Metric', '# of Users']
+        csv << ['Started IdV Verification', idv_doc_auth_image_vendor_submitted]
+        csv << ['Incomplete Users', incomplete_users]
+        csv << ['Address Confirmation Letters Requested', idv_gpo_address_letter_requested]
+        csv << ['Started In-Person Verification', usps_ipp_enrollment_created]
+        csv << ['Alternative Process Users', alternative_process_users]
+        csv << ['Success through Online Verification', idv_final_resolution]
+        csv << ['Success through Address Confirmation Letters', gpo_verification_submitted]
+        csv << ['Success through In-Person Verification', usps_enrollment_status_updated]
+        csv << ['Successfully Verified Users', successfully_verified_users]
+      end
+    end
+
+    def incomplete_users
+      idv_doc_auth_image_vendor_submitted - successfully_verified_users - alternative_process_users
+    end
+
+    def idv_gpo_address_letter_requested
+      data[Events::IDV_GPO_ADDRESS_LETTER_REQUESTED].to_i
+    end
+
+    def usps_ipp_enrollment_created
+      data[Events::USPS_IPP_ENROLLMENT_CREATED].to_i
+    end
+
+    def alternative_process_users
+      [
+        idv_gpo_address_letter_requested,
+        usps_ipp_enrollment_created,
+        -gpo_verification_submitted,
+        -usps_enrollment_status_updated,
+      ].sum
+    end
+
+    def idv_final_resolution
+      data[Events::IDV_FINAL_RESOLUTION].to_i
+    end
+
+    def gpo_verification_submitted
+      data[Events::GPO_VERIFICATION_SUBMITTED].to_i
+    end
+
+    def usps_enrollment_status_updated
+      data[Events::USPS_ENROLLMENT_STATUS_UPDATED].to_i
+    end
+
+    def successfully_verified_users
+      idv_final_resolution + gpo_verification_submitted + usps_enrollment_status_updated
+    end
+
+    def idv_doc_auth_image_vendor_submitted
+      data[Events::IDV_DOC_AUTH_IMAGE_UPLOAD].to_i
+    end
+
+    # Turns query results into a hash keyed by event name, values are a count of unique users
+    # for that event
+    # @return [Hash<String,Integer>]
+    def data
+      @data ||= begin
+        event_users = Hash.new do |h, uuid|
+          h[uuid] = Set.new
+        end
+
+        # IDEA: maybe there's a block form if this we can do that yields results as it loads them
+        # to go slightly faster
+        fetch_results.each do |row|
+          event_users[row['name']] << row['user_id']
+        end
+
+        event_users.transform_values(&:count)
+      end
+    end
+
+    def fetch_results
+      cloudwatch_client.fetch(query:, from: time_range.begin, to: time_range.end)
+    end
+
+    def query
+      params = {
+        issuer: quote(issuer),
+        event_names: quote(Events.all_events),
+        usps_enrollment_status_updated: quote(Events::USPS_ENROLLMENT_STATUS_UPDATED),
+        gpo_verification_submitted: quote(Events::GPO_VERIFICATION_SUBMITTED),
+        idv_final_resolution: quote(Events::IDV_FINAL_RESOLUTION),
+      }
+
+      format(<<~QUERY, params)
+        fields
+            name
+          , properties.user_id AS user_id
+        | filter properties.service_provider = %{issuer}
+        | filter name in %{event_names}
+        | filter (name = %{usps_enrollment_status_updated} and properties.event_properties.passed = 1)
+                 or (name != %{usps_enrollment_status_updated})
+        | filter (name = %{gpo_verification_submitted} and properties.event_properties.success = 1)
+                 or (name != %{gpo_verification_submitted})
+        | filter (name = %{idv_final_resolution} and isblank(properties.event_properties.deactivation_reason))
+                 or (name != %{idv_final_resolution})
+        | limit 10000
+      QUERY
+    end
+
+    def cloudwatch_client
+      @cloudwatch_client ||= Reporting::CloudwatchClient.new(
+        num_threads: @threads,
+        ensure_complete_logs: true,
+        slice_interval: @slice,
+        progress: progress?,
+        logger: verbose? ? Logger.new(STDERR) : nil,
+      )
+    end
+  end
+end
+
+# rubocop:disable Rails/Output
+if __FILE__ == $PROGRAM_NAME
+  options = Reporting::CommandLineOptions.new.parse!(ARGV)
+
+  puts Reporting::IdentityVerificationReport.new(**options).to_csv
+end
+# rubocop:enable Rails/Output

--- a/lib/reporting/monthly_proofing_report.rb
+++ b/lib/reporting/monthly_proofing_report.rb
@@ -178,7 +178,7 @@ end
 
 # rubocop:disable Rails/Output
 if __FILE__ == $PROGRAM_NAME
-  options = Reporting::CommandLineOptions.new.parse!(ARGV)
+  options = Reporting::CommandLineOptions.new.parse!(ARGV, require_issuer: false)
 
   puts Reporting::IdentityVerificationReport.new(**options).to_csv
 end

--- a/lib/reporting/monthly_proofing_report.rb
+++ b/lib/reporting/monthly_proofing_report.rb
@@ -56,7 +56,7 @@ module Reporting
       CSV.generate do |csv|
         csv << ['report_start', time_range.begin.iso8601]
         csv << ['report_end', time_range.end.iso8601]
-        csv << ['report_generated', Date.today.to_s]
+        csv << ['report_generated', Date.today.to_s] # rubocop:disable Rails/Date
         csv << ['metric', 'num_users', 'percent']
 
         start = idv_doc_auth_image_vendor_submitted
@@ -66,12 +66,11 @@ module Reporting
           ['verified', idv_final_resolution],
           ['started_gpo', idv_gpo_address_letter_requested],
           ['started_in_person', usps_ipp_enrollment_created],
-          ['started_fraud_review', idv_please_call_visited]
+          ['started_fraud_review', idv_please_call_visited],
         ].each do |(label, num)|
           csv << [label, num, num.to_f / start.to_f]
         end
       end
-      # rubocop:enable Metrics/LineLength
     end
 
     def idv_doc_auth_image_vendor_submitted

--- a/lib/reporting/monthly_proofing_report.rb
+++ b/lib/reporting/monthly_proofing_report.rb
@@ -135,8 +135,12 @@ module Reporting
             name
           , properties.user_id AS user_id
         | filter name in %{event_names}
-        | filter (name = %{idv_final_resolution} and isblank(properties.event_properties.deactivation_reason))
-                 or (name != %{idv_final_resolution})
+        | filter (
+               name = %{idv_final_resolution}
+           and isblank(properties.event_properties.deactivation_reason)
+           and properties.event_properties.fraud_review_pending != 1
+          )
+          or (name != %{idv_final_resolution})
         | limit 10000
       QUERY
     end

--- a/spec/lib/reporting/command_line_options_spec.rb
+++ b/spec/lib/reporting/command_line_options_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe Reporting::CommandLineOptions do
 
     let(:stdout) { StringIO.new }
     let(:argv) { [] }
+    let(:require_issuer) { true }
 
-    subject(:parse!) { instance.parse!(argv, out: stdout) }
+    subject(:parse!) { instance.parse!(argv, out: stdout, require_issuer: require_issuer) }
 
     context 'with no arguments' do
       let(:argv) { [] }
@@ -51,6 +52,33 @@ RSpec.describe Reporting::CommandLineOptions do
           slice: 3.hours,
           threads: 5,
         )
+      end
+    end
+
+    context 'missing --issuer' do
+      let(:argv) { %w[--date 2023-1-1] }
+
+      it 'prints help and exits uncleanly' do
+        expect(instance).to receive(:exit).and_return(1)
+
+        parse!
+
+        expect(stdout.string).to include('Usage:')
+      end
+
+      context 'with require_issuer: false' do
+        let(:require_issuer) { false }
+
+        it 'returns the parsed options' do
+          expect(parse!).to match(
+            time_range: Date.new(2023, 1, 1).in_time_zone('UTC').all_day,
+            issuer: nil,
+            verbose: false,
+            progress: true,
+            slice: 3.hours,
+            threads: 5,
+          )
+        end
       end
     end
 

--- a/spec/lib/reporting/monthly_proofing_report_spec.rb
+++ b/spec/lib/reporting/monthly_proofing_report_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe Reporting::MonthlyProofingReport do
         ['metric', 'num_users', 'percent'],
         ['image_submitted', 5, 5.0 / 5],
         ['verified', 1, 1.0 / 5],
-        ['started_gpo', 1, 1.0 / 5],
-        ['started_in_person', 1, 1.0 / 5],
-        ['started_fraud_review', 1, 1.0 / 5],
+        ['not_verified_started_gpo', 1, 1.0 / 5],
+        ['not_verified_started_in_person', 1, 1.0 / 5],
+        ['not_verified_started_fraud_review', 1, 1.0 / 5],
       ]
 
       aggregate_failures do
@@ -59,13 +59,13 @@ RSpec.describe Reporting::MonthlyProofingReport do
   end
 
   describe '#data' do
-    it 'counts unique users per event as a hash' do
+    it 'keeps unique users per event as a hash' do
       expect(report.data).to eq(
-        'IdV: doc auth image upload vendor submitted' => 5,
-        'IdV: final resolution' => 1,
-        'IdV: USPS address letter requested' => 1,
-        'USPS IPPaaS enrollment created' => 1,
-        'IdV: Verify please call visited' => 1,
+        'IdV: doc auth image upload vendor submitted' => %w[user1 user2 user3 user4 user5].to_set,
+        'IdV: final resolution' => %w[user1].to_set,
+        'IdV: USPS address letter requested' => %w[user2].to_set,
+        'IdV: Verify please call visited' => %w[user3].to_set,
+        'USPS IPPaaS enrollment created' => %w[user4].to_set,
       )
     end
   end

--- a/spec/lib/reporting/monthly_proofing_report_spec.rb
+++ b/spec/lib/reporting/monthly_proofing_report_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Reporting::MonthlyProofingReport do
       expected_csv = [
         ['report_start', time_range.begin.iso8601],
         ['report_end', time_range.end.iso8601],
-        ['report_generated', Date.today.to_s],
+        ['report_generated', Date.today.to_s], # rubocop:disable Rails/Date
         ['metric', 'num_users', 'percent'],
         ['image_submitted', 5, 5.0 / 5],
         ['verified', 1, 1.0 / 5],

--- a/spec/lib/reporting/monthly_proofing_report_spec.rb
+++ b/spec/lib/reporting/monthly_proofing_report_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+require 'reporting/monthly_proofing_report'
+
+RSpec.describe Reporting::MonthlyProofingReport do
+  let(:time_range) { Date.new(2022, 1, 1).all_month }
+
+  subject(:report) { Reporting::MonthlyProofingReport.new(time_range:) }
+
+  before do
+    cloudwatch_client = double(
+      'Reporting::CloudwatchClient',
+      fetch: [
+        # Success
+        { 'user_id' => 'user1', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
+
+        # Letter requested user
+        { 'user_id' => 'user2', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user2', 'name' => 'IdV: USPS address letter requested' },
+
+        # Fraud review user
+        { 'user_id' => 'user3', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user3', 'name' => 'IdV: Verify please call visited' },
+
+        # In-person user
+        { 'user_id' => 'user4', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user4', 'name' => 'USPS IPPaaS enrollment created' },
+
+        # Incomplete user
+        { 'user_id' => 'user5', 'name' => 'IdV: doc auth image upload vendor submitted' },
+      ],
+    )
+
+    allow(report).to receive(:cloudwatch_client).and_return(cloudwatch_client)
+  end
+
+  describe '#to_csv' do
+    it 'generates a csv' do
+      csv = CSV.parse(report.to_csv, headers: false)
+
+      expected_csv = [
+        ['report_start', time_range.begin.iso8601],
+        ['report_end', time_range.end.iso8601],
+        ['report_generated', Date.today.to_s],
+        ['metric', 'num_users', 'percent'],
+        ['image_submitted', 5, 5.0 / 5],
+        ['verified', 1, 1.0 / 5],
+        ['started_gpo', 1, 1.0 / 5],
+        ['started_in_person', 1, 1.0 / 5],
+        ['started_fraud_review', 1, 1.0 / 5],
+      ]
+
+      aggregate_failures do
+        csv.map(&:to_a).zip(expected_csv).each do |actual, expected|
+          expect(actual).to eq(expected.map(&:to_s))
+        end
+      end
+    end
+  end
+
+  describe '#data' do
+    it 'counts unique users per event as a hash' do
+      expect(report.data).to eq(
+        'IdV: doc auth image upload vendor submitted' => 5,
+        'IdV: final resolution' => 1,
+        'IdV: USPS address letter requested' => 1,
+        'USPS IPPaaS enrollment created' => 1,
+        'IdV: Verify please call visited' => 1,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10005](https://cm-jira.usa.gov/browse/LG-10005)

## 🛠 Summary of changes

Adds a new report intended to be run monthly. This report is based on the Identity Verification Report added in #8008, but for an internal audience.

## 📜 Testing Plan

Run it like so:

```bash
aws-vault exec prod-power -- ./bin/rails runner ./lib/reporting/monthly_proofing_report.rb --date=2023-05-01
```

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
