### PR TITLE
LG-9931 show capture complete on hybrid rate limit

### DIFF
--- a/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
+++ b/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
@@ -19,12 +19,6 @@ module Idv
         return handle_invalid_document_capture_session if document_capture_session.expired?
       end
 
-      def confirm_document_capture_session_complete
-        return if document_capture_session&.load_result&.success?
-
-        redirect_to idv_hybrid_mobile_document_capture_url
-      end
-
       def document_capture_session
         return @document_capture_session if defined?(@document_capture_session)
         @document_capture_session =

--- a/app/controllers/idv/hybrid_mobile/capture_complete_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/capture_complete_controller.rb
@@ -4,7 +4,6 @@ module Idv
       include HybridMobileConcern
 
       before_action :check_valid_document_capture_session
-      before_action :confirm_document_capture_session_complete
 
       def show
         analytics.idv_doc_auth_capture_complete_visited(**analytics_arguments)

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -29,10 +29,9 @@ module Idv
         Funnel::DocAuth::RegisterStep.new(document_capture_user.id, sp_session[:issuer]).
           call('document_capture', :update, true)
 
+        # rate limiting redirect is in ImageUploadResponsePresenter
         if result.success?
           flash[:success] = t('doc_auth.headings.capture_complete')
-          redirect_to idv_hybrid_mobile_capture_complete_url
-        elsif rate_limited?
           redirect_to idv_hybrid_mobile_capture_complete_url
         else
           redirect_to idv_hybrid_mobile_document_capture_url
@@ -70,13 +69,6 @@ module Idv
           extra = { stored_result_present: stored_result.present? }
           failure(I18n.t('doc_auth.errors.general.network_error'), extra)
         end
-      end
-
-      def rate_limited?
-        Throttle.new(
-          user: idv_session_user,
-          throttle_type: :idv_doc_auth,
-        ).throttled?
       end
 
       def native_camera_ab_testing_variables

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -32,7 +32,10 @@ module Idv
         if result.success?
           flash[:success] = t('doc_auth.headings.capture_complete')
           redirect_to idv_hybrid_mobile_capture_complete_url
+        elsif throttled
+          redirect_to idv_hybrid_mobile_capture_complete_url
         else
+
           redirect_to idv_hybrid_mobile_document_capture_url
         end
       end

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -32,10 +32,9 @@ module Idv
         if result.success?
           flash[:success] = t('doc_auth.headings.capture_complete')
           redirect_to idv_hybrid_mobile_capture_complete_url
-        elsif throttled
+        elsif rate_limited?
           redirect_to idv_hybrid_mobile_capture_complete_url
         else
-
           redirect_to idv_hybrid_mobile_document_capture_url
         end
       end
@@ -71,6 +70,13 @@ module Idv
           extra = { stored_result_present: stored_result.present? }
           failure(I18n.t('doc_auth.errors.general.network_error'), extra)
         end
+      end
+
+      def rate_limited?
+        Throttle.new(
+          user: idv_session_user,
+          throttle_type: :idv_doc_auth,
+        ).throttled?
       end
 
       def native_camera_ab_testing_variables

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -10,7 +10,6 @@ module Idv
       presenter = ImageUploadResponsePresenter.new(
         form_response: image_upload_form_response,
         url_options: url_options,
-        flow_path: params[:flow_path],
       )
 
       render json: presenter, status: presenter.status

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -7,12 +7,10 @@ module Idv
     def create
       image_upload_form_response = image_upload_form.submit
 
-      flow_path = user_session&.dig('idv/doc_auth', :flow_path)
-
       presenter = ImageUploadResponsePresenter.new(
         form_response: image_upload_form_response,
         url_options: url_options,
-        flow_path: flow_path,
+        flow_path: params[:flow_path],
       )
 
       render json: presenter, status: presenter.status

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -7,9 +7,12 @@ module Idv
     def create
       image_upload_form_response = image_upload_form.submit
 
