### PR TITLE
LG-9483: Filter WebAuthn verification credential by attachment

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -89,9 +89,11 @@ module TwoFactorAuthentication
     end
 
     def credentials
-      MfaContext.new(current_user).webauthn_configurations.map do |configuration|
-        { id: configuration.credential_id, transports: configuration.transports }
-      end
+      MfaContext.new(current_user).webauthn_configurations.
+        select { |configuration| configuration.platform_authenticator? == platform_authenticator? }.
+        map do |configuration|
+          { id: configuration.credential_id, transports: configuration.transports }
+        end
     end
 
     def analytics_properties

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
         end
 
         it 'assigns presenter instance variable with initialized credentials' do
-          get :show, params: { platform: true }
+          get :show
 
           presenter = assigns(:presenter)
 
@@ -70,6 +70,32 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
               transports: webauthn_configuration.transports,
             ],
           )
+        end
+
+        context 'with multiple webauthn configured' do
+          let!(:webauthn_platform_configuration) do
+            create(:webauthn_configuration, :platform_authenticator, user:)
+          end
+
+          it 'filters credentials based on requested authenticator attachment' do
+            get :show
+
+            expect(assigns(:presenter).credentials).to eq(
+              [
+                id: webauthn_configuration.credential_id,
+                transports: webauthn_configuration.transports,
+              ],
+            )
+
+            get :show, params: { platform: true }
+
+            expect(assigns(:presenter).credentials).to eq(
+              [
+                id: webauthn_platform_configuration.credential_id,
+                transports: webauthn_platform_configuration.transports,
+              ],
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-9483](https://cm-jira.usa.gov/browse/LG-9483)

## 🛠 Summary of changes

Fixes an issue where a user with multiple WebAuthn configurations (both platform and non-platform) would be prompted for _any_ of their authenticators, regardless of the verification flow, resulting in potentially-confusing scenarios where the user could be prompted for their platform authenticator when trying to use a security key.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create an account
3. Add "Security Key" and "Face or Touch Unlock" during MFA setup
4. Once you reach account dashboard, click "Forget all browsers" in sidebar and confirm prompt
5. Sign out
6. Sign in
7. Click "Use face or touch unlock" or "Use security key", depending which method you're prompted for
8. Observe that the browser dialog to use your authenticator corresponds to the expected authenticator for security key or face or touch unlock
9. Cancel prompt
10. Click "Choose another authentication method"
11. Choose the other WebAuthn authenticator method
12. Click Continue
13. Repeat Steps 7 and 8

## 👀 Screenshots

Authenticator|Before|After
---|---|---
Security Key|![image](https://github.com/18F/identity-idp/assets/1779930/e4deee8f-309f-4eeb-a0c2-6cccbe087cfd)|![image](https://github.com/18F/identity-idp/assets/1779930/fe9343c9-6bbd-4600-8e96-2a4e3211fe96)
Face or touch unlock|![image](https://github.com/18F/identity-idp/assets/1779930/b0088f43-4b89-4a6a-99a6-0a9053ee01e6)|![image](https://github.com/18F/identity-idp/assets/1779930/0f73ce1f-370d-459f-aeff-4fe489b79fa1)

