### PR TITLE
Revert "Add temporary redirect for WebAuthn error page"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,6 @@ Rails.application.routes.draw do
       get '/login/two_factor/piv_cac' => 'two_factor_authentication/piv_cac_verification#show'
       get '/login/two_factor/piv_cac/present_piv_cac' => 'two_factor_authentication/piv_cac_verification#redirect_to_piv_cac_service'
       get '/login/two_factor/webauthn' => 'two_factor_authentication/webauthn_verification#show'
-      get '/login/two_factor/webauthn_error', to: redirect('/login/two_factor/webauthn')
       patch '/login/two_factor/webauthn' => 'two_factor_authentication/webauthn_verification#confirm'
       get 'login/two_factor/backup_code' => 'two_factor_authentication/backup_code_verification#show'
       post 'login/two_factor/backup_code' => 'two_factor_authentication/backup_code_verification#create'


### PR DESCRIPTION
Reverts 18F/identity-idp#8773

The changes in #8773 were intended to be temporary for the initial deploy. This pull request removes them, and should only be merged after #8773 is live in production.