### PR TITLE
LG-10405: Implement full address PO search page behind feature flag

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -28,20 +28,16 @@ interface DocumentCaptureProps {
    * Callback triggered on step change.
    */
   onStepChange?: () => void;
-  inPersonFullAddressEntryEnabled: Boolean;
 }
 
-function DocumentCapture({
-  onStepChange = () => {},
-  inPersonFullAddressEntryEnabled,
-}: DocumentCaptureProps) {
+function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
   const [formValues, setFormValues] = useState<Record<string, any> | null>(null);
   const [submissionError, setSubmissionError] = useState<Error | undefined>(undefined);
   const [stepName, setStepName] = useState<string | undefined>(undefined);
   const { t } = useI18n();
   const { flowPath } = useContext(UploadContext);
   const { trackSubmitEvent, trackVisitEvent } = useContext(AnalyticsContext);
-  const { inPersonURL } = useContext(InPersonContext);
+  const { inPersonFullAddressEntryEnabled, inPersonURL } = useContext(InPersonContext);
   const appName = getConfigValue('appName');
 
   useDidUpdateEffect(onStepChange, [stepName]);

--- a/app/javascript/packages/document-capture/components/in-person-full-address-search.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-full-address-search.spec.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import { useSandbox } from '@18f/identity-test-helpers';
+import userEvent from '@testing-library/user-event';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import type { SetupServer } from 'msw/node';
+import { SWRConfig } from 'swr';
+import { LOCATIONS_URL } from '@18f/identity-address-search';
+import FullAddressSearch from './in-person-full-address-search';
+
+describe('FullAddressSearch', () => {
+  const sandbox = useSandbox();
+  context('when an address is found', () => {
+    let server: SetupServer;
+    before(() => {
+      server = setupServer(
+        rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json([{ name: 'Baltimore' }]))),
+      );
+      server.listen();
+    });
+
+    after(() => {
+      server.close();
+    });
+
+    it('fires the callback with correct input', async () => {
+      const handleLocationsFound = sandbox.stub();
+      const { findByText, findByLabelText } = render(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <FullAddressSearch onFoundLocations={handleLocationsFound} />
+        </SWRConfig>,
+      );
+
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+        '200 main',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+        'Endeavor',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+        'DE',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+        '17201',
+      );
+      await userEvent.click(
+        await findByText('in_person_proofing.body.location.po_search.search_button'),
+      );
+
+      await expect(handleLocationsFound).to.eventually.be.called();
+    });
+  });
+});

