### PR TITLE
Allow configuring Sender ID countries (LG-9846)

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -310,6 +310,7 @@ s3_reports_enabled: false
 saml_secret_rotation_enabled: false
 seed_agreements_data: true
 service_provider_request_ttl_hours: 24
+sender_id_countries: 'BY,EG,FR,JO,PH,TH'
 session_check_delay: 30
 session_check_frequency: 30
 session_encryptor_alert_enabled: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -411,7 +411,7 @@ class IdentityConfig
     config.add(:scrypt_cost, type: :string)
     config.add(:secret_key_base, type: :string)
     config.add(:seed_agreements_data, type: :boolean)
-    config.add(:sender_id_countries, type: :comma_separated_list)
+    config.add(:sender_id_countries, type: :comma_separated_string_list)
     config.add(:service_provider_request_ttl_hours, type: :integer)
     config.add(:session_check_delay, type: :integer)
     config.add(:session_check_frequency, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -411,6 +411,7 @@ class IdentityConfig
     config.add(:scrypt_cost, type: :string)
     config.add(:secret_key_base, type: :string)
     config.add(:seed_agreements_data, type: :boolean)
+    config.add(:sender_id_countries, type: :comma_separated_list)
     config.add(:service_provider_request_ttl_hours, type: :integer)
     config.add(:session_check_delay, type: :integer)
     config.add(:session_check_frequency, type: :integer)

--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -9,7 +9,6 @@ class PinpointSupportedCountries
   PINPOINT_SMS_URL = 'https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html'.freeze
   PINPOINT_VOICE_URL = 'https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-voice-countries.html'.freeze
 
-  # The list of countries where we have our sender ID registered
 
   CountrySupport = Struct.new(
     :iso_code,

--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -10,15 +10,6 @@ class PinpointSupportedCountries
   PINPOINT_VOICE_URL = 'https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-voice-countries.html'.freeze
 
   # The list of countries where we have our sender ID registered
-  SENDER_ID_COUNTRIES = %w[
-    BY
-    EG
-    FR
-    JO
-    MX
-    PH
-    TH
-  ].to_set.freeze
 
   CountrySupport = Struct.new(
     :iso_code,
@@ -70,7 +61,7 @@ class PinpointSupportedCountries
         iso_code = sms_config['ISO code']
         supports_sms = case trim_spaces(sms_config['Supports Sender IDs'])
         when 'Registration required1'
-          SENDER_ID_COUNTRIES.include?(iso_code)
+          IdentityConfig.store.sender_id_countries.include?(iso_code)
         when 'Registration required3' # basically only India, has special rules
           true
         else


### PR DESCRIPTION
## 🛠 Summary of changes

This allows us to configure which countries use Sender ID rather than having to make code updates each time.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
