### PR TITLE
Remove duplicative fully authenticated check in welcome template

### DIFF
--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -110,13 +110,7 @@
           ) %>
     </p>
 
-    <% if user_fully_authenticated? %>
-      <%= render 'shared/cancel', link: idv_cancel_path(step: 'welcome') %>
-    <% else %>
-      <div class='margin-top-2 padding-top-2 border-top border-primary-light'>
-        <%= link_to(t('two_factor_authentication.choose_another_option'), authentication_methods_setup_path) %>
-      </div>
-    <% end %>
+    <%= render 'shared/cancel', link: idv_cancel_path(step: 'welcome') %>
   <% end %>
 <% end %>
 

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -47,16 +47,6 @@ RSpec.describe 'idv/welcome/show.html.erb' do
     end
   end
 
-  context 'in recovery without an authenticated user' do
-    let(:user_fully_authenticated) { false }
-
-    it 'renders a link to return to the MFA step' do
-      render
-
-      expect(rendered).to have_link(t('two_factor_authentication.choose_another_option'))
-    end
-  end
-
   context 'during the acuant maintenance window' do
     let(:start) { Time.zone.parse('2020-01-01T00:00:00Z') }
     let(:now) { Time.zone.parse('2020-01-01T12:00:00Z') }


### PR DESCRIPTION
## 🛠 Summary of changes

Some discussion in Slack [here](https://gsa-tts.slack.com/archives/CNCGEHG1G/p1689183454265999) that concluded that since the controller also checks for full authentication, the template doesn't need to as well. This PR removes the conditional.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
