### PR TITLE
Add `if` guard around address on GPO verify

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -40,6 +40,7 @@ class GpoVerifyForm
       errors: errors,
       extra: {
         enqueued_at: gpo_confirmation_code&.code_sent_at,
+        pii_missing: @pii.nil?,
         pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         pending_in_person_enrollment: pending_in_person_enrollment?,
         threatmetrix_check_failed: threatmetrix_check_failed,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -959,12 +959,14 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name Account verification submitted
   # @param [Boolean] success
   # @param [Hash] errors
+  # @param [Hash] pii_missing
   # @param [Hash] pii_like_keypaths
   # GPO verification submitted
   def idv_gpo_verification_submitted(
     success:,
     errors:,
     pii_like_keypaths:,
+    pii_missing: nil,
     **extra
   )
     track_event(
@@ -972,6 +974,7 @@ module AnalyticsEvents
       success: success,
       errors: errors,
       pii_like_keypaths: pii_like_keypaths,
+      pii_missing: pii_missing,
       **extra,
     )
   end

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -9,16 +9,18 @@
 
 <% title t('forms.verify_profile.title') %>
 
-<%= render AlertComponent.new(type: :info, class: 'margin-bottom-4', text_tag: 'div') do %>
-  <p>
-    <%= t('forms.verify_profile.alert_info') %>
-    <br>
-    <%= render 'shared/address', address: @gpo_verify_form.pii %>
-  </p>
-  <p>
-    <%= t('forms.verify_profile.wrong_address') %>
-    <%= link_to t('forms.verify_profile.clear_and_start_over'), idv_confirm_start_over_path %>
-  </p>
+<% if @gpo_verify_form.pii %>
+  <%= render AlertComponent.new(type: :info, class: 'margin-bottom-4', text_tag: 'div') do %>
+    <p>
+      <%= t('forms.verify_profile.alert_info') %>
+      <br>
+      <%= render 'shared/address', address: @gpo_verify_form.pii %>
+    </p>
+    <p>
+      <%= t('forms.verify_profile.wrong_address') %>
+      <%= link_to t('forms.verify_profile.clear_and_start_over'), idv_confirm_start_over_path %>
+    </p>
+  <% end %>
 <% end %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.verify_profile.welcome_back')) %>

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe Idv::GpoVerifyController do
           threatmetrix_check_failed: false,
           enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+          pii_missing: be_in([true, false]),
         )
         expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_submitted).
           with(success_properties)
@@ -180,6 +181,7 @@ RSpec.describe Idv::GpoVerifyController do
             threatmetrix_check_failed: false,
             enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
             pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+            pii_missing: be_in([true, false]),
           )
           expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_submitted).
             with(success_properties)
@@ -216,6 +218,7 @@ RSpec.describe Idv::GpoVerifyController do
               threatmetrix_check_failed: true,
               enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
               pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+              pii_missing: be_in([true, false]),
             )
             expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_submitted).
               with(success_properties)
@@ -252,6 +255,7 @@ RSpec.describe Idv::GpoVerifyController do
               threatmetrix_check_failed: true,
               enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
               pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+              pii_missing: be_in([true, false]),
             )
 
             action
@@ -289,6 +293,7 @@ RSpec.describe Idv::GpoVerifyController do
               threatmetrix_check_failed: true,
               enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
               pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+              pii_missing: be_in([true, false]),
             )
 
             action
@@ -312,6 +317,7 @@ RSpec.describe Idv::GpoVerifyController do
           enqueued_at: nil,
           error_details: otp_code_incorrect,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+          pii_missing: be_in([true, false]),
         )
         expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_submitted).
           with(success: false, failure_reason: otp_code_incorrect)
@@ -343,6 +349,7 @@ RSpec.describe Idv::GpoVerifyController do
           enqueued_at: nil,
           error_details: otp_code_incorrect,
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
+          pii_missing: be_in([true, false]),
         ).exactly(max_attempts - 1).times
 
         expect(@analytics).to receive(:track_event).with(

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe GpoVerifyForm do
 
       context 'pii is nil' do
         let(:applicant) { nil }
-        it 'reports pii not missing' do
+        it 'reports pii missing' do
           result = subject.submit
           expect(result.to_h[:pii_missing]).to eq(true)
         end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -118,6 +118,19 @@ RSpec.describe GpoVerifyForm do
         expect(result.to_h[:enqueued_at]).to eq(confirmation_code.code_sent_at)
       end
 
+      it 'reports pii not missing' do
+        result = subject.submit
+        expect(result.to_h[:pii_missing]).to eq(false)
+      end
+
+      context 'pii is nil' do
+        let(:applicant) { nil }
+        it 'reports pii not missing' do
+          result = subject.submit
+          expect(result.to_h[:pii_missing]).to eq(true)
+        end
+      end
+
       context 'pending in person enrollment' do
         let!(:enrollment) do
           create(:in_person_enrollment, :establishing, profile: pending_profile, user: user)

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -13,7 +13,12 @@ class FakeAnalytics < Analytics
 
       string_payload = attributes.to_json
 
-      if string_payload.include?('pii') && !pii_like_keypaths.include?([:pii])
+      event_says_pii = string_payload.gsub(
+        'pii_missing',
+        '',
+      ).include?('pii') && !pii_like_keypaths.include?([:pii])
+
+      if event_says_pii
         raise PiiDetected, <<~ERROR
           track_event string 'pii' detected in attributes
           event: #{event} (#{constant_name})


### PR DESCRIPTION
Addressing errors in prod rendering this page because gpo_verify_form.pii is nil.

See https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&begin=1687274067964&end=1687275867964&state=4ec06d58-b97c-4380-b04c-5a0647b437b6

changelog: Bug Fixes, Identity verification, Fix error on US mail OTP verification page

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
