### PR TITLE
Add word-wrap security advisory to audit allowlist

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -7,7 +7,9 @@
         "active": true,
         "notes": "semver RegExp DoS, pending upstream release, vulnerable path not applicable",
         "expiry": "2023-09-01"
-      },
+      }
+    },
+    {
       "GHSA-j8xg-fqg3-53r7": {
         "active": true,
         "notes": "word-wrap RegExp DoS, pending upstream release, vulnerable path not applicable",

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -7,6 +7,11 @@
         "active": true,
         "notes": "semver RegExp DoS, pending upstream release, vulnerable path not applicable",
         "expiry": "2023-09-01"
+      },
+      "GHSA-j8xg-fqg3-53r7": {
+        "active": true,
+        "notes": "word-wrap RegExp DoS, pending upstream release, vulnerable path not applicable",
+        "expiry": "2023-08-01"
       }
     }
   ]


### PR DESCRIPTION
## 🛠 Summary of changes

Resolves security advisory notices affecting all builds on `main`, related to a a [security advisory](https://github.com/advisories/GHSA-j8xg-fqg3-53r7) in the `word-wrap` dependency.

This is a temporary alternative to #8677 to allow builds to pass again. #8677 is a viable path forward, but requires more work to address issues with upgrades to the affected packages. This is enforced as temporary with an expiration of August 1.

The risk here is quite low due to how packages operate with `optionator` (see related comment https://github.com/gkz/optionator/issues/44#issuecomment-1518171047)

## 📜 Testing Plan

The `audit_yarn_package` exits with a successful exit code:

```bash
make audit_yarn_package
echo $?
# 0
```