### PR TITLE
LG-10152 check for outage in idv step concern

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -4,6 +4,7 @@ module IdvStepConcern
   include IdvSession
   include RateLimitConcern
   include FraudReviewConcern
+  include Idv::OutageConcern
 
   included do
     before_action :confirm_two_factor_authenticated
@@ -12,6 +13,7 @@ module IdvStepConcern
     before_action :confirm_no_pending_gpo_profile
     before_action :confirm_no_pending_in_person_enrollment
     before_action :handle_fraud
+    before_action :check_for_outage
   end
 
   def confirm_no_pending_gpo_profile

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -1,6 +1,5 @@
 module Idv
   class AddressController < ApplicationController
-    include IdvSession
     include IdvStepConcern
 
     before_action :confirm_document_capture_complete

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -1,15 +1,11 @@
 module Idv
   class AgreementController < ApplicationController
-    include IdvSession
     include IdvStepConcern
-    include OutageConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
 
-    before_action :confirm_two_factor_authenticated
     before_action :confirm_welcome_step_complete
     before_action :confirm_agreement_needed
-    before_action :check_for_outage, only: :show
 
     def show
       analytics.idv_doc_auth_agreement_visited(**analytics_arguments)

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -2,18 +2,14 @@ module Idv
   class DocumentCaptureController < ApplicationController
     include AcuantConcern
     include DocumentCaptureConcern
-    include IdvSession
     include IdvStepConcern
-    include OutageConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
     include RateLimitConcern
 
-    before_action :confirm_two_factor_authenticated
     before_action :confirm_hybrid_handoff_complete
     before_action :confirm_document_capture_needed
     before_action :override_csp_to_allow_acuant
-    before_action :check_for_outage, only: :show
 
     def show
       analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -1,16 +1,12 @@
 module Idv
   class HybridHandoffController < ApplicationController
     include ActionView::Helpers::DateHelper
-    include IdvSession
     include IdvStepConcern
-    include OutageConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
 
-    before_action :confirm_two_factor_authenticated
     before_action :confirm_agreement_step_complete
     before_action :confirm_hybrid_handoff_needed, only: :show
-    before_action :check_for_outage, only: :show
 
     def show
       analytics.idv_doc_auth_upload_visited(**analytics_arguments)

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -6,11 +6,9 @@ module Idv
       include StepUtilitiesConcern
       include Steps::ThreatMetrixStepHelper
       include VerifyInfoConcern
-      include OutageConcern
 
       before_action :confirm_ssn_step_complete
       before_action :confirm_verify_info_step_needed
-      before_action :check_for_outage, only: :show
 
       def show
         @step_indicator_steps = step_indicator_steps

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -1,17 +1,13 @@
 module Idv
   class LinkSentController < ApplicationController
     include DocumentCaptureConcern
-    include IdvSession
     include IdvStepConcern
-    include OutageConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
 
-    before_action :confirm_two_factor_authenticated
     before_action :confirm_hybrid_handoff_complete
     before_action :confirm_document_capture_needed
     before_action :extend_timeout_using_meta_refresh
-    before_action :check_for_outage, only: :show
 
     def show
       analytics.idv_doc_auth_link_sent_visited(**analytics_arguments)

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -2,7 +2,6 @@ module Idv
   class PhoneController < ApplicationController
     include IdvStepConcern
     include StepIndicatorConcern
-    include OutageConcern
     include PhoneOtpRateLimitable
     include PhoneOtpSendable
 
@@ -11,9 +10,6 @@ module Idv
     before_action :confirm_verify_info_step_complete
     before_action :confirm_step_needed
     before_action :set_idv_form
-    # rubocop:disable Rails/LexicallyScopedActionFilter
-    before_action :check_for_outage, only: :show
-    # rubocop:enable Rails/LexicallyScopedActionFilter
 
     def new
       flash.keep(:success) if should_keep_flash_success?

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -1,8 +1,6 @@
 module Idv
   class SsnController < ApplicationController
-    include IdvSession
     include IdvStepConcern
-    include OutageConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
     include Steps::ThreatMetrixStepHelper