+      flow_path = user_session&.dig('idv/doc_auth', :flow_path)
+
       presenter = ImageUploadResponsePresenter.new(
         form_response: image_upload_form_response,
         url_options: url_options,
+        flow_path: flow_path,
       )
 
       render json: presenter, status: presenter.status

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -1,10 +1,9 @@
 class ImageUploadResponsePresenter
   include Rails.application.routes.url_helpers
 
-  def initialize(form_response:, url_options:, flow_path:)
+  def initialize(form_response:, url_options:)
     @form_response = form_response
     @url_options = url_options
-    @flow_path = flow_path
   end
 
   def success?
@@ -37,7 +36,7 @@ class ImageUploadResponsePresenter
     else
       json = { success: false, errors: errors, remaining_attempts: remaining_attempts }
       if remaining_attempts&.zero?
-        if @flow_path == 'standard'
+        if @form_response.extra[:flow_path] == 'standard'
           json[:redirect] = idv_session_errors_throttled_url
         else # hybrid flow on mobile
           json[:redirect] = idv_hybrid_mobile_capture_complete_url

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -1,9 +1,10 @@
 class ImageUploadResponsePresenter
   include Rails.application.routes.url_helpers
 
-  def initialize(form_response:, url_options:)
+  def initialize(form_response:, url_options:, flow_path:)
     @form_response = form_response
     @url_options = url_options
+    @flow_path = flow_path
   end
 
   def success?
@@ -35,7 +36,13 @@ class ImageUploadResponsePresenter
       { success: true }
     else
       json = { success: false, errors: errors, remaining_attempts: remaining_attempts }
-      # json[:redirect] = idv_session_errors_throttled_url if remaining_attempts&.zero?
+      if remaining_attempts&.zero?
+        if @flow_path == 'standard'
+          json[:redirect] = idv_session_errors_throttled_url
+        else # hybrid flow on mobile
+          json[:redirect] = idv_hybrid_mobile_capture_complete_url
+        end
+      end
       json[:hints] = true if show_hints?
       json[:ocr_pii] = ocr_pii
       json[:result_failed] = doc_auth_result_failed?

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -35,7 +35,7 @@ class ImageUploadResponsePresenter
       { success: true }
     else
       json = { success: false, errors: errors, remaining_attempts: remaining_attempts }
-      json[:redirect] = idv_session_errors_throttled_url if remaining_attempts&.zero?
+      # json[:redirect] = idv_session_errors_throttled_url if remaining_attempts&.zero?
       json[:hints] = true if show_hints?
       json[:ocr_pii] = ocr_pii
       json[:result_failed] = doc_auth_result_failed?

--- a/app/views/idv/hybrid_mobile/document_capture/show.html.erb
+++ b/app/views/idv/hybrid_mobile/document_capture/show.html.erb
@@ -3,7 +3,7 @@
       document_capture_session_uuid: document_capture_session_uuid,
       flow_path: 'hybrid',
       sp_name: decorated_session.sp_name,
-      failure_to_proof_url: idv_doc_auth_return_to_sp_url,
+      failure_to_proof_url: failure_to_proof_url,
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,

--- a/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
@@ -38,13 +38,6 @@ RSpec.describe Idv::HybridMobile::CaptureCompleteController do
         :check_valid_document_capture_session,
       )
     end
-
-    it 'includes document capture session complete before action' do
-      expect(subject).to have_actions(
-        :before,
-        :confirm_document_capture_session_complete,
-      )
-    end
   end
 
   describe '#show' do

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         # final failure
         attach_and_submit_images
 
-        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
-        expect(page).not_ to have_content(t('doc_auth.headings.capture_complete').tr(' ', ' '))
+        #expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+        expect(page).not_to have_content(t('doc_auth.headings.capture_complete').tr(' ', ' '))
         expect(page).to have_text(t('doc_auth.instructions.switch_back'))
       end
 

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -38,10 +38,6 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
     perform_in_browser(:mobile) do
       visit @sms_link
 
