### PR TITLE
Add request duration to analytics for vendor image uploads

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -69,18 +69,23 @@ module Idv
     end
 
     def post_images_to_client
-      response = doc_auth_client.post_images(
-        front_image: front_image_bytes,
-        back_image: back_image_bytes,
-        image_source: image_source,
-        user_uuid: user_uuid,
-        uuid_prefix: uuid_prefix,
-      )
+      timer = JobHelpers::Timer.new
+
+      response = timer.time 'vendor_request' do
+        doc_auth_client.post_images(
+          front_image: front_image_bytes,
+          back_image: back_image_bytes,
+          image_source: image_source,
+          user_uuid: user_uuid,
+          uuid_prefix: uuid_prefix,
+        )
+      end
+
       response.extra.merge!(extra_attributes)
       response.extra[:state] = response.pii_from_doc[:state]
       response.extra[:state_id_type] = response.pii_from_doc[:state_id_type]
 
-      update_analytics(response)
+      update_analytics(response, timer.results['vendor_request'])
 
       response
     end
@@ -204,7 +209,7 @@ module Idv
       end
     end
 
-    def update_analytics(client_response)
+    def update_analytics(client_response, vendor_request_time_in_ms)
       add_costs(client_response)
       update_funnel(client_response)
       analytics.idv_doc_auth_submitted_image_upload_vendor(
@@ -212,6 +217,7 @@ module Idv
           client_image_metrics: image_metadata,
           async: false,
           flow_path: params[:flow_path],
+          vendor_request_time_in_ms: vendor_request_time_in_ms,
         ).merge(acuant_sdk_upgrade_ab_test_data),
       )
     end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -71,7 +71,7 @@ module Idv
     def post_images_to_client
       timer = JobHelpers::Timer.new
 
-      response = timer.time 'vendor_request' do
+      response = timer.time('vendor_request') do
         doc_auth_client.post_images(
           front_image: front_image_bytes,
           back_image: back_image_bytes,

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -85,7 +85,10 @@ module Idv
       response.extra[:state] = response.pii_from_doc[:state]
       response.extra[:state_id_type] = response.pii_from_doc[:state_id_type]
 
-      update_analytics(response, timer.results['vendor_request'])
+      update_analytics(
+        client_response: response,
+        vendor_request_time_in_ms: timer.results['vendor_request'],
+      )
 
       response
     end
@@ -209,7 +212,7 @@ module Idv
       end
     end
 
-    def update_analytics(client_response, vendor_request_time_in_ms)
+    def update_analytics(client_response:, vendor_request_time_in_ms:)
       add_costs(client_response)
       update_funnel(client_response)
       analytics.idv_doc_auth_submitted_image_upload_vendor(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -751,6 +751,7 @@ module AnalyticsEvents
   # @param [Integer] remaining_attempts
   # @param [Hash] client_image_metrics
   # @param [String] flow_path
+  # @param [Float] vendor_request_time_in_ms Time it took to upload images & get a response.
   # The document capture image was uploaded to vendor during the IDV process
   def idv_doc_auth_submitted_image_upload_vendor(
     success:,
@@ -764,6 +765,7 @@ module AnalyticsEvents
     flow_path:,
     billed: nil,
     doc_auth_result: nil,
+    vendor_request_time_in_ms: nil,
     **extra
   )
     track_event(
@@ -780,6 +782,7 @@ module AnalyticsEvents
       remaining_attempts: remaining_attempts,
       client_image_metrics: client_image_metrics,
       flow_path: flow_path,
+      vendor_request_time_in_ms: vendor_request_time_in_ms,
       **extra,
     )
   end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -319,7 +319,7 @@ describe Idv::ImageUploadsController do
           },
           pii_like_keypaths: [[:pii]],
           flow_path: 'standard',
-          vendor_request_time_in_ms: a_kind_of(Numeric),
+          vendor_request_time_in_ms: a_kind_of(Float),
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -469,7 +469,7 @@ describe Idv::ImageUploadsController do
               },
               pii_like_keypaths: [[:pii]],
               flow_path: 'standard',
-              vendor_request_time_in_ms: be_a_kind_of(Float),
+              vendor_request_time_in_ms: a_kind_of(Float),
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -549,7 +549,7 @@ describe Idv::ImageUploadsController do
               },
               pii_like_keypaths: [[:pii]],
               flow_path: 'standard',
