### PR TITLE
Delete GPO route that no longer has matching controller action

### DIFF
--- a/app/views/idv/gpo/_address_on_file.html.erb
+++ b/app/views/idv/gpo/_address_on_file.html.erb
@@ -1,4 +1,0 @@
-<%= button_to @presenter.button,
-              idv_gpo_path,
-              method: 'put',
-              class: 'usa-button usa-button--big usa-button--wide' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -398,7 +398,6 @@ Rails.application.routes.draw do
       if FeatureManagement.gpo_verification_enabled?
         get '/usps' => 'gpo#index', as: :gpo
         put '/usps' => 'gpo#create'
-        post '/usps' => 'gpo#update'
       end
 
       # deprecated routes


### PR DESCRIPTION
## 🛠 Summary of changes

It looks like this GPO action was deleted in #6775 and the `app/views/idv/gpo/_address_on_file.html.erb` template partial became unused. I've deleted both in this PR.
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
