### PR TITLE
LG-10016 agreement controller

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -37,6 +37,8 @@ module Idv
         idv_session.idv_consent_given = true
 
         redirect_to idv_hybrid_handoff_url
+      else
+        redirect_to idv_agreement_url
       end
     end
 

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -18,7 +18,7 @@ module Idv
         true
       )
 
-      render :show
+      render :show, locals: { flow_session: flow_session }
     end
 
     def update

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -24,9 +24,6 @@ module Idv
     end
 
     def update
-      # for the 50/50 state
-      flow_session['Idv::Steps::AgreementStep'] = true
-
       skip_to_capture if params[:skip_upload]
 
       result = Idv::ConsentForm.new.submit(consent_form_params)
@@ -37,6 +34,9 @@ module Idv
 
       if result.success?
         idv_session.idv_consent_given = true
+
+        # for the 50/50 state
+        flow_session['Idv::Steps::AgreementStep'] = true
 
         redirect_to idv_hybrid_handoff_url
       else

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -2,6 +2,7 @@ module Idv
   class AgreementController < ApplicationController
     include IdvSession
     include IdvStepConcern
+    include OutageConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
 
@@ -9,6 +10,7 @@ module Idv
     before_action :render_404_if_agreement_controller_disabled
     before_action :confirm_welcome_step_complete
     before_action :confirm_agreement_needed
+    before_action :check_for_outage, only: :show
 
     def show
       analytics.idv_doc_auth_agreement_visited(**analytics_arguments)

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -1,0 +1,74 @@
+module Idv
+  class AgreementController < ApplicationController
+    include IdvSession
+    include IdvStepConcern
+    include StepIndicatorConcern
+    include StepUtilitiesConcern
+
+    before_action :confirm_two_factor_authenticated
+    before_action :render_404_if_agreement_controller_disabled
+    before_action :confirm_welcome_step_complete
+    before_action :confirm_agreement_needed
+
+    def show
+      analytics.idv_doc_auth_agreement_visited(**analytics_arguments)
+
+      Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).call(
+        'agreement', :view,
+        true
+      )
+
+      render :show
+    end
+
+    def update
+      analytics.idv_doc_auth_agreement_submitted(**analytics_arguments)
+
+      # for the 50/50 state
+      flow_session['Idv::Steps::AgreementStep'] = true
+
+      skip_to_capture if params[:skip_upload]
+
+      Idv::ConsentForm.new.submit(consent_form_params)
+
+      idv_session.agreement_checked = true
+
+      redirect_to idv_hybrid_handoff_url
+    end
+
+    private
+
+    def analytics_arguments
+      {
+        step: 'agreement',
+        analytics_id: 'Doc Auth',
+        irs_reproofing: irs_reproofing?,
+      }
+    end
+
+    def skip_to_capture
+      flow_session[:skip_upload_step] = true
+      flow_session[:flow_path] = 'standard'
+    end
+
+    def consent_form_params
+      params.require(:doc_auth).permit(:ial2_consent_given)
+    end
+
+    def confirm_welcome_step_complete
+      return if flow_session['Idv::Steps::WelcomeStep']
+
+      redirect_to idv_doc_auth_url
+    end
+
+    def confirm_agreement_needed
+      return unless idv_session.agreement_checked
+
+      redirect_to idv_hybrid_handoff_url
+    end
+
+    def render_404_if_agreement_controller_disabled
+      render_not_found unless IdentityConfig.store.doc_auth_agreement_controller_enabled
+    end
+  end
+end

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -31,7 +31,7 @@ module Idv
 
       Idv::ConsentForm.new.submit(consent_form_params)
 
-      idv_session.agreement_checked = true
+      idv_session.idv_consent_given = true
 
       redirect_to idv_hybrid_handoff_url
     end
@@ -52,7 +52,7 @@ module Idv
     end
 
     def consent_form_params
-      params.require(:doc_auth).permit(:ial2_consent_given)
+      params.require(:doc_auth).permit(:idv_consent_given)
     end
 
     def confirm_welcome_step_complete
@@ -62,7 +62,7 @@ module Idv
     end
 
     def confirm_agreement_needed
-      return unless idv_session.agreement_checked
+      return unless idv_session.idv_consent_given
 
       redirect_to idv_hybrid_handoff_url
     end

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -207,10 +207,13 @@ module Idv
     def confirm_agreement_step_complete
       # delete when removing doc_auth_agreement_controller_enabled flag
       return if flow_session['Idv::Steps::AgreementStep']
-
       return if idv_session.idv_consent_given
 
