### PR TITLE
LG-10201: cancel stale enrollments on doc capture visit

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -9,6 +9,7 @@ module Idv
 
     before_action :confirm_hybrid_handoff_complete
     before_action :confirm_document_capture_needed
+    before_action :cancel_establishing_in_person_enrollments
     before_action :override_csp_to_allow_acuant
 
     def show
@@ -61,6 +62,11 @@ module Idv
       return if pii.blank? && !idv_session.verify_info_step_complete?
 
       redirect_to idv_ssn_url
+    end
+
+    def cancel_establishing_in_person_enrollments
+      UspsInPersonProofing::EnrollmentHelper.
+        cancel_stale_establishing_enrollments_for_user(current_user)
     end
 
     def analytics_arguments

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -9,7 +9,6 @@ module Idv
 
     before_action :confirm_hybrid_handoff_complete
     before_action :confirm_document_capture_needed
-    before_action :cancel_establishing_in_person_enrollments
     before_action :override_csp_to_allow_acuant
 
     def show
@@ -28,6 +27,8 @@ module Idv
 
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('document_capture', :update, true)
+
+      cancel_establishing_in_person_enrollments
 
       if result.success?
         redirect_to idv_ssn_url

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -46,13 +46,6 @@ RSpec.describe Idv::DocumentCaptureController do
         :confirm_hybrid_handoff_complete,
       )
     end
-
-    it 'cancels any stale establishing in person enrollments' do
-      expect(subject).to have_actions(
-        :before,
-        :cancel_establishing_in_person_enrollments,
-      )
-    end
   end
 
   describe '#show' do
@@ -142,19 +135,6 @@ RSpec.describe Idv::DocumentCaptureController do
         expect(response).to redirect_to(idv_session_errors_throttled_url)
       end
     end
-
-    context 'user has an establishing in-person enrollment' do
-      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user, profile: nil) }
-
-      it 'cancels the establishing enrollment' do
-        expect(user.establishing_in_person_enrollment).to eq enrollment
-
-        get :show
-
-        expect(enrollment.reload.cancelled?).to eq(true)
-        expect(user.reload.establishing_in_person_enrollment).to be_nil
-      end
-    end
   end
 
   describe '#update' do
@@ -181,6 +161,19 @@ RSpec.describe Idv::DocumentCaptureController do
       expect { put :update }.to(
         change { doc_auth_log.reload.document_capture_submit_count }.from(0).to(1),
       )
+    end
+
+    context 'user has an establishing in-person enrollment' do
+      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user, profile: nil) }
+
+      it 'cancels the establishing enrollment' do
+        expect(user.establishing_in_person_enrollment).to eq enrollment
+
+        put :update
+
+        expect(enrollment.reload.cancelled?).to eq(true)
+        expect(user.reload.establishing_in_person_enrollment).to be_nil
+      end
     end
   end
 end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe Idv::DocumentCaptureController do
         :confirm_hybrid_handoff_complete,
       )
     end
+
+    it 'cancels any stale establishing in person enrollments' do
+      expect(subject).to have_actions(
+        :before,
+        :cancel_establishing_in_person_enrollments,
+      )
+    end
   end
 
   describe '#show' do
@@ -133,6 +140,19 @@ RSpec.describe Idv::DocumentCaptureController do
         get :show
 
         expect(response).to redirect_to(idv_session_errors_throttled_url)
+      end
+    end
+
+    context 'user has an establishing in-person enrollment' do
+      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user, profile: nil) }
+
+      it 'cancels the establishing enrollment' do
+        expect(user.establishing_in_person_enrollment).to eq enrollment
+
+        get :show
+
+        expect(enrollment.reload.cancelled?).to eq(true)
+        expect(user.reload.establishing_in_person_enrollment).to be_nil
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10201](https://cm-jira.usa.gov/browse/LG-10201)

## 🛠 Summary of changes

Cancels any 'establishing' in-person enrollments when the document capture page is loaded. This fixes a bug where the progressive proofer was trying to follow the double address verification flow even though the user was verifying remotely, because they'd previously begun the in-person flow and then started over.

## 📜 Testing Plan

Once the change is on staging,

1. go to staging and create an account via the OIDC app;
2. fail doc capture & start down the in-person flow, get as far as selecting a location and loading the state ID page;
3. return to doc capture (**do not click 'cancel'**); you can do this by taking one of the below actions:

    1. return to the OIDC app and click 'sign in' again;
    2. go to the root URL (which will redirect to your profile) and click 'Continue to Sample OpenID Connect Sinatra SP'
    3. edit the URL to `/verify`

5. successfully pass doc capture & continue the remote verification flow;
6. confirm that you are able to verify successfully
