### PR TITLE
LG-9499: Add banner to alert user they already tried to verify with a phone number

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -141,7 +141,7 @@ module Idv
         previous_params: idv_session.previous_phone_step_params,
         allowed_countries:
           PhoneNumberCapabilities::ADDRESS_IDENTITY_PROOFING_SUPPORTED_COUNTRY_CODES,
-        failed_phone_numbers: idv_session.failed_phone_step_numbers
+        failed_phone_numbers: idv_session.failed_phone_step_numbers,
       )
     end
 

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -141,6 +141,7 @@ module Idv
         previous_params: idv_session.previous_phone_step_params,
         allowed_countries:
           PhoneNumberCapabilities::ADDRESS_IDENTITY_PROOFING_SUPPORTED_COUNTRY_CODES,
+        failed_phone_numbers: idv_session.failed_phone_step_numbers
       )
     end
 

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -62,12 +62,11 @@ module Idv
       end
 
       if failed_phone_numbers.include?(Phonelib.parse(phone).e164)
-        phone = nil
+        [nil, nil]
       else
         phone = PhoneFormatter.format(phone, country_code: international_code)
+        [international_code, phone]
       end
-
-      [international_code, phone]
     end
 
     def country_code_for(phone)

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -61,7 +61,11 @@ module Idv
         international_code ||= country_code_for(phone)
       end
 
-      phone = PhoneFormatter.format(phone, country_code: international_code)
+      if failed_phone_numbers.include?(Phonelib.parse(phone).e164)
+        phone = nil
+      else
+        phone = PhoneFormatter.format(phone, country_code: international_code)
+      end
 
       [international_code, phone]
     end

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -5,7 +5,7 @@ module Idv
     ALL_DELIVERY_METHODS = [:sms, :voice].freeze
 
     attr_reader :user, :phone, :allowed_countries, :delivery_methods, :international_code,
-                :otp_delivery_preference
+                :otp_delivery_preference, :failed_phone_numbers
 
     validate :validate_valid_phone_for_allowed_countries
     validate :validate_phone_delivery_methods
@@ -19,12 +19,14 @@ module Idv
       user:,
       previous_params:,
       allowed_countries: nil,
-      delivery_methods: ALL_DELIVERY_METHODS
+      delivery_methods: ALL_DELIVERY_METHODS,
+      failed_phone_numbers: []
     )
       previous_params ||= {}
       @user = user
       @allowed_countries = allowed_countries
       @delivery_methods = delivery_methods
