### PR TITLE
LG-9838: Move GPO routes under /verify

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -394,21 +394,25 @@ Rails.application.routes.draw do
       get '/in_person/:step' => 'in_person#show', as: :in_person_step
       put '/in_person/:step' => 'in_person#update'
 
+      get '/by_mail' => 'gpo_verify#index', as: :gpo_verify
+      post '/by_mail' => 'gpo_verify#create'
+      get '/by_mail/confirm_start_over' => 'confirm_start_over#index',
+          as: :confirm_start_over
+
+      if FeatureManagement.gpo_verification_enabled?
+        get '/usps' => 'gpo#index', as: :gpo
+        put '/usps' => 'gpo#create'
+        post '/usps' => 'gpo#update'
+      end
+
       # deprecated routes
       get '/confirmations' => 'personal_key#show'
       post '/confirmations' => 'personal_key#update'
     end
 
-    get '/account/verify' => 'idv/gpo_verify#index', as: :idv_gpo_verify
-    post '/account/verify' => 'idv/gpo_verify#create'
-    get '/account/verify/confirm_start_over' => 'idv/confirm_start_over#index', as: :idv_confirm_start_over
-    if FeatureManagement.gpo_verification_enabled?
-      scope '/verify', module: 'idv', as: 'idv' do
-        get '/usps' => 'gpo#index', as: :gpo
-        put '/usps' => 'gpo#create'
-        post '/usps' => 'gpo#update'
-      end
-    end
+    # Old paths to GPO outside of IdV.
+    get '/account/verify', to: redirect('/verify/by_mail')
+    get '/account/verify/confirm_start_over', to: redirect('/verify/by_mail/confirm_start_over')
 
     root to: 'users/sessions#new'
   end

--- a/spec/presenters/idv/gpo_presenter_spec.rb
+++ b/spec/presenters/idv/gpo_presenter_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Idv::GpoPresenter do
     context 'when the user has a pending profile' do
       it 'returns the verify account path' do
         create(:profile, user: user, gpo_verification_pending_at: 1.day.ago)
-        expect(subject.fallback_back_path).to eq('/account/verify')
+        expect(subject.fallback_back_path).to eq('/verify/by_mail')
       end
     end
 

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe 'Redirecting Legacy Routes', type: :request do
       expect(response).to redirect_to('/account/verify')
     end
   end
+
+  describe '/account/verify' do
+    it 'redirects to /verify/by_mail' do
+      get '/account/verify'
+
+      expect(response).to redirect_to('/verify/by_mail')
+    end
+  end
+
+  describe '/account/verify/confirm_start_over' do
+    it 'redirects to /verify/by_mail/confirm_start_over' do
+      get '/account/verify/confirm_start_over'
+
+      expect(response).to redirect_to('/verify/by_mail/confirm_start_over')
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9838](https://cm-jira.usa.gov/browse/LG-9838)

## 🛠 Summary of changes

Moves a few GPO-related routes to be under `/verify` (like the rest of the IdV code).

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Sign up and verify your address via GPO. 
- Confirm you end up on `/verify/by_mail` to enter your OTP.
- Confirm that if you visit `/account/verify` and confirm you end up redirected to `/verify/by_mail`
- Click the "Clear my information and start over" link and verify you end up on `/verify/by_mail/confirm_start_over`
- Cancel that and confirm you can enter your GPO OTP

