### PR TITLE
Try to improve reliability of doc capture redo spec

### DIFF
--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
       mock_doc_auth_attention_with_barcode
       attach_and_submit_images
       click_idv_continue
+      expect(page).to have_current_path(idv_ssn_path, wait: 5)
 
       if use_bad_ssn
         fill_out_ssn_form_with_ssn_that_fails_resolution


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a wait tolerance for the browser to arrive at the SSN screen after barcode attention warning, in an attempt to improve the reliability of this very flakey spec.

Example failure: https://gitlab.login.gov/lg/identity-idp/-/jobs/584438

The hypothesis is that because the page submission is triggered by JavaScript, Capybara's default wait for page navigation is not happening.

https://github.com/18F/identity-idp/blob/66d58b5f40f550f223da4d5989675e70c9c83d4e/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx#L21-L26

## 📜 Testing Plan

```
rspec spec/features/idv/doc_auth/redo_document_capture_spec.rb
```