### PR TITLE
LG-9981 IdvSession activates new profile after confirming it can be activated

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -71,7 +71,7 @@ class Profile < ApplicationRecord
     if pending_reasons.any?
       "Attempting to activate profile with pending reasons: #{pending_reasons.join(',')}"
     elsif deactivation_reason.present?
-      return "Attempting to activate profile with deactivation reason: #{deactivation_reason}"
+      "Attempting to activate profile with deactivation reason: #{deactivation_reason}"
     end
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -67,7 +67,7 @@ class Profile < ApplicationRecord
   end
   # rubocop:enable Rails/SkipsModelValidations
 
-  def reason_that_profile_cannot_be_activated
+  def reason_not_to_activate
     if pending_reasons.any?
       return "Attempting to activate profile with pending reasons: #{pending_reasons.join(',')}"
     elsif deactivation_reason.present?
@@ -219,7 +219,7 @@ class Profile < ApplicationRecord
   private
 
   def confirm_that_profile_can_be_activated!
-    reason = reason_that_profile_cannot_be_activated
+    reason = reason_not_to_activate
     raise reason if reason
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -219,8 +219,7 @@ class Profile < ApplicationRecord
   private
 
   def confirm_that_profile_can_be_activated!
-    reason = reason_not_to_activate
-    raise reason if reason
+    raise reason_not_to_activate if reason_not_to_activate
   end
 
   def track_fraud_review_adjudication(decision:)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -69,7 +69,7 @@ class Profile < ApplicationRecord
 
   def reason_not_to_activate
     if pending_reasons.any?
-      return "Attempting to activate profile with pending reasons: #{pending_reasons.join(',')}"
+      "Attempting to activate profile with pending reasons: #{pending_reasons.join(',')}"
     elsif deactivation_reason.present?
       return "Attempting to activate profile with deactivation reason: #{deactivation_reason}"
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -67,11 +67,11 @@ class Profile < ApplicationRecord
   end
   # rubocop:enable Rails/SkipsModelValidations
 
-  def confirm_that_profile_can_be_activated!
+  def reason_that_profile_cannot_be_activated
     if pending_reasons.any?
-      raise "Attempting to activate profile with pending reasons: #{pending_reasons.join(',')}"
+      return "Attempting to activate profile with pending reasons: #{pending_reasons.join(',')}"
     elsif deactivation_reason.present?
-      raise "Attempting to activate profile with deactivation reason: #{deactivation_reason}"
+      return "Attempting to activate profile with deactivation reason: #{deactivation_reason}"
     end
   end
 
@@ -217,6 +217,11 @@ class Profile < ApplicationRecord
   end
 
   private
+
+  def confirm_that_profile_can_be_activated!
+    reason = reason_that_profile_cannot_be_activated
+    raise reason if reason
+  end
 
   def track_fraud_review_adjudication(decision:)
     if IdentityConfig.store.irs_attempt_api_track_idv_fraud_review

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -21,7 +21,8 @@ module Idv
       profile.save!
       profile.deactivate_for_gpo_verification if gpo_verification_needed
       profile.deactivate_for_fraud_review if fraud_review_needed
-      profile.activate
+      # profile.activate
+      profile
     end
 
     private

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -18,7 +18,7 @@ module Idv
       profile.initiating_service_provider = initiating_service_provider
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
-      profile.verified_at = Time.zone.now unless deactivation_reason # is this necessary to preserve?
+      profile.verified_at = Time.zone.now unless deactivation_reason || gpo_verification_needed
       profile.save!
       profile.deactivate_for_gpo_verification if gpo_verification_needed
       profile.deactivate_for_fraud_review if fraud_review_needed

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -10,20 +10,18 @@ module Idv
     end
 
     def save_profile(
-      active:,
       fraud_review_needed:,
       gpo_verification_needed:,
       deactivation_reason: nil
     )
-      profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason)
+      profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason, verified_at: Time.zone.now)
       profile.initiating_service_provider = initiating_service_provider
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
       profile.save!
