### PR TITLE
fix `_html` on keys

### DIFF
--- a/app/views/users/backup_code_setup/confirm_backup_codes.html.erb
+++ b/app/views/users/backup_code_setup/confirm_backup_codes.html.erb
@@ -27,7 +27,7 @@
           big: true,
           full_width: true,
           outline: true,
-        ).with_content(t('two_factor_authentication.backup_codes.new_backup_codes')) %> 
+        ).with_content(t('two_factor_authentication.backup_codes.new_backup_codes_html')) %> 
   </div>
 </div>
 

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -24,7 +24,7 @@ en:
       instructions: If you don’t have access to another device, keep your backup codes
         safe. If you lose your backup codes, you won’t be able to sign into
         %{app_name}.
-      new_backup_codes: I need new backup&nbsp;codes
+      new_backup_codes_html: I need new backup&nbsp;codes
       saved_backup_codes: I’ve saved my backup codes
       warning_html: <strong>You’ve only set up backup codes on your account.
         </strong>If you have access to another device, such as a phone, protect

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -24,7 +24,7 @@ es:
       instructions: Si no tiene acceso a otro dispositivo, guarde bien sus códigos de
         respaldo. No podrá iniciar sesión en %{app_name} si pierde sus códigos
         de respaldo.
-      new_backup_codes: Necesito nuevos códigos de respaldo
+      new_backup_codes_html: Necesito nuevos códigos de respaldo
       saved_backup_codes: Ya guardé mis códigos de respaldo
       warning_html: <strong>Solo ha configurado códigos de respaldo en su cuenta.
         </strong>Si tiene acceso a otro dispositivo, como un celular, proteja su

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -25,7 +25,7 @@ fr:
       instructions: Si vous n’avez pas accès à un autre appareil, conservez vos codes
         de sauvegarde en lieu sûr. Si vous perdez vos codes de sauvegarde, vous
         ne pourrez plus vous connecter à %{app_name}.
-      new_backup_codes: J’ai besoin de nouveaux codes de sauvegarde
+      new_backup_codes_html: J’ai besoin de nouveaux codes de sauvegarde
       saved_backup_codes: J’ai sauvegardé mes codes de sauvegarde
       warning_html: <strong>Vous n’avez configuré que des codes de sauvegarde sur
         votre compte. </strong>Si vous avez accès à un autre appareil, tel qu’un

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -168,7 +168,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
     end
 
     it 'regenerates backup codes path if a user clicks that they need new backup codes' do
-      click_link text: 'I need new backup codes'
+      click_link strip_tags(t('two_factor_authentication.backup_codes.new_backup_codes_html'))
       expect(page).to have_current_path backup_code_regenerate_path
     end
   end

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -168,7 +168,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
     end
 
     it 'regenerates backup codes path if a user clicks that they need new backup codes' do
-      click_link t('two_factor_authentication.backup_codes.new_backup_codes')
+      click_link t('two_factor_authentication.backup_codes.new_backup_codes_html')
       expect(page).to have_current_path backup_code_regenerate_path
     end
   end

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -168,7 +168,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
     end
 
     it 'regenerates backup codes path if a user clicks that they need new backup codes' do
-      click_link t('two_factor_authentication.backup_codes.new_backup_codes_html')
+      click_link text: 'I need new backup codes'
       expect(page).to have_current_path backup_code_regenerate_path
     end
   end


### PR DESCRIPTION
This ticket is a bug fix--users will no longer see `&nbsp;` on the English "I need new backup codes" button


Before
![Image of confirm your backup codes in production](https://github.com/18F/identity-idp/assets/17969963/4401c48c-5a25-4c2b-8f79-8e771728106f)

After
![Proposed change of "Confirm you backup codes" page](https://github.com/18F/identity-idp/assets/17969963/78c476d0-67de-4020-9fdc-f4d442533685)


