### PR TITLE
Remove SpinnerButton from barcode warning

### DIFF
--- a/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
+++ b/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
@@ -1,5 +1,4 @@
 import { Button, StatusPage } from '@18f/identity-components';
-import { SpinnerButton } from '@18f/identity-spinner-button';
 import { t } from '@18f/identity-i18n';
 import { trackEvent } from '@18f/identity-analytics';
 import { removeUnloadProtection } from '@18f/identity-url';
@@ -36,9 +35,9 @@ function BarcodeAttentionWarning({ onDismiss, pii }: BarcodeAttentionWarningProp
       header={t('doc_auth.errors.barcode_attention.heading')}
       status="warning"
       actionButtons={[
-        <SpinnerButton key="continue" isBig isWide onClick={skipAttention}>
+        <Button key="continue" isBig isWide onClick={skipAttention}>
           {t('forms.buttons.continue')}
-        </SpinnerButton>,
+        </Button>,
         <Button key="add-new" isBig isOutline isWide onClick={handleDismiss}>
           {t('doc_auth.buttons.add_new_photos')}
         </Button>,


### PR DESCRIPTION
Quick follow-on to #8540 to address @aduth's feedback. Replace a `<SpinnerButton>` with a regular `<Button>` now that its onclick handler is not async.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