-      profile.activate if active
       profile.deactivate_for_gpo_verification if gpo_verification_needed
       profile.deactivate_for_fraud_review if fraud_review_needed
-      profile
+      profile.activate
     end
 
     private

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -14,13 +14,11 @@ module Idv
       gpo_verification_needed:,
       deactivation_reason: nil
     )
-      profile = Profile.new(
-        user: user, active: false, deactivation_reason: deactivation_reason,
-        verified_at: Time.zone.now
-      )
+      profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason)
       profile.initiating_service_provider = initiating_service_provider
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
+      profile.verified_at = Time.zone.now unless deactivation_reason # is this necessary to preserve?
       profile.save!
       profile.deactivate_for_gpo_verification if gpo_verification_needed
       profile.deactivate_for_fraud_review if fraud_review_needed

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -14,14 +14,16 @@ module Idv
       gpo_verification_needed:,
       deactivation_reason: nil
     )
-      profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason, verified_at: Time.zone.now)
+      profile = Profile.new(
+        user: user, active: false, deactivation_reason: deactivation_reason,
+        verified_at: Time.zone.now
+      )
       profile.initiating_service_provider = initiating_service_provider
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
       profile.save!
       profile.deactivate_for_gpo_verification if gpo_verification_needed
       profile.deactivate_for_fraud_review if fraud_review_needed
-      # profile.activate
       profile
     end
 

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -18,7 +18,6 @@ module Idv
       profile.initiating_service_provider = initiating_service_provider
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
-      profile.verified_at = Time.zone.now unless deactivation_reason || gpo_verification_needed
       profile.save!
       profile.deactivate_for_gpo_verification if gpo_verification_needed
       profile.deactivate_for_fraud_review if fraud_review_needed

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -52,6 +52,7 @@ module Idv
         fraud_review_needed: threatmetrix_failed_and_needs_review?,
         gpo_verification_needed: gpo_verification_needed?,
       )
+      profile.activate
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id
       self.personal_key = profile.personal_key

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -55,8 +55,8 @@ module Idv
 
       begin
         profile.activate
-      rescue RuntimeError => exception
-        NewRelic::Agent.notice_error(exception)
+      rescue RuntimeError => error
+        NewRelic::Agent.notice_error(error)
       end
 
       self.pii = profile_maker.pii_attributes

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -52,13 +52,13 @@ module Idv
         fraud_review_needed: threatmetrix_failed_and_needs_review?,
         gpo_verification_needed: gpo_verification_needed?,
       )
-      
+
       begin
         profile.activate
       rescue RuntimeError => exception
         NewRelic::Agent.notice_error(exception)
       end
-      
+
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id
       self.personal_key = profile.personal_key

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -52,7 +52,13 @@ module Idv
         fraud_review_needed: threatmetrix_failed_and_needs_review?,
         gpo_verification_needed: gpo_verification_needed?,
       )
-      profile.activate
+      
+      begin
+        profile.activate
+      rescue RuntimeError => exception
+        NewRelic::Agent.notice_error(exception)
+      end
+      
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id
       self.personal_key = profile.personal_key

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -48,7 +48,6 @@ module Idv
     def create_profile_from_applicant_with_password(user_password)
       profile_maker = build_profile_maker(user_password)
       profile = profile_maker.save_profile(
-        active: deactivation_reason.nil?,
         deactivation_reason: deactivation_reason,
         fraud_review_needed: threatmetrix_failed_and_needs_review?,
         gpo_verification_needed: gpo_verification_needed?,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -53,7 +53,7 @@ module Idv
         gpo_verification_needed: gpo_verification_needed?,
       )
 
-      profile.activate unless reason_that_profile_cannot_be_activated
+      profile.activate unless profile.reason_that_profile_cannot_be_activated
 
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -53,11 +53,7 @@ module Idv
         gpo_verification_needed: gpo_verification_needed?,
       )
 
