### PR TITLE
Avoid loading Tab Navigation component stylesheet dependencies

### DIFF
--- a/app/components/tab_navigation_component.scss
+++ b/app/components/tab_navigation_component.scss
@@ -1,6 +1,6 @@
 @use 'uswds-core' as *;
 
-@forward 'usa-button-group';
+@forward 'usa-button-group/src/styles';
 
 // Upstream: https://github.com/uswds/uswds/pull/5324
 .usa-button-group--segmented {


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-9973](https://cm-jira.usa.gov/browse/LG-9973)

## 🛠 Summary of changes

Updates the TabNavigationComponent stylesheet to avoid loading dependencies associated with [the design system Button Group](https://designsystem.digital.gov/components/button-group/). Loading the bare identifier of a component will load all required dependencies. In the case of Button Group, this means that the Tab Navigation Component stylesheet is produced with all button styles ([source](https://github.com/uswds/uswds/blob/cf8c634b17bf3e41975a19bd50ae8bbb15d36eb7/packages/usa-button-group/_index.scss#L1-L2)), which are already present in the main application stylesheet ([source](https://github.com/18F/identity-idp/blob/62a93d1f2a51b5d0da8d35a063f477981b4564b6/app/assets/stylesheets/_uswds.scss#L8)). Since it should be assumed the button styles will be present anywhere the tab navigation component is used, avoid loading duplicated styles by referencing only the Button Group's _own_ styles.

This is a supported usage pattern, documented by USWDS: https://designsystem.digital.gov/documentation/migration/#using-package-source

Technically this bypasses the Login.gov Design System's current override mechanism, but (a) the published version of LGDS does not have custom Button Group styles, and (b) this is being improved in https://github.com/18F/identity-design-system/pull/356 so that the revisions here would begin incorporating any LGDS customizations.

### Performance Results

`NODE_ENV=production yarn build:css && brotli-size app/assets/builds/tab_navigation_component.css`

**Before:** 1.99kb
**After:** 0.62kb
**Diff:** -1.37kb (-68.8%)

## 📜 Testing Plan

1. Run `yarn build:css`
2. Open `app/assets/builds/tab_navigation_component.css`
3. Observe that you don't see any `.usa-button` styles