### PR TITLE
Jmax/lg 9296 updates to phone rate limit screen

### DIFF
--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -9,28 +9,23 @@
           text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
           new_tab: true,
         },
-        decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path(step: 'phone', location: request.params[:action]),
-          text: t('idv.failure.phone.rate_limited.option_cancel_and_return_to_sp'),
-          new_tab: false,
-        },
       ].select(&:present?),
     ) do %>
       <p>
-        <%= t(
-              'idv.failure.phone.rate_limited.body',
-              time_left: distance_of_time_in_words(
-                Time.zone.now,
-                [@expires_at, Time.zone.now].compact.max,
-                except: :seconds,
-              ),
-            ) %>
+        <%= t('idv.failure.phone.rate_limited.body') %>
       </p>
       <%= t('idv.failure.phone.rate_limited.options_header') %>
       <ul>
         <% if @gpo_letter_available %>
           <li><%= t('idv.failure.phone.rate_limited.option_verify_by_mail_html') %></li>
         <% end %>
+        <li>
+          <%= t('idv.failure.phone.rate_limited.option_try_again_later',
+                time_left: distance_of_time_in_words(Time.zone.now,
+                                                     [@expires_at, Time.zone.now].compact.max,
+                                                     except: :seconds)
+              ) %>
+        </li>
       </ul>
 
       <% if @gpo_letter_available %>
@@ -43,5 +38,7 @@
         </div>
       <% end %>
     <% end %>
-    <%= link_to(t('links.cancel'), return_to_sp_cancel_url) %>
+    <%= render PageFooterComponent.new do %>
+      <%= link_to(t('links.cancel'), return_to_sp_cancel_url) %>
+    <% end %>
 

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -39,6 +39,11 @@
       <% end %>
     <% end %>
     <%= render PageFooterComponent.new do %>
-      <%= link_to(t('links.cancel'), return_to_sp_cancel_url) %>
+      <%=
+        link_to(
+          t('links.cancel'),
+          return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
+        )
+      %>
     <% end %>
 

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -42,9 +42,6 @@
       <% end %>
     <% end %>
     <%= render PageFooterComponent.new do %>
-      <%= link_to(
-            t('links.cancel'),
-            return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
-          ) %>
+      <%= link_to(t('links.cancel'), idv_cancel_path) %>
     <% end %>
 

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -31,12 +31,15 @@
         <% if @gpo_letter_available %>
           <li><%= t('idv.failure.phone.rate_limited.option_verify_by_mail_html') %></li>
         <% end %>
-        <li><%=
-              t('idv.failure.phone.rate_limited.option_cancel',
-                time_left: distance_of_time_in_words(Time.zone.now,
-                                                     [@expires_at, Time.zone.now].compact.max,
-                                                     except: :seconds))
-              %>
+        <li>
+         <%= t(
+               'idv.failure.phone.rate_limited.option_cancel',
+               time_left: distance_of_time_in_words(
+                 Time.zone.now,
+                 [@expires_at, Time.zone.now].compact.max,
+                 except: :seconds,
+               ),
+             ) %>
         </li>
       </ul>
 

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -4,14 +4,14 @@
       heading: t('idv.failure.phone.rate_limited.heading'),
       current_step: :verify_phone_or_address,
       options: [
-        decorated_session.sp_name && {
-          url: return_to_sp_failure_to_proof_path(step: 'phone', location: request.params[:action]),
-          text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-          new_tab: true,
-        },
         {
           url: MarketingSite.contact_url,
           text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+          new_tab: true,
+        },
+        decorated_session.sp_name && {
+          url: return_to_sp_failure_to_proof_path(step: 'phone', location: request.params[:action]),
+          text: t('idv.failure.phone.rate_limited.option_cancel_and_return_to_sp'),
           new_tab: true,
         },
       ].select(&:present?),

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -43,6 +43,5 @@
         </div>
       <% end %>
     <% end %>
