### PR TITLE
Add tests to cover password resets with a pending profile

### DIFF
--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
       deactivation_reason { :encryption_error }
     end
 
+    trait :in_person_verification_pending do
+      deactivation_reason { :in_person_verification_pending }
+    end
+
     trait :fraud_review_pending do
       fraud_review_pending_at { 15.days.ago }
       proofing_components { { threatmetrix_review_status: 'review' } }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -198,7 +198,7 @@ FactoryBot.define do
 
     trait :with_pending_in_person_enrollment do
       after :build do |user|
-        profile = create(:profile, :with_pii, user: user)
+        profile = create(:profile, :with_pii, :in_person_verification_pending, user: user)
         create(:in_person_enrollment, :pending, user: user, profile: profile)
       end
     end

--- a/spec/features/idv/pending_profile_password_reset_spec.rb
+++ b/spec/features/idv/pending_profile_password_reset_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe 'Resetting password with a pending profile' do
+  include OidcAuthHelper
+
+  scenario 'while GPO pending requires the user to reproof' do
+    user = create(:user, :with_phone, :with_pending_gpo_profile)
+
+    visit_idp_from_ial2_oidc_sp
+    fill_forgot_password_form(user)
+    click_reset_password_link_from_email
+
+    new_password = '$alty pickles'
+    fill_in t('forms.passwords.edit.labels.password'), with: new_password
+    click_button t('forms.passwords.edit.buttons.submit')
+
+    user.password = new_password
+    sign_in_live_with_2fa(user)
+
+    expect(page).to have_content(t('doc_auth.headings.welcome'))
+    expect(current_path).to eq(idv_doc_auth_step_path(step: :welcome))
+
+    expect(user.reload.active_or_pending_profile).to be_nil
+  end
+
+  scenario 'while in-person pending requires the user to reproof' do
+    user = create(:user, :with_phone, :with_pending_in_person_enrollment)
+
+    visit_idp_from_ial2_oidc_sp
+    fill_forgot_password_form(user)
+    click_reset_password_link_from_email
+
+    new_password = '$alty pickles'
+    fill_in t('forms.passwords.edit.labels.password'), with: new_password
+    click_button t('forms.passwords.edit.buttons.submit')
+
+    user.password = new_password
+    sign_in_live_with_2fa(user)
+
+    expect(page).to have_content(t('doc_auth.headings.welcome'))
+    expect(current_path).to eq(idv_doc_auth_step_path(step: :welcome))
+
+    expect(user.reload.active_or_pending_profile).to be_nil
+  end
+
+  scenario 'while fraud pending' do
+    user = create(:user, :with_phone, :fraud_review_pending)
+
+    visit_idp_from_ial2_oidc_sp
+    fill_forgot_password_form(user)
+    click_reset_password_link_from_email
+
+    new_password = '$alty pickles'
+    fill_in t('forms.passwords.edit.labels.password'), with: new_password
+    click_button t('forms.passwords.edit.buttons.submit')
+
+    user.password = new_password
+    sign_in_live_with_2fa(user)
+
+    expect(page).to have_content(t('doc_auth.headings.welcome'))
+    expect(current_path).to eq(idv_doc_auth_step_path(step: :welcome))
+
+    expect(user.reload.active_or_pending_profile).to be_nil
+  end
+end


### PR DESCRIPTION
We have uncovered a number of bugs that occur when a user with a pending profile resets their password. This commit adds tests to cover this behavior and make sure everything works as expected.

Currently if a user with a pending profile resets their profile we deactivate their profile and it is unrecoverable. These tests may need to change if we give users the option to recover these profiles.
