### PR TITLE
LG-9968 Read from `fraud_pending_reason` to find fraud pending profiles

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -31,7 +31,7 @@ class Profile < ApplicationRecord
   attr_reader :personal_key
 
   def fraud_review_pending?
-    fraud_review_pending_at.present?
+    fraud_pending_reason.present? && !fraud_rejection?
   end
 
   def fraud_rejection?
@@ -121,10 +121,6 @@ class Profile < ApplicationRecord
 
   def deactivate(reason)
     update!(active: false, deactivation_reason: reason)
-  end
-
-  def has_deactivation_reason?
-    deactivation_reason.present? || has_fraud_deactivation_reason? || gpo_verification_pending?
   end
 
   def has_fraud_deactivation_reason?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,9 +140,7 @@ class User < ApplicationRecord
       pending = profiles.where(deactivation_reason: :in_person_verification_pending).or(
         profiles.where.not(gpo_verification_pending_at: nil),
       ).or(
-        profiles.where.not(fraud_review_pending_at: nil),
-      ).or(
-        profiles.where.not(fraud_rejection_at: nil),
+        profiles.where.not(fraud_pending_reason: nil),
       ).order(created_at: :desc).first
 
       if pending.blank?


### PR DESCRIPTION
This commit makes the first change to switch over to the new `fraud_pending_reason` column. It reads from the column instead of the `fraud_review_pending_at` timestamp to determine if a profile is fraud review pending. This will allow us to stop writing to the `fraud_review_pending_at` timestamp until the user actually enters the fraud review workflow and go back and make the value nil for users who have not entered fraud review.

Eventually we will need to consider the presence of `fraud_pending_reason` and absence of `fraud_review_pending_at` as a new state (i.e. the user has not started fraud review but is eligible to start fraud review once they verify their address). That is out of scope for this PR which is intended to switch the reads to make that new state possible in a future release.
