### PR TITLE
Refactor verify info update

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -2,7 +2,7 @@ module Idv
   module VerifyInfoConcern
     extend ActiveSupport::Concern
 
-    def update
+    def shared_update
       return if idv_session.verify_info_step_document_capture_session_uuid
       analytics.idv_doc_auth_verify_submitted(**analytics_arguments)
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -56,7 +56,8 @@ module Idv
 
       # Mark the FSM verify step completed. This is for the 50/50 state
       flow_session['Idv::Steps::InPerson::VerifyStep'] = true
-      redirect_to after_update_url
+
+      return true
     end
 
     private

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -48,12 +48,6 @@ module Idv
         double_address_verification: capture_secondary_id_enabled,
       )
 
-      # Don't allow the user to go back to document capture after verifying
-      if flow_session['redo_document_capture']
-        flow_session.delete('redo_document_capture')
-        flow_session[:flow_path] ||= 'standard'
-      end
-
       return true
     end
 

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -54,9 +54,6 @@ module Idv
         flow_session[:flow_path] ||= 'standard'
       end
 
-      # Mark the FSM verify step completed. This is for the 50/50 state
-      flow_session['Idv::Steps::InPerson::VerifyStep'] = true
-
       return true
     end
 

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -37,7 +37,8 @@ module Idv
       end
 
       def update
-        shared_update
+        success = shared_update
+        redirect_to idv_in_person_verify_info_url if success
       end
 
       private
@@ -52,10 +53,6 @@ module Idv
 
       def invalid_state?
         pii.blank?
-      end
-
-      def after_update_url
-        idv_in_person_verify_info_url
       end
 
       def prev_url

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -38,7 +38,13 @@ module Idv
 
       def update
         success = shared_update
-        redirect_to idv_in_person_verify_info_url if success
+
+        if success
+          # Mark the FSM verify step completed. This is for the 50/50 state
+          flow_session['Idv::Steps::InPerson::VerifyStep'] = true
+
+          redirect_to idv_in_person_verify_info_url
+        end
       end
 
       private

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -36,6 +36,10 @@ module Idv
         process_async_state(load_async_state)
       end
 
+      def update
+        shared_update
+      end
+
       private
 
       # state_id_type is hard-coded here because it's required for proofing against

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -35,17 +35,14 @@ module Idv
     end
 
     def update
-      shared_update
+      success = shared_update
+      redirect_to idv_verify_info_url if success
     end
 
     private
 
     # state ID type isn't manually set for Idv::VerifyInfoController
     def set_state_id_type; end
-
-    def after_update_url
-      idv_verify_info_url
-    end
 
     def prev_url
       idv_ssn_url

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -34,6 +34,10 @@ module Idv
       process_async_state(load_async_state)
     end
 
+    def update
+      shared_update
+    end
+
     private
 
     # state ID type isn't manually set for Idv::VerifyInfoController

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -36,7 +36,16 @@ module Idv
 
     def update
       success = shared_update
-      redirect_to idv_verify_info_url if success
+
+      if success
+        # Don't allow the user to go back to document capture after verifying
+        if flow_session['redo_document_capture']
+          flow_session.delete('redo_document_capture')
+          flow_session[:flow_path] ||= 'standard'
+        end
+
+        redirect_to idv_verify_info_url
+      end
     end
 
     private


### PR DESCRIPTION
For the deployment of InPerson::VerifyInfoController, in PR #8585 the InPerson::VerifyStep was marked complete at the end of VerifyInfoConcern#update. This method is shared with doc_auth VerifyInfoController. To eliminate the possibility of unintended effects, and to clarify #update for both controllers, give them each their own update method and rename the method in VerifyInfoConcern to shared_update.

In #8576 we recently added code to the shared update method that prevents redoing document capture after VerifyInfo is submitted. This does not apply to InPerson::VerifyInfoController, so this code was moved to the doc_auth VerifyInfoController#update.

## 📜 Testing Plan
- [ ] Create account, start IdV
- [ ] Continue past submitting VerifyInfo
- [ ] Cancel and Start Over
- [ ] In DocumentCapture submit yaml file with an error
- [ ] Choose In Person verification
- [ ] Continue past submitting VerifyInfo
- [ ] Expect unchanged functionality, no errors
