### PR TITLE
LG-10025: Add users:verified_but_not_in_csv rake task

### DIFF
--- a/lib/tasks/find_verified_users_not_in_csv.rake
+++ b/lib/tasks/find_verified_users_not_in_csv.rake
@@ -61,7 +61,7 @@ namespace :users do
         output << ['uuid', 'closest_timestamp', *extra_attributes]
       end
 
-      output << [uuid, closest_timestamp, *extra_attributes.map { |attr| profile.send(attr) }]
+      output << [uuid, closest_timestamp, *profile.values_at(extra_attributes)]
 
       progress.increment
     end

--- a/lib/tasks/find_verified_users_not_in_csv.rake
+++ b/lib/tasks/find_verified_users_not_in_csv.rake
@@ -1,0 +1,137 @@
+namespace :users do
+  desc 'Finds all verified users NOT present in a CSV file'
+  task verified_but_not_in_csv: :environment do |t|
+    DEFAULT_WINDOW_IN_SECONDS = 60
+    DEFAULT_EXTRA_ATTRIBUTES = 'created_at,activated_at'
+
+    if STDIN.isatty
+      puts <<~HOWTOUSE
+        This task requires CSV data be piped into it, for example:
+
+        $ bundle exec rake #{t.name} < my_csv_file.csv
+
+        Your data should have two columns, a user id (UUID) and a timestamp (formatted as something 
+        DateTime can parse). You don't need to have headers in your file.
+
+        This task will output UUIDs for _active_ users that:
+
+        - Do not appear in the CSV file
+        - Appear in the CSV file, but the associated timestamp is within a window of the 
+          Profile's creation timestamp (set WINDOW_IN_SECONDS to control this behavior,
+          the default is #{DEFAULT_WINDOW_IN_SECONDS}).
+
+      HOWTOUSE
+      exit 1
+    end
+
+    batch_size = ENV['BATCH_SIZE'] || 100
+    window_in_seconds = ENV['WINDOW_IN_SECONDS'].nil? ?
+      DEFAULT_WINDOW_IN_SECONDS :
+      ENV['WINDOW_IN_SECONDS']
+    timestamp_column_index = ENV['TIMESTAMP_COLUMN_INDEX']
+    user_id_column_index = ENV['USER_ID_COLUMN_INDEX']
+    extra_attributes = (ENV['EXTRA_ATTRIBUTES'] || DEFAULT_EXTRA_ATTRIBUTES).split(',')
+
+    timestamps_by_user_id = build_user_id_timestamp_index(
+      csv: CSV.new(STDIN),
+      user_id_column_index:,
+      timestamp_column_index:,
+    )
+
+    profiles = Profile.where(active: true).includes(:user)
+    est_batches = (profiles.length.to_f / batch_size).ceil
+    progress = ProgressBar.create(
+      format: '%t: |%B| %j%% [%a / %e]',
+      output: STDERR,
+      title: 'Profiles',
+      total: est_batches * batch_size,
+    )
+
+    output = CSV.new(STDOUT)
+    output_headers = false
+
+    find_profiles_not_in_index(
+      profiles:,
+      timestamps_by_user_id:,
+      batch_size:,
+      window_in_seconds:,
+    ) do |uuid, profile, closest_timestamp|
+      if !output_headers
+        output_headers = true
+        output << ['uuid', 'closest_timestamp', *extra_attributes]
+      end
+
+      output << [uuid, closest_timestamp, *extra_attributes.map { |attr| profile.send(attr) }]
+
+      progress.increment
+    end
+  end
+
+  def build_user_id_timestamp_index(csv:, user_id_column_index:, timestamp_column_index:)
+    timestamps_by_user_id = {}
+
+    csv.each.with_index do |row, index|
+      # We may or may not have headers in column output. Try and discover a user id and
+      # timestamp in the first couple of rows to figure out which is which.
+      if user_id_column_index.nil? && timestamp_column_index.nil?
+        user_id_column_index = discover_user_id_column_index(row)
+        timestamp_column_index = discover_timestamp_column_index(row)
+      end
+
+      if user_id_column_index.nil? || timestamp_column_index.nil?
+        if index < 2
+          next
+        else
+          raise 'Could not identify user id and timestamp columns'
+        end
+      end
+
+      timestamp = DateTime.parse(row[timestamp_column_index])
+      user_id = row[user_id_column_index]
+      timestamps_by_user_id[user_id] ||= []
+      timestamps_by_user_id[user_id] << timestamp
+    end
+
+    timestamps_by_user_id
+  end
+
+  def discover_timestamp_column_index(row)
+    candidates = row.map.with_index do |value, index|
+      index if DateTime.parse(value)
+    rescue Date::Error
+    end.filter
+
+    candidates.first
+  end
+
+  def discover_user_id_column_index(row)
+    uuid_regex = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i
+    candidates = row.map.with_index do |value, index|
+      index if uuid_regex.match(value)
+    end.filter(&:present?)
+
+    candidates.first
+  end
+
+  def find_profiles_not_in_index(
+    batch_size:,
+    profiles:,
+    timestamps_by_user_id:,
+    window_in_seconds:
+  )
+    profiles.find_in_batches(batch_size:) do |profiles|
+      profiles.each do |profile|
+        uuid = profile.user.uuid
+
+        closest_timestamp = timestamps_by_user_id[uuid]&.sort do |a, b|
+          (profile.created_at - a).abs <=> (profile.created_at - b).abs
+        end&.first
+
+        timestamp_in_window = closest_timestamp.present? &&
+                              (profile.created_at - closest_timestamp).abs <= window_in_seconds
+
+        yield uuid, profile, closest_timestamp if !timestamp_in_window
+      end
+    end
+  end
+end

