### PR TITLE
LG-9433: Create USPS auth token refresh job

### DIFF
--- a/app/jobs/usps_auth_token_refresh_job.rb
+++ b/app/jobs/usps_auth_token_refresh_job.rb
@@ -7,8 +7,6 @@ class UspsAuthTokenRefreshJob < ApplicationJob
     if token_expiration < 7.minutes
       usps_proofer.retrieve_token!
     end
-
-    return true
   ensure
     analytics.idv_usps_auth_token_refresh_job_completed
   end

--- a/app/jobs/usps_auth_token_refresh_job.rb
+++ b/app/jobs/usps_auth_token_refresh_job.rb
@@ -1,0 +1,38 @@
+class UspsAuthTokenRefreshJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    analytics.idv_usps_auth_token_refresh_job_started
+
+    if token_expiration < 7.minutes
+      usps_proofer.retrieve_token!
+    end
+
+    return true
+  ensure
+    analytics.idv_usps_auth_token_refresh_job_completed
+  end
+
+  private
+
+  def usps_proofer
+    if IdentityConfig.store.usps_mock_fallback
+      UspsInPersonProofing::Mock::Proofer.new
+    else
+      UspsInPersonProofing::Proofer.new
+    end
+  end
+
+  def token_expiration
+    Rails.cache.redis.ttl(usps_proofer.AUTH_TOKEN_CACHE_KEY)
+  end
+
+  def analytics
+    @analytics ||= Analytics.new(
+      user: AnonymousUser.new,
+      request: nil,
+      session: {},
+      sp: nil,
+    )
+  end
+end

--- a/app/jobs/usps_auth_token_refresh_job.rb
+++ b/app/jobs/usps_auth_token_refresh_job.rb
@@ -19,10 +19,6 @@ class UspsAuthTokenRefreshJob < ApplicationJob
     end
   end
 
-  def token_expiration
-    Rails.cache.redis.ttl(usps_proofer.AUTH_TOKEN_CACHE_KEY)
-  end
-
   def analytics
     @analytics ||= Analytics.new(
       user: AnonymousUser.new,

--- a/app/jobs/usps_auth_token_refresh_job.rb
+++ b/app/jobs/usps_auth_token_refresh_job.rb
@@ -4,9 +4,7 @@ class UspsAuthTokenRefreshJob < ApplicationJob
   def perform
     analytics.idv_usps_auth_token_refresh_job_started
 
-    if token_expiration < 7.minutes
-      usps_proofer.retrieve_token!
-    end
+    usps_proofer.retrieve_token!
   ensure
     analytics.idv_usps_auth_token_refresh_job_completed
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2209,6 +2209,22 @@ module AnalyticsEvents
     )
   end
 
+  # Track when USPS auth token refresh job started
+  def idv_usps_auth_token_refresh_job_started(**extra)
+    track_event(
+      'UspsAuthTokenRefreshJob: Started',
+      **extra,
+    )
+  end
+
+  # Track when USPS auth token refresh job completed
+  def idv_usps_auth_token_refresh_job_completed(**extra)
+    track_event(
+      'UspsAuthTokenRefreshJob: Completed',
+      **extra,
+    )
+  end
+
   # @param [String] flow_path Document capture path ("hybrid" or "standard")
   # The user clicked the troubleshooting option to start in-person proofing
   def idv_verify_in_person_troubleshooting_option_clicked(flow_path:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2209,18 +2209,18 @@ module AnalyticsEvents
     )
   end
 
-  # Track when USPS auth token refresh job started
-  def idv_usps_auth_token_refresh_job_started(**extra)
-    track_event(
-      'UspsAuthTokenRefreshJob: Started',
-      **extra,
-    )
-  end
-
   # Track when USPS auth token refresh job completed
   def idv_usps_auth_token_refresh_job_completed(**extra)
     track_event(
       'UspsAuthTokenRefreshJob: Completed',
+      **extra,
+    )
+  end
+
+  # Track when USPS auth token refresh job started
+  def idv_usps_auth_token_refresh_job_started(**extra)
+    track_event(
+      'UspsAuthTokenRefreshJob: Started',
       **extra,
     )
   end

--- a/app/services/usps_in_person_proofing/mock/proofer.rb
+++ b/app/services/usps_in_person_proofing/mock/proofer.rb
@@ -1,9 +1,6 @@
 module UspsInPersonProofing
   module Mock
     class Proofer < UspsInPersonProofing::Proofer
-      def AUTH_TOKEN_CACHE_KEY
-        :usps_ippaas_api_auth_token
-      end
       def request_enroll(applicant)
         case applicant['first_name']
         when 'usps waiting'

--- a/app/services/usps_in_person_proofing/mock/proofer.rb
+++ b/app/services/usps_in_person_proofing/mock/proofer.rb
@@ -1,6 +1,9 @@
 module UspsInPersonProofing
   module Mock
     class Proofer < UspsInPersonProofing::Proofer
