### PR TITLE
LG-9815: Personal key screen success banner in GPO flow should be updated

### DIFF
--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -55,7 +55,7 @@ en:
       verification:
         instructions: Your account requires a one-time code to be verified.
         reactivate_button: Enter the code you received via US mail
-        success: Your account has been verified.
+        success: We verified your information
       webauthn: Security key
       webauthn_add: Add security key
       webauthn_confirm_delete: Yes, remove key

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -56,7 +56,7 @@ es:
       verification:
         instructions: Su cuenta requiere un código único para ser verificado.
         reactivate_button: Ingrese el código que recibió por correo postal.
-        success: Su cuenta ha sido verificada.
+        success: Verificamos tu información
       webauthn: Clave de seguridad
       webauthn_add: Añadir clave de seguridad
       webauthn_confirm_delete: Si quitar la llave

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -59,7 +59,7 @@ fr:
       verification:
         instructions: Votre compte nécessite un code à usage unique pour être vérifié.
         reactivate_button: Entrez le code que vous avez reçu par la poste
-        success: Votre compte a été vérifié.
+        success: Nous avons vérifié vos informations
       webauthn: Clé de sécurité
       webauthn_add: Ajouter une clé de sécurité
       webauthn_confirm_delete: Oui, supprimer la clé

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -92,6 +92,7 @@ RSpec.feature 'idv gpo otp verification step' do
       profile.reload
 
       expect(page).to have_current_path(idv_personal_key_path)
+      expect(page).to have_content(t('account.index.verification.success'))
 
       expect(profile.active).to be(true)
       expect(profile.deactivation_reason).to be(nil)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-9815](https://cm-jira.usa.gov/browse/LG-9815)

## 🛠 Summary of changes
Peronal key controller checks to see if the address is confirmed in the idv_session in order to display correct banner message.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
There are automated test to verify.

Manual:
- [x] verify address w/ gpo and observe flash banner on personal key confirmation page
- [x] verify address w/ phone and observe flash banner on personal key confirmation page

## 👀 Screenshots
<details>
<summary>Before:</summary>

<img width="850" alt="Screen Shot 2023-06-21 at 4 12 27 PM" src="https://github.com/18F/identity-idp/assets/1261794/4b906fe9-65d8-49f8-a8e4-b7d2b55922c0">

</details>
<details>
<summary>After:</summary>

<img width="842" alt="Screen Shot 2023-06-21 at 3 56 40 PM" src="https://github.com/18F/identity-idp/assets/1261794/af632aee-1c62-46b1-9d0c-1bf581e703fc">

<img width="809" alt="Screen Shot 2023-06-21 at 4 01 42 PM" src="https://github.com/18F/identity-idp/assets/1261794/ad1c7dbf-2c16-44c9-b067-c1b842c2697e">

<img width="873" alt="Screen Shot 2023-06-21 at 3 59 45 PM" src="https://github.com/18F/identity-idp/assets/1261794/d70e873f-512d-47a7-95ca-0a0632787452">

</details>

