### PR TITLE
LG-10255: Capture cardtype in sdk

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.tsx
@@ -202,7 +202,7 @@ interface AcuantDetectedResult {
 }
 
 /**
- * @see https://github.com/Acuant/JavascriptWebSDKV11/tree/11.4.3/SimpleHTMLApp#acuantcamera
+ * @see https://github.com/Acuant/JavascriptWebSDKV11/tree/11.8.1#image-from-acuantcameraui-and-acuantcamera
  */
 export interface AcuantSuccessResponse {
   /**
@@ -212,7 +212,7 @@ export interface AcuantSuccessResponse {
   /**
    * Document type
    */
-  cardType: AcuantDocumentType;
+  cardtype: AcuantDocumentType;
   /**
    * Detected image glare
    */

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -61,7 +61,7 @@ interface ImageAnalyticsPayload {
 }
 
 interface AcuantImageAnalyticsPayload extends ImageAnalyticsPayload {
-  documentType: AcuantDocumentTypeLabel;
+  documentType: AcuantDocumentTypeLabel | string;
   dpi: number;
   moire: number;
   glare: number;
@@ -135,14 +135,16 @@ export const isAcuantCameraAccessFailure = (error: AcuantCaptureFailureError): e
  * Returns a human-readable document label corresponding to the given document type constant.
  *
  */
-function getDocumentTypeLabel(documentType: AcuantDocumentType): AcuantDocumentTypeLabel {
+function getDocumentTypeLabel(documentType: AcuantDocumentType): AcuantDocumentTypeLabel | string {
   switch (documentType) {
+    case 0:
+      return 'none';
     case 1:
       return 'id';
     case 2:
       return 'passport';
     default:
-      return 'none';
+      return `An error in document type returned: ${documentType}`;
   }
 }
 
@@ -553,6 +555,7 @@ function AcuantCapture(
             isFlexibleWidth
             isOutline={!value}
             isUnstyled={!!value}
+            // below log happens
             onClick={withLoggedClick('button')(startCaptureOrTriggerUpload)}
             className={value ? 'margin-right-1' : 'margin-right-2'}
           >

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -555,7 +555,6 @@ function AcuantCapture(
             isFlexibleWidth
             isOutline={!value}
             isUnstyled={!!value}
-            // below log happens
             onClick={withLoggedClick('button')(startCaptureOrTriggerUpload)}
             className={value ? 'margin-right-1' : 'margin-right-2'}
           >

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -433,7 +433,7 @@ function AcuantCapture(
   }
 
   function onAcuantImageCaptureSuccess(nextCapture: AcuantSuccessResponse) {
-    const { image, cardType, dpi, moire, glare, sharpness } = nextCapture;
+    const { image, cardtype, dpi, moire, glare, sharpness } = nextCapture;
     const isAssessedAsGlare = glare < glareThreshold;
     const isAssessedAsBlurry = sharpness < sharpnessThreshold;
     const { width, height, data } = image;
@@ -454,7 +454,7 @@ function AcuantCapture(
       height,
       mimeType: 'image/jpeg', // Acuant Web SDK currently encodes all images as JPEG
       source: 'acuant',
-      documentType: getDocumentTypeLabel(cardType),
+      documentType: getDocumentTypeLabel(cardtype),
       dpi,
       moire,
       glare,

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -28,11 +28,6 @@ const ACUANT_CAPTURE_SUCCESS_RESULT = {
   sharpness: 100,
 };
 
-const ACUANT_CAPTURE_CARDTYPE_ERROR = { ...ACUANT_CAPTURE_SUCCESS_RESULT };
-
-delete ACUANT_CAPTURE_CARDTYPE_ERROR.cardtype;
-ACUANT_CAPTURE_CARDTYPE_ERROR.cardType = 2;
-
 describe('getDecodedBase64ByteSize', () => {
   it('returns the decoded byte size', () => {
     const original = 'Hello World';
@@ -763,6 +758,7 @@ describe('document-capture/components/acuant-capture', () => {
 
     it('logs a human readable error when the document type errs', async () => {
       const trackEvent = sinon.spy();
+      const incorrectCardType = 5;
       const { findByText, getByText } = render(
         <AnalyticsContext.Provider value={{ trackEvent }}>
           <DeviceContext.Provider value={{ isMobile: true }}>
@@ -778,7 +774,7 @@ describe('document-capture/components/acuant-capture', () => {
           await Promise.resolve();
           callbacks.onCaptured();
           await Promise.resolve();
-          callbacks.onCropped(ACUANT_CAPTURE_CARDTYPE_ERROR);
+          callbacks.onCropped({ ...ACUANT_CAPTURE_SUCCESS_RESULT, cardtype: incorrectCardType });
         }),
       });
 
@@ -790,7 +786,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(trackEvent).to.have.been.calledWith(
         'IdV: test image added',
         sinon.match({
-          documentType: 'An error in document type returned: undefined',
+          documentType: `An error in document type returned: ${incorrectCardType}`,
         }),
       );
     });

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -20,7 +20,7 @@ const ACUANT_CAPTURE_SUCCESS_RESULT = {
     width: 1748,
     height: 1104,
   },
-  cardType: 1,
+  cardtype: 1,
   dpi: 519,
   moire: 99,
   moireraw: 99,

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -787,8 +787,6 @@ describe('document-capture/components/acuant-capture', () => {
 
       await findByText('doc_auth.info.image_loading');
 
-      // await findByText('doc_auth.buttons.take_picture_retry');
-
       expect(trackEvent).to.have.been.calledWith(
         'IdV: test image added',
         sinon.match({


### PR DESCRIPTION
## 🎫 Ticket
[Check ID 'card type' when using SDK](https://cm-jira.usa.gov/browse/LG-10255)


## 🛠 Summary of changes
- Correctly capture acuant document types during sdk image capture. Previously, all document types were captured as "undefined" and logged as "none."
- Update the logs to display when a value other than "none," "id," or "passport" is captured.
- Update spec file to use the key "cardtype" instead of "cardType"
- Write a test for the new log option




## 📜 Testing Plan
- Run automated tests.
- N.B. I didn't notice this bug until I made an actual request to acuant, rather than using our mock client.  As a result, I think acceptance testing done in staging will be more effective than manual testing with the mock client.


## 👀 Screenshots

Here's a screenshot debugger, which shows the cardType/cardtype bug.
<details>
<summary>Screenshot:</summary>
<img width="672" alt="cardtypeDebuggerScreenshot" src="https://github.com/18F/identity-idp/assets/80347702/900fa232-698f-474b-99eb-e1ed4da6b58d">
</details>

P.S. This seems like it might be a bug in the Acuant SDK, because [their documentation](https://github.com/Acuant/JavascriptWebSDKV11/tree/11.8.1#image-from-acuantcameraui-and-acuantcamera) indicates that the response from the `onCropped` callback should use `cardType`, not `cardtype`.  



