### PR TITLE
Separate OpenID Connect Authorization Request and Handoff Logging

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -30,15 +30,13 @@ module OpenidConnect
       link_identity_to_service_provider
 
       result = @authorize_form.submit
-      # track successful forms, see pre_validate_authorize_form for unsuccessful
-      # this needs to be after link_identity_to_service_provider so that "code" is present
 
       referer = request.referer
       if auth_count == 1 && first_visit_for_sp?
-        track_authorize_analytics(result, user_sp_authorized: false, referer: referer)
+        track_handoff_analytics(result, user_sp_authorized: false, referer: referer)
         return redirect_to(user_authorization_confirmation_url)
       end
-      track_authorize_analytics(result, user_sp_authorized: true, referer: referer)
+      track_handoff_analytics(result, user_sp_authorized: true, referer: referer)
       handle_successful_handoff
     end
 
@@ -79,11 +77,11 @@ module OpenidConnect
       delete_branded_experience
     end
 
-    def track_authorize_analytics(result, extra = {})
+    def track_handoff_analytics(result, extra = {})
       extra[:user_fully_authenticated] = user_fully_authenticated?
       analytics_attributes = result.to_h.except(:redirect_uri).merge(extra)
 
-      analytics.openid_connect_request_authorization(**analytics_attributes)
+      analytics.openid_connect_authorization_handoff(**analytics_attributes)
     end
 
     def identity_needs_verification?
@@ -111,10 +109,11 @@ module OpenidConnect
 
     def pre_validate_authorize_form
       result = @authorize_form.submit
+      analytics_attributes = result.to_h.except(:redirect_uri, :code_digest)
+      analytics_attributes[:user_fully_authenticated] = user_fully_authenticated?
+      analytics_attributes[:referer] = request.referer
+      analytics.openid_connect_request_authorization(**analytics_attributes)
       return if result.success?
-
-      # track forms with errors
-      track_authorize_analytics(result, referer: request.referer)
 
       if (redirect_uri = result.extra[:redirect_uri])
         redirect_to redirect_uri, allow_other_host: true

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -31,12 +31,11 @@ module OpenidConnect
 
       result = @authorize_form.submit
 
-      referer = request.referer
       if auth_count == 1 && first_visit_for_sp?
-        track_handoff_analytics(result, user_sp_authorized: false, referer: referer)
+        track_handoff_analytics(result, user_sp_authorized: false)
         return redirect_to(user_authorization_confirmation_url)
       end
-      track_handoff_analytics(result, user_sp_authorized: true, referer: referer)
+      track_handoff_analytics(result, user_sp_authorized: true)
       handle_successful_handoff
     end
 
@@ -77,11 +76,13 @@ module OpenidConnect
       delete_branded_experience
     end
 
-    def track_handoff_analytics(result, extra = {})
-      extra[:user_fully_authenticated] = user_fully_authenticated?
-      analytics_attributes = result.to_h.except(:redirect_uri).merge(extra)
+    def track_handoff_analytics(result, attributes = {})
+      result_attributes = result.to_h
+      attributes[:success] = result.success?
+      attributes[:client_id] = result_attributes[:client_id]
+      attributes[:code_digest] = result_attributes[:code_digest]
 
-      analytics.openid_connect_authorization_handoff(**analytics_attributes)
+      analytics.openid_connect_authorization_handoff(**attributes)
     end
 
     def identity_needs_verification?

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -110,10 +110,12 @@ module OpenidConnect
 
     def pre_validate_authorize_form
       result = @authorize_form.submit
-      analytics_attributes = result.to_h.except(:redirect_uri, :code_digest)
-      analytics_attributes[:user_fully_authenticated] = user_fully_authenticated?
-      analytics_attributes[:referer] = request.referer
-      analytics.openid_connect_request_authorization(**analytics_attributes)
+      analytics.openid_connect_request_authorization(
+        **result.to_h.except(:redirect_uri, :code_digest).merge(
+          user_fully_authenticated: user_fully_authenticated?,
+          referer: request.referer,
+        ),
+      )
       return if result.success?
 
       if (redirect_uri = result.extra[:redirect_uri])

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -77,12 +77,11 @@ module OpenidConnect
     end
 
     def track_handoff_analytics(result, attributes = {})
