### PR TITLE
LG-9449: Implement and configure ArcGIS API token refresh job

### DIFF
--- a/app/jobs/arcgis_token_job.rb
+++ b/app/jobs/arcgis_token_job.rb
@@ -1,0 +1,31 @@
+# Refresh the ArcGIS API token
+#
+# Keeping this behavior in a job reduces the latency and probability
+# of user-facing errors related to the post office search for in-person
+# proofing.
+class ArcgisTokenJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    analytics.idv_arcgis_token_job_started
+    geocoder.retrieve_token!
+    return true
+  ensure
+    analytics.idv_arcgis_token_job_completed
+  end
+
+  private
+
+  def geocoder
+    @geocoder ||= ArcgisApi::Geocoder.new
+  end
+
+  def analytics
+    @analytics ||= Analytics.new(
+      user: AnonymousUser.new,
+      request: nil,
+      session: {},
+      sp: nil,
+    )
+  end
+end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -559,6 +559,22 @@ module AnalyticsEvents
     )
   end
 
+  # Track when ArcGIS auth token refresh job completed
+  def idv_arcgis_token_job_completed(**extra)
+    track_event(
+      'ArcgisTokenJob: Completed',
+      **extra,
+    )
+  end
+
+  # Track when ArcGIS auth token refresh job started
+  def idv_arcgis_token_job_started(**extra)
+    track_event(
+      'ArcgisTokenJob: Started',
+      **extra,
+    )
+  end
+
   # @param [String] step the step that the user was on when they clicked cancel
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user confirmed their choice to cancel going through IDV

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -48,6 +48,7 @@ arcgis_mock_fallback: true
 arcgis_api_generate_token_url: 'https://gis.gsa.gov/portal/sharing/rest/generateToken'
 arcgis_api_suggest_url: 'https://gis.gsa.gov/servernh/rest/services/GSA/USA/GeocodeServer/suggest'
 arcgis_api_find_address_candidates_url: 'https://gis.gsa.gov/servernh/rest/services/GSA/USA/GeocodeServer/findAddressCandidates'
+arcgis_api_refresh_token_job_cron: '0/55 * * * *'
 arcgis_api_refresh_token_job_enabled: false
 arcgis_api_request_timeout_seconds: 5
 asset_host: ''

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -48,6 +48,7 @@ arcgis_mock_fallback: true
 arcgis_api_generate_token_url: 'https://gis.gsa.gov/portal/sharing/rest/generateToken'
 arcgis_api_suggest_url: 'https://gis.gsa.gov/servernh/rest/services/GSA/USA/GeocodeServer/suggest'
 arcgis_api_find_address_candidates_url: 'https://gis.gsa.gov/servernh/rest/services/GSA/USA/GeocodeServer/findAddressCandidates'
+arcgis_api_refresh_token_job_enabled: false
 arcgis_api_request_timeout_seconds: 5
 asset_host: ''
 async_wait_timeout_seconds: 60
@@ -444,6 +445,7 @@ production:
   aamva_private_key: ''
   aamva_public_key: ''
   aamva_verification_url: 'https://verificationservices-cert.aamva.org:18449/dldv/2.1/online'
+  arcgis_api_refresh_token_job_enabled: true
   attribute_encryption_key:
   attribute_encryption_key_queue: '[]'
   aws_kms_regions: '["us-west-2"]'

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -3,7 +3,6 @@ cron_1h = '0 * * * *'
 cron_24h = '0 0 * * *'
 gpo_cron_24h = '0 10 * * *' # 10am UTC is 5am EST/6am EDT
 cron_1w = '0 0 * * 0'
-cron_55m = '0/55 * * * *'
 
 if defined?(Rails::Console)
   Rails.logger.info 'job_configurations: console detected, skipping schedule'
@@ -173,7 +172,7 @@ else
       arcgis_token: (if IdentityConfig.store.arcgis_api_refresh_token_job_enabled
                        {
                          class: 'ArcgisTokenJob',
-                         cron: cron_55m,
+                         cron: IdentityConfig.store.arcgis_api_refresh_token_job_cron,
                        }
                      end),
     }.compact

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -3,6 +3,7 @@ cron_1h = '0 * * * *'
 cron_24h = '0 0 * * *'
 gpo_cron_24h = '0 10 * * *' # 10am UTC is 5am EST/6am EDT
 cron_1w = '0 0 * * 0'
