### PR TITLE
LG-9966 send email on gpo letter enqueue

### DIFF
--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -99,7 +99,6 @@ module Idv
 
     def send_reminder
       current_user.send_email_to_all_addresses(:letter_reminder)
-      end
     end
 
     def pii_locked?

--- a/app/controllers/idv/gpo_controller.rb
+++ b/app/controllers/idv/gpo_controller.rb
@@ -98,9 +98,7 @@ module Idv
     end
 
     def send_reminder
-      current_user.confirmed_email_addresses.each do |email_address|
-        UserMailer.with(user: current_user, email_address: email_address).
-          letter_reminder.deliver_now_or_later
+      current_user.send_email_to_all_addresses(:letter_reminder)
       end
     end
 

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -92,11 +92,7 @@ module Idv
       idv_session.create_profile_from_applicant_with_password(password)
 
       if idv_session.address_verification_mechanism == 'gpo'
-        current_user.confirmed_email_addresses.each do |email_address|
-          UserMailer.with(user: current_user, email_address: email_address).
-            letter_reminder.deliver_now_or_later
-        end
-
+        current_user.send_email_to_all_addresses(:letter_reminder)
         analytics.idv_gpo_address_letter_enqueued(enqueued_at: Time.zone.now, resend: false)
       end
 

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -92,6 +92,11 @@ module Idv
       idv_session.create_profile_from_applicant_with_password(password)
 
       if idv_session.address_verification_mechanism == 'gpo'
+        current_user.confirmed_email_addresses.each do |email_address|
+          UserMailer.with(user: current_user, email_address: email_address).
+            letter_reminder.deliver_now_or_later
+        end
+
         analytics.idv_gpo_address_letter_enqueued(enqueued_at: Time.zone.now, resend: false)
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -405,9 +405,10 @@ class User < ApplicationRecord
 
   def send_email_to_all_addresses(user_mailer_template)
     confirmed_email_addresses.each do |email_address|
-      UserMailer.with(user: self,
-                      email_address: email_address).
-        send(user_mailer_template).
+      UserMailer.with(
+        user: self,
+        email_address: email_address,
+      ).send(user_mailer_template).
         deliver_now_or_later
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -403,6 +403,15 @@ class User < ApplicationRecord
 
   add_method_tracer :send_devise_notification, "Custom/#{name}/send_devise_notification"
 
+  def send_email_to_all_addresses(user_mailer_template)
+    confirmed_email_addresses.each do |email_address|
+      UserMailer.with(user: self,
+                      email_address: email_address).
+        send(user_mailer_template).
+        deliver_now_or_later
+    end
+  end
+
   private
 
   def lockout_period

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -214,9 +214,7 @@ RSpec.describe Idv::GpoController do
 
     expect(gpo_confirmation_maker).to receive(:perform)
     expect(gpo_confirmation_maker).to receive(:otp) if otp
-
-    put :create
-
+    expect { put :create }.to(change { ActionMailer::Base.deliveries.count }).by(1)
     expect(response).to redirect_to idv_come_back_later_path
   end
 end

--- a/spec/controllers/idv/gpo_controller_spec.rb
+++ b/spec/controllers/idv/gpo_controller_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Idv::GpoController do
 
     expect(gpo_confirmation_maker).to receive(:perform)
     expect(gpo_confirmation_maker).to receive(:otp) if otp
-    expect { put :create }.to(change { ActionMailer::Base.deliveries.count }).by(1)
+    expect { put :create }.to change { ActionMailer::Base.deliveries.count }.by(1)
     expect(response).to redirect_to idv_come_back_later_path
   end
 end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -668,6 +668,12 @@ RSpec.describe Idv::ReviewController do
           expect(profile).to_not be_active
         end
 
+        it 'sends an email about the gpo letter' do
+          expect { put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } } }.to(
+            change { ActionMailer::Base.deliveries.count }.by(1),
+          )
+        end
+
         it 'redirects to come back later page' do
           put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -669,9 +669,12 @@ RSpec.describe Idv::ReviewController do
         end
 
         it 'sends an email about the gpo letter' do
-          expect { put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } } }.to(
-            change { ActionMailer::Base.deliveries.count }.by(1),
-          )
+          expect do
+            put :create,
+                params: {
+                  user: { password: ControllerHelper::VALID_PASSWORD },
+                }
+          end.to(change { ActionMailer::Base.deliveries.count }.by(1))
         end
 
         it 'redirects to come back later page' do

--- a/spec/features/idv/steps/review_step_spec.rb
+++ b/spec/features/idv/steps/review_step_spec.rb
@@ -59,11 +59,16 @@ RSpec.feature 'idv review step', :js do
       complete_idv_steps_with_gpo_before_review_step(user)
     end
 
-    it 'sends a letter and creates an unverified profile' do
+    it 'sends a letter, creates an unverified profile, and sends an email' do
       fill_in 'Password', with: user_password
+
+      email_count_before_continue = ActionMailer::Base.deliveries.count
 
       expect { click_continue }.
         to change { GpoConfirmation.count }.from(0).to(1)
+
+      expect_delivered_email_count(email_count_before_continue + 1)
+      expect(last_email.subject).to eq(t('user_mailer.letter_reminder.subject'))
 
       expect(user.events.account_verified.size).to be(0)
       expect(user.profiles.count).to eq 1


### PR DESCRIPTION
## 🎫 Ticket

[LG-9966](https://cm-jira.usa.gov/browse/LG-9966)

## 🛠 Summary of changes

Added code to `ReviewController` to send reminder email on initial enqueue of GPO letter.

Also refactored a bit; there's now a `User` method to send an arbitrary email to all of a user's email addresses.
ToDo: Open a ticket to see where else we can use that method.

## 📜 Testing Plan

- [ ] Create an account and proceed through GPO proofing
- [ ] Verify that when you ask for a letter, an email notification is sent to you.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>After:</summary>
![your-letter-is-coming-screen](https://github.com/18F/identity-idp/assets/101212334/d2b050df-233f-48c8-adfd-68ad846cbbe5)

![your-letter-is-coming-email](https://github.com/18F/identity-idp/assets/101212334/b124aaa4-b795-45f0-bbf9-706b88611679)
</details>
