### PR TITLE
LG-9815: Personal key screen success banner in GPO flow should be updated

### DIFF
--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -64,7 +64,12 @@ module Idv
 
       irs_attempts_api_tracker.idv_personal_key_generated
 
-      flash.now[:success] = t('idv.messages.confirm')
+      if idv_session.address_confirmed?
+        flash.now[:success] = t('idv.messages.gpo.confirm')
+      else
+        flash.now[:success] = t('idv.messages.confirm')
+      end
+
       flash[:allow_confirmations_continue] = true
     end
 

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -197,6 +197,7 @@ en:
       gpo:
         address_on_file_html: We will mail a letter with a <strong>one-time
           code</strong> to the address that you provided on the previous step.
+        confirm: We verified your information
         info_alert: You’ll need to wait until your letter is delivered to finish
           verifying your identity.
         resend: Send me another letter

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -209,6 +209,7 @@ es:
       gpo:
         address_on_file_html: Le enviaremos una carta con <strong>un código único
           </strong> a la dirección que nos facilitó en el paso anterior.
+        confirm: Verificamos tu información
         info_alert: Tendrá que esperar a que su carta sea entregada para terminar de
           verificar su identidad.
         resend: Envíeme otra carta

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -222,6 +222,7 @@ fr:
         address_on_file_html: Nous enverrons une lettre avec <strong>un code à usage
           unique </strong> à l’adresse que vous avez indiquée à l’étape
           précédente.
+        confirm: Nous avons vérifié vos informations
         info_alert: Vous devrez attendre la livraison de votre lettre pour compléter la
           vérification de votre identité.
         resend: Envoyez-moi une autre lettre

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -163,6 +163,17 @@ RSpec.describe Idv::PersonalKeyController do
       expect(flash[:success]).to eq t('idv.messages.confirm')
     end
 
+    context 'when user is gpo confirmed' do
+      before do
+        subject.idv_session.gpo_code_verified = true
+      end
+
+      it 'sets flash.now[:success]' do
+        get :show
+        expect(flash[:success]).to eq t('idv.messages.gpo.confirm')
+      end
+    end
+
     context 'user selected gpo verification' do
       before do
         subject.idv_session.address_verification_mechanism = 'gpo'

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature 'idv gpo otp verification step' do
       profile.reload
 
       expect(page).to have_current_path(idv_personal_key_path)
-
+      expect(page).to have_content(t('idv.messages.gpo.confirm'))
       expect(profile.active).to be(true)
       expect(profile.deactivation_reason).to be(nil)
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-9815](https://cm-jira.usa.gov/browse/LG-9815)

## 🛠 Summary of changes
Peronal key controller checks to see if the address is confirmed in the idv_session in order to display correct banner message.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
There are automated test to verify.

Manual:
- [x] verify address w/ gpo and observe flash banner on personal key confirmation page
- [x] verify address w/ phone and observe flash banner on personal key confirmation page


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

<img width="881" alt="Screen Shot 2023-06-15 at 12 09 21 PM" src="https://github.com/18F/identity-idp/assets/1261794/30da4935-4121-4716-a492-e13698bd595e">

</details>

<details>
<summary>After:</summary>

<img width="818" alt="Screen Shot 2023-06-15 at 12 11 13 PM" src="https://github.com/18F/identity-idp/assets/1261794/56f420f3-3a19-4eff-9b38-51f0c1c2eb21">

</details>
