### PR TITLE
LG-9806 Do not redirect to address controller when a PR user updates their address

### DIFF
--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -77,7 +77,7 @@ module Idv
     end
 
     def next_url
-      if pii_from_doc[:state] == 'PR'
+      if pii_from_doc[:state] == 'PR' && !updating_ssn?
         idv_address_url
       else
         idv_verify_info_url

--- a/app/forms/idv/ssn_format_form.rb
+++ b/app/forms/idv/ssn_format_form.rb
@@ -14,6 +14,7 @@ module Idv
     def initialize(user, flow_session = {})
       @user = user
       @ssn = flow_session.dig('pii_from_doc', :ssn)
+      @updating_ssn = ssn.present?
     end
 
     def submit(params)
@@ -27,7 +28,7 @@ module Idv
     end
 
     def updating_ssn?
-      ssn.present?
+      @updating_ssn
     end
 
     private

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -175,12 +175,23 @@ RSpec.describe Idv::SsnController do
         expect(flow_session['pii_from_doc'][:ssn]).to eq(ssn)
       end
 
-      it 'redirects to address controller for Puerto Rico addresses' do
-        flow_session['pii_from_doc'][:state] = 'PR'
+      context 'with a Puerto Rico address' do
+        it 'redirects to address controller after enters their SSN' do
+          flow_session['pii_from_doc'][:state] = 'PR'
 
-        put :update, params: params
+          put :update, params: params
 
-        expect(response).to redirect_to(idv_address_url)
+          expect(response).to redirect_to(idv_address_url)
+        end
+
+        it 'redirects to the verify info controller if a user is updating their SSN' do
+          flow_session['pii_from_doc'][:ssn] = ssn
+          flow_session['pii_from_doc'][:state] = 'PR'
+
+          put :update, params: params
+
+          expect(response).to redirect_to(idv_verify_info_url)
+        end
       end
 
       it 'logs attempts api event' do

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Idv::SsnController do
       end
 
       context 'with a Puerto Rico address' do
-        it 'redirects to address controller after enters their SSN' do
+        it 'redirects to address controller after user enters their SSN' do
           flow_session['pii_from_doc'][:state] = 'PR'
 
           put :update, params: params

--- a/spec/features/idv/puerto_rican_address_spec.rb
+++ b/spec/features/idv/puerto_rican_address_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'proofing flow with a Puerto Rican document', :js do
+  include DocAuthHelper
+  include IdvStepHelper
+
+  before do
+    sign_in_and_2fa_user
+    complete_doc_auth_steps_before_document_capture_step
+    complete_document_capture_step_with_yml('spec/fixtures/puerto_rico_resident.yml')
+  end
+
+  it 'redirects the user to the address step after the ssn step' do
+    complete_ssn_step
+
+    expect(page).to have_content(t('doc_auth.headings.address'))
+    expect(current_path).to eq(idv_address_path)
+
+    click_button t('forms.buttons.submit.update')
+
+    expect(page).to have_content(t('headings.verify'))
+    expect(current_path).to eq(idv_verify_info_path)
+  end
+
+  it 'does not redirect to the user to the address step after they update their SSN' do
+    complete_ssn_step
+    click_button t('forms.buttons.submit.update')
+
+    expect(page).to have_content(t('headings.verify'))
+    expect(current_path).to eq(idv_verify_info_path)
+
+    click_link t('idv.buttons.change_ssn_label')
+
+    expect(page).to have_current_path(idv_ssn_path)
+
+    fill_in t('idv.form.ssn_label_html'), with: '900456789'
+    click_button t('forms.buttons.submit.update')
+
+    expect(page).to have_current_path(idv_verify_info_path)
+  end
+end


### PR DESCRIPTION
Users who upload a Puerto Rican document during IdV are redirected to the address controller after they enter their SSN. This differs from the rest of users who are sent to the verify info screen and only see the address controller views if they choose to update their address there. This is because Puerto Rican addresses have been problematic and seeing the address screen gives users with Puerto Rican documents a chance to modify their address if the address is read incorrectly. There are also alerts specific to formatting PR addresses that appear on the address update screen.

To enable the above behavior the SSN controller redirects to the address controller if the jurisdiction for the user's address is "PR". This approach worked well for PR users who are entering their SSN for the first time. This was problematic for Puerto Rican users who are updating their SSN after reaching the verify info screen. They would be sent to the address screen after updating their SSN even though they had already seen the address screen on their way to the verify info screen originally.

This commit address the problematic behavior by also checking whether the user is updating their SSN before the redirect to the address controller. Changes were necessary in `SsnFormatForm` to allow this. Previously the `updating_ssn?` method looked for the presence of an SSN to determine if the SSN was being updated. This does not work in the PR case since after a valid submission the form always has an SSN. Instead `updated_ssn?`'s return value is set in the initializer when the existing SSN is passed in as a parameter.

changelog: Improvements, Puerto Rican Proofing Experience, Users who are proofing and upload a Puerto Rican document during document capture and do not change their jursidiction on the address update page are no longer redirected to the address update page after submitting an ssn after choosing to update their ssn from the verify info page.
