### PR TITLE
Refactor WebAuthn enrollment to package function

### DIFF
--- a/app/javascript/app/webauthn.ts
+++ b/app/javascript/app/webauthn.ts
@@ -1,12 +1,4 @@
-interface EnrollResult {
-  webauthnId: string;
-
-  webauthnPublicKey: string;
-
-  attestationObject: string;
-
-  clientDataJSON: string;
-}
+import { extractCredentials, arrayBufferToBase64 } from '@18f/identity-webauthn';
 
 interface VerifyResult {
   credentialId: string;
@@ -17,115 +9,6 @@ interface VerifyResult {
 
   signature: string;
 }
-
-const base64ToArrayBuffer = (base64: string): ArrayBuffer => {
-  const bytes = Uint8Array.from(
-    window
-      .atob(base64)
-      .split('')
-      .map((char) => char.charCodeAt(0)),
-  );
-  return bytes.buffer;
-};
-
-const arrayBufferToBase64 = (arrayBuffer: ArrayBuffer): string => {
-  const buffer = new Uint8Array(arrayBuffer);
-  const binaryString = Array.from(buffer)
-    .map((byte) => String.fromCharCode(byte))
-    .join('');
-  return window.btoa(binaryString);
-};
-
-const longToByteArray = (long: number): Uint8Array =>
-  new Uint8Array(8).map(() => {
-    const byte = long & 0xff; // eslint-disable-line no-bitwise
-    long = (long - byte) / 256;
-    return byte;
-  });
-
-const extractCredentials = (credentials: string): PublicKeyCredentialDescriptor[] => {
-  if (!credentials) {
-    // empty string check
-    return [];
-  }
-  return credentials.split(',').map((credential) => ({
-    type: 'public-key',
-    id: base64ToArrayBuffer(credential),
-  }));
-};
-
-const enrollWebauthnDevice = async ({
-  userId,
-  userEmail,
-  userChallenge,
-  excludeCredentials,
-  platformAuthenticator,
-}: {
-  userId: string;
-  userEmail: string;
-  userChallenge: string;
-  excludeCredentials: string;
-  platformAuthenticator: boolean;
-}): Promise<EnrollResult> => {
-  const newCred = (await navigator.credentials.create({
-    publicKey: {
-      challenge: new Uint8Array(JSON.parse(userChallenge)),
-      rp: { name: window.location.hostname },
-      user: {
-        id: longToByteArray(Number(userId)),
-        name: userEmail,
-        displayName: userEmail,
-      },
-      pubKeyCredParams: [
-        {
-          type: 'public-key',
-          alg: -7, // ECDSA w/ SHA-256
-        },
-        {
-          type: 'public-key',
-          alg: -35, // ECDSA w/ SHA-384
-        },
-        {
-          type: 'public-key',
-          alg: -36, // ECDSA w/ SHA-512
-        },
-        {
-          type: 'public-key',
-          alg: -37, // RSASSA-PSS w/ SHA-256
-        },
-        {
-          type: 'public-key',
-          alg: -38, // RSASSA-PSS w/ SHA-384
-        },
-        {
-          type: 'public-key',
-          alg: -39, // RSASSA-PSS w/ SHA-512
-        },
-        {
-          type: 'public-key',
-          alg: -257, // RSASSA-PKCS1-v1_5 w/ SHA-256
-        },
-      ],
-      timeout: 800000,
-      attestation: 'none',
-      authenticatorSelection: {
-        // Prevents user from needing to use PIN with Security Key
-        userVerification: 'discouraged',
-        authenticatorAttachment: platformAuthenticator ? 'platform' : 'cross-platform',
-      },
-      excludeCredentials: extractCredentials(excludeCredentials),
-    },
-  })) as PublicKeyCredential;
-
-  const response = newCred.response as AuthenticatorAttestationResponse;
-
-  return {
-    webauthnId: arrayBufferToBase64(newCred.rawId),
-    webauthnPublicKey: newCred.id,
-    attestationObject: arrayBufferToBase64(response.attestationObject),
-    clientDataJSON: arrayBufferToBase64(response.clientDataJSON),
-  };
-};
 
 async function verifyWebauthnDevice({
   userChallenge,
@@ -138,7 +21,7 @@ async function verifyWebauthnDevice({
     publicKey: {
       challenge: new Uint8Array(JSON.parse(userChallenge)),
       rpId: window.location.hostname,
-      allowCredentials: extractCredentials(credentialIds),
+      allowCredentials: extractCredentials(credentialIds.split(',')),
       timeout: 800000,
     },
   };
@@ -155,4 +38,4 @@ async function verifyWebauthnDevice({
   };
 }
 
-export { extractCredentials, enrollWebauthnDevice, verifyWebauthnDevice };
+export { verifyWebauthnDevice };

--- a/app/javascript/packages/webauthn/converters.spec.ts
+++ b/app/javascript/packages/webauthn/converters.spec.ts
@@ -1,0 +1,24 @@
+import { base64ToArrayBuffer, arrayBufferToBase64, longToByteArray } from './converters';
+
+const stringAsBase64 = 'Y3JlZGVudGlhbDEyMw==';
+const stringAsArrayBuffer = Uint8Array.from([
+  99, 114, 101, 100, 101, 110, 116, 105, 97, 108, 49, 50, 51,
+]).buffer;
+
+describe('base64ToArrayBuffer', () => {
+  it('converts a base64 string to an equivalent array buffer', () => {
+    expect(base64ToArrayBuffer(stringAsBase64)).to.deep.equal(stringAsArrayBuffer);
+  });
+});
+
+describe('arrayBufferToBase64', () => {
+  it('converts an array buffer to an equivalent string', () => {
+    expect(arrayBufferToBase64(stringAsArrayBuffer)).to.equal(stringAsBase64);
+  });
+});
+
+describe('longToByteArray', () => {
+  it('converts a number to an equivalent byte array', () => {
+    expect(longToByteArray(123)).to.deep.equal(new Uint8Array([123, 0, 0, 0, 0, 0, 0, 0]));
+  });
+});

--- a/app/javascript/packages/webauthn/converters.ts
+++ b/app/javascript/packages/webauthn/converters.ts
@@ -1,0 +1,39 @@
+/**
+ * Converts a base64-encoded string to an array buffer.
+ *
+ * @param base64 String to convert.
+ * @return Converted string.
+ */
+export const base64ToArrayBuffer = (base64: string): ArrayBuffer =>
+  Uint8Array.from(
+    window
+      .atob(base64)
+      .split('')
+      .map((char) => char.charCodeAt(0)),
+  ).buffer;
+
+/**
+ * Converts an array buffer to a base64-encoded string.
+ *
+ * @param arrayBuffer ArrayBuffer to convert.
+ * @return Converted string.
+ */
+export const arrayBufferToBase64 = (arrayBuffer: ArrayBuffer): string =>
+  window.btoa(
+    Array.from(new Uint8Array(arrayBuffer))
+      .map((byte) => String.fromCharCode(byte))
+      .join(''),
+  );
+
+/**
+ * Given a number, returns the value represented as a byte array.
+ *
+ * @param long Number to convert.
+ * @return Converted number.
+ */
+export const longToByteArray = (long: number): Uint8Array =>
+  new Uint8Array(8).map(() => {
+    const byte = long & 0xff; // eslint-disable-line no-bitwise
+    long = (long - byte) / 256;
+    return byte;
+  });

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -1,0 +1,123 @@
+import { useSandbox, useDefineProperty } from '@18f/identity-test-helpers';
+import enrollWebauthnDevice from './enroll-webauthn-device';
+import extractCredentials from './extract-credentials';
+import { longToByteArray } from './converters';
+
+describe('enrollWebauthnDevice', () => {
+  const sandbox = useSandbox();
+  const defineProperty = useDefineProperty();
+  const user = {
+    id: longToByteArray(123),
+    displayName: 'test@test.com',
+    name: 'test@test.com',
+  };
+  const challenge = new Uint8Array(JSON.parse('[1, 2, 3, 4, 5, 6, 7, 8]'));
+  const excludeCredentials = extractCredentials(
+    'Y3JlZGVudGlhbDEyMw==,Y3JlZGVudGlhbDQ1Ng=='.split(','),
+  ); // Base64-encoded 'credential123,credential456'
+
+  beforeEach(() => {
+    defineProperty(navigator, 'credentials', {
+      configurable: true,
+      value: {
+        create: sandbox.stub().resolves({
+          rawId: Buffer.from([214, 109]), // encodes to '123'
+          id: '123',
+          response: {
+            // decodes to 'attest'
+            attestationObject: Buffer.from([97, 116, 116, 101, 115, 116]),
+            // decodes to 'json'
+            clientDataJSON: Buffer.from([106, 115, 111, 110]),
+          },
+        }),
+      },
+    });
+  });
+
+  it('enrolls a device using the proper create options', async () => {
+    const result = await enrollWebauthnDevice({
+      user,
+      challenge,
+      excludeCredentials,
+      authenticatorAttachment: 'cross-platform',
+    });
+
+    expect(navigator.credentials.create).to.have.been.calledWith({
+      publicKey: {
+        challenge: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+        rp: { name: 'example.test' },
+        user: {
+          id: new Uint8Array([123, 0, 0, 0, 0, 0, 0, 0]),
+          name: 'test@test.com',
+          displayName: 'test@test.com',
+        },
+        pubKeyCredParams: [
+          { type: 'public-key', alg: -7 },
+          { type: 'public-key', alg: -35 },
+          { type: 'public-key', alg: -36 },
+          { type: 'public-key', alg: -37 },
+          { type: 'public-key', alg: -38 },
+          { type: 'public-key', alg: -39 },
+          { type: 'public-key', alg: -257 },
+        ],
+        timeout: 800000,
+        attestation: 'none',
+        authenticatorSelection: {
+          authenticatorAttachment: 'cross-platform',
+          userVerification: 'discouraged',
+        },
+        excludeCredentials: [
+          {
+            id: new TextEncoder().encode('credential123').buffer,
+            type: 'public-key',
+          },
+          {
+            id: new TextEncoder().encode('credential456').buffer,
+            type: 'public-key',
+          },
+        ],
+      },
+    });
+
+    expect(result).to.deep.equal({
+      webauthnId: '1m0=', // Base64.encode64('123'),
+      webauthnPublicKey: '123',
+      attestationObject: 'YXR0ZXN0', // Base64.encode('attest')
+      clientDataJSON: 'anNvbg==', // Base64.encode('json')
+    });
+  });
+
+  it('forwards errors from the webauthn api', async () => {
+    const dummyError = new Error('dummy error');
+    navigator.credentials.create = () => Promise.reject(dummyError);
+
+    let didCatch;
+    try {
+      await enrollWebauthnDevice({ user, challenge, excludeCredentials });
+    } catch (error) {
+      expect(error).to.equal(dummyError);
+      didCatch = true;
+    }
+
+    expect(didCatch).to.be.true();
+  });
+
+  context('platform authenticator', () => {
+    it('enrolls a device with correct authenticatorAttachment', async () => {
+      await enrollWebauthnDevice({
+        user,
+        challenge,
+        excludeCredentials,
+        authenticatorAttachment: 'platform',
+      });
+
+      expect(navigator.credentials.create).to.have.been.calledWithMatch({
+        publicKey: {
+          authenticatorSelection: {
+            authenticatorAttachment: 'platform',
+          },
+        },
+      });
+    });
+  });
+});

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -1,0 +1,85 @@
+import { arrayBufferToBase64 } from './converters';
+
+interface EnnrollOptions {
+  user: PublicKeyCredentialUserEntity;
+
+  challenge: BufferSource;
+
+  excludeCredentials: PublicKeyCredentialDescriptor[];
+
+  authenticatorAttachment?: AuthenticatorAttachment;
+}
+
+interface EnrollResult {
+  webauthnId: string;
+
+  webauthnPublicKey: string;
+
+  attestationObject: string;
+
+  clientDataJSON: string;
+}
+
+async function enrollWebauthnDevice({
+  user,
+  challenge,
+  excludeCredentials,
+  authenticatorAttachment,
+}: EnnrollOptions): Promise<EnrollResult> {
+  const credential = (await navigator.credentials.create({
+    publicKey: {
+      challenge,
+      rp: { name: window.location.hostname },
+      user,
+      pubKeyCredParams: [
+        {
+          type: 'public-key',
+          alg: -7, // ECDSA w/ SHA-256
+        },
+        {
+          type: 'public-key',
+          alg: -35, // ECDSA w/ SHA-384
+        },
+        {
+          type: 'public-key',
+          alg: -36, // ECDSA w/ SHA-512
+        },
+        {
+          type: 'public-key',
+          alg: -37, // RSASSA-PSS w/ SHA-256
+        },
+        {
+          type: 'public-key',
+          alg: -38, // RSASSA-PSS w/ SHA-384
+        },
+        {
+          type: 'public-key',
+          alg: -39, // RSASSA-PSS w/ SHA-512
+        },
+        {
+          type: 'public-key',
+          alg: -257, // RSASSA-PKCS1-v1_5 w/ SHA-256
+        },
+      ],
+      timeout: 800000,
+      attestation: 'none',
+      authenticatorSelection: {
+        // Prevents user from needing to use PIN with Security Key
+        userVerification: 'discouraged',
+        authenticatorAttachment,
+      },
+      excludeCredentials,
+    },
+  })) as PublicKeyCredential;
+
+  const response = credential.response as AuthenticatorAttestationResponse;
+
+  return {
+    webauthnId: arrayBufferToBase64(credential.rawId),
+    webauthnPublicKey: credential.id,
+    attestationObject: arrayBufferToBase64(response.attestationObject),
+    clientDataJSON: arrayBufferToBase64(response.clientDataJSON),
+  };
+}
+
+export default enrollWebauthnDevice;

--- a/app/javascript/packages/webauthn/extract-credentials.spec.ts
+++ b/app/javascript/packages/webauthn/extract-credentials.spec.ts
@@ -1,0 +1,22 @@
+import extractCredentials from './extract-credentials';
+
+describe('extractCredentials', () => {
+  it('filters empty values', () => {
+    expect(extractCredentials([''])).to.deep.equal([]);
+  });
+
+  it('returns an array of converted credential descriptors', () => {
+    const result = extractCredentials(['Y3JlZGVudGlhbDEyMw==', 'Y3JlZGVudGlhbDQ1Ng==']);
+
+    expect(result).to.deep.equal([
+      {
+        id: Uint8Array.from([99, 114, 101, 100, 101, 110, 116, 105, 97, 108, 49, 50, 51]).buffer,
+        type: 'public-key',
+      },
+      {
+        id: Uint8Array.from([99, 114, 101, 100, 101, 110, 116, 105, 97, 108, 52, 53, 54]).buffer,
+        type: 'public-key',
+      },
+    ]);
+  });
+});

--- a/app/javascript/packages/webauthn/extract-credentials.ts
+++ b/app/javascript/packages/webauthn/extract-credentials.ts
@@ -1,0 +1,15 @@
+import { base64ToArrayBuffer } from './converters';
+
+/**
+ * Converts an array of base64-encoded strings to credential descriptors.
+ *
+ * @param credentials Strings to convert.
+ * @return Converted credentials.
+ */
+const extractCredentials = (credentials: string[]): PublicKeyCredentialDescriptor[] =>
+  credentials.filter(Boolean).map((credential) => ({
+    type: 'public-key',
+    id: base64ToArrayBuffer(credential),
+  }));
+
+export default extractCredentials;

--- a/app/javascript/packages/webauthn/index.ts
+++ b/app/javascript/packages/webauthn/index.ts
@@ -1,1 +1,4 @@
 export { default as isWebauthnSupported } from './is-webauthn-supported';
+export { default as enrollWebauthnDevice } from './enroll-webauthn-device';
+export { default as extractCredentials } from './extract-credentials';
+export * from './converters';

--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -1,5 +1,9 @@
-import { isWebauthnSupported } from '@18f/identity-webauthn';
-import { enrollWebauthnDevice } from '../app/webauthn';
+import {
+  isWebauthnSupported,
+  enrollWebauthnDevice,
+  extractCredentials,
+  longToByteArray,
+} from '@18f/identity-webauthn';
 
 /**
  * Reloads the current page, presenting the message corresponding to the given error key.
@@ -30,12 +34,18 @@ function webauthn() {
       (document.getElementById('platform_authenticator') as HTMLInputElement).value === 'true';
 
     enrollWebauthnDevice({
-      userId: (document.getElementById('user_id') as HTMLInputElement).value,
-      userEmail: (document.getElementById('user_email') as HTMLInputElement).value,
-      userChallenge: (document.getElementById('user_challenge') as HTMLInputElement).value,
-      excludeCredentials: (document.getElementById('exclude_credentials') as HTMLInputElement)
-        .value,
-      platformAuthenticator,
+      user: {
+        id: longToByteArray(Number((document.getElementById('user_id') as HTMLInputElement).value)),
+        name: (document.getElementById('user_email') as HTMLInputElement).value,
+        displayName: (document.getElementById('user_email') as HTMLInputElement).value,
+      },
+      challenge: new Uint8Array(
+        JSON.parse((document.getElementById('user_challenge') as HTMLInputElement).value),
+      ),
+      excludeCredentials: extractCredentials(
+        (document.getElementById('exclude_credentials') as HTMLInputElement).value.split(','),
+      ),
+      authenticatorAttachment: platformAuthenticator ? 'platform' : 'cross-platform',
     })
       .then((result) => {
         (document.getElementById('webauthn_id') as HTMLInputElement).value = result.webauthnId;

--- a/spec/javascript/app/webauthn_spec.js
+++ b/spec/javascript/app/webauthn_spec.js
@@ -1,17 +1,13 @@
 import { TextEncoder } from 'util';
-import { useSandbox } from '@18f/identity-test-helpers';
 import * as WebAuthn from '../../../app/javascript/app/webauthn';
 
 describe('WebAuthn', () => {
-  const sandbox = useSandbox();
-
   let originalNavigator;
   let originalCredentials;
   beforeEach(() => {
     originalNavigator = global.navigator;
     originalCredentials = global.navigator.credentials;
     global.navigator.credentials = {
-      create: () => {},
       get: () => {},
     };
   });
@@ -19,136 +15,6 @@ describe('WebAuthn', () => {
   afterEach(() => {
     global.navigator = originalNavigator;
     global.navigator.credentials = originalCredentials;
-  });
-
-  describe('extractCredentials', () => {
-    it('returns [] if credentials are empty string', () => {
-      expect(WebAuthn.extractCredentials('')).to.eql([]);
-    });
-  });
-
-  describe('enrollWebauthnDevice', () => {
-    const userId = '123';
-    const userEmail = 'test@test.com';
-    const userChallenge = '[1, 2, 3, 4, 5, 6, 7, 8]';
-    const excludeCredentials = 'Y3JlZGVudGlhbDEyMw==,Y3JlZGVudGlhbDQ1Ng=='; // Base64-encoded 'credential123,credential456'
-
-    const createReturnValue = {
-      rawId: Buffer.from([214, 109]), // encodes to '123'
-      id: '123',
-      response: {
-        // decodes to 'attest'
-        attestationObject: Buffer.from([97, 116, 116, 101, 115, 116]),
-        // decodes to 'json'
-        clientDataJSON: Buffer.from([106, 115, 111, 110]),
-      },
-    };
-
-    it('enrolls a device using the proper create options', (done) => {
-      const expectedCreateOptions = {
-        publicKey: {
-          challenge: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
-          rp: { name: 'example.test' },
-          user: {
-            id: new Uint8Array([123, 0, 0, 0, 0, 0, 0, 0]),
-            name: 'test@test.com',
-            displayName: 'test@test.com',
-          },
-          pubKeyCredParams: [
-            { type: 'public-key', alg: -7 },
-            { type: 'public-key', alg: -35 },
-            { type: 'public-key', alg: -36 },
-            { type: 'public-key', alg: -37 },
-            { type: 'public-key', alg: -38 },
-            { type: 'public-key', alg: -39 },
-            { type: 'public-key', alg: -257 },
-          ],
-          timeout: 800000,
-          attestation: 'none',
-          authenticatorSelection: {
-            authenticatorAttachment: 'cross-platform',
-            userVerification: 'discouraged',
-          },
-          excludeCredentials: [
-            {
-              id: new TextEncoder().encode('credential123').buffer,
-              type: 'public-key',
-            },
-            {
-              id: new TextEncoder().encode('credential456').buffer,
-              type: 'public-key',
-            },
-          ],
-        },
-      };
-
-      const expectedReturnValue = {
-        webauthnId: '1m0=', // Base64.encode64('123'),
-        webauthnPublicKey: '123',
-        attestationObject: 'YXR0ZXN0', // Base64.encode('attest')
-        clientDataJSON: 'anNvbg==', // Base64.encode('json')
-      };
-
-      let createCalled = false;
-      navigator.credentials.create = (createOptions) => {
-        createCalled = true;
-        expect(createOptions).to.deep.equal(expectedCreateOptions);
-        return Promise.resolve(createReturnValue);
-      };
-
-      WebAuthn.enrollWebauthnDevice({
-        userId,
-        userEmail,
-        userChallenge,
-        excludeCredentials,
-        platformAuthenticator: false,
-      })
-        .then((result) => {
-          expect(createCalled).to.eq(true);
-          expect(result).to.deep.equal(expectedReturnValue);
-        })
-        .then(() => done())
-        .catch(done);
-    });
-
-    it('forwards errors from the webauthn api', (done) => {
-      const dummyError = new Error('dummy error');
-      navigator.credentials.create = () => Promise.reject(dummyError);
-
-      WebAuthn.enrollWebauthnDevice({
-        userId,
-        userEmail,
-        userChallenge,
-        excludeCredentials,
-      })
-        .catch((error) => {
-          expect(error).to.equal(dummyError);
-          done();
-        })
-        .catch(done);
-    });
-
-    context('platform authenticator', () => {
-      it('enrolls a device with correct authenticatorAttachment', async () => {
-        sandbox.stub(navigator.credentials, 'create').resolves(createReturnValue);
-
-        await WebAuthn.enrollWebauthnDevice({
-          userId,
-          userEmail,
-          userChallenge,
-          excludeCredentials,
-          platformAuthenticator: true,
-        });
-
-        expect(navigator.credentials.create).to.have.been.calledWithMatch({
-          publicKey: {
-            authenticatorSelection: {
-              authenticatorAttachment: 'platform',
-            },
-          },
-        });
-      });
-    });
   });
 
   describe('verifyWebauthnDevice', () => {


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-9873](https://cm-jira.usa.gov/browse/LG-9873)

## 🛠 Summary of changes

Refactors and moves code related to WebAuthn credential enrollment to the new `@18f/identity-webauthn` package.

**Why?**

- Better testability and separation of concerns
- Consolidate WebAuthn-related behaviors
- A step toward eliminating `app/javascript/app`

**Open Questions:**

This alters the interface of the enrollment function slightly to act more as a pass-through for various options on the underlying WebAuthn interfaces, which avoids some abstraction, and allows for some more visibility to the TypeScript types. It's a tricky balance between the utility being useful in converting to and from raw input values, so I'm open to feedback on if it went a little too far here in losing some usefulness.

## 📜 Testing Plan

- `yarn test`
- Verify you can still enroll a Face/Touch Unlock or Security Key credential without regressions