### PR TITLE
Clear `fraud_pending_reason` when activating fraud pending profiles when TMx is disabled

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -25,11 +25,9 @@ class GpoVerifyForm
         pending_profile&.deactivate(:in_person_verification_pending)
       elsif fraud_review_checker.fraud_check_failed? && threatmetrix_enabled?
         bump_fraud_review_pending_timestamps
+      elsif fraud_review_checker.fraud_check_failed?
+        pending_profile&.activate_after_fraud_review_unnecessary
       else
-        pending_profile&.update!(
-          fraud_review_pending_at: nil,
-          fraud_rejection_at: nil,
-        )
         activate_profile
       end
     else

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -98,6 +98,17 @@ class Profile < ApplicationRecord
     track_fraud_review_adjudication(decision: 'pass') if active?
   end
 
+  def activate_after_fraud_review_unnecessary
+    transaction do
+      update!(
+        fraud_review_pending_at: nil,
+        fraud_rejection_at: nil,
+        fraud_pending_reason: nil,
+      )
+      activate
+    end
+  end
+
   def activate_after_passing_in_person
     transaction do
       update!(

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe GpoVerifyForm do
   let(:pending_profile) do
     create(
       :profile,
+      :verify_by_mail_pending,
       user: user,
-      gpo_verification_pending_at: 1.day.ago,
       proofing_components: proofing_components,
     )
   end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -151,12 +151,7 @@ RSpec.describe GpoVerifyForm do
 
       context 'ThreatMetrix rejection' do
         let(:pending_profile) do
-          create(
-            :profile,
-            user: user,
-            gpo_verification_pending_at: 1.day.ago,
-            fraud_review_pending_at: 1.day.ago,
-          )
+          create(:profile, :verify_by_mail_pending, :fraud_review_pending, user: user)
         end
 
         let(:threatmetrix_review_status) { 'reject' }

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1034,7 +1034,7 @@ RSpec.describe Profile do
 
     context 'it notifies the user' do
       let(:profile) do
-        profile = user.profiles.create(fraud_review_pending_at: 1.day.ago)
+        profile = create(:profile, :fraud_review_pending, user: user)
         profile.reject_for_fraud(notify_user: true)
         profile
       end
@@ -1054,7 +1054,7 @@ RSpec.describe Profile do
 
     context 'it does not notify the user' do
       let(:profile) do
-        profile = user.profiles.create(fraud_review_pending_at: 1.day.ago)
+        profile = create(:profile, :fraud_review_pending, user: user)
         profile.reject_for_fraud(notify_user: false)
         profile
       end
@@ -1069,11 +1069,7 @@ RSpec.describe Profile do
     context 'when the SP is the IRS' do
       let(:sp) { create(:service_provider, :irs) }
       let(:profile) do
-        user.profiles.create(
-          active: false,
-          fraud_review_pending_at: 1.day.ago,
-          initiating_service_provider: sp,
-        )
+        create(:profile, :fraud_review_pending, active: false, initiating_service_provider: sp)
       end
 
       context 'and notify_user is true' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -892,7 +892,7 @@ RSpec.describe Profile do
   end
 
   describe '#activate_after_fraud_review_unnecessary' do
-    it 'activates a profile if raud review is unnecessary' do
+    it 'activates a profile if fraud review is unnecessary' do
       profile = create(:profile, :fraud_review_pending, user: user)
 
       expect(profile.activated_at).to be_nil # to change
@@ -902,6 +902,10 @@ RSpec.describe Profile do
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
+
+      expect(profile).to_not be_active
+      expect(profile.fraud_review_pending_at).to_not be_nil
+      expect(profile.fraud_pending_reason).to_not be_nil
 
       profile.activate_after_fraud_review_unnecessary
 


### PR DESCRIPTION
When ThreatMetrix decisioning is not enabled we do not put users through the fraud review process after they enter their GPO code. This requires clearing out the fraud review columns on their profile.

Previously, this was done by explicitly overwriting the fraud review columns on their profile. We are trying to move away from this pattern and moved these methods into the profile.

We recently added `fraud_pending_reason` and since the profile was explicitly overwritten by the GPO verify form we missed that we needed to update it in this case.

This commit adds a method to the profile for activating the profile when fraud review is not necessary. That method is used in the GPO verify form instead of explicitly modifying the profile.

