### PR TITLE
LG-9727 Add a fraud_pending_reason_column

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -23,6 +23,11 @@ class Profile < ApplicationRecord
     in_person_verification_pending: 5,
   }
 
+  enum fraud_pending_reason: {
+    threatmetrix_review: 1,
+    threatmetrix_reject: 2,
+  }
+
   attr_reader :personal_key
 
   def fraud_review_pending?
@@ -85,6 +90,7 @@ class Profile < ApplicationRecord
       update!(
         fraud_review_pending_at: nil,
         fraud_rejection_at: nil,
+        fraud_pending_reason: nil,
       )
       activate
     end

--- a/db/primary_migrate/20230622142018_add_fraud_pending_reason_to_profile.rb
+++ b/db/primary_migrate/20230622142018_add_fraud_pending_reason_to_profile.rb
@@ -1,0 +1,8 @@
+class AddFraudPendingReasonToProfile < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :profiles, :fraud_pending_reason, :integer
+    add_index :profiles, :fraud_pending_reason, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_01_195606) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_22_142018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -446,6 +446,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_01_195606) do
     t.datetime "fraud_review_pending_at"
     t.datetime "fraud_rejection_at"
     t.datetime "gpo_verification_pending_at"
+    t.integer "fraud_pending_reason"
+    t.index ["fraud_pending_reason"], name: "index_profiles_on_fraud_pending_reason"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
     t.index ["gpo_verification_pending_at"], name: "index_profiles_on_gpo_verification_pending_at"

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -477,11 +477,14 @@ RSpec.describe Profile do
     it 'activates a profile if it passes fraud review' do
       profile = create(
         :profile, user: user, active: false,
+                  fraud_pending_reason: :threatmetrix_review,
                   fraud_review_pending_at: 1.day.ago
       )
       profile.activate_after_passing_review
 
       expect(profile).to be_active
+      expect(profile.fraud_review_pending_at).to be_nil
+      expect(profile.fraud_pending_reason).to be_nil
     end
 
     it 'does not activate a profile if transaction raises an error' do


### PR DESCRIPTION
This commit adds a column for holding the reason that a user is fraud pending. This commit also clears the fraud review pending reason if it exists when the profile is activated after fraud review.

In order to maintain consistency the commit that adds the fraud review pending reason will need to follow this one in a different deploy.
