### PR TITLE
LG-8830 redo_document_capture logging

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -69,12 +69,18 @@ module Idv
     end
 
     def analytics_arguments
-      {
+      args = {
         flow_path: flow_path,
         step: 'document_capture',
         analytics_id: 'Doc Auth',
         irs_reproofing: irs_reproofing?,
       }.merge(**acuant_sdk_ab_test_analytics_args)
+
+      if flow_session[:redo_document_capture]
+        args[:redo_document_capture] = flow_session[:redo_document_capture]
+      end
+
+      args
     end
 
     def handle_stored_result

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -69,18 +69,13 @@ module Idv
     end
 
     def analytics_arguments
-      args = {
+      {
         flow_path: flow_path,
         step: 'document_capture',
         analytics_id: 'Doc Auth',
         irs_reproofing: irs_reproofing?,
-      }.merge(**acuant_sdk_ab_test_analytics_args)
-
-      if flow_session[:redo_document_capture]
-        args[:redo_document_capture] = flow_session[:redo_document_capture]
-      end
-
-      args
+        redo_document_capture: flow_session[:redo_document_capture],
+      }.compact.merge(**acuant_sdk_ab_test_analytics_args)
     end
 
     def handle_stored_result

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -156,15 +156,12 @@ module Idv
     end
 
     def analytics_arguments
-      args = {
+      {
         step: 'upload',
         analytics_id: 'Doc Auth',
         irs_reproofing: irs_reproofing?,
-      }.merge(**acuant_sdk_ab_test_analytics_args)
-
-      args[:redo_document_capture] = true if params[:redo]
-
-      args
+        redo_document_capture: params[:redo] ? true : nil,
+      }.compact.merge(**acuant_sdk_ab_test_analytics_args)
     end
 
     def form_response(destination:)

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -156,11 +156,15 @@ module Idv
     end
 
     def analytics_arguments
-      {
+      args = {
         step: 'upload',
         analytics_id: 'Doc Auth',
         irs_reproofing: irs_reproofing?,
       }.merge(**acuant_sdk_ab_test_analytics_args)
+
+      args[:redo_document_capture] = true if params[:redo]
+
+      args
     end
 
     def form_response(destination:)

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -71,6 +71,17 @@ RSpec.describe Idv::DocumentCaptureController do
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
+    context 'redo_document_capture' do
+      it 'adds redo_document_capture to analytics' do
+        flow_session[:redo_document_capture] = true
+
+        get :show
+
+        analytics_args[:redo_document_capture] = true
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      end
+    end
+
     it 'updates DocAuthLog document_capture_view_count' do
       doc_auth_log = DocAuthLog.create(user_id: user.id)
 

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -101,32 +101,39 @@ RSpec.describe Idv::HybridHandoffController do
         expect(response).to redirect_to(idv_link_sent_url)
       end
     end
-  end
 
-  context 'redo document capture' do
-    it 'does not redirect in standard flow' do
-      subject.user_session['idv/doc_auth'][:flow_path] = 'standard'
+    context 'redo document capture' do
+      it 'does not redirect in standard flow' do
+        subject.user_session['idv/doc_auth'][:flow_path] = 'standard'
 
-      get :show, params: { redo: true }
+        get :show, params: { redo: true }
 
-      expect(response).to render_template :show
-    end
+        expect(response).to render_template :show
+      end
 
-    it 'does not redirect in hybrid flow' do
-      subject.user_session['idv/doc_auth'][:flow_path] = 'hybrid'
+      it 'does not redirect in hybrid flow' do
+        subject.user_session['idv/doc_auth'][:flow_path] = 'hybrid'
 
-      get :show, params: { redo: true }
+        get :show, params: { redo: true }
 
-      expect(response).to render_template :show
-    end
+        expect(response).to render_template :show
+      end
 
-    it 'redirects to document_capture on a mobile device' do
-      subject.user_session['idv/doc_auth'][:flow_path] = 'standard'
-      subject.user_session['idv/doc_auth'][:skip_upload_step] = true
+      it 'redirects to document_capture on a mobile device' do
+        subject.user_session['idv/doc_auth'][:flow_path] = 'standard'
+        subject.user_session['idv/doc_auth'][:skip_upload_step] = true
 
-      get :show, params: { redo: true }
+        get :show, params: { redo: true }
 
-      expect(response).to redirect_to(idv_document_capture_url)
+        expect(response).to redirect_to(idv_document_capture_url)
+      end
+
+      it 'adds redo_document_capture to analytics' do
+        get :show, params: { redo: true }
+
+        analytics_args[:redo_document_capture] = true
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      end
     end
   end
 

--- a/spec/features/idv/actions/redo_document_capture_action_spec.rb
+++ b/spec/features/idv/actions/redo_document_capture_action_spec.rb
@@ -4,6 +4,12 @@ RSpec.feature 'doc auth redo document capture action', js: true do
   include IdvStepHelper
   include DocAuthHelper
 
+  let(:fake_analytics) { FakeAnalytics.new }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+  end
+
   context 'when barcode scan returns a warning', allow_browser_log: true do
     let(:use_bad_ssn) { false }
 
@@ -36,7 +42,15 @@ RSpec.feature 'doc auth redo document capture action', js: true do
       click_link warning_link_text
 
       expect(current_path).to eq(idv_hybrid_handoff_path)
+      expect(fake_analytics).to have_logged_event(
+        'IdV: doc auth upload visited',
+        hash_including(redo_document_capture: true),
+      )
       complete_hybrid_handoff_step
+      expect(fake_analytics).to have_logged_event(
+        'IdV: doc auth document_capture visited',
+        hash_including(redo_document_capture: true),
+      )
       DocAuth::Mock::DocAuthMockClient.reset!
       attach_and_submit_images
 
@@ -120,6 +134,10 @@ RSpec.feature 'doc auth redo document capture action', js: true do
         click_link warning_link_text
 
         expect(current_path).to eq(idv_document_capture_path)
+        expect(fake_analytics).to have_logged_event(
+          'IdV: doc auth document_capture visited',
+          hash_including(redo_document_capture: true),
+        )
         DocAuth::Mock::DocAuthMockClient.reset!
         attach_and_submit_images
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-8830](https://cm-jira.usa.gov/browse/LG-8830)

## 🛠 Summary of changes

Now that we don't have a separate RedoDocumentCaptureAction, log that the user is redoing document capture by adding params to the logging for the HybridHandoff and DocumentCapture steps.

We want to log when redo_document_capture happens because it sometimes causes unexpected results for the user. When it was its own action it had its own analytics event, but now we are combining it with document_capture_visited. It will also be added to hybrid_handoff for users who are not on mobile.
