### PR TITLE
LG-9727 Write to the fraud_pending_reason column

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -24,7 +24,7 @@ class GpoVerifyForm
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
         pending_profile&.deactivate(:in_person_verification_pending)
       elsif fraud_review_checker.fraud_check_failed? && threatmetrix_enabled?
-        deactivate_for_fraud_review
+        bump_fraud_review_pending_timestamps
       else
         pending_profile&.update!(
           fraud_review_pending_at: nil,
@@ -59,8 +59,8 @@ class GpoVerifyForm
     pending_profile.gpo_confirmation_codes.first_with_otp(otp)
   end
 
-  def deactivate_for_fraud_review
-    pending_profile&.deactivate_for_fraud_review
+  def bump_fraud_review_pending_timestamps
+    pending_profile&.bump_fraud_review_pending_timestamps
   end
 
   def validate_otp_not_expired

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -135,9 +135,17 @@ class Profile < ApplicationRecord
     update!(active: false, gpo_verification_pending_at: Time.zone.now)
   end
 
-  def deactivate_for_fraud_review
+  def deactivate_for_fraud_review(fraud_pending_reason:)
     update!(
       active: false,
+      fraud_pending_reason: fraud_pending_reason,
+      fraud_review_pending_at: Time.zone.now,
+      fraud_rejection_at: nil,
+    )
+  end
+
+  def bump_fraud_review_pending_timestamps
+    update!(
       fraud_review_pending_at: Time.zone.now,
       fraud_rejection_at: nil,
     )

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -10,7 +10,7 @@ module Idv
     end
 
     def save_profile(
-      fraud_review_needed:,
+      fraud_pending_reason:,
       gpo_verification_needed:,
       deactivation_reason: nil
     )
@@ -20,7 +20,9 @@ module Idv
       profile.proofing_components = current_proofing_components
       profile.save!
       profile.deactivate_for_gpo_verification if gpo_verification_needed
-      profile.deactivate_for_fraud_review if fraud_review_needed
+      if fraud_pending_reason.present?
+        profile.deactivate_for_fraud_review(fraud_pending_reason: fraud_pending_reason)
+      end
       profile
     end
 

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Idv::PersonalKeyController do
       user_password: password,
     )
     profile = profile_maker.save_profile(
-      fraud_review_needed: false,
+      fraud_pending_reason: nil,
       gpo_verification_needed: false,
     )
     idv_session.pii = profile_maker.pii_attributes
@@ -90,7 +90,7 @@ RSpec.describe Idv::PersonalKeyController do
       context 'profile is pending from a different session' do
         context 'profile is pending due to fraud review' do
           before do
-            profile.deactivate_for_fraud_review
+            profile.deactivate_for_fraud_review(fraud_pending_reason: 'threatmetrix_review')
             subject.idv_session.profile_id = nil
           end
 
@@ -290,7 +290,7 @@ RSpec.describe Idv::PersonalKeyController do
 
       context 'profile is in fraud_review' do
         before do
-          profile.deactivate_for_fraud_review
+          profile.deactivate_for_fraud_review(fraud_pending_reason: 'threatmetrix_review')
         end
 
         it 'redirects to idv please call path' do

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -31,11 +31,13 @@ FactoryBot.define do
     end
 
     trait :fraud_review_pending do
+      fraud_pending_reason { 'threatmetrix_review' }
       fraud_review_pending_at { 15.days.ago }
       proofing_components { { threatmetrix_review_status: 'review' } }
     end
 
     trait :fraud_rejection do
+      fraud_pending_reason { 'threatmetrix_review' }
       fraud_rejection_at { 15.days.ago }
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -485,11 +485,7 @@ RSpec.describe Profile do
 
   describe '#activate_after_passing_review' do
     it 'activates a profile if it passes fraud review' do
-      profile = create(
-        :profile, user: user, active: false,
-                  fraud_pending_reason: :threatmetrix_review,
-                  fraud_review_pending_at: 1.day.ago
-      )
+      profile = create(:profile, :fraud_review_pending, user: user)
       profile.activate_after_passing_review
 
       expect(profile).to be_active
