### PR TITLE
LG-10181 Gpo_only_warning fixes for welcome controller

### DIFF
--- a/app/controllers/idv/gpo_only_warning_controller.rb
+++ b/app/controllers/idv/gpo_only_warning_controller.rb
@@ -7,11 +7,19 @@ module Idv
 
     def show
       user_session.fetch('idv/doc_auth', {})[:skip_vendor_outage] = true
-      render :show, locals: { current_sp:, exit_url: }
+      render :show, locals: { current_sp:, exit_url:, welcome_url: }
     end
 
     def exit_url
       current_sp&.return_to_sp_url || account_path
+    end
+
+    def welcome_url
+      if IdentityConfig.store.doc_auth_welcome_controller_enabled
+        idv_welcome_url
+      else
+        idv_doc_auth_step_path(step: :welcome)
+      end
     end
   end
 end

--- a/app/controllers/idv/gpo_only_warning_controller.rb
+++ b/app/controllers/idv/gpo_only_warning_controller.rb
@@ -7,19 +7,11 @@ module Idv
 
     def show
       user_session.fetch('idv/doc_auth', {})[:skip_vendor_outage] = true
-      render :show, locals: { current_sp:, exit_url:, welcome_url: }
+      render :show, locals: { current_sp:, exit_url: }
     end
 
     def exit_url
       current_sp&.return_to_sp_url || account_path
-    end
-
-    def welcome_url
-      if IdentityConfig.store.doc_auth_welcome_controller_enabled
-        idv_welcome_url
-      else
-        idv_doc_auth_step_path(step: :welcome)
-      end
     end
   end
 end

--- a/app/controllers/idv/gpo_only_warning_controller.rb
+++ b/app/controllers/idv/gpo_only_warning_controller.rb
@@ -6,6 +6,8 @@ module Idv
     before_action :confirm_two_factor_authenticated
 
     def show
+      analytics.idv_mail_only_warning_visited(analytics_id: 'Doc Auth')
+
       user_session.fetch('idv/doc_auth', {})[:skip_vendor_outage] = true
       render :show, locals: { current_sp:, exit_url: }
     end

--- a/app/controllers/idv/gpo_only_warning_controller.rb
+++ b/app/controllers/idv/gpo_only_warning_controller.rb
@@ -6,7 +6,7 @@ module Idv
     before_action :confirm_two_factor_authenticated
 
     def show
-      user_session['idv/doc_auth'][:skip_vendor_outage] = true
+      user_session.fetch('idv/doc_auth', {})[:skip_vendor_outage] = true
       render :show, locals: { current_sp:, exit_url: }
     end
 

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -30,6 +30,7 @@ class IdvController < ApplicationController
   def verify_identity
     analytics.idv_intro_visit
     if IdentityConfig.store.doc_auth_welcome_controller_enabled
+      user_session['idv/doc_auth'] ||= {}
       redirect_to idv_welcome_url
     else
       redirect_to idv_doc_auth_url

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1717,6 +1717,14 @@ module AnalyticsEvents
     track_event('IdV: intro visited')
   end
 
+  # Tracks when the user visits Mail only warning when vendor_status_sms is set to full_outage
+  def idv_mail_only_warning_visited(**extra)
+    track_event(
+      'IdV: Mail only warning visited',
+      **extra,
+    )
+  end
+
   # Tracks whether the user's device appears to be mobile device with a camera attached.
   # @param [Boolean] is_camera_capable_mobile Whether we think the device _could_ have a camera.
   # @param [Boolean,nil] camera_present Whether the user's device _actually_ has a camera available.

