### PR TITLE
Refactor telephony.log logging to use common interface to enable including metadata in logs

### DIFF
--- a/lib/telephony.rb
+++ b/lib/telephony.rb
@@ -34,6 +34,7 @@ module Telephony
                    GSM_DOUBLE_CHARACTERS).freeze
 
   UCS_2_BASIC_CHAR_MAX = 0xFFFF
+  LOG_FILENAME = 'telephony.log'
 
   extend SingleForwardable
 
@@ -94,6 +95,16 @@ module Telephony
     end
 
     sender.phone_info(phone_number)
+  end
+
+  def self.log_info(event:)
+    event[:log_filename] = LOG_FILENAME
+    self.config.logger.info(event.to_json)
+  end
+
+  def self.log_warn(event:)
+    event[:log_filename] = LOG_FILENAME
+    self.config.logger.warn(event.to_json)
   end
 
   # A character in a GSM 03.38 message counts as one character, unless it is explicitly one of

--- a/lib/telephony/alert_sender.rb
+++ b/lib/telephony/alert_sender.rb
@@ -72,11 +72,11 @@ module Telephony
         context: context,
       }
       output = response.to_h.merge(extra)
-      Telephony.config.log_info(event: output)
+      Telephony.log_info(event: output)
     end
 
     def log_warning(alert, context:)
-      Telephony.config.log_warn(
+      Telephony.log_warn(
         {
           alert: alert,
           adapter: Telephony.config.adapter,

--- a/lib/telephony/alert_sender.rb
+++ b/lib/telephony/alert_sender.rb
@@ -71,18 +71,18 @@ module Telephony
         channel: :sms,
         context: context,
       }
-      output = response.to_h.merge(extra).to_json
-      Telephony.config.logger.info(output)
+      output = response.to_h.merge(extra)
+      Telephony.config.log_info(event: output)
     end
 
     def log_warning(alert, context:)
-      Telephony.config.logger.warn(
+      Telephony.config.log_warn(
         {
           alert: alert,
           adapter: Telephony.config.adapter,
           channel: :sms,
           context: context,
-        }.to_json,
+        },
       )
     end
   end

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -56,11 +56,9 @@ module Telephony
   )
 
   class Configuration
-    LOG_FILENAME = 'telephony.log'
-
     attr_writer :adapter
     attr_reader :pinpoint
-    attr_writer :logger
+    attr_accessor :logger
     attr_accessor :voice_pause_time
     attr_accessor :voice_rate
 
@@ -81,16 +79,6 @@ module Telephony
 
     def country_sender_ids
       @country_sender_ids || {}
-    end
-
-    def log_info(event:)
-      event[:log_filename] = LOG_FILENAME
-      @logger.info(event.to_json)
-    end
-
-    def log_warn(event:)
-      event[:log_filename] = LOG_FILENAME
-      @logger.warn(event.to_json)
     end
   end
 end

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -56,9 +56,11 @@ module Telephony
   )
 
   class Configuration
+    LOG_FILENAME = 'telephony.log'
+
     attr_writer :adapter
     attr_reader :pinpoint
-    attr_accessor :logger
+    attr_writer :logger
     attr_accessor :voice_pause_time
     attr_accessor :voice_rate
 
@@ -79,6 +81,16 @@ module Telephony
 
     def country_sender_ids
       @country_sender_ids || {}
+    end
+
+    def log_info(event:)
+      event[:log_filename] = LOG_FILENAME
+      @logger.info(event.to_json)
+    end
+
+    def log_warn(event:)
+      event[:log_filename] = LOG_FILENAME
+      @logger.warn(event.to_json)
     end
   end
 end

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -89,8 +89,8 @@ module Telephony
           country_code: country_code,
         },
       )
-      output = response.to_h.merge(extra).to_json
-      Telephony.config.logger.info(output)
+      output = response.to_h.merge(extra)
+      Telephony.config.log_info(event: output)
     end
 
     def otp_transformed_for_channel

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -90,7 +90,7 @@ module Telephony
         },
       )
       output = response.to_h.merge(extra)
-      Telephony.config.log_info(event: output)
+      Telephony.log_info(event: output)
     end
 
     def otp_transformed_for_channel

