### PR TITLE
Redirect from hybrid_handoff to document_capture on :skip_upload_step

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -220,6 +220,8 @@ module Idv
     def confirm_hybrid_handoff_needed
       setup_for_redo if params[:redo]
 
+      flow_session[:flow_path] = 'standard' if flow_session[:skip_upload_step]
+
       return if !flow_session[:flow_path]
 
       if flow_session[:flow_path] == 'standard'


### PR DESCRIPTION
## 🎫 Ticket

[LG-9367](https://cm-jira.usa.gov/browse/LG-9367)

## 🛠 Summary of changes

In a HybridHandoffController before action, redirect to DocumentCaptureController if flow_session[:skip_upload_step] is set. This is needed for outage specs which use :skip_upload_step to indicate that hybrid flow is turned off. The Flow State Machine was taking care of this from the AgreementStep, but now that it is being removed from the FSM, the HybridHandoffController needs to handle it.

We may want to consider checking the FeatureManagement flag directly in the future.

## 📜 Testing Plan

- [ ] Create account, start IdV
- [ ] Confirm that HybridHandoff is shown as expected
- [ ] Cancel and restart IdV
- [ ] Set browser to "mobile" (Click on phone shape in upper left of browser inspector)
- [ ] Confirm that HybridHandoff is skipped
- [ ] In application.yml, set `feature_idv_hybrid_flow_enabled=false`
- [ ] Restart local server, set browser back to desktop (close inspector)
- [ ] Cancel and restart IdV
- [ ] Confirm that HybridHandoff is skipped
- [ ] Set `feature_idv_hybrid_flow_enabled=true` in application.yml for your future testing happiness