### PR TITLE
LG-10123: Add data model for notification SMS numbers

### DIFF
--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -9,7 +9,7 @@ class InPersonEnrollment < ApplicationRecord
              inverse_of: :in_person_enrollments,
              optional: true
 
-  has_one :notification_phone_configurations, dependent: :destroy, inverse_of: :in_person_enrollment
+  has_one :notification_phone_configuration, dependent: :destroy, inverse_of: :in_person_enrollment
 
   enum status: {
     establishing: 0,

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -8,6 +8,9 @@ class InPersonEnrollment < ApplicationRecord
              primary_key: 'issuer',
              inverse_of: :in_person_enrollments,
              optional: true
+
+  has_one :notification_phone_configurations, dependent: :destroy, inverse_of: :in_person_enrollment
+
   enum status: {
     establishing: 0,
     pending: 1,

--- a/app/models/notification_phone_configuration.rb
+++ b/app/models/notification_phone_configuration.rb
@@ -7,14 +7,11 @@ class NotificationPhoneConfiguration < ApplicationRecord
   encrypted_attribute(name: :phone)
 
   def formatted_phone
-    Phonelib.parse(phone).international
+    PhoneFormatter.format(phone)
   end
 
   def masked_phone
-    return '' if phone.blank?
-
-    formatted = Phonelib.parse(phone).national
-    formatted[0..-5].gsub(/\d/, '*') + formatted[-4..-1]
+    PhoneFormatter.mask(phone)
   end
 
   def friendly_name

--- a/app/models/notification_phone_configuration.rb
+++ b/app/models/notification_phone_configuration.rb
@@ -1,0 +1,23 @@
+class NotificationPhoneConfiguration < ApplicationRecord
+  include EncryptableAttribute
+
+  belongs_to :in_person_enrollment, inverse_of: :notifcation_phone_configurations
+  validates :encrypted_phone, presence: true
+
+  encrypted_attribute(name: :phone)
+
+  def formatted_phone
+    Phonelib.parse(phone).international
+  end
+
+  def masked_phone
+    return '' if phone.blank?
+
+    formatted = Phonelib.parse(phone).national
+    formatted[0..-5].gsub(/\d/, '*') + formatted[-4..-1]
+  end
+
+  def friendly_name
+    :phone
+  end
+end

--- a/app/models/notification_phone_configuration.rb
+++ b/app/models/notification_phone_configuration.rb
@@ -1,8 +1,7 @@
 class NotificationPhoneConfiguration < ApplicationRecord
   include EncryptableAttribute
 
-  belongs_to :in_person_enrollment, inverse_of: :notifcation_phone_configurations
-  validates :encrypted_phone, presence: true
+  belongs_to :in_person_enrollment, inverse_of: :notification_phone_configuration
 
   encrypted_attribute(name: :phone)
 
@@ -15,6 +14,11 @@ class NotificationPhoneConfiguration < ApplicationRecord
 
     formatted = Phonelib.parse(phone).national
     formatted[0..-5].gsub(/\d/, '*') + formatted[-4..-1]
+  end
+
+  def erase_phone_number_and_mark_notification_sent
+    self.notification_sent_at = Time.zone.now
+    self.phone = nil
   end
 
   def friendly_name

--- a/app/models/notification_phone_configuration.rb
+++ b/app/models/notification_phone_configuration.rb
@@ -2,6 +2,7 @@ class NotificationPhoneConfiguration < ApplicationRecord
   include EncryptableAttribute
 
   belongs_to :in_person_enrollment, inverse_of: :notification_phone_configuration
+  validates :encrypted_phone, presence: true
 
   encrypted_attribute(name: :phone)
 
@@ -14,11 +15,6 @@ class NotificationPhoneConfiguration < ApplicationRecord
 
     formatted = Phonelib.parse(phone).national
     formatted[0..-5].gsub(/\d/, '*') + formatted[-4..-1]
-  end
-
-  def erase_phone_number_and_mark_notification_sent
-    self.notification_sent_at = Time.zone.now
-    self.phone = nil
   end
 
   def friendly_name

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -9,14 +9,11 @@ class PhoneConfiguration < ApplicationRecord
   enum delivery_preference: { sms: 0, voice: 1 }
 
   def formatted_phone
-    Phonelib.parse(phone).international
+    PhoneFormatter.format(phone)
   end
 
   def masked_phone
-    return '' if phone.blank?
-
-    formatted = Phonelib.parse(phone).national
-    formatted[0..-5].gsub(/\d/, '*') + formatted[-4..-1]
+    PhoneFormatter.mask(phone)
   end
 
   def selection_presenters

--- a/app/services/phone_formatter.rb
+++ b/app/services/phone_formatter.rb
@@ -5,4 +5,11 @@ module PhoneFormatter
     country_code = DEFAULT_COUNTRY if country_code.nil? && !phone&.start_with?('+')
     Phonelib.parse(phone, country_code)&.international
   end
+
+  def self.mask(phone)
+    return '' if phone.blank?
+
+    formatted = Phonelib.parse(phone).national
+    formatted[0..-5].gsub(/\d/, '*') + formatted[-4..-1]
+  end
 end

--- a/db/primary_migrate/20230627213457_add_notification_phone_configurations_table.rb
+++ b/db/primary_migrate/20230627213457_add_notification_phone_configurations_table.rb
@@ -1,0 +1,10 @@
+class AddNotificationPhoneConfigurationsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notification_phone_configurations do |t|
+      t.references :in_person_enrollment, null: false, index: { name: 'index_notification_phone_configurations_on_enrollment_id' }
+      t.text :encrypted_phone, comment: 'Encrypted phone number to send notifications to. Will be NULL after a notification is sent'
+      t.timestamp :notification_sent_at, comment: 'Timestamp when a notification was sent to the phone number'
+      t.timestamps
+    end
+  end
+end

--- a/db/primary_migrate/20230627213457_add_notification_phone_configurations_table.rb
+++ b/db/primary_migrate/20230627213457_add_notification_phone_configurations_table.rb
@@ -1,7 +1,7 @@
 class AddNotificationPhoneConfigurationsTable < ActiveRecord::Migration[7.0]
   def change
     create_table :notification_phone_configurations do |t|
-      t.references :in_person_enrollment, null: false, index: { name: 'index_notification_phone_configurations_on_enrollment_id' }
+      t.references :in_person_enrollment, null: false, index: { name: 'index_notification_phone_configurations_on_enrollment_id', unique: true }
       t.text :encrypted_phone, null: false, comment: 'Encrypted phone number to send notifications to'
       t.timestamps
     end

--- a/db/primary_migrate/20230627213457_add_notification_phone_configurations_table.rb
+++ b/db/primary_migrate/20230627213457_add_notification_phone_configurations_table.rb
@@ -2,8 +2,7 @@ class AddNotificationPhoneConfigurationsTable < ActiveRecord::Migration[7.0]
   def change
     create_table :notification_phone_configurations do |t|
       t.references :in_person_enrollment, null: false, index: { name: 'index_notification_phone_configurations_on_enrollment_id' }
-      t.text :encrypted_phone, comment: 'Encrypted phone number to send notifications to. Will be NULL after a notification is sent'
-      t.timestamp :notification_sent_at, comment: 'Timestamp when a notification was sent to the phone number'
+      t.text :encrypted_phone, null: false, comment: 'Encrypted phone number to send notifications to'
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -373,8 +373,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_213457) do
 
   create_table "notification_phone_configurations", force: :cascade do |t|
     t.bigint "in_person_enrollment_id", null: false
-    t.text "encrypted_phone", comment: "Encrypted phone number to send notifications to. Will be NULL after a notification is sent"
-    t.datetime "notification_sent_at", precision: nil, comment: "Timestamp when a notification was sent to the phone number"
+    t.text "encrypted_phone", null: false, comment: "Encrypted phone number to send notifications to"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["in_person_enrollment_id"], name: "index_notification_phone_configurations_on_enrollment_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -376,7 +376,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_213457) do
     t.text "encrypted_phone", null: false, comment: "Encrypted phone number to send notifications to"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["in_person_enrollment_id"], name: "index_notification_phone_configurations_on_enrollment_id"
+    t.index ["in_person_enrollment_id"], name: "index_notification_phone_configurations_on_enrollment_id", unique: true
   end
 
   create_table "partner_account_statuses", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_22_142018) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_27_213457) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -369,6 +369,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_22_142018) do
     t.integer "user_id", null: false
     t.integer "auth_count", default: 1, null: false
     t.index ["issuer", "year_month", "user_id"], name: "index_monthly_auth_counts_on_issuer_and_year_month_and_user_id", unique: true
