### PR TITLE
Render TOTP help text in verification view

### DIFF
--- a/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
@@ -4,13 +4,6 @@ module TwoFactorAuthCode
       t('two_factor_authentication.totp_header_text')
     end
 
-    def help_text
-      t(
-        'instructions.mfa.authenticator.confirm_code_html',
-        app_name_html: content_tag(:strong, APP_NAME),
-      )
-    end
-
     def fallback_question
       t('two_factor_authentication.totp_fallback.question')
     end

--- a/app/presenters/two_factor_auth_code/backup_code_presenter.rb
+++ b/app/presenters/two_factor_auth_code/backup_code_presenter.rb
@@ -2,10 +2,6 @@ module TwoFactorAuthCode
   class BackupCodePresenter < TwoFactorAuthCode::GenericDeliveryPresenter
     include ActionView::Helpers::TranslationHelper
 
-    def help_text
-      ''
-    end
-
     def cancel_link
       if reauthn
         account_path

--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -19,10 +19,6 @@ module TwoFactorAuthCode
       raise NotImplementedError
     end
 
-    def help_text
-      raise NotImplementedError
-    end
-
     def link_text
       t('two_factor_authentication.login_options_link_text')
     end

--- a/app/presenters/two_factor_auth_code/personal_key_presenter.rb
+++ b/app/presenters/two_factor_auth_code/personal_key_presenter.rb
@@ -2,10 +2,6 @@ module TwoFactorAuthCode
   class PersonalKeyPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
     def initialize; end
 
-    def help_text
-      ''
-    end
-
     def fallback_question
       t('two_factor_authentication.personal_key_fallback.question')
     end

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -41,10 +41,6 @@ module TwoFactorAuthCode
       t('two_factor_authentication.phone_fallback.question')
     end
 
-    def help_text
-      ''
-    end
-
     def troubleshooting_header
       t('components.troubleshooting_options.default_heading')
     end

--- a/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
@@ -18,10 +18,6 @@ module TwoFactorAuthCode
       end
     end
 
-    def help_text
-      ''
-    end
-
     def piv_cac_capture_text
       t('forms.piv_cac_mfa.submit')
     end

--- a/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
@@ -37,10 +37,6 @@ module TwoFactorAuthCode
       end
     end
 
-    def help_text
-      ''
-    end
-
     def header
       if platform_authenticator?
         t('two_factor_authentication.webauthn_platform_header_text')

--- a/app/views/shared/_fallback_links.html.erb
+++ b/app/views/shared/_fallback_links.html.erb
@@ -1,7 +1,4 @@
-<div class="margin-top-5">
-  <% if @presenter.help_text.present? %>
-    <p><%= @presenter.help_text %></p>
-  <% end %>
+<div>
   <h2 class="h3 margin-top-4 margin-bottom-1">
     <%= @presenter.fallback_question %>
   </h2>

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -12,7 +12,7 @@
       html: { autocomplete: 'off', method: :post },
     ) do |f| %>
   <%= render 'partials/backup_code/entry_fields', f: f, attribute_name: :backup_code %>
-  <%= f.submit t('forms.buttons.submit.default') %>
+  <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>
 
 <%= render 'shared/fallback_links', presenter: @presenter %>

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -11,7 +11,7 @@
                           html: { autocomplete: 'off', method: :post }
     ) do |f| %>
   <%= render 'partials/personal_key/entry_fields', f: f, attribute_name: :personal_key %>
-  <%= f.submit t('forms.buttons.submit.default') %>
+  <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>
 
 <%= render 'shared/fallback_links', presenter: @presenter %>

--- a/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
+++ b/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
@@ -6,12 +6,14 @@
   <%= @presenter.piv_cac_help %>
 </p>
 
-<%= render SpinnerButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        link_to(@presenter.piv_cac_service_link, **tag_options, &block)
-      end,
-      big: true,
-      wide: true,
-    ).with_content(@presenter.piv_cac_capture_text) %>
+<div class="margin-y-5">
+  <%= render SpinnerButtonComponent.new(
+        action: ->(**tag_options, &block) do
+          link_to(@presenter.piv_cac_service_link, **tag_options, &block)
+        end,
+        big: true,
+        wide: true,
+      ).with_content(@presenter.piv_cac_capture_text) %>
+</div>
 <%= render 'shared/fallback_links', presenter: @presenter %>
 <%= render 'shared/cancel', link: @presenter.cancel_link %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -26,5 +26,12 @@
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-top-5' %>
 <% end %>
 
