### PR TITLE
LG-9873: Use "transports" to optimize platform authentication prompt

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -83,8 +83,7 @@ module TwoFactorAuthentication
     def presenter_for_two_factor_authentication_method
       TwoFactorAuthCode::WebauthnAuthenticationPresenter.new(
         view: view_context,
-        data: { credential_ids: credential_ids,
-                user_opted_remember_device_cookie: user_opted_remember_device_cookie },
+        data: { credentials:, user_opted_remember_device_cookie: },
         service_provider: current_sp,
         remember_device_default: remember_device_default,
         platform_authenticator: params[:platform].to_s == 'true',
@@ -96,8 +95,10 @@ module TwoFactorAuthentication
       user_session[:webauthn_challenge] = credential_creation_options.challenge.bytes.to_a
     end
 
-    def credential_ids
-      MfaContext.new(current_user).webauthn_configurations.map(&:credential_id).join(',')
+    def credentials
+      MfaContext.new(current_user).webauthn_configurations.map do |configuration|
+        { id: configuration.credential_id, transports: configuration.transports }
+      end.to_json
     end
 
     def analytics_properties

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -196,7 +196,13 @@ module Users
     end
 
     def confirm_params
-      params.permit(:attestation_object, :client_data_json, :name, :platform_authenticator)
+      params.permit(
+        :attestation_object,
+        :client_data_json,
+        :transports,
+        :name,
+        :platform_authenticator,
+      )
     end
 
     def delete_params

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -43,7 +43,7 @@ class WebauthnSetupForm
 
   private
 
-  attr_reader :success
+  attr_reader :success, :transports, :invalid_transports
   attr_accessor :user, :challenge, :attestation_object, :client_data_json,
                 :name, :platform_authenticator
 
@@ -52,6 +52,9 @@ class WebauthnSetupForm
     @client_data_json = params[:client_data_json]
     @name = params[:name]
     @platform_authenticator = (params[:platform_authenticator].to_s == 'true')
+    @transports, @invalid_transports = params[:transports]&.split(',')&.partition do |transport|
+      WebauthnConfiguration::VALID_TRANSPORTS.include?(transport)
+    end
   end
 
   def name_is_unique
@@ -98,6 +101,7 @@ class WebauthnSetupForm
       credential_id: id,
       name: name,
       platform_authenticator: platform_authenticator,
+      transports: transports.presence,
     )
   end
 
@@ -116,6 +120,7 @@ class WebauthnSetupForm
       enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
       multi_factor_auth_method: auth_method,
       pii_like_keypaths: [[:mfa_method_counts, :phone]],
-    }
+      unknown_transports: invalid_transports.presence,
+    }.compact
   end
 end

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -24,6 +24,7 @@ describe('enrollWebauthnDevice', () => {
           response: {
             attestationObject: Buffer.from('attest', 'utf-8'),
             clientDataJSON: Buffer.from('json', 'utf-8'),
+            getTransports: () => ['usb'],
           },
         }),
       },
