### PR TITLE
Document country code parameter with phone reCAPTCHA result

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3097,12 +3097,14 @@ module AnalyticsEvents
   # @param [Boolean] evaluated_as_valid Whether result was considered valid
   # @param [String] validator_class Class name of validator
   # @param [String, nil] exception_class Class name of exception, if error occurred
+  # @param [String, nil] phone_country_code Country code associated with reCAPTCHA phone result
   def recaptcha_verify_result_received(
     recaptcha_result:,
     score_threshold:,
     evaluated_as_valid:,
     validator_class:,
     exception_class:,
+    phone_country_code: nil,
     **extra
   )
     track_event(
@@ -3112,6 +3114,7 @@ module AnalyticsEvents
       evaluated_as_valid:,
       validator_class:,
       exception_class:,
+      phone_country_code:,
       **extra,
     )
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the documentation for the "reCAPTCHA verify result received" analytics method to explicitly document the `phone_country_code`. This is already being passed, captured as one of the `extra` parameters, but was not previously documented. This was partly intentional, since the analytics method is intended to be generic for use across any reCAPTCHA validation, though in practice it would probably cause more confusion to the availability of the property.

It is assigned here:

https://github.com/18F/identity-idp/blob/f63904171e603cc133072c583152a260e2816f92/app/services/phone_recaptcha_validator.rb#L32-L34

## 📜 Testing Plan

- This is largely a documentation-only change, there should be no user-facing impact