-      # Confirm app disallows jumping ahead to CaptureComplete page
-      visit idv_hybrid_mobile_capture_complete_url
-      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
-
       # Confirm that jumping to LinkSent page does not cause errors
       visit idv_link_sent_url
       expect(page).to have_current_path(root_url)
@@ -150,13 +146,13 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         # final failure
         attach_and_submit_images
 
-        #expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
         expect(page).not_to have_content(t('doc_auth.headings.capture_complete').tr(' ', ' '))
         expect(page).to have_text(t('doc_auth.instructions.switch_back'))
       end
 
       perform_in_browser(:desktop) do
-        expect(page).to have_current_path(idv_session_errors_throttled_path)
+        expect(page).to have_current_path(idv_session_errors_throttled_path, wait: 10)
       end
     end
   end

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -110,4 +110,54 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       expect(page).to have_content(t('doc_auth.headings.text_message'))
     end
   end
+
+  context 'user is rate limited on mobile' do
+    let(:max_attempts) { IdentityConfig.store.doc_auth_max_attempts }
+
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
+      DocAuth::Mock::DocAuthMockClient.mock_response!(
+        method: :post_front_image,
+        response: DocAuth::Response.new(
+          success: false,
+          errors: { network: I18n.t('doc_auth.errors.general.network_error') },
+        ),
+      )
+    end
+
+    it 'it shows capture complete on mobile and error page on desktop', js: true do
+      user = nil
+
+      perform_in_browser(:desktop) do
+        user = sign_in_and_2fa_user
+        complete_doc_auth_steps_before_hybrid_handoff_step
+        clear_and_fill_in(:doc_auth_phone, phone_number)
+        click_send_link
+
+        expect(page).to have_content(t('doc_auth.headings.text_message'))
+      end
+
+      expect(@sms_link).to be_present
+
+      perform_in_browser(:mobile) do
+        visit @sms_link
+
+        (max_attempts - 1).times do
+          attach_and_submit_images
+          click_on t('idv.failure.button.warning')
+        end
+
+        # final failure
+        attach_and_submit_images
+
+        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+        expect(page).not_ to have_content(t('doc_auth.headings.capture_complete').tr(' ', ' '))
+        expect(page).to have_text(t('doc_auth.instructions.switch_back'))
+      end
+
+      perform_in_browser(:desktop) do
+        expect(page).to have_current_path(idv_session_errors_throttled_path)
+      end
+    end
+  end
 end

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -3,8 +3,12 @@ require 'rails_helper'
 RSpec.describe ImageUploadResponsePresenter do
   include Rails.application.routes.url_helpers
 
+  let(:extra_attributes) do
+    { remaining_attempts: 3, flow_path: 'standard' }
+  end
+
   let(:form_response) do
-    FormResponse.new(success: true, errors: {}, extra: { remaining_attempts: 3 })
+    FormResponse.new(success: true, errors: {}, extra: extra_attributes)
   end
   let(:presenter) { described_class.new(form_response: form_response, url_options: {}) }
 
@@ -123,6 +127,24 @@ RSpec.describe ImageUploadResponsePresenter do
         }
 
         expect(presenter.as_json).to eq expected
+      end
+
+      context 'hybrid flow' do
+        let(:extra_attributes) do
+          { remaining_attempts: 3, flow_path: 'hybrid' }
+        end
+
+        it 'returns hash of properties redirecting to capture_complete' do
+          expected = {
+            success: false,
+            result_failed: false,
+            errors: [{ field: :limit, message: t('errors.doc_auth.throttled_heading') }],
+            redirect: idv_hybrid_mobile_capture_complete_url,
+            remaining_attempts: 0,
+            ocr_pii: nil,
+          }
+
+          expect(presenter.as_json).to eq expected
       end
     end
 

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -106,13 +106,16 @@ RSpec.describe ImageUploadResponsePresenter do
     end
 
     context 'throttled' do
