### PR TITLE
LG-9865: Add same_address_as_id to in person verify visited analytics

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -54,7 +54,7 @@ module Idv
         flow_session[:flow_path] ||= 'standard'
       end
 
-      # for the 50/50 state
+      # Mark the FSM verify step completed. This is for the 50/50 state
       flow_session['Idv::Steps::InPerson::VerifyStep'] = true
       redirect_to after_update_url
     end

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -54,6 +54,8 @@ module Idv
         flow_session[:flow_path] ||= 'standard'
       end
 
+      # for the 50/50 state
+      flow_session['Idv::Steps::InPerson::VerifyStep'] = true
       redirect_to after_update_url
     end
 

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -37,7 +37,6 @@ module Idv
 
         # for the 50/50 state
         flow_session['Idv::Steps::AgreementStep'] = true
-        flow_session['Idv::Steps::InPerson::VerifyStep'] = true
 
         redirect_to idv_hybrid_handoff_url
       else

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -37,6 +37,7 @@ module Idv
 
         # for the 50/50 state
         flow_session['Idv::Steps::AgreementStep'] = true
+        flow_session['Idv::Steps::InPerson::VerifyStep'] = true
 
         redirect_to idv_hybrid_handoff_url
       else

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -85,7 +85,7 @@ module Idv
         extra = {
           pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
         }
-        unless flow_session[:pii_from_user]&.[](:same_address_as_id).nil?
+        unless flow_session.dig(:pii_from_user, :same_address_as_id).nil?
           extra[:same_address_as_id] =
             flow_session[:pii_from_user][:same_address_as_id].to_s == 'true'
         end

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -73,11 +73,23 @@ module Idv
 
       def analytics_arguments
         {
-          flow_path: flow_path,
+          flow_path: flow_session[:flow_path],
           step: 'verify',
           analytics_id: 'In Person Proofing',
           irs_reproofing: irs_reproofing?,
-        }.merge(**acuant_sdk_ab_test_analytics_args)
+        }.merge(**acuant_sdk_ab_test_analytics_args).
+          merge(**extra_analytics_properties)
+      end
+
+      def extra_analytics_properties
+        extra = {
+          pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
+        }
+        unless flow_session[:pii_from_user]&.[](:same_address_as_id).nil?
+          extra[:same_address_as_id] =
+            flow_session[:pii_from_user][:same_address_as_id].to_s == 'true'
+        end
+        extra
       end
     end
   end

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Idv::InPerson::VerifyInfoController do
   include IdvHelper
 
-  let(:pii_from_user) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup }
+  let(:pii_from_user) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup }
   let(:flow_session) do
     { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
       :pii_from_user => pii_from_user,
@@ -67,6 +67,8 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
           flow_path: 'standard',
           irs_reproofing: false,
           step: 'verify',
+          same_address_as_id: true,
+          pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
         }
       end
 


### PR DESCRIPTION
## 🎫 Ticket
[LG-9865](https://cm-jira.usa.gov/browse/LG-9865) Work for Remove In Person Verify

## 🛠 Summary of changes
Add same_address_as_id to in person verify visited analytics



