### PR TITLE
LG-8034 redundant enrollments - Do not merge, overridden by a new rebased version.

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -33,6 +33,14 @@ class GetUspsProofingResultsJob < ApplicationJob
     )
 
     started_at = Time.zone.now
+
+#    enrollments.update(:last_batch_claim_at => started_at)
+    enrollments.each do |enroll|
+      enroll.update(:last_batch_claim_at => started_at)
+    end
+    puts("there are #{enrollments.size} before calling batch")
+    enrollments = InPersonEnrollment.needs_usps_status_check_batch(started_at) if enrollments.size > 0 
+    puts("there are #{enrollments.size} after calling batch")
     analytics.idv_in_person_usps_proofing_results_job_started(
       enrollments_count: enrollments.count,
       reprocess_delay_minutes: reprocess_delay_minutes,

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -33,7 +33,6 @@ class GetUspsProofingResultsJob < ApplicationJob
     )
 
     started_at = Time.zone.now
-
     enrollments.each do |enroll|
       enroll.update(last_batch_claim_at: started_at)
     end

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -37,7 +37,8 @@ class GetUspsProofingResultsJob < ApplicationJob
     enrollments.each do |enroll|
       enroll.update(last_batch_claim_at: started_at)
     end
-    enrollments = InPersonEnrollment.needs_usps_status_check_batch(started_at) if enrollments.size > 0 
+    enrollments = InPersonEnrollment.needs_usps_status_check_batch(started_at) if
+      enrollments.size > 0
     analytics.idv_in_person_usps_proofing_results_job_started(
       enrollments_count: enrollments.count,
       reprocess_delay_minutes: reprocess_delay_minutes,

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -34,9 +34,6 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     started_at = Time.zone.now
     enrollments.update(last_batch_claim_at: started_at)
-   # enrollments.each do |enroll|
-   #   enroll.update(last_batch_claim_at: started_at)
-   # end
     enrollments = InPersonEnrollment.needs_usps_status_check_batch(started_at) if
       enrollments.size > 0
     analytics.idv_in_person_usps_proofing_results_job_started(
@@ -44,7 +41,6 @@ class GetUspsProofingResultsJob < ApplicationJob
       reprocess_delay_minutes: reprocess_delay_minutes,
       job_name: self.class.name,
     )
-    puts("---------> fahr be they #{enrollments.size}")
     check_enrollments(enrollments)
     analytics.idv_in_person_usps_proofing_results_job_completed(
       **enrollment_outcomes,
@@ -96,20 +92,15 @@ class GetUspsProofingResultsJob < ApplicationJob
       enrollment.unique_id, enrollment.enrollment_code
     )
   rescue Faraday::BadRequestError => err
-    puts('bad request')
     # 400 status code. This is used for some status updates and some common client errors
     handle_bad_request_error(err, enrollment)
   rescue Faraday::ClientError, Faraday::ServerError, Faraday::Error => err
-    puts('server error')
     # 4xx, 5xx and any other Faraday error besides a 400 status code.
     # These errors may or may not have a response body that we can pull info from.
     handle_client_or_server_error(err, enrollment)
   rescue StandardError => err
-    puts('standard error')
-    puts("#{err}")
     handle_standard_error(err, enrollment)
   else
-    puts('process time')
     process_enrollment_response(enrollment, response)
   ensure
     # Record the attempt to update the enrollment

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -36,11 +36,9 @@ class GetUspsProofingResultsJob < ApplicationJob
 
 #    enrollments.update(:last_batch_claim_at => started_at)
     enrollments.each do |enroll|
-      enroll.update(:last_batch_claim_at => started_at)
+      enroll.update(last_batch_claim_at: started_at)
     end
-    puts("there are #{enrollments.size} before calling batch")
     enrollments = InPersonEnrollment.needs_usps_status_check_batch(started_at) if enrollments.size > 0 
-    puts("there are #{enrollments.size} after calling batch")
     analytics.idv_in_person_usps_proofing_results_job_started(
       enrollments_count: enrollments.count,
       reprocess_delay_minutes: reprocess_delay_minutes,

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -34,7 +34,6 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     started_at = Time.zone.now
 
-#    enrollments.update(:last_batch_claim_at => started_at)
     enrollments.each do |enroll|
       enroll.update(last_batch_claim_at: started_at)
     end

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -61,8 +61,9 @@ class InPersonEnrollment < ApplicationRecord
   def self.needs_usps_status_check_batch(batch_at)
     where(status: :pending).
       and(
-        where(last_batch_claim_at: ((batch_at - 1.second)..(batch_at + 1.second)))).
-        order(status_check_attempted_at: :asc)
+        where(last_batch_claim_at: batch_at),
+      ).
+      order(status_check_attempted_at: :asc)
   end
 
   # Does this enrollment need a status check via the USPS API?

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -52,10 +52,17 @@ class InPersonEnrollment < ApplicationRecord
   def self.needs_usps_status_check(check_interval)
     where(status: :pending).
       and(
-        where(status_check_attempted_at: check_interval).
-        or(where(status_check_attempted_at: nil)),
+        where(last_batch_claim_at: check_interval).
+        or(where(last_batch_claim_at: nil)),
       ).
       order(status_check_attempted_at: :asc)
+  end
+
+  def self.needs_usps_status_check_batch(batch_at)
+    where(status: :pending).
+      and(
+        where(last_batch_claim_at: ((batch_at - 1.second)..(batch_at + 1.second)))).
+        order(status_check_attempted_at: :asc)
   end
 
   # Does this enrollment need a status check via the USPS API?

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -69,8 +69,8 @@ class InPersonEnrollment < ApplicationRecord
   # Does this enrollment need a status check via the USPS API?
   def needs_usps_status_check?(check_interval)
     pending? && (
-      status_check_attempted_at.nil? ||
-      check_interval.cover?(status_check_attempted_at)
+      last_batch_claim_at.nil? ||
+      check_interval.cover?(last_batch_claim_at)
     )
   end
 

--- a/db/primary_migrate/20230712204949_add_last_batch_claim_at_to_in_person_enrollment.rb
+++ b/db/primary_migrate/20230712204949_add_last_batch_claim_at_to_in_person_enrollment.rb
@@ -1,0 +1,5 @@
+class AddLastBatchClaimAtToInPersonEnrollment < ActiveRecord::Migration[7.0]
+  def change
+    add_column :in_person_enrollments, :last_batch_claim_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_27_213457) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_12_204949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -310,6 +310,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_213457) do
     t.boolean "capture_secondary_id_enabled", default: false, comment: "record and proof state ID and residential addresses separately"
     t.datetime "status_check_completed_at", comment: "The last time a status check was successfully completed"
     t.boolean "ready_for_status_check", default: false
