### PR TITLE
LG-10123: Save sms phone number for in person sessions

### DIFF
--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -32,6 +32,7 @@ module Idv
 
       if result.success?
         idv_session.user_phone_confirmation = true
+        save_in_person_notification_phone
         flash[:success] = t('idv.messages.review.phone_verified')
         redirect_to idv_review_url
       else
@@ -68,6 +69,25 @@ module Idv
         flash.now[:error] = t('two_factor_authentication.invalid_otp')
         render :show
       end
+    end
+
+    def save_in_person_notification_phone
+      return unless is_in_person_session?
+      # future tickets will support voice otp
+      return unless idv_session.user_phone_confirmation_session.delivery_method == :sms
+
+      current_enrollment.notification_phone_configuration =
+        NotificationPhoneConfiguration.new(
+          phone: idv_session.user_phone_confirmation_session.phone,
+        )
+    end
+
+    def current_enrollment
+      current_user.establishing_in_person_enrollment
+    end
+
+    def is_in_person_session?
+      current_enrollment.present?
     end
 
     def phone_confirmation_otp_verification_form

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -73,22 +73,23 @@ module Idv
 
     def save_in_person_notification_phone
       return unless IdentityConfig.store.in_person_send_proofing_notifications_enabled
-      return unless is_in_person_session?
+      return unless in_person_enrollment?
       # future tickets will support voice otp
       return unless idv_session.user_phone_confirmation_session.delivery_method == :sms
 
-      current_enrollment.notification_phone_configuration =
+      establishing_enrollment.notification_phone_configuration =
         NotificationPhoneConfiguration.new(
           phone: idv_session.user_phone_confirmation_session.phone,
         )
     end
 
-    def current_enrollment
+    def establishing_enrollment
       current_user.establishing_in_person_enrollment
     end
 
-    def is_in_person_session?
-      current_enrollment.present?
+    def in_person_enrollment?
+      return false unless IdentityConfig.store.in_person_proofing_enabled
+      establishing_enrollment.present?
     end
 
     def phone_confirmation_otp_verification_form

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -72,6 +72,7 @@ module Idv
     end
 
     def save_in_person_notification_phone
+      return unless IdentityConfig.store.in_person_send_proofing_notifications_enabled
       return unless is_in_person_session?
       # future tickets will support voice otp
       return unless idv_session.user_phone_confirmation_session.delivery_method == :sms

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -212,6 +212,7 @@ module TwoFactorAuthentication
       end
 
       update_phone_attributes
+      # todo: save to notification phone config if user is in in-person
     end
 
     def updating_existing_number?

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -212,7 +212,6 @@ module TwoFactorAuthentication
       end
 
       update_phone_attributes
-      # todo: save to notification phone config if user is in in-person
     end
 
     def updating_existing_number?

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -150,6 +150,7 @@ in_person_enrollments_ready_job_wait_time_seconds: 20
 in_person_results_delay_in_hours: 1
 in_person_completion_survey_url: 'https://login.gov'
 in_person_usps_outage_message_enabled: false
+in_person_send_proofing_notifications_enabled: false
 in_person_stop_expiring_enrollments: false
 include_slo_in_saml_metadata: false
 key_pair_generation_percent: 0

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -241,6 +241,7 @@ class IdentityConfig
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:in_person_completion_survey_url, type: :string)
     config.add(:in_person_usps_outage_message_enabled, type: :boolean)
+    config.add(:in_person_send_proofing_notifications_enabled, type: :boolean)
     config.add(:in_person_stop_expiring_enrollments, type: :boolean)
     config.add(:include_slo_in_saml_metadata, type: :boolean)
     config.add(:lexisnexis_base_url, type: :string)

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -89,6 +89,39 @@ RSpec.describe Idv::OtpVerificationController do
       end
     end
 
