### PR TITLE
Delete session data when hybrid session is invalid

### DIFF
--- a/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
+++ b/app/controllers/concerns/idv/hybrid_mobile/hybrid_mobile_concern.rb
@@ -35,6 +35,9 @@ module Idv
       end
 
       def handle_invalid_document_capture_session
+        # it is critical to remove all session data to avoid authenticating and
+        # resuming a partial session
+        sign_out
         flash[:error] = t('errors.capture_doc.invalid_link')
         redirect_to root_url
       end

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -89,9 +89,11 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController do
             minutes: IdentityConfig.store.doc_capture_request_valid_for_minutes * -2,
           )
         end
-        it 'redirects to root' do
+        it 'redirects to root, displays flash, and deletes session' do
           get :show
           expect(response).to redirect_to(root_url)
+          expect(session.delete('flash')).to be
+          expect(session).to be_blank
         end
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

We are currently seeing some odd logging (discussed [here](https://gsa-tts.slack.com/archives/C16RSBG49/p1688752177992979)) where the `doc_capture_user_id` is persisting when it shouldn't. This PR adds a `sign_out` call to delete the session everywhere before redirecting and showing an error message.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
