### PR TITLE
LG-10107 welcome controller

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -61,8 +61,13 @@ module Idv
 
     def confirm_welcome_step_complete
       return if flow_session['Idv::Steps::WelcomeStep']
+      return if idv_session.welcome_visited
 
-      redirect_to idv_doc_auth_url
+      if IdentityConfig.store.doc_auth_welcome_controller_enabled
+        redirect_to idv_welcome_url
+      else
+        redirect_to idv_doc_auth_url
+      end
     end
 
     def confirm_agreement_needed

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -1,0 +1,67 @@
+module Idv
+  class WelcomeController < ApplicationController
+    include IdvSession
+    include IdvStepConcern
+    include OutageConcern
+    include StepIndicatorConcern
+    include StepUtilitiesConcern
+
+    before_action :confirm_two_factor_authenticated
+    before_action :render_404_if_welcome_controller_disabled
+    before_action :confirm_welcome_needed
+    before_action :check_for_outage, only: :show
+
+    def show
+      analytics.idv_doc_auth_welcome_visited(**analytics_arguments)
+
+      Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).call(
+        'welcome', :view,
+        true
+      )
+
+      render :show, locals: { flow_session: flow_session }
+    end
+
+    def update
+      flow_session[:skip_upload_step] = true unless FeatureManagement.idv_allow_hybrid_flow?
+
+      analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
+
+      # TEMP create_document_capture_session(document_capture_session_uuid_key)
+      cancel_previous_in_person_enrollments
+
+      idv_session.welcome_visited = true
+
+      # for the 50/50 state
+      flow_session['Idv::Steps::WelcomeStep'] = true
+
+      redirect_to idv_agreement_url
+    end
+
+    private
+
+    def analytics_arguments
+      {
+        step: 'welcome',
+        analytics_id: 'Doc Auth',
+        irs_reproofing: irs_reproofing?,
+      }
+    end
+
+    def cancel_previous_in_person_enrollments
+      return unless IdentityConfig.store.in_person_proofing_enabled
+      UspsInPersonProofing::EnrollmentHelper.
+        cancel_stale_establishing_enrollments_for_user(current_user)
+    end
+
+    def confirm_welcome_needed
+      return unless idv_session.welcome_visited
+
+      redirect_to idv_agreement_url
+    end
+
+    def render_404_if_welcome_controller_disabled
+      render_not_found unless IdentityConfig.store.doc_auth_welcome_controller_enabled
+    end
+  end
+end

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -27,7 +27,7 @@ module Idv
 
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
 
-      # TEMP create_document_capture_session(document_capture_session_uuid_key)
+      create_document_capture_session
       cancel_previous_in_person_enrollments
 
       idv_session.welcome_visited = true
@@ -46,6 +46,14 @@ module Idv
         analytics_id: 'Doc Auth',
         irs_reproofing: irs_reproofing?,
       }
+    end
+
+    def create_document_capture_session
+      document_capture_session = DocumentCaptureSession.create(
+        user_id: current_user.id,
+        issuer: sp_session[:issuer],
+      )
+      flow_session[:document_capture_session_uuid] = document_capture_session.uuid
     end
 
     def cancel_previous_in_person_enrollments

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -29,7 +29,11 @@ class IdvController < ApplicationController
 
   def verify_identity
     analytics.idv_intro_visit
-    redirect_to idv_doc_auth_url
+    if IdentityConfig.store.doc_auth_welcome_controller_enabled
+      redirect_to idv_welcome_url
+    else
+      redirect_to idv_doc_auth_url
+    end
   end
 
   def profile_needs_reactivation?

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -19,6 +19,7 @@ module Idv
       personal_key
       resolution_successful
       threatmetrix_review_status
