### PR TITLE
Refactor Acuant document detection to use more enum features

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.tsx
@@ -93,6 +93,9 @@ interface AcuantCameraUIOptions {
   text: AcuantCameraUIText;
 }
 
+/**
+ * We call String.toLowerCase() on these when sending analytics events to the server
+ */
 export enum AcuantDocumentType {
   NONE = 0,
   ID = 1,

--- a/app/javascript/packages/document-capture/components/acuant-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.tsx
@@ -94,9 +94,9 @@ interface AcuantCameraUIOptions {
 }
 
 export enum AcuantDocumentType {
-  NONE = 0,
-  ID = 1,
-  PASSPORT = 2,
+  none = 0,
+  id = 1,
+  passport = 2,
 }
 
 export type AcuantCaptureFailureError =

--- a/app/javascript/packages/document-capture/components/acuant-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.tsx
@@ -94,9 +94,9 @@ interface AcuantCameraUIOptions {
 }
 
 export enum AcuantDocumentType {
-  none = 0,
-  id = 1,
-  passport = 2,
+  NONE = 0,
+  ID = 1,
+  PASSPORT = 2,
 }
 
 export type AcuantCaptureFailureError =

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -16,20 +16,16 @@ import type { ReactNode, MouseEvent, Ref } from 'react';
 import AnalyticsContext from '../context/analytics';
 import AcuantContext from '../context/acuant';
 import FailedCaptureAttemptsContext from '../context/failed-capture-attempts';
-import AcuantCamera from './acuant-camera';
+import AcuantCamera, { AcuantDocumentType } from './acuant-camera';
 import AcuantCaptureCanvas from './acuant-capture-canvas';
 import FileInput from './file-input';
 import DeviceContext from '../context/device';
 import UploadContext from '../context/upload';
 import useCounter from '../hooks/use-counter';
 import useCookie from '../hooks/use-cookie';
-import type {
-  AcuantSuccessResponse,
-  AcuantDocumentType,
-  AcuantCaptureFailureError,
-} from './acuant-camera';
+import type { AcuantSuccessResponse, AcuantCaptureFailureError } from './acuant-camera';
 
-type AcuantDocumentTypeLabel = 'id' | 'passport' | 'none';
+type AcuantDocumentTypeLabel = keyof typeof AcuantDocumentType;
 type AcuantImageAssessment = 'success' | 'glare' | 'blurry' | 'unsupported';
 type ImageSource = 'acuant' | 'upload';
 
@@ -136,16 +132,11 @@ export const isAcuantCameraAccessFailure = (error: AcuantCaptureFailureError): e
  *
  */
 function getDocumentTypeLabel(documentType: AcuantDocumentType): AcuantDocumentTypeLabel | string {
-  switch (documentType) {
-    case 0:
-      return 'none';
-    case 1:
-      return 'id';
-    case 2:
-      return 'passport';
-    default:
-      return `An error in document type returned: ${documentType}`;
+  const label = AcuantDocumentType[documentType];
+  if (label === undefined) {
+    return `An error in document type returned: ${documentType}`;
   }
+  return label;
 }
 
 export function getNormalizedAcuantCaptureFailureMessage(
@@ -438,7 +429,7 @@ function AcuantCapture(
     const { image, cardtype, dpi, moire, glare, sharpness } = nextCapture;
     const isAssessedAsGlare = glare < glareThreshold;
     const isAssessedAsBlurry = sharpness < sharpnessThreshold;
-    const isAssessedAsUnsupported = cardtype !== 1;
+    const isAssessedAsUnsupported = cardtype !== AcuantDocumentType.id;
     const { width, height, data } = image;
 
     let assessment: AcuantImageAssessment;

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -131,13 +131,8 @@ export const isAcuantCameraAccessFailure = (error: AcuantCaptureFailureError): e
  * Returns a human-readable document label corresponding to the given document type constant.
  *
  */
-function getDocumentTypeLabel(documentType: AcuantDocumentType): AcuantDocumentTypeLabel | string {
-  const label = AcuantDocumentType[documentType];
-  if (label === undefined) {
-    return `An error in document type returned: ${documentType}`;
-  }
-  return label;
-}
+const getDocumentTypeLabel = (documentType: AcuantDocumentType): AcuantDocumentTypeLabel | string =>
+  AcuantDocumentType[documentType] ?? `An error in document type returned: ${documentType}`;
 
 export function getNormalizedAcuantCaptureFailureMessage(
   error: AcuantCaptureFailureError,

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -132,7 +132,8 @@ export const isAcuantCameraAccessFailure = (error: AcuantCaptureFailureError): e
  *
  */
 const getDocumentTypeLabel = (documentType: AcuantDocumentType): AcuantDocumentTypeLabel | string =>
-  AcuantDocumentType[documentType]?.toLowerCase() ?? `An error in document type returned: ${documentType}`;
+  AcuantDocumentType[documentType]?.toLowerCase() ??
+  `An error in document type returned: ${documentType}`;
 
 export function getNormalizedAcuantCaptureFailureMessage(
   error: AcuantCaptureFailureError,

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -127,8 +127,8 @@ export const isAcuantCameraAccessFailure = (error: AcuantCaptureFailureError): e
   error instanceof Error;
 
 /**
- * Returns a human-readable document label corresponding to the given document type constant.
- *
+ * Returns a human-readable document label corresponding to the given document type constant,
+ * such as "id" "passport" or "none"
  */
 const getDocumentTypeLabel = (documentType: AcuantDocumentType): string =>
   AcuantDocumentType[documentType]?.toLowerCase() ??

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -25,7 +25,6 @@ import useCounter from '../hooks/use-counter';
 import useCookie from '../hooks/use-cookie';
 import type { AcuantSuccessResponse, AcuantCaptureFailureError } from './acuant-camera';
 
-type AcuantDocumentTypeLabel = keyof typeof AcuantDocumentType;
 type AcuantImageAssessment = 'success' | 'glare' | 'blurry' | 'unsupported';
 type ImageSource = 'acuant' | 'upload';
 
@@ -57,7 +56,7 @@ interface ImageAnalyticsPayload {
 }
 
 interface AcuantImageAnalyticsPayload extends ImageAnalyticsPayload {
-  documentType: AcuantDocumentTypeLabel | string;
+  documentType: string;
   dpi: number;
   moire: number;
   glare: number;
@@ -131,7 +130,7 @@ export const isAcuantCameraAccessFailure = (error: AcuantCaptureFailureError): e
  * Returns a human-readable document label corresponding to the given document type constant.
  *
  */
-const getDocumentTypeLabel = (documentType: AcuantDocumentType): AcuantDocumentTypeLabel | string =>
+const getDocumentTypeLabel = (documentType: AcuantDocumentType): string =>
   AcuantDocumentType[documentType]?.toLowerCase() ??
   `An error in document type returned: ${documentType}`;
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -132,7 +132,7 @@ export const isAcuantCameraAccessFailure = (error: AcuantCaptureFailureError): e
  *
  */
 const getDocumentTypeLabel = (documentType: AcuantDocumentType): AcuantDocumentTypeLabel | string =>
-  AcuantDocumentType[documentType] ?? `An error in document type returned: ${documentType}`;
+  AcuantDocumentType[documentType]?.toLowerCase() ?? `An error in document type returned: ${documentType}`;
 
 export function getNormalizedAcuantCaptureFailureMessage(
   error: AcuantCaptureFailureError,
@@ -424,7 +424,7 @@ function AcuantCapture(
     const { image, cardtype, dpi, moire, glare, sharpness } = nextCapture;
     const isAssessedAsGlare = glare < glareThreshold;
     const isAssessedAsBlurry = sharpness < sharpnessThreshold;
-    const isAssessedAsUnsupported = cardtype !== AcuantDocumentType.id;
+    const isAssessedAsUnsupported = cardtype !== AcuantDocumentType.ID;
     const { width, height, data } = image;
 
     let assessment: AcuantImageAssessment;
@@ -579,3 +579,4 @@ function AcuantCapture(
 }
 
 export default forwardRef(AcuantCapture);
+export { AcuantDocumentType };

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -7,7 +7,11 @@ import AcuantCapture, {
   getNormalizedAcuantCaptureFailureMessage,
   getDecodedBase64ByteSize,
 } from '@18f/identity-document-capture/components/acuant-capture';
-import { AcuantContextProvider, AnalyticsContext } from '@18f/identity-document-capture';
+import {
+  AcuantContextProvider,
+  AnalyticsContext,
+  AcuantDocumentType,
+} from '@18f/identity-document-capture';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import { I18nContext } from '@18f/identity-react-i18n';
 import { I18n } from '@18f/identity-i18n';
@@ -20,7 +24,7 @@ const ACUANT_CAPTURE_SUCCESS_RESULT = {
     width: 1748,
     height: 1104,
   },
-  cardtype: 1,
+  cardtype: AcuantDocumentType.id,
   dpi: 519,
   moire: 99,
   moireraw: 99,
@@ -566,7 +570,7 @@ describe('document-capture/components/acuant-capture', () => {
           await Promise.resolve();
           callbacks.onCropped({
             ...ACUANT_CAPTURE_SUCCESS_RESULT,
-            cardtype: 2,
+            cardtype: AcuantDocumentType.passport,
           });
         }),
       });

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -6,12 +6,9 @@ import AcuantCapture, {
   isAcuantCameraAccessFailure,
   getNormalizedAcuantCaptureFailureMessage,
   getDecodedBase64ByteSize,
-} from '@18f/identity-document-capture/components/acuant-capture';
-import {
-  AcuantContextProvider,
-  AnalyticsContext,
   AcuantDocumentType,
-} from '@18f/identity-document-capture';
+} from '@18f/identity-document-capture/components/acuant-capture';
+import { AcuantContextProvider, AnalyticsContext } from '@18f/identity-document-capture';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import { I18nContext } from '@18f/identity-react-i18n';
 import { I18n } from '@18f/identity-i18n';
@@ -24,7 +21,7 @@ const ACUANT_CAPTURE_SUCCESS_RESULT = {
     width: 1748,
     height: 1104,
   },
-  cardtype: AcuantDocumentType.id,
+  cardtype: AcuantDocumentType.ID,
   dpi: 519,
   moire: 99,
   moireraw: 99,
@@ -570,7 +567,7 @@ describe('document-capture/components/acuant-capture', () => {
           await Promise.resolve();
           callbacks.onCropped({
             ...ACUANT_CAPTURE_SUCCESS_RESULT,
-            cardtype: AcuantDocumentType.passport,
+            cardtype: AcuantDocumentType.PASSPORT,
           });
         }),
       });

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -16,9 +16,9 @@ import DocumentCapture from '@18f/identity-document-capture/components/document-
 import { FlowContext } from '@18f/identity-verify-flow';
 import { expect } from 'chai';
 import { useSandbox } from '@18f/identity-test-helpers';
+import { AcuantDocumentType } from '@18f/identity-document-capture/components/acuant-camera';
 import { render, useAcuant, useDocumentCaptureForm } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
-import { AcuantDocumentType } from '@18f/identity-document-capture/components/acuant-camera';
 
 describe('document-capture/components/document-capture', () => {
   const onSubmit = useDocumentCaptureForm();

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import { useSandbox } from '@18f/identity-test-helpers';
 import { render, useAcuant, useDocumentCaptureForm } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
+import { AcuantDocumentType } from '@18f/identity-document-capture/components/acuant-camera';
 
 describe('document-capture/components/document-capture', () => {
   const onSubmit = useDocumentCaptureForm();
@@ -91,7 +92,7 @@ describe('document-capture/components/document-capture', () => {
         image: {
           data: validUpload,
         },
-        cardtype: 1,
+        cardtype: AcuantDocumentType.id,
       });
     });
 

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -92,7 +92,7 @@ describe('document-capture/components/document-capture', () => {
         image: {
           data: validUpload,
         },
-        cardtype: AcuantDocumentType.id,
+        cardtype: AcuantDocumentType.ID,
       });
     });
 

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
@@ -67,7 +67,7 @@ describe('document-capture/components/documents-step', () => {
     );
 
     initialize();
-    const result = { sharpness: 100, image: { data: '' }, cardtype: AcuantDocumentType.id };
+    const result = { sharpness: 100, image: { data: '' }, cardtype: AcuantDocumentType.ID };
 
     window.AcuantCameraUI.start.callsFake(({ onCropped }) => onCropped({ ...result, glare: 10 }));
     await userEvent.click(getByLabelText('doc_auth.headings.document_capture_front'));

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
@@ -9,6 +9,7 @@ import {
   UploadContextProvider,
 } from '@18f/identity-document-capture';
 import DocumentsStep from '@18f/identity-document-capture/components/documents-step';
+import { AcuantDocumentType } from '@18f/identity-document-capture/components/acuant-camera';
 import { render, useAcuant } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
 
@@ -66,7 +67,7 @@ describe('document-capture/components/documents-step', () => {
     );
 
     initialize();
-    const result = { sharpness: 100, image: { data: '' }, cardtype: 1 };
+    const result = { sharpness: 100, image: { data: '' }, cardtype: AcuantDocumentType.id };
 
     window.AcuantCameraUI.start.callsFake(({ onCropped }) => onCropped({ ...result, glare: 10 }));
     await userEvent.click(getByLabelText('doc_auth.headings.document_capture_front'));


### PR DESCRIPTION
Following up with a few more nice things we can do to simplify and extend enum conversion, based on comment: https://github.com/18F/identity-idp/pull/8789#discussion_r1268247849