-      result_attributes = result.to_h
-      attributes[:success] = result.success?
-      attributes[:client_id] = result_attributes[:client_id]
-      attributes[:code_digest] = result_attributes[:code_digest]
-
-      analytics.openid_connect_authorization_handoff(**attributes)
+      analytics.openid_connect_authorization_handoff(
+        **attributes.merge(result.to_h.slice(:client_id, :code_digest)).merge(
+          success: result.success?,
+        ),
+      )
     end
 
     def identity_needs_verification?

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2826,6 +2826,34 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when a sucessful openid authorization request is returned
+  # @param [String] client_id
+  # @param [String] scope
+  # @param [Array] acr_values
+  # @param [Boolean] unauthorized_scope
+  # @param [Boolean] user_fully_authenticated
+  # @param [String] code_digest hash of returned "code" param
+  def openid_connect_authorization_handoff(
+    client_id:,
+    scope:,
+    acr_values:,
+    unauthorized_scope:,
+    user_fully_authenticated:,
+    code_digest:,
+    **extra
+  )
+    track_event(
+      'OpenID Connect: authorization request handoff',
+      client_id: client_id,
+      scope: scope,
+      acr_values: acr_values,
+      unauthorized_scope: unauthorized_scope,
+      user_fully_authenticated: user_fully_authenticated,
+      code_digest: code_digest,
+      **extra,
+    )
+  end
+
   # Tracks when an openid connect bearer token authentication request is made
   # @param [Boolean] success
   # @param [Integer] ial
@@ -2848,14 +2876,12 @@ module AnalyticsEvents
   # @param [Array] acr_values
   # @param [Boolean] unauthorized_scope
   # @param [Boolean] user_fully_authenticated
-  # @param [String] code_digest hash of returned "code" param
   def openid_connect_request_authorization(
     client_id:,
     scope:,
     acr_values:,
     unauthorized_scope:,
     user_fully_authenticated:,
-    code_digest:,
     **extra
   )
     track_event(
@@ -2865,10 +2891,10 @@ module AnalyticsEvents
       acr_values: acr_values,
       unauthorized_scope: unauthorized_scope,
       user_fully_authenticated: user_fully_authenticated,
-      code_digest: code_digest,
       **extra,
     )
   end
+
 
   # Tracks when an openid connect token request is made
   # @param [String] client_id

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2828,27 +2828,15 @@ module AnalyticsEvents
 
   # Tracks when a sucessful openid authorization request is returned
   # @param [String] client_id
-  # @param [String] scope
-  # @param [Array] acr_values
-  # @param [Boolean] unauthorized_scope
-  # @param [Boolean] user_fully_authenticated
   # @param [String] code_digest hash of returned "code" param
   def openid_connect_authorization_handoff(
     client_id:,
-    scope:,
-    acr_values:,
-    unauthorized_scope:,
-    user_fully_authenticated:,
     code_digest:,
     **extra
   )
     track_event(
       'OpenID Connect: authorization request handoff',
       client_id: client_id,
-      scope: scope,
-      acr_values: acr_values,
-      unauthorized_scope: unauthorized_scope,
-      user_fully_authenticated: user_fully_authenticated,
       code_digest: code_digest,
       **extra,
     )
@@ -2894,7 +2882,6 @@ module AnalyticsEvents
       **extra,
     )
   end
-
 
   # Tracks when an openid connect token request is made
   # @param [String] client_id

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  client_id: client_id,
                  prompt: 'select_account',
                  referer: nil,
+                 allow_prompt_login: true,
+                 errors: {},
+                 unauthorized_scope: true,
+                 user_fully_authenticated: true,
+                 acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+                 scope: 'openid')
+          expect(@analytics).to receive(:track_event).
+            with('OpenID Connect: authorization request handoff',
+                 success: true,
+                 client_id: client_id,
+                 prompt: 'select_account',
+                 referer: nil,
                  user_sp_authorized: true,
                  allow_prompt_login: true,
                  errors: {},
@@ -115,6 +127,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
               stub_analytics
               expect(@analytics).to receive(:track_event).
                 with('OpenID Connect: authorization request',
+                     success: true,
+                     client_id: client_id,
+                     prompt: 'select_account',
+                     referer: nil,
+                     allow_prompt_login: true,
+                     errors: {},
+                     unauthorized_scope: false,
+                     user_fully_authenticated: true,
+                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
+                     scope: 'openid profile')
+              expect(@analytics).to receive(:track_event).
+                with('OpenID Connect: authorization request handoff',
                      success: true,
                      client_id: client_id,
                      prompt: 'select_account',
@@ -277,6 +301,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
                        client_id: client_id,
                        prompt: 'select_account',
                        referer: nil,
+                       allow_prompt_login: true,
+                       errors: {},
+                       unauthorized_scope: false,
+                       user_fully_authenticated: true,
+                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                       scope: 'openid profile')
+                expect(@analytics).to receive(:track_event).
+                  with('OpenID Connect: authorization request handoff',
+                       success: true,
+                       client_id: client_id,
+                       prompt: 'select_account',
+                       referer: nil,
                        user_sp_authorized: true,
                        allow_prompt_login: true,
                        errors: {},
@@ -319,6 +355,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 stub_analytics
                 expect(@analytics).to receive(:track_event).
                   with('OpenID Connect: authorization request',
+                       success: true,
+                       client_id: client_id,
+                       prompt: 'select_account',
+                       referer: nil,
+                       allow_prompt_login: true,
+                       errors: {},
+                       unauthorized_scope: false,
+                       user_fully_authenticated: true,
+                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                       scope: 'openid profile')
+                expect(@analytics).to receive(:track_event).
+                  with('OpenID Connect: authorization request handoff',
                        success: true,
                        client_id: client_id,
                        prompt: 'select_account',
@@ -366,6 +414,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 stub_analytics
                 expect(@analytics).to receive(:track_event).
                   with('OpenID Connect: authorization request',
+                       success: true,
+                       client_id: client_id,
+                       prompt: 'select_account',
+                       referer: nil,
+                       allow_prompt_login: true,
+                       errors: {},
+                       unauthorized_scope: false,
+                       user_fully_authenticated: true,
+                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
+                       scope: 'openid profile')
+                expect(@analytics).to receive(:track_event).
+                  with('OpenID Connect: authorization request handoff',
                        success: true,
                        client_id: client_id,
                        prompt: 'select_account',
@@ -459,8 +519,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  error_details: hash_including(:prompt),
                  user_fully_authenticated: true,
                  acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
-                 scope: 'openid',
-                 code_digest: nil)
+                 scope: 'openid')
           expect(@analytics).to_not receive(:track_event).with('SP redirect initiated')
 
           action
@@ -491,8 +550,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  error_details: hash_including(:client_id),
                  user_fully_authenticated: true,
                  acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
-                 scope: 'openid',
-                 code_digest: nil)
+                 scope: 'openid')
           expect(@analytics).to_not receive(:track_event).with('SP redirect initiated')
 
           action