+      welcome_visited
     ].freeze
 
     attr_reader :current_user, :gpo_otp, :service_provider

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -1,0 +1,123 @@
+<% title t('doc_auth.headings.welcome') %>
+
+<% content_for(:pre_flash_content) do %>
+  <%= render StepIndicatorComponent.new(
+        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        current_step: :getting_started,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      ) %>
+<% end %>
+
+<%= render 'shared/maintenance_window_alert' do %>
+  <%= render JavascriptRequiredComponent.new(
+        header: t('idv.welcome.no_js_header'),
+        intro: t('idv.welcome.no_js_intro', sp_name: decorated_session.sp_name || t('doc_auth.info.no_sp_name')),
+      ) do %>
+
+    <% if @current_user&.reproof_for_irs?(service_provider: @current_sp) %>
+    <%= render AlertComponent.new(
+          type: :info,
+          message: t('doc_auth.info.irs_reproofing_explanation'),
+          class: ['margin-bottom-2', 'usa-alert--info-important'],
+        )
+    %>
+    <% end %>
+
+  <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.welcome')) %>
+    <p>
+      <%= t('doc_auth.info.welcome_html', sp_name: decorated_session.sp_name || t('doc_auth.info.no_sp_name')) %>
+    </p>
+
+    <h2><%= t('doc_auth.instructions.welcome') %></h2>
+
+    <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
+      <%= c.with_item(heading: t('doc_auth.instructions.bullet1')) do %>
+        <p><%= t('doc_auth.instructions.text1') %></p>
+      <% end %>
+      <%= c.with_item(heading: t('doc_auth.instructions.bullet2')) do %>
+        <p><%= t('doc_auth.instructions.text2') %></p>
+      <% end %>
+      <%= c.with_item(heading: t('doc_auth.instructions.bullet3')) do %>
+        <ul class="usa-list">
+          <% t('doc_auth.instructions.text3_html').each do |bullet_item| %>
+            <li><%= bullet_item %></li>
+          <% end %>
+        </ul>
+        <%= new_tab_link_to(
+              t('idv.troubleshooting.options.learn_more_address_verification_options'),
+              help_center_redirect_path(
+                category: 'verify-your-identity',
+                article: 'phone-number',
+                flow: :idv,
+                step: :welcome,
+                location: 'you_will_need',
+              ),
+            ) %>
+      <% end %>
+    <% end %>
+
+    <%= simple_form_for :doc_auth,
+                        url: url_for,
+                        method: 'put',
+                        html: { autocomplete: 'off', class: 'margin-y-5 js-consent-continue-form' } do |f| %>
+      <%= f.submit t('doc_auth.buttons.continue') %>
+    <% end %>
+
+    <%= render(
+          'shared/troubleshooting_options',
+          heading_tag: :h3,
+          heading: t('idv.troubleshooting.headings.missing_required_items'),
+          options: [
+            {
+              url: help_center_redirect_path(
+                category: 'verify-your-identity',
+                article: 'accepted-state-issued-identification',
+                flow: :idv,
+                step: :welcome,
+                location: 'missing_items',
+              ),
+              text: t('idv.troubleshooting.options.supported_documents'),
+              new_tab: true,
+            },
+            {
+              url: help_center_redirect_path(
+                category: 'verify-your-identity',
+                article: 'phone-number',
+                flow: :idv,
+                step: :welcome,
+                location: 'missing_items',
+              ),
+              text: t('idv.troubleshooting.options.learn_more_address_verification_options'),
+              new_tab: true,
+            },
+            decorated_session.sp_name && {
+              url: idv_doc_auth_return_to_sp_path(location: 'missing_items'),
+              text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
+              new_tab: true,
+            },
+          ].select(&:present?),
+        ) %>
+
+    <h3><%= t('doc_auth.instructions.privacy') %></h3>
+    <p>
+      <%= t('doc_auth.info.privacy', app_name: APP_NAME) %>
+    </p>
+    <p>
+      <%= new_tab_link_to(
+            t('doc_auth.instructions.learn_more'),
+            policy_redirect_url(flow: :idv, step: :welcome, location: :footer),
+          ) %>
+    </p>
+
+    <% if user_fully_authenticated? %>
+      <%= render 'shared/cancel', link: idv_cancel_path(step: 'welcome') %>
+    <% else %>
+      <div class='margin-top-2 padding-top-2 border-top border-primary-light'>
+        <%= link_to(t('two_factor_authentication.choose_another_option'), authentication_methods_setup_path) %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= javascript_packs_tag_once('document-capture-welcome') %>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -92,7 +92,7 @@
               new_tab: true,
             },
             decorated_session.sp_name && {
-              url: idv_doc_auth_return_to_sp_path(location: 'missing_items'),
+              url: return_to_sp_failure_to_proof_url(step: 'welcome', location: 'missing_items'),
               text: t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
               new_tab: true,
             },

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -96,6 +96,7 @@ doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_tips: 3
 doc_auth_max_capture_attempts_before_native_camera: 2
 doc_auth_max_submission_attempts_before_native_camera: 2
