### PR TITLE
LG-10259: Increase doc_auth_max_capture_attempts_before_native_camera to 3

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -95,7 +95,7 @@ doc_auth_error_glare_threshold: 40
 doc_auth_error_sharpness_threshold: 40
 doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_tips: 3
-doc_auth_max_capture_attempts_before_native_camera: 2
+doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 2
 doc_capture_request_valid_for_minutes: 15
 email_from: no-reply@login.gov


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
https://cm-jira.usa.gov/browse/LG-10259

## 🛠 Summary of changes

This PR increases the number of times someone can try to capture their document using the Acuant SDK before the app falls back to native camera capture.

## 📜 Testing Plan

To test these changes you should make sure that you have the mobile device testing working per here: https://github.com/18F/identity-idp/blob/main/docs/mobile.md. There are a couple of extra steps though.

- [ ] Checkout this branch.
- [ ] Set up the mobile testing and make sure it works correctly.
- [ ] Change these values in `application.default.yml` and restart the local server. This makes the upload always fail so we can observe the SDK to Native switchover.
```
doc_auth_error_sharpness_threshold: 100
doc_auth_client_sharpness_threshold: 100
doc_auth_error_sharpness_threshold: 100
```
- [ ] On the mobile app get to the document authentication step. Something like: `https:192.168.1.6:3000/verify`, it's a few steps in.
- [ ] Take a picture of a card you have with no PII (I used a costco card). You'll get the Acuant SDK upload.
- [ ] That upload should fail with red text and keep you on the same page, the page that shows the Front/Back of the ID.
- [ ] If at this point you end up on a page that doesn't show the Front/Back, that's a problem.
- [ ] The thing we're interested in is how many times you get the Acuant SDK upload before you get an error page. It should be three times with this PR.
- [ ] After you take a picture and it failes three times you should get a different page explaining that it's not working.
- [ ] After the error page, continue, and you'll be back on the Front/Back upload page.
- [ ] Now if you try and take a picture you won't get the Acuant SDK, you'll get the native camera capture.
