### PR TITLE
use transaction_with_timeout method

### DIFF
--- a/app/jobs/reports/sp_issuer_user_counts_report.rb
+++ b/app/jobs/reports/sp_issuer_user_counts_report.rb
@@ -9,7 +9,9 @@ module Reports
         emails = report_hash['emails']
         issuer = report_hash['issuer']
 
-        user_counts = Db::Identity::SpUserCounts.with_issuer(issuer)
+        user_counts = transaction_with_timeout do
+          Db::Identity::SpUserCounts.with_issuer(issuer)
+        end
 
         emails.each do |email|
           ReportMailer.sp_issuer_user_counts_report(


### PR DESCRIPTION
## 🎫 Ticket

Follow up from LG-9956 (it didn't work because I was missing `transaction_with_timeout`) 

[Previous PR](https://github.com/18F/identity-idp/pull/8596)

[See error in NewRelic](https://onenr.io/0VjY6Y120Q0)

[Resolution thread in slack ](https://gsa-tts.slack.com/archives/C05E50XNN8Z/p1687795636353019)