--- a/lib/telephony/pinpoint/aws_credential_builder.rb
+++ b/lib/telephony/pinpoint/aws_credential_builder.rb
@@ -41,7 +41,7 @@ module Telephony
 
       def notify_role_failure(error:, region:)
         error_log = { error: error, region: region }
-        Telephony.config.logger.warn(error_log.to_json)
+        Telephony.config.log_warn(event: error_log)
       end
     end
   end

--- a/lib/telephony/pinpoint/aws_credential_builder.rb
+++ b/lib/telephony/pinpoint/aws_credential_builder.rb
@@ -41,7 +41,7 @@ module Telephony
 
       def notify_role_failure(error:, region:)
         error_log = { error: error, region: region }
-        Telephony.config.log_warn(event: error_log)
+        Telephony.log_warn(event: error_log)
       end
     end
   end

--- a/lib/telephony/pinpoint/pinpoint_helper.rb
+++ b/lib/telephony/pinpoint/pinpoint_helper.rb
@@ -11,7 +11,7 @@ module Telephony
             channel: channel,
           ),
         )
-        Telephony.config.logger.warn(response.to_h.to_json)
+        Telephony.config.log_warn(event: response.to_h)
       end
 
       # @return [Response]
@@ -24,7 +24,7 @@ module Telephony
           },
         )
 
-        Telephony.config.logger.warn(response.to_h.to_json)
+        Telephony.config.log_warn(event: response.to_h)
 
         response
       end

--- a/lib/telephony/pinpoint/pinpoint_helper.rb
+++ b/lib/telephony/pinpoint/pinpoint_helper.rb
@@ -11,7 +11,7 @@ module Telephony
             channel: channel,
           ),
         )
-        Telephony.config.log_warn(event: response.to_h)
+        Telephony.log_warn(event: response.to_h)
       end
 
       # @return [Response]
@@ -24,7 +24,7 @@ module Telephony
           },
         )
 
-        Telephony.config.log_warn(event: response.to_h)
+        Telephony.log_warn(event: response.to_h)
 
         response
       end

--- a/spec/lib/telephony/alert_sender_spec.rb
+++ b/spec/lib/telephony/alert_sender_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Telephony::AlertSender do
     it 'warns if the link is longer than 160 characters' do
       long_link = 'a' * 161
 
