### PR TITLE
LG-10224: Doc auth error page shows styling tag hypertext to users

### DIFF
--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -124,7 +124,9 @@ function ReviewIssuesStep({
 
             {remainingAttempts <= DISPLAY_ATTEMPTS && (
               <p>
-                <strong>{t('idv.failure.attempts_html', { count: remainingAttempts })}</strong>
+                {formatWithStrongNoWrap(
+                  t('idv.failure.attempts_html', { count: remainingAttempts }),
+                )}
               </p>
             )}
           </Warning>

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -69,7 +69,7 @@ describe('document-capture/components/review-issues-step', () => {
     ).to.exist();
   });
   it('renders initially with warning page and displays attempts remaining with IPP', () => {
-    const {getByRole, getByText, } = render(
+    const { getByRole, getByText } = render(
       <InPersonContext.Provider value={{ inPersonURL: true }}>
         <I18nContext.Provider
           value={

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -68,6 +68,41 @@ describe('document-capture/components/review-issues-step', () => {
       }),
     ).to.exist();
   });
+  it('renders initially with warning page and displays attempts remaining with IPP', () => {
+    const {getByRole, getByText, } = render(
+      <InPersonContext.Provider value={{ inPersonURL: true }}>
+        <I18nContext.Provider
+          value={
+            new I18n({
+              strings: {
+                'idv.failure.attempts_html': {
+                  one: '<strong>One attempt</strong> remaining',
+                  other: '<strong>%{count} attempts</strong> remaining',
+                },
+              },
+            })
+          }
+        >
+          <ReviewIssuesStep {...DEFAULT_PROPS} />
+        </I18nContext.Provider>
+      </InPersonContext.Provider>,
+    );
+
+    expect(getByText('errors.doc_auth.throttled_heading')).to.be.ok();
+    expect(getByText('3 attempts', { selector: 'strong' })).to.be.ok();
+    expect(getByText('remaining')).to.be.ok();
+    expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
+    expect(getByRole('button', { name: 'in_person_proofing.body.cta.button' })).to.be.ok();
+
+    expect(
+      getByRole('link', { name: 'idv.troubleshooting.options.doc_capture_tips links.new_tab' }),
+    ).to.exist();
+    expect(
+      getByRole('link', {
+        name: 'idv.troubleshooting.options.supported_documents links.new_tab',
+      }),
+    ).to.exist();
+  });
 
   it('renders warning page with error and displays one attempt remaining then continues on', async () => {
     const { getByRole, getByLabelText, getByText } = render(

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -44,8 +44,8 @@ describe('document-capture/components/review-issues-step', () => {
           new I18n({
             strings: {
               'idv.failure.attempts_html': {
-                one: 'One attempt remaining',
-                other: '%{count} attempts remaining',
+                one: '<strong>One attempt</strong> remaining',
+                other: '<strong>%{count} attempts</strong> remaining',
               },
             },
           })
@@ -56,7 +56,8 @@ describe('document-capture/components/review-issues-step', () => {
     );
 
     expect(getByText('errors.doc_auth.throttled_heading')).to.be.ok();
-    expect(getByText('3 attempts remaining')).to.be.ok();
+    expect(getByText('3 attempts', { selector: 'strong' })).to.be.ok();
+    expect(getByText('remaining')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
 
     expect(
@@ -70,7 +71,7 @@ describe('document-capture/components/review-issues-step', () => {
   });
   it('renders initially with warning page and displays attempts remaining with IPP', () => {
     const { getByRole, getByText } = render(
-      <InPersonContext.Provider value={{ inPersonURL: true }}>
+      <InPersonContext.Provider value={{ inPersonURL: '/' }}>
         <I18nContext.Provider
           value={
             new I18n({


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket [LG-10224](https://cm-jira.usa.gov/browse/LG-10224):Doc auth error page shows styling tag hypertext to users

## 🛠 Summary of changes

Remove the tag and consistent display when IPP enabled or disabled.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Enable IPP,  fail doc auth multiple times, check remaining attempts text
- [ ] Disable IPP,  fail doc auth multiple times, check remaining attempts text, should match IPP enabled

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before</summary>
![attempts_tag_text](https://github.com/18F/identity-idp/assets/130466753/900e0520-539d-43d4-bc57-0065fb7e8f14)

</details>

<details>
<summary>After: with IPP enabled </summary>
![LG10224-ipp](https://github.com/18F/identity-idp/assets/130466753/7dece53d-7eb1-4ba0-9701-6717502336d4)

</details>

<details>
<summary>After: with IPP disabled</summary>
![LG10224-noipp](https://github.com/18F/identity-idp/assets/130466753/d88a62d1-2853-457c-9ee1-cd600f0c5ea8)

</details>
