### PR TITLE
LG-9526 Remove troubleshooting section on pinpoint outage

### DIFF
--- a/app/views/idv/gpo_only_warning/show.html.erb
+++ b/app/views/idv/gpo_only_warning/show.html.erb
@@ -38,19 +38,4 @@
        outline: true,
        class: 'usa-button',
      ).with_content(t('links.exit_login', app_name: APP_NAME)) %>
-  <% c.with_troubleshooting_options do |tc| %>
-    <% tc.with_header { t('components.troubleshooting_options.default_heading') } %>
-    <% tc.with_option(
-         url: StatusPage.base_url,
-         new_tab: true,
-       ).with_content(t('vendor_outage.get_updates_on_status_page')) %>
-    <% if decorated_session.sp_name %>
-      <% tc.with_option(
-           url: current_sp.return_to_sp_url,
-           new_tab: true,
-         ).with_content(
-           t('idv.troubleshooting.options.get_help_at_sp', sp_name: decorated_session.sp_name),
-         ) %>
-    <% end %>
-  <% end %>
 <% end %>


### PR DESCRIPTION


<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->


## 🛠 Summary of changes

Removed the troubleshooting section from the phone finder/pinpoint outage screen. A fix for https://github.com/18F/identity-idp/pull/8762

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