+    t.datetime "last_batch_claim_at"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["ready_for_status_check"], name: "index_in_person_enrollments_on_ready_for_status_check", where: "(ready_for_status_check = true)"
     t.index ["status_check_attempted_at"], name: "index_in_person_enrollments_on_status_check_attempted_at", where: "(status = 1)"

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -245,8 +245,6 @@ RSpec.describe GetUspsProofingResultsJob do
         before do
           allow(InPersonEnrollment).to receive(:needs_usps_status_check).
             and_return([pending_enrollment])
-          #allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
-          #  and_return([pending_enrollment])
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end
 
@@ -363,8 +361,8 @@ RSpec.describe GetUspsProofingResultsJob do
         it 'logs a message with counts of various outcomes when the job completes (errored = 0)' do
           allow(InPersonEnrollment).to receive(:needs_usps_status_check).
             and_return(pending_enrollments)
-         # allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
-         #   and_return(pending_enrollments)
+          # allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
+          #   and_return(pending_enrollments)
           stub_request_proofing_results_with_responses(
             request_passed_proofing_results_args,
           )
@@ -682,7 +680,7 @@ RSpec.describe GetUspsProofingResultsJob do
 
           it 'logs failure details' do
             job.perform(Time.zone.now)
-            
+
             pending_enrollment.reload
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
@@ -1118,10 +1116,10 @@ RSpec.describe GetUspsProofingResultsJob do
           )
         end
         before do
