### PR TITLE
Kmas lg 9997 add account creation date deletion analytics event

### DIFF
--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -71,6 +71,7 @@ module AccountReset
         user_id: user.uuid,
         email: user.email_addresses.take&.email,
         account_age_in_days: account_age,
+        account_created_at: user.created_at,
         mfa_method_counts: mfa_method_counts,
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
       }

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -71,7 +71,7 @@ module AccountReset
         user_id: user.uuid,
         email: user.email_addresses.take&.email,
         account_age_in_days: account_age,
-        account_created_at: user.created_at,
+        account_confirmed_at: user.confirmed_at,
         mfa_method_counts: mfa_method_counts,
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
       }

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -70,6 +70,7 @@ module AnalyticsEvents
     success:,
     user_id:,
     account_age_in_days:,
+    account_created_at:, 
     mfa_method_counts:,
     errors: nil,
     **extra
@@ -79,6 +80,7 @@ module AnalyticsEvents
       success: success,
       user_id: user_id,
       account_age_in_days: account_age_in_days,
+      account_created_at: account_created_at,
       mfa_method_counts: mfa_method_counts,
       errors: errors,
       **extra,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -70,7 +70,7 @@ module AnalyticsEvents
     success:,
     user_id:,
     account_age_in_days:,
-    account_created_at:, 
+    account_confirmed_at:, 
     mfa_method_counts:,
     errors: nil,
     **extra
@@ -80,7 +80,7 @@ module AnalyticsEvents
       success: success,
       user_id: user_id,
       account_age_in_days: account_age_in_days,
-      account_created_at: account_created_at,
+      account_confirmed_at: account_confirmed_at,
       mfa_method_counts: mfa_method_counts,
       errors: errors,
       **extra,

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-
+require 'pp'
 RSpec.describe AccountReset::DeleteAccountController do
   include AccountResetHelper
 
@@ -25,6 +25,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         mfa_method_counts: { backup_codes: 10, webauthn: 2, phone: 2 },
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
+        account_created_at: user.created_at
       }
       expect(@analytics).
         to receive(:track_event).with('Account Reset: delete', properties)
@@ -53,6 +54,7 @@ RSpec.describe AccountReset::DeleteAccountController do
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq(invalid_token_message)
     end
+
 
     it 'displays a flash and redirects to root if the token is missing' do
       stub_analytics
@@ -92,6 +94,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         mfa_method_counts: {},
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 2,
+        account_created_at: user.created_at
       }
       expect(@analytics).to receive(:track_event).with('Account Reset: delete', properties)
 

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AccountReset::DeleteAccountController do
   end
   let(:invalid_token_error) { { token: [invalid_token_message] } }
 
+  before { stub_analytics }
   describe '#delete' do
     it 'logs a good token to the analytics' do
       user = create(:user, :fully_registered, :with_backup_code)
@@ -17,7 +18,6 @@ RSpec.describe AccountReset::DeleteAccountController do
       grant_request(user)
 
       session[:granted_token] = AccountResetRequest.first.granted_token
-      stub_analytics
       properties = {
         user_id: user.uuid,
         success: true,
@@ -37,7 +37,6 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'redirects to root if the token does not match one in the DB' do
       session[:granted_token] = 'foo'
-      stub_analytics
       properties = {
         user_id: 'anonymous-uuid',
         success: false,
@@ -57,7 +56,6 @@ RSpec.describe AccountReset::DeleteAccountController do
     end
 
     it 'displays a flash and redirects to root if the token is missing' do
-      stub_analytics
       properties = {
         user_id: 'anonymous-uuid',
         success: false,
@@ -84,7 +82,6 @@ RSpec.describe AccountReset::DeleteAccountController do
       create_account_reset_request_for(user)
       grant_request(user)
 
-      stub_analytics
       properties = {
         user_id: user.uuid,
         success: false,
@@ -113,7 +110,6 @@ RSpec.describe AccountReset::DeleteAccountController do
 
   describe '#show' do
     it 'redirects to root if the token does not match one in the DB' do
-      stub_analytics
       properties = {
         user_id: 'anonymous-uuid',
         success: false,
@@ -134,7 +130,6 @@ RSpec.describe AccountReset::DeleteAccountController do
       create_account_reset_request_for(user)
       grant_request(user)
 
-      stub_analytics
       properties = {
         user_id: user.uuid,
         success: false,

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -1,6 +1,6 @@
 module AnalyticsHelper
-  def stub_analytics
-    controller.analytics = FakeAnalytics.new
+  def stub_analytics(user: nil)
+    controller.analytics = FakeAnalytics.new(user:)
     @analytics = controller.analytics
   end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-9997](https://cm-jira.usa.gov/browse/LG-9997)


## 🛠 Summary of changes

Passes the User's confirmed Date Time value through the Analytics Attributes hash to the AnalyticsEvents module. It creates a searchable date stamp to query and monitor account deletions.



## 📜 Testing Plan

- [ ] Create an account and add text MFA, don't select "remember my browser"
- [ ] Log out of the account.
- [ ] Log back in. 
- [ ] Click choose another code when prompted for the text confirmation. 
- [ ] At Select other method view click Deleting your account, Yes continue deletion
- [ ] Await Deletion cooldown period (default is 24 hours, can be set locally in config/application.yml)
- [ ] Click Yes, continue deleting in the confirmation screen that follows. And then again.
- [ ] Check the events.log file for the deletion event. It should start with "{"name":"Account Reset: delete","properties":{"event_properties":{"success":true,"account_age_in_days":0,"account_confirmed_at":..."


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