-      redirect_to idv_doc_auth_url
+      if IdentityConfig.store.doc_auth_agreement_controller_enabled
+        redirect_to idv_agreement_url
+      else
+        redirect_to idv_doc_auth_url
+      end
     end
 
     def confirm_hybrid_handoff_needed

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -208,7 +208,7 @@ module Idv
       # delete when removing doc_auth_agreement_controller_enabled flag
       return if flow_session['Idv::Steps::AgreementStep']
 
-      return if idv_session.agreement_checked
+      return if idv_session.idv_consent_given
 
       redirect_to idv_doc_auth_url
     end

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -205,7 +205,10 @@ module Idv
     end
 
     def confirm_agreement_step_complete
+      # delete when removing doc_auth_agreement_controller_enabled flag
       return if flow_session['Idv::Steps::AgreementStep']
+
+      return if idv_session.agreement_checked
 
       redirect_to idv_doc_auth_url
     end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -2,10 +2,10 @@ module Idv
   class Session
     VALID_SESSION_ATTRIBUTES = %i[
       address_verification_mechanism
-      agreement_checked
       applicant
       go_back_path
       verify_info_step_document_capture_session_uuid
+      idv_consent_given
       idv_phone_step_document_capture_session_uuid
       vendor_phone_confirmation
       user_phone_confirmation

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -2,6 +2,7 @@ module Idv
   class Session
     VALID_SESSION_ATTRIBUTES = %i[
       address_verification_mechanism
+      agreement_checked
       applicant
       go_back_path
       verify_info_step_document_capture_session_uuid

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -16,6 +16,8 @@ module Idv
 
         create_document_capture_session(document_capture_session_uuid_key)
         cancel_previous_in_person_enrollments
+
+        redirect_to idv_agreement_url if IdentityConfig.store.doc_auth_agreement_controller_enabled
       end
 
       private

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -26,7 +26,7 @@
   <%= render ClickObserverComponent.new(event_name: 'IdV: consent checkbox toggled') do %>
     <%= render ValidatedFieldComponent.new(
           form: f,
-          name: :idv_consent_given,
+          name: :ial2_consent_given,
           as: :boolean,
           label: t('doc_auth.instructions.consent', app_name: APP_NAME),
           required: true,

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -26,7 +26,7 @@
   <%= render ClickObserverComponent.new(event_name: 'IdV: consent checkbox toggled') do %>
     <%= render ValidatedFieldComponent.new(
           form: f,
-          name: :ial2_consent_given,
+          name: :idv_consent_given,
           as: :boolean,
           label: t('doc_auth.instructions.consent', app_name: APP_NAME),
           required: true,

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -1,0 +1,55 @@
+<% title t('doc_auth.headings.lets_go') %>
+
+<%= render AlertComponent.new(
+      type: :error,
+      class: [
+        'js-consent-form-alert',
+        'margin-bottom-4',
+        flow_session[:error_message].blank? && 'display-none',
+      ].select(&:present?),
+      message: flow_session[:error_message].presence || t('errors.doc_auth.consent_form'),
+    ) %>
+
+<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.lets_go')) %>
+<p><%= t('doc_auth.info.lets_go') %></p>
+<h2><%= t('doc_auth.headings.verify_identity') %></h2>
+<p><%= t('doc_auth.info.verify_identity') %></p>
+<h2><%= t('doc_auth.headings.secure_account') %></h2>
+<p><%= t('doc_auth.info.secure_account') %></p>
+
+<%= simple_form_for(
+      :doc_auth,
+      url: url_for,
+      method: 'put',
+      html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
+    ) do |f| %>
+  <%= render ClickObserverComponent.new(event_name: 'IdV: consent checkbox toggled') do %>
+    <%= render ValidatedFieldComponent.new(
+          form: f,
+          name: :ial2_consent_given,
+          as: :boolean,
+          label: t('doc_auth.instructions.consent', app_name: APP_NAME),
+          required: true,
+        ) %>
+  <% end %>
+  <p class="margin-top-2">
+    <%= new_tab_link_to(
+          t('doc_auth.instructions.learn_more'),
+          policy_redirect_url(flow: :idv, step: :agreement, location: :consent),
+        ) %>
+  </p>
+  <div class="margin-top-4">
+    <%= render(
+          SpinnerButtonComponent.new(
+            type: :submit,
+            big: true,
+            wide: true,
+            spin_on_click: false,
+          ).with_content(t('doc_auth.buttons.continue')),
+        ) %>
+  </div>
+<% end %>
+
+<%= render 'idv/doc_auth/cancel', step: 'agreement' %>
+
+<%= javascript_packs_tag_once('document-capture-welcome') %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -87,6 +87,7 @@ doc_capture_polling_enabled: true
 doc_auth_client_glare_threshold: 50
 doc_auth_client_sharpness_threshold: 50
 doc_auth_s3_request_timeout: 5
+doc_auth_agreement_controller_enabled: false
 doc_auth_error_dpi_threshold: 290
 doc_auth_error_glare_threshold: 40
 doc_auth_error_sharpness_threshold: 40

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -329,6 +329,8 @@ Rails.application.routes.draw do
       post '/personal_key' => 'personal_key#update'
       get '/forgot_password' => 'forgot_password#new'
       post '/forgot_password' => 'forgot_password#update'
+      get '/agreement' => 'agreement#show'
+      put '/agreement' => 'agreement#update'
       get '/document_capture' => 'document_capture#show'
       put '/document_capture' => 'document_capture#update'
       # This route is included in SMS messages sent to users who start the IdV hybrid flow. It

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -153,6 +153,7 @@ class IdentityConfig
     config.add(:disable_email_sending, type: :boolean)
     config.add(:disallow_all_web_crawlers, type: :boolean)
     config.add(:disposable_email_services, type: :json)
+    config.add(:doc_auth_agreement_controller_enabled, type: :boolean)
     config.add(:doc_auth_attempt_window_in_minutes, type: :integer)
     config.add(:doc_auth_client_glare_threshold, type: :integer)
     config.add(:doc_auth_client_sharpness_threshold, type: :integer)

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -100,5 +100,4 @@ describe Idv::AgreementController do
       expect(response.status).to eq(404)
     end
   end
-
 end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -64,7 +64,7 @@ describe Idv::AgreementController do
 
     context 'agreement already visited' do
       it 'redirects to hybrid_handoff' do
-        allow(subject.idv_session).to receive(:agreement_checked).and_return(true)
+        allow(subject.idv_session).to receive(:idv_consent_given).and_return(true)
 
         get :show
 

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -22,6 +22,13 @@ describe Idv::AgreementController do
         :confirm_two_factor_authenticated,
       )
     end
+
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
   end
 
   describe '#show' do

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -84,8 +84,8 @@ describe Idv::AgreementController do
         irs_reproofing: false }
     end
 
-    it 'sends analytics_submitted event' do
-      put :update
+    it 'sends analytics_submitted event with consent given' do
+      put :update, params: { doc_auth: { ial2_consent_given: 1 } }
 
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -51,7 +51,7 @@ describe Idv::AgreementController do
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
-    it 'updates DocAuthLog document_capture_view_count' do
+    it 'updates DocAuthLog agreement_view_count' do
       doc_auth_log = DocAuthLog.create(user_id: user.id)
 
       expect { get :show }.to(
@@ -98,7 +98,7 @@ describe Idv::AgreementController do
     end
   end
 
-  context 'when doc_auth_document_capture_controller_enabled is false' do
+  context 'when doc_auth_agreement_controller_enabled is false' do
     let(:feature_flag_enabled) { false }
 
     it 'returns 404' do

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+describe Idv::AgreementController do
+  include IdvHelper
+
+  let(:user) { create(:user) }
+
+  let(:feature_flag_enabled) { true }
+
+  before do
+    allow(IdentityConfig.store).to receive(:doc_auth_agreement_controller_enabled).
+      and_return(feature_flag_enabled)
+    stub_sign_in(user)
+    stub_analytics
+    subject.user_session['idv/doc_auth'] = { 'Idv::Steps::WelcomeStep' => true }
+  end
+
+  describe 'before_actions' do
+    it 'includes authentication before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+      )
+    end
+  end
+
+  describe '#show' do
+    let(:analytics_name) { 'IdV: doc auth agreement visited' }
+    let(:analytics_args) do
+      { step: 'agreement',
+        analytics_id: 'Doc Auth',
+        irs_reproofing: false }
+    end
+
+    it 'renders the show template' do
+      get :show
+
+      expect(response).to render_template :show
+    end
+
+    it 'sends analytics_visited event' do
+      get :show
+
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+    end
+
+    it 'updates DocAuthLog document_capture_view_count' do
+      doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+      expect { get :show }.to(
+        change { doc_auth_log.reload.agreement_view_count }.from(0).to(1),
+      )
+    end
+
+    context 'welcome step is not complete' do
+      it 'redirects to idv_doc_auth_url' do
+        subject.user_session['idv/doc_auth']['Idv::Steps::WelcomeStep'] = nil
+
+        get :show
+
+        expect(response).to redirect_to(idv_doc_auth_url)
+      end
+    end
+
+    context 'agreement already visited' do
+      it 'redirects to hybrid_handoff' do
+        allow(subject.idv_session).to receive(:agreement_checked).and_return(true)
+
+        get :show
+
+        expect(response).to redirect_to(idv_hybrid_handoff_url)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:analytics_name) { 'IdV: doc auth agreement submitted' }
+
+    let(:analytics_args) do
+      { success: true,
+        errors: {},
+        step: 'agreement',
+        analytics_id: 'Doc Auth',
+        irs_reproofing: false }
+    end
+
+    it 'sends analytics_submitted event' do
+      put :update
+
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+    end
+  end
+
+  context 'when doc_auth_document_capture_controller_enabled is false' do
+    let(:feature_flag_enabled) { false }
+
+    it 'returns 404' do
+      get :show
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -64,12 +64,23 @@ describe Idv::HybridHandoffController do
     end
 
     context 'agreement step is not complete' do
-      it 'redirects to idv_doc_auth_url' do
+      before do
         subject.user_session['idv/doc_auth']['Idv::Steps::AgreementStep'] = nil
+      end
 
+      it 'redirects to idv_doc_auth_url' do
         get :show
 
         expect(response).to redirect_to(idv_doc_auth_url)
+      end
+
+      it 'redirects to idv_agreement_url when feature flag is set' do
+        allow(IdentityConfig.store).to receive(:doc_auth_agreement_controller_enabled).
+          and_return(true)
+
+        get :show
+
+        expect(response).to redirect_to(idv_agreement_url)
       end
     end
 

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -55,7 +55,7 @@ describe Idv::HybridHandoffController do
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
-    it 'updates DocAuthLog document_capture_view_count' do
+    it 'updates DocAuthLog upload_view_count' do
       doc_auth_log = DocAuthLog.create(user_id: user.id)
 
       expect { get :show }.to(

--- a/spec/features/idv/doc_auth/agreement_spec.rb
+++ b/spec/features/idv/doc_auth/agreement_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+feature 'doc auth agreement step' do
+  include DocAuthHelper
+
+  before do
+    allow(IdentityConfig.store).to receive(:doc_auth_agreement_controller_enabled).
+      and_return(true)
+  end
+
+  context 'when JS is enabled', :js do
+    before do
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_agreement_step
+    end
+
+    it 'shows an inline error if the user clicks continue without giving consent' do
+      click_continue
+
+      expect(page).to have_current_path(idv_agreement_url)
+      expect(page).to have_content(t('forms.validation.required_checkbox'))
+    end
+
+    it 'allows the user to continue after checking the checkbox' do
+      check t('doc_auth.instructions.consent', app_name: APP_NAME)
+      click_continue
+
+      expect(page).to have_current_path(idv_hybrid_handoff_path)
+    end
+  end
+
+  context 'when JS is disabled' do
+    before do
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_agreement_step
+    end
+
+    it 'shows the notice if the user clicks continue without giving consent' do
+      click_continue
+
+      expect(page).to have_current_path(idv_agreement_url)
+      expect(page).to have_content(t('errors.doc_auth.consent_form'))
+    end
+
+    it 'allows the user to continue after checking the checkbox' do
+      check t('doc_auth.instructions.consent', app_name: APP_NAME)
+      click_continue
+
+      expect(page).to have_current_path(idv_hybrid_handoff_path)
+    end
+  end
+
+  context 'skipping hybrid_handoff step', :js, driver: :headless_chrome_mobile do
+    let(:fake_analytics) { FakeAnalytics.new }
+
+    before do
+      allow_any_instance_of(ApplicationController).
+        to receive(:analytics).and_return(fake_analytics)
+
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_agreement_step
+      complete_agreement_step
+    end
+
+    it 'progresses to document capture' do
+      expect(page).to have_current_path(idv_document_capture_url)
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10016](https://cm-jira.usa.gov/browse/LG-10016)

## 🛠 Summary of changes

New AgreementController behind feature flag to replace FSM AgreementStep.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] In application.yml, add `doc_auth_agreement_controller_enabled: true`
- [ ] Create account, go to `/verify`
- [ ] From Welcome step, navigate to `/verify/agreement`
- [ ] Expect to stay on Welcome step
- [ ] Click Continue
- [ ] Expect to be on `/verify/agreement`
- [ ] Try to continue without clicking checkbox
- [ ] Expect to see error
- [ ] Check box, click Continue
- [ ] Expect to be on HybridHandoff
- [ ] Navigate to `/verify/agreement`
- [ ] Expect to stay on HybridHandoff

## 👀 Screenshots

<details>
<summary>After:</summary>
  
![Agreement](https://github.com/18F/identity-idp/assets/2381438/11d34df6-527d-4a39-ab46-06df4e769a01)
</details>

