### PR TITLE
Fix tab navigation current path detection for non-GET request

### DIFF
--- a/app/components/tab_navigation_component.rb
+++ b/app/components/tab_navigation_component.rb
@@ -8,7 +8,7 @@ class TabNavigationComponent < BaseComponent
   end
 
   def is_current_path?(path)
-    recognized_path = Rails.application.routes.recognize_path(path)
+    recognized_path = Rails.application.routes.recognize_path(path, method: request.method)
     request[:controller] == recognized_path[:controller] &&
       request[:action] == recognized_path[:action]
   rescue ActionController::RoutingError


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a regression introduced in #8792 where the tab navigation would not show the correct selected tab if the request was not a GET request, such as a submission from the Sign In page.

Note: #8792 is not live yet in production, so this should not be affecting users.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Enter an email address and an incorrect password for that email address
3. Submit
4. Observe "Sign in" is still selected

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/9cd06763-7c1f-4ec8-b4db-915add7a323a)|![image](https://github.com/18F/identity-idp/assets/1779930/3e2956eb-9713-4ebf-a308-5e093ba57c01)