-        #  allow(InPersonEnrollment).to receive(:needs_usps_status_check).
-        #   and_return([pending_enrollment])
-        #  allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
-        #    and_return([pending_enrollment])
+          #  allow(InPersonEnrollment).to receive(:needs_usps_status_check).
+          #   and_return([pending_enrollment])
+          #  allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
+          #    and_return([pending_enrollment])
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -217,38 +217,13 @@ RSpec.describe GetUspsProofingResultsJob do
   describe '#perform' do
     describe 'IPP enabled' do
       describe 'DAV not enabled' do
-        # let!(:pending_enrollments) do
         let!(:pending_enrollments) do
-          # [
           locations = ['BALTIMORE', 'FRIENDSHIP', 'WASHINGTON', 'ARLINGTON', 'DEANWOOD']
           build_list(:in_person_enrollment, 5, :pending) do |record, i|
             record.issuer = 'http://localhost:3000'
             record.selected_location_details = { name: locations[i] }
             record.save!
           end
-          #  create(
-          #    :in_person_enrollment, :pending,
-          #    selected_location_details: { name: 'BALTIMORE' },
-          #    issuer: 'http://localhost:3000'
-          #  ),
-          #  create(
-          #    :in_person_enrollment, :pending,
-          #    selected_location_details: { name: 'FRIENDSHIP' }
-          #  ),
-          #  create(
-          #    :in_person_enrollment, :pending,
-          #    selected_location_details: { name: 'WASHINGTON' }
-          #  ),
-          #  create(
-          #    :in_person_enrollment, :pending,
-          #    selected_location_details: { name: 'ARLINGTON' }
-          #  ),
-          #  create(
-          #    :in_person_enrollment, :pending,
-          #    selected_location_details: { name: 'DEANWOOD' }
-          #  ),
-          # ]
-          # end
         end
         let(:pending_enrollment) { pending_enrollments.first }
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -245,8 +245,8 @@ RSpec.describe GetUspsProofingResultsJob do
         before do
           allow(InPersonEnrollment).to receive(:needs_usps_status_check).
             and_return([pending_enrollment])
-          allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
-            and_return([pending_enrollment])
+          #allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
+          #  and_return([pending_enrollment])
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end
 
@@ -363,8 +363,8 @@ RSpec.describe GetUspsProofingResultsJob do
         it 'logs a message with counts of various outcomes when the job completes (errored = 0)' do
           allow(InPersonEnrollment).to receive(:needs_usps_status_check).
             and_return(pending_enrollments)
-          allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
-            and_return(pending_enrollments)
+         # allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
+         #   and_return(pending_enrollments)
           stub_request_proofing_results_with_responses(
             request_passed_proofing_results_args,
           )
@@ -461,9 +461,10 @@ RSpec.describe GetUspsProofingResultsJob do
           it 'generates a backwards-compatible unique ID' do
             pending_enrollment.update(unique_id: nil)
             stub_request_passed_proofing_results
-            expect(pending_enrollment).to receive(:usps_unique_id).and_call_original
+            expect_any_instance_of(InPersonEnrollment).to receive(:usps_unique_id).and_call_original
 
             job.perform(Time.zone.now)
+            pending_enrollment.reload
 
             expect(pending_enrollment.unique_id).not_to be_nil
           end
@@ -643,6 +644,7 @@ RSpec.describe GetUspsProofingResultsJob do
           it 'logs details about the success' do
             job.perform(Time.zone.now)
 
+            pending_enrollment.reload
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: Enrollment status updated',
@@ -680,7 +682,8 @@ RSpec.describe GetUspsProofingResultsJob do
 
           it 'logs failure details' do
             job.perform(Time.zone.now)
