### PR TITLE
Adding in allow_failure for review stage to not disrupt CI checks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,6 +290,7 @@ trigger_devops:
 
 review-app:
   stage: review
+  allow_failure: true
   needs:
     - job: build-idp-image
   resource_group: $CI_ENVIRONMENT_SLUG.review-app.identitysandbox.gov


### PR DESCRIPTION
Does what it says
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->
Does what it says, adds allow_failure to the review-app stage. Tested to see when the helm chart would lock and how long it took and decided against adding the retry in to the helm upgrade command since it wouldn't help with actual failures and would just draw the failure out longer.
<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
