### PR TITLE
Show Face/Touch Unlock setup on unsupported devices in local development

### DIFF
--- a/app/components/webauthn_input_component.rb
+++ b/app/components/webauthn_input_component.rb
@@ -1,12 +1,19 @@
 class WebauthnInputComponent < BaseComponent
-  attr_reader :platform, :passkey_supported_only, :tag_options
+  attr_reader :platform, :passkey_supported_only, :show_unsupported_passkey, :tag_options
 
   alias_method :platform?, :platform
   alias_method :passkey_supported_only?, :passkey_supported_only
+  alias_method :show_unsupported_passkey?, :show_unsupported_passkey
 
-  def initialize(platform: false, passkey_supported_only: false, **tag_options)
+  def initialize(
+    platform: false,
+    passkey_supported_only: false,
+    show_unsupported_passkey: false,
+    **tag_options
+  )
     @platform = platform
     @passkey_supported_only = passkey_supported_only
+    @show_unsupported_passkey = show_unsupported_passkey
     @tag_options = tag_options
   end
 
@@ -16,8 +23,9 @@ class WebauthnInputComponent < BaseComponent
       content,
       **tag_options,
       hidden: true,
-      platform: platform.presence,
-      'passkey-supported-only': passkey_supported_only.presence,
+      platform: platform?.presence,
+      'passkey-supported-only': passkey_supported_only?.presence,
+      'show-unsupported-passkey': show_unsupported_passkey?.presence,
     )
   end
 end

--- a/app/components/webauthn_input_component.scss
+++ b/app/components/webauthn_input_component.scss
@@ -1,0 +1,3 @@
+.webauthn-input--unsupported-passkey .usa-checkbox__label {
+  background: rgba(255, 0, 0, 0.1);
+}

