### PR TITLE
Delete invalid symlinks referencing identity-idp-config

### DIFF
--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -73,11 +73,20 @@ module Deploy
         File.join(root, 'certs/sp'),
       )
 
+      idp_logos_dir = File.join(root, 'public/assets/sp-logos')
+      FileUtils.mkdir_p(idp_logos_dir)
+
+      # Invalid symlinks can cause issues in the build process, so this step iterates through the
+      # sp-logos directory in the IDP to delete any broken symlinks.
+      Dir.entries(idp_logos_dir).each do |name|
+        next if name.start_with?('.')
+        target = File.join(idp_logos_dir, name)
+        File.rm(target) if File.symlink?(target) && !File.file?(target)
+      end
       # Public assets: sp-logos
       # Inject the logo files into the app's asset folder. deploy/activate is
       # run before deploy/build-post-config, so these will be picked up by the
       # rails asset pipeline.
-      FileUtils.mkdir_p(File.join(root, 'public/assets/sp-logos'))
       logos_dir = File.join(root, idp_config_checkout_name, 'public/assets/images/sp-logos')
       Dir.entries(logos_dir).each do |name|
         next if name.start_with?('.')


### PR DESCRIPTION
## 🛠 Summary of changes

This is still a bit experimental and I'm working to confirm that the theory below is correct and the proposed solution resolves the problem we're seeing every now and then.

We've run into the situation a couple times where a built application artifact includes symlinks to the identity-idp-config directory. Since identity-idp-config is cloned each time regardless of whether the artifact exists for the SHA, it is possible for an SP logo to be deleted from identity-idp-config which breaks the symlink and can cause build or provisioning issues.

This PR goes through the target `public` directory for SP logos and deletes any symlinks that exist but do not link to an existing file.

Other options:
- Delete all symlinks regardless of whether they are valid since we'll be re-creating them
  - This is quite straightforward and would be my preferred alternative
- Do not include SP logo symlinks in the build artifact
  - This is a bit more work on the platform side and is likely more complicated to implement and maintain since it would require changes outside of this repo

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
