### PR TITLE
Generalize MFA learn more locale string key

### DIFF
--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -70,7 +70,7 @@ module TwoFactorAuthCode
             flow: :two_factor_authentication,
             step: :otp_confirmation,
           ),
-          text: t('two_factor_authentication.phone_verification.troubleshooting.learn_more'),
+          text: t('two_factor_authentication.learn_more'),
           new_tab: true,
         },
       ]

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -57,7 +57,7 @@
            step: :webauthn_verification,
          ),
          new_tab: true,
-       ).with_content(t('two_factor_authentication.phone_verification.troubleshooting.learn_more')) %>
+       ).with_content(t('two_factor_authentication.learn_more')) %>
   <% end %>
 <% end %>
 <%= render 'shared/cancel', link: @presenter.cancel_link %>

--- a/app/views/users/phone_setup/spam_protection.html.erb
+++ b/app/views/users/phone_setup/spam_protection.html.erb
@@ -56,7 +56,7 @@
          step: :phone_setup_spam_protection,
        ),
        new_tab: true,
-     ).with_content(t('two_factor_authentication.phone_verification.troubleshooting.learn_more')) %>
+     ).with_content(t('two_factor_authentication.learn_more')) %>
 <% end %>
 
 <% unless local_assigns[:two_factor_options_path].present? %>

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -39,6 +39,7 @@ en:
       this account. If it is, there may be a problem with your PIV/CAC, PIN, or
       something went wrong on our end. Try again or choose another
       authentication method.
+    learn_more: Learn more about authentication options
     login_intro: You set these up when you created your account.
     login_options:
       auth_app: Authentication app
@@ -128,7 +129,6 @@ en:
       troubleshooting:
         change_number: Use another phone number
         code_not_received: I didn’t receive my one-time code
-        learn_more: Learn more about authentication options
     piv_cac_fallback:
       question: Don’t have your PIV or CAC available?
     piv_cac_header_text: Present your PIV/CAC

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -40,6 +40,7 @@ es:
       correcto para esta cuenta. Si es así, puede haber un problema con su
       PIV/CAC, PIN o algo salió mal de nuestra parte. Intente nuevamente o elija
       otro método de autenticación.
+    learn_more: Más información sobre las opciones de autenticación.
     login_intro: Usted configuró esto cuando creó su cuenta.
     login_options:
       auth_app: Aplicación de autenticación
@@ -136,7 +137,6 @@ es:
       troubleshooting:
         change_number: Utilice otro número de teléfono.
         code_not_received: No recibí mi código de un solo uso.
-        learn_more: Más información sobre las opciones de autenticación.
     piv_cac_fallback:
       question: '¿No tienes su PIV o CAC disponibles?'
     piv_cac_header_text: Presenta tu PIV/CAC

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -41,6 +41,7 @@ fr:
       PIV/CAC pour ce compte. Si c’est le cas, votre PIV/CAC, votre NIP ou un
       problème survenu de notre côté pourrait bien poser problème. Réessayez ou
       choisissez une autre méthode d’authentification.
+    learn_more: En savoir plus sur les options d’authentification
     login_intro: Vous les avez configurés lorsque vous avez crée votre compte.
     login_options:
       auth_app: Application d’authentification
@@ -142,7 +143,6 @@ fr:
       troubleshooting:
         change_number: Utilisez un autre numéro de téléphone
         code_not_received: Je n’ai pas reçu mon code à usage unique
-        learn_more: En savoir plus sur les options d’authentification
     piv_cac_fallback:
       question: Votre PIV ou CAC n’est pas disponible?
     piv_cac_header_text: Veuillez présenter votre carte PIV/CAC

--- a/spec/views/phone_setup/spam_protection.html.erb_spec.rb
+++ b/spec/views/phone_setup/spam_protection.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'users/phone_setup/spam_protection.html.erb' do
 
   it 'has expected troubleshooting options' do
     expect(rendered).to have_link(
-      t('two_factor_authentication.phone_verification.troubleshooting.learn_more'),
+      t('two_factor_authentication.learn_more'),
       href: help_center_redirect_path(
         category: 'get-started',
         article: 'authentication-options',


### PR DESCRIPTION
## 🎫 Ticket

Refactoring related to [LG-10286](https://cm-jira.usa.gov/browse/LG-10286)

## 🛠 Summary of changes

Removes "phone" as a qualifier for the "Learn more about authentication options" troubleshooting text, as refactoring ahead of planned common usage across all MFA types.

## 📜 Testing Plan

1. SIgn in to an account which has a phone configured
2. Observe no regressions in appearance of the troubleshooting text "Learn more about authentication options"