@@ -541,6 +599,20 @@ RSpec.describe OpenidConnect::AuthorizationController do
       end
 
       it 'redirects to SP landing page with the request_id in the params' do
+        stub_analytics
+        expect(@analytics).to receive(:track_event).
+          with('OpenID Connect: authorization request',
+               success: true,
+               client_id: client_id,
+               prompt: 'select_account',
+               referer: nil,
+               allow_prompt_login: true,
+               errors: {},
+               unauthorized_scope: true,
+               user_fully_authenticated: false,
+               acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+               scope: 'openid')
+
         action
         sp_request_id = ServiceProviderRequestProxy.last.uuid
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -65,15 +65,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             with('OpenID Connect: authorization request handoff',
                  success: true,
                  client_id: client_id,
-                 prompt: 'select_account',
-                 referer: nil,
                  user_sp_authorized: true,
-                 allow_prompt_login: true,
-                 errors: {},
-                 unauthorized_scope: true,
-                 user_fully_authenticated: true,
-                 acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
-                 scope: 'openid',
                  code_digest: kind_of(String))
           expect(@analytics).to receive(:track_event).
             with(
@@ -141,15 +133,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 with('OpenID Connect: authorization request handoff',
                      success: true,
                      client_id: client_id,
-                     prompt: 'select_account',
-                     referer: nil,
                      user_sp_authorized: true,
-                     allow_prompt_login: true,
-                     errors: {},
-                     unauthorized_scope: false,
-                     user_fully_authenticated: true,
-                     acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
-                     scope: 'openid profile',
                      code_digest: kind_of(String))
               expect(@analytics).to receive(:track_event).
                 with(
@@ -311,15 +295,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                   with('OpenID Connect: authorization request handoff',
                        success: true,
                        client_id: client_id,
-                       prompt: 'select_account',
-                       referer: nil,
                        user_sp_authorized: true,
-                       allow_prompt_login: true,
-                       errors: {},
-                       unauthorized_scope: false,
-                       user_fully_authenticated: true,
-                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                       scope: 'openid profile',
                        code_digest: kind_of(String))
                 expect(@analytics).to receive(:track_event).
                   with(
@@ -369,15 +345,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                   with('OpenID Connect: authorization request handoff',
                        success: true,
                        client_id: client_id,
-                       prompt: 'select_account',
-                       referer: nil,
                        user_sp_authorized: true,
-                       allow_prompt_login: true,
-                       errors: {},
-                       unauthorized_scope: false,
-                       user_fully_authenticated: true,
-                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                       scope: 'openid profile',
                        code_digest: kind_of(String))
                 expect(@analytics).to receive(:track_event).
                   with(
@@ -428,15 +396,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                   with('OpenID Connect: authorization request handoff',
                        success: true,
                        client_id: client_id,
-                       prompt: 'select_account',
-                       referer: nil,
                        user_sp_authorized: true,
-                       allow_prompt_login: true,
-                       errors: {},
-                       unauthorized_scope: false,
-                       user_fully_authenticated: true,
-                       acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
-                       scope: 'openid profile',
                        code_digest: kind_of(String))
                 expect(@analytics).to receive(:track_event).
                   with(


### PR DESCRIPTION
## 🛠 Summary of changes

Currently we do not log successful OIDC auth requests when they are not ultimately going to redirect. This was changed in #6942, so this maintains that by splitting the events and ensuring we always log the request when we get it.

I'm not 100% happy with this, but want to get CI going

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
