### PR TITLE
LG-9449: Configure ArcGIS token job to respect mock geocoder setting

### DIFF
--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -26,8 +26,7 @@ module Idv
       end
 
       def geocoder
-        @geocoder ||= IdentityConfig.store.arcgis_mock_fallback ?
-          ArcgisApi::Mock::Geocoder.new : ArcgisApi::Geocoder.new
+        @geocoder ||= ArcgisApi::GeocoderFactory.new.create
       end
 
       def report_errors(error)

--- a/app/jobs/arcgis_token_job.rb
+++ b/app/jobs/arcgis_token_job.rb
@@ -17,7 +17,7 @@ class ArcgisTokenJob < ApplicationJob
   private
 
   def geocoder
-    @geocoder ||= ArcgisApi::Geocoder.new
+    @geocoder ||= ArcgisApi::GeocoderFactory.new.create
   end
 
   def analytics

--- a/app/services/arcgis_api/geocoder_factory.rb
+++ b/app/services/arcgis_api/geocoder_factory.rb
@@ -1,0 +1,11 @@
+module ArcgisApi
+  class GeocoderFactory
+    def create
+      if IdentityConfig.store.arcgis_mock_fallback
+        ArcgisApi::Mock::Geocoder.new
+      else
+        ArcgisApi::Geocoder.new
+      end
+    end
+  end
+end

--- a/spec/jobs/arcgis_token_job_spec.rb
+++ b/spec/jobs/arcgis_token_job_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe ArcgisTokenJob, type: :job do
   let(:job) { described_class.new }
   let(:geocoder) { instance_double(ArcgisApi::Geocoder) }
+  let(:geocoder_factory) { instance_double(ArcgisApi::GeocoderFactory) }
   let(:analytics) { instance_double(Analytics) }
   describe 'arcgis token job' do
     before do
@@ -13,7 +14,8 @@ RSpec.describe ArcgisTokenJob, type: :job do
           session: {},
           sp: nil,
         ).and_return(analytics)
-      allow(ArcgisApi::Geocoder).to receive(:new).and_return(geocoder)
+      allow(ArcgisApi::GeocoderFactory).to receive(:new).and_return(geocoder_factory)
+      allow(geocoder_factory).to receive(:create).and_return(geocoder)
     end
 
     it 'fetches token and logs analytics' do

--- a/spec/services/arcgis_api/geocoder_factory_spec.rb
+++ b/spec/services/arcgis_api/geocoder_factory_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe ArcgisApi::GeocoderFactory do
+  subject(:geocoder_factory) { described_class.new }
+  context 'mock is enabled' do
+    it 'returns a mock geocoder' do
+      expect(IdentityConfig.store).to receive(:arcgis_mock_fallback).
+        and_return(true)
+      expect(geocoder_factory.create).to be_instance_of(ArcgisApi::Mock::Geocoder)
+    end
+  end
+
+  context 'mock is disabled' do
+    it 'returns a geocoder' do
+      expect(IdentityConfig.store).to receive(:arcgis_mock_fallback).
+        and_return(false)
+      expect(geocoder_factory.create).to be_instance_of(ArcgisApi::Geocoder)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

- [LG-9449](https://cm-jira.usa.gov/browse/LG-9449)

## 🛠 Summary of changes

- Update the ArcGIS token job to respect the mock geocoder setting

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Configure environment to use the mock geocoder
- [ ] Verify that no calls are made to ArcGIS and that no related errors occur 