-    <%= link_to(t('idv.failure.phone.rate_limited.option_cancel'),
-                return_to_sp_cancel_url) %>
+    <%= link_to(t('links.cancel'), return_to_sp_cancel_url) %>
 

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -12,7 +12,7 @@
         decorated_session.sp_name && {
           url: return_to_sp_failure_to_proof_path(step: 'phone', location: request.params[:action]),
           text: t('idv.failure.phone.rate_limited.option_cancel_and_return_to_sp'),
-          new_tab: true,
+          new_tab: false,
         },
       ].select(&:present?),
     ) do %>

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -31,16 +31,6 @@
         <% if @gpo_letter_available %>
           <li><%= t('idv.failure.phone.rate_limited.option_verify_by_mail_html') %></li>
         <% end %>
-        <li>
-         <%= t(
-               'idv.failure.phone.rate_limited.option_cancel',
-               time_left: distance_of_time_in_words(
-                 Time.zone.now,
-                 [@expires_at, Time.zone.now].compact.max,
-                 except: :seconds,
-               ),
-             ) %>
-        </li>
       </ul>
 
       <% if @gpo_letter_available %>
@@ -53,3 +43,6 @@
         </div>
       <% end %>
     <% end %>
+    <%= link_to(t('idv.failure.phone.rate_limited.option_cancel'),
+                return_to_sp_cancel_url) %>
+

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -20,10 +20,13 @@
           <li><%= t('idv.failure.phone.rate_limited.option_verify_by_mail_html') %></li>
         <% end %>
         <li>
