### PR TITLE
Don't commit sessions for frontend log requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -371,12 +371,17 @@ class ApplicationController < ActionController::Base
     MfaPolicy.new(current_user).two_factor_enabled?
   end
 
+  # Prevent the session from being written back to the session store at the end of the request.
+  def skip_session_commit
+    request.session_options[:skip] = true
+  end
+
   def skip_session_expiration
     @skip_session_expiration = true
   end
 
   def skip_session_load
-    request.session_options[:skip] = true
+    skip_session_commit
     @skip_session_load = true
   end
 

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -4,6 +4,10 @@ class FrontendLogController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :validate_parameter_types
 
+  # Don't write session data back to Redis for these requests.
+  # In rare circumstances, these writes can clobber other, more important writes.
+  before_action :skip_session_commit
+
   # rubocop:disable Layout/LineLength
   EVENT_MAP = {
     'IdV: verify in person troubleshooting option clicked' => :idv_verify_in_person_troubleshooting_option_clicked,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -346,6 +346,20 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe '#skip_session_commit' do
+    controller do
+      before_action :skip_session_commit
+      def index
+        render plain: 'Hello'
+      end
+    end
+
+    it 'tells rack not to commit session' do
+      get :index
+      expect(request.session_options[:skip]).to eql(true)
+    end
+  end
+
   describe '#redirect_with_flash_if_timeout' do
     before { routes.draw { get 'index' => 'anonymous#index' } }
     after { Rails.application.reload_routes! }

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe FrontendLogController do
         expect(json[:success]).to eq(true)
       end
 
+      it 'does not commit session' do
+        action
+        expect(request.session_options[:skip]).to eql(true)
+      end
+
       context 'allowlisted analytics event' do
         let(:event) { 'IdV: download personal key' }
 
@@ -183,6 +188,11 @@ RSpec.describe FrontendLogController do
 
         expect(response).to have_http_status(:ok)
         expect(json[:success]).to eq(true)
+      end
+
+      it 'does not commit session' do
+        action
+        expect(request.session_options[:skip]).to eql(true)
       end
     end
   end

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
       click_idv_continue
     end
 
-    xit 'shows a warning message to allow the user to return to upload new images' do
+    it 'shows a warning message to allow the user to return to upload new images' do
       warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
 
       expect(page).to have_css(
@@ -60,7 +60,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
       expect(page).to have_css('[role="status"]')  # We verified your ID
     end
 
-    xit 'document capture cannot be reached after submitting verify info step' do
+    it 'document capture cannot be reached after submitting verify info step' do
       warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
 
       expect(page).to have_css(
@@ -106,7 +106,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
     context 'with a bad SSN' do
       let(:use_bad_ssn) { true }
 
-      xit 'shows a troubleshooting option to allow the user to cancel and return to SP' do
+      it 'shows a troubleshooting option to allow the user to cancel and return to SP' do
         click_idv_continue
 
         expect(page).to have_link(


### PR DESCRIPTION
## 🎫 Ticket

This fixes [LG-10192](https://cm-jira.usa.gov/browse/LG-10192)

## 🛠 Summary of changes

This PR:
- Adds a new filter to ApplicationController called `skip_session_commit`
- Refactors the existing `skip_session_load` filter to use `skip_session_commit`
- Updates the FrontendLogController to opt out of session committing
- Re-enables IdV "Redo document capture" feature tests previously disabled due to flakiness

### THE BACKSTORY

If you read from the session while processing a request, rack will, by default, write that session data back to the session store when the request ends. This is referred to as ["committing" the session](https://github.com/rack/rack/blob/v2.2.7/lib/rack/session/abstract/id.rb#L373-L405). 

So if:

- Two requests for the same user are processed in parallel AND
- Both requests read from the session AND
- Only one adds new data to the session (or they both add different data)

Then it is possible that the changes to the session will be lost. It looks something like:

- Request 1 reads current session
- Request 2 reads current session
- Request 1 processes and sets some important data in its local copy of session data
- Request 2 processes but doesn't change session 
- Request 1 ends and writes its modified session to Redis
- Request 2 ends and writes its unmodified session to Redis, clobbering the changes from Request 1

I haven't looked into how prevalent this problem is in production--my guess is not very, since it involves fairly precise timing. But it **DEFINITELY** is a problem in CI, where we run automated tests that make many requests in rapid succession.

Lately we've seen flakiness on the IdV "Redo document capture" feature test. Running locally, I was seeing roughly **1 out of 100 executions** of the spec file fail. Failures seemed to be more frequent in CI–I'm guessing that the reduced CPU of CI runners compared to my laptop resulted in requests being processed in parallel more often.

Eventually, I traced the flakiness to the how frontend API logger requests are handled. The feature test would perform an action, which would result in a frontend API logger request, then submit a form, which would result in a request that modified the session. Occasionally, these requests would be processed such that the session write from the logging would clobber the meaningful session write from the form submission.

The frontend logging endpoint needs to _read_ the session, since it augments log messages with user information, but it does not need to _write_ it back. It turns out that setting `request.session_options[:skip] = true` will [tell Rack not to write the session](https://github.com/rack/rack/blob/v2.2.7/lib/rack/session/abstract/id.rb#L343-L345).

We have some existing session-related filters in `ApplicationController`, so I added a new one: `skip_session_commit`. Adding this filter to `FrontendLogController` _seems_ to have fixed the issue (I ran the test file more than 1500 times and did not see the error reappear).

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Run `spec/features/idv/doc_auth/redo_document_capture_spec.rb` 1500 times and verify that you don't get the error `Unable to find field "Social Security number" that is not disabled`