### PR TITLE
Remove IE 11 warning banner

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,7 +20,6 @@ module Users
       override_csp_for_google_analytics
 
       @ial = sp_session_ial
-      @browser_is_ie11 = browser_is_ie11?
       analytics.sign_in_page_visit(
         flash: flash[:alert],
         stored_location: session['user_return_to'],
@@ -114,10 +113,6 @@ module Users
         email: auth_params[:email],
       )
       redirect_to next_url_after_valid_authentication
-    end
-
-    def browser_is_ie11?
-      BrowserCache.parse(request.user_agent).ie?(11)
     end
 
     def track_authentication_attempt(email)

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,11 +1,4 @@
 <% title t('titles.visitors.index') %>
-<% if @browser_is_ie11 %>
-  <%= render AlertComponent.new(
-        type: :warning,
-        class: 'margin-bottom-2',
-        message: t('account.login.ie_not_supported', date: I18n.l(IdentityConfig.store.ie11_support_end_date, format: :event_date)),
-      ) %>
-<% end %>
 <%= render 'shared/maintenance_window_alert' %>
 
 <% if decorated_session.sp_name %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -132,7 +132,6 @@ idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 idv_tmx_test_csp_disabled_emails: '[]'
 idv_tmx_test_js_disabled_emails: '[]'
-ie11_support_end_date: '2022-12-31'
 idv_sp_required: false
 in_person_capture_secondary_id_enabled: false
 in_person_email_reminder_early_benchmark_in_days: 11

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -71,7 +71,6 @@ en:
       delete_account: Delete
       regenerate_personal_key: Reset
     login:
-      ie_not_supported: Internet Explorer 11 is no longer supported as of %{date}
       piv_cac: Sign in with your government employee ID
       tab_navigation: Account creation tabs
     navigation:

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -72,7 +72,6 @@ es:
       delete_account: Eliminar
       regenerate_personal_key: Restablecer
     login:
-      ie_not_supported: Internet Explorer 11 dejó de ser compatible a partir del %{date}
       piv_cac: Inicie sesión con su identificación de empleado del gobierno
       tab_navigation: Pestañas de creación de cuenta
     navigation:

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -77,7 +77,6 @@ fr:
       delete_account: Effacer
       regenerate_personal_key: Réinitialiser
     login:
-      ie_not_supported: Internet Explorer 11 n’est plus pris en charge à partir du %{date}
       piv_cac: Connectez-vous avec votre ID d’employé du gouvernement
       tab_navigation: Onglets de création de compte
     navigation:

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -224,7 +224,6 @@ class IdentityConfig
     config.add(:idv_sp_required, type: :boolean)
     config.add(:idv_tmx_test_csp_disabled_emails, type: :json)
     config.add(:idv_tmx_test_js_disabled_emails, type: :json)
-    config.add(:ie11_support_end_date, type: :timestamp)
     config.add(:in_person_capture_secondary_id_enabled, type: :boolean)
     config.add(:in_person_email_reminder_early_benchmark_in_days, type: :integer)
     config.add(:in_person_email_reminder_final_benchmark_in_days, type: :integer)


### PR DESCRIPTION
## 🛠 Summary of changes

We dropped support for IE 11 over 6 months ago, and while we do have some related tickets to display a more comprehensive notice to all unsupported browsers, we can remove this for now.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