+doc_auth_welcome_controller_enabled: false
 doc_capture_request_valid_for_minutes: 15
 email_from: no-reply@login.gov
 email_from_display_name: Login.gov

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -344,6 +344,8 @@ Rails.application.routes.draw do
       put '/ssn' => 'ssn#update'
       get '/verify_info' => 'verify_info#show'
       put '/verify_info' => 'verify_info#update'
+      get '/welcome' => 'welcome#show'
+      put '/welcome' => 'welcome#update'
       get '/phone' => 'phone#new'
       put '/phone' => 'phone#create'
       get '/phone/errors/warning' => 'phone_errors#warning'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -179,6 +179,7 @@ class IdentityConfig
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_capture_attempts_before_tips, type: :integer)
+    config.add(:doc_auth_welcome_controller_enabled, type: :boolean)
     config.add(:doc_auth_s3_request_timeout, type: :integer)
     config.add(:doc_auth_vendor, type: :string)
     config.add(:doc_auth_vendor_randomize, type: :boolean)

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -85,6 +85,11 @@ RSpec.describe Idv::WelcomeController do
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
+    it 'creates a document capture session' do
+      expect { put :update }.
+        to change { subject.user_session['idv/doc_auth'][:document_capture_session_uuid] }.from(nil)
+    end
+
     context 'with previous establishing in-person enrollments' do
       let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user, profile: nil) }
 

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe Idv::WelcomeController do
+  include IdvHelper
+
+  let(:user) { create(:user) }
+
+  let(:feature_flag_enabled) { true }
+
+  before do
+    allow(IdentityConfig.store).to receive(:doc_auth_welcome_controller_enabled).
+      and_return(feature_flag_enabled)
+    stub_sign_in(user)
+    stub_analytics
+    subject.user_session['idv/doc_auth'] = {}
+  end
+
+  describe 'before_actions' do
+    it 'includes authentication before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+      )
+    end
+
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
+  end
+
+  describe '#show' do
+    let(:analytics_name) { 'IdV: doc auth welcome visited' }
+    let(:analytics_args) do
+      { step: 'welcome',
+        analytics_id: 'Doc Auth',
+        irs_reproofing: false }
+    end
+
+    it 'renders the show template' do
+      get :show
+
+      expect(response).to render_template :show
+    end
+
+    it 'sends analytics_visited event' do
+      get :show
+
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+    end
+
+    it 'updates DocAuthLog welcome_view_count' do
+      doc_auth_log = DocAuthLog.create(user_id: user.id)
+
+      expect { get :show }.to(
+        change { doc_auth_log.reload.welcome_view_count }.from(0).to(1),
+      )
+    end
+
+    context 'welcome already visited' do
+      it 'redirects to agreement' do
+        allow(subject.idv_session).to receive(:welcome_visited).and_return(true)
+
+        get :show
+
+        expect(response).to redirect_to(idv_agreement_url)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:analytics_name) { 'IdV: doc auth welcome submitted' }
+
+    let(:analytics_args) do
+      { step: 'welcome',
+        analytics_id: 'Doc Auth',
+        irs_reproofing: false }
+    end
+
+    it 'sends analytics_submitted event with consent given' do
+      put :update, params: { doc_auth: { ial2_consent_given: 1 } }
+
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+    end
+  end
+
+  context 'when doc_auth_welcome_controller_enabled is false' do
+    let(:feature_flag_enabled) { false }
+
+    it 'returns 404' do
+      get :show
+
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/spec/features/idv/doc_auth/welcome_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.feature 'doc auth welcome step' do
+  include IdvHelper
+  include DocAuthHelper
+
+  let(:fake_analytics) { FakeAnalytics.new }
+  let(:maintenance_window) { [] }
+  let(:sp_name) { 'Test SP' }
+
+  before do
+    allow(IdentityConfig.store).to receive(:doc_auth_welcome_controller_enabled).
+      and_return(true)
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+    allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).and_return(sp_name)
+    start, finish = maintenance_window
+    allow(IdentityConfig.store).to receive(:acuant_maintenance_window_start).and_return(start)
+    allow(IdentityConfig.store).to receive(:acuant_maintenance_window_finish).and_return(finish)
+
+    visit_idp_from_sp_with_ial2(:oidc)
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_welcome_step
+  end
+
+  it 'logs return to sp link click' do
+    click_on t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name)
+
+    expect(fake_analytics).to have_logged_event(
+      'Return to SP: Failed to proof',
+      flow: nil,
+      location: 'missing_items',
+      redirect_url: instance_of(String),
+      step: 'welcome',
+    )
+  end
+
+  it 'logs supported documents troubleshooting link click' do
+    click_on t('idv.troubleshooting.options.supported_documents')
+
+    expect(fake_analytics).to have_logged_event(
+      'External Redirect',
+      step: 'welcome',
+      location: 'missing_items',
+      flow: 'idv',
+      redirect_url: MarketingSite.help_center_article_url(
+        category: 'verify-your-identity',
+        article: 'accepted-state-issued-identification',
+      ),
+    )
+  end
+
+  it 'logs missing items troubleshooting link click' do
+    within '.troubleshooting-options' do
+      click_on t('idv.troubleshooting.options.learn_more_address_verification_options')
+    end
+
+    expect(fake_analytics).to have_logged_event(
+      'External Redirect',
+      step: 'welcome',
+      location: 'missing_items',
+      flow: 'idv',
+      redirect_url: MarketingSite.help_center_article_url(
+        category: 'verify-your-identity',
+        article: 'phone-number',
+      ),
+    )
+  end
+
+  it 'logs "you will need" learn more link click' do
+    within '.usa-process-list' do
+      click_on t('idv.troubleshooting.options.learn_more_address_verification_options')
+    end
+
+    expect(fake_analytics).to have_logged_event(
+      'External Redirect',
+      step: 'welcome',
+      location: 'you_will_need',
+      flow: 'idv',
+      redirect_url: MarketingSite.help_center_article_url(
+        category: 'verify-your-identity',
+        article: 'phone-number',
+      ),
+    )
+  end
+
+  context 'during the acuant maintenance window' do
+    let(:maintenance_window) do
+      [Time.zone.parse('2020-01-01T00:00:00Z'), Time.zone.parse('2020-01-01T23:59:59Z')]
+    end
+    let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
+
+    around do |ex|
+      travel_to(now) { ex.run }
+    end
+
+    it 'renders the warning banner but no other content' do
+      expect(page).to have_content('We are currently under maintenance')
+      expect(page).to_not have_content(t('doc_auth.headings.welcome'))
+    end
+  end
+end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -58,7 +58,11 @@ module DocAuthHelper
   end
 
   def complete_doc_auth_steps_before_welcome_step(expect_accessible: false)