-
+            
+            pending_enrollment.reload
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: Enrollment status updated',
@@ -719,6 +722,7 @@ RSpec.describe GetUspsProofingResultsJob do
           it 'logs fraud failure details' do
             job.perform(Time.zone.now)
 
+            pending_enrollment.reload
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: Enrollment status updated',
@@ -758,6 +762,7 @@ RSpec.describe GetUspsProofingResultsJob do
           it 'logs a message about the unsupported ID' do
             job.perform Time.zone.now
 
+            pending_enrollment.reload
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: Enrollment status updated',
@@ -1113,10 +1118,10 @@ RSpec.describe GetUspsProofingResultsJob do
           )
         end
         before do
-          allow(InPersonEnrollment).to receive(:needs_usps_status_check).
-           and_return([pending_enrollment])
-          allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
-            and_return([pending_enrollment])
+        #  allow(InPersonEnrollment).to receive(:needs_usps_status_check).
+        #   and_return([pending_enrollment])
+        #  allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
+        #    and_return([pending_enrollment])
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end
 
@@ -1136,6 +1141,8 @@ RSpec.describe GetUspsProofingResultsJob do
 
           it 'logs a message about enrollment with secondary ID' do
             job.perform Time.zone.now
+
+            pending_enrollment.reload
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(pending_enrollment.profile.active).to eq(false)
             expect(job_analytics).to have_logged_event(

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -285,7 +285,6 @@ RSpec.describe GetUspsProofingResultsJob do
 
           freeze_time do
             job.perform(Time.zone.now)
-
             expect(
               pending_enrollments.
                 map(&:reload).

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -245,6 +245,8 @@ RSpec.describe GetUspsProofingResultsJob do
         before do
           allow(InPersonEnrollment).to receive(:needs_usps_status_check).
             and_return([pending_enrollment])
+          allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
+            and_return([pending_enrollment])
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end
 
@@ -360,6 +362,8 @@ RSpec.describe GetUspsProofingResultsJob do
 
         it 'logs a message with counts of various outcomes when the job completes (errored = 0)' do
           allow(InPersonEnrollment).to receive(:needs_usps_status_check).
+            and_return(pending_enrollments)
+          allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
             and_return(pending_enrollments)
           stub_request_proofing_results_with_responses(
             request_passed_proofing_results_args,
@@ -1110,6 +1114,8 @@ RSpec.describe GetUspsProofingResultsJob do
         end
         before do
           allow(InPersonEnrollment).to receive(:needs_usps_status_check).
+           and_return([pending_enrollment])
+          allow(InPersonEnrollment).to receive(:needs_usps_status_check_batch).
             and_return([pending_enrollment])
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe InPersonEnrollment, type: :model do
     let!(:failing_enrollment) { create(:in_person_enrollment, :failed) }
     let!(:expired_enrollment) { create(:in_person_enrollment, :expired) }
     let!(:checked_pending_enrollment) do
-      create(:in_person_enrollment, :pending, status_check_attempted_at: Time.zone.now)
+      create(:in_person_enrollment, :pending, last_batch_claim_at: Time.zone.now)
     end
     let!(:needy_enrollments) do
       [
@@ -193,7 +193,7 @@ RSpec.describe InPersonEnrollment, type: :model do
     end
     let!(:checked_pending_enrollment) do
       create(
-        :in_person_enrollment, :pending, status_check_attempted_at: Time.zone.now,
+        :in_person_enrollment, :pending, last_batch_claim_at: Time.zone.now,
                                          ready_for_status_check: true
       )
     end


### PR DESCRIPTION
## 🎫 Ticket
[LG-8034](https://cm-jira.usa.gov/browse/LG-8034)

## 🛠 Summary of changes
Add a new column to set the batch time of InPersonEnrollment to reduce the chance of a redundant batch of enrollments.
Add logic to set the batch time when the InPersonEnrollment is picked up in a batch instead of relying on when it was actually processed.

changelog: Internal, IPP Enrollments, prevent InPersonEnrollment from appearing in two batches