--- a/app/views/idv/gpo_only_warning/show.html.erb
+++ b/app/views/idv/gpo_only_warning/show.html.erb
@@ -20,7 +20,7 @@
   </ul>
   <% c.with_action_button(
        action: ->(**tag_options, &block) do
-         link_to(idv_doc_auth_step_path(step: :welcome), **tag_options, &block)
+         link_to(welcome_url, **tag_options, &block)
        end,
        big: true,
        wide: true,

--- a/app/views/idv/gpo_only_warning/show.html.erb
+++ b/app/views/idv/gpo_only_warning/show.html.erb
@@ -20,7 +20,7 @@
   </ul>
   <% c.with_action_button(
        action: ->(**tag_options, &block) do
-         link_to(welcome_url, **tag_options, &block)
+         link_to(idv_url, **tag_options, &block)
        end,
        big: true,
        wide: true,

--- a/spec/controllers/idv/gpo_only_warning_controller_spec.rb
+++ b/spec/controllers/idv/gpo_only_warning_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Idv::GpoOnlyWarningController do
 
   before do
     stub_sign_in(user)
+    stub_analytics
     subject.user_session['idv/doc_auth'] = {}
   end
 
@@ -20,14 +21,25 @@ RSpec.describe Idv::GpoOnlyWarningController do
   end
 
   describe '#show' do
+    let(:analytics_name) { 'IdV: Mail only warning visited' }
+    let(:analytics_args) do
+      { analytics_id: 'Doc Auth' }
+    end
+
     it 'renders the show template' do
       get :show
 
       expect(response).to render_template :show
     end
 
+    it 'sends analytics_visited event' do
+      get :show
+
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+    end
+
     context 'flow_session is nil' do
-      it 'sends analytics_visited event' do
+      it 'renders the show template' do
         subject.user_session.delete('idv/doc_auth')
 
         get :show

--- a/spec/controllers/idv/gpo_only_warning_controller_spec.rb
+++ b/spec/controllers/idv/gpo_only_warning_controller_spec.rb
@@ -36,4 +36,47 @@ RSpec.describe Idv::GpoOnlyWarningController do
       end
     end
   end
+
+  context 'page links' do
+    render_views
+    context 'exit url' do
+      let(:sp) { create(:service_provider, issuer: 'urn:gov:gsa:openidconnect:sp:test_cookie') }
+
+      context 'with current sp' do
+        it 'links to return_to_sp_url' do
+          allow(controller).to receive(:current_sp).and_return(sp)
+          get :show
+          expect(response.body).to include(sp.return_to_sp_url)
+        end
+      end
+
+      context 'without current sp' do
+        it 'links to account_path' do
+          allow(controller).to receive(:current_sp).and_return(nil)
+          get :show
+          expect(response.body).to include(account_path)
+        end
+      end
+    end
+
+    context 'welcome url' do
+      context 'welcome controller is enabled' do
+        it 'links to idv_welcome_url' do
+          allow(IdentityConfig.store).to receive(:doc_auth_welcome_controller_enabled).
+            and_return(true)
+          get :show
+          expect(response.body).to include(idv_welcome_url)
+        end
+      end
+
+      context 'welcome controller is not enabled' do
+        it 'links to FSM welcome step' do
+          allow(IdentityConfig.store).to receive(:doc_auth_welcome_controller_enabled).
+            and_return(false)
+          get :show
+          expect(response.body).to include(idv_doc_auth_step_path(step: :welcome))
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/idv/gpo_only_warning_controller_spec.rb
+++ b/spec/controllers/idv/gpo_only_warning_controller_spec.rb
@@ -58,25 +58,5 @@ RSpec.describe Idv::GpoOnlyWarningController do
         end
       end
     end
-
-    context 'welcome url' do
-      context 'welcome controller is enabled' do
-        it 'links to idv_welcome_url' do
-          allow(IdentityConfig.store).to receive(:doc_auth_welcome_controller_enabled).
-            and_return(true)
-          get :show
-          expect(response.body).to include(idv_welcome_url)
-        end
-      end
-
-      context 'welcome controller is not enabled' do
-        it 'links to FSM welcome step' do
-          allow(IdentityConfig.store).to receive(:doc_auth_welcome_controller_enabled).
-            and_return(false)
-          get :show
-          expect(response.body).to include(idv_doc_auth_step_path(step: :welcome))
-        end
-      end
-    end
   end
 end

--- a/spec/controllers/idv/gpo_only_warning_controller_spec.rb
+++ b/spec/controllers/idv/gpo_only_warning_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Idv::GpoOnlyWarningController do
+  include IdvHelper
+
+  let(:user) { create(:user) }
+
+  before do
+    stub_sign_in(user)
+    subject.user_session['idv/doc_auth'] = {}
+  end
+
+  describe 'before_actions' do
+    it 'includes authentication before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+      )
+    end
+  end
+
+  describe '#show' do
+    it 'renders the show template' do
+      get :show
+
+      expect(response).to render_template :show
+    end
+
+    context 'flow_session is nil' do
+      it 'sends analytics_visited event' do
+        subject.user_session.delete('idv/doc_auth')
+
+        get :show
+
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -174,6 +174,19 @@ RSpec.feature 'IdV Outage Spec' do
           expect(current_path).to eq idv_doc_auth_step_path(step: :welcome)
         end
 
+        it 'goes to idv_welcome_url when welcome controller is enabled' do
+          allow(IdentityConfig.store).to receive(:doc_auth_welcome_controller_enabled).
+            and_return(true)
+
+          sign_in_with_idv_required(user: user, sms_or_totp: :totp)
+
+          expect(current_path).to eq idv_mail_only_warning_path
+
+          click_idv_continue
+
+          expect(current_path).to eq idv_welcome_path
+        end
+
         it 'returns to the correct page when clicking to exit' do
           sign_in_with_idv_required(user: user, sms_or_totp: :totp)
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9365](https://cm-jira.usa.gov/browse/LG-9365)
[LG-10181](https://cm-jira.usa.gov/browse/LG-10181)

## 🛠 Summary of changes

This is a followup on #8643 to make GpoOnlyWarningController compatible with the WelcomeController.
- Allow nil flow_session in gpo_only_warning controller
- Add controller specs
- Redirect to idv_url instead of directly to FSM welcome step.
- Initialize flow session in idv_controller before redirecting to idv_welcome_url. Previously base_flow did that.
- Add `IdV: mail only warning visited` analytics event

Note:
- May want to move :skip_vendor_outage out of flow_session in the long run

## 📜 Testing Plan

- [ ] In application.yml, add 
```
vendor_status_sms: full_outage
doc_auth_welcome_controller_enabled: true
```
- [ ] Create account, navigate to `/verify`
- [ ] Expect to see mail_only_warning screen
- [ ] Click Continue
- [ ] Expect to be on `/verify/welcome`
