### PR TITLE
Refactor some tests to avoid stubbing calls to .new

### DIFF
--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -175,16 +175,10 @@ RSpec.describe Idv::LinkSentController do
         let(:load_result_success) { false }
 
         it 'returns an empty response' do
-          error_message = t('errors.doc_auth.phone_step_incomplete')
-          expect(FormResponse).to receive(:new).with(
-            { success: false,
-              errors: { message: error_message } },
-          )
-
           put :update
 
           expect(response).to have_http_status(204)
-          expect(flow_session[:error_message]).to eq(error_message)
+          expect(flow_session[:error_message]).to eq(t('errors.doc_auth.phone_step_incomplete'))
         end
       end
     end

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -41,25 +41,20 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
 
   describe '#create' do
     context 'when the user enters a valid personal key' do
+      let(:user) { create(:user, :with_phone) }
+      let(:personal_key) { { personal_key: PersonalKeyGenerator.new(user).create } }
+      let(:payload) { { personal_key_form: personal_key } }
       it 'tracks the valid authentication event' do
-        sign_in_before_2fa(create(:user, :with_webauthn, :with_phone, :with_personal_key))
-        personal_key_generated_at = controller.current_user.
-          encrypted_recovery_code_digest_generated_at
-
-        form = instance_double(PersonalKeyForm)
-        response = FormResponse.new(
-          success: true, errors: {}, extra: { multi_factor_auth_method: 'personal-key' },
-        )
-        allow(PersonalKeyForm).to receive(:new).
-          with(subject.current_user, 'foo').and_return(form)
-        allow(form).to receive(:submit).and_return(response)
-
+        personal_key
+        sign_in_before_2fa(user)
         stub_analytics
+
         analytics_hash = {
           success: true,
           errors: {},
           multi_factor_auth_method: 'personal-key',
-          multi_factor_auth_method_created_at: personal_key_generated_at,
+          multi_factor_auth_method_created_at: user.reload.
+            encrypted_recovery_code_digest_generated_at,
         }
 
         expect(@analytics).to receive(:track_mfa_submit_event).
@@ -112,13 +107,6 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
       before do
         user = create(:user, :with_personal_key, :with_phone, with: { phone: '+1 (703) 555-1212' })
         stub_sign_in_before_2fa(user)
-        form = instance_double(PersonalKeyForm)
-        response = FormResponse.new(
-          success: false, errors: {}, extra: { multi_factor_auth_method: 'personal-key' },
-        )
-        allow(PersonalKeyForm).to receive(:new).
-          with(subject.current_user, '').and_return(form)
-        allow(form).to receive(:submit).and_return(response)
       end
 
       it 'renders the show page' do
@@ -135,13 +123,6 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
       end
       before do
         stub_sign_in_before_2fa(user)
-        form = instance_double(PersonalKeyForm)
-        response = FormResponse.new(
-          success: false, errors: {}, extra: { multi_factor_auth_method: 'personal-key' },
-        )
-        allow(PersonalKeyForm).to receive(:new).
-          with(subject.current_user, 'foo').and_return(form)
-        allow(form).to receive(:submit).and_return(response)
       end
 
       it 'calls handle_invalid_otp' do
@@ -165,13 +146,14 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
           IdentityConfig.store.login_otp_confirmation_max_attempts - 1
         user.save
         personal_key_generated_at = controller.current_user.
-          encrypted_recovery_code_digest_generated_at.change(usec: 0)
+          encrypted_recovery_code_digest_generated_at
         stub_analytics
         stub_attempts_tracker
 
         properties = {
           success: false,
-          errors: {},
+          errors: { personal_key: [t('errors.messages.personal_key_incorrect')] },
+          error_details: { personal_key: [:personal_key_incorrect] },
           multi_factor_auth_method: 'personal-key',
           multi_factor_auth_method_created_at: personal_key_generated_at,
         }

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
           IdentityConfig.store.login_otp_confirmation_max_attempts - 1
         user.save
         personal_key_generated_at = controller.current_user.
-          encrypted_recovery_code_digest_generated_at
+          encrypted_recovery_code_digest_generated_at.change(usec: 0)
         stub_analytics
         stub_attempts_tracker
 

--- a/spec/forms/user_piv_cac_verification_form_spec.rb
+++ b/spec/forms/user_piv_cac_verification_form_spec.rb
@@ -26,15 +26,16 @@ RSpec.describe UserPivCacVerificationForm do
         let(:user) { create(:user) }
 
         it 'returns FormResponse with success: false' do
-          result = instance_double(FormResponse)
+          result = form.submit
+          expect(result.to_h).to eq(
+            success: false,
+            errors: { type: 'user.no_piv_cac_associated' },
+            multi_factor_auth_method: 'piv_cac',
+            piv_cac_configuration_id: nil,
+            multi_factor_auth_method_created_at: nil,
+            key_id: nil,
+          )
 
-          expect(FormResponse).to receive(:new).
-            with(success: false, errors: { type: 'user.no_piv_cac_associated' },
-                 extra: { multi_factor_auth_method: 'piv_cac',
-                          piv_cac_configuration_id: nil,
-                          multi_factor_auth_method_created_at: nil,
-                          key_id: nil }).and_return(result)
-          expect(form.submit).to eq result
           expect(form.error_type).to eq 'user.no_piv_cac_associated'
         end
       end
