### PR TITLE
Enable platform authenticators in local development

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -412,6 +412,7 @@ development:
   otp_delivery_blocklist_findtime: 5
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
+  platform_auth_set_up_enabled: true
   rails_mailer_previews_enabled: true
   rack_timeout_service_timeout_seconds: 9_999_999_999
   recurring_jobs_disabled_names: "[]"
@@ -487,7 +488,6 @@ production:
   password_pepper:
   phone_recaptcha_mock_validator: false
   piv_cac_verify_token_secret:
-  platform_auth_set_up_enabled: false
   session_encryptor_alert_enabled: true
   reauthentication_for_second_factor_management_enabled: false
   recurring_jobs_disabled_names: "[]"


### PR DESCRIPTION
## 🛠 Summary of changes

Enables platform authenticators by default in local development, to reduce effort in testing, increase visibility across development team to build familiarity, and (ideally) quickly identify potential bugs.

## 📜 Testing Plan

1. Remove or comment `config/application.yml`
2. Run `make run`
3. Go to http://localhost:3000
4. Create an account
5. At MFA setup screen, you should see Face or Touch Unlock option, assuming your device has hardware support for platform authenticators (e.g. fingerprint reader)