### PR TITLE
LG-9790: Content change for OTP pages

### DIFF
--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -29,7 +29,7 @@ en:
       warning_html: <strong>You’ve only set up backup codes on your account.
         </strong>If you have access to another device, such as a phone, protect
         your account with another authentication method.
-    choose_another_option: '‹ Choose another option'
+    choose_another_option: '‹ Choose another authentication method'
     header_text: Enter your one-time code
     important_alert_icon: important alert icon
     invalid_backup_code: That backup code is invalid.

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -29,7 +29,7 @@ es:
       warning_html: <strong>Solo ha configurado códigos de respaldo en su cuenta.
         </strong>Si tiene acceso a otro dispositivo, como un celular, proteja su
         cuenta mediante otro método de autenticación.
-    choose_another_option: '‹ Elige otra opción'
+    choose_another_option: '‹ Elige otra opción de seguridad'
     header_text: Introduzca su código único
     important_alert_icon: ícono de aviso importante
     invalid_backup_code: Esa código de respaldo no es válida.

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -30,7 +30,7 @@ fr:
         votre compte. </strong>Si vous avez accès à un autre appareil, tel qu’un
         téléphone, protégez votre compte à l’aide d’une autre méthode
         d’authentification.
-    choose_another_option: '‹ Choisissez une autre option'
+    choose_another_option: '‹ Choisissez une autre option de sécurité'
     header_text: Entrez votre code à usage unique
     important_alert_icon: Icône d’alerte importante
     invalid_backup_code: Ce code de sauvegarde est invalide.


### PR DESCRIPTION
## 🎫 Ticket
[LG-9790](https://cm-jira.usa.gov/browse/LG-9790)


## 🛠 Summary of changes

This is a simple content change to swap the phrase "Choose another option" for "Choose another authentication method". The phrase is found in a link on OTP pages.

The change can be seen when adding or using the authentication method OTP at routes such as:

- `/phone_setup`
- `/login/two_factor/sms`

## 📜 Testing Plan

- [ ] Register a new account
- [ ] Add the authentication method SMS/OTP
- [ ] Notice the new text "Choose another authentication method" in a link towards the bottom of the page

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