+      def AUTH_TOKEN_CACHE_KEY
+        :usps_ippaas_api_auth_token
+      end
       def request_enroll(applicant)
         case applicant['first_name']
         when 'usps waiting'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -330,6 +330,7 @@ verify_personal_key_max_attempts: 5
 version_headers_enabled: false
 use_dashboard_service_providers: false
 use_kms: false
+usps_auth_token_refresh_job_enabled: false
 usps_confirmation_max_days: 10
 usps_ipp_password: ''
 usps_ipp_client_id: ''
@@ -481,6 +482,7 @@ production:
   state_tracking_enabled: false
   telephony_adapter: pinpoint
   use_kms: true
+  usps_auth_token_refresh_job_enabled: true
   usps_confirmation_max_days: 30
   usps_upload_sftp_directory: ''
   usps_upload_sftp_host: ''

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -164,10 +164,12 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.yesterday] },
       },
-      usps_auth_token_refresh: {
-        class: 'UspsAuthTokenRefreshJob',
-        cron: cron_12m,
-      },
+      usps_auth_token_refresh: (if IdentityConfig.store.usps_auth_token_refresh_job_enabled
+                                  {
+                                    class: 'UspsAuthTokenRefreshJob',
+                                    cron: cron_12m,
+                                  }
+                                end),
       arcgis_token: (if IdentityConfig.store.arcgis_api_refresh_token_job_enabled
                        {
                          class: 'ArcgisTokenJob',

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -163,6 +163,10 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.yesterday] },
       },
