### PR TITLE
LG-10055 Do not change CSP or render TMx JS for specific users

### DIFF
--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -18,6 +18,17 @@ module Idv
     def override_csp_for_threat_metrix_no_fsm
       return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
 
+      ##
+      # In order to test the behavior without the CSP changes, we do not perform the CSP override
+      # if the user's email is on a list of CSP disabled emails.
+      #
+      current_user.email_addresses.each do |email_address|
+        no_csp_email = IdentityConfig.store.idv_tmx_test_csp_disabled_emails.include?(
+          email_address.email,
+        )
+        return nil if no_csp_email
+      end
+
       threat_metrix_csp_overrides
     end
 

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -14,6 +14,8 @@ module Idv
     before_action :override_csp_for_threat_metrix_no_fsm
     before_action :check_for_outage, only: :show
 
+    helper_method :should_render_threatmetrix_js?
+
     attr_accessor :error_message
 
     def show
@@ -49,6 +51,23 @@ module Idv
         @error_message = form_response.first_error_message
         render :show, locals: threatmetrix_view_variables
       end
+    end
+
+    ##
+    # In order to test the behavior without the threatmetrix JS, we do not load the threatmetrix
+    # JS if the user's email is on a list of JS disabled emails.
+    #
+    def should_render_threatmetrix_js?
+      return false unless FeatureManagement.proofing_device_profiling_collecting_enabled?
+
+      current_user.email_addresses.each do |email_address|
+        no_csp_email = IdentityConfig.store.idv_tmx_test_js_disabled_emails.include?(
+          email_address.email,
+        )
+        return false if no_csp_email
+      end
+
+      true
     end
 
     private

--- a/app/views/idv/ssn/show.html.erb
+++ b/app/views/idv/ssn/show.html.erb
@@ -30,7 +30,7 @@ locals:
   <% end %>
 </p>
 
-<% if FeatureManagement.proofing_device_profiling_collecting_enabled? %>
+<% if should_render_threatmetrix_js? %>
   <% if threatmetrix_session_id.present? %>
     <% threatmetrix_javascript_urls.each do |threatmetrix_javascript_url| %>
       <%= javascript_include_tag threatmetrix_javascript_url, nonce: true %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -132,6 +132,8 @@ idv_acuant_sdk_upgrade_a_b_testing_enabled: false
 idv_acuant_sdk_upgrade_a_b_testing_percent: 50
 idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
+idv_tmx_test_csp_disabled_emails: '[]'
+idv_tmx_test_js_disabled_emails: '[]'
 ie11_support_end_date: '2022-12-31'
 idv_sp_required: false
 in_person_capture_secondary_id_enabled: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -225,6 +225,8 @@ class IdentityConfig
     config.add(:idv_send_link_attempt_window_in_minutes, type: :integer)
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_sp_required, type: :boolean)
+    config.add(:idv_tmx_test_csp_disabled_emails, type: :json)
+    config.add(:idv_tmx_test_js_disabled_emails, type: :json)
     config.add(:ie11_support_end_date, type: :timestamp)
     config.add(:in_person_capture_secondary_id_enabled, type: :boolean)
     config.add(:in_person_email_reminder_early_benchmark_in_days, type: :integer)

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -131,6 +131,29 @@ RSpec.describe Idv::SsnController do
         expect(csp.directives['img-src']).to include('*.online-metrix.net')
       end
     end
+
+    it 'does not override the Content Security for CSP disabled test users' do
+      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
+        and_return(:enabled)
+      allow(IdentityConfig.store).to receive(:idv_tmx_test_csp_disabled_emails).
+        and_return([user.email_addresses.first.email])
+
+      get :show
+
+      csp = response.request.content_security_policy
+
+      aggregate_failures do
+        expect(csp.directives['script-src']).to_not include('h.online-metrix.net')
+
+        expect(csp.directives['style-src']).to_not include("'unsafe-inline'")
+
+        expect(csp.directives['child-src']).to_not include('h.online-metrix.net')
+
+        expect(csp.directives['connect-src']).to_not include('h.online-metrix.net')
+
+        expect(csp.directives['img-src']).to_not include('*.online-metrix.net')
+      end
+    end
   end
 
   describe '#update' do
@@ -250,6 +273,31 @@ RSpec.describe Idv::SsnController do
         expect(response.status).to eq 302
         expect(response).to redirect_to idv_hybrid_handoff_url
       end
+    end
+  end
+
+  describe '#should_render_threatmetrix_js?' do
+    it 'returns true if the JS should be disabled for the user' do
+      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
+        and_return(:enabled)
+      allow(IdentityConfig.store).to receive(:idv_tmx_test_js_disabled_emails).
+        and_return([user.email_addresses.first.email])
+
+      expect(controller.should_render_threatmetrix_js?).to eq(false)
+    end
+
+    it 'returns true if the JS should not be disabled for the user' do
+      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
+        and_return(:enabled)
+
+      expect(controller.should_render_threatmetrix_js?).to eq(true)
+    end
+
+    it 'returns false if TMx profiling is disabled' do
+      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
+        and_return(:disabled)
+
+      expect(controller.should_render_threatmetrix_js?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
We have code that modifies the CSP and renders special javascript on the SSN page for device profiling.

We are planning a test to see how this page performs if the CSP changes are not in place or if the device profiling javascript is not enabled.

This commit adds 2 new configs:

- `idv_tmx_test_csp_disabled_emails`: A list of emails for which the CSP changes are not made
- `idv_tmx_test_js_disabled_emails`: A list of emails for which the JS is not loaded

These configs are empty by default. After this commit, adding an email address will cause the desired effect for a user with that email.

These lists are only intended to be populated in the staging environment. After the test this change should be reverted.
