### PR TITLE
Enable the v3 session encryptor by default

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -316,7 +316,7 @@ service_provider_request_ttl_hours: 24
 session_check_delay: 30
 session_check_frequency: 30
 session_encryptor_alert_enabled: false
-session_encryptor_v3_enabled: false
+session_encryptor_v3_enabled: true
 session_timeout_in_minutes: 15
 session_timeout_warning_seconds: 150
 session_total_duration_timeout_in_minutes: 720


### PR DESCRIPTION
We added the v3 session encryptor a while back. This conifg was used to migrate away from the v2 encryptor to the v3 encryptor. This commit flips it on to default not that that migration is done.

This change is in anticipation of removing the legacy session encryptor code which can safely be done 1 release cycle after this change.
