### PR TITLE
LG-10029: verified_at not updated during password reset

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -46,7 +46,7 @@ class Profile < ApplicationRecord
   end
 
   # rubocop:disable Rails/SkipsModelValidations
-  def activate(reason_deactivated = nil)
+  def activate(reason_deactivated: nil)
     confirm_that_profile_can_be_activated!
 
     now = Time.zone.now
@@ -101,7 +101,7 @@ class Profile < ApplicationRecord
       update!(
         deactivation_reason: nil,
       )
-      activate(:password_reset)
+      activate(reason_deactivated: :password_reset)
     end
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -46,18 +46,22 @@ class Profile < ApplicationRecord
   end
 
   # rubocop:disable Rails/SkipsModelValidations
-  def activate
+  def activate(reason_deactivated = nil)
     confirm_that_profile_can_be_activated!
 
     now = Time.zone.now
     is_reproof = Profile.find_by(user_id: user_id, active: true)
+
+    attrs = {
+      active: true,
+      activated_at: now,
+    }
+
+    attrs[:verified_at] = now unless reason_deactivated == :password_reset
+
     transaction do
       Profile.where(user_id: user_id).update_all(active: false)
-      update!(
-        active: true,
-        activated_at: now,
-        verified_at: now,
-      )
+      update!(attrs)
     end
     send_push_notifications if is_reproof
   end
@@ -97,7 +101,7 @@ class Profile < ApplicationRecord
       update!(
         deactivation_reason: nil,
       )
-      activate
+      activate(:password_reset)
     end
   end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -332,6 +332,22 @@ describe Profile do
 
       expect(profile.active).to eq true
       expect(profile.deactivation_reason).to eq nil
+      expect(profile.verified_at).to eq nil
+    end
+
+    it 'activates a previously verified profile after password reset' do
+      verified_at = Time.now - 1.year
+      profile = create(
+        :profile,
+        user: user,
+        active: false,
+        deactivation_reason: :password_reset,
+        verified_at: verified_at
+      )
+
+      profile.activate_after_password_reset
+
+      expect(profile.verified_at).to eq verified_at
     end
 
     it 'does not activate a profile if it has a pending reason' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -347,6 +347,8 @@ describe Profile do
 
       profile.activate_after_password_reset
 
+      expect(profile.active).to eq true
+      expect(profile.deactivation_reason).to eq nil
       expect(profile.verified_at).to eq verified_at
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -336,13 +336,13 @@ describe Profile do
     end
 
     it 'activates a previously verified profile after password reset' do
-      verified_at = Time.now - 1.year
+      verified_at = Time.zone.now - 1.year
       profile = create(
         :profile,
         user: user,
         active: false,
         deactivation_reason: :password_reset,
-        verified_at: verified_at
+        verified_at: verified_at,
       )
 
       profile.activate_after_password_reset


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-10029](https://cm-jira.usa.gov/browse/LG-10029)

## 🛠 Summary of changes
Added an optional argument to the Profile#activate method which is used to detail why the account is being activated; and, if it is due to a passoword reset, then verified_at is not set during profile update.


## 📜 Testing Plan
Added an automated test to check this in profile_spec.rb

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