--- a/app/javascript/packages/webauthn/webauthn-input-element.spec.ts
+++ b/app/javascript/packages/webauthn/webauthn-input-element.spec.ts
@@ -44,15 +44,31 @@ describe('WebauthnInputElement', () => {
 
     context('passkey supported only', () => {
       context('device does not support passkey', () => {
-        beforeEach(() => {
-          isWebauthnPasskeySupported.returns(false);
-          document.body.innerHTML = `<lg-webauthn-input platform passkey-supported-only hidden></lg-webauthn-input>`;
+        context('unsupported passkey not shown', () => {
+          beforeEach(() => {
+            isWebauthnPasskeySupported.returns(false);
+            document.body.innerHTML = `<lg-webauthn-input platform passkey-supported-only hidden></lg-webauthn-input>`;
+          });
+
+          it('stays hidden', () => {
+            const element = document.querySelector('lg-webauthn-input')!;
+
+            expect(element.hidden).to.be.true();
+          });
         });
 
-        it('stays hidden', () => {
-          const element = document.querySelector('lg-webauthn-input')!;
+        context('unsupported passkey shown', () => {
+          beforeEach(() => {
+            isWebauthnPasskeySupported.returns(false);
+            document.body.innerHTML = `<lg-webauthn-input platform passkey-supported-only show-unsupported-passkey hidden></lg-webauthn-input>`;
+          });
 
-          expect(element.hidden).to.be.true();
+          it('becomes visible, with modifier class', () => {
+            const element = document.querySelector('lg-webauthn-input')!;
+
+            expect(element.hidden).to.be.false();
+            expect(element.classList.contains('webauthn-input--unsupported-passkey'));
+          });
         });
       });
 

--- a/app/javascript/packages/webauthn/webauthn-input-element.spec.ts
+++ b/app/javascript/packages/webauthn/webauthn-input-element.spec.ts
@@ -67,7 +67,7 @@ describe('WebauthnInputElement', () => {
             const element = document.querySelector('lg-webauthn-input')!;
 
             expect(element.hidden).to.be.false();
-            expect(element.classList.contains('webauthn-input--unsupported-passkey'));
+            expect(element.classList.contains('webauthn-input--unsupported-passkey')).to.be.true();
           });
         });
       });

--- a/app/javascript/packages/webauthn/webauthn-input-element.ts
+++ b/app/javascript/packages/webauthn/webauthn-input-element.ts
@@ -13,13 +13,20 @@ export class WebauthnInputElement extends HTMLElement {
     return this.hasAttribute('passkey-supported-only');
   }
 
+  get showUnsupportedPasskey(): boolean {
+    return this.hasAttribute('show-unsupported-passkey');
+  }
+
   isSupported(): boolean {
     return !this.isPlatform || !this.isOnlyPasskeySupported || isWebauthnPasskeySupported();
   }
 
   toggleVisibleIfSupported() {
     if (this.isSupported()) {
-      this.removeAttribute('hidden');
+      this.hidden = false;
+    } else if (this.showUnsupportedPasskey) {
+      this.hidden = false;
+      this.classList.add('webauthn-input--unsupported-passkey');
     }
   }
 }

--- a/app/presenters/two_factor_authentication/webauthn_platform_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/webauthn_platform_selection_presenter.rb
@@ -6,7 +6,13 @@ module TwoFactorAuthentication
 
     def render_in(view_context, &block)
       view_context.render(
-        WebauthnInputComponent.new(platform: true, passkey_supported_only: configuration.blank?),
+        WebauthnInputComponent.new(
+          platform: true,
+          passkey_supported_only: configuration.blank?,
+          show_unsupported_passkey:
+            configuration.blank? &&
+            IdentityConfig.store.show_unsupported_passkey_platform_authentication_setup,
+        ),
         &block
       )
     end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -305,6 +305,7 @@ session_total_duration_timeout_in_minutes: 720
 ses_configuration_set_name: ''
 set_remember_device_session_expiration: false
 sp_handoff_bounce_max_seconds: 2
+show_unsupported_passkey_platform_authentication_setup: false
 show_user_attribute_deprecation_warnings: false
 otp_min_attempts_remaining_warning_count: 3
 system_demand_report_email: 'foo@bar.com'
@@ -400,6 +401,7 @@ development:
   scrypt_cost: 10000$8$1$
   secret_key_base: development_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
+  show_unsupported_passkey_platform_authentication_setup: true
   skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"]'
   state_tracking_enabled: true
   telephony_adapter: test

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -417,6 +417,7 @@ class IdentityConfig
     config.add(:ses_configuration_set_name, type: :string)
     config.add(:set_remember_device_session_expiration, type: :boolean)
     config.add(:sp_issuer_user_counts_report_configs, type: :json)
+    config.add(:show_unsupported_passkey_platform_authentication_setup, type: :boolean)
     config.add(:show_user_attribute_deprecation_warnings, type: :boolean)
     config.add(:skip_encryption_allowed_list, type: :json)
     config.add(:sp_handoff_bounce_max_seconds, type: :integer)

--- a/spec/components/webauthn_input_component_spec.rb
+++ b/spec/components/webauthn_input_component_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe WebauthnInputComponent, type: :component do
   subject(:rendered) { render_inline component }
 
   it 'renders element with expected attributes' do
-    expect(rendered).to have_css('lg-webauthn-input[hidden]:not([platform])', visible: false)
+    element = rendered.css('lg-webauthn-input').first
+
+    expect(element.attr('hidden')).to be_present
+    expect(element.attr('platform')).to be_nil
+    expect(element.attr('passkey-supported-only')).to be_nil
+    expect(element.attr('show-unsupported-passkey')).to be_nil
   end
 
   it 'exposes boolean alias for platform option' do
@@ -15,6 +20,10 @@ RSpec.describe WebauthnInputComponent, type: :component do
 
   it 'exposes boolean alias for passkey_supported_only option' do
     expect(component.passkey_supported_only?).to eq(false)
+  end
+
+  it 'exposes boolean alias for show_unsupported_passkey option' do
+    expect(component.show_unsupported_passkey?).to eq(false)
   end
 
   context 'with platform option' do
@@ -53,6 +62,30 @@ RSpec.describe WebauthnInputComponent, type: :component do
       it 'renders with passkey-supported-only attribute' do
         expect(rendered).to have_css(
           'lg-webauthn-input[hidden][passkey-supported-only]',
+          visible: false,
+        )
+      end
+    end
+  end
+
+  context 'with show_unsupported_passkey option' do
+    context 'with show_unsupported_passkey option false' do
+      let(:options) { { show_unsupported_passkey: false } }
+
+      it 'renders without show-unsupported-passkey attribute' do
+        expect(rendered).to have_css(
+          'lg-webauthn-input[hidden]:not([show-unsupported-passkey])',
+          visible: false,
+        )
+      end
+    end
+
+    context 'with show_unsupported_passkey option true' do
+      let(:options) { { show_unsupported_passkey: true } }
+
+      it 'renders with show-unsupported-passkey attribute' do
+        expect(rendered).to have_css(
+          'lg-webauthn-input[hidden][show-unsupported-passkey]',
           visible: false,
         )
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Allows Face or Touch Unlock option to be shown in account creation in local development on devices which do not support passkey, with additional effect to indicate that the passkey is not supported. This is intended to help facilitate testing of Face or Touch Unlock outside devices which are supported for the initial relaunch (iOS 16+ and Android).

## 📜 Testing Plan

**Option enabled:**

1. Go to http://localhost:3000
2. Create an account
3. On the "Authentication method setup" screen, observe that the "Face or touch unlock" option is visible, and tinted red if the current device is not iOS 16+ or Android

**Option enabled:**

Add to `config/application.yml`:

```yml
development:
  show_unsupported_passkey_platform_authentication_setup: false
```

1. Go to http://localhost:3000
2. Create an account
3. On the "Authentication method setup" screen, observe that the "Face or touch unlock" option is only visible if the current device is iOS 16+ or Android

## 👀 Screenshots

Before|After
---|---
![before](https://github.com/18F/identity-idp/assets/1779930/703c79d1-a73d-472f-8eec-e31a226196f2)|![after](https://github.com/18F/identity-idp/assets/1779930/1ab97c6e-4cd4-4b74-8eb7-88cd07977ac6)
