### PR TITLE
LG-10151 Add handle_fraud to IdvStepConcern before actions

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -3,6 +3,7 @@ module IdvStepConcern
 
   include IdvSession
   include RateLimitConcern
+  include FraudReviewConcern
 
   included do
     before_action :confirm_two_factor_authenticated
@@ -10,6 +11,7 @@ module IdvStepConcern
     before_action :confirm_not_rate_limited
     before_action :confirm_no_pending_gpo_profile
     before_action :confirm_no_pending_in_person_enrollment
+    before_action :handle_fraud
   end
 
   def confirm_no_pending_gpo_profile

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe 'IdvStepConcern' do
         :confirm_not_rate_limited,
       )
     end
+
+    it 'includes handle_fraud' do
+      expect(Idv::StepController).to have_actions(
+        :before,
+        :handle_fraud,
+      )
+    end
   end
 
   describe '#confirm_idv_needed' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-10151](https://cm-jira.usa.gov/browse/LG-10151)

## 🛠 Summary of changes

DocAuthController calls handle_fraud as a before_action to send users to the right page if they are under fraud review or rejection. Add the before_action to IdvStepConcern so post-FSM controllers also send users to the right page.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
