### PR TITLE
Fix current path detection for locale URL parameter

### DIFF
--- a/app/components/tab_navigation_component.rb
+++ b/app/components/tab_navigation_component.rb
@@ -8,8 +8,9 @@ class TabNavigationComponent < BaseComponent
   end
 
   def is_current_path?(path)
-    request.path == URI.parse(path).path
-  rescue URI::InvalidURIError
+    recognized_path = Rails.application.routes.recognize_path(path)
+    [recognized_path, request].pluck(:controller, :action).uniq.one?
+  rescue ActionController::RoutingError
     false
   end
 end

--- a/app/components/tab_navigation_component.rb
+++ b/app/components/tab_navigation_component.rb
@@ -9,7 +9,8 @@ class TabNavigationComponent < BaseComponent
 
   def is_current_path?(path)
     recognized_path = Rails.application.routes.recognize_path(path)
-    [recognized_path, request].pluck(:controller, :action).uniq.one?
+    request[:controller] == recognized_path[:controller] &&
+      request[:action] == recognized_path[:action]
   rescue ActionController::RoutingError
     false
   end

--- a/spec/components/tab_navigation_component_spec.rb
+++ b/spec/components/tab_navigation_component_spec.rb
@@ -26,12 +26,10 @@ RSpec.describe TabNavigationComponent, type: :component do
   context 'with link for current request' do
     let(:request_path) { '/first' }
 
-    class ExampleController < ApplicationController; end
-
     around do |example|
       Rails.application.routes.draw do
-        get '(:example_param)/first' => 'example#first'
-        get '(:example_param)/second' => 'example#second'
+        get '(:example_param)/first' => 'application#first'
+        get '(:example_param)/second' => 'application#second'
       end
 
       with_request_url(request_path) { example.run }

--- a/spec/components/tab_navigation_component_spec.rb
+++ b/spec/components/tab_navigation_component_spec.rb
@@ -24,8 +24,19 @@ RSpec.describe TabNavigationComponent, type: :component do
   end
 
   context 'with link for current request' do
-    before do
-      allow(vc_test_request).to receive(:path).and_return('/first')
+    let(:request_path) { '/first' }
+
+    class ExampleController < ApplicationController; end
+
+    around do |example|
+      Rails.application.routes.draw do
+        get '(:example_param)/first' => 'example#first'
+        get '(:example_param)/second' => 'example#second'
+      end
+
+      with_request_url(request_path) { example.run }
+
+      Rails.application.reload_routes!
     end
 
     it 'renders current link as highlighted' do
@@ -50,8 +61,22 @@ RSpec.describe TabNavigationComponent, type: :component do
     context 'with routes including query parameters' do
       let(:routes) do
         [
-          { path: '/first?foo=bar', text: 'First' },
-          { path: '/second?foo=bar', text: 'Second' },
+          { path: '/first?example_param=example_param_value', text: 'First' },
+          { path: '/second?example_param=example_param_value', text: 'Second' },
+        ]
+      end
+
+      it 'renders current link as highlighted' do
+        expect(rendered).to have_link('First') { |link| is_current_link?(link) }
+        expect(rendered).to have_link('Second') { |link| !is_current_link?(link) }
+      end
+    end
+
+    context 'with equivalent routes based on param' do
+      let(:routes) do
+        [
+          { path: '/example_param_value/first', text: 'First' },
+          { path: '/example_param_value/second', text: 'Second' },
         ]
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Improves "current path" detection for TabNavigationComponent, fixing an issue where locale specified through a URL parameter would not be reflected.

Example: https://secure.login.gov/?locale=es

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1689604911179219

## 📜 Testing Plan

1. Go to all of the following URLs and observe that "Sign in" is shown as the currently-selected link:
   - http://localhost:3000
   - http://localhost:3000/es/
   - http://localhost:3000/?locale=es

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/04fa5946-5c5c-4edb-8039-f0135d051ac4)|![image](https://github.com/18F/identity-idp/assets/1779930/429f95f5-4777-49ce-9b02-2db3c765b5a3)