-    visit idv_doc_auth_welcome_step unless current_path == idv_doc_auth_welcome_step
+    if IdentityConfig.store.doc_auth_welcome_controller_enabled
+      visit idv_welcome_url unless current_path == idv_welcome_url
+    else
+      visit idv_doc_auth_welcome_step unless current_path == idv_doc_auth_welcome_step
+    end
     click_idv_continue if current_path == idv_mail_only_warning_path
 
     expect(page).to be_axe_clean.according_to :section508, :"best-practice" if expect_accessible

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/welcome/show.html.erb' do
+  let(:flow_session) { {} }
+  let(:user_fully_authenticated) { true }
+  let(:sp_name) { nil }
+  let(:user) { create(:user) }
+
+  before do
+    @decorated_session = instance_double(ServiceProviderSessionDecorator)
+    allow(@decorated_session).to receive(:sp_name).and_return(sp_name)
+    allow(view).to receive(:decorated_session).and_return(@decorated_session)
+    allow(view).to receive(:flow_session).and_return(flow_session)
+    allow(view).to receive(:user_fully_authenticated?).and_return(user_fully_authenticated)
+    allow(view).to receive(:user_signing_up?).and_return(false)
+    allow(view).to receive(:url_for).and_wrap_original do |method, *args, &block|
+      method.call(*args, &block)
+    rescue
+      ''
+    end
+  end
+
+  context 'in doc auth with an authenticated user' do
+    let(:need_irs_reproofing) { false }
+
+    before do
+      allow(user).to receive(:reproof_for_irs?).and_return(need_irs_reproofing)
+      assign(:current_user, user)
+
+      render
+    end
+
+    it 'does not render the IRS reproofing explanation' do
+      expect(rendered).not_to have_text(t('doc_auth.info.irs_reproofing_explanation'))
+    end
+
+    it 'renders a link to return to the SP' do
+      expect(rendered).to have_link(t('links.cancel'))
+    end
+
+    context 'when trying to log in to the IRS' do
+      let(:need_irs_reproofing) { true }
+
+      it 'renders the IRS reproofing explanation' do
+        expect(rendered).to have_text(t('doc_auth.info.irs_reproofing_explanation'))
+      end
+    end
+  end
+
+  context 'in recovery without an authenticated user' do
+    let(:user_fully_authenticated) { false }
+
+    it 'renders a link to return to the MFA step' do
+      render
+
+      expect(rendered).to have_link(t('two_factor_authentication.choose_another_option'))
+    end
+  end
+
+  context 'during the acuant maintenance window' do
+    let(:start) { Time.zone.parse('2020-01-01T00:00:00Z') }
+    let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }
+    let(:finish) { Time.zone.parse('2020-01-01T23:59:59Z') }
+
+    before do
+      allow(IdentityConfig.store).to receive(:acuant_maintenance_window_start).and_return(start)
+      allow(IdentityConfig.store).to receive(:acuant_maintenance_window_finish).and_return(finish)
+    end
+
+    around do |ex|
+      travel_to(now) { ex.run }
+    end
+
+    it 'renders the warning banner but no other content' do
+      render
+
+      expect(rendered).to have_content('We are currently under maintenance')
+      expect(rendered).to_not have_content(t('doc_auth.headings.welcome'))
+    end
+  end
+
+  context 'without service provider' do
+    it 'renders troubleshooting options' do
+      render
+
+      expect(rendered).to have_link(t('idv.troubleshooting.options.supported_documents'))
+      expect(rendered).to have_link(
+        t('idv.troubleshooting.options.learn_more_address_verification_options'),
+      )
+      expect(rendered).not_to have_link(
+        nil,
+        href: return_to_sp_failure_to_proof_url(step: 'welcome', location: 'missing_items'),
+      )
+    end
+  end
+
+  context 'with service provider' do
+    let(:sp_name) { 'Example App' }
+
+    it 'renders troubleshooting options' do
+      render
+
+      expect(rendered).to have_link(t('idv.troubleshooting.options.supported_documents'))
+      expect(rendered).to have_link(
+        t('idv.troubleshooting.options.learn_more_address_verification_options'),
+      )
+      expect(rendered).to have_link(
+        t('idv.troubleshooting.options.get_help_at_sp', sp_name: sp_name),
+        href: return_to_sp_failure_to_proof_url(step: 'welcome', location: 'missing_items'),
+      )
+    end
+  end
+
+  it 'renders a link to the privacy & security page' do
+    render
+    expect(rendered).to have_link(
+      t('doc_auth.instructions.learn_more'),
+      href: policy_redirect_url(flow: :idv, step: :welcome, location: :footer),
+    )
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10107](https://cm-jira.usa.gov/browse/LG-10107)

## 🛠 Summary of changes

Create WelcomeController behind a feature flag to replace WelcomeStep.

Note: There is additional work required to take DocAuthController (Flow State Machine) entirely out of the loop before the feature flag is turned on.

## 📜 Testing Plan

- [ ] In application.yml, set doc_auth_welcome_controller_enabled: true
- [ ] Create account, start IdV
- [ ] Try to navigate forward from welcome screen to `verify/agreement`
- [ ] Expect to stay on Welcome screen
- [ ] Click on doc links, confirm they work
- [ ] Click Continue
- [ ] Continue past HybridHandoff screen and confirm DocumentCapture works as expected

## 👀 Screenshots

<details>
<summary>New view </summary>
  
![Welcome](https://github.com/18F/identity-idp/assets/2381438/9eae651f-e621-435e-960e-8c9ea7a88a56)
</details>