--- a/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
@@ -106,7 +106,12 @@ function useUspsLocations() {
       validatedZipCodeFieldRef.current?.setCustomValidity('');
       validatedZipCodeFieldRef.current?.reportValidity();
 
-      if (addressInput === '' || cityInput === '' || stateInput === '' || zipCodeInput === '') {
+      if (
+        addressInput.trim().length === 0 ||
+        cityInput.trim().length === 0 ||
+        stateInput.trim().length === 0 ||
+        zipCodeInput.trim().length === 0
+      ) {
         return;
       }
 

--- a/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
@@ -1,0 +1,295 @@
+import { TextInput } from '@18f/identity-components';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { t } from '@18f/identity-i18n';
+import { request } from '@18f/identity-request';
+import ValidatedField from '@18f/identity-validated-field/validated-field';
+import SpinnerButton, { SpinnerButtonRefHandle } from '@18f/identity-spinner-button/spinner-button';
+import type { RegisterFieldCallback } from '@18f/identity-form-steps';
+import useSWR from 'swr/immutable';
+import { useDidUpdateEffect } from '@18f/identity-react-hooks';
+
+export const LOCATIONS_URL = new URL(
+  '/verify/in_person/usps_locations',
+  window.location.href,
+).toString();
+
+export interface FormattedLocation {
+  formattedCityStateZip: string;
+  distance: string;
+  id: number;
+  name: string;
+  saturdayHours: string;
+  streetAddress: string;
+  sundayHours: string;
+  weekdayHours: string;
+  isPilot: boolean;
+}
+
+export interface PostOffice {
+  address: string;
+  city: string;
+  distance: string;
+  name: string;
+  saturday_hours: string;
+  state: string;
+  sunday_hours: string;
+  weekday_hours: string;
+  zip_code_4: string;
+  zip_code_5: string;
+  is_pilot: boolean;
+}
+
+export interface LocationQuery {
+  streetAddress: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  address: string;
+}
+
+const formatLocations = (postOffices: PostOffice[]): FormattedLocation[] =>
+  postOffices.map((po: PostOffice, index) => ({
+    formattedCityStateZip: `${po.city}, ${po.state}, ${po.zip_code_5}-${po.zip_code_4}`,
+    id: index,
+    distance: po.distance,
+    name: po.name,
+    saturdayHours: po.saturday_hours,
+    streetAddress: po.address,
+    sundayHours: po.sunday_hours,
+    weekdayHours: po.weekday_hours,
+    isPilot: !!po.is_pilot,
+  }));
+
+export const snakeCase = (value: string) =>
+  value
+    .split(/(?=[A-Z])/)
+    .join('_')
+    .toLowerCase();
+
+// snake case the keys of the location
+export const transformKeys = (location: object, predicate: (key: string) => string) =>
+  Object.keys(location).reduce(
+    (acc, key) => ({
+      [predicate(key)]: location[key],
+      ...acc,
+    }),
+    {},
+  );
+
+const requestUspsLocations = async (address: LocationQuery): Promise<FormattedLocation[]> => {
+  const response = await request<PostOffice[]>(LOCATIONS_URL, {
+    method: 'post',
+    json: { address: transformKeys(address, snakeCase) },
+  });
+
+  return formatLocations(response);
+};
+
+function useUspsLocations() {
+  // raw text input that is set when user clicks search
+  const [addressQuery, setAddressQuery] = useState<LocationQuery | null>(null);
+  // todo: are these all necessary?
+  const validatedAddressFieldRef = useRef<HTMLFormElement>(null);
+  const validatedCityFieldRef = useRef<HTMLFormElement>(null);
+  const validatedStateFieldRef = useRef<HTMLFormElement>(null);
+  const validatedZipCodeFieldRef = useRef<HTMLFormElement>(null);
+
+  const handleLocationSearch = useCallback(
+    (event, addressInput, cityInput, stateInput, zipCodeInput) => {
+      event.preventDefault();
+      validatedAddressFieldRef.current?.setCustomValidity('');
+      validatedAddressFieldRef.current?.reportValidity();
+      validatedCityFieldRef.current?.setCustomValidity('');
+      validatedCityFieldRef.current?.reportValidity();
+      validatedStateFieldRef.current?.setCustomValidity('');
+      validatedStateFieldRef.current?.reportValidity();
+      validatedZipCodeFieldRef.current?.setCustomValidity('');
+      validatedZipCodeFieldRef.current?.reportValidity();
+
+      // if (unvalidatedAddressInput === '') {
+      //   return;
+      // }
+
+      setAddressQuery({
+        // do we need streetAddress and address?
+        streetAddress: addressInput,
+        address: addressInput,
+        city: cityInput,
+        state: stateInput,
+        zipCode: zipCodeInput,
+      });
+    },
+    [],
+  );
+
+  const {
+    data: locationResults,
+    isLoading: isLoadingLocations,
+    error: uspsError,
+  } = useSWR([addressQuery], ([address]) => (address ? requestUspsLocations(address) : null));
+
+  return {
+    addressQuery,
+    locationResults,
+    uspsError,
+    isLoading: isLoadingLocations,
+    handleLocationSearch,
+    validatedAddressFieldRef,
+    validatedCityFieldRef,
+    validatedStateFieldRef,
+    validatedZipCodeFieldRef,
+  };
+}
+
+interface FullAddressSearchProps {
+  registerField?: RegisterFieldCallback;
+  onFoundLocations?: (
+    address: LocationQuery,
+    locations: FormattedLocation[] | null | undefined,
+  ) => void;
+  onLoadingLocations?: (isLoading: boolean) => void;
+  onError?: (error: Error | null) => void;
+  disabled?: boolean;
+}
+
+function FullAddressSearch({
+  registerField = () => undefined,
+  onFoundLocations = () => undefined,
+  onLoadingLocations = () => undefined,
+  onError = () => undefined,
+  disabled = false,
+}: FullAddressSearchProps) {
+  // todo: should we get rid of verbose 'input' word?
+  const spinnerButtonRef = useRef<SpinnerButtonRefHandle>(null);
+  const [addressInput, setAddressInput] = useState('');
+  const [cityInput, setCityInput] = useState('');
+  const [stateInput, setStateInput] = useState('');
+  const [zipCodeInput, setZipCodeInput] = useState('');
+  const {
+    addressQuery,
+    locationResults,
+    uspsError,
+    isLoading,
+    handleLocationSearch: onSearch,
+    validatedAddressFieldRef,
+    validatedCityFieldRef,
+    validatedStateFieldRef,
+    validatedZipCodeFieldRef,
+  } = useUspsLocations();
+
+  const textInputChangeHandler = (input) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { target } = event;
+    input(target.value);
+  };
+
+  const onAddressChange = textInputChangeHandler(setAddressInput);
+  const onCityChange = textInputChangeHandler(setCityInput);
+  const onStateChange = textInputChangeHandler(setStateInput);
+  const onZipCodeChange = textInputChangeHandler(setZipCodeInput);
+
+  useEffect(() => {
+    spinnerButtonRef.current?.toggleSpinner(isLoading);
+    onLoadingLocations(isLoading);
+  }, [isLoading]);
+
+  useEffect(() => {
+    uspsError && onError(uspsError);
+  }, [uspsError]);
+
+  useDidUpdateEffect(() => {
+    onFoundLocations(addressQuery, locationResults);
+  }, [locationResults]);
+
+  const handleSearch = useCallback(
+    (event) => {
+      onError(null);
+      onSearch(event, addressInput, cityInput, stateInput, zipCodeInput);
+    },
+    [addressInput, cityInput, stateInput, zipCodeInput],
+  );
+
+  return (
+    <>
+      <ValidatedField
+        ref={validatedAddressFieldRef}
+        messages={{
+          valueMissing: t('in_person_proofing.body.location.inline_error'),
+        }}
+      >
+        <TextInput
+          required
+          ref={registerField('address')}
+          value={addressInput}
+          onChange={onAddressChange}
+          label={t('in_person_proofing.body.location.po_search.address_search_label')}
+          hint={t('in_person_proofing.body.location.po_search.address_search_hint')}
+          disabled={disabled}
+        />
+      </ValidatedField>
+      <ValidatedField
+        ref={validatedCityFieldRef}
+        messages={{
+          valueMissing: t('in_person_proofing.body.location.inline_error'),
+        }}
+      >
+        <TextInput
+          required
+          ref={registerField('city')}
+          value={cityInput}
+          onChange={onCityChange}
+          label={t('in_person_proofing.body.location.po_search.city_search_label')}
+          hint={t('in_person_proofing.body.location.po_search.city_search_hint')}
+          disabled={disabled}
+        />
+      </ValidatedField>
+      <ValidatedField
+        ref={validatedStateFieldRef}
+        messages={{
+          valueMissing: t('in_person_proofing.body.location.inline_error'),
+        }}
+      >
+        <TextInput
+          required
+          ref={registerField('state')}
+          value={stateInput}
+          onChange={onStateChange}
+          label={t('in_person_proofing.body.location.po_search.state_search_label')}
+          hint={t('in_person_proofing.body.location.po_search.state_search_hint')}
+          disabled={disabled}
+        />
+      </ValidatedField>
+      <ValidatedField
+        ref={validatedZipCodeFieldRef}
+        messages={{
+          valueMissing: t('in_person_proofing.body.location.inline_error'),
+        }}
+      >
+        <TextInput
+          required
+          ref={registerField('zip_code')}
+          value={zipCodeInput}
+          onChange={onZipCodeChange}
+          label={t('in_person_proofing.body.location.po_search.zip_code_search_label')}
+          hint={t('in_person_proofing.body.location.po_search.zip_code_search_hint')}
+          disabled={disabled}
+        />
+      </ValidatedField>
+      <div className="margin-y-5">
+        <SpinnerButton
+          isWide
+          isBig
+          ref={spinnerButtonRef}
+          type="submit"
+          onClick={handleSearch}
+          spinOnClick={false}
+          actionMessage={t('in_person_proofing.body.location.po_search.is_searching_message')}
+          longWaitDurationMs={1}
+        >
+          {t('in_person_proofing.body.location.po_search.search_button')}
+        </SpinnerButton>
+      </div>
+    </>
+  );
+}
+
+export default FullAddressSearch;

--- a/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
@@ -7,45 +7,14 @@ import SpinnerButton, { SpinnerButtonRefHandle } from '@18f/identity-spinner-but
 import type { RegisterFieldCallback } from '@18f/identity-form-steps';
 import useSWR from 'swr/immutable';
 import { useDidUpdateEffect } from '@18f/identity-react-hooks';
-
-export const LOCATIONS_URL = new URL(
-  '/verify/in_person/usps_locations',
-  window.location.href,
-).toString();
-
-export interface FormattedLocation {
-  formattedCityStateZip: string;
-  distance: string;
-  id: number;
-  name: string;
-  saturdayHours: string;
-  streetAddress: string;
-  sundayHours: string;
-  weekdayHours: string;
-  isPilot: boolean;
-}
-
-export interface PostOffice {
-  address: string;
-  city: string;
-  distance: string;
-  name: string;
-  saturday_hours: string;
-  state: string;
-  sunday_hours: string;
-  weekday_hours: string;
-  zip_code_4: string;
-  zip_code_5: string;
-  is_pilot: boolean;
-}
-
-export interface LocationQuery {
-  streetAddress: string;
-  city: string;
-  state: string;
-  zipCode: string;
-  address: string;
-}
+import {
+  FormattedLocation,
+  transformKeys,
+  snakeCase,
+  LocationQuery,
+  LOCATIONS_URL,
+  PostOffice,
+} from '@18f/identity-address-search';
 
 const formatLocations = (postOffices: PostOffice[]): FormattedLocation[] =>
   postOffices.map((po: PostOffice, index) => ({
@@ -60,22 +29,6 @@ const formatLocations = (postOffices: PostOffice[]): FormattedLocation[] =>
     isPilot: !!po.is_pilot,
   }));
 
-export const snakeCase = (value: string) =>
-  value
-    .split(/(?=[A-Z])/)
-    .join('_')
-    .toLowerCase();
-
-// snake case the keys of the location
-export const transformKeys = (location: object, predicate: (key: string) => string) =>
-  Object.keys(location).reduce(
-    (acc, key) => ({
-      [predicate(key)]: location[key],
-      ...acc,
-    }),
-    {},
-  );
-
 const requestUspsLocations = async (address: LocationQuery): Promise<FormattedLocation[]> => {
   const response = await request<PostOffice[]>(LOCATIONS_URL, {
     method: 'post',
@@ -86,9 +39,7 @@ const requestUspsLocations = async (address: LocationQuery): Promise<FormattedLo
 };
 
 function useUspsLocations() {
-  // raw text input that is set when user clicks search
-  const [addressQuery, setAddressQuery] = useState<LocationQuery | null>(null);
-  // todo: are these all necessary?
+  const [locationQuery, setLocationQuery] = useState<LocationQuery | null>(null);
   const validatedAddressFieldRef = useRef<HTMLFormElement>(null);
   const validatedCityFieldRef = useRef<HTMLFormElement>(null);
   const validatedStateFieldRef = useRef<HTMLFormElement>(null);
@@ -115,7 +66,7 @@ function useUspsLocations() {
         return;
       }
 
-      setAddressQuery({
+      setLocationQuery({
         address: `${addressInput}, ${cityInput}, ${stateInput} ${zipCodeInput}`,
         streetAddress: addressInput,
         city: cityInput,
@@ -130,10 +81,10 @@ function useUspsLocations() {
     data: locationResults,
     isLoading: isLoadingLocations,
     error: uspsError,
-  } = useSWR([addressQuery], ([address]) => (address ? requestUspsLocations(address) : null));
+  } = useSWR([locationQuery], ([address]) => (address ? requestUspsLocations(address) : null));
 
   return {
-    addressQuery,
+    locationQuery,
     locationResults,
     uspsError,
     isLoading: isLoadingLocations,
@@ -170,7 +121,7 @@ function FullAddressSearch({
   const [stateInput, setStateInput] = useState('');
   const [zipCodeInput, setZipCodeInput] = useState('');
   const {
-    addressQuery,
+    locationQuery,
     locationResults,
     uspsError,
     isLoading,
@@ -201,7 +152,7 @@ function FullAddressSearch({
   }, [uspsError]);
 
   useDidUpdateEffect(() => {
-    onFoundLocations(addressQuery, locationResults);
+    onFoundLocations(locationQuery, locationResults);
   }, [locationResults]);
 
   const handleSearch = useCallback(

--- a/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
@@ -106,14 +106,13 @@ function useUspsLocations() {
       validatedZipCodeFieldRef.current?.setCustomValidity('');
       validatedZipCodeFieldRef.current?.reportValidity();
 
-      // if (unvalidatedAddressInput === '') {
-      //   return;
-      // }
+      if (addressInput === '' || cityInput === '' || stateInput === '' || zipCodeInput === '') {
+        return;
+      }
 
       setAddressQuery({
-        // do we need streetAddress and address?
+        address: `${addressInput}, ${cityInput}, ${stateInput} ${zipCodeInput}`,
         streetAddress: addressInput,
-        address: addressInput,
         city: cityInput,
         state: stateInput,
         zipCode: zipCodeInput,

--- a/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
@@ -99,7 +99,7 @@ function useUspsLocations() {
 interface FullAddressSearchProps {
   registerField?: RegisterFieldCallback;
   onFoundLocations?: (
-    address: LocationQuery,
+    address: LocationQuery | null,
     locations: FormattedLocation[] | null | undefined,
   ) => void;
   onLoadingLocations?: (isLoading: boolean) => void;

--- a/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-full-address-search.tsx
@@ -210,67 +210,44 @@ function FullAddressSearch({
 
   return (
     <>
-      <ValidatedField
-        ref={validatedAddressFieldRef}
-        messages={{
-          valueMissing: t('in_person_proofing.body.location.inline_error'),
-        }}
-      >
+      <ValidatedField ref={validatedAddressFieldRef}>
         <TextInput
           required
           ref={registerField('address')}
           value={addressInput}
           onChange={onAddressChange}
-          label={t('in_person_proofing.body.location.po_search.address_search_label')}
-          hint={t('in_person_proofing.body.location.po_search.address_search_hint')}
+          label={t('in_person_proofing.body.location.po_search.address_label')}
           disabled={disabled}
         />
       </ValidatedField>
-      <ValidatedField
-        ref={validatedCityFieldRef}
-        messages={{
-          valueMissing: t('in_person_proofing.body.location.inline_error'),
-        }}
-      >
+      <ValidatedField ref={validatedCityFieldRef}>
         <TextInput
           required
           ref={registerField('city')}
           value={cityInput}
           onChange={onCityChange}
-          label={t('in_person_proofing.body.location.po_search.city_search_label')}
-          hint={t('in_person_proofing.body.location.po_search.city_search_hint')}
+          label={t('in_person_proofing.body.location.po_search.city_label')}
           disabled={disabled}
         />
       </ValidatedField>
-      <ValidatedField
-        ref={validatedStateFieldRef}
-        messages={{
-          valueMissing: t('in_person_proofing.body.location.inline_error'),
-        }}
-      >
+      <ValidatedField ref={validatedStateFieldRef}>
         <TextInput
           required
           ref={registerField('state')}
           value={stateInput}
           onChange={onStateChange}
-          label={t('in_person_proofing.body.location.po_search.state_search_label')}
-          hint={t('in_person_proofing.body.location.po_search.state_search_hint')}
+          label={t('in_person_proofing.body.location.po_search.state_label')}
           disabled={disabled}
         />
       </ValidatedField>
-      <ValidatedField
-        ref={validatedZipCodeFieldRef}
-        messages={{
-          valueMissing: t('in_person_proofing.body.location.inline_error'),
-        }}
-      >
+      <ValidatedField ref={validatedZipCodeFieldRef}>
         <TextInput
           required
+          className="tablet:grid-col-5"
           ref={registerField('zip_code')}
           value={zipCodeInput}
           onChange={onZipCodeChange}
-          label={t('in_person_proofing.body.location.po_search.zip_code_search_label')}
-          hint={t('in_person_proofing.body.location.po_search.zip_code_search_hint')}
+          label={t('in_person_proofing.body.location.po_search.zipcode_label')}
           disabled={disabled}
         />
       </ValidatedField>

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
@@ -1,7 +1,38 @@
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18n } from '@18f/identity-i18n';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
 import { SWRConfig } from 'swr';
+import { I18nContext } from '@18f/identity-react-i18n';
 import { ComponentType } from 'react';
+import { LOCATIONS_URL } from '@18f/identity-address-search';
 import InPersonLocationFullAddressEntryPostOfficeSearchStep from './in-person-location-full-address-entry-post-office-search-step';
+
+const USPS_RESPONSE = [
+  {
+    address: '100 Main St E, Bronwood, Georgia, 39826',
+    location: {
+      latitude: 31.831686000000005,
+      longitude: -84.363768,
+    },
+    street_address: '100 Main St E',
+    city: 'Bronwood',
+    state: 'GA',
+    zip_code: '39826',
+  },
+  {
+    address: '200 Main St E, Bronwood, Georgia, 39826',
+    location: {
+      latitude: 32.831686000000005,
+      longitude: -83.363768,
+    },
+    street_address: '200 Main St E',
+    city: 'Bronwood',
+    state: 'GA',
+    zip_code: '39826',
+  },
+];
 
 const DEFAULT_PROPS = {
   toPreviousStep() {},
@@ -15,6 +46,25 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
     <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
   );
 
+  let server: SetupServer;
+
+  before(() => {
+    server = setupServer();
+    server.listen();
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  beforeEach(() => {
+    server.resetHandlers();
+    // todo: should we return USPS_RESPONSE here?
+    server.use(
+      rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json([{ name: 'Baltimore' }]))),
+    );
+  });
+
   it('renders the step', () => {
     const { getByRole } = render(
       <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
@@ -24,5 +74,274 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
     );
 
     expect(getByRole('heading', { name: 'in_person_proofing.headings.po_search.location' }));
+  });
+
+  context('USPS request returns an error', () => {
+    beforeEach(() => {
+      server.use(rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.status(500))));
+    });
+
+    it('displays a try again error message', async () => {
+      const { findByText, findByLabelText } = render(
+        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+        { wrapper },
+      );
+
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+        '222 Merchandise Mart Plaza',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+        'Endeavor',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+        'DE',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+        '19701',
+      );
+
+      await userEvent.click(
+        await findByText('in_person_proofing.body.location.po_search.search_button'),
+      );
+
+      const error = await findByText('idv.failure.exceptions.post_office_search_error');
+      expect(error).to.exist();
+    });
+  });
+
+  it('displays validation error messages to the user if fields are empty', async () => {
+    const { findAllByText, findByText } = render(
+      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      {
+        wrapper,
+      },
+    );
+
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+
+    const errors = await findAllByText('simple_form.required.text');
+    expect(errors).to.have.lengthOf(4);
+  });
+
+  it('displays no post office results if a successful search is followed by an unsuccessful search', async () => {
+    const { findByText, findByLabelText, queryByRole } = render(
+      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      { wrapper },
+    );
+
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+      '222 Merchandise Mart Plaza',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+      'Endeavor',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+      'DE',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+      '19701',
+    );
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+      '00000',
+    );
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+
+    const results = queryByRole('status', {
+      name: 'in_person_proofing.body.location.location_button',
+    });
+    expect(results).not.to.exist();
+  });
+
+  it('clicking search again after first results do not clear results', async () => {
+    const { findAllByText, findByText, findByLabelText } = render(
+      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      { wrapper },
+    );
+
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+      '222 Merchandise Mart Plaza',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+      'Endeavor',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+      'DE',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+      '19701',
+    );
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+    await findAllByText('in_person_proofing.body.location.location_button');
+  });
+
+  it('displays correct pluralization for a single location result', async () => {
+    const { findByLabelText, findByText } = render(
+      <I18nContext.Provider
+        value={
+          new I18n({
+            strings: {
+              'in_person_proofing.body.location.po_search.results_description': {
+                one: 'There is one participating Post Office within 50 miles of %{address}.',
+                other:
+                  'There are %{count} participating Post Offices within 50 miles of %{address}.',
+              },
+            },
+          })
+        }
+      >
+        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />
+      </I18nContext.Provider>,
+      { wrapper },
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+      '222 Merchandise Mart Plaza',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+      'Endeavor',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+      'DE',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+      '19701',
+    );
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+
+    const addressQuery = '222 Merchandise Mart Plaza, Endeavor, DE 19701';
+    const searchResultAlert = await findByText(
+      `There is one participating Post Office within 50 miles of ${addressQuery}.`,
+    );
+    expect(searchResultAlert).to.exist();
+  });
+
+  it('displays correct pluralization for multiple location results', async () => {
+    server.resetHandlers();
+    server.use(rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json(USPS_RESPONSE))));
+    const { findByLabelText, findByText } = render(
+      <I18nContext.Provider
+        value={
+          new I18n({
+            strings: {
+              'in_person_proofing.body.location.po_search.results_description': {
+                one: 'There is one participating Post Office within 50 miles of %{address}.',
+                other:
+                  'There are %{count} participating Post Offices within 50 miles of %{address}.',
+              },
+            },
+          })
+        }
+      >
+        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />
+      </I18nContext.Provider>,
+      { wrapper },
+    );
+
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+      '222 Merchandise Mart Plaza',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+      'Endeavor',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+      'DE',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+      '19701',
+    );
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+
+    const addressQuery = '222 Merchandise Mart Plaza, Endeavor, DE 19701';
+    const searchResultAlert = await findByText(
+      `There are ${USPS_RESPONSE.length} participating Post Offices within 50 miles of ${addressQuery}.`,
+    );
+    expect(searchResultAlert).to.exist();
+  });
+
+  it('allows user to select a location', async () => {
+    const { findAllByText, findByLabelText, findByText, queryByText } = render(
+      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      { wrapper },
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+      '222 Merchandise Mart Plaza',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+      'Endeavor',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+      'DE',
+    );
+    await userEvent.type(
+      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+      '19701',
+    );
+
+    await userEvent.click(
+      await findByText('in_person_proofing.body.location.po_search.search_button'),
+    );
+
+    await userEvent.clear(
+      await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+    );
+    await userEvent.clear(
+      await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+    );
+    await userEvent.clear(
+      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+    );
+    await userEvent.clear(
+      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+    );
+
+    await userEvent.click(findAllByText('in_person_proofing.body.location.location_button')[0]);
+
+    expect(await queryByText('simple_form.required.text')).to.be.null();
   });
 });

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
@@ -2,11 +2,13 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18n } from '@18f/identity-i18n';
 import { setupServer } from 'msw/node';
+import type { SetupServer } from 'msw/node';
 import { rest } from 'msw';
 import { SWRConfig } from 'swr';
 import { I18nContext } from '@18f/identity-react-i18n';
 import { ComponentType } from 'react';
 import { LOCATIONS_URL } from '@18f/identity-address-search';
+import { InPersonContext } from '../context';
 import InPersonLocationFullAddressEntryPostOfficeSearchStep from './in-person-location-full-address-entry-post-office-search-step';
 
 const USPS_RESPONSE = [
@@ -67,10 +69,17 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
 
   it('renders the step', () => {
     const { getByRole } = render(
-      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
-      {
-        wrapper,
-      },
+      <InPersonContext.Provider
+        value={{
+          inPersonOutageMessageEnabled: false,
+          inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+          inPersonFullAddressEntryEnabled: true,
+          usStatesTerritories: [['Delaware', 'DE']],
+        }}
+      >
+        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      </InPersonContext.Provider>,
+      { wrapper },
     );
 
     expect(getByRole('heading', { name: 'in_person_proofing.headings.po_search.location' }));
@@ -83,7 +92,16 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
 
     it('displays a try again error message', async () => {
       const { findByText, findByLabelText } = render(
-        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+        <InPersonContext.Provider
+          value={{
+            inPersonOutageMessageEnabled: false,
+            inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+            inPersonFullAddressEntryEnabled: true,
+            usStatesTerritories: [['Delaware', 'DE']],
+          }}
+        >
+          <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+        </InPersonContext.Provider>,
         { wrapper },
       );
 
@@ -95,7 +113,7 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
         await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
         'Endeavor',
       );
-      await userEvent.type(
+      await userEvent.selectOptions(
         await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
         'DE',
       );
@@ -115,10 +133,17 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
 
   it('displays validation error messages to the user if fields are empty', async () => {
     const { findAllByText, findByText } = render(
-      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
-      {
-        wrapper,
-      },
+      <InPersonContext.Provider
+        value={{
+          inPersonOutageMessageEnabled: false,
+          inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+          inPersonFullAddressEntryEnabled: true,
+          usStatesTerritories: [['Delaware', 'DE']],
+        }}
+      >
+        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      </InPersonContext.Provider>,
+      { wrapper },
     );
 
     await userEvent.click(
@@ -131,7 +156,16 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
 
   it('displays no post office results if a successful search is followed by an unsuccessful search', async () => {
     const { findByText, findByLabelText, queryByRole } = render(
-      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      <InPersonContext.Provider
+        value={{
+          inPersonOutageMessageEnabled: false,
+          inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+          inPersonFullAddressEntryEnabled: true,
+          usStatesTerritories: [['Delaware', 'DE']],
+        }}
+      >
+        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      </InPersonContext.Provider>,
       { wrapper },
     );
 
@@ -143,7 +177,7 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
       await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
       'Endeavor',
     );
-    await userEvent.type(
+    await userEvent.selectOptions(
       await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
       'DE',
     );
@@ -171,7 +205,16 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
 
   it('clicking search again after first results do not clear results', async () => {
     const { findAllByText, findByText, findByLabelText } = render(
-      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      <InPersonContext.Provider
+        value={{
+          inPersonOutageMessageEnabled: false,
+          inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+          inPersonFullAddressEntryEnabled: true,
+          usStatesTerritories: [['Delaware', 'DE']],
+        }}
+      >
+        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      </InPersonContext.Provider>,
       { wrapper },
     );
 
@@ -183,7 +226,7 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
       await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
       'Endeavor',
     );
-    await userEvent.type(
+    await userEvent.selectOptions(
       await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
       'DE',
     );
@@ -215,7 +258,17 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
           })
         }
       >
-        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />
+        <InPersonContext.Provider
+          value={{
+            inPersonOutageMessageEnabled: false,
+            inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+            inPersonFullAddressEntryEnabled: true,
+            usStatesTerritories: [['Delaware', 'DE']],
+          }}
+        >
+          <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+        </InPersonContext.Provider>
+        ,
       </I18nContext.Provider>,
       { wrapper },
     );
@@ -227,7 +280,7 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
       await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
       'Endeavor',
     );
-    await userEvent.type(
+    await userEvent.selectOptions(
       await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
       'DE',
     );
@@ -266,7 +319,17 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
           })
         }
       >
-        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />
+        <InPersonContext.Provider
+          value={{
+            inPersonOutageMessageEnabled: false,
+            inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+            inPersonFullAddressEntryEnabled: true,
+            usStatesTerritories: [['Delaware', 'DE']],
+          }}
+        >
+          <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+        </InPersonContext.Provider>
+        ,
       </I18nContext.Provider>,
       { wrapper },
     );
@@ -279,7 +342,7 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
       await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
       'Endeavor',
     );
-    await userEvent.type(
+    await userEvent.selectOptions(
       await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
       'DE',
     );
@@ -303,7 +366,16 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
 
   it('allows user to select a location', async () => {
     const { findAllByText, findByLabelText, findByText, queryByText } = render(
-      <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      <InPersonContext.Provider
+        value={{
+          inPersonOutageMessageEnabled: false,
+          inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+          inPersonFullAddressEntryEnabled: true,
+          usStatesTerritories: [['Delaware', 'DE']],
+        }}
+      >
+        <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
+      </InPersonContext.Provider>,
       { wrapper },
     );
     await userEvent.type(
@@ -314,7 +386,7 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
       await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
       'Endeavor',
     );
-    await userEvent.type(
+    await userEvent.selectOptions(
       await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
       'DE',
     );
@@ -332,9 +404,6 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
     );
     await userEvent.clear(
       await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
-    );
-    await userEvent.clear(
-      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
     );
     await userEvent.clear(
       await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
@@ -1,14 +1,133 @@
+import { useState, useEffect, useCallback, useRef, useContext } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
-import { PageHeading } from '@18f/identity-components';
+import { Alert, PageHeading } from '@18f/identity-components';
+import { request } from '@18f/identity-request';
+import { forceRedirect } from '@18f/identity-url';
+import FullAddressSearch, {
+  transformKeys,
+  snakeCase,
+  LocationQuery,
+  LOCATIONS_URL,
+} from './in-person-full-address-search';
 import BackButton from './back-button';
+import AnalyticsContext from '../context/analytics';
+import InPersonLocations, { FormattedLocation } from './in-person-locations';
+import { InPersonContext } from '../context';
+import UploadContext from '../context/upload';
 
-function InPersonLocationFullAddressEntryPostOfficeSearchStep({ toPreviousStep }) {
+function InPersonLocationFullAddressEntryPostOfficeSearchStep({
+  onChange,
+  toPreviousStep,
+  registerField,
+}) {
+  const { inPersonURL } = useContext(InPersonContext);
   const { t } = useI18n();
+  const [inProgress, setInProgress] = useState<boolean>(false);
+  const [isLoadingLocations, setLoadingLocations] = useState<boolean>(false);
+  const [autoSubmit, setAutoSubmit] = useState<boolean>(false);
+  const { trackEvent } = useContext(AnalyticsContext);
+  const [locationResults, setLocationResults] = useState<FormattedLocation[] | null | undefined>(
+    null,
+  );
+  const [foundAddress, setFoundAddress] = useState<LocationQuery | null>(null);
+  const [apiError, setApiError] = useState<Error | null>(null);
+  const [disabledAddressSearch, setDisabledAddressSearch] = useState<boolean>(false);
+  const { flowPath } = useContext(UploadContext);
+
+  const onFoundLocations = (address: LocationQuery, locations: FormattedLocation[]) => {
+    setFoundAddress(address);
+    setLocationResults(locations);
+  };
+
+  // ref allows us to avoid a memory leak
+  // todo: is this necessary?
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // useCallBack here prevents unnecessary rerenders due to changing function identity
+  const handleLocationSelect = useCallback(
+    async (e: any, id: number) => {
+      if (flowPath !== 'hybrid') {
+        e.preventDefault();
+      }
+      const selectedLocation = locationResults![id]!;
+      const { streetAddress, formattedCityStateZip } = selectedLocation;
+      const selectedLocationAddress = `${streetAddress}, ${formattedCityStateZip}`;
+      onChange({ selectedLocationAddress });
+      if (autoSubmit) {
+        setDisabledAddressSearch(true);
+        setTimeout(() => {
+          if (mountedRef.current) {
+            setDisabledAddressSearch(false);
+          }
+        }, 250);
+        return;
+      }
+      if (inProgress) {
+        return;
+      }
+      const selected = transformKeys(selectedLocation, snakeCase);
+      setInProgress(true);
+      try {
+        await request(LOCATIONS_URL, {
+          json: selected,
+          method: 'PUT',
+        });
+        // In try block set success of request. If the request is successful, fire remaining code?
+        if (mountedRef.current) {
+          setAutoSubmit(true);
+          setImmediate(() => {
+            e.target.disabled = false;
+            if (flowPath !== 'hybrid') {
+              trackEvent('IdV: location submitted', {
+                selected_location: selectedLocationAddress,
+              });
+              forceRedirect(inPersonURL!);
+            }
+            // allow process to be re-triggered in case submission did not work as expected
+            setAutoSubmit(false);
+          });
+        }
+      } catch {
+        setAutoSubmit(false);
+      } finally {
+        if (mountedRef.current) {
+          setInProgress(false);
+        }
+      }
+    },
+    [locationResults, inProgress],
+  );
 
   return (
     <>
+      {apiError && (
+        <Alert type="error" className="margin-bottom-4">
+          {t('idv.failure.exceptions.post_office_search_error')}
+        </Alert>
+      )}
       <PageHeading>{t('in_person_proofing.headings.po_search.location')}</PageHeading>
       <p>{t('in_person_proofing.body.location.po_search.po_search_about')}</p>
+      <FullAddressSearch
+        registerField={registerField}
+        onFoundLocations={onFoundLocations}
+        onLoadingLocations={setLoadingLocations}
+        onError={setApiError}
+        disabled={disabledAddressSearch}
+      />
+      {locationResults && foundAddress && !isLoadingLocations && (
+        <InPersonLocations
+          locations={locationResults}
+          onSelect={handleLocationSelect}
+          address={foundAddress?.address || ''}
+        />
+      )}
       <BackButton role="link" includeBorder onClick={toPreviousStep} />
     </>
   );

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
@@ -35,7 +35,10 @@ function InPersonLocationFullAddressEntryPostOfficeSearchStep({
   const [disabledAddressSearch, setDisabledAddressSearch] = useState<boolean>(false);
   const { flowPath } = useContext(UploadContext);
 
-  const onFoundLocations = (address: LocationQuery, locations: FormattedLocation[]) => {
+  const onFoundLocations = (
+    address: LocationQuery | null,
+    locations: FormattedLocation[] | null | undefined,
+  ) => {
     setFoundAddress(address);
     setLocationResults(locations);
   };

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
@@ -128,7 +128,7 @@ function InPersonLocationFullAddressEntryPostOfficeSearchStep({
         <InPersonLocations
           locations={locationResults}
           onSelect={handleLocationSelect}
-          address={foundAddress?.address || ''}
+          address={foundAddress.address || ''}
         />
       )}
       <BackButton role="link" includeBorder onClick={toPreviousStep} />

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
@@ -3,12 +3,13 @@ import { useI18n } from '@18f/identity-react-i18n';
 import { Alert, PageHeading } from '@18f/identity-components';
 import { request } from '@18f/identity-request';
 import { forceRedirect } from '@18f/identity-url';
-import FullAddressSearch, {
+import {
   transformKeys,
   snakeCase,
   LocationQuery,
   LOCATIONS_URL,
-} from './in-person-full-address-search';
+} from '@18f/identity-address-search';
+import FullAddressSearch from './in-person-full-address-search';
 import BackButton from './back-button';
 import AnalyticsContext from '../context/analytics';
 import InPersonLocations, { FormattedLocation } from './in-person-locations';
@@ -40,7 +41,6 @@ function InPersonLocationFullAddressEntryPostOfficeSearchStep({
   };
 
   // ref allows us to avoid a memory leak
-  // todo: is this necessary?
   const mountedRef = useRef(false);
 
   useEffect(() => {

--- a/app/javascript/packages/document-capture/components/in-person-outage-alert.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-outage-alert.spec.tsx
@@ -11,6 +11,7 @@ describe('InPersonOutageAlert', () => {
           inPersonOutageExpectedUpdateDate: 'January 1, 2024',
           inPersonOutageMessageEnabled: true,
           inPersonFullAddressEntryEnabled: false,
+          usStatesTerritories: [],
         }}
       >
         <InPersonOutageAlert />

--- a/app/javascript/packages/document-capture/components/in-person-outage-alert.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-outage-alert.spec.tsx
@@ -10,6 +10,7 @@ describe('InPersonOutageAlert', () => {
         value={{
           inPersonOutageExpectedUpdateDate: 'January 1, 2024',
           inPersonOutageMessageEnabled: true,
+          inPersonFullAddressEntryEnabled: false,
         }}
       >
         <InPersonOutageAlert />

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
@@ -26,6 +26,7 @@ describe('InPersonPrepareStep', () => {
             inPersonOutageMessageEnabled: true,
             inPersonOutageExpectedUpdateDate: 'January 1, 2024',
             inPersonFullAddressEntryEnabled: false,
+            usStatesTerritories: [],
           }}
         >
           <InPersonPrepareStep {...DEFAULT_PROPS} />
@@ -38,7 +39,11 @@ describe('InPersonPrepareStep', () => {
     it('does not render a warning when the flag is disabled', () => {
       const { queryByText } = render(
         <InPersonContext.Provider
-          value={{ inPersonOutageMessageEnabled: false, inPersonFullAddressEntryEnabled: false }}
+          value={{
+            inPersonOutageMessageEnabled: false,
+            inPersonFullAddressEntryEnabled: false,
+            usStatesTerritories: [],
+          }}
         >
           <InPersonPrepareStep {...DEFAULT_PROPS} />
         </InPersonContext.Provider>,

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
@@ -25,6 +25,7 @@ describe('InPersonPrepareStep', () => {
           value={{
             inPersonOutageMessageEnabled: true,
             inPersonOutageExpectedUpdateDate: 'January 1, 2024',
+            inPersonFullAddressEntryEnabled: false,
           }}
         >
           <InPersonPrepareStep {...DEFAULT_PROPS} />
@@ -36,7 +37,9 @@ describe('InPersonPrepareStep', () => {
     });
     it('does not render a warning when the flag is disabled', () => {
       const { queryByText } = render(
-        <InPersonContext.Provider value={{ inPersonOutageMessageEnabled: false }}>
+        <InPersonContext.Provider
+          value={{ inPersonOutageMessageEnabled: false, inPersonFullAddressEntryEnabled: false }}
+        >
           <InPersonPrepareStep {...DEFAULT_PROPS} />
         </InPersonContext.Provider>,
       );

--- a/app/javascript/packages/document-capture/context/in-person.ts
+++ b/app/javascript/packages/document-capture/context/in-person.ts
@@ -24,6 +24,7 @@ export interface InPersonContextProps {
 
 const InPersonContext = createContext<InPersonContextProps>({
   inPersonOutageMessageEnabled: false,
+  inPersonFullAddressEntryEnabled: false,
 });
 
 InPersonContext.displayName = 'InPersonContext';

--- a/app/javascript/packages/document-capture/context/in-person.ts
+++ b/app/javascript/packages/document-capture/context/in-person.ts
@@ -20,11 +20,18 @@ export interface InPersonContextProps {
    * When true users must enter a full address when searching for a Post Office location
    */
   inPersonFullAddressEntryEnabled: boolean;
+
+  /**
+   * Collection of US states and territories
+   * Each item is [Long name, abbreviation], e.g. ['Ohio', 'OH']
+   */
+  usStatesTerritories: Array<[string, string]>;
 }
 
 const InPersonContext = createContext<InPersonContextProps>({
   inPersonOutageMessageEnabled: false,
   inPersonFullAddressEntryEnabled: false,
+  usStatesTerritories: [],
 });
 
 InPersonContext.displayName = 'InPersonContext';

--- a/app/javascript/packages/document-capture/context/in-person.ts
+++ b/app/javascript/packages/document-capture/context/in-person.ts
@@ -15,6 +15,11 @@ export interface InPersonContextProps {
    * Date communicated to users regarding expected update about their enrollment after an outage
    */
   inPersonOutageExpectedUpdateDate?: string;
+
+  /**
+   * When true users must enter a full address when searching for a Post Office location
+   */
+  inPersonFullAddressEntryEnabled: boolean;
 }
 
 const InPersonContext = createContext<InPersonContextProps>({

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -95,6 +95,7 @@ const App = composeComponents(
         inPersonURL,
         inPersonOutageMessageEnabled: inPersonOutageMessageEnabled === 'true',
         inPersonOutageExpectedUpdateDate,
+        inPersonFullAddressEntryEnabled: inPersonFullAddressEntryEnabled === 'true',
       },
     },
   ],
@@ -143,7 +144,6 @@ const App = composeComponents(
     DocumentCapture,
     {
       onStepChange: extendSession,
-      inPersonFullAddressEntryEnabled: inPersonFullAddressEntryEnabled === 'true',
     },
   ],
 );

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -83,7 +83,13 @@ const {
   inPersonFullAddressEntryEnabled,
   inPersonOutageMessageEnabled,
   inPersonOutageExpectedUpdateDate,
+  usStatesTerritories = '',
 } = appRoot.dataset as DOMStringMap & AppRootData;
+
+let parsedUsStatesTerritories = [];
+try {
+  parsedUsStatesTerritories = JSON.parse(usStatesTerritories);
+} catch (e) {}
 
 const App = composeComponents(
   [MarketingSiteContextProvider, { helpCenterRedirectURL, securityAndPrivacyHowItWorksURL }],
@@ -96,6 +102,7 @@ const App = composeComponents(
         inPersonOutageMessageEnabled: inPersonOutageMessageEnabled === 'true',
         inPersonOutageExpectedUpdateDate,
         inPersonFullAddressEntryEnabled: inPersonFullAddressEntryEnabled === 'true',
+        usStatesTerritories: parsedUsStatesTerritories,
       },
     },
   ],

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -33,6 +33,7 @@
       in_person_full_address_entry_enabled: IdentityConfig.store.in_person_full_address_entry_enabled,
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
+      us_states_territories: us_states_territories,
     } %>
   <%= simple_form_for(
         :doc_auth,

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -41,8 +41,10 @@ en:
         inline_error: Enter a valid address with city, state, and ZIP code
         location_button: Select
         po_search:
+          address_label: Address
           address_search_hint: 'Example: 1234 N Example St., Allentown, PA 12345'
           address_search_label: Enter an address to find a Post Office near you
+          city_label: City
           is_searching_message: Searching for Post Office locations…
           none_found: Sorry, there are no participating Post Offices within 50 miles of
             %{address}.
@@ -57,6 +59,8 @@ en:
           results_instructions: Select a Post Office location below, or search again using
             a different address.
           search_button: Search
+          state_label: State
+          zipcode_label: ZIP Code
         retail_hours_heading: Retail Hours
         retail_hours_sat: 'Sat:'
         retail_hours_sun: 'Sun:'

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -44,9 +44,11 @@ es:
         inline_error: Ingrese una dirección válida que incluya ciudad, estado y código postal
         location_button: Seleccionar
         po_search:
+          address_label: Dirección
           address_search_hint: 'Ejemplo: 1234 N Example St., Allentown, PA 12345'
           address_search_label: Introduzca una dirección para encontrar una Oficina de
             Correos cercana a usted
+          city_label: Ciudad
           is_searching_message: Buscando oficinas de correos…
           none_found: Lo sentimos, no hay Oficinas de Correos participantes en un radio de
             50 millas de la %{address}.
@@ -63,6 +65,8 @@ es:
           results_instructions: Seleccione una ubicación de la Oficina de Correos a
             continuación, o busque de nuevo utilizando una dirección diferente.
           search_button: Buscar
+          state_label: Estado
+          zipcode_label: Código postal
         retail_hours_heading: Horario de atención al público
         retail_hours_sat: 'Sáb:'
         retail_hours_sun: 'Dom:'

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -45,8 +45,10 @@ fr:
         inline_error: Saisissez une adresse valide avec la ville, l’état et le code postal
         location_button: Sélectionner
         po_search:
+          address_label: Adresse
           address_search_hint: 'Exemple: 1234 N Example St., Allentown, PA 12345'
           address_search_label: Entrez une adresse pour trouver un bureau de poste près de chez vous.
+          city_label: Ville
           is_searching_message: Recherche des emplacements de bureau de poste…
           none_found: Désolé, il n’y a pas de bureaux de poste participants dans un rayon
             de 50 miles de la ville %{address}
@@ -63,6 +65,8 @@ fr:
           results_instructions: Sélectionnez un emplacement de bureau de poste ci-dessous,
             ou effectuez une nouvelle recherche en utilisant une autre adresse.
           search_button: Rechercher
+          state_label: État
+          zipcode_label: Code postal
         retail_hours_heading: Heures de vente au détail
         retail_hours_sat: 'Sam:'
         retail_hours_sun: 'Dim:'

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -118,8 +118,7 @@ module InPersonHelper
             with: GOOD_ADDRESS1
     fill_in t('in_person_proofing.body.location.po_search.city_label'),
             with: GOOD_CITY
-    fill_in t('in_person_proofing.body.location.po_search.state_label'),
-            with: GOOD_STATE
+    select GOOD_STATE, from: t('in_person_proofing.form.state_id.identity_doc_address_state')
     fill_in t('in_person_proofing.body.location.po_search.zipcode_label'),
             with: GOOD_ZIPCODE
     click_spinner_button_and_wait(t('in_person_proofing.body.location.po_search.search_button'))

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -110,6 +110,37 @@ module InPersonHelper
     end
   end
 
+  def search_for_post_office_with_full_address
+    expect(page).to(have_content(t('in_person_proofing.headings.po_search.location')))
+    expect(page).to(have_content(t('in_person_proofing.body.location.po_search.po_search_about')))
+    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.find_a_post_office'))
+    fill_in t('in_person_proofing.body.location.po_search.address_label'),
+            with: GOOD_ADDRESS1
+    fill_in t('in_person_proofing.body.location.po_search.city_label'),
+            with: GOOD_CITY
+    fill_in t('in_person_proofing.body.location.po_search.state_label'),
+            with: GOOD_STATE
+    fill_in t('in_person_proofing.body.location.po_search.zipcode_label'),
+            with: GOOD_ZIPCODE
+    click_spinner_button_and_wait(t('in_person_proofing.body.location.po_search.search_button'))
+    expect(page).to have_css('.location-collection-item')
+  end
+
+  def complete_full_address_location_step(_user = nil)
+    search_for_post_office_with_full_address
+    within first('.location-collection-item') do
+      click_spinner_button_and_wait t('in_person_proofing.body.location.location_button')
+    end
+
+    # pause for the location list to disappear
+    begin
+      expect(page).to have_no_css('.location-collection-item')
+    rescue Selenium::WebDriver::Error::StaleElementReferenceError
+      # A StaleElementReferenceError means that the context the element
+      # was in has disappeared, which means the element is gone too.
+    end
+  end
+
   def complete_prepare_step(_user = nil)
     expect(page).to(have_content(t('in_person_proofing.headings.prepare')))
     expect(page).to(have_content(t('in_person_proofing.body.prepare.verify_step_about')))


### PR DESCRIPTION
## 🎫 Ticket

[LG-10405](https://cm-jira.usa.gov/browse/LG-10405)

Note: there was some confusion on how to go about getting these changes merged in order to make it into a patch release. This code has already been reviewed in #8815, #8825, and #8824. This PR is to merge these changes into main.

<details>
<summary>how did you pull in these commits?</summary>

```
git checkout tbradley/po-search-aggregate-pr
git pull
git checkout -b sbachstein/po-search-aggregate-against-main
git rebase --onto origin/main 80afdc2c941d37b34bc48ad098bc2597cc4a176f
git commit --allow-empty -m 'changelog: User-Facing Improvements, In-person full address entry, Add full address PO search form'
git push origin sbachstein/po-search-aggregate-against-main
```

</details>

## 🛠 Summary of changes

* Refactors the feature flag to use the InPersonContext
* Implements an address entry form on the alternative PO search page, behind a feature flag

## 📜 Testing Plan

- [ ] Set the `in_person_full_address_entry_enabled` to true
- [ ] Create a new account and start the in person flow

When you reach the PO Location Search page,
- [ ] Confirm that all fields are required
- [ ] Confirm that search can be submitted when all fields are filled

## 👀 Screenshots

<details>
<summary>On first load</summary>

<img width="637" alt="Screenshot 2023-07-20 at 9 26 22 PM" src="https://github.com/18F/identity-idp/assets/45415133/da4de168-1078-4db7-bc1f-36556a34c288">

</details>

<details>
<summary>With validation errors</summary>

<img width="637" alt="Screenshot 2023-07-20 at 9 26 34 PM" src="https://github.com/18F/identity-idp/assets/45415133/5ee91977-afdc-4bea-895b-67cc03ab318e">

</details>

<details>
<summary>With values, submitted and showing results</summary>

<img width="636" alt="Screenshot 2023-07-20 at 9 27 11 PM" src="https://github.com/18F/identity-idp/assets/45415133/e591159a-0d92-45d2-b3db-ba7842fbef6f">

</details>