@@ -590,13 +586,42 @@ RSpec.describe Profile do
   end
 
   describe '#deactivate_for_fraud_review' do
-    it 'sets fraud_review_pending to true' do
+    it 'sets fraud_review_pending to true and sets fraud_pending_reason' do
       profile = create(:profile, user: user)
-      profile.deactivate_for_fraud_review
+      profile.deactivate_for_fraud_review(fraud_pending_reason: 'threatmetrix_review')
 
       expect(profile).to_not be_active
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.fraud_rejection?).to eq(false)
+      expect(profile.fraud_pending_reason).to eq('threatmetrix_review')
+    end
+  end
+
+  describe '#bump_fraud_review_pending_timestamps' do
+    context 'a profile is fraud review pending' do
+      it 'updates the fraud review pending timestamp' do
+        profile = create(:profile, :fraud_review_pending, user: user)
+
+        profile.bump_fraud_review_pending_timestamps
+
+        expect(profile).to_not be_active
+        expect(profile.fraud_review_pending?).to eq(true)
+        expect(profile.fraud_rejection?).to eq(false)
+        expect(profile.fraud_pending_reason).to eq('threatmetrix_review')
+      end
+    end
+
+    context 'a profile is fraud review rejected' do
+      it 'removes the fraud rejection timestamp and updates the fraud review pending timestamp' do
+        profile = create(:profile, :fraud_rejection, user: user)
+
+        profile.bump_fraud_review_pending_timestamps
+
+        expect(profile).to_not be_active
+        expect(profile.fraud_review_pending?).to eq(true)
+        expect(profile.fraud_rejection?).to eq(false)
+        expect(profile.fraud_pending_reason).to eq('threatmetrix_review')
+      end
     end
   end
 

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Idv::ProfileMaker do
     it 'creates an inactive Profile with encrypted PII' do
       proofing_component = ProofingComponent.create(user_id: user.id, document_check: 'acuant')
       profile = subject.save_profile(
-        fraud_review_needed: false,
+        fraud_pending_reason: nil,
         gpo_verification_needed: false,
       )
       pii = subject.pii_attributes
@@ -40,7 +40,7 @@ RSpec.describe Idv::ProfileMaker do
     context 'with deactivation reason' do
       it 'creates an inactive profile with deactivation reason' do
         profile = subject.save_profile(
-          fraud_review_needed: false,
+          fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: :encryption_error,
         )
@@ -58,7 +58,7 @@ RSpec.describe Idv::ProfileMaker do
     context 'with fraud review needed' do
       it 'deactivates a profile for fraud review' do
         profile = subject.save_profile(
-          fraud_review_needed: true,
+          fraud_pending_reason: 'threatmetrix_review',
           gpo_verification_needed: false,
           deactivation_reason: nil,
         )
@@ -76,7 +76,7 @@ RSpec.describe Idv::ProfileMaker do
     context 'with gpo_verification_needed' do
       it 'deactivates a profile for gpo verification' do
         profile = subject.save_profile(
-          fraud_review_needed: false,
+          fraud_pending_reason: nil,
           gpo_verification_needed: true,
           deactivation_reason: nil,
         )
@@ -94,7 +94,7 @@ RSpec.describe Idv::ProfileMaker do
     context 'as active' do
       it 'creates an active profile' do
         profile = subject.save_profile(
-          fraud_review_needed: false,
+          fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: nil,
         )
@@ -114,7 +114,7 @@ RSpec.describe Idv::ProfileMaker do
 
       it 'creates a profile with the initiating sp recorded' do
         profile = subject.save_profile(
-          fraud_review_needed: false,
+          fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: nil,
         )


### PR DESCRIPTION
This commit changes `Idv::Session` and `Idv::ProfileMaker` to write the reason a profile is fraud pending to `fraud_pending_reason`. A previous commit will overwrite the value with nil when the profile is activated after fraud review.

This change depends on #8635. It should not be merged until the changes in that PR are in production.
