### PR TITLE
LG-9996: Don't allow redoing doc capture after verify info

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -48,6 +48,12 @@ module Idv
         double_address_verification: capture_secondary_id_enabled,
       )
 
+      # Don't allow the user to go back to document capture after verifying
+      if flow_session['redo_document_capture']
+        flow_session.delete('redo_document_capture')
+        flow_session[:flow_path] ||= 'standard'
+      end
+
       redirect_to after_update_url
     end
 

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -5,13 +5,21 @@ RSpec.feature 'doc auth redo document capture action', js: true do
   include DocAuthHelper
 
   context 'when barcode scan returns a warning', allow_browser_log: true do
+    let(:use_bad_ssn) { false }
+
     before do
       sign_in_and_2fa_user
       complete_doc_auth_steps_before_document_capture_step
       mock_doc_auth_attention_with_barcode
       attach_and_submit_images
       click_idv_continue
-      fill_out_ssn_form_with_ssn_that_fails_resolution
+
+      if use_bad_ssn
+        fill_out_ssn_form_with_ssn_that_fails_resolution
+      else
+        fill_out_ssn_form_ok
+      end
+
       click_idv_continue
     end
 
@@ -34,21 +42,68 @@ RSpec.feature 'doc auth redo document capture action', js: true do
 
       expect(current_path).to eq(idv_verify_info_path)
       check t('forms.ssn.show')
-      expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
+      expect(page).to have_content(DocAuthHelper::GOOD_SSN)
       expect(page).to have_css('[role="status"]')  # We verified your ID
     end
 
-    it 'shows a troubleshooting option to allow the user to cancel and return to SP' do
+    it 'document capture cannot be reached after submitting verify info step' do
+      warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
+
+      expect(page).to have_css(
+        '[role="status"]',
+        text: t(
+          'doc_auth.headings.capture_scan_warning_html',
+          link: warning_link_text,
+        ).tr(' ', ' '),
+      )
+      click_link warning_link_text
+
+      expect(current_path).to eq(idv_hybrid_handoff_path)
+      complete_hybrid_handoff_step
+
+      visit idv_verify_info_url
+
       click_idv_continue
 
-      expect(page).to have_link(
-        t('links.cancel'),
-        href: idv_cancel_path,
-      )
+      expect(page).to have_current_path(idv_phone_path)
 
-      click_link t('links.cancel')
+      fill_out_phone_form_fail
 
-      expect(current_path).to eq(idv_cancel_path)
+      click_idv_send_security_code
+
+      expect(page).to have_content(t('idv.failure.phone.warning.heading'))
+
+      visit idv_url
+      expect(current_path).to eq(idv_phone_path)
+
+      visit idv_hybrid_handoff_url
+      expect(current_path).to eq(idv_phone_path)
+
+      visit idv_document_capture_url
+      expect(current_path).to eq(idv_phone_path)
+
+      visit idv_ssn_url
+      expect(current_path).to eq(idv_phone_path)
+
+      visit idv_verify_info_url
+      expect(current_path).to eq(idv_phone_path)
+    end
+
+    context 'with a bad SSN' do
+      let(:use_bad_ssn) { true }
+
+      it 'shows a troubleshooting option to allow the user to cancel and return to SP' do
+        click_idv_continue
+
+        expect(page).to have_link(
+          t('links.cancel'),
+          href: idv_cancel_path,
+        )
+
+        click_link t('links.cancel')
+
+        expect(current_path).to eq(idv_cancel_path)
+      end
     end
 
     context 'on mobile', driver: :headless_chrome_mobile do
@@ -70,7 +125,7 @@ RSpec.feature 'doc auth redo document capture action', js: true do
 
         expect(current_path).to eq(idv_verify_info_path)
         check t('forms.ssn.show')
-        expect(page).to have_content(DocAuthHelper::SSN_THAT_FAILS_RESOLUTION)
+        expect(page).to have_content(DocAuthHelper::GOOD_SSN)
         expect(page).to have_css('[role="status"]') # We verified your ID
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9996](https://cm-jira.usa.gov/browse/LG-9996)

## 🛠 Summary of changes

Prevent users who've used the redo document capture link on the verify info step from from going back to verify info, submitting it, then going back to document capture.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify using an ID that will generate a "bad barcode" error. When prompted if you want to continue anyway, hit "Continue"
- [ ] Enter an SSN
- [ ] On the Verify Info screen, click the link to redo document capture
- [ ] Manually navigate back to `/verify/verify_info`
- [ ] Submit the verify info step
- [ ] Enter the bad phone number (703-555-5555) and hit submit to fail phone finder
- [ ] Manually navigate to `/verify` and check that you are redirected back to the phone step
- [ ] Manually navigate to `/verify/hybrid_handoff` and check that you are redirected back to the phone step
- [ ] Manually navigate to `/verify/document_capture` and check that you are redirected back to the phone step
- [ ] Manually navigate to `/verify/ssn` and check that you are redirected back to the phone step