+  end
+
+  create_table "notification_phone_configurations", force: :cascade do |t|
+    t.bigint "in_person_enrollment_id", null: false
+    t.text "encrypted_phone", comment: "Encrypted phone number to send notifications to. Will be NULL after a notification is sent"
+    t.datetime "notification_sent_at", precision: nil, comment: "Timestamp when a notification was sent to the phone number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["in_person_enrollment_id"], name: "index_notification_phone_configurations_on_enrollment_id"
   end
 
   create_table "partner_account_statuses", force: :cascade do |t|

--- a/spec/factories/notification_phone_configurations.rb
+++ b/spec/factories/notification_phone_configurations.rb
@@ -5,9 +5,4 @@ FactoryBot.define do
     phone { '+1 202-555-1212' }
     in_person_enrollment { association :in_person_enrollment }
   end
-
-  trait :notifcation_sent do
-    phone { nil }
-    notification_sent_at { Time.zone.now }
-  end
 end

--- a/spec/factories/notification_phone_configurations.rb
+++ b/spec/factories/notification_phone_configurations.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  Faker::Config.locale = :en
+
+  factory :notification_phone_configuration do
+    phone { '+1 202-555-1212' }
+    in_person_enrollment { association :in_person_enrollment }
+  end
+
+  trait :notifcation_sent do
+    phone { nil }
+    notification_sent_at { Time.zone.now }
+  end
+end

