### PR TITLE
Remove default ActiveJob logger

### DIFF
--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -1,6 +1,8 @@
 # ActiveJob events documentation:
 # https://edgeguides.rubyonrails.org/active_support_instrumentation.html#active-job
 # https://github.com/rails/rails/blob/v6.1.3.1/activejob/lib/active_job/log_subscriber.rb
+require 'active_job/log_subscriber'
+
 class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
   def enqueue(event)
     job = event.payload[:job]
@@ -206,4 +208,5 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
   end
 end
 
+ActiveJob::LogSubscriber.detach_from :active_job
 IdentityJobLogSubscriber.attach_to :active_job


### PR DESCRIPTION
## 🛠 Summary of changes

The default logger isn't in a format that we use and it mostly duplicates a lot of what we have in [IdentityJobLogSubscriber](https://github.com/18F/identity-idp/blob/mitchellhenke/remove-default-activejob-logger/lib/identity_job_log_subscriber.rb)

Example:
```
{"duration_ms":88.27300000190735,"timestamp":"2023-06-15T17:48:40.098Z","name":"enqueue.active_job","job_class":"HeartbeatJob","trace_id":null,"queue_name":"GoodJob(default)","job_id":"d36d287c-d3af-4237-8c76-d477656c2e3c"}
Enqueued HeartbeatJob (Job ID: d36d287c-d3af-4237-8c76-d477656c2e3c) to GoodJob(default)
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