+cron_55m = '0/55 * * * *'
 
 if defined?(Rails::Console)
   Rails.logger.info 'job_configurations: console detected, skipping schedule'
@@ -169,7 +170,13 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.yesterday] },
       },
-    }
+      arcgis_token: (if IdentityConfig.store.arcgis_api_refresh_token_job_enabled
+                       {
+                         class: 'ArcgisTokenJob',
+                         cron: cron_55m,
+                       }
+                     end),
+    }.compact
   end
   # rubocop:enable Metrics/BlockLength
 

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -125,6 +125,7 @@ class IdentityConfig
     config.add(:arcgis_api_generate_token_url, type: :string)
     config.add(:arcgis_api_suggest_url, type: :string)
     config.add(:arcgis_api_find_address_candidates_url, type: :string)
+    config.add(:arcgis_api_refresh_token_job_cron, type: :string)
     config.add(:arcgis_api_refresh_token_job_enabled, type: :boolean)
     config.add(:arcgis_api_request_timeout_seconds, type: :integer)
     config.add(:aws_http_retry_limit, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -125,6 +125,7 @@ class IdentityConfig
     config.add(:arcgis_api_generate_token_url, type: :string)
     config.add(:arcgis_api_suggest_url, type: :string)
     config.add(:arcgis_api_find_address_candidates_url, type: :string)
+    config.add(:arcgis_api_refresh_token_job_enabled, type: :boolean)
     config.add(:arcgis_api_request_timeout_seconds, type: :integer)
     config.add(:aws_http_retry_limit, type: :integer)
     config.add(:aws_http_retry_max_delay, type: :integer)

--- a/spec/jobs/arcgis_token_job_spec.rb
+++ b/spec/jobs/arcgis_token_job_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe ArcgisTokenJob, type: :job do
+  let(:job) { described_class.new }
+  let(:geocoder) { instance_double(ArcgisApi::Geocoder) }
+  let(:analytics) { instance_double(Analytics) }
+  describe 'arcgis token job' do
+    before do
+      allow(Analytics).to receive(:new).
+        with(
+          user: an_instance_of(AnonymousUser),
+          request: nil,
+          session: {},
+          sp: nil,
+        ).and_return(analytics)
+      allow(ArcgisApi::Geocoder).to receive(:new).and_return(geocoder)
+    end
+
+    it 'fetches token and logs analytics' do
+      expect(analytics).to receive(
+        :idv_arcgis_token_job_started,
+      ).once
+      expect(geocoder).to receive(:retrieve_token!).once
+      expect(analytics).to receive(
+        :idv_arcgis_token_job_completed,
+      ).once
+      expect(job.perform).to eq(true)
+    end
+
+    context 'geocoder throws error' do
+      it 'fetches token and logs analytics' do
+        err = RuntimeError.new
+        expect(analytics).to receive(
+          :idv_arcgis_token_job_started,
+        ).once
+        expect(geocoder).to receive(:retrieve_token!).and_raise(err).once
+        expect(analytics).to receive(
+          :idv_arcgis_token_job_completed,
+        ).once
+        expect do
+          job.perform
+        end.to raise_error(err)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

- [LG-9449](https://cm-jira.usa.gov/browse/LG-9449)

## 🛠 Summary of changes

- Create scheduled job to refresh ArcGIS token regularly before it expires
  - Cron is configurable because while the [default expiration](https://developers.arcgis.com/rest/users-groups-and-items/generate-token.htm) is 1 hour, the server can use a different value.

This intentionally excludes the retry and sliding window logic that was attempted in #8662 and #8579. These features can help with availability, but they contribute enough complexity that it doesn't make sense to shoehorn them into the same story.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Deploy with job enabled
- [ ] Wait for job window to pass
- [ ] Check that analytics shows job logs
- [ ] Check that analytics shows API call from job
- [ ] Check that the PO search does not attempt to fetch a different token
- [ ] Disable job
- [ ] Wait for job window to pass
- [ ] Check that analytics does not show job logs
- [ ] Check that analytics does not show API call from job
- [ ] Re-enable job
