### PR TITLE
Render a 404 if a step handler is not found on update requests

### DIFF
--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -4,7 +4,7 @@ module Flow
 
     included do
       before_action :initialize_flow_state_machine
-      before_action :ensure_correct_step, only: :show
+      before_action :ensure_correct_step, only: [:show, :update]
     end
 
     attr_accessor :flow

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -27,7 +27,7 @@ module Flow
 
       increment_step_name_counts
       analytics.public_send(
-        flow.step_handler_instance(step).analytics_submitted_event || '',
+        flow.step_handler_instance(step).analytics_submitted_event,
         **result.to_h.merge(analytics_properties),
       )
 

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -4,7 +4,7 @@ module Flow
 
     included do
       before_action :initialize_flow_state_machine
-      before_action :ensure_correct_step, only: [:show, :update]
+      before_action :ensure_correct_step, only: :show
     end
 
     attr_accessor :flow
@@ -20,11 +20,14 @@ module Flow
 
     def update
       step = current_step
+
+      return render_not_found unless flow.step_handler_instance(step).present?
+
       result = flow.handle(step)
 
       increment_step_name_counts
       analytics.public_send(
-        flow.step_handler_instance(step).analytics_submitted_event,
+        flow.step_handler_instance(step).analytics_submitted_event || '',
         **result.to_h.merge(analytics_properties),
       )
 


### PR DESCRIPTION
This change makes it such that you see a 404 error if you make a post request to a step that is not allowed. Previously this would 500 as the step handler would not be found resulting in a `NoMethodError`.