-      expect(Telephony.config.logger).to receive(:warn)
+      expect(Telephony.config).to receive(:log_warn)
 
       subject.send_doc_auth_link(
         to: recipient,

--- a/spec/lib/telephony/alert_sender_spec.rb
+++ b/spec/lib/telephony/alert_sender_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Telephony::AlertSender do
     it 'warns if the link is longer than 160 characters' do
       long_link = 'a' * 161
 
-      expect(Telephony.config).to receive(:log_warn)
+      expect(Telephony).to receive(:log_warn)
 
       subject.send_doc_auth_link(
         to: recipient,

--- a/spec/lib/telephony/otp_sender_spec.rb
+++ b/spec/lib/telephony/otp_sender_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Telephony::OtpSender do
       end
 
       it 'logs a message being sent' do
-        expect(Telephony.config).to receive(:log_info).with(
+        expect(Telephony).to receive(:log_info).with(
           event: {
             success: true,
             errors: {},

--- a/spec/lib/telephony/otp_sender_spec.rb
+++ b/spec/lib/telephony/otp_sender_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Telephony::OtpSender do
       end
 
       it 'logs a message being sent' do
-        expect(Telephony.config.logger).to receive(:info).with(
-          {
+        expect(Telephony.config).to receive(:log_info).with(
+          event: {
             success: true,
             errors: {},
             request_id: 'fake-message-request-id',
@@ -66,7 +66,7 @@ RSpec.describe Telephony::OtpSender do
             channel: :sms,
             context: :authentication,
             country_code: 'US',
-          }.to_json,
+          },
         )
 
         subject.send_authentication_otp

--- a/spec/lib/telephony/pinpoint/aws_credential_builder_spec.rb
+++ b/spec/lib/telephony/pinpoint/aws_credential_builder_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Telephony::Pinpoint::AwsCredentialBuilder do
       expect(Aws::STS::Client).to receive(:new).and_raise(
         Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new),
       )
-      expect(Telephony.config.logger).to receive(:warn)
+      expect(Telephony.config).to receive(:log_warn)
 
       result = credential_builder.call
       expect(result).to eq(nil)

--- a/spec/lib/telephony/pinpoint/aws_credential_builder_spec.rb
+++ b/spec/lib/telephony/pinpoint/aws_credential_builder_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Telephony::Pinpoint::AwsCredentialBuilder do
       expect(Aws::STS::Client).to receive(:new).and_raise(
         Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new),
       )
-      expect(Telephony.config).to receive(:log_warn)
+      expect(Telephony).to receive(:log_warn)
 
       result = credential_builder.call
       expect(result).to eq(nil)

--- a/spec/lib/telephony/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/sms_sender_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe Telephony::Pinpoint::SmsSender do
         end
 
         it 'logs a warning for each failure and tries the other configs' do
-          expect(Telephony.config.logger).to receive(:warn).exactly(2).times
+          expect(Telephony.config).to receive(:log_warn).exactly(2).times
 
           response = subject.deliver(
             message: 'This is a test!',
@@ -562,7 +562,7 @@ RSpec.describe Telephony::Pinpoint::SmsSender do
       end
 
       it 'logs a warning for each failure and tries the other configs' do
-        expect(Telephony.config.logger).to receive(:warn).exactly(1).times
+        expect(Telephony.config).to receive(:log_warn).exactly(1).times
 
         expect(phone_info.type).to eq(:voip)
         expect(phone_info.error).to be_nil
@@ -578,7 +578,7 @@ RSpec.describe Telephony::Pinpoint::SmsSender do
       end
 
       it 'logs a warning for each failure and returns unknown' do
-        expect(Telephony.config.logger).to receive(:warn).exactly(2).times
+        expect(Telephony.config).to receive(:log_warn).exactly(2).times
 
         expect(phone_info.type).to eq(:unknown)
         expect(phone_info.error).to be_kind_of(Seahorse::Client::NetworkingError)

--- a/spec/lib/telephony/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/sms_sender_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe Telephony::Pinpoint::SmsSender do
         end
 
         it 'logs a warning for each failure and tries the other configs' do
-          expect(Telephony.config).to receive(:log_warn).exactly(2).times
+          expect(Telephony).to receive(:log_warn).exactly(2).times
 
           response = subject.deliver(
             message: 'This is a test!',
@@ -562,7 +562,7 @@ RSpec.describe Telephony::Pinpoint::SmsSender do
       end
 
       it 'logs a warning for each failure and tries the other configs' do
-        expect(Telephony.config).to receive(:log_warn).exactly(1).times
+        expect(Telephony).to receive(:log_warn).exactly(1).times
 
         expect(phone_info.type).to eq(:voip)
         expect(phone_info.error).to be_nil
@@ -578,7 +578,7 @@ RSpec.describe Telephony::Pinpoint::SmsSender do
       end
 
       it 'logs a warning for each failure and returns unknown' do
-        expect(Telephony.config).to receive(:log_warn).exactly(2).times
+        expect(Telephony).to receive(:log_warn).exactly(2).times
 
         expect(phone_info.type).to eq(:unknown)
         expect(phone_info.error).to be_kind_of(Seahorse::Client::NetworkingError)

--- a/spec/lib/telephony/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/voice_sender_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Telephony::Pinpoint::VoiceSender do
         end
 
         it 'logs a warning and tries the other configs' do
-          expect(Telephony.config).to receive(:log_warn)
+          expect(Telephony).to receive(:log_warn)
 
           response = voice_sender.deliver(message: message, to: recipient_phone, country_code: 'US')
           expect(response.success?).to eq(true)

--- a/spec/lib/telephony/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/voice_sender_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Telephony::Pinpoint::VoiceSender do
         end
 
         it 'logs a warning and tries the other configs' do
-          expect(Telephony.config.logger).to receive(:warn)
+          expect(Telephony.config).to receive(:log_warn)
 
           response = voice_sender.deliver(message: message, to: recipient_phone, country_code: 'US')
           expect(response.success?).to eq(true)


### PR DESCRIPTION
## 🛠 Summary of changes

A small followup to #8610 to add `log_filename` to the Telephony logger. This one was a bit more involved than the ones in #8610 since previously calls were being made directly to `Telephony.config.logger`. This PR refactors the logging to put it behind a method so that we can add the metadata to all logging calls.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
