### PR TITLE
LG-10255: Display inline error messages when Acuant SDK recognizes a document is not an ID card type

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.tsx
@@ -93,14 +93,11 @@ interface AcuantCameraUIOptions {
   text: AcuantCameraUIText;
 }
 
-/**
- * Document type.
- *
- * 0 = None
- * 1 = ID
- * 2 = Passport
- */
-export type AcuantDocumentType = 0 | 1 | 2;
+export enum AcuantDocumentType {
+  NONE = 0,
+  ID = 1,
+  PASSPORT = 2,
+}
 
 export type AcuantCaptureFailureError =
   | undefined // Cropping failure (SDK v11.5.0, L1171)

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -442,15 +442,15 @@ function AcuantCapture(
     const { width, height, data } = image;
 
     let assessment: AcuantImageAssessment;
-    if (isAssessedAsUnsupported) {
-      setOwnErrorMessage(t('doc_auth.errors.card_type'));
-      assessment = 'unsupported';
+    if (isAssessedAsBlurry) {
+      setOwnErrorMessage(t('doc_auth.errors.sharpness.failed_short'));
+      assessment = 'blurry';
     } else if (isAssessedAsGlare) {
       setOwnErrorMessage(t('doc_auth.errors.glare.failed_short'));
       assessment = 'glare';
-    } else if (isAssessedAsBlurry) {
-      setOwnErrorMessage(t('doc_auth.errors.sharpness.failed_short'));
-      assessment = 'blurry';
+    } else if (isAssessedAsUnsupported) {
+      setOwnErrorMessage(t('doc_auth.errors.card_type'));
+      assessment = 'unsupported';
     } else {
       assessment = 'success';
     }

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -483,7 +483,7 @@ function AcuantCapture(
       onFailedCaptureAttempt({
         isAssessedAsGlare,
         isAssessedAsBlurry,
-        isUnsupportedDocument: isAssessedAsUnsupported,
+        isAssessedAsUnsupported,
       });
     }
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -30,7 +30,7 @@ import type {
 } from './acuant-camera';
 
 type AcuantDocumentTypeLabel = 'id' | 'passport' | 'none';
-type AcuantImageAssessment = 'success' | 'glare' | 'blurry';
+type AcuantImageAssessment = 'success' | 'glare' | 'blurry' | 'unsupported';
 type ImageSource = 'acuant' | 'upload';
 
 interface ImageAnalyticsPayload {
@@ -438,10 +438,14 @@ function AcuantCapture(
     const { image, cardtype, dpi, moire, glare, sharpness } = nextCapture;
     const isAssessedAsGlare = glare < glareThreshold;
     const isAssessedAsBlurry = sharpness < sharpnessThreshold;
+    const isUnsupportedDocument = cardtype !== 1;
     const { width, height, data } = image;
 
     let assessment: AcuantImageAssessment;
-    if (isAssessedAsGlare) {
+    if (isUnsupportedDocument) {
+      setOwnErrorMessage(t('doc_auth.errors.card_type'));
+      assessment = 'unsupported';
+    } else if (isAssessedAsGlare) {
       setOwnErrorMessage(t('doc_auth.errors.glare.failed_short'));
       assessment = 'glare';
     } else if (isAssessedAsBlurry) {
@@ -475,7 +479,7 @@ function AcuantCapture(
       onChangeAndResetError(data, analyticsPayload);
       onResetFailedCaptureAttempts();
     } else {
-      onFailedCaptureAttempt({ isAssessedAsGlare, isAssessedAsBlurry });
+      onFailedCaptureAttempt({ isAssessedAsGlare, isAssessedAsBlurry, isUnsupportedDocument });
     }
 
     setIsCapturingEnvironment(false);

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -438,11 +438,11 @@ function AcuantCapture(
     const { image, cardtype, dpi, moire, glare, sharpness } = nextCapture;
     const isAssessedAsGlare = glare < glareThreshold;
     const isAssessedAsBlurry = sharpness < sharpnessThreshold;
-    const isUnsupportedDocument = cardtype !== 1;
+    const isAssessedAsUnsupported = cardtype !== 1;
     const { width, height, data } = image;
 
     let assessment: AcuantImageAssessment;
-    if (isUnsupportedDocument) {
+    if (isAssessedAsUnsupported) {
       setOwnErrorMessage(t('doc_auth.errors.card_type'));
       assessment = 'unsupported';
     } else if (isAssessedAsGlare) {
@@ -460,6 +460,7 @@ function AcuantCapture(
       height,
       mimeType: 'image/jpeg', // Acuant Web SDK currently encodes all images as JPEG
       source: 'acuant',
+      isAssessedAsUnsupported,
       documentType: getDocumentTypeLabel(cardtype),
       dpi,
       moire,
@@ -479,7 +480,11 @@ function AcuantCapture(
       onChangeAndResetError(data, analyticsPayload);
       onResetFailedCaptureAttempts();
     } else {
-      onFailedCaptureAttempt({ isAssessedAsGlare, isAssessedAsBlurry, isUnsupportedDocument });
+      onFailedCaptureAttempt({
+        isAssessedAsGlare,
+        isAssessedAsBlurry,
+        isUnsupportedDocument: isAssessedAsUnsupported,
+      });
     }
 
     setIsCapturingEnvironment(false);

--- a/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
+++ b/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
@@ -5,7 +5,7 @@ import useCounter from '../hooks/use-counter';
 interface CaptureAttemptMetadata {
   isAssessedAsGlare: boolean;
   isAssessedAsBlurry: boolean;
-  isUnsupportedDocument: boolean;
+  isAssessedAsUnsupported: boolean;
 }
 
 interface FailedCaptureAttemptsContextInterface {
@@ -67,7 +67,7 @@ interface FailedCaptureAttemptsContextInterface {
 const DEFAULT_LAST_ATTEMPT_METADATA: CaptureAttemptMetadata = {
   isAssessedAsGlare: false,
   isAssessedAsBlurry: false,
-  isUnsupportedDocument: false,
+  isAssessedAsUnsupported: false,
 };
 
 const FailedCaptureAttemptsContext = createContext<FailedCaptureAttemptsContextInterface>({

--- a/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
+++ b/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
@@ -5,6 +5,7 @@ import useCounter from '../hooks/use-counter';
 interface CaptureAttemptMetadata {
   isAssessedAsGlare: boolean;
   isAssessedAsBlurry: boolean;
+  isUnsupportedDocument: boolean;
 }
 
 interface FailedCaptureAttemptsContextInterface {
@@ -66,6 +67,7 @@ interface FailedCaptureAttemptsContextInterface {
 const DEFAULT_LAST_ATTEMPT_METADATA: CaptureAttemptMetadata = {
   isAssessedAsGlare: false,
   isAssessedAsBlurry: false,
+  isUnsupportedDocument: false,
 };
 
 const FailedCaptureAttemptsContext = createContext<FailedCaptureAttemptsContextInterface>({

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -52,6 +52,7 @@ en:
           browser or system settings, reload this page, or upload a photo
           instead.
         failed: Camera failed to start, please try again.
+      card_type: Try again with your driver’s license or state ID card.
       dpi:
         failed_short: Image is too small or blurry, please try again.
         top_msg: We couldn’t read your ID. Your image size may be too small, or your ID

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -62,7 +62,8 @@ es:
           compruebe la configuración de su navegador o sistema, recargue esta
           página o suba una foto en su lugar.
         failed: No se ha podido encender la cámara, por favor, inténtelo de nuevo.
-      card_type: Solo se aceptan licencias de conducir o documentos de identidad estatales.
+      card_type: Solo se aceptan licencias de conducir o documentos de identidad
+        estatales.
       dpi:
         failed_short: La imagen es demasiado pequeña o está borrosa, por favor inténtelo
           de nuevo.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -62,6 +62,7 @@ es:
           compruebe la configuración de su navegador o sistema, recargue esta
           página o suba una foto en su lugar.
         failed: No se ha podido encender la cámara, por favor, inténtelo de nuevo.
+      card_type: Solo se aceptan licencias de conducir o documentos de identidad estatales.
       dpi:
         failed_short: La imagen es demasiado pequeña o está borrosa, por favor inténtelo
           de nuevo.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -67,6 +67,7 @@ fr:
           Veuillez vérifier les paramètres de votre navigateur ou de votre
           système, recharger cette page ou télécharger une photo à la place.
         failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
+      card_type: Réessayez avec votre permis de conduire ou carte d'identité délivrée par l'État.
       dpi:
         failed_short: L’image est trop petite ou floue, veuillez réessayer.
         top_msg: Nous n’avons pas pu lire votre pièce d’identité. La taille de votre

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -67,7 +67,8 @@ fr:
           Veuillez vérifier les paramètres de votre navigateur ou de votre
           système, recharger cette page ou télécharger une photo à la place.
         failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
-      card_type: Réessayez avec votre permis de conduire ou carte d'identité délivrée par l'État.
+      card_type: Réessayez avec votre permis de conduire ou carte d’identité délivrée
+        par l’État.
       dpi:
         failed_short: L’image est trop petite ou floue, veuillez réessayer.
         top_msg: Nous n’avons pas pu lire votre pièce d’identité. La taille de votre

--- a/spec/javascript/packages/document-capture/components/capture-troubleshooting-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/capture-troubleshooting-spec.jsx
@@ -92,7 +92,7 @@ describe('document-capture/context/capture-troubleshooting', () => {
     expect(trackEvent).to.have.been.calledWith('IdV: Capture troubleshooting shown', {
       isAssessedAsGlare: false,
       isAssessedAsBlurry: false,
-      isUnsupportedDocument: false,
+      isAssessedAsUnsupported: false,
     });
 
     const tryAgainButton = getByRole('button', { name: 'idv.failure.button.warning' });

--- a/spec/javascript/packages/document-capture/components/capture-troubleshooting-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/capture-troubleshooting-spec.jsx
@@ -92,6 +92,7 @@ describe('document-capture/context/capture-troubleshooting', () => {
     expect(trackEvent).to.have.been.calledWith('IdV: Capture troubleshooting shown', {
       isAssessedAsGlare: false,
       isAssessedAsBlurry: false,
+      isUnsupportedDocument: false,
     });
 
     const tryAgainButton = getByRole('button', { name: 'idv.failure.button.warning' });

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -91,6 +91,7 @@ describe('document-capture/components/document-capture', () => {
         image: {
           data: validUpload,
         },
+        cardtype: 1,
       });
     });
 

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
@@ -66,7 +66,7 @@ describe('document-capture/components/documents-step', () => {
     );
 
     initialize();
-    const result = { sharpness: 100, image: { data: '' } };
+    const result = { sharpness: 100, image: { data: '' }, cardtype: 1 };
 
     window.AcuantCameraUI.start.callsFake(({ onCropped }) => onCropped({ ...result, glare: 10 }));
     await userEvent.click(getByLabelText('doc_auth.headings.document_capture_front'));


### PR DESCRIPTION
## 🎫 Ticket
[LG-10255: Check id 'card type' when using SDK](https://cm-jira.usa.gov/browse/LG-10255)


## 🛠 Summary of changes
1. Display an error message when the user, using Acuant SDK, captures a photo of something that is not an ID card type.
2. Prevent the user from submitting photos that have triggered this inline error.

## 📜 Testing Plan
In staging, attempt to submit a photo of a passport.  Voila!  Errors.


## 👀 Screenshots

![EnglishErrors10255](https://github.com/18F/identity-idp/assets/80347702/0553b4ee-0737-4ab7-96d4-d03d40af8efd)

![FrenchErrors10255](https://github.com/18F/identity-idp/assets/80347702/d7203e65-5b63-465a-bfdc-25f52defa4f9)

![SpanishErrors10255](https://github.com/18F/identity-idp/assets/80347702/6e1eca91-7a20-4c97-81c2-f0b4a76a7573)

