### PR TITLE
Avoid missing styles during CSS compilation

### DIFF
--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -6,6 +6,10 @@
   - Before: (1) `node_modules`, (2) default load paths, (3) custom `--load-path` load paths
   - After: (1) custom `--load-path` load paths, (2) default load paths, (3) `node_modules`
 
+### Improvements
+
+- Prevent situations where overridden output stylesheets may be temporarily emptied during parallel builds.
+
 ## 1.3.0
 
 ### Improvements

--- a/app/javascript/packages/build-sass/index.js
+++ b/app/javascript/packages/build-sass/index.js
@@ -1,5 +1,7 @@
-import { basename, join } from 'path';
-import { writeFile } from 'fs/promises';
+import { basename, join } from 'node:path';
+import { createWriteStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import sass from 'sass-embedded';
 import { transform as lightningTransform, browserslistToTargets } from 'lightningcss';
 import browserslist from 'browserslist';
@@ -48,7 +50,7 @@ export async function buildFile(file, options) {
     outFile = join(outDir, outFile);
   }
 
-  await writeFile(outFile, lightningResult.code);
+  await pipeline(Readable.from(lightningResult.code), createWriteStream(outFile));
 
   return sassResult;
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Updates CSS compilation utility to avoid situations where the output stylesheet is temporarily emptied while the contents are being written. This frequently resulted in missing styles when attempting to load pages in the IdP in local development during initial startup.

If pressed, I'm not sure I could explain why the implementation would work any differently between `fs.writeFile` and the writable stream, since both `writeFile` and `createWritableStream` should have the same effect of truncating the original file. But these should be functionally equivalent as far as writing to the file.

## 📜 Testing Plan

1. Remove existing stylesheets `rm -f app/assets/builds/*.css`
2. Run `make run`
3. Go to http://localhost:3000
   - You may receive an error before first build, this is expected
4. Observe styles (no regression in build)
5. Stop `make run` process
6. Run `make run`
7. Refresh page repeatedly at http://localhost:3000
8. Observe that styles never appear missing at any point