### PR TITLE
Fix session timeout modal styles

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -15,6 +15,7 @@
 @forward 'icon';
 @forward 'language-picker';
 @forward 'list';
+@forward 'modal';
 @forward 'nav';
 @forward 'page-heading';
 @forward 'password';

--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -1,5 +1,5 @@
 @use 'uswds-core' as *;
-@use 'variables/app' as *;
+@use '../variables/app' as *;
 
 .usa-modal-overlay {
   // Temporary styles to avoid inheriting too much of the USWDS opinionated modal styling until


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where the session timeout modal styles are missing.

Likely a regression of #8571, where modal is susceptible to the same issue as Language Picker described in the original pull request description, since it is also [rendered in the base layout](https://github.com/18F/identity-idp/blob/0d55b58169680f06eb7708c7de6b26221549f66c/app/views/layouts/base.html.erb#L87-L100):

>This was originally going to include a refactor of LanguagePickerComponent to have a component stylesheet, but there's an issue with how we [render the "stylesheet once" tags](https://github.com/18F/identity-idp/blob/62a93d1f2a51b5d0da8d35a063f477981b4564b6/app/views/layouts/base.html.erb#L29) which is incompatible with components rendered as part of the base layout. This will need to be fixed first.

## 👀 Screenshots

Before|After
---|---
![Screen Shot 2023-07-10 at 2 45 49 PM](https://github.com/18F/identity-idp/assets/1779930/f89cdac7-c337-4e51-846e-29b28e3e93eb)|![Screen Shot 2023-07-10 at 2 46 53 PM](https://github.com/18F/identity-idp/assets/1779930/9e9f9dee-f9a8-49c0-95b1-7b3e819af8ff)
