### PR TITLE
LG-10405: Add new placeholder manual address entry page behind a flag

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -10,6 +10,7 @@ import { UploadFormEntriesError } from '../services/upload';
 import DocumentsStep from './documents-step';
 import InPersonPrepareStep from './in-person-prepare-step';
 import InPersonLocationPostOfficeSearchStep from './in-person-location-post-office-search-step';
+import InPersonLocationFullAddressEntryPostOfficeSearchStep from './in-person-location-full-address-entry-post-office-search-step';
 import InPersonSwitchBackStep from './in-person-switch-back-step';
 import ReviewIssuesStep from './review-issues-step';
 import UploadContext from '../context/upload';
@@ -27,9 +28,13 @@ interface DocumentCaptureProps {
    * Callback triggered on step change.
    */
   onStepChange?: () => void;
+  inPersonFullAddressEntryEnabled: Boolean;
 }
 
-function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
+function DocumentCapture({
+  onStepChange = () => {},
+  inPersonFullAddressEntryEnabled,
+}: DocumentCaptureProps) {
   const [formValues, setFormValues] = useState<Record<string, any> | null>(null);
   const [submissionError, setSubmissionError] = useState<Error | undefined>(undefined);
   const [stepName, setStepName] = useState<string | undefined>(undefined);
@@ -78,6 +83,10 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
     initialValues = formValues;
   }
 
+  const inPersonLocationPostOfficeSearchForm = inPersonFullAddressEntryEnabled
+    ? InPersonLocationFullAddressEntryPostOfficeSearchStep
+    : InPersonLocationPostOfficeSearchStep;
+
   const inPersonSteps: FormStep[] =
     inPersonURL === undefined
       ? []
