### PR TITLE
Add temporary redirect for WebAuthn error page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Rails.application.routes.draw do
       get '/login/two_factor/piv_cac' => 'two_factor_authentication/piv_cac_verification#show'
       get '/login/two_factor/piv_cac/present_piv_cac' => 'two_factor_authentication/piv_cac_verification#redirect_to_piv_cac_service'
       get '/login/two_factor/webauthn' => 'two_factor_authentication/webauthn_verification#show'
+      get '/login/two_factor/webauthn_error', to: redirect('/login/two_factor/webauthn')
       patch '/login/two_factor/webauthn' => 'two_factor_authentication/webauthn_verification#confirm'
       get 'login/two_factor/backup_code' => 'two_factor_authentication/backup_code_verification#show'
       post 'login/two_factor/backup_code' => 'two_factor_authentication/backup_code_verification#create'


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a redirect route for the error page removed in #8764, as a temporary solution to avoid potential issues during deployment.

See: https://github.com/18F/identity-idp/pull/8764#discussion_r1262564677

## 📜 Testing Plan

```
$ curl -I --silent http://localhost:3000/login/two_factor/webauthn_error | grep Location 
Location: http://localhost:3000/login/two_factor/webauthn
```
