### PR TITLE
Remove Redis-specific code for ArcGIS API token caching

### DIFF
--- a/app/services/arcgis_api/geocoder.rb
+++ b/app/services/arcgis_api/geocoder.rb
@@ -99,11 +99,6 @@ module ArcgisApi
       token, expires = request_token.fetch_values('token', 'expires')
       expires_at = Time.zone.at(expires / 1000)
       Rails.cache.write(API_TOKEN_CACHE_KEY, token, expires_at: expires_at)
-      # If using a redis cache we have to manually set the expires_at. This is because we aren't
-      # using a dedicated Redis cache and instead are just using our existing Redis server with
-      # mixed usage patterns. Without this cache entries don't expire.
-      # More at https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html
-      Rails.cache.try(:redis)&.expireat(API_TOKEN_CACHE_KEY, expires_at.to_i)
       token
     end
 

--- a/spec/services/arcgis_api/geocoder_spec.rb
+++ b/spec/services/arcgis_api/geocoder_spec.rb
@@ -197,20 +197,5 @@ RSpec.describe ArcgisApi::Geocoder do
       expect(WebMock).to have_requested(:get, %r{/suggest}).
         with(headers: { 'Authorization' => 'Bearer token1' }).twice
     end
-
-    context 'when using redis as a backing store' do
-      before do |ex|
-        allow(Rails).to receive(:cache).and_return(
-          ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
-        )
-      end
-
-      it 'manually sets the expiration' do
-        stub_generate_token_response
-        subject.retrieve_token!
-        ttl = Rails.cache.redis.ttl(ArcgisApi::Geocoder::API_TOKEN_CACHE_KEY)
-        expect(ttl).to be > 0
-      end
-    end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

- [LG-9449](https://cm-jira.usa.gov/browse/LG-9449)
   - This PR removes code that may otherwise need to be updated for the story.

## 🛠 Summary of changes

- Remove manual Redis TTL usage
  - This is no longer required to workaround Rails cache behavior.
  - See the following:
    - https://github.com/18F/identity-idp/pull/8035#discussion_r1143376028
    - https://github.com/rails/rails/pull/45047

## 📜 Testing Plan

- Automated tests
