### PR TITLE
Remove MX from Sender ID countries

### DIFF
--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -15,7 +15,6 @@ class PinpointSupportedCountries
     EG
     FR
     JO
-    MX
     PH
     TH
   ].to_set.freeze


### PR DESCRIPTION
## 🛠 Summary of changes

Now that we have international shortcodes from #8486, we can remove MX from the Sender ID country list

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
