### PR TITLE
Fix bug with verifying address by mail when logging in with PIV/CAC by prompting for password first

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -20,6 +20,8 @@ module Idv
 
       if throttle.throttled?
         render_throttled
+      elsif pii_locked?
+        redirect_to capture_password_url
       else
         render :index
       end
@@ -118,6 +120,10 @@ module Idv
 
     def threatmetrix_enabled?
       FeatureManagement.proofing_device_profiling_decisioning_enabled?
+    end
+
+    def pii_locked?
+      !Pii::Cacher.new(current_user, user_session).exists_in_session?
     end
   end
 end

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Idv::GpoVerifyController do
 
     context 'user has pending profile' do
       it 'renders page' do
+        controller.user_session[:decrypted_pii] = { address1: 'Address1' }.to_json
         expect(@analytics).to receive(:track_event).with('IdV: GPO verification visited')
 
         action

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -76,6 +76,15 @@ RSpec.feature 'idv gpo step' do
         gpo_confirmation_code
 
         signin_with_piv(user)
+        fill_in t('account.index.password'), with: user.password
+        click_button t('forms.buttons.submit.default')
+
+        fill_in t('forms.verify_profile.name'), with: otp
+        click_button t('forms.verify_profile.submit')
+
+        expect(user.identity_verified?).to be(true)
+
+        expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
       end
     end
 

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'idv gpo step', :js do
+RSpec.feature 'idv gpo step' do
   include IdvStepHelper
   include OidcAuthHelper
 
-  it 'redirects to the review step when the user chooses to verify by letter' do
+  it 'redirects to the review step when the user chooses to verify by letter', :js do
     start_idv_from_sp
     complete_idv_steps_before_gpo_step
     click_on t('idv.buttons.mail.send')
@@ -13,7 +13,7 @@ RSpec.feature 'idv gpo step', :js do
     expect(page).to have_current_path(idv_review_path)
   end
 
-  it 'allows the user to go back' do
+  it 'allows the user to go back', :js do
     start_idv_from_sp
     complete_idv_steps_before_gpo_step
 
@@ -33,7 +33,7 @@ RSpec.feature 'idv gpo step', :js do
       )
     end
 
-    it 'allows the user to resend a letter and redirects to the come back later step' do
+    it 'allows the user to resend a letter and redirects to the come back later step', :js do
       complete_idv_and_return_to_gpo_step
 
       # Confirm that we show the correct content on
@@ -69,7 +69,17 @@ RSpec.feature 'idv gpo step', :js do
       expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
     end
 
-    context 'too much time has passed' do
+    context 'logged in with PIV/CAC and no password' do
+      it 'does not 500' do
+        create(:profile, :with_pii, user: user, gpo_verification_pending_at: 1.day.ago)
+        create(:piv_cac_configuration, user: user, x509_dn_uuid: 'helloworld', name: 'My PIV Card')
+        gpo_confirmation_code
+
+        signin_with_piv(user)
+      end
+    end
+
+    context 'too much time has passed', :js do
       let(:days_passed) { 31 }
       let(:max_days_before_resend_disabled) { 30 }
 
@@ -78,7 +88,7 @@ RSpec.feature 'idv gpo step', :js do
           and_return(max_days_before_resend_disabled)
       end
 
-      it 'does not present the user the option to to resend' do
+      it 'does not present the user the option to to resend', :js do
         complete_idv_and_sign_out
         travel_to(days_passed.days.from_now) do
           sign_in_live_with_2fa(user)
@@ -98,7 +108,7 @@ RSpec.feature 'idv gpo step', :js do
       end
     end
 
-    it 'allows the user to return to gpo otp confirmation' do
+    it 'allows the user to return to gpo otp confirmation', :js do
       complete_idv_and_return_to_gpo_step
       click_doc_auth_back_link
 
@@ -135,7 +145,7 @@ RSpec.feature 'idv gpo step', :js do
     end
   end
 
-  context 'GPO verified user has reset their password and needs to re-verify with GPO again' do
+  context 'GPO verified user has reset their password and needs to re-verify with GPO again', :js do
     let(:user) { user_verified_with_gpo }
 
     it 'shows the user a GPO index screen asking to send a letter' do
@@ -152,7 +162,7 @@ RSpec.feature 'idv gpo step', :js do
     end
   end
 
-  context 'Verified resets password, requests GPO, then signs in using SP' do
+  context 'Verified resets password, requests GPO, then signs in using SP', :js do
     let(:user) { user_verified }
     let(:new_password) { 'a really long password' }
 


### PR DESCRIPTION
## 🛠 Summary of changes

If a user logs in with a PIV directly (which skips entering their password) with a GPO pending profile, they are taken directly to the verify screen. This screen now shows attributes from the PII bundle as of https://github.com/18F/identity-idp/pull/8582, which means we need to prompt the user for their password first.

This fix is similar to the ones in #6121 #6309 which checks if the PII is missing from the session and redirects to password capture first.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