--- a/lib/tasks/find_verified_users_not_in_csv.rake
+++ b/lib/tasks/find_verified_users_not_in_csv.rake
@@ -4,7 +4,7 @@ namespace :users do
     DEFAULT_WINDOW_IN_SECONDS = 60
     DEFAULT_EXTRA_ATTRIBUTES = 'created_at,activated_at'
 
-    if STDIN.isatty
+    if STDIN.tty?
       puts <<~HOWTOUSE
         This task requires CSV data be piped into it, for example:
 

--- a/lib/tasks/find_verified_users_not_in_csv.rake
+++ b/lib/tasks/find_verified_users_not_in_csv.rake
@@ -123,8 +123,8 @@ namespace :users do
       profiles.each do |profile|
         uuid = profile.user.uuid
 
-        closest_timestamp = timestamps_by_user_id[uuid]&.sort do |a, b|
-          (profile.created_at - a).abs <=> (profile.created_at - b).abs
+        closest_timestamp = timestamps_by_user_id[uuid]&.sort_by do |timestamp|
+          (profile.created_at - timestamp).abs
         end&.first
 
         timestamp_in_window = closest_timestamp.present? &&


### PR DESCRIPTION
## 🎫 Ticket

[LG-10025](https://cm-jira.usa.gov/browse/LG-10025)

## 🛠 Summary of changes

Add a new rake task, `users:verified_but_not_in_csv`. This task takes CSV input (via STDIN) that looks like:

```csv
2022-01-18 07:39:54.587,b55dda2c-b351-4a29-9baf-d61f51925223
2022-01-18 07:33:42.181,676fab3c-094d-4b71-86ee-b752cf31b3ce
2022-01-18 07:24:42.539,202baf0d-25de-4a9c-9448-47b6f37e2256
2022-01-18 07:10:36.051,e1a6fa05-6618-4ced-947b-3d102235143d
```

Then it finds all _active_ profiles where the associated user's UUID is either:

- **Not** present in the input CSV
- Present in the input CSV, but with an associated timestamp that is outside a window of time around the Profile's created_at timestamp (controllable via `ENV['WINDOW_IN_SECONDS']`)

Then it outputs CSV on STDOUT including the following for the discovered profiles:

- The user's UUID
- The timestamp found in the CSV for the UUID that is _closest to_ the Profiles' created_at (will be nil if UUID was just not present in the CSV)
- Any other profile attributes specified in `ENV['EXTRA_ATTRIBUTES']` (defaults to `created_at,activated_at`)

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Obtain a CSV file of timestamps and UUIDs
- [ ] Run `rake users:verified_but_not_in_csv < my_file.csv`             
- [ ] Thrill as data scrolls down your screen

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