@@ -43,15 +44,16 @@ RSpec.describe UserPivCacVerificationForm do
         let(:user) { create(:user, :with_piv_or_cac) }
 
         it 'returns FormResponse with success: false' do
-          result = instance_double(FormResponse)
+          result = form.submit
 
-          expect(FormResponse).to receive(:new).
-            with(success: false, errors: { type: 'user.piv_cac_mismatch' },
-                 extra: { multi_factor_auth_method: 'piv_cac',
-                          multi_factor_auth_method_created_at: nil,
-                          piv_cac_configuration_id: nil,
-                          key_id: nil }).and_return(result)
-          expect(form.submit).to eq result
+          expect(result.to_h).to eq(
+            success: false,
+            errors: { type: 'user.piv_cac_mismatch' },
+            multi_factor_auth_method: 'piv_cac',
+            multi_factor_auth_method_created_at: nil,
+            piv_cac_configuration_id: nil,
+            key_id: nil,
+          )
           expect(form.error_type).to eq 'user.piv_cac_mismatch'
         end
       end
@@ -63,18 +65,14 @@ RSpec.describe UserPivCacVerificationForm do
         let(:piv_cac_configuration) { user.piv_cac_configurations.first }
 
         it 'returns FormResponse with success: true' do
-          expect(FormResponse).to receive(:new).
-            with(
-              success: true,
-              errors: {},
-              extra: {
-                multi_factor_auth_method: 'piv_cac',
-                piv_cac_configuration_id: piv_cac_configuration.id,
-                multi_factor_auth_method_created_at: piv_cac_configuration.created_at,
-              },
-            ).
-            and_return(result)
-          expect(form.submit).to eq result
+          result = form.submit
+          expect(result.to_h).to eq(
+            success: true,
+            errors: {},
+            multi_factor_auth_method: 'piv_cac',
+            piv_cac_configuration_id: piv_cac_configuration.id,
+            multi_factor_auth_method_created_at: piv_cac_configuration.created_at,
+          )
         end
 
         context 'when nonce is bad' do
@@ -83,16 +81,17 @@ RSpec.describe UserPivCacVerificationForm do
           end
 
           it 'returns FormResponse with success: false' do
-            result = instance_double(FormResponse)
+            result = form.submit
+            expect(result.to_h).to eq(
+              success: false,
+              errors: { type: 'token.invalid' },
+              multi_factor_auth_method: 'piv_cac',
+              piv_cac_configuration_id: nil,
+              multi_factor_auth_method_created_at: nil,
+              key_id: nil,
+            )
 
-            expect(FormResponse).to receive(:new).
-              with(success: false, errors: { type: 'token.invalid' },
-                   extra: { multi_factor_auth_method: 'piv_cac',
-                            piv_cac_configuration_id: nil,
-                            multi_factor_auth_method_created_at: nil,
-                            key_id: nil }).and_return(result)
             expect(Event).to_not receive(:create)
-            expect(form.submit).to eq result
             expect(form.error_type).to eq 'token.invalid'
           end
         end
@@ -106,17 +105,17 @@ RSpec.describe UserPivCacVerificationForm do
       end
 
       it 'returns FormResponse with success: false' do
-        result = instance_double(FormResponse)
-
-        expect(FormResponse).to receive(:new).
-          with(success: false, errors: { type: 'token.bad' },
-               extra: { multi_factor_auth_method: 'piv_cac',
-                        multi_factor_auth_method_created_at: nil,
-                        piv_cac_configuration_id: nil,
-                        key_id: nil }).and_return(result)
+        result = form.submit
         expect(Event).to_not receive(:create)
-        expect(form.submit).to eq result
         expect(form.error_type).to eq 'token.bad'
+        expect(result.to_h).to eq(
+          success: false,
+          errors: { type: 'token.bad' },
+          multi_factor_auth_method: 'piv_cac',
+          multi_factor_auth_method_created_at: nil,
+          piv_cac_configuration_id: nil,
+          key_id: nil,
+        )
       end
     end
 
@@ -124,15 +123,16 @@ RSpec.describe UserPivCacVerificationForm do
       let(:token) {}
 
       it 'returns FormResponse with success: false' do
-        result = instance_double(FormResponse)
-
-        expect(FormResponse).to receive(:new).
-          with(success: false, errors: {}, extra: { multi_factor_auth_method: 'piv_cac',
-                                                    multi_factor_auth_method_created_at: nil,
-                                                    piv_cac_configuration_id: nil }).
-          and_return(result)
+        result = form.submit
         expect(Event).to_not receive(:create)
-        expect(form.submit).to eq result
+
+        expect(result.to_h).to eq(
+          success: false,
+          errors: {},
+          multi_factor_auth_method: 'piv_cac',
+          multi_factor_auth_method_created_at: nil,
+          piv_cac_configuration_id: nil,
+        )
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Related to a bug that snuck in due to stubbing calls to `:new` (fixed in #8756), this PR tries to remove some of the other instances. The `PersonalKeyForm` ones are the riskiest and ones that should be included, this PR fixes an issue in the tests where the value logged was being asserted incorrectly. The rest of the changes are more stylistic and less pressing. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