--- a/spec/models/notification_phone_configuration_spec.rb
+++ b/spec/models/notification_phone_configuration_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe NotificationPhoneConfiguration do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:in_person_enrollment) }
+  end
+
+  let(:phone) { '+1 703 555 1212' }
+
+  let(:notification_phone_configuration) { create(:notification_phone_configuration, phone: phone) }
+
+  describe 'creation' do
+    it 'stores an encrypted form of the phone number' do
+      expect(notification_phone_configuration.encrypted_phone).to_not be_blank
+      expect(notification_phone_configuration.notification_sent_at).to be_nil
+    end
+  end
+
+  describe 'encrypted attributes' do
+    it 'decrypts phone' do
+      expect(notification_phone_configuration.phone).to eq phone
+    end
+
+    context 'with unnormalized phone' do
+      let(:phone) { '  555 555 5555     ' }
+      let(:normalized_phone) { '555 555 5555' }
+
+      it 'normalizes phone' do
+        expect(notification_phone_configuration.phone).to eq normalized_phone
+      end
+    end
+  end
+
+  describe '#masked_phone' do
+    let(:notification_phone_configuration) do
+      build(:notification_phone_configuration, phone: phone)
+    end
+    let(:phone) { '+1 703 555 1212' }
+
+    subject(:masked_phone) { notification_phone_configuration.masked_phone }
+
+    it 'masks the phone number, leaving the last 4 digits' do
+      expect(masked_phone).to eq('(***) ***-1212')
+    end
+
+    context 'with a blank phone number' do
+      let(:phone) { '   ' }
+
+      it 'is the empty string' do
+        expect(masked_phone).to eq('')
+      end
+    end
+
+    context 'with an international number' do
+      let(:phone) { '+212 636-023853' }
+
+      it 'keeps the groupings and leaves the last 4 digits' do
+        expect(masked_phone).to eq('****-**3853')
+      end
+    end
+  end
+
+  describe '#erase_phone_number_and_mark_notification_sent' do
+    it 'erases the phone number' do
+      notification_phone_configuration.erase_phone_number_and_mark_notification_sent
+
+      expect(notification_phone_configuration.encrypted_phone).to be_nil
+      expect(notification_phone_configuration.notification_sent_at).to_not be_blank
+    end
+  end
+end

--- a/spec/models/notification_phone_configuration_spec.rb
+++ b/spec/models/notification_phone_configuration_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe NotificationPhoneConfiguration do
   describe 'Associations' do
     it { is_expected.to belong_to(:in_person_enrollment) }
+    it { is_expected.to validate_presence_of(:encrypted_phone) }
   end
 
   let(:phone) { '+1 703 555 1212' }
@@ -12,7 +13,6 @@ RSpec.describe NotificationPhoneConfiguration do
   describe 'creation' do
     it 'stores an encrypted form of the phone number' do
       expect(notification_phone_configuration.encrypted_phone).to_not be_blank
-      expect(notification_phone_configuration.notification_sent_at).to be_nil
     end
   end
 
@@ -57,15 +57,6 @@ RSpec.describe NotificationPhoneConfiguration do
       it 'keeps the groupings and leaves the last 4 digits' do
         expect(masked_phone).to eq('****-**3853')
       end
-    end
-  end
-
-  describe '#erase_phone_number_and_mark_notification_sent' do
-    it 'erases the phone number' do
-      notification_phone_configuration.erase_phone_number_and_mark_notification_sent
-
-      expect(notification_phone_configuration.encrypted_phone).to be_nil
-      expect(notification_phone_configuration.notification_sent_at).to_not be_blank
     end
   end
 end

--- a/spec/services/phone_formatter_spec.rb
+++ b/spec/services/phone_formatter_spec.rb
@@ -56,4 +56,24 @@ RSpec.describe PhoneFormatter do
       expect(formatted_phone).to be_nil
     end
   end
+
+  describe '#mask' do
+    it 'masks all but the last four digits' do
+      phone = '+1 703 555 1212'
+      masked_phone = PhoneFormatter.mask(phone)
+      expect(masked_phone).to eq('(***) ***-1212')
+    end
+
+    it 'masks all but the last four digits of formatted international numbers' do
+      phone = '+212 636-023853'
+      masked_phone = PhoneFormatter.mask(phone)
+      expect(masked_phone).to eq('****-**3853')
+    end
+
+    it 'returns an empty string for a blank phone number' do
+      phone = '    '
+      masked_phone = PhoneFormatter.mask(phone)
+      expect(masked_phone).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10123](https://cm-jira.usa.gov/browse/LG-10123)

## 🛠 Summary of changes

* Added a new data model for storing the SMS phone number to use for SMS notifications related to the in-person proofing flow
* A follow-up PR will add a feature flag and begin saving users' phone numbers to this table

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
