### PR TITLE
Fix crasher in Telephony::AlertSender

### DIFF
--- a/lib/telephony/alert_sender.rb
+++ b/lib/telephony/alert_sender.rb
@@ -77,7 +77,7 @@ module Telephony
 
     def log_warning(alert, context:)
       Telephony.log_warn(
-        {
+        event: {
           alert: alert,
           adapter: Telephony.config.adapter,
           channel: :sms,

--- a/spec/lib/telephony/alert_sender_spec.rb
+++ b/spec/lib/telephony/alert_sender_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Telephony::AlertSender do
     it 'warns if the link is longer than 160 characters' do
       long_link = 'a' * 161
 
-      expect(Telephony).to receive(:log_warn)
+      expect(Telephony).to receive(:log_warn).and_call_original
 
       subject.send_doc_auth_link(
         to: recipient,


### PR DESCRIPTION
A missing `event:` named arg results in `wrong number of arguments (given 1, expected 0; required keyword: event)` error.

(The spec was stubbing but not calling the original implementation, which is why the tests were green before.)

I found this while investigating [this Slack thread](https://gsa-tts.slack.com/archives/C056RD1NEHW/p1689874340147939)
