### PR TITLE
LG-10183 Pending profiles should redirect to proper page

### DIFF
--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -33,7 +33,7 @@ class IdvController < ApplicationController
   end
 
   def handle_pending_profile
-    return redirect_to url_for_pending_profile_reason if user_has_pending_profile?
+    redirect_to url_for_pending_profile_reason if user_has_pending_profile?
   end
 
   def profile_needs_reactivation?

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -1,12 +1,12 @@
 class IdvController < ApplicationController
   include IdvSession
   include AccountReactivationConcern
-  include FraudReviewConcern
+  include VerifyProfileConcern
   include RateLimitConcern
 
   before_action :confirm_two_factor_authenticated
   before_action :profile_needs_reactivation?, only: [:index]
-  before_action :handle_fraud
+  before_action :handle_pending_profile, only: [:index]
   before_action :confirm_not_rate_limited
 
   def index
@@ -30,6 +30,10 @@ class IdvController < ApplicationController
   def verify_identity
     analytics.idv_intro_visit
     redirect_to idv_welcome_url
+  end
+
+  def handle_pending_profile
+    return redirect_to url_for_pending_profile_reason if user_has_pending_profile?
   end
 
   def profile_needs_reactivation?

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
               context 'user has an in person pending profile' do
                 let(:user) { create(:profile, :in_person_verification_pending).user }
 
-                it 'redirects to gpo verify page' do
+                it 'redirects to in person ready to verify page' do
                   action
                   expect(controller).to redirect_to(idv_in_person_ready_to_verify_url)
                 end
@@ -199,7 +199,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                     ).user
                   end
 
-                  it 'redirects to gpo verify page if user has gpo and fraud pending' do
+                  it 'redirects to gpo verify page' do
                     action
                     expect(controller).to redirect_to(idv_gpo_verify_url)
                   end
@@ -214,7 +214,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                     ).user
                   end
 
-                  it 'redirects to gpo verify page if user has gpo and in person pending' do
+                  it 'redirects to gpo verify page' do
                     action
                     expect(controller).to redirect_to(idv_gpo_verify_url)
                   end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -152,21 +152,73 @@ RSpec.describe OpenidConnect::AuthorizationController do
               expect(controller).to redirect_to(idv_url)
             end
 
-            context 'user is under fraud review' do
-              let(:user) { create(:profile, :fraud_review_pending).user }
+            context 'user has a pending profile' do
+              context 'user has a gpo pending profile' do
+                let(:user) { create(:profile, :verify_by_mail_pending).user }
 
-              it 'redirects to fraud review page if fraud review is pending' do
-                action
-                expect(controller).to redirect_to(idv_please_call_url)
+                it 'redirects to gpo verify page' do
+                  action
+                  expect(controller).to redirect_to(idv_gpo_verify_url)
+                end
               end
-            end
 
-            context 'user is rejected due to fraud' do
-              let(:user) { create(:profile, :fraud_rejection).user }
+              context 'user has an in person pending profile' do
+                let(:user) { create(:profile, :in_person_verification_pending).user }
 
-              it 'redirects to fraud rejection page if user is fraud rejected ' do
-                action
-                expect(controller).to redirect_to(idv_not_verified_url)
+                it 'redirects to gpo verify page' do
+                  action
+                  expect(controller).to redirect_to(idv_in_person_ready_to_verify_url)
+                end
+              end
+
+              context 'user is under fraud review' do
+                let(:user) { create(:profile, :fraud_review_pending).user }
+
+                it 'redirects to fraud review page if fraud review is pending' do
+                  action
+                  expect(controller).to redirect_to(idv_please_call_url)
+                end
+              end
+
+              context 'user is rejected due to fraud' do
+                let(:user) { create(:profile, :fraud_rejection).user }
+
+                it 'redirects to fraud rejection page if user is fraud rejected ' do
+                  action
+                  expect(controller).to redirect_to(idv_not_verified_url)
+                end
+              end
+
+              context 'user has two pending reasons' do
+                context 'user has gpo and fraud review pending' do
+                  let(:user) do
+                    create(
+                      :profile,
+                      :verify_by_mail_pending,
+                      :fraud_review_pending,
+                    ).user
+                  end
+
+                  it 'redirects to gpo verify page if user has gpo and fraud pending' do
+                    action
+                    expect(controller).to redirect_to(idv_gpo_verify_url)
+                  end
+                end
+
+                context 'user has gpo and in person pending' do
+                  let(:user) do
+                    create(
+                      :profile,
+                      :verify_by_mail_pending,
+                      :in_person_verification_pending,
+                    ).user
+                  end
+
+                  it 'redirects to gpo verify page if user has gpo and in person pending' do
+                    action
+                    expect(controller).to redirect_to(idv_gpo_verify_url)
+                  end
+                end
               end
             end
           end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10183](https://cm-jira.usa.gov/browse/LG-10183)


## 🛠 Summary of changes

Added some tests to ensure users aren't reaching the "Please call" page before other pending profile reasons are resolved. Also place pending reasons in IdV controller.


## 📜 Testing Plan


- [ ] Go through IdV flow selecting "review" during the SSN step.
- [ ] Go through either verify by mail or in-person flow
- [ ] Ensure that you do not get redirected to the "Please call" page until after completing GPO verification. (In person should never see the please call page)



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
