### PR TITLE
Add log filename to logs to disambiguate in STDOUT

### DIFF
--- a/app/services/encryption/kms_logger.rb
+++ b/app/services/encryption/kms_logger.rb
@@ -1,11 +1,13 @@
 module Encryption
   class KmsLogger
+    LOG_FILENAME = 'kms.log'
     def self.log(action, context = nil)
       output = {
         kms: {
           action: action,
           encryption_context: context,
         },
+        log_filename: LOG_FILENAME,
       }
       logger.info(output.to_json)
     end
@@ -14,7 +16,7 @@ module Encryption
       @logger ||= if FeatureManagement.log_to_stdout?
                     Logger.new(STDOUT)
                   else
-                    Logger.new('log/kms.log')
+                    Logger.new(Rails.root.join('log', LOG_FILENAME))
                   end
     end
   end

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -12,6 +12,8 @@ Ahoy.track_bots = true
 
 module Ahoy
   class Store < Ahoy::BaseStore
+    EVENT_FILENAME = 'events.log'
+
     def track_visit(data)
       log_visit(data)
     end
@@ -21,6 +23,7 @@ module Ahoy
       data[:id] = data.delete(:event_id)
       data[:visitor_id] = ahoy.visitor_token
       data[:visit_id] = data.delete(:visit_token)
+      data[:log_filename] = EVENT_FILENAME
 
       log_event(data)
     end
@@ -57,7 +60,7 @@ module Ahoy
       @event_logger ||= if FeatureManagement.log_to_stdout?
                           ActiveSupport::Logger.new(STDOUT)
                         else
-                          ActiveSupport::Logger.new(Rails.root.join('log', 'events.log'))
+                          ActiveSupport::Logger.new(Rails.root.join('log', EVENT_FILENAME))
                         end
     end
 

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Instruments Faraday requests using ActiveSupport::Notifications and Faraday's
 # instrumentation middleware. This file subscribes to both 'request_metric.faraday' and
 # 'request_log.faraday' events. 'request_metric.faraday' is for requests which we

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -34,6 +34,7 @@ ActiveSupport::Notifications.subscribe('request_metric.faraday') do |name, start
     status: env.status,
     service: service,
     name: 'request_metric.faraday',
+    log_filename: 'rails.log',
   }
   Rails.logger.info(
     metadata.to_json,
@@ -53,6 +54,7 @@ ActiveSupport::Notifications.subscribe('request_log.faraday') do |name, starts, 
     status: env.status,
     service: service,
     name: 'request_log.faraday',
+    log_filename: 'rails.log',
   }
   Rails.logger.info(
     metadata.to_json,

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -36,7 +36,6 @@ ActiveSupport::Notifications.subscribe('request_metric.faraday') do |name, start
     status: env.status,
     service: service,
     name: 'request_metric.faraday',
-    log_filename: 'rails.log',
   }
   Rails.logger.info(
     metadata.to_json,
@@ -56,7 +55,6 @@ ActiveSupport::Notifications.subscribe('request_log.faraday') do |name, starts, 
     status: env.status,
     service: service,
     name: 'request_log.faraday',
-    log_filename: 'rails.log',
   }
   Rails.logger.info(
     metadata.to_json,

--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -4,6 +4,8 @@
 require 'active_job/log_subscriber'
 
 class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
+  LOG_FILENAME = 'workers.log'
+
   def enqueue(event)
     job = event.payload[:job]
     ex = event.payload[:exception_object]
@@ -125,7 +127,7 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
     if FeatureManagement.log_to_stdout?
       @worker_logger = ActiveSupport::Logger.new(STDOUT)
     else
-      @worker_logger = ActiveSupport::Logger.new(Rails.root.join('log', 'workers.log'))
+      @worker_logger = ActiveSupport::Logger.new(Rails.root.join('log', LOG_FILENAME))
     end
   end
 
@@ -173,6 +175,7 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
       trace_id: trace_id(job),
       queue_name: queue_name(event),
       job_id: job.job_id,
+      log_filename: LOG_FILENAME,
     }
   end
 

--- a/spec/lib/identity_job_log_subscriber_spec.rb
+++ b/spec/lib/identity_job_log_subscriber_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           queue_name: kind_of(String),
           timestamp: kind_of(String),
           trace_id: nil,
+          log_filename: IdentityJobLogSubscriber::LOG_FILENAME,
         )
       end
 
@@ -163,6 +164,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           queue_name: kind_of(String),
           timestamp: kind_of(String),
           trace_id: nil,
+          log_filename: IdentityJobLogSubscriber::LOG_FILENAME,
         )
       end
 
@@ -198,6 +200,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           queue_name: 'NilClass(low)',
           timestamp: kind_of(String),
           trace_id: nil,
+          log_filename: IdentityJobLogSubscriber::LOG_FILENAME,
         )
       end
 
@@ -232,6 +235,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           trace_id: nil,
           queue_name: 'NilClass(low)',
           job_id: job.job_id,
+          log_filename: IdentityJobLogSubscriber::LOG_FILENAME,
         )
       end
 
@@ -296,6 +300,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           queue_name: kind_of(String),
           timestamp: kind_of(String),
           trace_id: nil,
+          log_filename: IdentityJobLogSubscriber::LOG_FILENAME,
         )
       end
 
@@ -350,6 +355,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           queue_name: 'NilClass(low)',
           timestamp: kind_of(String),
           trace_id: nil,
+          log_filename: IdentityJobLogSubscriber::LOG_FILENAME,
         )
       end
 
@@ -385,6 +391,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           queue_name: 'NilClass(low)',
           job_id: job.job_id,
           scheduled_at: kind_of(String),
+          log_filename: IdentityJobLogSubscriber::LOG_FILENAME,
         )
       end
 
@@ -426,6 +433,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           queue_name: kind_of(String),
           job_id: job.job_id,
           exception_class_warn: 'Errno::ECONNREFUSED',
+          log_filename: IdentityJobLogSubscriber::LOG_FILENAME,
         )
       end
 

--- a/spec/services/encryption/kms_logger_spec.rb
+++ b/spec/services/encryption/kms_logger_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Encryption::KmsLogger do
             action: 'encrypt',
             encryption_context: { context: 'pii-encryption', user_uuid: '1234-abc' },
           },
+          log_filename: Encryption::KmsLogger::LOG_FILENAME,
         }.to_json
 
         expect(described_class.logger).to receive(:info).with(log)
@@ -24,6 +25,7 @@ RSpec.describe Encryption::KmsLogger do
             action: 'decrypt',
             encryption_context: nil,
           },
+          log_filename: Encryption::KmsLogger::LOG_FILENAME,
         }.to_json
 
         expect(described_class.logger).to receive(:info).with(log)


### PR DESCRIPTION
## 🛠 Summary of changes

We are experimenting with logging all logs to STDOUT in containers, and ensuring they end up in the right log groups in CloudWatch requires a way to disambiguate the lines from one another.

The one that is TBD is the Rails logs, which will likely be our fallback case and may not need the additional metadata.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