@@ -12,7 +10,6 @@ module Idv
     before_action :confirm_document_capture_complete
     before_action :confirm_repeat_ssn, only: :show
     before_action :override_csp_for_threat_metrix_no_fsm
-    before_action :check_for_outage, only: :show
 
     attr_accessor :error_message
 

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -1,7 +1,6 @@
 module Idv
   class VerifyInfoController < ApplicationController
     include IdvStepConcern
-    include OutageConcern
     include StepUtilitiesConcern
     include StepIndicatorConcern
     include VerifyInfoConcern
@@ -9,7 +8,6 @@ module Idv
 
     before_action :confirm_ssn_step_complete
     before_action :confirm_verify_info_step_needed
-    before_action :check_for_outage, only: :show
 
     def show
       @step_indicator_steps = step_indicator_steps

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -1,15 +1,11 @@
 module Idv
   class WelcomeController < ApplicationController
-    include IdvSession
     include IdvStepConcern
-    include OutageConcern
     include StepIndicatorConcern
     include StepUtilitiesConcern
 
-    before_action :confirm_two_factor_authenticated
     before_action :render_404_if_welcome_controller_disabled
     before_action :confirm_welcome_needed
-    before_action :check_for_outage, only: :show
 
     def show
       analytics.idv_doc_auth_welcome_visited(**analytics_arguments)

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe 'IdvStepConcern' do
         :handle_fraud,
       )
     end
+
+    it 'includes check_for_outage before_action' do
+      expect(Idv::StepController).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
   end
 
   describe '#confirm_idv_needed' do

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Idv::DocumentCaptureController do
       )
     end
 
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
+
     it 'checks that hybrid_handoff is complete' do
       expect(subject).to have_actions(
         :before,

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Idv::HybridHandoffController do
       )
     end
 
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
+
     it 'checks that agreement step is complete' do
       expect(subject).to have_actions(
         :before,

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
       )
     end
 
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
+
     it 'confirms ssn step complete' do
       expect(subject).to have_actions(
         :before,

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Idv::LinkSentController do
       )
     end
 
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
+
     it 'checks that hybrid_handoff is complete' do
       expect(subject).to have_actions(
         :before,

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Idv::PhoneController do
         :confirm_verify_info_step_complete,
       )
     end
+
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
   end
 
   describe 'before_actions' do

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Idv::SsnController do
       )
     end
 
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
+
     it 'checks that the previous step is complete' do
       expect(subject).to have_actions(
         :before,
@@ -74,16 +81,6 @@ RSpec.describe Idv::SsnController do
       expect { get :show }.to(
         change { doc_auth_log.reload.ssn_view_count }.from(0).to(1),
       )
-    end
-
-    context 'without a flow session' do
-      let(:flow_session) { nil }
-
-      it 'redirects to hybrid_handoff' do
-        get :show
-
-        expect(response).to redirect_to(idv_hybrid_handoff_url)
-      end
     end
 
     context 'with an ssn in session' do

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Idv::VerifyInfoController do
       )
     end
 
+    it 'includes outage before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :check_for_outage,
+      )
+    end
+
     it 'confirms ssn step complete' do
       expect(subject).to have_actions(
         :before,


### PR DESCRIPTION
## 🎫 Ticket

[LG-10152](https://cm-jira.usa.gov/browse/LG-10152)

## 🛠 Summary of changes

- Include OutageConcern and :check_for_outage before_action in IdvStepConcern so it will be included in all post-FSM controllers.
- Remove OutageConcern and :check_for_outage from individual controllers. Add controller specs to ensure it is still indirectly included.
- Extra cleanup: Since IdvSession and :confirm_two_factor_authenticated are also included in IdvStepConcern, remove them from individual controllers. There are already controller specs confirming inclusion of that before action.

Note:
- removed `only: :show` restriction for :check_for_outage. If we put it back, we should include `:new` for the phone_controller.
- personal_key_controller, gpo_controller and gpo_verify_controller don't include IdvStepConcern. Should they? They also don't include check_for_outage and handle_fraud before actions.

## 📜 Testing Plan

- [ ] In application.yml, set  `vendor_status_sms: full_outage`
- [ ] Create account, navigate to `verify`
- [ ] Expect to see mail_only_warning screen
