### PR TITLE
LG-10233: Add "Learn more" troubleshooting link to Face or Touch sign-in

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -6,14 +6,15 @@ class MarketingSite
   HELP_CENTER_ARTICLES = %w[
     authentication-methods/which-authentication-method-should-i-use
     creating-an-account/authentication-application
+    get-started/authentication-options
     manage-your-account/personal-key
     signing-in/what-is-a-hardware-security-key
+    trouble-signing-in/face-or-touch-unlock
     verify-your-identity/accepted-state-issued-identification
     verify-your-identity/how-to-add-images-of-your-state-issued-id
     verify-your-identity/verify-your-identity-in-person
     verify-your-identity/phone-number
     verify-your-identity/verify-your-address-by-mail
-    get-started/authentication-options
   ].to_set.freeze
 
   def self.locale_segment

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -56,6 +56,17 @@
     <% if @presenter.link_path.present? %>
       <% c.with_option(url: @presenter.link_path).with_content(@presenter.link_text) %>
     <% end %>
+    <% if @presenter.platform_authenticator? %>
+      <% c.with_option(
+           url: help_center_redirect_path(
+             category: 'trouble-signing-in',
+             article: 'face-or-touch-unlock',
+             flow: :two_factor_authentication,
+             step: :webauthn_verification,
+           ),
+           new_tab: true,
+         ).with_content(t('instructions.mfa.webauthn_platform.learn_more_help')) %>
+    <% end %>
     <% c.with_option(
          url: help_center_redirect_path(
            category: 'get-started',

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -79,6 +79,8 @@ en:
           to verify your identity using a physical device such as a security key
           or government employee ID (PIV or CAC) to access your information.
         confirm_webauthn_platform: You have face or touch unlock enabled for your %{app_name} account.
+      webauthn_platform:
+        learn_more_help: Learn more about face or touch unlock
       wrong_number: Entered the wrong phone number?
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -84,6 +84,8 @@ es:
           para acceder a su información.
         confirm_webauthn_platform: Tiene activado el desbloqueo facial o táctil para su
           cuenta de %{app_name}.
+      webauthn_platform:
+        learn_more_help: Conozca más sobre el desbloqueo facial o táctil
       wrong_number: '¿Ingresó el número de teléfono equivocado?'
     password:
       forgot: '¿No sabe su contraseña? Restablézcala después de confirmar su email.'

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -95,6 +95,8 @@ fr:
           gouvernement (PIV ou CAC) pour accéder à vos informations.
         confirm_webauthn_platform: Vous avez activé le déverrouillage facial ou tactile
           pour votre compte %{app_name}.
+      webauthn_platform:
+        learn_more_help: En savoir plus sur le déverrouillage facial ou tactile
       wrong_number: Vous avez entré un mauvais numéro de téléphone?
     password:
       forgot: Vous ne connaissez pas votre mot de passe? Réinitialisez-le après avoir

--- a/spec/views/two_factor_authentication/webauthn_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/webauthn_verification/show.html.erb_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe 'two_factor_authentication/webauthn_verification/show.html.erb' d
     it 'includes hidden platform form input with value false' do
       expect(rendered).to have_field('platform', with: 'true', type: 'hidden')
     end
+
+    it 'includes troubleshooting link to learn more about face/touch unlock' do
+      expect(rendered).to have_css('.troubleshooting-options li', count: 3)
+      expect(rendered).to have_link(
+        t('instructions.mfa.webauthn_platform.learn_more_help'),
+        href: help_center_redirect_path(
+          category: 'trouble-signing-in',
+          article: 'face-or-touch-unlock',
+          flow: :two_factor_authentication,
+          step: :webauthn_verification,
+        ),
+      )
+    end
   end
 
   context 'with phishing-resistant MFA requirement' do


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a troubleshooting link "Learn more about Face or Touch Unlock" when signing in with Face or Touch Unlock.

This is a straight revert of the commit [02c631d](https://github.com/18F/identity-idp/pull/8741/commits/02c631d6f7c26d9c3d651c3f5b6aa03019dfb671) from #8741.

~Blocked by https://github.com/18F/identity-site/pull/1122~ **Edit:** Blocker has been merged.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in to an account with Face or Touch Unlock configured
3. When prompted for MFA, observe link "Learn more about Face or Touch Unlock"
4. Click link
5. Observe that a new tab is opened to the related help article

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/5593229d-b99a-45c7-9b4b-651188e36be4)|![image](https://github.com/18F/identity-idp/assets/1779930/d80a3824-d30b-4dc4-96a1-fc5db5ebfdff)