+      usps_auth_token_refresh: {
+        class: 'UspsAuthTokenRefreshJob',
+        cron: cron_5m,
+      },
       arcgis_token: (if IdentityConfig.store.arcgis_api_refresh_token_job_enabled
                        {
                          class: 'ArcgisTokenJob',

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -1,5 +1,5 @@
 cron_5m = '0/5 * * * *'
-cron_12m = '0/5 * * * *'
+cron_12m = '0/12 * * * *'
 cron_1h = '0 * * * *'
 cron_24h = '0 0 * * *'
 gpo_cron_24h = '0 10 * * *' # 10am UTC is 5am EST/6am EDT

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -1,4 +1,5 @@
 cron_5m = '0/5 * * * *'
+cron_12m = '0/5 * * * *'
 cron_1h = '0 * * * *'
 cron_24h = '0 0 * * *'
 gpo_cron_24h = '0 10 * * *' # 10am UTC is 5am EST/6am EDT
@@ -165,7 +166,7 @@ else
       },
       usps_auth_token_refresh: {
         class: 'UspsAuthTokenRefreshJob',
-        cron: cron_5m,
+        cron: cron_12m,
       },
       arcgis_token: (if IdentityConfig.store.arcgis_api_refresh_token_job_enabled
                        {

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -429,6 +429,7 @@ class IdentityConfig
     config.add(:unauthorized_scope_enabled, type: :boolean)
     config.add(:use_dashboard_service_providers, type: :boolean)
     config.add(:use_kms, type: :boolean)
+    config.add(:usps_auth_token_refresh_job_enabled, type: :boolean)
     config.add(:usps_mock_fallback, type: :boolean)
     config.add(:usps_confirmation_max_days, type: :integer)
     config.add(:usps_ipp_password, type: :string)

--- a/spec/jobs/usps_auth_token_refresh_job_spec.rb
+++ b/spec/jobs/usps_auth_token_refresh_job_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe UspsAuthTokenRefreshJob, type: :job do
       end
 
       it 'requests and sets a new token in the cache' do
+        new_token_value = "Bearer ==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7=="
         stub_request_token
 
         expect(analytics).to receive(
@@ -42,11 +43,12 @@ RSpec.describe UspsAuthTokenRefreshJob, type: :job do
           usps_auth_token_cache_key,
           an_instance_of(String),
           hash_including(expires_in: an_instance_of(ActiveSupport::Duration)),
-        )
+        ).and_call_original
 
         subject.perform
 
         expect(WebMock).to have_requested(:post, "#{root_url}/oauth/authenticate")
+        expect(Rails.cache.fetch(usps_auth_token_cache_key)).to eq(new_token_value)
       end
 
       it 'manually sets the expiration' do

--- a/spec/jobs/usps_auth_token_refresh_job_spec.rb
+++ b/spec/jobs/usps_auth_token_refresh_job_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe UspsAuthTokenRefreshJob, type: :job do
 
       it 'requests and sets a new token in the cache' do
         # rubocop:disable Layout/LineLength
-        new_token_value = 'Bearer ==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7=='
+        new_token_value = '==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7=='
         # rubocop:enable Layout/LineLength
         stub_request_token
 
@@ -50,7 +50,7 @@ RSpec.describe UspsAuthTokenRefreshJob, type: :job do
         subject.perform
 
         expect(WebMock).to have_requested(:post, "#{root_url}/oauth/authenticate")
-        expect(Rails.cache.fetch(usps_auth_token_cache_key)).to eq(new_token_value)
+        expect(Rails.cache.fetch(usps_auth_token_cache_key)).to eq("Bearer #{new_token_value}")
       end
 
       it 'manually sets the expiration' do

--- a/spec/jobs/usps_auth_token_refresh_job_spec.rb
+++ b/spec/jobs/usps_auth_token_refresh_job_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe UspsAuthTokenRefreshJob, type: :job do
       end
 
       it 'requests and sets a new token in the cache' do
-        new_token_value = "Bearer ==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7=="
+        # rubocop:disable Layout/LineLength
+        new_token_value = 'Bearer ==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7=='
+        # rubocop:enable Layout/LineLength
         stub_request_token
 
         expect(analytics).to receive(

--- a/spec/jobs/usps_auth_token_refresh_job_spec.rb
+++ b/spec/jobs/usps_auth_token_refresh_job_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe UspsAuthTokenRefreshJob, type: :job do
+  include UspsIppHelper
+
+  let(:subject) { described_class.new }
+  let(:root_url) { 'http://my.root.url' }
+  let(:analytics) { instance_double(Analytics) }
+  let(:usps_auth_token_cache_key) { UspsInPersonProofing::Proofer::AUTH_TOKEN_CACHE_KEY }
+
+  before do
+    allow(IdentityConfig.store).to receive(:usps_ipp_root_url).and_return(root_url)
+
+    allow(Analytics).to receive(:new).
+      with(
+        user: an_instance_of(AnonymousUser),
+        request: nil,
+        session: {},
+        sp: nil,
+      ).and_return(analytics)
+  end
+
+  describe 'usps auth token refresh job' do
+    context 'the token in the cache is more than 7 mins from expiration' do
+      it 'checks the cache but does not make a request' do
+        Rails.cache.write(usps_auth_token_cache_key, "test token", expires_in: 900)
+
+        stub_request_token
+
+        expect(WebMock).not_to have_requested(:post, "#{root_url}/oauth/authenticate")
+      end
+    end
+
+    context 'the token in the cache is less than 7 mins from expiration' do
+      context 'when using redis as a backing store' do
+        before do |ex|
+          allow(Rails).to receive(:cache).and_return(
+            ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
+          )
+        end
+
+        it 'requests and sets a new token in the cache' do
+          stub_request_token
+
+          expect(analytics).to receive(
+            :idv_usps_auth_token_refresh_job_started,
+          ).once
+          expect(analytics).to receive(
+            :idv_usps_auth_token_refresh_job_completed,
+          ).once
+
+          expect(Rails.cache).to receive(:write).with(
+            usps_auth_token_cache_key,
+            an_instance_of(String),
+            hash_including(expires_in: an_instance_of(ActiveSupport::Duration)),
+          )
+
+          subject.perform
+
+          expect(WebMock).to have_requested(:post, "#{root_url}/oauth/authenticate")
+        end
+
+        it 'manually sets the expiration' do
+          allow(analytics).to receive(:idv_usps_auth_token_refresh_job_started)
+          allow(analytics).to receive(:idv_usps_auth_token_refresh_job_completed)
+
+          stub_request_token
+          subject.perform
+
+          ttl = Rails.cache.redis.ttl(usps_auth_token_cache_key)
+          expect(ttl).to be > 0
+        end
+      end
+    end
+
+    context 'auth request throws error' do
+      it 'fetches token and logs analytics' do
+        stub_error_request_token
+
+        expect(analytics).to receive(
+          :idv_usps_auth_token_refresh_job_started,
+        ).once
+        expect(analytics).to receive(
+          :idv_usps_auth_token_refresh_job_completed,
+        ).once
+
+        expect do
+          subject.perform
+        end.to raise_error
+      end
+    end
+  end
+end

--- a/spec/jobs/usps_auth_token_refresh_job_spec.rb
+++ b/spec/jobs/usps_auth_token_refresh_job_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe UspsAuthTokenRefreshJob, type: :job do
     end
 
     context 'auth request throws error' do
-      it 'fetches token and logs analytics' do
+      it 'still logs analytics' do
         stub_error_request_token
 
         expect(analytics).to receive(

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -15,6 +15,14 @@ module UspsIppHelper
     )
   end
 
+  def stub_error_request_token
+    stub_request(:post, %r{/oauth/authenticate}).to_return(
+      status: 500,
+      body: [],
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_facilities
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
       status: 200,


### PR DESCRIPTION
## 🎫 Ticket

[LG-9433](https://cm-jira.usa.gov/browse/LG-9433)

## 🛠 Summary of changes

Right now, the responsibility for renewing the authentication token lies
with the methods calling out to the USPS API for any reason. This can
delay requests to, for example, search for nearby post offices, as they
have to first do the authentication and then do the work.

Creating a USPS authentication token refresh job takes the
responsibility away from the other calls to the API. They still have the
logic and ability to do so as a failsafe in case all the refresh jobs
fail, but if the jobs are working properly they should never need to
make the call.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Connect to the USPS API locally and request a token
- [x] Deploy to the sandbox environment and watch to see analytics come through in AWS to make sure the job is working
- [ ] Deploy through staging or production and watch in New Relic to see if the spikes [mentioned in this Slack conversation](https://gsa-tts.slack.com/archives/C42TZ3K5H/p1680877814227199?thread_ts=1680858541.420489&cid=C42TZ3K5H) are gone, to make sure the refresh token job is working as expected