### PR TITLE
Add location to events logged by promptOnNavigate

### DIFF
--- a/app/javascript/packages/prompt-on-navigate/index.spec.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.spec.ts
@@ -35,7 +35,7 @@ describe('promptOnNavigate', () => {
 
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT);
+    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT, { location: '/' });
     trackEvent.resetHistory();
 
     sandbox.clock.tick(2000);
@@ -43,6 +43,7 @@ describe('promptOnNavigate', () => {
 
     sandbox.clock.tick(3000);
     expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
+      location: '/',
       seconds: 5,
     });
   });
@@ -56,7 +57,7 @@ describe('promptOnNavigate', () => {
 
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT);
+    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT, { location: '/' });
     trackEvent.resetHistory();
 
     sandbox.clock.tick(5000);
@@ -65,6 +66,7 @@ describe('promptOnNavigate', () => {
 
     sandbox.clock.tick(10000);
     expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
+      location: '/',
       seconds: 15,
     });
   });
@@ -91,6 +93,7 @@ describe('promptOnNavigate', () => {
 
     sandbox.clock.tick(15000);
     expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
+      location: '/',
       seconds: 30,
     });
   });

--- a/app/javascript/packages/prompt-on-navigate/index.spec.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.spec.ts
@@ -35,7 +35,7 @@ describe('promptOnNavigate', () => {
 
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT, { location: '/' });
+    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT, { path: '/' });
     trackEvent.resetHistory();
 
     sandbox.clock.tick(2000);
@@ -43,7 +43,7 @@ describe('promptOnNavigate', () => {
 
     sandbox.clock.tick(3000);
     expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
-      location: '/',
+      path: '/',
       seconds: 5,
     });
   });
@@ -57,7 +57,7 @@ describe('promptOnNavigate', () => {
 
     window.dispatchEvent(event);
 
-    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT, { location: '/' });
+    expect(trackEvent).to.have.been.calledOnceWith(PROMPT_EVENT, { path: '/' });
     trackEvent.resetHistory();
 
     sandbox.clock.tick(5000);
@@ -66,7 +66,7 @@ describe('promptOnNavigate', () => {
 
     sandbox.clock.tick(10000);
     expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
-      location: '/',
+      path: '/',
       seconds: 15,
     });
   });
@@ -93,7 +93,7 @@ describe('promptOnNavigate', () => {
 
     sandbox.clock.tick(15000);
     expect(trackEvent).to.have.been.calledWith(STILL_ON_PAGE_EVENT, {
-      location: '/',
+      path: '/',
       seconds: 30,
     });
   });

--- a/app/javascript/packages/prompt-on-navigate/index.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.ts
@@ -1,6 +1,7 @@
 import { trackEvent } from '@18f/identity-analytics';
 
 export type PromptOnNavigateOptions = {
+  location?: string;
   stillOnPageIntervalsInSeconds: number[];
 };
 
@@ -25,7 +26,7 @@ export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): (
     ev.preventDefault();
     ev.returnValue = '';
 
-    trackEvent(PROMPT_EVENT);
+    trackEvent(PROMPT_EVENT, { location: options.location ?? window.location.pathname });
 
     const stillOnPageIntervalsInSeconds = [...options.stillOnPageIntervalsInSeconds];
     let elapsed = 0;
@@ -46,6 +47,7 @@ export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): (
 
       stillOnPageTimer = window.setTimeout(() => {
         trackEvent(STILL_ON_PAGE_EVENT, {
+          location: options.location ?? window.location.pathname,
           seconds: elapsed,
         });
         scheduleNextStillOnPagePing();

--- a/app/javascript/packages/prompt-on-navigate/index.ts
+++ b/app/javascript/packages/prompt-on-navigate/index.ts
@@ -1,7 +1,6 @@
 import { trackEvent } from '@18f/identity-analytics';
 
 export type PromptOnNavigateOptions = {
-  location?: string;
   stillOnPageIntervalsInSeconds: number[];
 };
 
@@ -26,7 +25,7 @@ export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): (
     ev.preventDefault();
     ev.returnValue = '';
 
-    trackEvent(PROMPT_EVENT, { location: options.location ?? window.location.pathname });
+    trackEvent(PROMPT_EVENT, { path: window.location.pathname });
 
     const stillOnPageIntervalsInSeconds = [...options.stillOnPageIntervalsInSeconds];
     let elapsed = 0;
@@ -47,7 +46,7 @@ export function promptOnNavigate(options: PromptOnNavigateOptions = defaults): (
 
       stillOnPageTimer = window.setTimeout(() => {
         trackEvent(STILL_ON_PAGE_EVENT, {
-          location: options.location ?? window.location.pathname,
+          path: window.location.pathname,
           seconds: elapsed,
         });
         scheduleNextStillOnPagePing();

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3581,18 +3581,23 @@ module AnalyticsEvents
 
   # User was shown an "Are you sure you want to navigate away from this page?" message from their
   # browser (via onbeforeunload). (This is a frontend event.)
-  def user_prompted_before_navigation
+  # @param [String] location Where this event was encountered.
+  def user_prompted_before_navigation(location:, **extra)
     track_event(
       'User prompted before navigation',
+      location: location,
+      **extra,
     )
   end
 
   # User was shown an "Are you sure you want to navigate away from this page?" prompt via
   # onbeforeunload and was still on the page <seconds> later. (This is a frontend event.)
+  # @param [String] location Where this event was encountered.
   # @param [Integer] seconds Amount of time user has been on page since prompt.
-  def user_prompted_before_navigation_and_still_on_page(seconds:, **extra)
+  def user_prompted_before_navigation_and_still_on_page(location:, seconds:, **extra)
     track_event(
       'User prompted before navigation and still on page',
+      location: location,
       seconds: seconds,
       **extra,
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3581,23 +3581,23 @@ module AnalyticsEvents
 
   # User was shown an "Are you sure you want to navigate away from this page?" message from their
   # browser (via onbeforeunload). (This is a frontend event.)
-  # @param [String] location Where this event was encountered.
-  def user_prompted_before_navigation(location:, **extra)
+  # @param [String] path Path where this event was encountered.
+  def user_prompted_before_navigation(path:, **extra)
     track_event(
       'User prompted before navigation',
-      location: location,
+      path: path,
       **extra,
     )
   end
 
   # User was shown an "Are you sure you want to navigate away from this page?" prompt via
   # onbeforeunload and was still on the page <seconds> later. (This is a frontend event.)
-  # @param [String] location Where this event was encountered.
+  # @param [String] path Path where this event was encountered.
   # @param [Integer] seconds Amount of time user has been on page since prompt.
-  def user_prompted_before_navigation_and_still_on_page(location:, seconds:, **extra)
+  def user_prompted_before_navigation_and_still_on_page(path:, seconds:, **extra)
     track_event(
       'User prompted before navigation and still on page',
-      location: location,
+      path: path,
       seconds: seconds,
       **extra,
     )


### PR DESCRIPTION
In #8512 I added some analytics to our `onbeforeunload` handlers. Unfortunately, I neglected to augment the events to say _where_ they were actually occurring (`path` is always set to `/api/logger` for frontend events--I investigated fixing this for frontend events but it's a bigger lift than I'm looking for ATM).

This PR just augments analytics events related to `onbeforeunload` with a `location` parameter (which defaults to `location.pathname`).

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