+      @failed_phone_numbers = failed_phone_numbers
 
       @international_code, @phone = determine_initial_values(
         **previous_params.

--- a/app/javascript/packs/idv-phone-alert.ts
+++ b/app/javascript/packs/idv-phone-alert.ts
@@ -1,9 +1,9 @@
 const alertElement = document.getElementById('phone-already-submitted-alert')!;
 const input = document.getElementById('idv_phone_form_phone') as HTMLInputElement;
-const alreadySubmittedNumbers: string[] = JSON.parse(alertElement.dataset.alreadySubmittedNumbers!);
+const failedPhoneNumbers: string[] = JSON.parse(alertElement.dataset.failedPhoneNumbers!);
 const iti = window.intlTelInputGlobals.getInstance(input);
 
 input.addEventListener('input', () => {
-    const isAlreadySubmittedNumber = alreadySubmittedNumbers.includes(iti.getNumber(intlTelInputUtils.numberFormat.E164));
-    alertElement.hidden = !isAlreadySubmittedNumber;
+    const isFailedPhoneNumber = failedPhoneNumbers.includes(iti.getNumber(intlTelInputUtils.numberFormat.E164));
+    alertElement.hidden = !isFailedPhoneNumber;
 });

--- a/app/javascript/packs/idv-phone-alert.ts
+++ b/app/javascript/packs/idv-phone-alert.ts
@@ -4,6 +4,8 @@ const failedPhoneNumbers: string[] = JSON.parse(alertElement.dataset.failedPhone
 const iti = window.intlTelInputGlobals.getInstance(input);
 
 input.addEventListener('input', () => {
-    const isFailedPhoneNumber = failedPhoneNumbers.includes(iti.getNumber(intlTelInputUtils.numberFormat.E164));
-    alertElement.hidden = !isFailedPhoneNumber;
+  const isFailedPhoneNumber = failedPhoneNumbers.includes(
+    iti.getNumber(intlTelInputUtils.numberFormat.E164),
+  );
+  alertElement.hidden = !isFailedPhoneNumber;
 });

--- a/app/javascript/packs/idv-phone-alert.ts
+++ b/app/javascript/packs/idv-phone-alert.ts
@@ -1,12 +1,9 @@
 const alertElement = document.getElementById('phone-already-submitted-alert')!;
 const input = document.getElementById('idv_phone_form_phone') as HTMLInputElement;
 const alreadySubmittedNumbers: string[] = JSON.parse(alertElement.dataset.alreadySubmittedNumbers!);
+const iti = window.intlTelInputGlobals.getInstance(input);
 
 input.addEventListener('input', () => {
-    // 513-555-0100
-    // (513) 555-0100
-    // 5135550100
-    // intlTelInput - this.iti
-    const isAlreadySubmittedNumber = alreadySubmittedNumbers.includes(input.value);
+    const isAlreadySubmittedNumber = alreadySubmittedNumbers.includes(iti.getNumber(intlTelInputUtils.numberFormat.E164));
     alertElement.hidden = !isAlreadySubmittedNumber;
 });

--- a/app/javascript/packs/idv-phone-alert.ts
+++ b/app/javascript/packs/idv-phone-alert.ts
@@ -1,0 +1,12 @@
+const alertElement = document.getElementById('phone-already-submitted-alert')!;
+const input = document.getElementById('idv_phone_form_phone') as HTMLInputElement;
+const alreadySubmittedNumbers: string[] = JSON.parse(alertElement.dataset.alreadySubmittedNumbers!);
+
+input.addEventListener('input', () => {
+    // 513-555-0100
+    // (513) 555-0100
+    // 5135550100
+    // intlTelInput - this.iti
+    const isAlreadySubmittedNumber = alreadySubmittedNumbers.includes(input.value);
+    alertElement.hidden = !isAlreadySubmittedNumber;
+});

--- a/app/javascript/packs/idv-phone-alert.ts
+++ b/app/javascript/packs/idv-phone-alert.ts
@@ -1,7 +1,8 @@
+import type { PhoneInputElement } from '@18f/identity-phone-input';
+
 const alertElement = document.getElementById('phone-already-submitted-alert')!;
-const input = document.getElementById('idv_phone_form_phone') as HTMLInputElement;
+const { iti, textInput: input } = document.querySelector('lg-phone-input') as PhoneInputElement;
 const failedPhoneNumbers: string[] = JSON.parse(alertElement.dataset.failedPhoneNumbers!);
-const iti = window.intlTelInputGlobals.getInstance(input);
 
 input.addEventListener('input', () => {
   const isFailedPhoneNumber = failedPhoneNumbers.includes(

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -43,7 +43,11 @@ module Idv
       @idv_result = async_state.result
 
       success = idv_result[:success]
-      handle_successful_proofing_attempt if success
+      if success
+        handle_successful_proofing_attempt
+      else
+        idv_session.add_failed_phone_step_number(idv_session.previous_phone_step_params[:phone])
+      end
 
       delete_async
       FormResponse.new(

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -46,7 +46,9 @@ module Idv
       if success
         handle_successful_proofing_attempt
       else
-        idv_session.add_failed_phone_step_number(idv_session.previous_phone_step_params[:phone])
+        unless failure_reason == :timeout
+          idv_session.add_failed_phone_step_number(idv_session.previous_phone_step_params[:phone])
+        end
       end
 
       delete_async

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -46,9 +46,7 @@ module Idv
       if success
         handle_successful_proofing_attempt
       else
-        unless failure_reason == :timeout
-          idv_session.add_failed_phone_step_number(idv_session.previous_phone_step_params[:phone])
-        end
+        handle_failed_proofing_attempt
       end
 
       delete_async
@@ -175,6 +173,12 @@ module Idv
 
     def delete_async
       idv_session.idv_phone_step_document_capture_session_uuid = nil
+    end
+
+    def handle_failed_proofing_attempt
+      return if failure_reason == :timeout
+
+      idv_session.add_failed_phone_step_number(idv_session.previous_phone_step_params[:phone])
     end
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -128,6 +128,16 @@ module Idv
       session[:user_phone_confirmation_session] = new_user_phone_confirmation_session.to_h
     end
 
+    def failed_phone_step_numbers
+      session[:failed_phone_step_params] ||= []
+    end
+
+    def add_failed_phone_step_number(phone)
+      parsed_phone = Phonelib.parse(phone)
+      phone_e164 = parsed_phone.e164
+      failed_phone_step_numbers << phone_e164 if !failed_phone_step_numbers.include?(phone_e164)
+    end
+
     def in_person_enrollment?
       ProofingComponent.find_by(user: current_user)&.document_check == Idp::Constants::Vendors::USPS
     end

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -76,12 +76,12 @@
         hidden: true,
       ) do %>
     <%= t(
-        'idv.messages.phone.failed_number.alert_html',
-        link_html: link_to(
-          t('idv.messages.phone.failed_number.gpo_verify_link'),
-          idv_gpo_path,
-        ),
-      ) %>
+          'idv.messages.phone.failed_number.alert_html',
+          link_html: link_to(
+            t('idv.messages.phone.failed_number.gpo_verify_link'),
+            idv_gpo_path,
+          ),
+        ) %>
   <% end %>
 
   <h2><%= t('idv.titles.otp_delivery_method') %></h2>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -75,8 +75,8 @@
         },
         hidden: true,
       ) do %>
-    <%= t(
-          'idv.messages.phone.failed_number.alert_html',
+    <%= t('idv.messages.phone.failed_number.alert_text')%>
+    <%= gpo_letter_available && t('idv.messages.phone.failed_number.gpo_alert_html',
           link_html: link_to(
             t('idv.messages.phone.failed_number.gpo_verify_link'),
             idv_gpo_path,

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -67,12 +67,22 @@
       ) %>
   <%= render AlertComponent.new(
         type: :warning,
+        class: 'margin-bottom-4',
+        text_tag: 'div',
         id: 'phone-already-submitted-alert',
         data: {
           failed_phone_numbers: @idv_form.failed_phone_numbers,
         },
         hidden: true,
-      ).with_content('...') %>
+      ) do %>
+    <%= t(
+        'idv.messages.phone.failed_number.alert_html',
+        link_html: link_to(
+          t('idv.messages.phone.failed_number.gpo_verify_link'),
+          idv_gpo_path,
+        ),
+      ) %>
+  <% end %>
 
   <h2><%= t('idv.titles.otp_delivery_method') %></h2>
   <p><%= t('idv.messages.otp_delivery_method_description') %></p>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -69,7 +69,7 @@
         type: :warning,
         id: 'phone-already-submitted-alert',
         data: {
-          already_submitted_numbers: ['703-555-1212', '...'],
+          failed_phone_numbers: @idv_form.failed_phone_numbers,
         },
         hidden: true,
       ).with_content('...') %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -75,7 +75,7 @@
         },
         hidden: true,
       ) do %>