-      begin
-        profile.activate
-      rescue RuntimeError => error
-        NewRelic::Agent.notice_error(error)
-      end
+      profile.activate unless reason_that_profile_cannot_be_activated
 
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -53,7 +53,7 @@ module Idv
         gpo_verification_needed: gpo_verification_needed?,
       )
 
-      profile.activate unless profile.reason_that_profile_cannot_be_activated
+      profile.activate unless profile.reason_not_to_activate
 
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Idv::PersonalKeyController do
       user_password: password,
     )
     profile = profile_maker.save_profile(
-      active: false,
       fraud_review_needed: false,
       gpo_verification_needed: false,
     )

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Idv::ProfileMaker do
     it 'creates an inactive Profile with encrypted PII' do
       proofing_component = ProofingComponent.create(user_id: user.id, document_check: 'acuant')
       profile = subject.save_profile(
-        active: false,
         fraud_review_needed: false,
         gpo_verification_needed: false,
       )
@@ -41,7 +40,6 @@ RSpec.describe Idv::ProfileMaker do
     context 'with deactivation reason' do
       it 'creates an inactive profile with deactivation reason' do
         profile = subject.save_profile(
-          active: false,
           fraud_review_needed: false,
           gpo_verification_needed: false,
           deactivation_reason: :encryption_error,
@@ -55,7 +53,6 @@ RSpec.describe Idv::ProfileMaker do
     context 'with fraud review needed' do
       it 'deactivates a profile for fraud review' do
         profile = subject.save_profile(
-          active: false,
           fraud_review_needed: true,
           gpo_verification_needed: false,
           deactivation_reason: nil,
@@ -69,7 +66,6 @@ RSpec.describe Idv::ProfileMaker do
     context 'with gpo_verification_needed' do
       it 'deactivates a profile for gpo verification' do
         profile = subject.save_profile(
-          active: false,
           fraud_review_needed: false,
           gpo_verification_needed: true,
           deactivation_reason: nil,
@@ -83,13 +79,12 @@ RSpec.describe Idv::ProfileMaker do
     context 'as active' do
       it 'creates an active profile' do
         profile = subject.save_profile(
-          active: true,
           fraud_review_needed: false,
           gpo_verification_needed: false,
           deactivation_reason: nil,
         )
 
-        expect(profile.active).to eq true
+        expect(profile.active).to eq false
         expect(profile.deactivation_reason).to be_nil
       end
     end
@@ -99,7 +94,6 @@ RSpec.describe Idv::ProfileMaker do
 
       it 'creates a profile with the initiating sp recorded' do
         profile = subject.save_profile(
-          active: true,
           fraud_review_needed: false,
           gpo_verification_needed: false,
           deactivation_reason: nil,

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe Idv::ProfileMaker do
 
         expect(profile.active).to eq false
         expect(profile.fraud_review_pending?).to eq(true)
-        expect(profile.verified_at).not_to be_nil
       end
     end
 
@@ -74,7 +73,6 @@ RSpec.describe Idv::ProfileMaker do
 
         expect(profile.active).to eq false
         expect(profile.gpo_verification_pending_at.present?).to eq true
-        expect(profile.verified_at).to be_nil
       end
     end
 

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Idv::ProfileMaker do
 
         expect(profile.active).to eq false
         expect(profile.fraud_review_pending?).to eq(true)
+        expect(profile.verified_at).not_to be_nil
       end
     end
 
@@ -73,6 +74,7 @@ RSpec.describe Idv::ProfileMaker do
 
         expect(profile.active).to eq false
         expect(profile.gpo_verification_pending_at.present?).to eq true
+        expect(profile.verified_at).to be_nil
       end
     end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-9981](https://cm-jira.usa.gov/browse/LG-9981)

## 🛠 Summary of changes
`ProfileMaker#save_profile` no longer activates the profile and only saves the profile; and now.
`IDV::Session#create_profile_from_applicant_with_password` creates the profile using `ProfileMaker#save_profile` and which is then activated based on `Profile#confirm_that_profile_can_be_activated!`.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
