### PR TITLE
Initialize flow_session when it is first used

### DIFF
--- a/app/controllers/concerns/idv/outage_concern.rb
+++ b/app/controllers/concerns/idv/outage_concern.rb
@@ -3,7 +3,7 @@ module Idv
     extend ActiveSupport::Concern
 
     def check_for_outage
-      return if user_session.fetch('idv/doc_auth', {})[:skip_vendor_outage]
+      return if flow_session[:skip_vendor_outage]
 
       return redirect_for_gpo_only if FeatureManagement.idv_gpo_only?
     end
@@ -14,7 +14,7 @@ module Idv
       # During a phone outage, skip the hybrid handoff
       # step and go straight to document upload
       unless FeatureManagement.idv_allow_hybrid_flow?
-        user_session.fetch('idv/doc_auth', {})[:skip_upload_step] = true
+        flow_session[:skip_upload_step] = true
       end
 
       redirect_to idv_mail_only_warning_url

--- a/app/controllers/concerns/idv/outage_concern.rb
+++ b/app/controllers/concerns/idv/outage_concern.rb
@@ -13,9 +13,7 @@ module Idv
 
       # During a phone outage, skip the hybrid handoff
       # step and go straight to document upload
-      unless FeatureManagement.idv_allow_hybrid_flow?
-        flow_session[:skip_upload_step] = true
-      end
+      flow_session[:skip_upload_step] = true unless FeatureManagement.idv_allow_hybrid_flow?
 
       redirect_to idv_mail_only_warning_url
     end

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -33,6 +33,10 @@ module IdvSession
     )
   end
 
+  def flow_session
+    user_session['idv/doc_auth'] ||= {}
+  end
+
   def redirect_unless_idv_session_user
     redirect_to root_url if !idv_session_user
   end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -26,7 +26,7 @@ module IdvStepConcern
   end
 
   def flow_session
-    user_session['idv/doc_auth'] || {}
+    user_session['idv/doc_auth'] ||= {}
   end
 
   def pii_from_doc

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -25,10 +25,6 @@ module IdvStepConcern
     redirect_to idv_in_person_ready_to_verify_url if current_user&.pending_in_person_enrollment
   end
 
-  def flow_session
-    user_session['idv/doc_auth'] ||= {}
-  end
-
   def pii_from_doc
     flow_session['pii_from_doc']
   end

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -29,7 +29,7 @@ module Idv
 
     def success
       profile_params.each do |key, value|
-        user_session['idv/doc_auth']['pii_from_doc'][key] = value
+        flow_session['pii_from_doc'][key] = value
       end
       redirect_to idv_verify_info_url
     end
@@ -44,7 +44,7 @@ module Idv
 
     def capture_address_edited(result)
       address_edited = result.to_h[:address_edited]
-      user_session['idv/doc_auth']['address_edited'] = address_edited if address_edited
+      flow_session['address_edited'] = address_edited if address_edited
     end
   end
 end

--- a/app/controllers/idv/gpo_only_warning_controller.rb
+++ b/app/controllers/idv/gpo_only_warning_controller.rb
@@ -8,7 +8,7 @@ module Idv
     def show
       analytics.idv_mail_only_warning_visited(analytics_id: 'Doc Auth')
 
-      user_session.fetch('idv/doc_auth', {})[:skip_vendor_outage] = true
+      flow_session[:skip_vendor_outage] = true
       render :show, locals: { current_sp:, exit_url: }
     end
 

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -30,7 +30,6 @@ class IdvController < ApplicationController
   def verify_identity
     analytics.idv_intro_visit
     if IdentityConfig.store.doc_auth_welcome_controller_enabled
-      user_session['idv/doc_auth'] ||= {}
       redirect_to idv_welcome_url
     else
       redirect_to idv_doc_auth_url

--- a/spec/controllers/idv/gpo_only_warning_controller_spec.rb
+++ b/spec/controllers/idv/gpo_only_warning_controller_spec.rb
@@ -39,12 +39,13 @@ RSpec.describe Idv::GpoOnlyWarningController do
     end
 
     context 'flow_session is nil' do
-      it 'renders the show template' do
+      it 'renders the show template and initializes flow session' do
         subject.user_session.delete('idv/doc_auth')
 
         get :show
 
         expect(response).to render_template :show
+        expect(subject.user_session['idv/doc_auth'][:skip_vendor_outage]).to eq(true)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9365](https://cm-jira.usa.gov/browse/LG-9365)

## 🛠 Summary of changes

This is in preparation for no longer going through the Flow State Machine for the Welcome Step. Initialize the doc_auth flow_session to {} when it is first used (if it is nil) rather than expecting the Flow State Machine to initialize it.

(Almost) everywhere that was accessing user_session['idv/doc_auth'] directly is now calling the flow_session method, which has been moved from IdvStepConcern to IdvSession for better access to it.

Note that this does not affect the in_person flow_session which is at user_session['idv/in_person'].

## 📜 Testing Plan

Added an expectation to gpo_only_warning_controller_spec which tests the flow_session method. Expecting feature and controller tests to provide overall coverage of the change.
