### PR TITLE
Add ECR reporting to gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,8 +96,9 @@ build-idp-image:
   needs: []
   interruptible: true
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
+      when: never
   tags:
     - build-pool
   image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,6 +59,7 @@ stages:
   - build
   - test
   - after_test
+  - build_image
   - review
   - scan
 
@@ -92,7 +93,7 @@ install:
 # Build a container image async, and don't block CI tests
 # Cache intermediate images for 1 week (168 hours)
 build-idp-image:
-  stage: review
+  stage: build_image
   needs: []
   interruptible: true
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,9 @@ build-idp-image:
   stage: review
   needs: []
   interruptible: true
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
   tags:
     - build-pool
   image:
@@ -400,6 +403,10 @@ include:
 ecr-scan:
   stage: scan
   interruptible: true
+  allow_failure: true
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
   tags:
     - build-pool
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -421,7 +421,7 @@ ecr-scan:
   script:
     - >
       while true; do
-        SCAN_STATUS=$(aws ecr describe-image-scan-findings --repository-name identity-idp/review --image-id imageTag=$CI_COMMIT_SHA --query 'imageScanStatus.status' --output text)
+        SCAN_STATUS=$(aws ecr describe-image-scan-findings --repository-name identity-idp/review --image-id imageTag=$CI_COMMIT_SHA --query 'imageScanStatus.status' --output text || true)
         if [ "$SCAN_STATUS" == "ACTIVE" ]; then
           break
         elif [ "$SCAN_STATUS" == "FAILED" ]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,6 +96,7 @@ build-idp-image:
   needs: []
   interruptible: true
   rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
     - if: $CI_PIPELINE_SOURCE != "merge_request_event"
       when: never
@@ -406,6 +407,7 @@ ecr-scan:
   interruptible: true
   allow_failure: true
   rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
     - if: $CI_PIPELINE_SOURCE != "merge_request_event"
       when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,7 @@ stages:
   - test
   - after_test
   - review
+  - scan
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -406,8 +406,9 @@ ecr-scan:
   interruptible: true
   allow_failure: true
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
+      when: never
   tags:
     - build-pool
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,9 +59,7 @@ stages:
   - build
   - test
   - after_test
-  - build_image
   - review
-  - scan
 
 workflow:
   rules:
@@ -93,7 +91,7 @@ install:
 # Build a container image async, and don't block CI tests
 # Cache intermediate images for 1 week (168 hours)
 build-idp-image:
-  stage: build_image
+  stage: review
   needs: []
   interruptible: true
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,7 @@ stages:
   - test
   - after_test
   - review
+  - scan
 
 workflow:
   rules:
@@ -397,3 +398,21 @@ stop-review-app:
 include:
   - template: Jobs/SAST.gitlab-ci.yml
   - template: Jobs/Dependency-Scanning.gitlab-ci.yml
+
+ecr-scan:
+  stage: scan
+  needs:
+    - job: build-idp-image
+  image:
+    name: amazon/aws-cli
+    entrypoint: [""] 
+  script:
+    - IMAGE_DIGEST=$(aws ecr describe-images --repository-name identity-idp/review --image-ids imageTag=$CI_COMMIT_SHA --query 'imageDetails[0].imageDigest' --output text)
+    - aws ecr wait image-scan-complete --repository-name identity-idp/review --image-id imageDigest=$IMAGE_DIGEST
+    - SCAN_FINDINGS=$(aws ecr describe-image-scan-findings --repository-name identity-idp/review --image-id imageDigest=$IMAGE_DIGEST)
+    - echo $SCAN_FINDINGS
+    - if [[ $SCAN_FINDINGS == *"CRITICAL"* ]]; then exit 1; fi
+  rules:
+    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
+      when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,10 +95,6 @@ build-idp-image:
   stage: review
   needs: []
   interruptible: true
-  rules:
-    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
-    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
-      when: never
   tags:
     - build-pool
   image:
@@ -399,20 +395,108 @@ include:
   - template: Jobs/SAST.gitlab-ci.yml
   - template: Jobs/Dependency-Scanning.gitlab-ci.yml
 
+# Export the automated ECR scan results into a format Gitlab can use
+# Report schema https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/master/dist/container-scanning-report-format.json
 ecr-scan:
   stage: scan
+  interruptible: true
+  tags:
+    - build-pool
   needs:
     - job: build-idp-image
   image:
     name: amazon/aws-cli
     entrypoint: [""] 
+  before_script:
+    - curl -LO https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64
+    - chmod +x jq-linux64
+    - mv jq-linux64 /usr/local/bin/jq
   script:
