### PR TITLE
Temporarily skip flaky redo doc capture test

### DIFF
--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
       expect(page).to have_css('[role="status"]')  # We verified your ID
     end
 
-    it 'document capture cannot be reached after submitting verify info step' do
+    xit 'document capture cannot be reached after submitting verify info step' do
       warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
 
       expect(page).to have_css(


### PR DESCRIPTION
We added a new test in #8576 that has been flaky in CI. Ada is investigating, but want to skip the test on main for now to unblock other teams.

[skip changelog]
