### PR TITLE
LG-8830: Replace RedoDocumentCaptureAction with redirect to hybrid handoff

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -211,12 +211,23 @@ module Idv
     end
 
     def confirm_hybrid_handoff_needed
+      setup_for_redo if params[:redo]
+
       return if !flow_session[:flow_path]
 
       if flow_session[:flow_path] == 'standard'
         redirect_to idv_document_capture_url
       elsif flow_session[:flow_path] == 'hybrid'
         redirect_to idv_link_sent_url
+      end
+    end
+
+    def setup_for_redo
+      flow_session[:redo_document_capture] = true
+      if flow_session[:skip_upload_step]
+        flow_session[:flow_path] = 'standard'
+      else
+        flow_session[:flow_path] = nil
       end
     end
 

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -26,11 +26,10 @@ locals:
       ) do %>
     <%= t(
           'doc_auth.headings.capture_scan_warning_html',
-          link: render(
-            FormLinkComponent.new(
-              href: idv_doc_auth_step_path(step: :redo_document_capture),
-              method: :put,
-            ).with_content(t('doc_auth.headings.capture_scan_warning_link')),
+          link: link_to(
+            t('doc_auth.headings.capture_scan_warning_link'),
+            idv_hybrid_handoff_url(redo: true),
+            'aria-label': t('doc_auth.headings.capture_scan_warning_link'),
           ),
         ) %>
   <% end %>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -57,4 +57,10 @@
   <%= javascript_packs_tag_once 'doc-capture-polling' %>
 <% end %>
 
-<%= render 'idv/shared/back', action: 'cancel_link_sent', class: 'link-sent-back-link', step_url: :idv_doc_auth_step_url %>
+<div class="margin-top-5 padding-top-2 border-top border-primary-light">
+  <%= link_to(
+        '‹ ' + t('forms.buttons.back'),
+        idv_hybrid_handoff_url(redo: true),
+        class: 'link-sent-back-link'
+      ) %>
+</div>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -61,6 +61,6 @@
   <%= link_to(
         '‹ ' + t('forms.buttons.back'),
         idv_hybrid_handoff_url(redo: true),
-        class: 'link-sent-back-link'
+        class: 'link-sent-back-link',
       ) %>
 </div>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -26,11 +26,10 @@ locals:
       ) do %>
     <%= t(
           'doc_auth.headings.capture_scan_warning_html',
-          link: render(
-            FormLinkComponent.new(
-              href: idv_doc_auth_step_path(step: :redo_document_capture),
-              method: :put,
-            ).with_content(t('doc_auth.headings.capture_scan_warning_link')),
+          link: link_to(
+            t('doc_auth.headings.capture_scan_warning_link'),
+            idv_hybrid_handoff_url(redo: true),
+            'aria-label': t('doc_auth.headings.capture_scan_warning_link'),
           ),
         ) %>
   <% end %>

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -92,6 +92,33 @@ describe Idv::HybridHandoffController do
     end
   end
 
+  context 'redo document capture' do
+    it 'does not redirect in standard flow' do
+      subject.user_session['idv/doc_auth'][:flow_path] = 'standard'
+
+      get :show, params: { redo: true }
+
+      expect(response).to render_template :show
+    end
+
+    it 'does not redirect in hybrid flow' do
+      subject.user_session['idv/doc_auth'][:flow_path] = 'hybrid'
+
+      get :show, params: { redo: true }
+
+      expect(response).to render_template :show
+    end
+
+    it 'redirects to document_capture on a mobile device' do
+      subject.user_session['idv/doc_auth'][:flow_path] = 'standard'
+      subject.user_session['idv/doc_auth'][:skip_upload_step] = true
+
+      get :show, params: { redo: true }
+
+      expect(response).to redirect_to(idv_document_capture_url)
+    end
+  end
+
   describe '#update' do
     let(:analytics_name) { 'IdV: doc auth upload submitted' }
 

--- a/spec/features/idv/actions/cancel_link_sent_action_spec.rb
+++ b/spec/features/idv/actions/cancel_link_sent_action_spec.rb
@@ -9,9 +9,9 @@ feature 'doc auth cancel link sent action' do
     complete_doc_auth_steps_before_link_sent_step
   end
 
-  it 'returns to link sent step' do
+  it 'returns to hybrid_handoff step' do
     click_doc_auth_back_link
 
-    expect(page).to have_current_path(idv_hybrid_handoff_path)
+    expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-8830](https://cm-jira.usa.gov/browse/LG-8830)

## 🛠 Summary of changes

Add a redo parameter to hybrid_handoff show, and change the before action to allow redoing hybrid_handoff when it is present. Once this is deployed we can remove RedoDocumentCaptureAction from DocAuthFlow and remove the code.

Similarly replace CancelLinkSentAction on the LinkSent page with a link to hybrid_handoff with redo=true parameter. No longer render _back partial.

## 📜 Testing Plan

- [ ] Create account, start IdV
- [ ] On HybridHandoff, select Send Link
- [ ] Click the Back link at the bottom of the page
- [ ] Expect to be on HybridHandoff
- [ ] This time, select Upload Photos
- [ ] For DocumentCapture, upload a yaml that causes a barcode read error
- [ ] Continue through to VerifyInfo
- [ ] Expect to see a banner at the top with a link to upload new images
- [ ] Click the link and expect to be on HybridHandoff
- [ ] Go forward with photos or a successful yaml file
- [ ] Expect no banner on VerifyInfo

## 👀 Screenshots

<details>
<summary>LinkSent Before:</summary>
  
![LinkSent before](https://github.com/18F/identity-idp/assets/2381438/8c9fc6bc-3464-4229-a33c-dc1b9484f6b1)
</details>

<details>
<summary>LinkSent After:</summary>
  
![LinkSent after](https://github.com/18F/identity-idp/assets/2381438/7d93788f-8959-4d2a-aa40-88c99b89f701)
</details>

