### PR TITLE
LG-9968 Read from `fraud_pending_reason` to find fraud pending profiles

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -31,7 +31,7 @@ class Profile < ApplicationRecord
   attr_reader :personal_key
 
   def fraud_review_pending?
-    fraud_review_pending_at.present?
+    fraud_pending_reason.present? && !fraud_rejection?
   end
 
   def fraud_rejection?
@@ -112,8 +112,10 @@ class Profile < ApplicationRecord
   def activate_after_passing_in_person
     transaction do
       update!(
-        deactivation_reason: nil,
         fraud_review_pending_at: nil,
+        fraud_rejection_at: nil,
+        fraud_pending_reason: nil,
+        deactivation_reason: nil,
       )
       activate
     end
@@ -132,10 +134,6 @@ class Profile < ApplicationRecord
 
   def deactivate(reason)
     update!(active: false, deactivation_reason: reason)
-  end
-
-  def has_deactivation_reason?
-    deactivation_reason.present? || has_fraud_deactivation_reason? || gpo_verification_pending?
   end
 
   def has_fraud_deactivation_reason?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,9 +140,7 @@ class User < ApplicationRecord
       pending = profiles.where(deactivation_reason: :in_person_verification_pending).or(
         profiles.where.not(gpo_verification_pending_at: nil),
       ).or(
-        profiles.where.not(fraud_review_pending_at: nil),
-      ).or(
-        profiles.where.not(fraud_rejection_at: nil),
+        profiles.where.not(fraud_pending_reason: nil),
       ).order(created_at: :desc).first
 
       if pending.blank?

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -203,8 +203,9 @@ RSpec.describe Idv::GpoVerifyController do
             create(
               :profile,
               :with_pii,
+              :fraud_review_pending,
+              fraud_pending_reason: 'threatmetrix_reject',
               user: user,
-              fraud_review_pending_at: 1.day.ago,
             )
           end
 
@@ -239,8 +240,9 @@ RSpec.describe Idv::GpoVerifyController do
             create(
               :profile,
               :with_pii,
+              :fraud_review_pending,
+              fraud_pending_reason: 'threatmetrix_reject',
               user: user,
-              fraud_review_pending_at: 1.day.ago,
             )
           end
 
@@ -276,8 +278,9 @@ RSpec.describe Idv::GpoVerifyController do
             create(
               :profile,
               :with_pii,
+              :fraud_review_pending,
+              fraud_pending_reason: 'threatmetrix_review',
               user: user,
-              fraud_review_pending_at: 1.day.ago,
             )
           end
 

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'idv gpo otp verification step' do
         dob: '1970-01-01',
       },
       fraud_review_pending_at: fraud_review_pending_timestamp,
+      fraud_pending_reason: fraud_pending_reason,
       fraud_rejection_at: fraud_rejection_timestamp,
     )
   end
@@ -32,6 +33,7 @@ RSpec.feature 'idv gpo otp verification step' do
   let(:user) { profile.user }
   let(:threatmetrix_enabled) { false }
   let(:fraud_review_pending_timestamp) { nil }
+  let(:fraud_pending_reason) { nil }
   let(:fraud_rejection_timestamp) { nil }
   let(:redirect_after_verification) { nil }
   let(:profile_should_be_active) { true }
@@ -47,6 +49,7 @@ RSpec.feature 'idv gpo otp verification step' do
   context 'ThreatMetrix disabled, but we have ThreatMetrix status on proofing component' do
     let(:threatmetrix_enabled) { false }
     let(:fraud_review_pending_timestamp) { 1.day.ago }
+    let(:fraud_pending_reason) { 'threatmetrix_review' }
     it_behaves_like 'gpo otp verification'
   end
 
@@ -60,6 +63,7 @@ RSpec.feature 'idv gpo otp verification step' do
 
     context 'ThreatMetrix says "review"' do
       let(:fraud_review_pending_timestamp) { 1.day.ago }
+      let(:fraud_pending_reason) { 'threatmetrix_review' }
       let(:profile_should_be_active) { false }
       let(:fraud_review_pending) { true }
       it_behaves_like 'gpo otp verification'
@@ -67,6 +71,7 @@ RSpec.feature 'idv gpo otp verification step' do
 
     context 'ThreatMetrix says "reject"' do
       let(:fraud_rejection_timestamp) { 1.day.ago }
+      let(:fraud_pending_reason) { 'threatmetrix_review' }
       let(:profile_should_be_active) { false }
       let(:fraud_review_pending) { true }
       it_behaves_like 'gpo otp verification'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -577,10 +577,7 @@ RSpec.describe User do
   describe '#fraud_review_pending?' do
     it 'returns true if fraud review is pending' do
       user = create(:user)
-      user.profiles.create(
-        active: false,
-        fraud_review_pending_at: 15.days.ago,
-      )
+      create(:profile, :fraud_review_pending, user: user)
 
       expect(user.fraud_review_pending?).to eq true
     end
@@ -589,10 +586,7 @@ RSpec.describe User do
   describe '#fraud_rejection?' do
     it 'returns true if fraud rejection' do
       user = create(:user)
-      user.profiles.create(
-        active: false,
-        fraud_rejection_at: 15.days.ago,
-      )
+      create(:profile, :fraud_rejection, user: user)
 
       expect(user.fraud_rejection?).to eq true
     end
@@ -602,10 +596,7 @@ RSpec.describe User do
     context 'with a fraud review pending profile' do
       it 'returns the profile pending review' do
         user = create(:user)
-        profile = user.profiles.create(
-          active: false,
-          fraud_review_pending_at: 15.days.ago,
-        )
+        profile = create(:profile, :fraud_review_pending, user: user)
 
         expect(user.fraud_review_pending_profile).to eq(profile)
       end
@@ -621,10 +612,7 @@ RSpec.describe User do
     context 'with a fraud rejection profile' do
       it 'returns the profile with rejection' do
         user = create(:user)
-        profile = user.profiles.create(
-          active: false,
-          fraud_rejection_at: 15.days.ago,
-        )
+        profile = create(:profile, :fraud_rejection, user: user)
 
         expect(user.fraud_rejection_profile).to eq(profile)
       end


### PR DESCRIPTION
This commit makes the first change to switch over to the new `fraud_pending_reason` column. It reads from the column instead of the `fraud_review_pending_at` timestamp to determine if a profile is fraud review pending. This will allow us to stop writing to the `fraud_review_pending_at` timestamp until the user actually enters the fraud review workflow and go back and make the value nil for users who have not entered fraud review.

Eventually we will need to consider the presence of `fraud_pending_reason` and absence of `fraud_review_pending_at` as a new state (i.e. the user has not started fraud review but is eligible to start fraud review once they verify their address). That is out of scope for this PR which is intended to switch the reads to make that new state possible in a future release.
