### PR TITLE
LG-9818 Set the `address_verification_mechanism` for the GPO verify action

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -81,6 +81,7 @@ module Idv
         flash[:success] = t('account.index.verification.success')
       end
 
+      idv_session.address_verification_mechanism = 'gpo'
       idv_session.address_confirmed!
     end
 

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -93,6 +93,7 @@ RSpec.feature 'idv gpo otp verification step' do
 
       expect(page).to have_current_path(idv_personal_key_path)
       expect(page).to have_content(t('account.index.verification.success'))
+      expect(page).to have_content(t('step_indicator.flows.idv.get_a_letter'))
 
       expect(profile.active).to be(true)
       expect(profile.deactivation_reason).to be(nil)


### PR DESCRIPTION
The personal key controller was previously always part of the main proofing flow and was always rendered after the password input. Recently we moved it to GPO verification for users in that workflow. This meant that when the user was seeing their personal key for the GPO verification workflow the `idv_session` had been cleared when their session expired. As a result the GPO verification screen needs to setup `idv_session` for the personal key.

When this was done the `address_verification_method` attribute was left off. The personal key controller uses the `StepIndicatorConcern` to determine which steps to show. That looks for the presence of a pending profile or that attribute on `idv_session`. Since the user no longer has a pending profile after confirming their GPO code and the GPO verification controller was not setting `address_verification_mechanism` the `StepIndicatorConcern` was using the default steps instead of the GPO specific ones.

This commit fixes the issue by setting `address_verification_method` when the user successfully confirm their code.
