### PR TITLE
Add contributing guidelines for code review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ reading.
 commits together, merges it, then deletes the branch.
 
 Everyone is encouraged to participate in code review. To solicit feedback from specific people,
-considering adding individuals or groups as requested reviewers on your pull request. Most internal
+consider adding individuals or groups as requested reviewers on your pull request. Most internal
 product teams have a team handle which can be used to notify everyone on that team, or you can
 request reviews from one of the available interest group teams:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,8 @@ request reviews from one of the available interest group teams:
 
 - `18f/identity-frontend` for developers interested in frontend development
 
+To request to join any of these teams, you can contact any existing member and ask to be added.
+
 ## Public domain
 
 This project is in the public domain within the United States, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,13 @@ reading.
 - Once a pull request is good to go, the person who opened it squashes related
 commits together, merges it, then deletes the branch.
 
+Everyone is encouraged to participate in code review. To solicit feedback from specific people,
+considering adding individuals or groups as requested reviewers on your pull request. Most internal
+product teams have a team handle which can be used to notify everyone on that team, or you can
+request reviews from one of the available interest group teams:
+
+- `identity-frontend` for developers interested in frontend development
+
 ## Public domain
 
 This project is in the public domain within the United States, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ considering adding individuals or groups as requested reviewers on your pull req
 product teams have a team handle which can be used to notify everyone on that team, or you can
 request reviews from one of the available interest group teams:
 
-- `identity-frontend` for developers interested in frontend development
+- `18f/identity-frontend` for developers interested in frontend development
 
 ## Public domain
 


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a new paragraph to `CONTRIBUTING.md` outlining some guidance for code review:

- Encouraging everyone to participate
- Mentioning internal product team handles to request review from your product team
- Mentioning interest group team handles
