### PR TITLE
Clean up feature flag for second factor reauthentication

### DIFF
--- a/app/controllers/accounts/personal_keys_controller.rb
+++ b/app/controllers/accounts/personal_keys_controller.rb
@@ -6,7 +6,7 @@ module Accounts
 
     before_action :confirm_two_factor_authenticated
     before_action :prompt_for_password_if_pii_locked
-    before_action :confirm_recently_authenticated
+    before_action :confirm_recently_authenticated_2fa
 
     def new
       analytics.profile_personal_key_visit

--- a/app/controllers/concerns/reauthentication_required_concern.rb
+++ b/app/controllers/concerns/reauthentication_required_concern.rb
@@ -1,18 +1,6 @@
 module ReauthenticationRequiredConcern
   include MfaSetupConcern
 
-  def confirm_recently_authenticated
-    if IdentityConfig.store.reauthentication_for_second_factor_management_enabled
-      confirm_recently_authenticated_2fa
-    else
-      @reauthn = reauthn?
-      return unless user_signed_in?
-      return if recently_authenticated?
-
-      prompt_for_current_password
-    end
-  end
-
   def confirm_recently_authenticated_2fa
     @reauthn = reauthn?
     return unless user_fully_authenticated?

--- a/app/controllers/concerns/reauthentication_required_concern.rb
+++ b/app/controllers/concerns/reauthentication_required_concern.rb
@@ -26,29 +26,11 @@ module ReauthenticationRequiredConcern
     authn_at > Time.zone.now - IdentityConfig.store.reauthn_window
   end
 
-  def prompt_for_current_password
-    store_location(request.url)
-    user_session[:context] = 'reauthentication'
-    user_session[:factor_to_change] = factor_from_controller_name
-    user_session[:current_password_required] = true
-    redirect_to user_password_confirm_url
-  end
-
   def prompt_for_second_factor
     store_location(request.url)
     user_session[:context] = 'reauthentication'
 
     redirect_to login_two_factor_options_path(reauthn: true)
-  end
-
-  def factor_from_controller_name
-    {
-      # see LG-5701, translate these
-      'emails' => 'email',
-      'passwords' => 'password',
-      'phones' => 'phone',
-      'personal_keys' => 'personal key',
-    }[controller_name]
   end
 
   def store_location(url)

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -14,11 +14,7 @@ module RememberDeviceConcern
   end
 
   def check_remember_device_preference
