### PR TITLE
LG-10103: Send only address line 1 to USPS when creating an enrollment

### DIFF
--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -53,14 +53,12 @@ module UspsInPersonProofing
             transform_keys(SECONDARY_ID_ADDRESS_MAP)
         end
 
-        address = [pii[:address1], pii[:address2]].select(&:present?).join(' ')
-
         applicant = UspsInPersonProofing::Applicant.new(
           {
             unique_id: unique_id,
             first_name: transliterate(pii[:first_name]),
             last_name: transliterate(pii[:last_name]),
-            address: transliterate(address),
+            address: transliterate(pii[:address1]),
             city: transliterate(pii[:city]),
             state: pii[:state],
             zip_code: pii[:zipcode],

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -553,14 +553,14 @@ RSpec.describe Idv::ReviewController do
           context 'when user enters an address2 value' do
             let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.merge(address2: '3b') }
 
-            it 'provides address2 if the user entered it' do
+            it 'does not include address2' do
               proofer = UspsInPersonProofing::Proofer.new
               mock = double
 
               expect(UspsInPersonProofing::Proofer).to receive(:new).and_return(mock)
               expect(mock).to receive(:request_enroll) do |applicant|
                 expect(applicant.address).
-                  to eq(Idp::Constants::MOCK_IDV_APPLICANT[:address1] + ' 3b')
+                  to eq(Idp::Constants::MOCK_IDV_APPLICANT[:address1])
                 proofer.request_enroll(applicant)
               end
 

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -116,11 +116,9 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
               expect(proofer).to receive(:request_enroll) do |applicant|
                 ADDR = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS
                 expect(applicant).to have_attributes(
-                  address: "#{
-                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address1]
-                  } #{
-                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address2]
-                  }",
+                  address: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
+                    :identity_doc_address1
+                  ],
                   city: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city],
                   state: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
                     :identity_doc_address_state


### PR DESCRIPTION
## 🎫 Ticket

[LG-10103](https://cm-jira.usa.gov/browse/LG-10103)

## 🛠 Summary of changes

Sends only address line 1 to the USPS API when creating an enrollment, instead sending the combined address lines 1 and 2.

