### PR TITLE
LG-10112 Move STEP_INDICATOR_STEPS and STEP_INDICATOR_STEPS_GPO from DocAuthFlow to StepIndicatorConcern

### DIFF
--- a/app/controllers/concerns/idv/step_indicator_concern.rb
+++ b/app/controllers/concerns/idv/step_indicator_concern.rb
@@ -2,6 +2,22 @@ module Idv
   module StepIndicatorConcern
     extend ActiveSupport::Concern
 
+    STEP_INDICATOR_STEPS = [
+      { name: :getting_started },
+      { name: :verify_id },
+      { name: :verify_info },
+      { name: :verify_phone_or_address },
+      { name: :secure_account },
+    ].freeze
+
+    STEP_INDICATOR_STEPS_GPO = [
+      { name: :getting_started },
+      { name: :verify_id },
+      { name: :verify_info },
+      { name: :get_a_letter },
+      { name: :secure_account },
+    ].freeze
+
     included do
       helper_method :step_indicator_steps
     end
@@ -14,9 +30,9 @@ module Idv
           Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS
         end
       elsif gpo_address_verification?
-        Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS_GPO
+        Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
       else
-        Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS
+        Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS
       end
     end
 

--- a/app/services/idv/flows/doc_auth_flow.rb
+++ b/app/services/idv/flows/doc_auth_flow.rb
@@ -5,22 +5,6 @@ module Idv
         welcome: Idv::Steps::WelcomeStep,
       }.freeze
 
-      STEP_INDICATOR_STEPS = [
-        { name: :getting_started },
-        { name: :verify_id },
-        { name: :verify_info },
-        { name: :verify_phone_or_address },
-        { name: :secure_account },
-      ].freeze
-
-      STEP_INDICATOR_STEPS_GPO = [
-        { name: :getting_started },
-        { name: :verify_id },
-        { name: :verify_info },
-        { name: :get_a_letter },
-        { name: :secure_account },
-      ].freeze
-
       OPTIONAL_SHOW_STEPS = {}.freeze
 
       ACTIONS = {}.freeze

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
         current_step: :verify_info,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
         current_step: :getting_started,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
         current_step: :verify_id,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
+++ b/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
         current_step: :verify_id,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
         current_step: :verify_id,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/app/views/idv/please_call/show.html.erb
+++ b/app/views/idv/please_call/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
         current_step: :secure_account,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/app/views/idv/ssn/show.html.erb
+++ b/app/views/idv/ssn/show.html.erb
@@ -8,7 +8,7 @@ locals:
 %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
         current_step: :verify_info,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
         current_step: :getting_started,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
+++ b/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
       context 'when user is not signed in' do
         let(:user) { nil }
         it 'returns doc auth flow steps and does not crash' do
-          expect(steps).to eq(Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS)
+          expect(steps).to eq(Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS)
         end
 
         context 'when idv_session method is not present' do
@@ -130,7 +130,7 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
             include Idv::StepIndicatorConcern
           end
           it 'returns doc auth flow steps and does not crash' do
-            expect(steps).to eq(Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS)
+            expect(steps).to eq(Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS)
           end
         end
 
@@ -144,7 +144,7 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
           end
 
           it 'returns doc auth flow steps and does not crash' do
-            expect(steps).to eq(Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS)
+            expect(steps).to eq(Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS)
           end
         end
       end

--- a/spec/views/idv/come_back_later/show.html.erb_spec.rb
+++ b/spec/views/idv/come_back_later/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'idv/come_back_later/show.html.erb' do
   let(:sp_name) { '🔒🌐💻' }
-  let(:step_indicator_steps) { Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS_GPO }
+  let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO }
 
   before do
     @decorated_session = instance_double(ServiceProviderSessionDecorator)

--- a/spec/views/idv/gpo/index.html.erb_spec.rb
+++ b/spec/views/idv/gpo/index.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'idv/gpo/index.html.erb' do
   let(:resend_requested) { false }
   let(:user_needs_address_otp_verification) { false }
   let(:go_back_path) { nil }
-  let(:step_indicator_steps) { Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS }
+  let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
   let(:presenter) do
     user = build_stubbed(:user, :fully_registered)
     Idv::GpoPresenter.new(user, {})

--- a/spec/views/idv/phone/new.html.erb_spec.rb
+++ b/spec/views/idv/phone/new.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'idv/phone/new.html.erb' do
   let(:gpo_letter_available) { false }
-  let(:step_indicator_steps) { Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS }
+  let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
 
   before do
     allow(view).to receive(:user_signing_up?).and_return(false)

--- a/spec/views/idv/review/new.html.erb_spec.rb
+++ b/spec/views/idv/review/new.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'idv/review/new.html.erb' do
       user = build_stubbed(:user, :fully_registered)
       allow(view).to receive(:current_user).and_return(user)
       allow(view).to receive(:step_indicator_steps).
-        and_return(Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS)
+        and_return(Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS)
       allow(view).to receive(:step_indicator_step).and_return(:secure_account)
 
       render

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe 'idv/shared/_error.html.erb' do
       end
 
       context 'step_indicator_steps helper available' do
-        let(:step_indicator_steps) { Idv::Flows::DocAuthFlow::STEP_INDICATOR_STEPS }
+        let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
         it 'renders a step indicator' do
           expect(view.content_for(:pre_flash_content)).to have_css('lg-step-indicator')
         end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10112](https://cm-jira.usa.gov/browse/LG-10112)

## 🛠 Summary of changes
Moved the the STEP_INDICATOR_STEPS constants from DocAuthFlow to StepIndicatorConcern.

## 📜 Testing Plan

Verify that the test suite passes without errors; this is a pure refactoring.