### PR TITLE
Add exception to sender_id requirement for Australia (AU)

### DIFF
--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -11,6 +11,7 @@ class PinpointSupportedCountries
 
   # The list of countries where we have our sender ID registered
   SENDER_ID_COUNTRIES = %w[
+    AU
     BY
     EG
     FR

--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -11,13 +11,18 @@ class PinpointSupportedCountries
 
   # The list of countries where we have our sender ID registered
   SENDER_ID_COUNTRIES = %w[
-    AU
     BY
     EG
     FR
     JO
     PH
     TH
+  ].to_set.freeze
+
+  # Countries where AWS claims sender ID is required, and we don't have one, and
+  # it seems to work anyway.
+  SENDER_ID_EXCEPTION_COUNTRIES = %w[
+    AU
   ].to_set.freeze
 
   CountrySupport = Struct.new(
@@ -70,7 +75,7 @@ class PinpointSupportedCountries
         iso_code = sms_config['ISO code']
         supports_sms = case trim_spaces(sms_config['Supports Sender IDs'])
         when 'Registration required1'
-          SENDER_ID_COUNTRIES.include?(iso_code)
+          SENDER_ID_COUNTRIES.include?(iso_code) || SENDER_ID_EXCEPTION_COUNTRIES.include?(iso_code)
         when 'Registration required3' # basically only India, has special rules
           true
         else

--- a/spec/lib/pinpoint_supported_countries_spec.rb
+++ b/spec/lib/pinpoint_supported_countries_spec.rb
@@ -150,9 +150,20 @@ RSpec.describe PinpointSupportedCountries do
         stub_const('PinpointSupportedCountries::SENDER_ID_COUNTRIES', [])
       end
 
-      it 'is supported' do
+      it 'is not supported' do
         belarus = countries.sms_support.find { |c| c.iso_code == 'BY' }
         expect(belarus.supports_sms).to eq(false)
+      end
+    end
+
+    context 'when we do not have a sender ID and the country is on our exceptions list' do
+      before do
+        stub_const('PinpointSupportedCountries::SENDER_ID_EXCEPTION_COUNTRIES', %w[BY])
+      end
+
+      it 'is supported' do
+        belarus = countries.sms_support.find { |c| c.iso_code == 'BY' }
+        expect(belarus.supports_sms).to eq(true)
       end
     end
   end


### PR DESCRIPTION
AWS updated their Supported countries and regions (SMS channel) to say that Australia needs sender ID, but we're not seeing that, so we are adding it to our list of SENDER_ID_COUNTRIES.
https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html