-    - IMAGE_DIGEST=$(aws ecr describe-images --repository-name identity-idp/review --image-ids imageTag=$CI_COMMIT_SHA --query 'imageDetails[0].imageDigest' --output text)
-    - aws ecr wait image-scan-complete --repository-name identity-idp/review --image-id imageDigest=$IMAGE_DIGEST
-    - SCAN_FINDINGS=$(aws ecr describe-image-scan-findings --repository-name identity-idp/review --image-id imageDigest=$IMAGE_DIGEST)
+    - >
+      while true; do
+        SCAN_STATUS=$(aws ecr describe-image-scan-findings --repository-name identity-idp/review --image-id imageTag=$CI_COMMIT_SHA --query 'imageScanStatus.status' --output text)
+        if [ "$SCAN_STATUS" == "ACTIVE" ]; then
+          break
+        elif [ "$SCAN_STATUS" == "FAILED" ]; then
+          echo "ECR scan failed"
+          exit 1
+        else
+          echo "Waiting for ECR scan to complete"
+          sleep 15
+        fi
+      done
+    - SCAN_FINDINGS=$(aws ecr describe-image-scan-findings --repository-name identity-idp/review --image-id imageTag=$CI_COMMIT_SHA)
     - echo $SCAN_FINDINGS
-    - if [[ $SCAN_FINDINGS == *"CRITICAL"* ]]; then exit 1; fi
-  rules:
-    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
-    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
-      when: never
+    - >
+      echo $SCAN_FINDINGS |
+      jq -r '
+      {
+        "version": "15.0.4",
+        "scan": {
+          "start_time": (.imageScanFindings.imageScanCompletedAt | sub("\\.[0-9]+"; "") | strptime("%Y-%m-%dT%H:%M:%S%z") | strftime("%Y-%m-%dT%H:%M:%S")),
+          "end_time": (.imageScanFindings.imageScanCompletedAt | sub("\\.[0-9]+"; "") | strptime("%Y-%m-%dT%H:%M:%S%z") | strftime("%Y-%m-%dT%H:%M:%S")),
+          "scanner": {
+            "id": "clair",
+            "name": "Amazon ECR Image Scan",
+            "version": "1.0.0",
+            "vendor": {
+              "name": "Amazon Web Services"
+            }
+          },
+          "analyzer": {
+            "id": "clair",
+            "name": "Amazon ECR Image Scan",
+            "version": "1.0.0",
+            "vendor": {
+              "name": "Amazon Web Services"
+            }
+          },
+          "status": "success",
+          "type": "container_scanning"
+        },
+        "vulnerabilities": [
+          .imageScanFindings.enhancedFindings[] |
+          {
+            "id": .packageVulnerabilityDetails.vulnerabilityId,
+            "name": .title,
+            "description": .description,
+            "severity": (if .severity == "HIGH" then "High"
+                        elif .severity == "MEDIUM" then "Medium"
+                        elif .severity == "LOW" then "Low"
+                        elif .severity == "CRITICAL" then "Critical"
+                        elif .severity == "INFORMATIONAL" then "Info"
+                        elif .severity == "UNTRIAGED" then "Info"
+                        else "Unknown" end),
+            "solution": .remediation.recommendation.text,
+            "identifiers": [
+              {
+                "type": "cve",
+                "name": .packageVulnerabilityDetails.vulnerabilityId,
+                "url": .packageVulnerabilityDetails.sourceUrl,
+                "value": .packageVulnerabilityDetails.vulnerabilityId
+              }
+            ],
+            "links": [
+              {
+                "name": .packageVulnerabilityDetails.vulnerabilityId,
+                "url": .packageVulnerabilityDetails.sourceUrl
+              }
+            ],
+            "location": {
+              "dependency": {
+                "package": {
+                  "name": .packageVulnerabilityDetails.vulnerablePackages[0].name
+                },
+                "version": .packageVulnerabilityDetails.vulnerablePackages[0].version
+              },
+              "operating_system": .resources[0].details.awsEcrContainerImage.platform,
+              "image": .resources[0].id
+            }
+          }
+        ]
+      }' > gl-container-scanning-report.json
+  artifacts:
+    paths: 
+      - gl-container-scanning-report.json
+    reports:
+      container_scanning: gl-container-scanning-report.json


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

## 🛠 Summary of changes

Grabs the results of the automated ECR scans and converts them to gitlabs `container_scanning` format for visualization on the Merge Request in Gitlab as well as in the `Security and Compliance` tab alongside the rest of our scanning tools with the tool source being `Container Scanning Amazon Web Services`. Related change for pipeline permissions located [HERE](https://github.com/18F/identity-devops/pull/6408)

## 📜 Testing Plan

New ECR job successfully running as part of this PR [HERE](https://gitlab.login.gov/lg/identity-idp/-/jobs/598162)

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
