### PR TITLE
Update review application configuration to behave closer to development environment

### DIFF
--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -28,3 +28,4 @@ production:
   ruby_workers_idv_enabled: false
   idv_sp_required: false
   telephony_adapter: test
+  doc_auth_vendor: 'mock'

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -24,5 +24,7 @@ production:
   use_kms: false
   email_from: no-reply@identitysandbox.gov
   aws_kms_key_id: alias/dev-login-dot-gov-keymaker
-  log_to_stdout: false
+  log_to_stdout: true
+  ruby_workers_idv_enabled: false
+  idv_sp_required: false
   telephony_adapter: test


### PR DESCRIPTION
## 🛠 Summary of changes

Following today's appdev/devops sync, this brings a few changes to make review apps to be a bit more useful for reviewing changes by making identity proofing possible. It also changes the logs to go to STDOUT (related to #8610)
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