-          <%= t('idv.failure.phone.rate_limited.option_try_again_later',
-                time_left: distance_of_time_in_words(Time.zone.now,
-                                                     [@expires_at, Time.zone.now].compact.max,
-                                                     except: :seconds)
+          <%= t(
+                'idv.failure.phone.rate_limited.option_try_again_later',
+                time_left: distance_of_time_in_words(
+                  Time.zone.now,
+                  [@expires_at, Time.zone.now].compact.max,
+                  except: :seconds,
+                ),
               ) %>
         </li>
       </ul>
@@ -39,11 +42,9 @@
       <% end %>
     <% end %>
     <%= render PageFooterComponent.new do %>
-      <%=
-        link_to(
-          t('links.cancel'),
-          return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
-        )
-      %>
+      <%= link_to(
+            t('links.cancel'),
+            return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
+          ) %>
     <% end %>
 

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -21,7 +21,7 @@
         <% end %>
         <li>
           <%= t(
-                'idv.failure.phone.rate_limited.option_try_again_later',
+                'idv.failure.phone.rate_limited.option_try_again_later_html',
                 time_left: distance_of_time_in_words(
                   Time.zone.now,
                   [@expires_at, Time.zone.now].compact.max,

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -26,10 +26,21 @@
               ),
             ) %>
       </p>
+      <%= t('idv.failure.phone.rate_limited.options_header') %>
+      <ul>
+        <% if @gpo_letter_available %>
+          <li><%= t('idv.failure.phone.rate_limited.option_verify_by_mail_html') %></li>
+        <% end %>
+        <li><%=
+              t('idv.failure.phone.rate_limited.option_cancel',
+                time_left: distance_of_time_in_words(Time.zone.now,
+                                                     [@expires_at, Time.zone.now].compact.max,
+                                                     except: :seconds))
+              %>
+        </li>
+      </ul>
+
       <% if @gpo_letter_available %>
-        <p>
-          <strong><%= t('idv.failure.phone.rate_limited.gpo.prompt') %></strong>
-        </p>
         <div class="margin-y-5">
           <%= render ButtonComponent.new(
                 action: ->(**tag_options, &block) { link_to idv_gpo_path, **tag_options, &block },

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -101,7 +101,7 @@ en:
           gpo:
             button: Verify by mail
           heading: 'We couldn’t verify your identity by phone'
-          option_try_again_later: Cancel and start over again after %{time_left}
+          option_try_again_later_html: 'Cancel and start over again after <b>%{time_left}</b>'
           option_verify_by_mail_html: 'Verify by mail, which typically takes <b>3-7 business days</b>'
           options_header: 'You can:'
         timeout: Our request to verify your information timed out. Please try again.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -98,16 +98,14 @@ en:
         rate_limited:
           body: For security reasons, we limit the number of times you can attempt to
             verify your phone number online.
-            # You will need to wait %{time_left}
-            # and start over before trying to verify by phone again.
           gpo:
             button: Verify by mail
             prompt: Continue now by verifying by mail, which typically takes 3 - 7 business
               days.
           heading: 'We couldn’t verify your identity by phone'
-          options_header: 'You can:'
-          option_verify_by_mail_html: 'Verify by mail, which typically takes <b>3-7 business days</b>'
           option_cancel: Cancel and start over again after %{time_left}
+          option_verify_by_mail_html: 'Verify by mail, which typically takes <b>3-7 business days</b>'
+          options_header: 'You can:'
         timeout: Our request to verify your information timed out. Please try again.
         warning:
           attempts:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -101,7 +101,6 @@ en:
           gpo:
             button: Verify by mail
           heading: 'We couldn’t verify your identity by phone'
-          option_cancel: Cancel and start over again after %{time_left}
           option_cancel_and_return_to_sp: Cancel
           option_verify_by_mail_html: 'Verify by mail, which typically takes <b>3-7 business days</b>'
           options_header: 'You can:'

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -100,8 +100,6 @@ en:
             verify your phone number online.
           gpo:
             button: Verify by mail
-            prompt: Continue now by verifying by mail, which typically takes 3 - 7 business
-              days.
           heading: 'We couldn’t verify your identity by phone'
           option_cancel: Cancel and start over again after %{time_left}
           option_verify_by_mail_html: 'Verify by mail, which typically takes <b>3-7 business days</b>'

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -102,6 +102,7 @@ en:
             button: Verify by mail
           heading: 'We couldn’t verify your identity by phone'
           option_cancel: Cancel and start over again after %{time_left}
+          option_cancel_and_return_to_sp: Cancel
           option_verify_by_mail_html: 'Verify by mail, which typically takes <b>3-7 business days</b>'
           options_header: 'You can:'
         timeout: Our request to verify your information timed out. Please try again.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -97,13 +97,17 @@ en:
           Please try again.
         rate_limited:
           body: For security reasons, we limit the number of times you can attempt to
-            verify your phone number online. You will need to wait %{time_left}
-            and start over before trying to verify by phone again.
+            verify your phone number online.
+            # You will need to wait %{time_left}
+            # and start over before trying to verify by phone again.
           gpo:
             button: Verify by mail
             prompt: Continue now by verifying by mail, which typically takes 3 - 7 business
               days.
           heading: 'We couldn’t verify your identity by phone'
+          options_header: 'You can:'
+          option_verify_by_mail_html: 'Verify by mail, which typically takes <b>3-7 business days</b>'
+          option_cancel: Cancel and start over again after %{time_left}
         timeout: Our request to verify your information timed out. Please try again.
         warning:
           attempts:
@@ -276,7 +280,7 @@ en:
       state_id:
         cancel_button: Exit %{app_name}
         explanation: |
-          Unfortunately, we’re experiencing technical difficulties 
+          Unfortunately, we’re experiencing technical difficulties
           with IDs from your state and are currently unable to verify your information.
         heading: We are working to resolve an error
         next_steps:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -101,7 +101,7 @@ en:
           gpo:
             button: Verify by mail
           heading: 'We couldn’t verify your identity by phone'
-          option_cancel_and_return_to_sp: Cancel
+          option_try_again_later: Cancel and start over again after %{time_left}
           option_verify_by_mail_html: 'Verify by mail, which typically takes <b>3-7 business days</b>'
           options_header: 'You can:'
         timeout: Our request to verify your information timed out. Please try again.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -103,14 +103,15 @@ es:
           Vuelve a intentarlo.
         rate_limited:
           body: Por motivos de seguridad, se limita el número de veces que puede intentar
-            verificar su número de teléfono por Internet. Tendrás que esperar
-            %{time_left} y volver a empezar antes de volver a intentar la
-            verificación por teléfono.
+            verificar su número de teléfono por Internet.
           gpo:
             button: Verificar por correo
-            prompt: Continúa ahora con la verificación por correo, que suele tardar entre 3
-              y 7 días laborables.
-          heading: 'No hemos podido verificar su identidad por teléfono'
+            prompt: Continúa ahora con la verificación por correo, que suele tardar entre
+              <b>3 y 7 días laborables</b>.
+          heading: No pudimos asociarlo a este número
+          option_cancel: Cancelar y empezar de nuevo transcurridas %{time_left}
+          option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de 3 a 7 días hábiles'
+          options_header: 'Puede:'
         timeout: Nuestra solicitud para verificar tu información ha caducado. Vuelve a
           intentarlo.
         warning:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -108,6 +108,7 @@ es:
             button: Verificar por correo
           heading: No pudimos asociarlo a este número
           option_cancel: Cancelar y empezar de nuevo transcurridas %{time_left}
+          option_cancel_and_return_to_sp: Cancelar
           option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de <b>3
             a 7 días hábiles</b>'
           options_header: 'Puede:'

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -107,7 +107,6 @@ es:
           gpo:
             button: Verificar por correo
           heading: No pudimos asociarlo a este número
-          option_cancel: Cancelar y empezar de nuevo transcurridas %{time_left}
           option_cancel_and_return_to_sp: Cancelar
           option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de <b>3
             a 7 días hábiles</b>'

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -108,7 +108,8 @@ es:
             button: Verificar por correo
           heading: No pudimos asociarlo a este número
           option_cancel: Cancelar y empezar de nuevo transcurridas %{time_left}
-          option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de <b>3 a 7 días hábiles</b>'
+          option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de <b>3
+            a 7 días hábiles</b>'
           options_header: 'Puede:'
         timeout: Nuestra solicitud para verificar tu información ha caducado. Vuelve a
           intentarlo.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -107,7 +107,7 @@ es:
           gpo:
             button: Verificar por correo
           heading: No pudimos asociarlo a este número
-          option_cancel_and_return_to_sp: Cancelar
+          option_try_again_later: Cancelar y empezar de nuevo transcurridas %{time_left}
           option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de <b>3
             a 7 días hábiles</b>'
           options_header: 'Puede:'

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -107,7 +107,7 @@ es:
           gpo:
             button: Verificar por correo
           heading: No pudimos asociarlo a este número
-          option_try_again_later: Cancelar y empezar de nuevo transcurridas %{time_left}
+          option_try_again_later_html: 'Cancelar y empezar de nuevo transcurridas <b>%{time_left}</b>'
           option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de <b>3
             a 7 días hábiles</b>'
           options_header: 'Puede:'

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -106,11 +106,9 @@ es:
             verificar su número de teléfono por Internet.
           gpo:
             button: Verificar por correo
-            prompt: Continúa ahora con la verificación por correo, que suele tardar entre
-              <b>3 y 7 días laborables</b>.
           heading: No pudimos asociarlo a este número
           option_cancel: Cancelar y empezar de nuevo transcurridas %{time_left}
-          option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de 3 a 7 días hábiles'
+          option_verify_by_mail_html: 'Verificar por correo, lo que suele demorar de <b>3 a 7 días hábiles</b>'
           options_header: 'Puede:'
         timeout: Nuestra solicitud para verificar tu información ha caducado. Vuelve a
           intentarlo.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -112,8 +112,6 @@ fr:
             vérification de votre numéro de téléphone en ligne.
           gpo:
             button: Vérifier par courrier
-            prompt: Continuez maintenant en vérifiant par courrier, ce qui prend
-              généralement de 3 à 7 jours ouvrables.
           heading: Nous n’avons pas pu vérifier votre identité par téléphone
           option_cancel: Annuler et recommencer après %{time_left}
           option_verify_by_mail_html: Vérifier par courrier, ce qui prend généralement de

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -113,7 +113,7 @@ fr:
           gpo:
             button: Vérifier par courrier
           heading: Nous n’avons pas pu vérifier votre identité par téléphone
-          option_try_again_later: Annuler et recommencer après %{time_left}
+          option_try_again_later_html: 'Annuler et recommencer après <b>%{time_left}</b>'
           option_verify_by_mail_html: Vérifier par courrier, ce qui prend généralement de
             <b>trois à sept jours ouvrables</b>.
           options_header: 'Vous Pouvez :'

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -113,7 +113,7 @@ fr:
           gpo:
             button: Vérifier par courrier
           heading: Nous n’avons pas pu vérifier votre identité par téléphone
-          option_cancel_and_return_to_sp: Annuler
+          option_try_again_later: Annuler et recommencer après %{time_left}
           option_verify_by_mail_html: Vérifier par courrier, ce qui prend généralement de
             <b>trois à sept jours ouvrables</b>.
           options_header: 'Vous Pouvez :'

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -109,14 +109,16 @@ fr:
           pour le moment. Veuillez réessayer.
         rate_limited:
           body: Pour des raisons de sécurité, nous limitons le nombre de tentatives de
-            vérification de votre numéro de téléphone en ligne. Vous devrez
-            attendre %{time_left} et recommencer avant d’essayer à nouveau de
-            vérifier votre identité par téléphone.
+            vérification de votre numéro de téléphone en ligne.
           gpo:
             button: Vérifier par courrier
             prompt: Continuez maintenant en vérifiant par courrier, ce qui prend
               généralement de 3 à 7 jours ouvrables.
           heading: Nous n’avons pas pu vérifier votre identité par téléphone
+          option_cancel: Annuler et recommencer après %{time_left}
+          option_verify_by_mail_html: Vérifier par courrier, ce qui prend généralement de
+            <b>trois à sept jours ouvrables</b>.
+          options_header: 'Vous Pouvez :'
         timeout: Notre demande de vérification de vos renseignements a expiré. Veuillez
           réessayer.
         warning:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -114,6 +114,7 @@ fr:
             button: Vérifier par courrier
           heading: Nous n’avons pas pu vérifier votre identité par téléphone
           option_cancel: Annuler et recommencer après %{time_left}
+          option_cancel_and_return_to_sp: Annuler
           option_verify_by_mail_html: Vérifier par courrier, ce qui prend généralement de
             <b>trois à sept jours ouvrables</b>.
           options_header: 'Vous Pouvez :'

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -113,7 +113,6 @@ fr:
           gpo:
             button: Vérifier par courrier
           heading: Nous n’avons pas pu vérifier votre identité par téléphone
-          option_cancel: Annuler et recommencer après %{time_left}
           option_cancel_and_return_to_sp: Annuler
           option_verify_by_mail_html: Vérifier par courrier, ce qui prend généralement de
             <b>trois à sept jours ouvrables</b>.

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -235,6 +235,11 @@ RSpec.feature 'idv phone step', :js do
       click_idv_continue_for_step(:phone)
     end
 
+    it 'takes them to the IdV cancel screen if they hit cancel', js: true do
+      click_on 'Cancel'
+      expect(current_path).to eq(idv_cancel_path)
+    end
+
     it 'still lets them access the GPO flow and return to the error' do
       click_on t('idv.failure.phone.rate_limited.gpo.button')
       expect(page).to have_content(t('idv.titles.mail.verify'))

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -246,7 +246,8 @@ RSpec.feature 'idv phone step', :js do
       let(:gpo_enabled) { false }
 
       it 'does not link out to GPO flow' do
-        expect(page).not_to have_content(t('idv.failure.phone.rate_limited.gpo.prompt'))
+        prompt_text = t('idv.failure.phone.rate_limited.option_verify_by_mail_html')
+        expect(page).not_to have_content(prompt_text)
         expect(page).not_to have_content(t('idv.failure.phone.rate_limited.gpo.button'))
       end
     end

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
   end
 
   it 'describes GPO as an alternative' do
-    expect(rendered).to have_text(t('idv.failure.phone.rate_limited.gpo.prompt'))
+    raw_expected_text = t('idv.failure.phone.rate_limited.option_verify_by_mail_html')
+    expected_text = ActionView::Base.full_sanitizer.sanitize(raw_expected_text)
+    expect(rendered).to have_text(expected_text)
   end
 
   it 'includes a link to GPO flow' do

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -22,12 +22,24 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
 
   it 'renders a list of troubleshooting options' do
     expect(rendered).to have_link(
-      t('idv.failure.phone.rate_limited.option_cancel_and_return_to_sp'),
-      href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
-    )
-    expect(rendered).to have_link(
       t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
       href: MarketingSite.contact_url,
+    )
+  end
+
+  it 'tells them they can try again later' do
+    expect(rendered).to have_text(
+      t(
+        'idv.failure.phone.rate_limited.option_try_again_later',
+        time_left: distance_of_time_in_words(Time.zone.now, @expires_at, except: :seconds),
+      ),
+    )
+  end
+
+  it 'renders a cancel link' do
+    expect(rendered).to have_link(
+      t('links.cancel'),
+      href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
     )
   end
 

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
   it 'renders a cancel link' do
     expect(rendered).to have_link(
       t('links.cancel'),
-      href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
+      href: idv_cancel_path,
     )
   end
 

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -59,7 +59,10 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
     let(:gpo_letter_available) { false }
 
     it 'does not describe GPO as an alternative' do
-      expect(rendered).not_to have_text(t('idv.failure.phone.rate_limited.gpo.prompt'))
+      raw_gpo_alternative = t('idv.failure.phone.rate_limited.option_verify_by_mail_html')
+      gpo_alternative = ActionView::Base.full_sanitizer.sanitize(raw_gpo_alternative)
+
+      expect(rendered).not_to have_text(gpo_alternative)
     end
 
     it 'does not include a link to GPO flow' do

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
 
   it 'renders a list of troubleshooting options' do
     expect(rendered).to have_link(
-      t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+      t('idv.failure.phone.rate_limited.option_cancel_and_return_to_sp'),
       href: return_to_sp_failure_to_proof_path(step: 'phone', location: 'failure'),
     )
     expect(rendered).to have_link(

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
   it 'tells them they can try again later' do
     expect(rendered).to have_text(
       t(
-        'idv.failure.phone.rate_limited.option_try_again_later',
+        'idv.failure.phone.rate_limited.option_try_again_later_html',
         time_left: distance_of_time_in_words(Time.zone.now, @expires_at, except: :seconds),
       ),
     )

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -28,12 +28,13 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
   end
 
   it 'tells them they can try again later' do
-    expect(rendered).to have_text(
-      t(
-        'idv.failure.phone.rate_limited.option_try_again_later_html',
-        time_left: distance_of_time_in_words(Time.zone.now, @expires_at, except: :seconds),
-      ),
+    raw_expected_text = t(
+      'idv.failure.phone.rate_limited.option_try_again_later_html',
+      time_left: distance_of_time_in_words(Time.zone.now, @expires_at, except: :seconds),
     )
+    expected_text = ActionView::Base.full_sanitizer.sanitize(raw_expected_text)
+
+    expect(rendered).to have_text(expected_text)
   end
 
   it 'renders a cancel link' do


### PR DESCRIPTION
## 🎫 Ticket
[LG-9296](https://cm-jira.usa.gov/browse/LG-9296)

## 🛠 Summary of changes

Updated the content and layout of the phone rate-limited screen.

Provide a checklist of steps to confirm the changes.

- [x] Bring up the app and begin identity verification. Proceed until phone verification.
- [x] Repeat phone verification until the app rate-limits you.
- [x] Verify that the phone rate-limited screen matches the Figma and translations from the ticket.

[Figma](https://www.figma.com/file/uM8T44ti0ROf9snqDyWOE8/Phone-Verification-Screen-Refinements?node-id=1730-16742&t=i8DkDVN5VDe39tbw-0)
[Translations](https://docs.google.com/document/d/1Cv2LOq9deAbPtPJ6b5MZVW0x_CuYtSOLSt4tt4-bvto/edit#)

## 👀 Screenshots

<details>
<summary>Before:</summary>

![before](https://github.com/18F/identity-idp/assets/101212334/23bd1f2d-557e-4be1-97c3-29cedc177ccd)
</details>

<details>
<summary>After:</summary>

![after](https://github.com/18F/identity-idp/assets/101212334/72c7fee0-8f21-491c-b057-5a431064d995)
</details>