-    <%= t('idv.messages.phone.failed_number.alert_text')%>
+    <%= t('idv.messages.phone.failed_number.alert_text') %>
     <%= gpo_letter_available && t('idv.messages.phone.failed_number.gpo_alert_html',
           link_html: link_to(
             t('idv.messages.phone.failed_number.gpo_verify_link'),

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -68,7 +68,6 @@
   <%= render AlertComponent.new(
         type: :warning,
         class: 'margin-bottom-4',
-        text_tag: 'div',
         id: 'phone-already-submitted-alert',
         data: {
           failed_phone_numbers: @idv_form.failed_phone_numbers,
@@ -76,13 +75,15 @@
         hidden: true,
       ) do %>
     <%= t('idv.messages.phone.failed_number.alert_text') %>
-    <%= gpo_letter_available && t(
-          'idv.messages.phone.failed_number.gpo_alert_html',
-          link_html: link_to(
-            t('idv.messages.phone.failed_number.gpo_verify_link'),
-            idv_gpo_path,
-          ),
-        ) %>
+    <% if gpo_letter_available %>
+      <%= t(
+            'idv.messages.phone.failed_number.gpo_alert_html',
+            link_html: link_to(
+              t('idv.messages.phone.failed_number.gpo_verify_link'),
+              idv_gpo_path,
+            ),
+          ) %>
+    <% end %>
   <% end %>
 
   <h2><%= t('idv.titles.otp_delivery_method') %></h2>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -76,7 +76,8 @@
         hidden: true,
       ) do %>
     <%= t('idv.messages.phone.failed_number.alert_text') %>
-    <%= gpo_letter_available && t('idv.messages.phone.failed_number.gpo_alert_html',
+    <%= gpo_letter_available && t(
+          'idv.messages.phone.failed_number.gpo_alert_html',
           link_html: link_to(
             t('idv.messages.phone.failed_number.gpo_verify_link'),
             idv_gpo_path,

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -65,6 +65,14 @@
         required: true,
         class: 'margin-bottom-4',
       ) %>
+  <%= render AlertComponent.new(
+        type: :warning,
+        id: 'phone-already-submitted-alert',
+        data: {
+          already_submitted_numbers: ['703-555-1212', '...'],
+        },
+        hidden: true,
+      ).with_content('...') %>
 
   <h2><%= t('idv.titles.otp_delivery_method') %></h2>
   <p><%= t('idv.messages.otp_delivery_method_description') %></p>
@@ -115,4 +123,4 @@
 
 <%= render 'idv/doc_auth/cancel', step: 'phone' %>
 
-<% javascript_packs_tag_once 'form-steps-wait' %>
+<% javascript_packs_tag_once 'form-steps-wait', 'idv-phone-alert' %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -214,7 +214,8 @@ en:
         description: We’ll check this number with records and send you a one-time code.
           This is to help verify your identity.
         failed_number:
-          alert_html: We couldn’t match you to this number. If you don’t have <strong>another</strong> number to try, %{link_html} instead.
+          alert_html: We couldn’t match you to this number. If you don’t have
+            <strong>another</strong> number to try, %{link_html} instead.
           gpo_verify_link: verify by mail
         rules:
           - Based in the United States (including U.S. territories)

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -214,8 +214,8 @@ en:
         description: We’ll check this number with records and send you a one-time code.
           This is to help verify your identity.
         failed_number:
-          alert_html: We couldn’t match you to this number. If you don’t have
-            <strong>another</strong> number to try, %{link_html} instead.
+          alert_text: We couldn’t match you to this number.
+          gpo_alert_html: If you don’t have <strong>another</strong> number to try, %{link_html} instead.
           gpo_verify_link: verify by mail
         rules:
           - Based in the United States (including U.S. territories)

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -215,7 +215,8 @@ en:
           This is to help verify your identity.
         failed_number:
           alert_text: We couldn’t match you to this number.
-          gpo_alert_html: If you don’t have <strong>another</strong> number to try, %{link_html} instead.
+          gpo_alert_html: If you don’t have <strong>another</strong> number to try,
+            %{link_html} instead.
           gpo_verify_link: verify by mail
         rules:
           - Based in the United States (including U.S. territories)

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -213,6 +213,9 @@ en:
         alert_html: '<strong>Enter a phone number that is:</strong>'
         description: We’ll check this number with records and send you a one-time code.
           This is to help verify your identity.
+        failed_number:
+          alert_html: We couldn’t match you to this number. If you don’t have <strong>another</strong> number to try, %{link_html} instead.
+          gpo_verify_link: verify by mail
         rules:
           - Based in the United States (including U.S. territories)
           - Your primary number (the one you use the most often)

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -225,8 +225,8 @@ es:
         description: Comprobaremos este número con los registros y le enviaremos un
           código único. Esto es para ayudar a verificar su identidad.
         failed_number:
-          alert_html: No pudimos asociarlo a este número. Si no dispone de
-            <strong>otro</strong> número de teléfono, %{link_html}.
+          alert_text: No pudimos asociarlo a este número.
+          gpo_alert_html: Si no dispone de <strong>otro</strong> número de teléfono, %{link_html}.
           gpo_verify_link: realice la verificación por correo
         rules:
           - Con base en Estados Unidos (incluidos los territorios de EE.UU.)

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -225,7 +225,8 @@ es:
         description: Comprobaremos este número con los registros y le enviaremos un
           código único. Esto es para ayudar a verificar su identidad.
         failed_number:
-          alert_html: No pudimos asociarlo a este número. Si no dispone de <strong>otro</strong> número de teléfono, %{link_html}.
+          alert_html: No pudimos asociarlo a este número. Si no dispone de
+            <strong>otro</strong> número de teléfono, %{link_html}.
           gpo_verify_link: realice la verificación por correo
         rules:
           - Con base en Estados Unidos (incluidos los territorios de EE.UU.)

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -224,6 +224,9 @@ es:
         alert_html: '<strong>Introduzca un número de teléfono que sea:</strong>'
         description: Comprobaremos este número con los registros y le enviaremos un
           código único. Esto es para ayudar a verificar su identidad.
+        failed_number:
+          alert_html: No pudimos asociarlo a este número. Si no dispone de <strong>otro</strong> número de teléfono, %{link_html}.
+          gpo_verify_link: realice la verificación por correo
         rules:
           - Con base en Estados Unidos (incluidos los territorios de EE.UU.)
           - Su número principal (el que utiliza con más frecuencia)

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -226,7 +226,8 @@ es:
           código único. Esto es para ayudar a verificar su identidad.
         failed_number:
           alert_text: No pudimos asociarlo a este número.
-          gpo_alert_html: Si no dispone de <strong>otro</strong> número de teléfono, %{link_html}.
+          gpo_alert_html: Si no dispone de <strong>otro</strong> número de teléfono,
+            %{link_html}.
           gpo_verify_link: realice la verificación por correo
         rules:
           - Con base en Estados Unidos (incluidos los territorios de EE.UU.)

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -239,7 +239,8 @@ fr:
           code à usage unique. Ceci est pour aider à vérifier votre identité.
         failed_number:
           alert_text: Nous n’avons pas pu vous associer à ce numéro.
-          gpo_alert_html: Si vous n’avez pas <strong>d’autre</strong> numéro de téléphone à essayer, %{link_html}.
+          gpo_alert_html: Si vous n’avez pas <strong>d’autre</strong> numéro de téléphone
+            à essayer, %{link_html}.
           gpo_verify_link: vérifiez plutôt par courrier
         rules:
           - Basé aux Etats-Unis (y compris les territoires américains)

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -238,7 +238,9 @@ fr:
         description: Nous vérifierons ce numéro dans nos archives et vous enverrons un
           code à usage unique. Ceci est pour aider à vérifier votre identité.
         failed_number:
-          alert_html: Nous n’avons pas pu vous associer à ce numéro. Si vous n’avez pas <strong>d’autre</strong> numéro de téléphone à essayer, %{link_html}.
+          alert_html: Nous n’avons pas pu vous associer à ce numéro. Si vous n’avez pas
+            <strong>d’autre</strong> numéro de téléphone à essayer,
+            %{link_html}.
           gpo_verify_link: vérifiez plutôt par courrier
         rules:
           - Basé aux Etats-Unis (y compris les territoires américains)

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -237,6 +237,9 @@ fr:
         alert_html: '<strong>Entrez un numéro de téléphone qui est :</strong>'
         description: Nous vérifierons ce numéro dans nos archives et vous enverrons un
           code à usage unique. Ceci est pour aider à vérifier votre identité.
+        failed_number:
+          alert_html: Nous n’avons pas pu vous associer à ce numéro. Si vous n’avez pas <strong>d’autre</strong> numéro de téléphone à essayer, %{link_html}.
+          gpo_verify_link: vérifiez plutôt par courrier
         rules:
           - Basé aux Etats-Unis (y compris les territoires américains)
           - Votre numéro principal (celui que vous utilisez le plus souvent)

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -238,9 +238,8 @@ fr:
         description: Nous vérifierons ce numéro dans nos archives et vous enverrons un
           code à usage unique. Ceci est pour aider à vérifier votre identité.
         failed_number:
-          alert_html: Nous n’avons pas pu vous associer à ce numéro. Si vous n’avez pas
-            <strong>d’autre</strong> numéro de téléphone à essayer,
-            %{link_html}.
+          alert_text: Nous n’avons pas pu vous associer à ce numéro.
+          gpo_alert_html: Si vous n’avez pas <strong>d’autre</strong> numéro de téléphone à essayer, %{link_html}.
           gpo_verify_link: vérifiez plutôt par courrier
         rules:
           - Basé aux Etats-Unis (y compris les territoires américains)

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -165,6 +165,10 @@ RSpec.describe 'Identity verification', :js do
       t('two_factor_authentication.otp_delivery_preference.sms'), visible: false
     )
 
+    # displays phone number by default
+    phone_field = find_field(t('two_factor_authentication.phone_label'))
+    expect(phone_field.value).not_to be_empty
+
     # displays error if invalid phone number is entered
     fill_in :idv_phone_form_phone, with: '578190'
     click_idv_send_security_code

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -173,6 +173,28 @@ RSpec.feature 'idv phone step', :js do
       end
     end
 
+    context 'phone number submission times out' do
+      it 'does not display failed alert message' do
+        timeout_phone_number = '7035555888'
+        start_idv_from_sp
+        complete_idv_steps_before_phone_step
+        fill_out_phone_form_ok(timeout_phone_number)
+        click_idv_send_security_code
+        click_on t('idv.failure.button.warning')
+
+        expect(page).to have_current_path(idv_phone_path)
+
+        fill_out_phone_form_ok(timeout_phone_number)
+
+        expect(page).not_to have_content(t('idv.messages.phone.failed_number.alert_text'))
+
+        click_idv_send_security_code
+        click_on t('idv.failure.button.warning')
+
+        expect(page).to have_current_path(idv_phone_path)
+      end
+    end
+
     it 'goes to the cancel page when cancel link is clicked' do
       start_idv_from_sp
       complete_idv_steps_before_phone_step

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -76,24 +76,22 @@ RSpec.feature 'idv phone step', :js do
   end
 
   context "when the user's information cannot be verified" do
-    it 'reports the number the user entered' do
+    before do
       start_idv_from_sp
       complete_idv_steps_before_phone_step
       fill_out_phone_form_fail
+    end
+
+    it 'reports the number the user entered' do
       click_idv_send_security_code
 
       expect(page).to have_content(t('idv.failure.phone.warning.heading'))
       expect(page).to have_content('+1 703-555-5555')
     end
 
-    context 'resubmission after failed number' do
+    context 'resubmission after number failed verification' do
       it 'phone field is empty after invalid submission' do
-        start_idv_from_sp
-        complete_idv_steps_before_phone_step
-
         phone_field = find_field(t('two_factor_authentication.phone_label'))
-
-        fill_out_phone_form_fail
 
         expect(phone_field.value).not_to be_empty
 
@@ -104,12 +102,7 @@ RSpec.feature 'idv phone step', :js do
         expect(phone_field.value).to be_empty
       end
 
-      it 'succeds to otp verificaiton with valid number' do
-        start_idv_from_sp
-        complete_idv_steps_before_phone_step
-
-        fill_out_phone_form_fail
-
+      it 'succeds to otp verificaiton with valid number resubmission' do
         click_idv_send_security_code
         click_on t('idv.failure.phone.warning.try_again_button')
 
@@ -123,9 +116,6 @@ RSpec.feature 'idv phone step', :js do
       context 'displays alert message if same nubmer is resubmitted' do
         context 'gpo verification is enabled' do
           it 'includes verify link' do
-            start_idv_from_sp
-            complete_idv_steps_before_phone_step
-            fill_out_phone_form_fail
             click_idv_send_security_code
             click_on t('idv.failure.phone.warning.try_again_button')
 
@@ -157,9 +147,6 @@ RSpec.feature 'idv phone step', :js do
           end
 
           it 'does not display verify link' do
-            start_idv_from_sp
-            complete_idv_steps_before_phone_step
-            fill_out_phone_form_fail
             click_idv_send_security_code
             click_on t('idv.failure.phone.warning.try_again_button')
 

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'idv phone step', :js do
         expect(phone_field.value).to be_empty
       end
 
-      it 'succeeds to otp verificaiton with valid number resubmission' do
+      it 'succeeds to otp verification with valid number resubmission' do
         click_idv_send_security_code
         click_on t('idv.failure.phone.warning.try_again_button')
 

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -161,6 +161,7 @@ RSpec.feature 'idv phone step', :js do
         click_idv_continue_for_step(:phone)
         click_on t('idv.failure.phone.warning.try_again_button')
       end
+      fill_out_phone_form_fail
       click_idv_continue_for_step(:phone)
     end
 

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -104,6 +104,22 @@ RSpec.feature 'idv phone step', :js do
         expect(phone_field.value).to be_empty
       end
 
+      it 'succeds to otp verificaiton with valid number' do
+        start_idv_from_sp
+        complete_idv_steps_before_phone_step
+
+        fill_out_phone_form_fail
+
+        click_idv_send_security_code
+        click_on t('idv.failure.phone.warning.try_again_button')
+
+        expect(page).to have_current_path(idv_phone_path)
+
+        fill_out_phone_form_ok
+        click_idv_send_security_code
+        expect(page).to have_current_path(idv_otp_verification_path)
+      end
+
       context 'displays alert message if same nubmer is resubmitted' do
         context 'gpo verification is enabled' do
           it 'includes verify link' do

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'idv phone step', :js do
         expect(phone_field.value).to be_empty
       end
 
-      it 'succeds to otp verificaiton with valid number resubmission' do
+      it 'succeeds to otp verificaiton with valid number resubmission' do
         click_idv_send_security_code
         click_on t('idv.failure.phone.warning.try_again_button')
 

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -82,14 +82,12 @@ RSpec.describe Idv::Session do
       expect(subject.failed_phone_step_numbers.length).to eq(2)
 
       # add duplicates
-      subject.add_failed_phone_step_number('(703) 355-7575')
+      subject.add_failed_phone_step_number('(703) 555-1234')
       subject.add_failed_phone_step_number('1703555-1212')
 
-      expect(subject.failed_phone_step_numbers.length).to eq(3)
-
-      ['+17035551212', '+17035557575', '+17033557575'].each do |num|
-        expect(subject.failed_phone_step_numbers.include?(num)).to be_truthy
-      end
+      expect(subject.failed_phone_step_numbers).to eq(
+        ['+17035551212', '+17035557575', '+17035551234'],
+      )
     end
   end
 

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -74,6 +74,31 @@ RSpec.describe Idv::Session do
     end
   end
 
+  describe '#add_failed_phone_step_number' do
+    it 'adds uniq phone numbers in e164 format' do
+      subject.add_failed_phone_step_number('+1703-555-1212')
+      subject.add_failed_phone_step_number('703555-7575')
+
+      expect(subject.failed_phone_step_numbers.length).to eq(2)
+
+      # add duplicates
+      subject.add_failed_phone_step_number('(703) 355-7575')
+      subject.add_failed_phone_step_number('1703555-1212')
+
+      expect(subject.failed_phone_step_numbers.length).to eq(3)
+
+      ['+17035551212', '+17035557575', '+17033557575'].each do |num|
+        expect(subject.failed_phone_step_numbers.include?(num)).to be_truthy
+      end
+    end
+  end
+
+  describe '#failed_phone_step_numbers' do
+    it 'defaults to an empy array' do
+      expect(subject.failed_phone_step_numbers).to eq([])
+    end
+  end
+
   describe '#create_profile_from_applicant_with_password' do
     before do
       subject.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-9499](https://cm-jira.usa.gov/browse/LG-9499)

## 🛠 Summary of changes
- add list of failed phone numbers to idv_session which is added to each time a phone verification fails
- add list of failed phone numbers to phone form to determine if inputted number has already failed; and, if so show alert message

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Attempt identity verification steps prior to phone verification
- [ ] verify user phone number is present if submitted for MFA
- [ ] submit a failing phone number 
- [ ] Click "Try Again" on failure page 
- [ ] verify the textfield is empty upon phone page rendering
- [ ] retype the same failed phone number into the phone textfield
- [ ] verify the alert message is present

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<!--
<details>
<summary>Before:</summary>

</details>
-->
<details>
<summary>After:</summary>

![LG-9499-en](https://github.com/18F/identity-idp/assets/1261794/022406c4-f352-491b-a960-93b12ec7ef8e)

![LG-9499-fr](https://github.com/18F/identity-idp/assets/1261794/b9dd700f-4dfa-4b51-89f0-639f3c237cd3)

![LG-9499-sp](https://github.com/18F/identity-idp/assets/1261794/a8f589d3-c63f-4111-b565-1c2e00691522)

</details>

