### PR TITLE
LG-10167: Delete notification phone no when associated enrollment canceled

### DIFF
--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -147,7 +147,7 @@ class InPersonEnrollment < ApplicationRecord
   end
 
   def enrollment_will_be_cancelled?
-    status_change_to_be_saved&.last == "cancelled"
+    status_change_to_be_saved&.last == 'cancelled'
   end
 
   def set_unique_id

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -140,7 +140,14 @@ class InPersonEnrollment < ApplicationRecord
   private
 
   def on_status_updated
+    if enrollment_will_be_cancelled? && notification_phone_configuration.present?
+      notification_phone_configuration.destroy!
+    end
     self.status_updated_at = Time.zone.now
+  end
+
+  def enrollment_will_be_cancelled?
+    status_change_to_be_saved&.last == "cancelled"
   end
 
   def set_unique_id

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -39,9 +39,8 @@ FactoryBot.define do
     end
 
     trait :with_notification_phone_configuration do
-      after(:build) do |enrollment|
-        enrollment.notification_phone_configuration =
-          FactoryBot.build(:notification_phone_configuration)
+      after(:create) do |enrollment|
+        create :notification_phone_configuration, in_person_enrollment: enrollment
       end
     end
   end

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -39,9 +39,7 @@ FactoryBot.define do
     end
 
     trait :with_notification_phone_configuration do
-      after(:create) do |enrollment|
-        create :notification_phone_configuration, in_person_enrollment: enrollment
-      end
+      association :notification_phone_configuration
     end
   end
 end

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -365,24 +365,27 @@ RSpec.describe InPersonEnrollment, type: :model do
   end
 
   describe 'when notification_sent_at is updated' do
-    let(:enrollment) do
-      create(:in_person_enrollment, :passed, :with_notification_phone_configuration)
+    context 'enrollment has a notification phone configuration' do
+      let!(:enrollment) do
+        create(:in_person_enrollment, :passed, :with_notification_phone_configuration)
+      end
+
+      it 'destroys the notification phone configuration' do
+        expect(enrollment.notification_phone_configuration).to_not be_nil
+
+        enrollment.update(notification_sent_at: Time.zone.now)
+
+        expect(enrollment.reload.notification_phone_configuration).to be_nil
+      end
     end
 
-    let(:enrollment_without_notification) { create(:in_person_enrollment, :passed) }
+    context 'enrollment does not have a notification phone configuration' do
+      let!(:enrollment) { create(:in_person_enrollment, :passed) }
 
-    it 'no error without notification phone configuration' do
-      now = Time.zone.now
-      enrollment_without_notification.update(notification_sent_at: now)
-      expect(enrollment_without_notification.notification_sent_at).to_not be(now)
-      expect(InPersonEnrollment.count).to eq(1)
-    end
-    it 'destroys notification phone configuration' do
-      now = Time.zone.now
-      enrollment.update(notification_sent_at: now)
-      expect(enrollment.notification_sent_at).to_not be(now)
-      expect(enrollment.reload.notification_phone_configuration).to be_nil
-      expect(InPersonEnrollment.count).to eq(1)
+      it 'does not raise an error' do
+        expect(enrollment.notification_phone_configuration).to be_nil
+        expect { enrollment.update!(notification_sent_at: Time.zone.now) }.to_not raise_error
+      end
     end
   end
 

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -413,4 +413,31 @@ RSpec.describe InPersonEnrollment, type: :model do
       expect(failed_enrollment_without_notification.skip_notification_sent_at_set?).to eq(true)
     end
   end
+
+  describe 'user cancelling their enrollment' do
+    context 'user has a notification phone number stored' do
+      it 'deletes the notification phone number' do
+        enrollment = create(:in_person_enrollment, :passed, :with_notification_phone_configuration)
+        config_id = enrollment.notification_phone_configuration.id
+        expect(NotificationPhoneConfiguration.find_by({id: config_id})).to_not eq(nil)
+
+        enrollment.cancelled!
+        enrollment.reload
+
+        expect(enrollment.notification_phone_configuration).to eq(nil)
+        expect(NotificationPhoneConfiguration.find_by({id: config_id})).to eq(nil)
+      end
+    end
+
+    context 'user has a "nil" for their notification phone number' do
+      it 'does nothing' do
+        enrollment = create(:in_person_enrollment, :pending, notification_phone_configuration: nil)
+
+        enrollment.cancelled!
+        enrollment.reload
+
+        expect(enrollment.notification_phone_configuration).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -419,13 +419,13 @@ RSpec.describe InPersonEnrollment, type: :model do
       it 'deletes the notification phone number' do
         enrollment = create(:in_person_enrollment, :passed, :with_notification_phone_configuration)
         config_id = enrollment.notification_phone_configuration.id
-        expect(NotificationPhoneConfiguration.find_by({id: config_id})).to_not eq(nil)
+        expect(NotificationPhoneConfiguration.find_by({ id: config_id })).to_not eq(nil)
 
         enrollment.cancelled!
         enrollment.reload
 
         expect(enrollment.notification_phone_configuration).to eq(nil)
-        expect(NotificationPhoneConfiguration.find_by({id: config_id})).to eq(nil)
+        expect(NotificationPhoneConfiguration.find_by({ id: config_id })).to eq(nil)
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-10167](https://cm-jira.usa.gov/browse/LG-10167)

## 🛠 Summary of changes

If a user cancels their enrollment, we also want to delete their
saved notification phone number.

## 📜 Testing Plan

- [ ] Set the `in_person_send_proofing_notifications_enabled` feature flag to true
- [ ] Create a new account and complete the in-person flow, creating a barcode
- [ ] in the console, verify that a `NotificationPhoneConfiguration` was created
    ```ruby
    e = InPersonEnrollment.last
    e.status
    => "pending"
    e.notification_phone_configuration.present?
    => true
    ```
- [ ] Click the cancel link on the barcode page to cancel your enrollment
- [ ] in the console, confirm that the associated `NotificationPhoneConfiguration` was deleted
    ```ruby
    e.reload.status
    => "cancelled"
    e.notification_phone_configuration.present?
    => false
    NotificationPhoneConfiguration.count
    => 0
    ```