### PR TITLE
Use aria-label to avoid radio label double-read

### DIFF
--- a/app/views/shared/_email_languages.html.erb
+++ b/app/views/shared/_email_languages.html.erb
@@ -19,17 +19,21 @@ locals:
         ),
       ),
       collection: I18n.available_locales.map do |locale|
+        label = locale == I18n.locale ?
+          t('account.email_language.default', language: t("i18n.locale.#{locale}")) :
+          t("i18n.locale.#{locale}")
+
         [
           content_tag(
             :span,
-            locale == I18n.locale ?
-              t('account.email_language.default', language: t("i18n.locale.#{locale}")) :
-              t("i18n.locale.#{locale}"),
+            label,
             lang: locale,
+            aria: { hidden: true },
           ),
           locale,
           checked: selection ? selection.to_s == locale.to_s : I18n.locale.to_s == locale.to_s,
           lang: locale,
+          aria: { label: label },
         ]
       end,
     ) %>

--- a/spec/features/visitors/email_language_preference_spec.rb
+++ b/spec/features/visitors/email_language_preference_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'visitor signs up with email language preference' do
+  it 'defaults to the current locale' do
+    visit sign_up_email_path
+
+    field = page.find_field(
+      t('account.email_language.default', language: t("i18n.locale.#{I18n.default_locale}")),
+    )
+    expect(field).to be_present
+    expect(field[:lang]).to eq(I18n.default_locale.to_s)
+    (I18n.available_locales - [I18n.default_locale]).each do |locale|
+      field = page.find_field(t("i18n.locale.#{locale}"))
+      expect(field).to be_present
+      expect(field[:lang]).to eq(locale.to_s)
+    end
+
+    visit sign_up_email_path(:es)
+
+    field = page.find_field(t('account.email_language.default', language: t('i18n.locale.es')))
+    expect(field).to be_present
+    expect(field[:lang]).to eq('es')
+    (I18n.available_locales - [:es]).each do |locale|
+      field = page.find_field(t("i18n.locale.#{locale}"))
+      expect(field).to be_present
+      expect(field[:lang]).to eq(locale.to_s)
+    end
+  end
+
+  it 'sends emails in the selected language' do
+    email = 'test@example.com'
+
+    visit sign_up_email_path
+    choose t('i18n.locale.es')
+    check t('sign_up.terms', app_name: APP_NAME)
+    fill_in t('forms.registration.labels.email'), with: email
+    click_button t('forms.buttons.submit.default')
+
+    emails = unread_emails_for(email)
+
+    expect(emails.last.subject).to eq(
+      t('user_mailer.email_confirmation_instructions.subject', locale: :es),
+    )
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9949](https://cm-jira.usa.gov/browse/LG-9949)

## 🛠 Summary of changes

Updates markup for email languages radio selection to improve how labels are read by screen readers, preventing the label from being read twice when navigating contents (via arrow keys or "Read All" functionality).

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Click "Create an account"
3. Activate screen reader
4. Navigate page contents with arrow keys
5. Observe that each radio button is read only once

## 👀 Screenshots

Before:

https://github.com/18F/identity-idp/assets/1779930/675609c8-7434-4070-84ad-f2c397762903

After:

https://github.com/18F/identity-idp/assets/1779930/b79c1367-69b0-4361-931b-5bc78ee2bcd8
