### PR TITLE
Remove deprecated "loa" ServiceProviderRequest attribute

### DIFF
--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -5,27 +5,16 @@ class ServiceProviderRequest
   attr_accessor :uuid, :issuer, :url, :ial, :aal, :requested_attributes
 
   def initialize(uuid: nil, issuer: nil, url: nil,
-                 loa: nil, ial: nil, aal: nil, requested_attributes: [])
+                 ial: nil, aal: nil, requested_attributes: [])
     @uuid = uuid
     @issuer = issuer
     @url = url
-    @ial = ial || loa
+    @ial = ial
     @aal = aal
     @requested_attributes = requested_attributes&.map(&:to_s)
-    Rails.logger.info { 'Note: loa used to initialize ServiceProviderRequest' } if loa
   end
 
   def ==(other)
     to_json == other.to_json
-  end
-
-  # To be deleted once we've been deployed for a while and
-  # the cached proxies are all using the new ial parameter
-  def loa
-    @ial
-  end
-
-  def loa=(val)
-    @ial = val
   end
 end

--- a/spec/services/service_provider_request_proxy_spec.rb
+++ b/spec/services/service_provider_request_proxy_spec.rb
@@ -15,30 +15,6 @@ RSpec.describe ServiceProviderRequestProxy do
         )
         expect(ServiceProviderRequestProxy.from_uuid('123')).to eq sp_request
       end
-
-      it 'both loa1 and ial1 values return the same thing' do
-        sp_request = ServiceProviderRequestProxy.create(
-          uuid: '123',
-          issuer: 'foo',
-          url: 'http://bar.com',
-          ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-        )
-
-        expect(sp_request.loa).to eq(sp_request.ial)
-        expect(ServiceProviderRequestProxy.from_uuid('123')).to eq sp_request
-      end
-
-      it 'both loa3 and ial2 values return the same thing' do
-        sp_request = ServiceProviderRequestProxy.create(
-          uuid: '123',
-          issuer: 'foo',
-          url: 'http://bar.com',
-          ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-        )
-
-        expect(sp_request.loa).to eq(sp_request.ial)
-        expect(ServiceProviderRequestProxy.from_uuid('123')).to eq sp_request
-      end
     end
 
     context 'when the record does not exist' do


### PR DESCRIPTION
## 🛠 Summary of changes

The deprecation of this attribute in #3851 will celebrate its 3rd birthday in a few days (🎉). I searched the logs for the warning and do not see any for the past few weeks, so this should be safe to remove now.

For posterity, this attribute was renamed in #3835.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
