### PR TITLE
Friday test hacking/fix delete account spec take 2

### DIFF
--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -8,6 +8,7 @@ describe 'Account Reset Request: Delete Account', email: true do
   let(:user) { create(:user, :fully_registered) }
   let(:user_email) { user.email_addresses.first.email }
   let(:push_notification_url) { 'http://localhost/push_notifications' }
+  let(:frozen_now) { Time.zone.local(2023, 'jun', 9, 9, 0) }
 
   let(:service_provider) do
     create(
@@ -50,7 +51,7 @@ describe 'Account Reset Request: Delete Account', email: true do
 
       reset_email
 
-      travel_to(Time.zone.now + 2.days + 1) do
+      travel_to(frozen_now + 2.days + 1) do
         AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
         open_last_email
         click_email_link_matching(/delete_account\?token/)
@@ -121,7 +122,7 @@ describe 'Account Reset Request: Delete Account', email: true do
       reset_email
 
       allow(IdentityConfig.store).to receive(:push_notifications_enabled).and_return(true)
-      travel_to(2.days.from_now + 1) do
+      travel_to(frozen_now + 2.days + 1) do
         request = stub_push_notification_request(
           sp_push_notification_endpoint: push_notification_url,
           event_type: PushNotification::AccountPurgedEvent::EVENT_TYPE,
@@ -234,7 +235,7 @@ describe 'Account Reset Request: Delete Account', email: true do
       expect(events.count).to eq received_event_types.count
       expect(received_event_types).to match_array(expected_event_types)
 
-      travel_to(Time.zone.now + 2.days + 1.second) do
+      travel_to(frozen_now + 2.days + 1.second) do
         AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
         open_last_email
         click_email_link_matching(/delete_account\?token/)

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -9,9 +9,6 @@ describe 'Account Reset Request: Delete Account', email: true do
   let(:user_email) { user.email_addresses.first.email }
   let(:push_notification_url) { 'http://localhost/push_notifications' }
 
-  # Force hour so that running this near midnight UTC doesn't fail
-  let(:frozen_now) { Time.zone.now.change(hour: 9) }
-
   let(:service_provider) do
     create(
       :service_provider,
@@ -20,6 +17,10 @@ describe 'Account Reset Request: Delete Account', email: true do
       ial: 2,
       irs_attempts_api_enabled: true,
     )
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(:account_reset_wait_period_days).and_return(1)
   end
 
   context 'as an IAL1 user' do
@@ -53,7 +54,7 @@ describe 'Account Reset Request: Delete Account', email: true do
 
       reset_email
 
-      travel_to(frozen_now + 2.days + 1) do
+      travel_to(Time.zone.now + 3.days + 1) do
         AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
         open_last_email
         click_email_link_matching(/delete_account\?token/)
@@ -124,7 +125,8 @@ describe 'Account Reset Request: Delete Account', email: true do
       reset_email
 
       allow(IdentityConfig.store).to receive(:push_notifications_enabled).and_return(true)
-      travel_to(frozen_now + 2.days + 1) do
+
+      travel_to(Time.zone.now + 3.days + 1) do
         request = stub_push_notification_request(
           sp_push_notification_endpoint: push_notification_url,
           event_type: PushNotification::AccountPurgedEvent::EVENT_TYPE,
@@ -237,7 +239,7 @@ describe 'Account Reset Request: Delete Account', email: true do
       expect(events.count).to eq received_event_types.count
       expect(received_event_types).to match_array(expected_event_types)
 
-      travel_to(frozen_now + 2.days + 1.second) do
+      travel_to(Time.zone.now + 3.days + 1.second) do
         AccountReset::GrantRequestsAndSendEmails.new.perform(Time.zone.today)
         open_last_email
         click_email_link_matching(/delete_account\?token/)

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -8,7 +8,9 @@ describe 'Account Reset Request: Delete Account', email: true do
   let(:user) { create(:user, :fully_registered) }
   let(:user_email) { user.email_addresses.first.email }
   let(:push_notification_url) { 'http://localhost/push_notifications' }
-  let(:frozen_now) { Time.zone.local(2023, 'jun', 9, 9, 0) }
+
+  # Force hour so that running this near midnight UTC doesn't fail
+  let(:frozen_now) { Time.zone.now.change(hour: 9) }
 
   let(:service_provider) do
     create(


### PR DESCRIPTION
## 🛠 Summary of changes
The delete account spec was freezing time at `now`. This caused the test to fail if run near midnight UTC. We freeze time at 9 AM now. 

## 📜 Testing Plan
Re-run the CI near midnight UTC repeatedly between now and Tuesday's deploy, ensuring that the test continues to pass.