+    context 'the user is going through in person proofing' do
+      before(:each) do
+        create(:in_person_enrollment, :establishing, user: user)
+      end
+
+      context 'the user uses sms otp' do
+        it 'saves the sms notification number to the enrollment' do
+          put :update, params: otp_code_param
+
+          phone_config = user.establishing_in_person_enrollment&.notification_phone_configuration
+          expect(phone_config).to be_present
+          expect(phone_config.phone).to eq(phone)
+        end
+      end
+
+      context 'the user uses voice otp' do
+        let(:phone_confirmation_session_properties) do
+          {
+            code: phone_confirmation_otp_code,
+            phone: phone,
+            delivery_method: :voice,
+          }
+        end
+
+        it 'does not save the sms notification number to the enrollment' do
+          put :update, params: otp_code_param
+
+          phone_config = user.establishing_in_person_enrollment&.notification_phone_configuration
+          expect(phone_config).to_not be_present
+        end
+      end
+    end
+
     it 'tracks an analytics event' do
       put :update, params: otp_code_param
 

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -92,10 +92,12 @@ RSpec.describe Idv::OtpVerificationController do
     context 'the user is going through in person proofing' do
       before(:each) do
         create(:in_person_enrollment, :establishing, user: user)
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
+          and_return(true)
       end
 
       context 'the user uses sms otp' do
-        it 'doesn not save the phone number if the feature flag is off' do
+        it 'does not save the phone number if the feature flag is off' do
           put :update, params: otp_code_param
 
           phone_config = user.establishing_in_person_enrollment&.notification_phone_configuration
@@ -123,7 +125,7 @@ RSpec.describe Idv::OtpVerificationController do
           }
         end
 
-        it 'doesn not save the phone number if the feature flag is off' do
+        it 'does not save the phone number if the feature flag is off' do
           put :update, params: otp_code_param
 
           phone_config = user.establishing_in_person_enrollment&.notification_phone_configuration

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -95,7 +95,17 @@ RSpec.describe Idv::OtpVerificationController do
       end
 
       context 'the user uses sms otp' do
+        it 'doesn not save the phone number if the feature flag is off' do
+          put :update, params: otp_code_param
+
+          phone_config = user.establishing_in_person_enrollment&.notification_phone_configuration
+          expect(phone_config).to_not be_present
+        end
+
         it 'saves the sms notification number to the enrollment' do
+          expect(IdentityConfig.store).to receive(:in_person_send_proofing_notifications_enabled).
+            and_return(true)
+
           put :update, params: otp_code_param
 
           phone_config = user.establishing_in_person_enrollment&.notification_phone_configuration
@@ -113,7 +123,17 @@ RSpec.describe Idv::OtpVerificationController do
           }
         end
 
+        it 'doesn not save the phone number if the feature flag is off' do
+          put :update, params: otp_code_param
+
+          phone_config = user.establishing_in_person_enrollment&.notification_phone_configuration
+          expect(phone_config).to_not be_present
+        end
+
         it 'does not save the sms notification number to the enrollment' do
+          expect(IdentityConfig.store).to receive(:in_person_send_proofing_notifications_enabled).
+            and_return(true)
+
           put :update, params: otp_code_param
 
           phone_config = user.establishing_in_person_enrollment&.notification_phone_configuration


### PR DESCRIPTION
## 🎫 Ticket

[LG-10123](https://cm-jira.usa.gov/browse/LG-10123?filter=-1)

## 🛠 Summary of changes

* Add a `in_person_send_proofing_notifications_enabled` feature flag to control the new in person notification feature
* Begin saving a user's confirmed SMS phone number as a NotificationPhoneConfiguration record
  * Only done when the user is going through the in person flow and when feature the flag is enabled

## 📜 Testing Plan

- [ ] Ensure the `in_person_send_proofing_notifications_enabled` feature flag is disabled
- [ ] Go through the in person flow and perform **SMS** otp on the phone step. Complete the flow and confirm that a NotificationPhoneConfiguration object was **not** created
- [ ] Enabled the `in_person_send_proofing_notifications_enabled` feature flag
- [ ] Go through the in person flow and perform **SMS** otp on the phone step. Complete the flow and confirm that a NotificationPhoneConfiguration object was created
- [ ] Go through the in person flow and perform **voice** otp on the phone step. Complete the flow and confirm that a NotificationPhoneConfiguration object was **not** created

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
