### PR TITLE
LG-10290: Fix F/T unlock cancel sign-in redirect

### DIFF
--- a/app/javascript/packs/webauthn-authenticate.ts
+++ b/app/javascript/packs/webauthn-authenticate.ts
@@ -6,8 +6,6 @@ function webauthn() {
   const webauthnSuccessContainer = document.getElementById('webauthn-auth-successful')!;
 
   const webauthAlertContainer = document.querySelector('.usa-alert--error')!;
-  const webauthnPlatformRequested =
-    webauthnInProgressContainer.dataset.platformAuthenticatorRequested === 'true';
 
   const spinner = document.getElementById('spinner')!;
   spinner.classList.remove('display-none');
@@ -41,8 +39,6 @@ function webauthn() {
       })
       .catch((error: Error) => {
         (document.getElementById('webauthn_error') as HTMLInputElement).value = error.name;
-        (document.getElementById('platform') as HTMLInputElement).value =
-          String(webauthnPlatformRequested);
         (document.getElementById('webauthn_form') as HTMLFormElement).submit();
       });
   }

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -22,7 +22,7 @@
   <%= hidden_field_tag :signature, '', id: 'signature' %>
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
   <%= hidden_field_tag :webauthn_error, '', id: 'webauthn_error' %>
-  <%= hidden_field_tag :platform, @presenter.platform_authenticator?, id: 'platform' %>
+  <%= hidden_field_tag :platform, @presenter.platform_authenticator? %>
 
   <%= content_tag(
         :div,


### PR DESCRIPTION
## 🎫 Ticket

[LG-10290](https://cm-jira.usa.gov/browse/LG-10290)

## 🛠 Summary of changes

Fixes an issue introduced in #8723 where a user would be redirected to the Security Key version of the WebAuthn MFA verification page if they cancelled the browser dialog for face or touch unlock.

## 📜 Testing Plan

1. Sign in to an account with Face or Touch Unlock configured
2. Click "Use face or touch unlock" when prompted for MFA
3. Click "Cancel" in the browser dialog

**Before:** User is redirected to an error page and prompted to "Connect your security key"
**After:** Error state reflects cancelled Face or Touch Unlock MFA