### PR TITLE
Use image caching during Kaniko build for review applications

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,7 +116,7 @@ build-idp-image:
       --context "${CI_PROJECT_DIR}"
       --dockerfile "${CI_PROJECT_DIR}/Dockerfile"
       --destination "${ECR_REGISTRY}/identity-idp/review:${CI_COMMIT_SHA}"
-      --cache-repo="${ECR_REGISTRY}/identity-idp/review"
+      --cache-repo="${ECR_REGISTRY}/identity-idp/review/cache"
       --cache=true
       --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}" --build-arg "https_proxy=${https_proxy}" --build-arg "no_proxy=${no_proxy}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,7 @@ build-idp-image:
       --context "${CI_PROJECT_DIR}"
       --dockerfile "${CI_PROJECT_DIR}/Dockerfile"
       --destination "${ECR_REGISTRY}/identity-idp/review:${CI_COMMIT_SHA}"
+      --cache=true
       --build-arg "http_proxy=${http_proxy}" --build-arg "https_proxy=${https_proxy}" --build-arg "no_proxy=${no_proxy}"
 
 check_changelog:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,6 +89,7 @@ install:
     - bundle exec rake assets:precompile
 
 # Build a container image async, and don't block CI tests
+# Cache intermediate images for 1 week (168 hours)
 build-idp-image:
   stage: review
   needs: []
@@ -117,6 +118,7 @@ build-idp-image:
       --dockerfile "${CI_PROJECT_DIR}/Dockerfile"
       --destination "${ECR_REGISTRY}/identity-idp/review:${CI_COMMIT_SHA}"
       --cache-repo="${ECR_REGISTRY}/identity-idp/review/cache"
+      --cache-ttl=168h
       --cache=true
       --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}" --build-arg "https_proxy=${https_proxy}" --build-arg "no_proxy=${no_proxy}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,6 +117,7 @@ build-idp-image:
       --dockerfile "${CI_PROJECT_DIR}/Dockerfile"
       --destination "${ECR_REGISTRY}/identity-idp/review:${CI_COMMIT_SHA}"
       --cache=true
+      --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}" --build-arg "https_proxy=${https_proxy}" --build-arg "no_proxy=${no_proxy}"
 
 check_changelog:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,7 @@ build-idp-image:
       --context "${CI_PROJECT_DIR}"
       --dockerfile "${CI_PROJECT_DIR}/Dockerfile"
       --destination "${ECR_REGISTRY}/identity-idp/review:${CI_COMMIT_SHA}"
+      --cache-repo="${ECR_REGISTRY}/identity-idp/review"
       --cache=true
       --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}" --build-arg "https_proxy=${https_proxy}" --build-arg "no_proxy=${no_proxy}"


### PR DESCRIPTION
## 🛠 Summary of changes

Trying to see if we can use the container cache to reduce build time

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