+      let(:extra_attributes) do
+        { remaining_attempts: 0, flow_path: 'standard' }
+      end
       let(:form_response) do
         FormResponse.new(
           success: false,
           errors: {
             limit: t('errors.doc_auth.throttled_heading'),
           },
-          extra: { remaining_attempts: 0 },
+          extra: extra_attributes,
         )
       end
 
@@ -131,7 +134,7 @@ RSpec.describe ImageUploadResponsePresenter do
 
       context 'hybrid flow' do
         let(:extra_attributes) do
-          { remaining_attempts: 3, flow_path: 'hybrid' }
+          { remaining_attempts: 0, flow_path: 'hybrid' }
         end
 
         it 'returns hash of properties redirecting to capture_complete' do
@@ -145,6 +148,7 @@ RSpec.describe ImageUploadResponsePresenter do
           }
 
           expect(presenter.as_json).to eq expected
+        end
       end
     end
 
@@ -156,7 +160,7 @@ RSpec.describe ImageUploadResponsePresenter do
             front: t('doc_auth.errors.not_a_file'),
             hints: true,
           },
-          extra: { remaining_attempts: 3 },
+          extra: extra_attributes,
         )
       end
 
@@ -200,6 +204,9 @@ RSpec.describe ImageUploadResponsePresenter do
       end
 
       context 'no remaining attempts' do
+        let(:extra_attributes) do
+          { remaining_attempts: 0, flow_path: 'standard' }
+        end
         let(:form_response) do
           FormResponse.new(
             success: false,
@@ -207,8 +214,28 @@ RSpec.describe ImageUploadResponsePresenter do
               front: t('doc_auth.errors.not_a_file'),
               hints: true,
             },
-            extra: { remaining_attempts: 0 },
+            extra: extra_attributes,
           )
+        end
+
+        context 'hybrid flow' do
+          let(:extra_attributes) do
+            { remaining_attempts: 0, flow_path: 'hybrid' }
+          end
+
+          it 'returns hash of properties' do
+            expected = {
+              success: false,
+              result_failed: false,
+              errors: [{ field: :front, message: t('doc_auth.errors.not_a_file') }],
+              hints: true,
+              redirect: idv_hybrid_mobile_capture_complete_url,
+              remaining_attempts: 0,
+              ocr_pii: nil,
+            }
+
+            expect(presenter.as_json).to eq expected
+          end
         end
 
         it 'returns hash of properties' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-9931](https://cm-jira.usa.gov/browse/LG-9931)

## 🛠 Summary of changes

When a user is rate limited on document capture during hybrid flow, they are now shown the CaptureComplete screen (without success banner) instead of rate limit error. Desktop already showed rate limit error.

Note that the before_action on CaptureComplete that requires document capture to be successful has been removed to allow it to be shown on rate limiting.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Create account, start IdV
- [x] Test hybrid flow: On HybridHandoff, choose Send Link
- [x] _In different browser_ ("mobile"), navigate to `http://localhost:3000/test/telephony`
- [x] Copy mobile link and navigate to it on "mobile" browser
- [x] Upload a yaml that generates an error (can download [here](https://developers.login.gov/testing/)) enough times to hit rate limit (usually 6)
- [x] Expect "Switch back to your computer" screen on "mobile" browser and rate limit screen on original browser.
- [x] Restart Idv with new account
- [x] Test standard flow: Choose Upload Photos
- [x] Upload yaml to cause an error enough times to be rate limited (usually 6)
- [x] Expect to see rate limit screen.

## 👀 Screenshots

<details>
<summary>After:</summary>
  
![Mobile rate limit](https://github.com/18F/identity-idp/assets/2381438/9373eca6-fece-4745-b1a6-14f75aa4a17c)
</details>

