### PR TITLE
LG-10225: Add JavaScript-enabled WebAuthn feature spec capability

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -55,7 +55,7 @@ module TwoFactorAuthentication
       is_platform_auth = params[:platform].to_s == 'true'
       if is_platform_auth
         flash[:error] = t(
-          'two_factor_authentication.webauthn_error.multiple_methods',
+          'two_factor_authentication.webauthn_error.try_again',
           link: view_context.link_to(
             t('two_factor_authentication.webauthn_error.additional_methods_link'),
             login_two_factor_options_path,

--- a/app/javascript/packages/webauthn/converters.ts
+++ b/app/javascript/packages/webauthn/converters.ts
@@ -5,12 +5,7 @@
  * @return Converted string.
  */
 export const base64ToArrayBuffer = (base64: string): ArrayBuffer =>
-  Uint8Array.from(
-    window
-      .atob(base64)
-      .split('')
-      .map((char) => char.charCodeAt(0)),
-  ).buffer;
+  Uint8Array.from(atob(base64), (c) => c.charCodeAt(0)).buffer;
 
 /**
  * Converts an array buffer to a base64-encoded string.

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -186,7 +186,7 @@ en:
     webauthn_authenticating: Authenticating your credentials…
     webauthn_error:
       additional_methods_link: choose another authentication method
-      multiple_methods: Face or touch unlock was unsuccessful. Please try again or %{link}.
+      try_again: Face or touch unlock was unsuccessful. Please try again or %{link}.
     webauthn_header_text: Connect your security key
     webauthn_piv_available: Use your PIV or CAC
     webauthn_platform_header_text: Use face or touch unlock

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -200,8 +200,8 @@ es:
     webauthn_authenticating: Autenticando sus credenciales…
     webauthn_error:
       additional_methods_link: elija otro método de autenticación
-      multiple_methods: El desbloqueo facial o táctil no fue exitoso. Por favor,
-        inténtelo de nuevo o %{link}.
+      try_again: El desbloqueo facial o táctil no fue exitoso. Por favor, inténtelo de
+        nuevo o %{link}.
     webauthn_header_text: Conecte su llave de seguridad
     webauthn_piv_available: Utilice su PIV o CAC
     webauthn_platform_header_text: Usar desbloqueo facial o táctil

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -206,8 +206,8 @@ fr:
     webauthn_authenticating: Authentification de vos informations d’identification…
     webauthn_error:
       additional_methods_link: choisir une autre méthode d’authentification
-      multiple_methods: Le déverrouillage facial ou tactile n’a pas fonctionné.
-        Veuillez réessayer ou %{link}.
+      try_again: Le déverrouillage facial ou tactile n’a pas fonctionné. Veuillez
+        réessayer ou %{link}.
     webauthn_header_text: Connectez votre clé de sécurité
     webauthn_piv_available: Utilisez votre PIV ou CAC
     webauthn_platform_header_text: Utilisez le déverrouillage facial ou tactile

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
         it 'displays flash error message' do
           patch :confirm, params: params
           expect(flash[:error]).to eq t(
-            'two_factor_authentication.webauthn_error.multiple_methods',
+            'two_factor_authentication.webauthn_error.try_again',
             link: view_context.link_to(
               t('two_factor_authentication.webauthn_error.additional_methods_link'),
               login_two_factor_options_path,

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'Unchecking remember device' do
         mock_webauthn_verification_challenge
         sign_in_user(user)
         uncheck(:remember_device)
-        mock_press_button_on_hardware_key_on_verification
+        click_webauthn_authenticate_button_and_verify
         first(:link, t('links.sign_out')).click
 
         sign_in_user(user)

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'Unchecking remember device' do
         mock_webauthn_verification_challenge
         sign_in_user(user)
         uncheck(:remember_device)
-        click_webauthn_authenticate_button_and_verify
+        mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
         first(:link, t('links.sign_out')).click
 
         sign_in_user(user)

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Remembering a webauthn device' do
         mock_webauthn_verification_challenge
         sign_in_user(user)
         check t('forms.messages.remember_device')
-        click_webauthn_authenticate_button_and_verify
+        mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
         first(:link, t('links.sign_out')).click
         user
       end
@@ -88,7 +88,7 @@ RSpec.describe 'Remembering a webauthn device' do
         mock_webauthn_verification_challenge
         sign_in_user(user)
         check t('forms.messages.remember_device')
-        click_webauthn_authenticate_button_and_verify
+        mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
         first(:link, t('links.sign_out')).click
         user
       end

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Remembering a webauthn device' do
         mock_webauthn_verification_challenge
         sign_in_user(user)
         check t('forms.messages.remember_device')
-        mock_press_button_on_hardware_key_on_verification
+        click_webauthn_authenticate_button_and_verify
         first(:link, t('links.sign_out')).click
         user
       end
@@ -88,7 +88,7 @@ RSpec.describe 'Remembering a webauthn device' do
         mock_webauthn_verification_challenge
         sign_in_user(user)
         check t('forms.messages.remember_device')
-        mock_press_button_on_hardware_key_on_verification
+        click_webauthn_authenticate_button_and_verify
         first(:link, t('links.sign_out')).click
         user
       end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -548,7 +548,7 @@ RSpec.feature 'Two Factor Authentication' do
           mock_webauthn_verification_challenge
 
           sign_in_user(webauthn_configuration.user)
-          click_webauthn_authenticate_button_and_verify
+          mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
 
           expect(page).to have_current_path(account_path)
         end
@@ -563,7 +563,7 @@ RSpec.feature 'Two Factor Authentication' do
           mock_webauthn_verification_challenge
 
           sign_in_user(webauthn_configuration.user)
-          click_webauthn_authenticate_button_and_verify
+          mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
 
           expect(page).to have_current_path(account_path)
         end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -548,7 +548,7 @@ RSpec.feature 'Two Factor Authentication' do
           mock_webauthn_verification_challenge
 
           sign_in_user(webauthn_configuration.user)
-          mock_press_button_on_hardware_key_on_verification
+          click_webauthn_authenticate_button_and_verify
 
           expect(page).to have_current_path(account_path)
         end
@@ -563,7 +563,7 @@ RSpec.feature 'Two Factor Authentication' do
           mock_webauthn_verification_challenge
 
           sign_in_user(webauthn_configuration.user)
-          mock_press_button_on_hardware_key_on_verification
+          click_webauthn_authenticate_button_and_verify
 
           expect(page).to have_current_path(account_path)
         end

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -50,4 +50,28 @@ RSpec.feature 'webauthn sign in' do
 
     expect(page).to_not have_content(t('errors.general'))
   end
+
+  it 'maintains correct platform attachment content if cancelled', :js do
+    mock_webauthn_verification_challenge
+
+    sign_in_user(user)
+    click_webauthn_authenticate_button_and_cancel
+
+    expect(page).to have_content(t('two_factor_authentication.webauthn_header_text'))
+  end
+
+  context 'platform authenticator' do
+    let(:user) do
+      create(:user, :with_webauthn_platform, with: { credential_id:, credential_public_key: })
+    end
+
+    it 'maintains correct platform attachment content if cancelled', :js do
+      mock_webauthn_verification_challenge
+
+      sign_in_user(user)
+      click_webauthn_authenticate_button_and_cancel
+
+      expect(page).to have_content(t('two_factor_authentication.webauthn_platform_header_text'))
+    end
+  end
 end

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -7,23 +7,13 @@ RSpec.feature 'webauthn sign in' do
     allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
   end
 
-  let(:webauthn_configuration) do
-    create(
-      :webauthn_configuration,
-      credential_id: credential_id,
-      credential_public_key: credential_public_key,
-      user: user,
-    )
-  end
-  let(:user) do
-    create(:user, :with_backup_code)
-  end
+  let(:user) { create(:user, :with_webauthn, with: { credential_id:, credential_public_key: }) }
 
   it 'allows the user to sign in if webauthn is successful' do
     mock_webauthn_verification_challenge
 
-    sign_in_user(webauthn_configuration.user)
-    mock_press_button_on_hardware_key_on_verification
+    sign_in_user(user)
+    click_webauthn_authenticate_button_and_verify
 
     expect(page).to have_current_path(account_path)
   end
@@ -31,8 +21,8 @@ RSpec.feature 'webauthn sign in' do
   it 'does not allow the user to sign in if the challenge/secret is incorrect' do
     # Not calling `mock_challenge` here means the challenge won't match the signature that is set
     # when the button is pressed.
-    sign_in_user(webauthn_configuration.user)
-    mock_press_button_on_hardware_key_on_verification
+    sign_in_user(user)
+    click_webauthn_authenticate_button_and_verify
 
     expect(page).to have_content(t('errors.general'))
     expect(page).to have_current_path(login_two_factor_webauthn_path)
@@ -41,23 +31,22 @@ RSpec.feature 'webauthn sign in' do
   it 'does not allow the user to sign in if the hardware button has not been pressed' do
     mock_webauthn_verification_challenge
 
-    sign_in_user(webauthn_configuration.user)
-    click_button t('two_factor_authentication.webauthn_use_key')
+    sign_in_user(user)
+    click_webauthn_authenticate_button_and_cancel
 
     expect(page).to have_content(t('errors.general'))
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 
-  it 'does not show error after successful challenge/secret reattempt' do
+  it 'does not show error after successful challenge/secret reattempt', :js do
     mock_webauthn_verification_challenge
 
-    sign_in_user(webauthn_configuration.user)
-    # click the next button or cancel from the browser dialog
-    click_button t('two_factor_authentication.webauthn_use_key')
+    sign_in_user(user)
+    click_webauthn_authenticate_button_and_cancel
 
     expect(page).to have_content(t('errors.general'))
 
-    mock_press_button_on_hardware_key_on_verification
+    click_webauthn_authenticate_button_and_verify
 
     expect(page).to_not have_content(t('errors.general'))
   end

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'webauthn sign in' do
     mock_webauthn_verification_challenge
 
     sign_in_user(user)
-    click_webauthn_authenticate_button_and_verify
+    mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
 
     expect(page).to have_current_path(account_path)
   end
@@ -22,7 +22,7 @@ RSpec.feature 'webauthn sign in' do
     # Not calling `mock_challenge` here means the challenge won't match the signature that is set
     # when the button is pressed.
     sign_in_user(user)
-    click_webauthn_authenticate_button_and_verify
+    mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
 
     expect(page).to have_content(t('errors.general'))
     expect(page).to have_current_path(login_two_factor_webauthn_path)
@@ -32,7 +32,7 @@ RSpec.feature 'webauthn sign in' do
     mock_webauthn_verification_challenge
 
     sign_in_user(user)
-    click_webauthn_authenticate_button_and_cancel
+    mock_cancelled_webauthn_authentication { click_webauthn_authenticate_button }
 
     expect(page).to have_content(t('errors.general'))
     expect(page).to have_current_path(login_two_factor_webauthn_path)
@@ -42,11 +42,11 @@ RSpec.feature 'webauthn sign in' do
     mock_webauthn_verification_challenge
 
     sign_in_user(user)
-    click_webauthn_authenticate_button_and_cancel
+    mock_cancelled_webauthn_authentication { click_webauthn_authenticate_button }
 
     expect(page).to have_content(t('errors.general'))
 
-    click_webauthn_authenticate_button_and_verify
+    mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
 
     expect(page).to_not have_content(t('errors.general'))
   end
@@ -55,7 +55,7 @@ RSpec.feature 'webauthn sign in' do
     mock_webauthn_verification_challenge
 
     sign_in_user(user)
-    click_webauthn_authenticate_button_and_cancel
+    mock_cancelled_webauthn_authentication { click_webauthn_authenticate_button }
 
     expect(page).to have_content(t('two_factor_authentication.webauthn_header_text'))
   end
@@ -69,7 +69,7 @@ RSpec.feature 'webauthn sign in' do
       mock_webauthn_verification_challenge
 
       sign_in_user(user)
-      click_webauthn_authenticate_button_and_cancel
+      mock_cancelled_webauthn_authentication { click_webauthn_authenticate_button }
 
       expect(page).to have_content(t('two_factor_authentication.webauthn_platform_header_text'))
     end

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -51,7 +51,9 @@ module WebAuthnHelper
       page.evaluate_script(<<~JS)
         navigator.credentials.get = () => Promise.reject(new DOMException('', 'NotAllowedError'));
       JS
+
       click_webauthn_authenticate_button
+      
       if platform_authenticator?
         expect(page).to have_content(
           strip_tags(

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -46,14 +46,14 @@ module WebAuthnHelper
     end
   end
 
-  def click_webauthn_authenticate_button_and_cancel
+  def mock_cancelled_webauthn_authentication
     if javascript_enabled?
       page.evaluate_script(<<~JS)
         navigator.credentials.get = () => Promise.reject(new DOMException('', 'NotAllowedError'));
       JS
 
-      click_webauthn_authenticate_button
-      
+      yield
+
       if platform_authenticator?
         expect(page).to have_content(
           strip_tags(
@@ -75,7 +75,7 @@ module WebAuthnHelper
     end
   end
 
-  def click_webauthn_authenticate_button_and_verify
+  def mock_successful_webauthn_authentication
     # this is required because the domain is embedded in the supplied attestation object
     allow(WebauthnSetupForm).to receive(:domain_name).and_return('localhost:3000')
 
@@ -94,7 +94,7 @@ module WebAuthnHelper
         });
       JS
       original_path = current_path
-      click_webauthn_authenticate_button
+      yield
       expect(page).not_to have_current_path(original_path, wait: 5)
     else
       # simulate javascript that is triggered when the hardware key button is pressed


### PR DESCRIPTION
## 🎫 Ticket

[LG-10225](https://cm-jira.usa.gov/browse/LG-10225)

## 🛠 Summary of changes

Adds support for simulating results of WebAuthn in JavaScript-enabled browsers in specs, allowing for more realistic test scenarios running in a real browser.

For example, this may have helped avoid the scenario fixed in #8738.

## 📜 Testing Plan

```
rspec spec/features/webauthn/sign_in_spec.rb
```