@@ -89,7 +98,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
           },
           {
             name: 'location',
-            form: InPersonLocationPostOfficeSearchStep,
+            form: inPersonLocationPostOfficeSearchForm,
             title: t('in_person_proofing.headings.po_search.location'),
           },
           flowPath === 'hybrid' && {

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
@@ -1,6 +1,4 @@
 import { render } from '@testing-library/react';
-import { setupServer } from 'msw/node';
-import type { SetupServer } from 'msw/node';
 import { SWRConfig } from 'swr';
 import { ComponentType } from 'react';
 import InPersonLocationFullAddressEntryPostOfficeSearchStep from './in-person-location-full-address-entry-post-office-search-step';
@@ -16,21 +14,6 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
   const wrapper: ComponentType = ({ children }) => (
     <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
   );
-
-  let server: SetupServer;
-
-  before(() => {
-    server = setupServer();
-    server.listen();
-  });
-
-  after(() => {
-    server.close();
-  });
-
-  beforeEach(() => {
-    server.resetHandlers();
-  });
 
   it('renders the step', () => {
     const { getByRole } = render(

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react';
+import { setupServer } from 'msw/node';
+import type { SetupServer } from 'msw/node';
+import { SWRConfig } from 'swr';
+import { ComponentType } from 'react';
+import InPersonLocationFullAddressEntryPostOfficeSearchStep from './in-person-location-full-address-entry-post-office-search-step';
+
+const DEFAULT_PROPS = {
+  toPreviousStep() {},
+  onChange() {},
+  value: {},
+  registerField() {},
+};
+
+describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
+  const wrapper: ComponentType = ({ children }) => (
+    <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
+  );
+
+  let server: SetupServer;
+
+  before(() => {
+    server = setupServer();
+    server.listen();
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  beforeEach(() => {
+    server.resetHandlers();
+  });
+
+  it('renders the step', () => {
+    const { getByRole } = render(
+      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      {
+        wrapper,
+      },
+    );
+
+    expect(getByRole('heading', { name: 'in_person_proofing.headings.po_search.location' }));
+  });
+});

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
@@ -1,26 +1,10 @@
-import { useState, useEffect, useCallback, useRef, useContext } from 'react';
+import { useEffect, useRef } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
-import { Alert, PageHeading } from '@18f/identity-components';
-import { request } from '@18f/identity-request';
-import { forceRedirect } from '@18f/identity-url';
+import { PageHeading } from '@18f/identity-components';
 import BackButton from './back-button';
-import AnalyticsContext from '../context/analytics';
-import InPersonLocations, { FormattedLocation } from './in-person-locations';
-import { InPersonContext } from '../context';
-import UploadContext from '../context/upload';
 
-function InPersonLocationFullAddressEntryPostOfficeSearchStep({ onChange, toPreviousStep }) {
-  const { inPersonURL } = useContext(InPersonContext);
+function InPersonLocationFullAddressEntryPostOfficeSearchStep({ toPreviousStep }) {
   const { t } = useI18n();
-  const [inProgress, setInProgress] = useState<boolean>(false);
-  const [isLoadingLocations] = useState<boolean>(false);
-  const [autoSubmit, setAutoSubmit] = useState<boolean>(false);
-  const { trackEvent } = useContext(AnalyticsContext);
-  const [locationResults] = useState<FormattedLocation[] | null | undefined>(null);
-  const [foundAddress] = useState<LocationQuery | null>(null);
-  const [apiError] = useState<Error | null>(null);
-  const [, setDisabledAddressSearch] = useState<boolean>(false);
-  const { flowPath } = useContext(UploadContext);
 
   // ref allows us to avoid a memory leak
   const mountedRef = useRef(false);
@@ -32,77 +16,10 @@ function InPersonLocationFullAddressEntryPostOfficeSearchStep({ onChange, toPrev
     };
   }, []);
 
-  // useCallBack here prevents unnecessary rerenders due to changing function identity
-  const handleLocationSelect = useCallback(
-    async (e: any, id: number) => {
-      if (flowPath !== 'hybrid') {
-        e.preventDefault();
-      }
-      const selectedLocation = locationResults![id]!;
-      const { streetAddress, formattedCityStateZip } = selectedLocation;
-      const selectedLocationAddress = `${streetAddress}, ${formattedCityStateZip}`;
-      onChange({ selectedLocationAddress });
-      if (autoSubmit) {
-        setDisabledAddressSearch(true);
-        setTimeout(() => {
-          if (mountedRef.current) {
-            setDisabledAddressSearch(false);
-          }
-        }, 250);
-        return;
-      }
-      if (inProgress) {
-        return;
-      }
-      const selected = transformKeys(selectedLocation, snakeCase);
-      setInProgress(true);
-      try {
-        await request(LOCATIONS_URL, {
-          json: selected,
-          method: 'PUT',
-        });
-        // In try block set success of request. If the request is successful, fire remaining code?
-        if (mountedRef.current) {
-          setAutoSubmit(true);
-          setImmediate(() => {
-            e.target.disabled = false;
-            if (flowPath !== 'hybrid') {
-              trackEvent('IdV: location submitted', {
-                selected_location: selectedLocationAddress,
-              });
-              forceRedirect(inPersonURL!);
-            }
-            // allow process to be re-triggered in case submission did not work as expected
-            setAutoSubmit(false);
-          });
-        }
-      } catch {
-        setAutoSubmit(false);
-      } finally {
-        if (mountedRef.current) {
-          setInProgress(false);
-        }
-      }
-    },
-    [locationResults, inProgress],
-  );
-
   return (
     <>
-      {apiError && (
-        <Alert type="error" className="margin-bottom-4">
-          {t('idv.failure.exceptions.post_office_search_error')}
-        </Alert>
-      )}
       <PageHeading>{t('in_person_proofing.headings.po_search.location')}</PageHeading>
       <p>{t('in_person_proofing.body.location.po_search.po_search_about')}</p>
-      {locationResults && foundAddress && !isLoadingLocations && (
-        <InPersonLocations
-          locations={locationResults}
-          onSelect={handleLocationSelect}
-          address={foundAddress?.address || ''}
-        />
-      )}
       <BackButton role="link" includeBorder onClick={toPreviousStep} />
     </>
   );

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
@@ -1,20 +1,9 @@
-import { useEffect, useRef } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
 import { PageHeading } from '@18f/identity-components';
 import BackButton from './back-button';
 
 function InPersonLocationFullAddressEntryPostOfficeSearchStep({ toPreviousStep }) {
   const { t } = useI18n();
-
-  // ref allows us to avoid a memory leak
-  const mountedRef = useRef(false);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
 
   return (
     <>

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
@@ -1,0 +1,111 @@
+import { useState, useEffect, useCallback, useRef, useContext } from 'react';
+import { useI18n } from '@18f/identity-react-i18n';
+import { Alert, PageHeading } from '@18f/identity-components';
+import { request } from '@18f/identity-request';
+import { forceRedirect } from '@18f/identity-url';
+import BackButton from './back-button';
+import AnalyticsContext from '../context/analytics';
+import InPersonLocations, { FormattedLocation } from './in-person-locations';
+import { InPersonContext } from '../context';
+import UploadContext from '../context/upload';
+
+function InPersonLocationFullAddressEntryPostOfficeSearchStep({ onChange, toPreviousStep }) {
+  const { inPersonURL } = useContext(InPersonContext);
+  const { t } = useI18n();
+  const [inProgress, setInProgress] = useState<boolean>(false);
+  const [isLoadingLocations] = useState<boolean>(false);
+  const [autoSubmit, setAutoSubmit] = useState<boolean>(false);
+  const { trackEvent } = useContext(AnalyticsContext);
+  const [locationResults] = useState<FormattedLocation[] | null | undefined>(null);
+  const [foundAddress] = useState<LocationQuery | null>(null);
+  const [apiError] = useState<Error | null>(null);
+  const [, setDisabledAddressSearch] = useState<boolean>(false);
+  const { flowPath } = useContext(UploadContext);
+
+  // ref allows us to avoid a memory leak
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // useCallBack here prevents unnecessary rerenders due to changing function identity
+  const handleLocationSelect = useCallback(
+    async (e: any, id: number) => {
+      if (flowPath !== 'hybrid') {
+        e.preventDefault();
+      }
+      const selectedLocation = locationResults![id]!;
+      const { streetAddress, formattedCityStateZip } = selectedLocation;
+      const selectedLocationAddress = `${streetAddress}, ${formattedCityStateZip}`;
+      onChange({ selectedLocationAddress });
+      if (autoSubmit) {
+        setDisabledAddressSearch(true);
+        setTimeout(() => {
+          if (mountedRef.current) {
+            setDisabledAddressSearch(false);
+          }
+        }, 250);
+        return;
+      }
+      if (inProgress) {
+        return;
+      }
+      const selected = transformKeys(selectedLocation, snakeCase);
+      setInProgress(true);
+      try {
+        await request(LOCATIONS_URL, {
+          json: selected,
+          method: 'PUT',
+        });
+        // In try block set success of request. If the request is successful, fire remaining code?
+        if (mountedRef.current) {
+          setAutoSubmit(true);
+          setImmediate(() => {
+            e.target.disabled = false;
+            if (flowPath !== 'hybrid') {
+              trackEvent('IdV: location submitted', {
+                selected_location: selectedLocationAddress,
+              });
+              forceRedirect(inPersonURL!);
+            }
+            // allow process to be re-triggered in case submission did not work as expected
+            setAutoSubmit(false);
+          });
+        }
+      } catch {
+        setAutoSubmit(false);
+      } finally {
+        if (mountedRef.current) {
+          setInProgress(false);
+        }
+      }
+    },
+    [locationResults, inProgress],
+  );
+
+  return (
+    <>
+      {apiError && (
+        <Alert type="error" className="margin-bottom-4">
+          {t('idv.failure.exceptions.post_office_search_error')}
+        </Alert>
+      )}
+      <PageHeading>{t('in_person_proofing.headings.po_search.location')}</PageHeading>
+      <p>{t('in_person_proofing.body.location.po_search.po_search_about')}</p>
+      {locationResults && foundAddress && !isLoadingLocations && (
+        <InPersonLocations
+          locations={locationResults}
+          onSelect={handleLocationSelect}
+          address={foundAddress?.address || ''}
+        />
+      )}
+      <BackButton role="link" includeBorder onClick={toPreviousStep} />
+    </>
+  );
+}
+
+export default InPersonLocationFullAddressEntryPostOfficeSearchStep;

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
@@ -56,7 +56,7 @@ const DEFAULT_PROPS = {
   registerField() {},
 };
 
-describe('InPersonPostOfficeSearchStep', () => {
+describe('InPersonLocationPostOfficeSearchStep', () => {
   const wrapper: ComponentType = ({ children }) => (
     <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
   );

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -80,6 +80,7 @@ const {
   cancelUrl: cancelURL,
   idvInPersonUrl: inPersonURL,
   securityAndPrivacyHowItWorksUrl: securityAndPrivacyHowItWorksURL,
+  inPersonFullAddressEntryEnabled,
   inPersonOutageMessageEnabled,
   inPersonOutageExpectedUpdateDate,
 } = appRoot.dataset as DOMStringMap & AppRootData;
@@ -138,7 +139,13 @@ const App = composeComponents(
       maxSubmissionAttemptsBeforeNativeCamera: Number(maxSubmissionAttemptsBeforeNativeCamera),
     },
   ],
-  [DocumentCapture, { onStepChange: extendSession }],
+  [
+    DocumentCapture,
+    {
+      onStepChange: extendSession,
+      inPersonFullAddressEntryEnabled: inPersonFullAddressEntryEnabled === 'true',
+    },
+  ],
 );
 
 render(<App />, appRoot);

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -30,6 +30,7 @@
       failure_to_proof_url: failure_to_proof_url,
       idv_in_person_url: (IdentityConfig.store.in_person_doc_auth_button_enabled && Idv::InPersonConfig.enabled_for_issuer?(decorated_session.sp_issuer)) ? idv_in_person_url : nil,
       security_and_privacy_how_it_works_url: MarketingSite.security_and_privacy_how_it_works_url,
+      in_person_full_address_entry_enabled: IdentityConfig.store.in_person_full_address_entry_enabled,
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
     } %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -153,8 +153,8 @@ in_person_enrollments_ready_job_wait_time_seconds: 20
 in_person_results_delay_in_hours: 1
 in_person_ssn_info_controller_enabled: false
 in_person_completion_survey_url: 'https://login.gov'
-in_person_outage_message_enabled: false
 in_person_full_address_entry_enabled: false
+in_person_outage_message_enabled: false
 # in_person_outage_expected_update_date and in_person_outage_emailed_by_date below
 # are strings in the format 'Month day, year'
 in_person_outage_expected_update_date: 'October 31, 2024'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -154,6 +154,7 @@ in_person_results_delay_in_hours: 1
 in_person_ssn_info_controller_enabled: false
 in_person_completion_survey_url: 'https://login.gov'
 in_person_outage_message_enabled: false
+in_person_full_address_entry_enabled: false
 # in_person_outage_expected_update_date and in_person_outage_emailed_by_date below
 # are strings in the format 'Month day, year'
 in_person_outage_expected_update_date: 'October 31, 2024'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -243,6 +243,7 @@ class IdentityConfig
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:in_person_ssn_info_controller_enabled, type: :boolean)
     config.add(:in_person_completion_survey_url, type: :string)
+    config.add(:in_person_full_address_entry_enabled, type: :boolean)
     config.add(:in_person_outage_message_enabled, type: :boolean)
     config.add(:in_person_outage_expected_update_date, type: :string)
     config.add(:in_person_outage_emailed_by_date, type: :string)


### PR DESCRIPTION
## 🎫 Ticket

[LG-10405](https://cm-jira.usa.gov/browse/LG-10405)

Note: this is one of multiple PRs for this ticket. There will be additional ones after this PR is merged.

## 🛠 Summary of changes

* Adds a new feature flag called `in_person_full_address_entry_enabled` which defaults to `false`
* Pulls the `in_person_full_address_entry_enabled` feature flag into the Document Capture React application
* If the `in_person_full_address_entry_enabled` feature flag is enabled then replaces the current verify/document_capture#location page (eg PO search page) with a new placeholder page
  * This page has a step indicator, heading, etc. but does not yet have PO search functionality. A future PR will add that functionality

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Checkout this branch and run the web server
- [x] Proceed through the in-person flow until you get to the PO search page. Confirm that you see an address search field and can search for an address
- [x] Change the value of the `in_person_full_address_entry_enabled` feature flag to true. Restart the web server
- [x] Proceed through the in-person flow until you reach the PO search page. Confirm that the page renders but does not have an address search field. **This is the new placeholder page that future PRs will build on.**

## 👀 Screenshots


<details>
<summary>Feature flag off:</summary>

![localhost_3000_verify_document_capture](https://github.com/18F/identity-idp/assets/9039672/3573f996-a4eb-443c-8fbd-46af2aff76b4)

</details>

<details>
<summary>Feature flag on:</summary>

![localhost_3000_verify_document_capture (2)](https://github.com/18F/identity-idp/assets/9039672/1d85d266-cd4b-4453-8cf8-ec8c7fe277a2)

</details>
