### PR TITLE
LG 10021 hide error after successful webauth authentication

### DIFF
--- a/app/javascript/packs/webauthn-authenticate.ts
+++ b/app/javascript/packs/webauthn-authenticate.ts
@@ -4,7 +4,7 @@ function webauthn() {
   const webauthnInProgressContainer = document.getElementById('webauthn-auth-in-progress')!;
   const webauthnSuccessContainer = document.getElementById('webauthn-auth-successful')!;
 
-  const webauthAlertContainer = document.getElementsByClassName('usa-alert--error')[0];
+  const webauthAlertContainer = document.querySelector('.usa-alert--error');
   const webauthnPlatformRequested =
     webauthnInProgressContainer.dataset.platformAuthenticatorRequested === 'true';
   const multipleFactorsEnabled =

--- a/app/javascript/packs/webauthn-authenticate.ts
+++ b/app/javascript/packs/webauthn-authenticate.ts
@@ -4,7 +4,7 @@ function webauthn() {
   const webauthnInProgressContainer = document.getElementById('webauthn-auth-in-progress')!;
   const webauthnSuccessContainer = document.getElementById('webauthn-auth-successful')!;
 
-  const webauthAlertContainer = document.querySelector('.usa-alert--error');
+  const webauthAlertContainer = document.querySelector('.usa-alert--error')!;
   const webauthnPlatformRequested =
     webauthnInProgressContainer.dataset.platformAuthenticatorRequested === 'true';
   const multipleFactorsEnabled =

--- a/app/javascript/packs/webauthn-authenticate.ts
+++ b/app/javascript/packs/webauthn-authenticate.ts
@@ -4,6 +4,7 @@ function webauthn() {
   const webauthnInProgressContainer = document.getElementById('webauthn-auth-in-progress')!;
   const webauthnSuccessContainer = document.getElementById('webauthn-auth-successful')!;
 
+  const webauthAlertContainer = document.getElementsByClassName('usa-alert--error')[0];
   const webauthnPlatformRequested =
     webauthnInProgressContainer.dataset.platformAuthenticatorRequested === 'true';
   const multipleFactorsEnabled =
@@ -35,6 +36,10 @@ function webauthn() {
         (document.getElementById('signature') as HTMLInputElement).value = result.signature;
         webauthnInProgressContainer.classList.add('display-none');
         webauthnSuccessContainer.classList.remove('display-none');
+        // Check if alert container is shown and remove when device passes successfully.
+        if (webauthAlertContainer) {
+          webauthAlertContainer.remove();
+        }
       })
       .catch((error: Error) => {
         (document.getElementById('webauthn_error') as HTMLInputElement).value = error.name;

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -40,21 +40,6 @@ RSpec.feature 'webauthn sign in' do
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 
-  it 'does not show error after successful challlenge/secret reattempt' do
-    mock_webauthn_verification_challenge
-
-    sign_in_user(webauthn_configuration.user)
-    # simulate clicking the next button or cancel from the browser dialog
-    click_button t('forms.buttons.continue')
-
-    expect(page).to have_content(t('errors.general'))
-
-    mock_press_button_on_hardware_key_on_verification
-    click_button t('forms.buttons.continue')
-
-    expect(page).to_not have_content(t('errors.general'))
-  end
-
   it 'does not allow the user to sign in if the hardware button has not been pressed' do
     mock_webauthn_verification_challenge
 
@@ -64,4 +49,19 @@ RSpec.feature 'webauthn sign in' do
     expect(page).to have_content(t('errors.general'))
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
+end
+
+it 'does not show error after successful challlenge/secret reattempt' do
+  mock_webauthn_verification_challenge
+
+  sign_in_user(webauthn_configuration.user)
+  # click the next button or cancel from the browser dialog
+  click_button t('forms.buttons.continue')
+
+  expect(page).to have_content(t('errors.general'))
+
+  mock_press_button_on_hardware_key_on_verification
+  click_button t('forms.buttons.continue')
+
+  expect(page).to_not have_content(t('errors.general'))
 end

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -49,19 +49,19 @@ RSpec.feature 'webauthn sign in' do
     expect(page).to have_content(t('errors.general'))
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
-end
 
-it 'does not show error after successful challlenge/secret reattempt' do
-  mock_webauthn_verification_challenge
-
-  sign_in_user(webauthn_configuration.user)
-  # click the next button or cancel from the browser dialog
-  click_button t('forms.buttons.continue')
-
-  expect(page).to have_content(t('errors.general'))
-
-  mock_press_button_on_hardware_key_on_verification
-  click_button t('forms.buttons.continue')
-
-  expect(page).to_not have_content(t('errors.general'))
+  it 'does not show error after successful challlenge/secret reattempt' do
+    mock_webauthn_verification_challenge
+  
+    sign_in_user(webauthn_configuration.user)
+    # click the next button or cancel from the browser dialog
+    click_button t('forms.buttons.continue')
+  
+    expect(page).to have_content(t('errors.general'))
+  
+    mock_press_button_on_hardware_key_on_verification
+    click_button t('forms.buttons.continue')
+  
+    expect(page).to_not have_content(t('errors.general'))
+  end
 end

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -40,6 +40,21 @@ RSpec.feature 'webauthn sign in' do
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 
+  it 'does not show error after successful challlenge/secret reattempt' do
+    mock_webauthn_verification_challenge
+
+    sign_in_user(webauthn_configuration.user)
+    # simulate clicking the next button or cancel from the browser dialog
+    click_button t('forms.buttons.continue')
+
+    expect(page).to have_content(t('errors.general'))
+
+    mock_press_button_on_hardware_key_on_verification
+    click_button t('forms.buttons.continue')
+
+    expect(page).to_not have_content(t('errors.general'))
+  end
+
   it 'does not allow the user to sign in if the hardware button has not been pressed' do
     mock_webauthn_verification_challenge
 

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -52,16 +52,16 @@ RSpec.feature 'webauthn sign in' do
 
   it 'does not show error after successful challlenge/secret reattempt' do
     mock_webauthn_verification_challenge
-  
+
     sign_in_user(webauthn_configuration.user)
     # click the next button or cancel from the browser dialog
     click_button t('forms.buttons.continue')
-  
+
     expect(page).to have_content(t('errors.general'))
-  
+
     mock_press_button_on_hardware_key_on_verification
     click_button t('forms.buttons.continue')
-  
+
     expect(page).to_not have_content(t('errors.general'))
   end
 end

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'webauthn sign in' do
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 
-  it 'does not show error after successful challlenge/secret reattempt' do
+  it 'does not show error after successful challenge/secret reattempt' do
     mock_webauthn_verification_challenge
 
     sign_in_user(webauthn_configuration.user)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-10021](https://cm-jira.usa.gov/browse/LG-10021)


## 🛠 Summary of changes

When a successful authentication is passed and the display of the progress and success containers are toggled, if an error alert container is present, it gets removed from the DOM.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

With an account that has Security Key or F/T Unlock as a MFA option and does not remember your browser...
- [ ] Login with username and password
- [ ] At Connect Security screen click "use security key" button
- [ ] Click cancel on the browser pop up
- [ ] You should see the error banner "Oops, something went wrong..."
- [ ] Click use security key again then follow through with the unlock procedure
- [ ] Security Key verified message should now show and the error banner should not appear.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