@@ -80,6 +81,7 @@ describe('enrollWebauthnDevice', () => {
       webauthnPublicKey: '123',
       attestationObject: btoa('attest'),
       clientDataJSON: btoa('json'),
+      transports: ['usb'],
     });
   });
 

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -18,6 +18,8 @@ interface EnrollResult {
   attestationObject: string;
 
   clientDataJSON: string;
+
+  transports: string[];
 }
 
 async function enrollWebauthnDevice({
@@ -79,6 +81,7 @@ async function enrollWebauthnDevice({
     webauthnPublicKey: credential.id,
     attestationObject: arrayBufferToBase64(response.attestationObject),
     clientDataJSON: arrayBufferToBase64(response.clientDataJSON),
+    transports: response.getTransports(),
   };
 }
 

--- a/app/javascript/packages/webauthn/index.ts
+++ b/app/javascript/packages/webauthn/index.ts
@@ -3,3 +3,5 @@ export { default as enrollWebauthnDevice } from './enroll-webauthn-device';
 export { default as extractCredentials } from './extract-credentials';
 export { default as verifyWebauthnDevice } from './verify-webauthn-device';
 export * from './converters';
+
+export type { VerifyCredentialDescriptor } from './verify-webauthn-device';

--- a/app/javascript/packages/webauthn/verify-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/verify-webauthn-device.spec.ts
@@ -7,7 +7,10 @@ describe('verifyWebauthnDevice', () => {
   const defineProperty = useDefineProperty();
 
   const userChallenge = '[1, 2, 3, 4, 5, 6, 7, 8]';
-  const credentialIds = [btoa('credential123'), btoa('credential456')].join(',');
+  const credentials = [
+    { id: btoa('credential123'), transports: ['usb'] as AuthenticatorTransport[] },
+    { id: btoa('credential456'), transports: ['internal', 'hybrid'] as AuthenticatorTransport[] },
+  ];
 
   context('webauthn api resolves credential', () => {
     beforeEach(() => {
@@ -35,10 +38,12 @@ describe('verifyWebauthnDevice', () => {
             {
               id: new TextEncoder().encode('credential123').buffer,
               type: 'public-key',
+              transports: ['usb'],
             },
             {
               id: new TextEncoder().encode('credential456').buffer,
               type: 'public-key',
+              transports: ['internal', 'hybrid'],
             },
           ],
           timeout: 800000,
@@ -47,7 +52,7 @@ describe('verifyWebauthnDevice', () => {
 
       const result = await verifyWebauthnDevice({
         userChallenge,
-        credentialIds,
+        credentials,
       });
 
       expect(navigator.credentials.get).to.have.been.calledWith(expectedGetOptions);
@@ -77,7 +82,7 @@ describe('verifyWebauthnDevice', () => {
       try {
         await verifyWebauthnDevice({
           userChallenge,
-          credentialIds,
+          credentials,
         });
       } catch (error) {
         expect(error).to.equal(error);

--- a/app/javascript/packs/webauthn-authenticate.ts
+++ b/app/javascript/packs/webauthn-authenticate.ts
@@ -1,4 +1,5 @@
 import { isWebauthnSupported, verifyWebauthnDevice } from '@18f/identity-webauthn';
+import type { VerifyCredentialDescriptor } from '@18f/identity-webauthn';
 
 function webauthn() {
   const webauthnInProgressContainer = document.getElementById('webauthn-auth-in-progress')!;
@@ -15,6 +16,10 @@ function webauthn() {
   const spinner = document.getElementById('spinner')!;
   spinner.classList.remove('display-none');
 
+  const credentials: VerifyCredentialDescriptor[] = JSON.parse(
+    (document.getElementById('credentials') as HTMLInputElement).value,
+  );
+
   if (
     !isWebauthnSupported() ||
     (webauthnPlatformRequested && !isPlatformAvailable && !multipleFactorsEnabled)
@@ -25,7 +30,7 @@ function webauthn() {
     // if platform auth is not supported on device, we should take user to the error screen if theres no additional methods.
     verifyWebauthnDevice({
       userChallenge: (document.getElementById('user_challenge') as HTMLInputElement).value,
-      credentialIds: (document.getElementById('credential_ids') as HTMLInputElement).value,
+      credentials,
     })
       .then((result) => {
         (document.getElementById('credential_id') as HTMLInputElement).value = result.credentialId;

--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -68,6 +68,8 @@ function webauthn() {
           result.attestationObject;
         (document.getElementById('client_data_json') as HTMLInputElement).value =
           result.clientDataJSON;
+        (document.getElementById('transports') as HTMLInputElement).value =
+          result.transports.join();
         (document.getElementById('webauthn_form') as HTMLFormElement).submit();
       })
       .catch((err) => reloadWithError(err.name, { force: true }));

--- a/app/models/webauthn_configuration.rb
+++ b/app/models/webauthn_configuration.rb
@@ -3,6 +3,17 @@ class WebauthnConfiguration < ApplicationRecord
   validates :name, presence: true
   validates :credential_id, presence: true
   validates :credential_public_key, presence: true
+  validate :valid_transports
+
+  # https://w3c.github.io/webauthn/#enum-transport
+  VALID_TRANSPORTS = %w[
+    usb
+    nfc
+    ble
+    smart-card
+    hybrid
+    internal
+  ].to_set.freeze
 
   def self.roaming_authenticators
     self.where(platform_authenticator: [nil, false])
@@ -38,5 +49,12 @@ class WebauthnConfiguration < ApplicationRecord
     else
       []
     end
+  end
+
+  private
+
+  def valid_transports
+    return if transports.blank? || (transports - VALID_TRANSPORTS.to_a).blank?
+    errors.add(:transports, I18n.t('errors.general'), type: :invalid_transports)
   end
 end

--- a/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
@@ -3,7 +3,7 @@ module TwoFactorAuthCode
   class WebauthnAuthenticationPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
     include ActionView::Helpers::TranslationHelper
 
-    attr_reader :credential_ids, :user_opted_remember_device_cookie
+    attr_reader :credentials, :user_opted_remember_device_cookie
 
     def initialize(data:, view:, service_provider:, remember_device_default: true,
                    platform_authenticator: false)

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -16,7 +16,7 @@
       },
     ) do |f| %>
   <%= hidden_field_tag :user_challenge, user_session[:webauthn_challenge].to_json, id: 'user_challenge' %>
-  <%= hidden_field_tag :credential_ids, @presenter.credential_ids, id: 'credential_ids' %>
+  <%= hidden_field_tag :credentials, @presenter.credentials, id: 'credentials' %>
   <%= hidden_field_tag :credential_id, '', id: 'credential_id' %>
   <%= hidden_field_tag :authenticator_data, '', id: 'authenticator_data' %>
   <%= hidden_field_tag :signature, '', id: 'signature' %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -29,6 +29,7 @@
   <%= hidden_field_tag :webauthn_public_key, '', id: 'webauthn_public_key' %>
   <%= hidden_field_tag :attestation_object, '', id: 'attestation_object' %>
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
+  <%= hidden_field_tag :transports, '', id: 'transports' %>
   <%= hidden_field_tag :platform_authenticator, @platform_authenticator, id: 'platform_authenticator' %>
   <%= render ValidatedFieldComponent.new(
         form: f,

--- a/db/primary_migrate/20230622125954_add_transports_to_webauthn_configurations.rb
+++ b/db/primary_migrate/20230622125954_add_transports_to_webauthn_configurations.rb
@@ -1,0 +1,7 @@
+class AddTransportsToWebauthnConfigurations < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :webauthn_configurations, :transports, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -623,6 +623,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_213457) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "platform_authenticator"
+    t.string "transports", array: true
     t.index ["user_id"], name: "index_webauthn_configurations_on_user_id"
   end
 

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Users::WebauthnSetupController do
           attestation_object: attestation_object,
           client_data_json: setup_client_data_json,
           name: 'mykey',
+          transports: 'usb',
         }
       end
 
@@ -174,6 +175,7 @@ RSpec.describe Users::WebauthnSetupController do
         attestation_object: attestation_object,
         client_data_json: setup_client_data_json,
         name: 'mykey',
+        transports: 'usb',
       }
     end
 
@@ -206,6 +208,7 @@ RSpec.describe Users::WebauthnSetupController do
             attestation_object: attestation_object,
             client_data_json: setup_client_data_json,
             name: 'mykey',
+            transports: 'usb',
           }
         end
         it 'should log expected events' do
@@ -258,6 +261,7 @@ RSpec.describe Users::WebauthnSetupController do
             attestation_object: attestation_object,
             client_data_json: setup_client_data_json,
             name: 'mykey',
+            transports: 'internal,hybrid',
             platform_authenticator: 'true',
           }
         end
@@ -306,6 +310,7 @@ RSpec.describe Users::WebauthnSetupController do
             attestation_object: attestation_object,
             client_data_json: setup_client_data_json,
             name: 'mykey',
+            transports: 'internal,hybrid',
             platform_authenticator: 'true',
           }
         end

--- a/spec/decorators/mfa_context_spec.rb
+++ b/spec/decorators/mfa_context_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe MfaContext do
       it 'returns 2' do
         user = create(:user)
         create(:webauthn_configuration, user: user)
-        create(:webauthn_configuration, platform_authenticator: true, user: user)
+        create(:webauthn_configuration, :platform_authenticator, user: user)
         subject = described_class.new(user.reload)
 
         expect(subject.enabled_mfa_methods_count).to eq(2)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -90,9 +90,9 @@ FactoryBot.define do
         next unless user.webauthn_configurations.empty?
         user.webauthn_configurations << build(
           :webauthn_configuration,
+          :platform_authenticator,
           {
             user_id: -1,
-            platform_authenticator: true,
           }.merge(
             evaluator.with.slice(:name, :credential_id, :credential_public_key),
           ),
@@ -103,7 +103,7 @@ FactoryBot.define do
         next unless user.webauthn_configurations.empty?
         user.webauthn_configurations << build(
           :webauthn_configuration,
-          { platform_authenticator: true }.
+          :platform_authenticator,
           evaluator.with.slice(:name, :credential_id, :credential_public_key),
         )
       end

--- a/spec/factories/webauthn_configurations.rb
+++ b/spec/factories/webauthn_configurations.rb
@@ -5,6 +5,12 @@ FactoryBot.define do
     sequence(:name) { |n| "token #{n}" }
     sequence(:credential_id) { |n| "credential #{n}" }
     sequence(:credential_public_key) { |n| "key #{n}" }
+    transports { ['usb'] }
     user { association :user }
+
+    trait :platform_authenticator do
+      platform_authenticator { true }
+      transports { ['internal', 'hybrid'] }
+    end
   end
 end

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe 'Remembering a webauthn device' do
       before do
         create(
           :webauthn_configuration,
+          :platform_authenticator,
           user: user,
-          platform_authenticator: true,
           credential_id: credential_id,
           credential_public_key: credential_public_key,
         )

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -144,8 +144,8 @@ RSpec.describe 'webauthn management' do
 
   context 'with webauthn platform associations' do
     it 'displays the user supplied names of the platform authenticators' do
-      webauthn_config1 = create(:webauthn_configuration, user: user, platform_authenticator: true)
-      webauthn_config2 = create(:webauthn_configuration, user: user, platform_authenticator: true)
+      webauthn_config1 = create(:webauthn_configuration, :platform_authenticator, user:)
+      webauthn_config2 = create(:webauthn_configuration, :platform_authenticator, user:)
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
@@ -161,7 +161,7 @@ RSpec.describe 'webauthn management' do
 
       it 'allows the user to setup another key' do
         mock_webauthn_setup_challenge
-        create(:webauthn_configuration, user: user, platform_authenticator: true)
+        create(:webauthn_configuration, :platform_authenticator, user:)
 
         sign_in_and_2fa_user(user)
 
@@ -194,7 +194,7 @@ RSpec.describe 'webauthn management' do
 
       it 'does not allows the user to setup another platform authenticator' do
         mock_webauthn_setup_challenge
-        create(:webauthn_configuration, user: user, platform_authenticator: true)
+        create(:webauthn_configuration, :platform_authenticator, user:)
 
         sign_in_and_2fa_user(user)
 
@@ -204,7 +204,7 @@ RSpec.describe 'webauthn management' do
     end
 
     it 'allows user to delete a platform authenticator when another 2FA option is set up' do
-      webauthn_config = create(:webauthn_configuration, user: user, platform_authenticator: true)
+      webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
@@ -223,7 +223,7 @@ RSpec.describe 'webauthn management' do
     end
 
     it 'allows the user to cancel deletion of the platform authenticator' do
-      webauthn_config = create(:webauthn_configuration, user: user, platform_authenticator: true)
+      webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
@@ -240,7 +240,7 @@ RSpec.describe 'webauthn management' do
     end
 
     it 'prevents a user from deleting the last key' do
-      webauthn_config = create(:webauthn_configuration, user: user, platform_authenticator: true)
+      webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
 
       sign_in_and_2fa_user(user)
       PhoneConfiguration.first.update(mfa_enabled: false)
@@ -254,7 +254,7 @@ RSpec.describe 'webauthn management' do
     end
 
     it 'gives an error if name is taken and stays on the configuration screen' do
-      webauthn_config = create(:webauthn_configuration, user: user, platform_authenticator: true)
+      webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
 
       mock_webauthn_setup_challenge
       sign_in_and_2fa_user(user)

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -5,18 +5,25 @@ RSpec.describe WebauthnSetupForm do
 
   let(:user) { create(:user) }
   let(:user_session) { { webauthn_challenge: webauthn_challenge } }
+  let(:domain_name) { 'localhost:3000' }
+  let(:params) do
+    {
+      attestation_object: attestation_object,
+      client_data_json: setup_client_data_json,
+      name: 'mykey',
+      platform_authenticator: false,
+      transports: 'usb',
+    }
+  end
   let(:subject) { WebauthnSetupForm.new(user, user_session) }
+
+  before do
+    allow(IdentityConfig.store).to receive(:domain_name).and_return(domain_name)
+  end
 
   describe '#submit' do
     context 'when the input is valid' do
       it 'returns FormResponse with success: true and creates a webauthn configuration' do
-        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
-        params = {
-          attestation_object: attestation_object,
-          client_data_json: setup_client_data_json,
-          name: 'mykey',
-          platform_authenticator: false,
-        }
         extra_attributes = {
           enabled_mfa_methods_count: 1,
           mfa_method_counts: { webauthn: 1 },
@@ -30,48 +37,68 @@ RSpec.describe WebauthnSetupForm do
           **extra_attributes,
         )
 
-        expect(user.reload.webauthn_configurations.roaming_authenticators.count).to eq(1)
-      end
+        user.reload
 
-      it 'creates a platform authenticator if the platform_authenticator param is set' do
-        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
-        params = {
-          attestation_object: attestation_object,
-          client_data_json: setup_client_data_json,
-          name: 'mykey',
-          platform_authenticator: true,
-        }
-
-        result = subject.submit(protocol, params)
-        expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
-
-        expect(user.reload.webauthn_configurations.platform_authenticators.count).to eq(1)
+        expect(user.webauthn_configurations.roaming_authenticators.count).to eq(1)
+        expect(user.webauthn_configurations.roaming_authenticators.first.transports).to eq(['usb'])
       end
 
       it 'sends a recovery information changed event' do
-        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
 
-        params = {
-          attestation_object: attestation_object,
-          client_data_json: setup_client_data_json,
-          name: 'mykey',
-          platform_authenticator: false,
-        }
-
         subject.submit(protocol, params)
+      end
+
+      context 'with platform authenticator' do
+        let(:params) do
+          super().merge(platform_authenticator: true, transports: 'internal,hybrid')
+        end
+
+        it 'creates a platform authenticator' do
+          result = subject.submit(protocol, params)
+          expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
+
+          user.reload
+
+          expect(user.webauthn_configurations.platform_authenticators.count).to eq(1)
+          expect(user.webauthn_configurations.platform_authenticators.first.transports).to eq(
+            ['internal', 'hybrid'],
+          )
+        end
+      end
+
+      context 'with invalid transports' do
+        let(:params) { super().merge(transports: 'wrong') }
+
+        it 'creates a webauthn configuration without transports' do
+          subject.submit(protocol, params)
+
+          user.reload
+
+          expect(user.webauthn_configurations.roaming_authenticators.first.transports).to be_nil
+        end
+
+        it 'includes unknown transports in extra analytics' do
+          result = subject.submit(protocol, params)
+
+          expect(result.to_h).to eq(
+            success: true,
+            errors: {},
+            enabled_mfa_methods_count: 1,
+            mfa_method_counts: { webauthn: 1 },
+            multi_factor_auth_method: 'webauthn',
+            pii_like_keypaths: [[:mfa_method_counts, :phone]],
+            unknown_transports: ['wrong'],
+          )
+        end
       end
     end
 
-    context 'when the input is invalid' do
+    context 'with invalid attestation response from domain' do
+      let(:domain_name) { 'example.com' }
+
       it 'returns FormResponse with success: false' do
-        params = {
-          attestation_object: attestation_object,
-          client_data_json: setup_client_data_json,
-          name: 'mykey',
-          platform_authenticator: false,
-        }
         extra_attributes = {
           enabled_mfa_methods_count: 0,
           mfa_method_counts: {},
@@ -85,17 +112,26 @@ RSpec.describe WebauthnSetupForm do
           **extra_attributes,
         )
       end
+    end
+
+    context 'with missing transports' do
+      let(:params) { super().except(:transports) }
+
+      it 'creates a webauthn configuration without transports' do
+        subject.submit(protocol, params)
+
+        user.reload
+
+        expect(user.webauthn_configurations.roaming_authenticators.first.transports).to be_nil
+      end
+    end
+
+    context 'when the attestation response raises an error' do
+      before do
+        allow(WebAuthn::AttestationStatement).to receive(:from).and_raise(StandardError)
+      end
 
       it 'returns false with an error when the attestation response raises an error' do
-        allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
-        allow(WebAuthn::AttestationStatement).to receive(:from).and_raise(StandardError)
-
-        params = {
-          attestation_object: attestation_object,
-          client_data_json: setup_client_data_json,
-          name: 'mykey',
-          platform_authenticator: false,
-        }
         extra_attributes = {
           enabled_mfa_methods_count: 0,
           mfa_method_counts: {},

--- a/spec/models/webauthn_configuration_spec.rb
+++ b/spec/models/webauthn_configuration_spec.rb
@@ -44,4 +44,48 @@ RSpec.describe WebauthnConfiguration do
 
     it { expect(mfa_enabled).to be_truthy }
   end
+
+  describe '#transports' do
+    context 'with nil transports' do
+      before { subject.transports = nil }
+
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with empty array transports' do
+      before { subject.transports = [] }
+
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with single valid transport' do
+      before { subject.transports = ['ble'] }
+
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with single invalid transport' do
+      before { subject.transports = ['wrong'] }
+
+      it { expect(subject).not_to be_valid }
+    end
+
+    context 'with multiple valid transports' do
+      before { subject.transports = ['ble', 'hybrid'] }
+
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with multiple invalid transports' do
+      before { subject.transports = ['wrong', 'also wrong'] }
+
+      it { expect(subject).not_to be_valid }
+    end
+
+    context 'with multiple mixed validity transports' do
+      before { subject.transports = ['ble', 'wrong'] }
+
+      it { expect(subject).not_to be_valid }
+    end
+  end
 end

--- a/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
@@ -5,10 +5,14 @@ RSpec.describe TwoFactorAuthCode::WebauthnAuthenticationPresenter do
 
   let(:view) { ActionController::Base.new.view_context }
   let(:reauthn) {}
-  let(:presenter) do
-    TwoFactorAuthCode::WebauthnAuthenticationPresenter.
-      new(data: { reauthn: reauthn }, service_provider: nil,
-          view: view, platform_authenticator: platform_authenticator)
+  let(:credentials) { [] }
+  subject(:presenter) do
+    TwoFactorAuthCode::WebauthnAuthenticationPresenter.new(
+      data: { reauthn:, credentials: },
+      service_provider: nil,
+      view: view,
+      platform_authenticator: platform_authenticator,
+    )
   end
 
   let(:allow_user_to_switch_method) { false }
@@ -220,6 +224,12 @@ RSpec.describe TwoFactorAuthCode::WebauthnAuthenticationPresenter do
       it 'returns the sign out path' do
         expect(presenter.cancel_link).to eq sign_out_path(locale: locale)
       end
+    end
+  end
+
+  describe '#credentials' do
+    it 'returns credentials from initialized data' do
+      expect(presenter.credentials).to eq credentials
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9873](https://cm-jira.usa.gov/browse/LG-9873)

## 🛠 Summary of changes

Records `transports` associated with WebAuthn configurations during enrollment and uses those values in the authentication prompt, so that the browser UI will optimize the display for the user to select the correct authenticator device. For example, this should prevent users from being shown options for using a "Security Key" to complete Face or Touch Unlock.

Via WebAuthn spec:

>The [credential request] items SHOULD specify transports whenever possible. This helps the client optimize the user experience for any given situation.

https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-allowcredentials

>When registering a new credential, the Relying Party SHOULD store the value returned from getTransports(). When creating a PublicKeyCredentialDescriptor for that credential, the Relying Party SHOULD retrieve that stored value and set it as the value of the transports member.

https://w3c.github.io/webauthn/#dictionary-credential-descriptor

## 📜 Testing Plan

1. On a [device supporting platform authenticators](https://github.com/18F/identity-idp/pull/8615), go to http://localhost:3000 (see [mobile testing docs](https://github.com/18F/identity-idp/blob/main/docs/mobile.md))
2. Create an account
3. Choose "Face or Touch Unlock" as the MFA method
4. Finish account creation
5. From your desktop computer, sign in to the account created in steps 2-4
6. Click "Continue" when prompted for Face or Touch Unlock

**Before:** You'd be asked to select between QR code & security key.
**After:** You're immediately shown a QR code.

## 👀 Screenshots

Before|After
---|---
![before](https://github.com/18F/identity-idp/assets/1779930/cbc3327e-ad33-4a0b-95e0-24e6bd35827c)|![after](https://github.com/18F/identity-idp/assets/1779930/af7bf63d-7c22-4b50-86a1-c4106234181a)