### PR TITLE
LG-9928: Implement User suspend and reinstate methods

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3875,20 +3875,17 @@ module AnalyticsEvents
 
   # Tracks when user reinstated
   # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [String] user_id
+  # @param [String] error_message
   def user_reinstated(
     success:,
-    errors:,
-    user_id: nil,
+    error_message: nil,
     **extra
   )
     track_event(
-      'User: Reinstated',
+      'User Suspension: Reinstated',
       {
         success: success,
-        errors: errors,
-        user_id: user_id,
+        error_message: error_message,
         **extra,
       }.compact,
     )
@@ -3896,20 +3893,17 @@ module AnalyticsEvents
 
   # Tracks when user suspended
   # @param [Boolean] success
-  # @param [Hash] errors
-  # @param [String] user_id
+  # @param [String] error_message
   def user_suspended(
     success:,
-    errors:,
-    user_id: nil,
+    error_message: nil,
     **extra
   )
     track_event(
-      'User: Suspended',
+      'User Suspension: Suspended',
       {
         success: success,
-        errors: errors,
-        user_id: user_id,
+        error_message: error_message,
         **extra,
       }.compact,
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3873,6 +3873,48 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when user reinstated
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] user_id
+  def user_reinstated(
+    success:,
+    errors:,
+    user_id: nil,
+    **extra
+  )
+    track_event(
+      'User: Reinstated',
+      {
+        success: success,
+        errors: errors,
+        user_id: user_id,
+        **extra,
+      }.compact,
+    )
+  end
+
+  # Tracks when user suspended
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] user_id
+  def user_suspended(
+    success:,
+    errors:,
+    user_id: nil,
+    **extra
+  )
+    track_event(
+      'User: Suspended',
+      {
+        success: success,
+        errors: errors,
+        user_id: user_id,
+        **extra,
+      }.compact,
+    )
+  end
+
   # Tracks when USPS in-person proofing enrollment is created
   # @param [String] enrollment_code
   # @param [Integer] enrollment_id

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -259,5 +259,15 @@ FactoryBot.define do
         create(:profile, :password_reset, :with_pii, user: user)
       end
     end
+
+    trait :suspended do
+      suspended_at { Time.zone.now }
+      reinstated_at { nil }
+    end
+
+    trait :reinstated do
+      suspended_at { Time.zone.now }
+      reinstated_at { Time.zone.now + 1.hour }
+    end
   end
 end


### PR DESCRIPTION


## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-9928)


## 🛠 Summary of changes

This pull request (PR) introduces new functionality that enables the marking of a user as suspended and the ability to mark a suspended user as reinstated. Additionally, it includes the implementation of tracking analytics events.

The following methods have been added:

- suspended?: This method allows for checking whether a user is currently suspended.
- reinstated?: This method allows for checking whether a suspended user has been reinstated.
- suspend: This method is used to suspend a user, marking them as suspended.
- reinstate: This method is used to reinstate a suspended user, reversing their suspended status.


