### PR TITLE
Only let users who are fraud review pending visit the please call controller

### DIFF
--- a/app/controllers/idv/please_call_controller.rb
+++ b/app/controllers/idv/please_call_controller.rb
@@ -1,14 +1,25 @@
 module Idv
   class PleaseCallController < ApplicationController
+    include FraudReviewConcern
+
     before_action :confirm_two_factor_authenticated
+    before_action :handle_fraud_rejection
+    before_action :confirm_fraud_pending
 
     FRAUD_REVIEW_CONTACT_WITHIN_DAYS = 14.days
 
     def show
       analytics.idv_please_call_visited
-      pending_at = current_user.fraud_review_pending_profile.fraud_review_pending_at ||
-                   Time.zone.today
+      pending_at = current_user.fraud_review_pending_profile.fraud_review_pending_at
       @call_by_date = pending_at + FRAUD_REVIEW_CONTACT_WITHIN_DAYS
+    end
+
+    private
+
+    def confirm_fraud_pending
+      if !fraud_review_pending?
+        redirect_to account_url
+      end
     end
   end
 end

--- a/spec/controllers/idv/please_call_controller_spec.rb
+++ b/spec/controllers/idv/please_call_controller_spec.rb
@@ -2,15 +2,30 @@ require 'rails_helper'
 
 RSpec.describe Idv::PleaseCallController do
   let(:user) { create(:user) }
-  let(:fraud_review_pending_date) { 5.days.ago }
-  let(:verify_date) { 20.days.ago }
+  let(:fraud_review_pending_date) { profile.fraud_review_pending_at }
+  let(:verify_date) { profile.verified_at }
+  let!(:profile) { create(:profile, :verified, :fraud_review_pending, user: user) }
 
   before do
-    user.profiles.create(
-      fraud_review_pending_at: fraud_review_pending_date,
-      verified_at: verify_date,
-    )
     stub_sign_in(user)
+  end
+
+  render_views
+
+  it 'redirects a user who is not fraud review pending' do
+    profile.activate_after_fraud_review_unnecessary
+
+    get :show
+
+    expect(response).to redirect_to(account_url)
+  end
+
+  it 'redirects a user who has been fraud rejected' do
+    profile.reject_for_fraud(notify_user: false)
+
+    get :show
+
+    expect(response).to redirect_to(idv_not_verified_url)
   end
 
   it 'renders the show template' do
@@ -25,8 +40,6 @@ RSpec.describe Idv::PleaseCallController do
 
     expect(response).to render_template :show
   end
-
-  render_views
 
   it 'asks user to call 2 weeks from fraud_review_pending_date' do
     get :show


### PR DESCRIPTION
The please call controller is used to instruct users who are pending fraud review to contact Login.gov to finish verification.

This controller should only be accessible to users who are fraud review. This commit adds a before action to redirect users in the following scenarios:

1. The user is not fraud review pending
2. The user has been fraud rejected (these users get a different message rendered by a different controller)

This commit also fixes a latent 500 error on this controller. A user who signs in but is not fraud pending would encounter a `NoMethodError` at this line:

```ruby
pending_at = current_user.fraud_review_pending_profile.fraud_review_pending_at
```

[skip changelog]
