### PR TITLE
Add guard for suspending user with no unique session ID

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,7 +119,7 @@ class User < ApplicationRecord
       analytics.user_suspended(success: false, error_message: :user_already_suspended)
       raise 'user_already_suspended'
     end
-    OutOfBandSessionAccessor.new(unique_session_id).destroy
+    OutOfBandSessionAccessor.new(unique_session_id).destroy if unique_session_id
     update!(suspended_at: Time.zone.now, unique_session_id: nil)
     analytics.user_suspended(success: true)
   end

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe ActionAccount do
       let(:config) { ScriptBase::Config.new(include_missing:) }
       subject(:result) { subtask.run(args:, config:) }
 
-      it 'Suspend a user that is not suspended already', aggregate_failures: true do
+      it 'suspend a user that is not suspended already', aggregate_failures: true do
         expect(result.table).to match_array(
           [
             ['uuid', 'status'],

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -810,6 +810,14 @@ RSpec.describe User do
 
           expect(OutOfBandSessionAccessor.new(mock_session_id).exists?).to eq false
         end
+
+        context 'user has a nil current session id' do
+          let(:mock_session_id) { nil }
+
+          it 'does not error' do
+            expect { user.suspend! }.to_not raise_error
+          end
+        end
       end
 
       it 'raises an error if the user is already suspended' do


### PR DESCRIPTION
**Why**: OutOfBandSessionAccessor will error with nil id

Looks like a bad combo of #8618 and #8624 surfaced an issue with nil session IDs being suspended