### PR TITLE
LG 10076 Remove Password Complexity Requirement from Signup

### DIFF
--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -108,20 +108,11 @@ function updatePasswordFeedback(cls, strength, feedback) {
   pwFeedback.innerHTML = feedback;
 }
 
-function validatePasswordField(score, input) {
-  if (score < 3) {
-    input.setCustomValidity(t('errors.messages.stronger_password'));
-  } else {
-    input.setCustomValidity('');
-  }
-}
-
-function checkPasswordStrength(password, minPasswordLength, forbiddenPasswords, input) {
+function checkPasswordStrength(password, minPasswordLength, forbiddenPasswords) {
   const z = zxcvbn(password, forbiddenPasswords);
   const [cls, strength] = getStrength(z);
   const feedback = getFeedback(z, minPasswordLength, forbiddenPasswords);
 
-  validatePasswordField(z.score, input);
   updatePasswordFeedback(cls, strength, feedback);
 }
 

--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -13,18 +13,10 @@ module FormPasswordValidator
               length: { in: Devise.password_length },
               if: -> { validate_confirmation }
 
-    validate :password_graphemes_length, :strong_password, :not_pwned, :passwords_match
+    validate :password_graphemes_length, :not_pwned, :passwords_match
   end
 
   private
-
-  ZXCVBN_TESTER = ::Zxcvbn::Tester.new
-
-  def strong_password
-    return unless errors.messages.blank? && password_score.score < min_password_score
-
-    errors.add :password, :weak_password, **i18n_variables, type: :weak_password
-  end
 
   def password_graphemes_length
     return if errors.messages.present?
@@ -38,13 +30,6 @@ module FormPasswordValidator
     elsif password.grapheme_clusters.length > Devise.password_length.max
       errors.add(:password, :too_long, count: Devise.password_length.max, type: :too_long)
     end
-  end
-
-  def password_score
-    @password_score = ZXCVBN_TESTER.test(
-      password,
-      user.email_addresses.flat_map { |address| ForbiddenPasswords.new(address.email).call },
-    )
   end
 
   def not_pwned
@@ -62,27 +47,5 @@ module FormPasswordValidator
         type: :mismatch
       )
     end
-  end
-
-  def min_password_score
-    IdentityConfig.store.min_password_score
-  end
-
-  def i18n_variables
-    {
-      feedback: zxcvbn_feedback,
-    }
-  end
-
-  def zxcvbn_feedback
-    feedback = @password_score.feedback.values.flatten.reject(&:empty?)
-
-    feedback.map do |error|
-      I18n.t("zxcvbn.feedback.#{i18n_key(error)}")
-    end.join('. ').gsub(/\.\s*\./, '.')
-  end
-
-  def i18n_key(key)
-    key.tr(' -', '_').gsub(/\W/, '').downcase
   end
 end


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG 10076](https://cm-jira.usa.gov/browse/LG-10076)

## 🛠 Summary of changes

Removed front and back end password validation controls that restricted signup based on zxcvbn library derived password strength score. 

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Start to create a new account. Enter email address, select language, click Rules checkbox, submit.
- [ ] Confirm the email address arrive at Choose a password screen.
- [ ] Enter a 12 character password that doesn't contain common phrases or repeated characters. (alliteration, unidentified, exacerbation, professional, etc.)
- [ ] The strength indicator will still show that it is weak but you are able to click Continue and finish setting up the account.

