### PR TITLE
LG-9958 add allow list for IALMAX

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -260,7 +260,8 @@ class OpenidConnectAuthorizeForm
 
   def validate_privileges
     if (ial2_requested? && !ial_context.ial2_service_provider?) ||
-       (ial_context.ialmax_requested? && !Idp::Constants::ALLOWED_IALMAX_PROVIDERS.include?(client_id))
+       (ial_context.ialmax_requested? &&
+        !Idp::Constants::ALLOWED_IALMAX_PROVIDERS.include?(client_id))
       errors.add(
         :acr_values, t('openid_connect.authorization.errors.no_auth'),
         type: :no_auth

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -260,7 +260,7 @@ class OpenidConnectAuthorizeForm
 
   def validate_privileges
     if (ial2_requested? && !ial_context.ial2_service_provider?) ||
-       (ial_context.ialmax_requested? && !ial_context.ial2_service_provider?)
+       (ial_context.ialmax_requested? && !Idp::Constants::ALLOWED_IALMAX_PROVIDERS.include?(client_id))
       errors.add(
         :acr_values, t('openid_connect.authorization.errors.no_auth'),
         type: :no_auth

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -261,7 +261,7 @@ class OpenidConnectAuthorizeForm
   def validate_privileges
     if (ial2_requested? && !ial_context.ial2_service_provider?) ||
        (ial_context.ialmax_requested? &&
-        !Idp::Constants::ALLOWED_IALMAX_PROVIDERS.include?(client_id))
+        !IdentityConfig.store.allowed_ialmax_providers.include?(client_id))
       errors.add(
         :acr_values, t('openid_connect.authorization.errors.no_auth'),
         type: :no_auth

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -39,7 +39,8 @@ class SamlRequestValidator
 
   def authorized_authn_context
     if !valid_authn_context? ||
-       (ial2_context_requested? && service_provider&.ial != 2)
+       (ial2_context_requested? && service_provider&.ial != 2) ||
+       (ial_max_requested? && !Idp::Constants::ALLOWED_IALMAX_PROVIDERS.include?(service_provider&.issuer))
       errors.add(:authn_context, :unauthorized_authn_context, type: :unauthorized_authn_context)
     end
   end
@@ -68,6 +69,17 @@ class SamlRequestValidator
       end
     else
       Saml::Idp::Constants::IAL2_AUTHN_CONTEXTS.include?(authn_context)
+    end
+  end
+
+  def ial_max_requested?
+    case authn_context
+    when Array
+      authn_context.any? do |classref|
+        Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF == classref
+      end
+    else
+      Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF == classref
     end
   end
 

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -41,7 +41,7 @@ class SamlRequestValidator
     if !valid_authn_context? ||
        (ial2_context_requested? && service_provider&.ial != 2) ||
        (ial_max_requested? &&
-        !Idp::Constants::ALLOWED_IALMAX_PROVIDERS.include?(service_provider&.issuer))
+        !IdentityConfig.store.allowed_ialmax_providers.include?(service_provider&.issuer))
       errors.add(:authn_context, :unauthorized_authn_context, type: :unauthorized_authn_context)
     end
   end

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -40,7 +40,8 @@ class SamlRequestValidator
   def authorized_authn_context
     if !valid_authn_context? ||
        (ial2_context_requested? && service_provider&.ial != 2) ||
-       (ial_max_requested? && !Idp::Constants::ALLOWED_IALMAX_PROVIDERS.include?(service_provider&.issuer))
+       (ial_max_requested? &&
+        !Idp::Constants::ALLOWED_IALMAX_PROVIDERS.include?(service_provider&.issuer))
       errors.add(:authn_context, :unauthorized_authn_context, type: :unauthorized_authn_context)
     end
   end

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -74,14 +74,7 @@ class SamlRequestValidator
   end
 
   def ial_max_requested?
-    case authn_context
-    when Array
-      authn_context.any? do |classref|
-        Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF == classref
-      end
-    else
-      Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF == classref
-    end
+    Array(authn_context).include?(Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF)
   end
 
   def authorized_email_nameid_format

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -22,7 +22,7 @@ aamva_supported_jurisdictions: '["AL","AR","AZ","CO","CT","DC","DE","FL","GA","H
 aamva_verification_request_timeout: 5.0
 aamva_verification_url: https://example.org:12345/verification/url
 all_redirect_uris_cache_duration_minutes: 2
-allowed_ialmax_providers: '["https://eauth.va.gov/isam/sps/saml20sp/saml20","https://myttbaccount.ttb.gov/realms/myTTB"]'
+allowed_ialmax_providers: '[]'
 account_reset_token_valid_for_days: 1
 account_reset_wait_period_days: 1
 account_suspended_support_code: EFGHI

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -22,6 +22,7 @@ aamva_supported_jurisdictions: '["AL","AR","AZ","CO","CT","DC","DE","FL","GA","H
 aamva_verification_request_timeout: 5.0
 aamva_verification_url: https://example.org:12345/verification/url
 all_redirect_uris_cache_duration_minutes: 2
+allowed_ialmax_providers: '["https://eauth.va.gov/isam/sps/saml20sp/saml20","https://myttbaccount.ttb.gov/realms/myTTB"]'
 account_reset_token_valid_for_days: 1
 account_reset_wait_period_days: 1
 account_suspended_support_code: EFGHI

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -95,11 +95,7 @@ class IdentityConfig
     config.add(:aamva_verification_request_timeout, type: :float)
     config.add(:aamva_verification_url)
     config.add(:all_redirect_uris_cache_duration_minutes, type: :integer)
-<<<<<<< HEAD
-=======
-    config.add(:allow_otp_countdown_expired_redirect, type: :boolean)
     config.add(:allowed_ialmax_providers, type: :json)
->>>>>>> 514fb7d9e (Changelog: Internal, IALMAX, Create allowlise of service providers that can utilize the IALMax flow)
     config.add(:account_reset_token_valid_for_days, type: :integer)
     config.add(:account_reset_wait_period_days, type: :integer)
     config.add(:account_suspended_support_code, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -95,6 +95,11 @@ class IdentityConfig
     config.add(:aamva_verification_request_timeout, type: :float)
     config.add(:aamva_verification_url)
     config.add(:all_redirect_uris_cache_duration_minutes, type: :integer)
+<<<<<<< HEAD
+=======
+    config.add(:allow_otp_countdown_expired_redirect, type: :boolean)
+    config.add(:allowed_ialmax_providers, type: :json)
+>>>>>>> 514fb7d9e (Changelog: Internal, IALMAX, Create allowlise of service providers that can utilize the IALMax flow)
     config.add(:account_reset_token_valid_for_days, type: :integer)
     config.add(:account_reset_wait_period_days, type: :integer)
     config.add(:account_suspended_support_code, type: :string)

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -127,5 +127,10 @@ module Idp
     MOCK_IDV_APPLICANT_FULL_STATE_ID_JURISDICTION = 'North Dakota'
     MOCK_IDV_APPLICANT_FULL_STATE = 'Montana'
     MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_ADDRESS_STATE = 'Virginia'
+
+    ALLOWED_IALMAX_PROVIDERS = %w[
+      https://eauth.va.gov/isam/sps/saml20sp/saml20
+      https://myttbaccount.ttb.gov/realms/myTTB
+    ]
   end
 end

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -131,6 +131,6 @@ module Idp
     ALLOWED_IALMAX_PROVIDERS = %w[
       https://eauth.va.gov/isam/sps/saml20sp/saml20
       https://myttbaccount.ttb.gov/realms/myTTB
-    ]
+    ].freeze
   end
 end

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -127,10 +127,5 @@ module Idp
     MOCK_IDV_APPLICANT_FULL_STATE_ID_JURISDICTION = 'North Dakota'
     MOCK_IDV_APPLICANT_FULL_STATE = 'Montana'
     MOCK_IDV_APPLICANT_FULL_IDENTITY_DOC_ADDRESS_STATE = 'Virginia'
-
-    ALLOWED_IALMAX_PROVIDERS = %w[
-      https://eauth.va.gov/isam/sps/saml20sp/saml20
-      https://myttbaccount.ttb.gov/realms/myTTB
-    ].freeze
   end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -182,161 +182,166 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         context 'with ialmax requested' do
-          before { params[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF }
-
-          context 'account is already verified' do
-            let(:user) do
-              create(
-                :profile, :active, :verified, proofing_components: { liveness_check: true }
-              ).user
+          context 'provider is on the ialmax allow list' do
+            before do
+              params[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
+              allow(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [client_id] }
             end
 
-            it 'redirects to the redirect_uri immediately when pii is unlocked' do
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
-              user.identities.last.update!(
-                verified_attributes: %w[given_name family_name birthdate verified_at],
-              )
-              allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
-              action
+            context 'account is already verified' do
+              let(:user) do
+                create(
+                  :profile, :active, :verified, proofing_components: { liveness_check: true }
+                ).user
+              end
 
-              expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+              it 'redirects to the redirect_uri immediately when pii is unlocked' do
+                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+                allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+                action
+
+                expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+              end
+
+              it 'redirects to the password capture url when pii is locked' do
+                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+                allow(controller).to receive(:pii_requested_but_locked?).and_return(true)
+                action
+
+                expect(response).to redirect_to(capture_password_url)
+              end
+
+              it 'tracks IAL2 authentication event' do
+                stub_analytics
+                expect(@analytics).to receive(:track_event).
+                  with('OpenID Connect: authorization request',
+                       success: true,
+                       client_id: client_id,
+                       prompt: 'select_account',
+                       referer: nil,
+                       user_sp_authorized: true,
+                       allow_prompt_login: true,
+                       errors: {},
+                       unauthorized_scope: false,
+                       user_fully_authenticated: true,
+                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                       scope: 'openid profile',
+                       code_digest: kind_of(String))
+                expect(@analytics).to receive(:track_event).
+                  with(
+                    'SP redirect initiated',
+                    ial: 0,
+                    billed_ial: 2,
+                  )
+
+                IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+                allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+                action
+
+                sp_return_log = SpReturnLog.find_by(issuer: client_id)
+                expect(sp_return_log.ial).to eq(2)
+              end
             end
 
-            it 'redirects to the password capture url when pii is locked' do
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
-              user.identities.last.update!(
-                verified_attributes: %w[given_name family_name birthdate verified_at],
-              )
-              allow(controller).to receive(:pii_requested_but_locked?).and_return(true)
-              action
-
-              expect(response).to redirect_to(capture_password_url)
-            end
-
-            it 'tracks IAL2 authentication event' do
-              stub_analytics
-              expect(@analytics).to receive(:track_event).
-                with('OpenID Connect: authorization request',
-                     success: true,
-                     client_id: client_id,
-                     prompt: 'select_account',
-                     referer: nil,
-                     user_sp_authorized: true,
-                     allow_prompt_login: true,
-                     errors: {},
-                     unauthorized_scope: false,
-                     user_fully_authenticated: true,
-                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                     scope: 'openid profile',
-                     code_digest: kind_of(String))
-              expect(@analytics).to receive(:track_event).
-                with(
-                  'SP redirect initiated',
-                  ial: 0,
-                  billed_ial: 2,
+            context 'account is not already verified' do
+              it 'redirects to the redirect_uri immediately without proofing' do
+                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 2)
-              user.identities.last.update!(
-                verified_attributes: %w[given_name family_name birthdate verified_at],
-              )
-              allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
-              action
+                action
+                expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+              end
 
-              sp_return_log = SpReturnLog.find_by(issuer: client_id)
-              expect(sp_return_log.ial).to eq(2)
+              it 'tracks IAL1 authentication event' do
+                stub_analytics
+                expect(@analytics).to receive(:track_event).
+                  with('OpenID Connect: authorization request',
+                       success: true,
+                       client_id: client_id,
+                       prompt: 'select_account',
+                       referer: nil,
+                       user_sp_authorized: true,
+                       allow_prompt_login: true,
+                       errors: {},
+                       unauthorized_scope: false,
+                       user_fully_authenticated: true,
+                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                       scope: 'openid profile',
+                       code_digest: kind_of(String))
+                expect(@analytics).to receive(:track_event).
+                  with(
+                    'SP redirect initiated',
+                    ial: 0,
+                    billed_ial: 1,
+                  )
+
+                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+                action
+
+                sp_return_log = SpReturnLog.find_by(issuer: client_id)
+                expect(sp_return_log.ial).to eq(1)
+              end
             end
-          end
 
-          context 'account is not already verified' do
-            it 'redirects to the redirect_uri immediately without proofing' do
-              IdentityLinker.new(user, service_provider).link_identity(ial: 1)
-              user.identities.last.update!(
-                verified_attributes: %w[given_name family_name birthdate verified_at],
-              )
+            context 'profile is reset' do
+              let(:user) { create(:profile, :verified, :password_reset).user }
 
-              action
-              expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
-            end
-
-            it 'tracks IAL1 authentication event' do
-              stub_analytics
-              expect(@analytics).to receive(:track_event).
-                with('OpenID Connect: authorization request',
-                     success: true,
-                     client_id: client_id,
-                     prompt: 'select_account',
-                     referer: nil,
-                     user_sp_authorized: true,
-                     allow_prompt_login: true,
-                     errors: {},
-                     unauthorized_scope: false,
-                     user_fully_authenticated: true,
-                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                     scope: 'openid profile',
-                     code_digest: kind_of(String))
-              expect(@analytics).to receive(:track_event).
-                with(
-                  'SP redirect initiated',
-                  ial: 0,
-                  billed_ial: 1,
+              it 'redirects to the redirect_uri immediately without proofing' do
+                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 1)
-              user.identities.last.update!(
-                verified_attributes: %w[given_name family_name birthdate verified_at],
-              )
-              action
+                action
+                expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+              end
 
-              sp_return_log = SpReturnLog.find_by(issuer: client_id)
-              expect(sp_return_log.ial).to eq(1)
-            end
-          end
+              it 'tracks IAL1 authentication event' do
+                stub_analytics
+                expect(@analytics).to receive(:track_event).
+                  with('OpenID Connect: authorization request',
+                       success: true,
+                       client_id: client_id,
+                       prompt: 'select_account',
+                       referer: nil,
+                       user_sp_authorized: true,
+                       allow_prompt_login: true,
+                       errors: {},
+                       unauthorized_scope: false,
+                       user_fully_authenticated: true,
+                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                       scope: 'openid profile',
+                       code_digest: kind_of(String))
+                expect(@analytics).to receive(:track_event).
+                  with(
+                    'SP redirect initiated',
+                    ial: 0,
+                    billed_ial: 1,
+                  )
 
-          context 'profile is reset' do
-            let(:user) { create(:profile, :verified, :password_reset).user }
-
-            it 'redirects to the redirect_uri immediately without proofing' do
-              IdentityLinker.new(user, service_provider).link_identity(ial: 1)
-              user.identities.last.update!(
-                verified_attributes: %w[given_name family_name birthdate verified_at],
-              )
-
-              action
-              expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
-            end
-
-            it 'tracks IAL1 authentication event' do
-              stub_analytics
-              expect(@analytics).to receive(:track_event).
-                with('OpenID Connect: authorization request',
-                     success: true,
-                     client_id: client_id,
-                     prompt: 'select_account',
-                     referer: nil,
-                     user_sp_authorized: true,
-                     allow_prompt_login: true,
-                     errors: {},
-                     unauthorized_scope: false,
-                     user_fully_authenticated: true,
-                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                     scope: 'openid profile',
-                     code_digest: kind_of(String))
-              expect(@analytics).to receive(:track_event).
-                with(
-                  'SP redirect initiated',
-                  ial: 0,
-                  billed_ial: 1,
+                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
+                action
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 1)
-              user.identities.last.update!(
-                verified_attributes: %w[given_name family_name birthdate verified_at],
-              )
-              action
-
-              sp_return_log = SpReturnLog.find_by(issuer: client_id)
-              expect(sp_return_log.ial).to eq(1)
+                sp_return_log = SpReturnLog.find_by(issuer: client_id)
+                expect(sp_return_log.ial).to eq(1)
+              end
             end
           end
         end
@@ -462,6 +467,24 @@ RSpec.describe OpenidConnect::AuthorizationController do
         it 'renders the error page' do
           action
           expect(controller).to render_template('openid_connect/authorization/error')
+        end
+      end
+
+      context 'ialmax requested when service provider is not in allowlist' do
+        before do
+          params[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
+        end
+
+        it 'redirect the user' do
+          action
+
+          expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+
+          redirect_params = UriService.params(response.location)
+
+          expect(redirect_params[:error]).to eq('invalid_request')
+          expect(redirect_params[:error_description]).to be_present
+          expect(redirect_params[:state]).to eq(params[:state])
         end
       end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Sign in' do
       visit_idp_from_oidc_sp_with_ialmax
 
       expect(page).to_not have_content t('devise.registrations.start.accordion')
-      expect(page).to_not have_content "The page you were looking for doesn’t exist"
+      expect(page).to_not have_content 'The page you were looking for doesn’t exist'
     end
   end
 
@@ -848,7 +848,9 @@ RSpec.feature 'Sign in' do
   context 'oidc sp requests ialmax' do
     context 'the service_provider is on the allow list' do
       before do
-        allow(IdentityConfig.store).to receive(:allowed_ialmax_providers) { ['urn:gov:gsa:openidconnect:sp:server']}
+        allow(IdentityConfig.store).to receive(:allowed_ialmax_providers) {
+                                         ['urn:gov:gsa:openidconnect:sp:server']
+                                       }
       end
 
       it 'returns ial1 info for a non-verified user' do
@@ -887,10 +889,10 @@ RSpec.feature 'Sign in' do
 
     context 'the service provider is not on the allow list' do
       it 'returns an error' do
-        user = create(:user, :fully_registered)
+        create(:user, :fully_registered)
         visit_idp_from_oidc_sp_with_ialmax
 
-        expect(page).to have_content "The page you were looking for doesn’t exist"
+        expect(page).to have_content 'The page you were looking for doesn’t exist'
       end
     end
   end
@@ -898,7 +900,7 @@ RSpec.feature 'Sign in' do
   context 'saml sp requests ialmax' do
     context 'the service provider is on the allow list' do
       before do
-        allow(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [sp1_issuer]}
+        allow(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [sp1_issuer] }
       end
 
       it 'returns ial1 info for a non-verified user' do
@@ -908,7 +910,8 @@ RSpec.feature 'Sign in' do
             issuer: sp1_issuer,
             authn_context: [
               Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF +
+               'first_name:last_name email, ssn',
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
           },
@@ -935,7 +938,8 @@ RSpec.feature 'Sign in' do
             issuer: sp1_issuer,
             authn_context: [
               Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF +
+              'first_name:last_name email, ssn',
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
           },
@@ -956,22 +960,23 @@ RSpec.feature 'Sign in' do
 
     context 'the service provider is not on the allow list' do
       it 'redirects to an error page for ial1 user' do
-        user = create(:user, :fully_registered)
+        create(:user, :fully_registered)
         visit_saml_authn_request_url(
           overrides: {
             issuer: sp1_issuer,
             authn_context: [
               Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF +
+              'first_name:last_name email, ssn',
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
           },
         )
-        expect(page).to_not have_content "The page you were looking for doesn’t exist"
+        expect(page).to_not have_content 'The page you were looking for doesn’t exist'
       end
 
       it 'redirects to an error page for ial2 user' do
-        user = create(
+        create(
           :profile, :active, :verified,
           pii: { first_name: 'John', ssn: '111223333' }
         ).user
@@ -980,12 +985,13 @@ RSpec.feature 'Sign in' do
             issuer: sp1_issuer,
             authn_context: [
               Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF +
+                'first_name:last_name email, ssn',
               "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
             ],
           },
         )
-        expect(page).to_not have_content "The page you were looking for doesn’t exist"
+        expect(page).to_not have_content 'The page you were looking for doesn’t exist'
       end
     end
   end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -15,10 +15,19 @@ RSpec.feature 'Sign in' do
     expect(page).to_not have_content t('devise.registrations.start.accordion')
   end
 
-  scenario 'user signs in as ialmax and does not see ial2 help text' do
-    visit_idp_from_oidc_sp_with_ialmax
+  context 'service provider is on the ialmax allow list' do
+    before do
+      allow(IdentityConfig.store).to receive(:allowed_ialmax_providers) {
+        ['urn:gov:gsa:openidconnect:sp:server']
+      }
+    end
 
-    expect(page).to_not have_content t('devise.registrations.start.accordion')
+    scenario 'user signs in as ialmax and does not see ial2 help text' do
+      visit_idp_from_oidc_sp_with_ialmax
+
+      expect(page).to_not have_content t('devise.registrations.start.accordion')
+      expect(page).to_not have_content "The page you were looking for doesn’t exist"
+    end
   end
 
   scenario 'user signs in as ial2 and does see ial2 help text' do
@@ -837,91 +846,147 @@ RSpec.feature 'Sign in' do
   end
 
   context 'oidc sp requests ialmax' do
-    it 'returns ial1 info for a non-verified user' do
-      user = create(:user, :fully_registered)
-      visit_idp_from_oidc_sp_with_ialmax
-      fill_in_credentials_and_submit(user.email, user.password)
-      fill_in_code_with_last_phone_otp
-      click_submit_default
+    context 'the service_provider is on the allow list' do
+      before do
+        allow(IdentityConfig.store).to receive(:allowed_ialmax_providers) { ['urn:gov:gsa:openidconnect:sp:server']}
+      end
 
-      expect(current_path).to eq sign_up_completed_path
-      expect(page).to have_content(user.email)
+      it 'returns ial1 info for a non-verified user' do
+        user = create(:user, :fully_registered)
+        visit_idp_from_oidc_sp_with_ialmax
+        fill_in_credentials_and_submit(user.email, user.password)
+        fill_in_code_with_last_phone_otp
+        click_submit_default
 
-      click_agree_and_continue
+        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_content(user.email)
 
-      expect(current_url).to start_with('http://localhost:7654/auth/result')
+        click_agree_and_continue
+
+        expect(current_url).to start_with('http://localhost:7654/auth/result')
+      end
+
+      it 'returns ial2 info for a verified user' do
+        user = create(
+          :profile, :active, :verified,
+          pii: { first_name: 'John', ssn: '111223333' }
+        ).user
+        visit_idp_from_oidc_sp_with_ialmax
+        fill_in_credentials_and_submit(user.email, user.password)
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_content('1**-**-***3')
+
+        click_agree_and_continue
+
+        expect(current_url).to start_with('http://localhost:7654/auth/result')
+      end
     end
 
-    it 'returns ial2 info for a verified user' do
-      user = create(
-        :profile, :active, :verified,
-        pii: { first_name: 'John', ssn: '111223333' }
-      ).user
-      visit_idp_from_oidc_sp_with_ialmax
-      fill_in_credentials_and_submit(user.email, user.password)
-      fill_in_code_with_last_phone_otp
-      click_submit_default
+    context 'the service provider is not on the allow list' do
+      it 'returns an error' do
+        user = create(:user, :fully_registered)
+        visit_idp_from_oidc_sp_with_ialmax
 
-      expect(current_path).to eq sign_up_completed_path
-      expect(page).to have_content('1**-**-***3')
-
-      click_agree_and_continue
-
-      expect(current_url).to start_with('http://localhost:7654/auth/result')
+        expect(page).to have_content "The page you were looking for doesn’t exist"
+      end
     end
   end
 
   context 'saml sp requests ialmax' do
-    it 'returns ial1 info for a non-verified user' do
-      user = create(:user, :fully_registered)
-      visit_saml_authn_request_url(
-        overrides: {
-          issuer: sp1_issuer,
-          authn_context: [
-            Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-          ],
-        },
-      )
-      fill_in_credentials_and_submit(user.email, user.password)
-      fill_in_code_with_last_phone_otp
-      click_submit_default_twice
+    context 'the service provider is on the allow list' do
+      before do
+        allow(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [sp1_issuer]}
+      end
 
-      expect(current_path).to eq sign_up_completed_path
-      expect(page).to have_content(user.email)
+      it 'returns ial1 info for a non-verified user' do
+        user = create(:user, :fully_registered)
+        visit_saml_authn_request_url(
+          overrides: {
+            issuer: sp1_issuer,
+            authn_context: [
+              Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+        )
+        fill_in_credentials_and_submit(user.email, user.password)
+        fill_in_code_with_last_phone_otp
+        click_submit_default_twice
 
-      click_agree_and_continue
+        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_content(user.email)
 
-      expect(current_url).to eq complete_saml_url
+        click_agree_and_continue
+
+        expect(current_url).to eq complete_saml_url
+      end
+
+      it 'returns ial2 info for a verified user' do
+        user = create(
+          :profile, :active, :verified,
+          pii: { first_name: 'John', ssn: '111223333' }
+        ).user
+        visit_saml_authn_request_url(
+          overrides: {
+            issuer: sp1_issuer,
+            authn_context: [
+              Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+        )
+        fill_in_credentials_and_submit(user.email, user.password)
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+        click_submit_default
+
+        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_content('1**-**-***3')
+
+        click_agree_and_continue
+
+        expect(current_url).to eq complete_saml_url
+      end
     end
 
-    it 'returns ial2 info for a verified user' do
-      user = create(
-        :profile, :active, :verified,
-        pii: { first_name: 'John', ssn: '111223333' }
-      ).user
-      visit_saml_authn_request_url(
-        overrides: {
-          issuer: sp1_issuer,
-          authn_context: [
-            Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-          ],
-        },
-      )
-      fill_in_credentials_and_submit(user.email, user.password)
-      fill_in_code_with_last_phone_otp
-      click_submit_default
-      click_submit_default
+    context 'the service provider is not on the allow list' do
+      it 'redirects to an error page for ial1 user' do
+        user = create(:user, :fully_registered)
+        visit_saml_authn_request_url(
+          overrides: {
+            issuer: sp1_issuer,
+            authn_context: [
+              Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+        )
+        expect(page).to_not have_content "The page you were looking for doesn’t exist"
+      end
 
-      expect(current_path).to eq sign_up_completed_path
-      expect(page).to have_content('1**-**-***3')
-
-      click_agree_and_continue
-
-      expect(current_url).to eq complete_saml_url
+      it 'redirects to an error page for ial2 user' do
+        user = create(
+          :profile, :active, :verified,
+          pii: { first_name: 'John', ssn: '111223333' }
+        ).user
+        visit_saml_authn_request_url(
+          overrides: {
+            issuer: sp1_issuer,
+            authn_context: [
+              Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+              "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+            ],
+          },
+        )
+        expect(page).to_not have_content "The page you were looking for doesn’t exist"
+      end
     end
   end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -139,9 +139,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
           expect(valid?).to eq true
           expect(form.errors).to be_blank
         end
-
       end
-
     end
 
     context 'with aal but not ial requested via acr_values' do

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
       context 'with a service provider on the allow list' do
         before do
-          expect(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [client_id]}
+          expect(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [client_id] }
         end
 
         it 'has no errors' do

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -119,6 +119,31 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
 
+    context 'with ialmax requested' do
+      let(:acr_values) {Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF }
+
+      context 'with a service provider not in the allow list' do
+        it 'has errors' do
+          expect(valid?).to eq false
+          expect(form.errors[:acr_values]).
+            to include(t('openid_connect.authorization.errors.no_auth'))
+        end
+      end
+
+      context 'with a service provider on the allow list' do
+        before do
+          stub_const('Idp::Constants::ALLOWED_IALMAX_PROVIDERS', [client_id])
+        end
+
+        it 'has no errors' do
+          expect(valid?).to eq true
+          expect(form.errors).to be_blank
+        end
+
+      end
+
+    end
+
     context 'with aal but not ial requested via acr_values' do
       let(:acr_values) { Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF }
       it 'has errors' do

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
     end
 
     context 'with ialmax requested' do
-      let(:acr_values) {Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF }
+      let(:acr_values) { Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF }
 
       context 'with a service provider not in the allow list' do
         it 'has errors' do
@@ -132,7 +132,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
       context 'with a service provider on the allow list' do
         before do
-          stub_const('Idp::Constants::ALLOWED_IALMAX_PROVIDERS', [client_id])
+          expect(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [client_id]}
         end
 
         it 'has no errors' do

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SamlRequestValidator do
       context 'ialmax authncontext and ialmax provider' do
         let(:authn_context) { [Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF] }
         before do
-          expect(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [sp.issuer]}
+          expect(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [sp.issuer] }
         end
 
         it 'returns FormResponse with success: true' do

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -2,52 +2,58 @@ require 'rails_helper'
 
 RSpec.describe SamlRequestValidator do
   describe '#call' do
+    let(:sp) { ServiceProvider.find_by(issuer: 'http://localhost:3000') }
+    let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT }
+    let(:authn_context) { [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF] }
+    let(:comparison) { 'exact'}
+    let(:extra) do
+      {
+        authn_context: authn_context,
+        service_provider: sp&.issuer,
+        nameid_format: name_id_format,
+        authn_context_comparison: comparison,
+      }
+    end
+
+    let(:response) do
+      SamlRequestValidator.new.call(
+        service_provider: sp,
+        authn_context: authn_context,
+        nameid_format: name_id_format,
+      )
+    end
+
     context 'valid authn context and sp and authorized nameID format' do
       it 'returns FormResponse with success: true' do
-        sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-        authn_context = [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF]
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
-
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
-
         expect(response.to_h).to include(
           success: true,
           errors: {},
           **extra,
         )
       end
+
+      context 'ialmax authncontext and ialmax provider' do
+        let(:authn_context) { [Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF] }
+        before do
+          stub_const('Idp::Constants::ALLOWED_IALMAX_PROVIDERS', [sp.issuer])
+        end
+
+        it 'returns FormResponse with success: true' do
+          expect(response.to_h).to include(
+            success: true,
+            errors: {},
+            **extra,
+          )
+        end
+      end
     end
 
     context 'valid authn context and invalid sp and authorized nameID format' do
+      let(:sp) { ServiceProvider.find_by(issuer: 'foo') }
       it 'returns FormResponse with success: false' do
-        sp = ServiceProvider.find_by(issuer: 'foo')
-        authn_context = [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF]
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp&.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
         errors = {
           service_provider: [t('errors.messages.unauthorized_service_provider')],
         }
-
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
 
         expect(response.to_h).to include(
           success: false,
@@ -59,25 +65,11 @@ RSpec.describe SamlRequestValidator do
     end
 
     context 'valid authn context and unauthorized nameid format' do
+      let(:name_id_format) {  Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL }
       it 'returns FormResponse with success: false' do
-        sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-        authn_context = [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF]
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
         errors = {
           nameid_format: [t('errors.messages.unauthorized_nameid_format')],
         }
-
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
 
         expect(response.to_h).to include(
           success: false,
@@ -89,24 +81,10 @@ RSpec.describe SamlRequestValidator do
     end
 
     context 'valid authn context and authorized email nameid format for SP' do
+      let(:sp) { ServiceProvider.find_by(issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata') }
+      let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL }
+      before { sp.update!(email_nameid_format_allowed: true) }
       it 'returns FormResponse with success: true' do
-        sp = ServiceProvider.find_by(issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata')
-        sp.update!(email_nameid_format_allowed: true)
-        authn_context = [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF]
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
-
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
-
         expect(response.to_h).to include(
           success: true,
           errors: {},
@@ -114,47 +92,24 @@ RSpec.describe SamlRequestValidator do
         )
       end
 
-      it 'returns FormResponse with success: true for ial2 on ial:2 sp' do
-        sp = ServiceProvider.find_by(issuer: 'https://rp1.serviceprovider.com/auth/saml/metadata')
-        sp.update!(email_nameid_format_allowed: true)
-        sp.ial = 2
-        authn_context = [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF]
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
-
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
-
-        expect(response.to_h).to include(
-          success: true,
-          errors: {},
-          **extra,
-        )
+      context 'ial2 authn context and ial2 sp' do
+        let(:authn_context) { [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF] }
+        before { sp.update!(ial: 2) }
+        it 'returns FormResponse with success: true for ial2 on ial:2 sp' do
+          expect(response.to_h).to include(
+            success: true,
+            errors: {},
+            **extra,
+          )
+        end
       end
     end
 
     context 'unsupported authn context with step up and valid sp and nameID format' do
-      it 'returns a FormResponse with success: true for Comparison=minimum' do
-        Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
-          sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-          authn_context = [password_context]
-          comparison = 'minimum'
-          name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-          extra = {
-            authn_context: authn_context,
-            service_provider: sp.issuer,
-            nameid_format: name_id_format,
-            authn_context_comparison: 'minimum',
-          }
-
+      Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
+        let(:authn_context) { [password_context] }
+        let(:comparison) { 'minimum' }
+        it 'returns a FormResponse with success: true for Comparison=minimum' do
           response = SamlRequestValidator.new.call(
             service_provider: sp,
             authn_context: authn_context,
@@ -170,19 +125,10 @@ RSpec.describe SamlRequestValidator do
         end
       end
 
-      it 'returns a FormResponse with success: true for Comparison=better' do
-        Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
-          sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-          authn_context = [password_context]
-          comparison = 'better'
-          name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-          extra = {
-            authn_context: authn_context,
-            service_provider: sp.issuer,
-            nameid_format: name_id_format,
-            authn_context_comparison: 'better',
-          }
-
+      Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
+        let(:authn_context) { [password_context] }
+        let(:comparison) { 'better' }
+        it 'returns a FormResponse with success: true for Comparison=better' do
           response = SamlRequestValidator.new.call(
             service_provider: sp,
             authn_context: authn_context,
@@ -200,26 +146,12 @@ RSpec.describe SamlRequestValidator do
     end
 
     context 'unsupported authn context without step up and valid sp and nameID format' do
-      it 'returns FormResponse with success: false for unknown authn context' do
-        Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
-          sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-          authn_context = [password_context]
-          name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-          extra = {
-            authn_context: authn_context,
-            service_provider: sp.issuer,
-            nameid_format: name_id_format,
-            authn_context_comparison: 'exact',
-          }
+      Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
+        let(:authn_context) { [password_context] }
+        it 'returns FormResponse with success: false for unknown authn context' do
           errors = {
             authn_context: [t('errors.messages.unauthorized_authn_context')],
           }
-
-          response = SamlRequestValidator.new.call(
-            service_provider: sp,
-            authn_context: authn_context,
-            nameid_format: name_id_format,
-          )
 
           expect(response.to_h).to include(
             success: false,
@@ -232,85 +164,66 @@ RSpec.describe SamlRequestValidator do
     end
 
     context 'invalid authn context and valid sp and authorized nameID format' do
-      it 'returns FormResponse with success: false for unknown authn context' do
-        sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-        authn_context = ['IAL1']
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
-        errors = {
-          authn_context: [t('errors.messages.unauthorized_authn_context')],
-        }
+      context 'unknown auth context' do
+        let(:authn_context) { ['IAL1'] }
+        it 'returns FormResponse with success: false' do
+          errors = {
+            authn_context: [t('errors.messages.unauthorized_authn_context')],
+          }
 
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
-
-        expect(response.to_h).to include(
-          success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
-        )
+          expect(response.to_h).to include(
+            success: false,
+            errors: errors,
+            error_details: hash_including(*errors.keys),
+            **extra,
+          )
+        end
       end
 
-      it 'returns FormResponse with success: false for ial2 on an ial:1 sp' do
-        sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-        sp.ial = 1
-        authn_context = [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF]
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
-        errors = {
-          authn_context: [t('errors.messages.unauthorized_authn_context')],
-        }
+      context 'authn context is ial2 when sp is ial 1' do
+        let(:authn_context) { [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF] }
 
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
+        it 'returns FormResponse with success: false' do
+          errors = {
+            authn_context: [t('errors.messages.unauthorized_authn_context')],
+          }
 
-        expect(response.to_h).to include(
-          success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
-        )
+          expect(response.to_h).to include(
+            success: false,
+            errors: errors,
+            error_details: hash_including(*errors.keys),
+            **extra,
+          )
+        end
+      end
+
+      context 'authn context is ialmax when sp is not included' do
+        let(:authn_context) { [Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF] }
+
+        it 'returns FormResponse with success: false' do
+          errors = {
+            authn_context: [t('errors.messages.unauthorized_authn_context')],
+          }
+
+          expect(response.to_h).to include(
+            success: false,
+            errors: errors,
+            error_details: hash_including(*errors.keys),
+            **extra,
+          )
+        end
       end
     end
 
     context 'invalid authn context and invalid sp and authorized nameID format' do
+      let(:sp) { ServiceProvider.find_by(issuer: 'foo') }
+      let(:authn_context) { ['IAL1'] }
+
       it 'returns FormResponse with success: false' do
-        sp = ServiceProvider.find_by(issuer: 'foo')
-        authn_context = ['IAL1']
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp&.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
         errors = {
           authn_context: [t('errors.messages.unauthorized_authn_context')],
           service_provider: [t('errors.messages.unauthorized_service_provider')],
         }
-
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
 
         expect(response.to_h).to include(
           success: false,
@@ -322,25 +235,11 @@ RSpec.describe SamlRequestValidator do
     end
 
     context 'valid authn context and sp and unauthorized nameID format' do
+      let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL }
       it 'returns FormResponse with success: false with unauthorized nameid format' do
-        sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-        authn_context = [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF]
-        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp.issuer,
-          nameid_format: name_id_format,
-          authn_context_comparison: 'exact',
-        }
         errors = {
           nameid_format: [t('errors.messages.unauthorized_nameid_format')],
         }
-
-        response = SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: name_id_format,
-        )
 
         expect(response.to_h).to include(
           success: false,

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SamlRequestValidator do
     let(:sp) { ServiceProvider.find_by(issuer: 'http://localhost:3000') }
     let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT }
     let(:authn_context) { [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF] }
-    let(:comparison) { 'exact'}
+    let(:comparison) { 'exact' }
     let(:extra) do
       {
         authn_context: authn_context,
@@ -65,7 +65,7 @@ RSpec.describe SamlRequestValidator do
     end
 
     context 'valid authn context and unauthorized nameid format' do
-      let(:name_id_format) {  Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL }
+      let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL }
       it 'returns FormResponse with success: false' do
         errors = {
           nameid_format: [t('errors.messages.unauthorized_nameid_format')],

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SamlRequestValidator do
       context 'ialmax authncontext and ialmax provider' do
         let(:authn_context) { [Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF] }
         before do
-          stub_const('Idp::Constants::ALLOWED_IALMAX_PROVIDERS', [sp.issuer])
+          expect(IdentityConfig.store).to receive(:allowed_ialmax_providers) { [sp.issuer]}
         end
 
         it 'returns FormResponse with success: true' do


### PR DESCRIPTION
## 🎫 Ticket
[add allow list config for IALMAX](https://cm-jira.usa.gov/browse/LG-9958)


## 🛠 Summary of changes
As a first step to deprecating IALMAX, we would like to constrain IALMAX to existing partners/integrations. This change introduces an allowlist of issuers for IALMAX, and if a partner is not on the allowlist, they will be unable to utilize the IALMAX flow.

