### PR TITLE
LG-9939 Addendum: Make /verify/doc_auth/:step redirect to /verify/welcome

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -403,7 +403,7 @@ Rails.application.routes.draw do
       # deprecated routes
       get '/confirmations' => 'personal_key#show'
       post '/confirmations' => 'personal_key#update'
-      get '/doc_auth/:step' => 'welcome#show'
+      get '/doc_auth/:step', to: redirect('/verify/welcome')
       get '/doc_auth/link_sent/poll' => 'capture_doc_status#show'
     end
 

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -27,16 +27,6 @@ RSpec.describe Idv::WelcomeController do
     end
   end
 
-  describe 'legacy redirect', type: :routing do
-    it 'redirects from /verify/doc_auth/:step to idv_welcome_url' do
-      expect(get('/verify/doc_auth/document_capture')).to route_to(
-        controller: 'idv/welcome',
-        action: 'show',
-        step: 'document_capture',
-      )
-    end
-  end
-
   describe '#show' do
     let(:analytics_name) { 'IdV: doc auth welcome visited' }
     let(:analytics_args) do

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -40,4 +40,16 @@ RSpec.describe 'Redirecting Legacy Routes', type: :request do
       expect(response).to redirect_to('/verify/by_mail/confirm_start_over')
     end
   end
+
+  describe '/verify/doc_auth/:step' do
+    it 'redirects to /verify/welcome' do
+      get '/verify/doc_auth/document_capture'
+
+      expect(response).to redirect_to('/verify/welcome')
+
+      get '/verify/doc_auth/welcome'
+
+      expect(response).to redirect_to('/verify/welcome')
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9939](https://cm-jira.usa.gov/browse/LG-9939)

## 🛠 Summary of changes

The previously added legacy route left the user on /verify/doc_auth/welcome which would give them a 404 when they click Continue.

Also moved redirect spec to spec/requests/redirects_spec.rb

## 📜 Testing Plan

- [ ] Create account
- [ ] Navigate to `/verify/doc_auth/welcome`
- [ ] Expect to be redirected to`/verify/welcome`
- [ ] Navigate to `/verify/doc_auth/document_capture`
- [ ] Expect to be redirected to`/verify/welcome`
- [ ] Click Continue
- [ ] Expect to be on `/verify/agreement`