-              vendor_request_time_in_ms: be_a_kind_of(Float),
+              vendor_request_time_in_ms: a_kind_of(Float),
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -629,7 +629,7 @@ describe Idv::ImageUploadsController do
               },
               pii_like_keypaths: [[:pii]],
               flow_path: 'standard',
-              vendor_request_time_in_ms: be_a_kind_of(Float),
+              vendor_request_time_in_ms: a_kind_of(Float),
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -734,7 +734,7 @@ describe Idv::ImageUploadsController do
           doc_auth_result: nil,
           pii_like_keypaths: [[:pii]],
           flow_path: 'standard',
-          vendor_request_time_in_ms: be_a_kind_of(Float),
+          vendor_request_time_in_ms: a_kind_of(Float),
         )
 
         action
@@ -799,7 +799,7 @@ describe Idv::ImageUploadsController do
           },
           pii_like_keypaths: [[:pii]],
           flow_path: 'standard',
-          vendor_request_time_in_ms: be_a_kind_of(Float),
+          vendor_request_time_in_ms: a_kind_of(Float),
         )
 
         action

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -319,6 +319,7 @@ describe Idv::ImageUploadsController do
           },
           pii_like_keypaths: [[:pii]],
           flow_path: 'standard',
+          vendor_request_time_in_ms: a_kind_of(Numeric),
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -468,6 +469,7 @@ describe Idv::ImageUploadsController do
               },
               pii_like_keypaths: [[:pii]],
               flow_path: 'standard',
+              vendor_request_time_in_ms: be_a_kind_of(Float),
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -547,6 +549,7 @@ describe Idv::ImageUploadsController do
               },
               pii_like_keypaths: [[:pii]],
               flow_path: 'standard',
+              vendor_request_time_in_ms: be_a_kind_of(Float),
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -626,6 +629,7 @@ describe Idv::ImageUploadsController do
               },
               pii_like_keypaths: [[:pii]],
               flow_path: 'standard',
+              vendor_request_time_in_ms: be_a_kind_of(Float),
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -730,6 +734,7 @@ describe Idv::ImageUploadsController do
           doc_auth_result: nil,
           pii_like_keypaths: [[:pii]],
           flow_path: 'standard',
+          vendor_request_time_in_ms: be_a_kind_of(Float),
         )
 
         action
@@ -794,6 +799,7 @@ describe Idv::ImageUploadsController do
           },
           pii_like_keypaths: [[:pii]],
           flow_path: 'standard',
+          vendor_request_time_in_ms: be_a_kind_of(Float),
         )
 
         action

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Idv::ApiImageUploadForm do
-  include AnalyticsEvents
-
   subject(:form) do
     Idv::ApiImageUploadForm.new(
       ActionController::Parameters.new(

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -106,6 +106,38 @@ RSpec.describe Idv::ApiImageUploadForm do
           user_id: document_capture_session.user.uuid,
           flow_path: anything,
         )
+
+        expect(fake_analytics).to have_logged_event(
+          'IdV: doc auth image upload vendor submitted',
+          async: false,
+          attempts: 1,
+          attention_with_barcode: false,
+          billed: true,
+          client_image_metrics: {
+            back: {
+              height: 20,
+              mimeType: 'image/png',
+              source: 'upload',
+              width: 20,
+            },
+            front: {
+              height: 40,
+              mimeType: 'image/png',
+              source: 'upload',
+              width: 40,
+            },
+          },
+          doc_auth_result: 'Passed',
+          errors: {},
+          exception: nil,
+          flow_path: anything,
+          remaining_attempts: 3,
+          state: 'MT',
+          state_id_type: 'drivers_license',
+          success: true,
+          user_id: document_capture_session.user.uuid,
+          vendor_request_time_in_ms: a_kind_of(Numeric),
+        )
       end
 
       it 'returns the expected response' do

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           state_id_type: 'drivers_license',
           success: true,
           user_id: document_capture_session.user.uuid,
-          vendor_request_time_in_ms: a_kind_of(Numeric),
+          vendor_request_time_in_ms: a_kind_of(Float),
         )
       end
 


### PR DESCRIPTION
I'm trying to track down whether some long-running image upload requests to vendors are actually succeeding or not. We have good metrics on request duration via our Faraday logging, but I don't believe we have a way to tie request duration to the status code ultimately returned from the vendor.

This PR updates `ApiImageUploadForm` to include a `vendor_request_time_in_ms` when logging the 'IdV: doc auth image upload vendor submitted' event.