+<p>
+  <%= t(
+        'instructions.mfa.authenticator.confirm_code_html',
+        app_name_html: content_tag(:strong, APP_NAME),
+      ) %>
+</p>
+
 <%= render 'shared/fallback_links', presenter: @presenter %>
 <%= render 'shared/cancel', link: @presenter.cancel_link %>

--- a/spec/presenters/two_factor_auth_code/backup_code_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/backup_code_presenter_spec.rb
@@ -28,10 +28,4 @@ RSpec.describe TwoFactorAuthCode::BackupCodePresenter do
         '/account'
     end
   end
-
-  describe '#help_text' do
-    it 'returns blank' do
-      expect(presenter.help_text).to eq ''
-    end
-  end
 end

--- a/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TwoFactorAuthCode::GenericDeliveryPresenter do
   it 'is an abstract presenter with methods that should be implemented' do
     presenter = presenter_with
 
-    %w[header help_text fallback_links].each do |m|
+    %w[header fallback_links].each do |m|
       expect { presenter.send(m.to_sym) }.to raise_error(NotImplementedError)
     end
   end

--- a/spec/presenters/two_factor_auth_code/personal_key_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/personal_key_presenter_spec.rb
@@ -13,10 +13,4 @@ RSpec.describe TwoFactorAuthCode::PersonalKeyPresenter do
         t('two_factor_authentication.personal_key_fallback.question')
     end
   end
-
-  describe '#help_text' do
-    it 'returns blank' do
-      expect(presenter.help_text).to eq ''
-    end
-  end
 end

--- a/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
@@ -91,12 +91,6 @@ RSpec.describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
     end
   end
 
-  describe 'help_text' do
-    it 'supplies no help text' do
-      expect(presenter.help_text).to eq('')
-    end
-  end
-
   describe '#link_text' do
     let(:phishing_resistant_required) { true }
 

--- a/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
@@ -137,12 +137,6 @@ RSpec.describe TwoFactorAuthCode::WebauthnAuthenticationPresenter do
     end
   end
 
-  describe '#help_text' do
-    it 'supplies no help text' do
-      expect(presenter.help_text).to eq('')
-    end
-  end
-
   describe '#link_text' do
     let(:phishing_resistant_required) { true }
 

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -54,30 +54,16 @@ RSpec.describe 'two_factor_authentication/otp_verification/show.html.erb' do
       end
     end
 
-    context 'OTP copy' do
-      let(:help_text) do
+    it 'informs the user that an OTP has been sent to their number' do
+      render
+
+      expect(rendered).to include(
         t(
           'instructions.mfa.sms.number_message_html',
           number_html: content_tag(:strong, presenter_data[:phone_number]),
           expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
-        )
-      end
-
-      it 'informs the user that an OTP has been sent to their number via #help_text' do
-        render
-
-        expect(rendered).to include help_text
-      end
-
-      context 'in other locales' do
-        before { I18n.locale = :es }
-
-        it 'translates correctly' do
-          render
-
-          expect(rendered).to include help_text
-        end
-      end
+        ),
+      )
     end
 
     context 'user signed up' do


### PR DESCRIPTION
## 🎫 Ticket

Refactoring related to [LG-10286](https://cm-jira.usa.gov/browse/LG-10286)

## 🛠 Summary of changes

Removes the `help_text` class method from MFA delivery presenters and renders it explicitly in the single place it's used (TOTP). This is part of a larger effort to bring consistency to how troubleshooting options are presented, eventually replacing `fallback_links` with a consistent troubleshooting options component.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create or sign in to an account with TOTP (authentication app) configured
3. When prompted for MFA, observe text "Enter the code from your authenticator app"
   - If not prompted for MFA, click and confirm "Forget all browsers" from account dashboard, sign out, and repeat steps 1-3

## 👀 Screenshots

With the changes in this pull request, there are not expected to be any visual effects. The help text in the screenshot is the "Enter the code [...]" text.

![Screen Shot 2023-07-21 at 9 00 39 AM](https://github.com/18F/identity-idp/assets/1779930/14de2417-8d94-4aa2-830f-d7f017cb891f)

