### PR TITLE
Allow commas in changelog changes

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -3,7 +3,7 @@ require 'open3'
 require 'optparse'
 
 CHANGELOG_REGEX =
-  %r{^(?:\* )?changelog: ?(?<category>[\w -/]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}i
+  %r{^(?:\* )?changelog: ?(?<category>[\w -]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}i
 CATEGORIES = [
   'User-Facing Improvements',
   'Improvements', # Temporary for transitional period

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -118,3 +118,15 @@ commit_changelog_whitespace:
   pr_number: '7000'
   commit_messages:
     - 'changelog:Internal,Changelog,Improve changelog tool flexibility for commit messages'
+commit_changelog_with_commas_in_change:
+  commit_log: |
+    title: Improve changelog tool flexibility for commit messages (#7000)
+    body:changelog:Internal,Changelog,Allow listing one, two, and more items with commas
+    DELIMITER
+  title: Improve changelog tool flexibility for commit messages (#7000)
+  category: Internal
+  subcategory: Changelog
+  change: Allow listing one, two, and more items with commas
+  pr_number: '7000'
+  commit_messages:
+    - 'changelog:Internal,Changelog,Allow listing one, two, and more items with commas'

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'scripts/changelog_check' do
     it 'builds a git log into structured changelog objects' do
       git_log = git_fixtures.values.pluck('commit_log').join("\n")
       changelog_entries = generate_changelog(git_log)
-      expect(changelog_entries.length).to eq 7
+      expect(changelog_entries.length).to eq 8
       fixture_and_changelog = git_fixtures.values.filter do |x|
         x['category'].present?
       end.zip(changelog_entries)


### PR DESCRIPTION
## 🛠 Summary of changes

I think the initial regular expression was a bit off in its implementation and was supposed to be words, dashes and forward slashes but it created a character class from ASCII character space (32) to forward slash (47) which includes the comma (42). 

This change fixes that so that we can use commas in the changelog.
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
