### PR TITLE
Log worker logs to STDOUT if configured to log to STDOUT

### DIFF
--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -118,7 +118,13 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def self.worker_logger
-    @worker_logger ||= ActiveSupport::Logger.new(Rails.root.join('log', 'workers.log'))
+    return @worker_logger if defined?(@worker_logger)
+
+    if FeatureManagement.log_to_stdout?
+      @worker_logger = ActiveSupport::Logger.new(STDOUT)
+    else
+      @worker_logger = ActiveSupport::Logger.new(Rails.root.join('log', 'workers.log'))
+    end
   end
 
   private


### PR DESCRIPTION
## 🛠 Summary of changes

The rest of our log files respect this config, so `workers.log` should too!

`events.log`: https://github.com/18F/identity-idp/blob/f2f2d1e0917855062a48f5580a50a212caa4a6a7/config/initializers/ahoy.rb#L48-L62
`telephony.log`: https://github.com/18F/identity-idp/blob/f2f2d1e0917855062a48f5580a50a212caa4a6a7/config/initializers/telephony.rb#L7-L11
`production.log`: https://github.com/18F/identity-idp/blob/f2f2d1e0917855062a48f5580a50a212caa4a6a7/config/environments/production.rb#L37-L40

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
