### PR TITLE
Remove more stubbing of Forms in controller specs

### DIFF
--- a/app/controllers/users/mfa_selection_controller.rb
+++ b/app/controllers/users/mfa_selection_controller.rb
@@ -30,6 +30,15 @@ module Users
       redirect_back(fallback_location: two_factor_options_path, allow_other_host: false)
     end
 
+    # @api private
+    def two_factor_options_form
+      @two_factor_options_form ||= TwoFactorOptionsForm.new(
+        user: current_user,
+        phishing_resistant_required: service_provider_mfa_policy.phishing_resistant_required?,
+        piv_cac_required: service_provider_mfa_policy.piv_cac_required?,
+      )
+    end
+
     private
 
     def submit_form
@@ -39,14 +48,6 @@ module Users
     def two_factor_options_presenter
       TwoFactorOptionsPresenter.new(
         user_agent: request.user_agent,
-        user: current_user,
-        phishing_resistant_required: service_provider_mfa_policy.phishing_resistant_required?,
-        piv_cac_required: service_provider_mfa_policy.piv_cac_required?,
-      )
-    end
-
-    def two_factor_options_form
-      @two_factor_options_form ||= TwoFactorOptionsForm.new(
         user: current_user,
         phishing_resistant_required: service_provider_mfa_policy.phishing_resistant_required?,
         piv_cac_required: service_provider_mfa_policy.piv_cac_required?,

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -34,6 +34,15 @@ module Users
       redirect_back(fallback_location: authentication_methods_setup_path, allow_other_host: false)
     end
 
+    # @api private
+    def two_factor_options_form
+      @two_factor_options_form ||= TwoFactorOptionsForm.new(
+        user: current_user,
+        phishing_resistant_required: service_provider_mfa_policy.phishing_resistant_required?,
+        piv_cac_required: service_provider_mfa_policy.piv_cac_required?,
+      )
+    end
+
     private
 
     def submit_form
@@ -43,14 +52,6 @@ module Users
     def two_factor_options_presenter
       TwoFactorOptionsPresenter.new(
         user_agent: request.user_agent,
-        user: current_user,
-        phishing_resistant_required: service_provider_mfa_policy.phishing_resistant_required?,
-        piv_cac_required: service_provider_mfa_policy.piv_cac_required?,
-      )
-    end
-
-    def two_factor_options_form
-      @two_factor_options_form ||= TwoFactorOptionsForm.new(
         user: current_user,
         phishing_resistant_required: service_provider_mfa_policy.phishing_resistant_required?,
         piv_cac_required: service_provider_mfa_policy.piv_cac_required?,

--- a/spec/controllers/users/mfa_selection_controller_spec.rb
+++ b/spec/controllers/users/mfa_selection_controller_spec.rb
@@ -30,16 +30,10 @@ RSpec.describe Users::MfaSelectionController do
           selection: 'voice',
         },
       }
-      params = ActionController::Parameters.new(voice_params)
-      response = FormResponse.new(success: true, errors: {}, extra: { selection: ['voice'] })
 
-      form_params = { user: user, phishing_resistant_required: false, piv_cac_required: nil }
-      form = instance_double(TwoFactorOptionsForm)
-      allow(TwoFactorOptionsForm).to receive(:new).with(form_params).and_return(form)
-      expect(form).to receive(:submit).
-        with(params.require(:two_factor_options_form).permit(:selection)).
-        and_return(response)
-      expect(form).to receive(:selection).and_return(['voice'])
+      expect(controller.two_factor_options_form).to receive(:submit).
+        with(hash_including(voice_params[:two_factor_options_form])).
+        and_call_original
 
       patch :update, params: voice_params
     end

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -64,21 +64,20 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController do
           selection: 'voice',
         },
       }
-      params = ActionController::Parameters.new(voice_params)
-      response = FormResponse.new(success: true, errors: {}, extra: { selection: ['voice'] })
-      analytics_hash = response.to_h
 
-      form_params = { user: user, phishing_resistant_required: false, piv_cac_required: nil }
-      form = instance_double(TwoFactorOptionsForm)
-      allow(TwoFactorOptionsForm).to receive(:new).with(form_params).and_return(form)
-      expect(form).to receive(:submit).
-        with(params.require(:two_factor_options_form).permit(:selection)).
-        and_return(response)
-      expect(form).to receive(:selection).twice.and_return(['voice'])
+      expect(controller.two_factor_options_form).to receive(:submit).
+        with(hash_including(voice_params[:two_factor_options_form])).and_call_original
 
       patch :create, params: voice_params
 
-      expect(@analytics).to have_logged_event('User Registration: 2FA Setup', analytics_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: 2FA Setup',
+        success: true,
+        errors: {},
+        enabled_mfa_methods_count: 0,
+        selected_mfa_count: 1,
+        selection: ['voice'],
+      )
     end
 
     it 'tracks analytics event' do


### PR DESCRIPTION
**Why**: Stubbing these forms can lead to gaps in coverage, this makes sure we're testing more realistic behavior

related to https://github.com/18F/identity-idp/pull/8758