-    if IdentityConfig.store.reauthentication_for_second_factor_management_enabled
-      return unless UserSessionContext.authentication_context?(context)
-    else
-      return unless UserSessionContext.authentication_or_reauthentication_context?(context)
-    end
+    return unless UserSessionContext.authentication_context?(context)
     return if remember_device_cookie.nil?
     return unless remember_device_cookie.valid_for_user?(
       user: current_user,

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -11,9 +11,7 @@ module Users
     before_action :set_backup_code_setup_presenter
     before_action :apply_secure_headers_override
     before_action :authorize_backup_code_disable, only: [:delete]
-    before_action :confirm_recently_authenticated_2fa, except: [:reminder], if: -> do
-      IdentityConfig.store.reauthentication_for_second_factor_management_enabled
-    end
+    before_action :confirm_recently_authenticated_2fa, except: [:reminder]
 
     helper_method :in_multi_mfa_selection_flow?
 

--- a/app/controllers/users/edit_phone_controller.rb
+++ b/app/controllers/users/edit_phone_controller.rb
@@ -6,7 +6,7 @@ module Users
     before_action :confirm_two_factor_authenticated
     before_action :confirm_user_can_edit_phone
     before_action :confirm_user_can_remove_phone, only: %i[destroy]
-    before_action :confirm_recently_authenticated
+    before_action :confirm_recently_authenticated_2fa
 
     def edit
       analytics.phone_change_viewed

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -6,7 +6,7 @@ module Users
     before_action :authorize_user_to_edit_email, except: %i[add show verify resend]
     before_action :check_max_emails_per_account, only: %i[show add]
     before_action :retain_confirmed_emails, only: %i[delete]
-    before_action :confirm_recently_authenticated
+    before_action :confirm_recently_authenticated_2fa
 
     def show
       @add_user_email_form = AddUserEmailForm.new

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -4,7 +4,7 @@ module Users
 
     before_action :confirm_two_factor_authenticated
     before_action :capture_password_if_pii_requested_but_locked
-    before_action :confirm_recently_authenticated
+    before_action :confirm_recently_authenticated_2fa
 
     def edit
       @update_user_password_form = UpdateUserPasswordForm.new(current_user)

--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -9,7 +9,7 @@ module Users
     before_action :redirect_if_phone_vendor_outage
     before_action :check_max_phone_numbers_per_account, only: %i[add create]
     before_action :allow_csp_recaptcha_src, if: :recaptcha_enabled?
-    before_action :confirm_recently_authenticated
+    before_action :confirm_recently_authenticated_2fa
 
     def add
       user_session[:phone_id] = nil

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -12,9 +12,7 @@ module Users
     before_action :authorize_piv_cac_disable, only: :delete
     before_action :set_piv_cac_setup_csp_form_action_uris, only: :new
     before_action :cap_piv_cac_count, only: %i[new submit_new_piv_cac]
-    before_action :confirm_recently_authenticated_2fa, if: -> do
-      IdentityConfig.store.reauthentication_for_second_factor_management_enabled
-    end
+    before_action :confirm_recently_authenticated_2fa
 
     helper_method :in_multi_mfa_selection_flow?
 

--- a/app/controllers/users/piv_cac_setup_controller.rb
+++ b/app/controllers/users/piv_cac_setup_controller.rb
@@ -4,7 +4,7 @@ module Users
     include ReauthenticationRequiredConcern
 
     before_action :confirm_two_factor_authenticated
-    before_action :confirm_recently_authenticated
+    before_action :confirm_recently_authenticated_2fa
 
     def delete; end
 

--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -6,9 +6,7 @@ module Users
     include ReauthenticationRequiredConcern
 
     before_action :confirm_two_factor_authenticated
-    before_action :confirm_recently_authenticated_2fa, if: -> do
-      IdentityConfig.store.reauthentication_for_second_factor_management_enabled
-    end
+    before_action :confirm_recently_authenticated_2fa
     before_action :apply_secure_headers_override, only: :success
     before_action :set_piv_cac_setup_csp_form_action_uris, only: :prompt
 

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -10,9 +10,7 @@ module Users
     before_action :set_totp_setup_presenter
     before_action :apply_secure_headers_override
     before_action :cap_auth_app_count, only: %i[new confirm]
-    before_action :confirm_recently_authenticated_2fa, if: -> do
-      IdentityConfig.store.reauthentication_for_second_factor_management_enabled
-    end
+    before_action :confirm_recently_authenticated_2fa
 
     helper_method :in_multi_mfa_selection_flow?
 

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -9,9 +9,7 @@ module Users
     before_action :confirm_user_authenticated_for_2fa_setup
     before_action :apply_secure_headers_override
     before_action :set_webauthn_setup_presenter
-    before_action :confirm_recently_authenticated_2fa, if: -> do
-      IdentityConfig.store.reauthentication_for_second_factor_management_enabled
-    end
+    before_action :confirm_recently_authenticated_2fa
 
     helper_method :in_multi_mfa_selection_flow?
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -252,7 +252,6 @@ rack_mini_profiler: false
 rack_timeout_service_timeout_seconds: 15
 rails_mailer_previews_enabled: false
 reauthn_window: 120
-reauthentication_for_second_factor_management_enabled: true
 recaptcha_enterprise_api_key: ''
 recaptcha_enterprise_project_id: ''
 recaptcha_site_key_v2: ''
@@ -463,7 +462,6 @@ production:
   phone_recaptcha_mock_validator: false
   piv_cac_verify_token_secret:
   session_encryptor_alert_enabled: true
-  reauthentication_for_second_factor_management_enabled: false
   recurring_jobs_disabled_names: "[]"
   redis_throttle_url: redis://redis.login.gov.internal:6379/1
   redis_url: redis://redis.login.gov.internal:6379

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -357,7 +357,6 @@ class IdentityConfig
     config.add(:rack_timeout_service_timeout_seconds, type: :integer)
     config.add(:rails_mailer_previews_enabled, type: :boolean)
     config.add(:reauthn_window, type: :integer)
-    config.add(:reauthentication_for_second_factor_management_enabled, type: :boolean)
     config.add(:recaptcha_enterprise_project_id, type: :string)
     config.add(:recaptcha_enterprise_api_key, type: :string)
     config.add(:recaptcha_site_key_v2, type: :string)

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Accounts::PersonalKeysController do
     it 'require recent reauthn' do
       expect(subject).to have_actions(
         :before,
-        :confirm_recently_authenticated,
+        :confirm_recently_authenticated_2fa,
         :prompt_for_password_if_pii_locked,
       )
     end

--- a/spec/controllers/concerns/reauthentication_required_concern_spec.rb
+++ b/spec/controllers/concerns/reauthentication_required_concern_spec.rb
@@ -3,51 +3,6 @@ require 'rails_helper'
 RSpec.describe ReauthenticationRequiredConcern, type: :controller do
   let(:user) { create(:user, :fully_registered, email: 'old_email@example.com') }
 
-  describe '#confirm_recently_authenticated' do
-    controller ApplicationController do
-      include ReauthenticationRequiredConcern
-
-      before_action :confirm_recently_authenticated
-
-      def index
-        render plain: 'Hello'
-      end
-    end
-
-    before(:each) do
-      stub_sign_in(user)
-      allow(IdentityConfig.store).to receive(
-        :reauthentication_for_second_factor_management_enabled,
-      ).and_return(false)
-    end
-
-    context 'recently authenticated' do
-      it 'allows action' do
-        get :index
-
-        expect(response.body).to eq 'Hello'
-      end
-    end
-
-    context 'authenticated outside the authn window' do
-      before do
-        controller.user_session[:authn_at] -= IdentityConfig.store.reauthn_window
-      end
-
-      it 'redirects to password confirmation' do
-        get :index
-
-        expect(response).to redirect_to user_password_confirm_url
-      end
-
-      it 'sets context to authentication' do
-        get :index
-
-        expect(controller.user_session[:context]).to eq 'reauthentication'
-      end
-    end
-  end
-
   describe '#confirm_recently_authenticated_2fa' do
     controller ApplicationController do
       include ReauthenticationRequiredConcern


### PR DESCRIPTION
## 🛠 Summary of changes

This was added in #8037 and has been enabled in the major environments for [awhile](https://gsa-tts.slack.com/archives/C0NGESUN5/p1686322921595399?thread_ts=1686322782.331309&cid=C0NGESUN5), so this PR enables it by default and removes the configuration for it.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
