### PR TITLE
Render non-passkey-restricted WebAuthn input as visible

### DIFF
--- a/app/components/webauthn_input_component.rb
+++ b/app/components/webauthn_input_component.rb
@@ -22,10 +22,16 @@ class WebauthnInputComponent < BaseComponent
       :'lg-webauthn-input',
       content,
       **tag_options,
-      hidden: true,
-      platform: platform?.presence,
-      'passkey-supported-only': passkey_supported_only?.presence,
+      **initial_hidden_tag_options,
       'show-unsupported-passkey': show_unsupported_passkey?.presence,
     )
+  end
+
+  def initial_hidden_tag_options
+    if platform? && passkey_supported_only?
+      { hidden: true }
+    else
+      { class: 'js' }
+    end
   end
 end

--- a/app/javascript/packages/webauthn/webauthn-input-element.spec.ts
+++ b/app/javascript/packages/webauthn/webauthn-input-element.spec.ts
@@ -17,8 +17,38 @@ describe('WebauthnInputElement', () => {
     quibble.reset();
   });
 
-  context('input for non-platform authenticator', () => {
+  context('device does not support passkey', () => {
+    context('unsupported passkey not shown', () => {
+      beforeEach(() => {
+        isWebauthnPasskeySupported.returns(false);
+        document.body.innerHTML = `<lg-webauthn-input hidden></lg-webauthn-input>`;
+      });
+
+      it('stays hidden', () => {
+        const element = document.querySelector('lg-webauthn-input')!;
+
+        expect(element.hidden).to.be.true();
+      });
+    });
+
+    context('unsupported passkey shown', () => {
+      beforeEach(() => {
+        isWebauthnPasskeySupported.returns(false);
+        document.body.innerHTML = `<lg-webauthn-input show-unsupported-passkey hidden></lg-webauthn-input>`;
+      });
+
+      it('becomes visible, with modifier class', () => {
+        const element = document.querySelector('lg-webauthn-input')!;
+
+        expect(element.hidden).to.be.false();
+        expect(element.classList.contains('webauthn-input--unsupported-passkey')).to.be.true();
+      });
+    });
+  });
+
+  context('device supports passkey', () => {
     beforeEach(() => {
+      isWebauthnPasskeySupported.returns(true);
       document.body.innerHTML = `<lg-webauthn-input hidden></lg-webauthn-input>`;
     });
 
@@ -26,64 +56,6 @@ describe('WebauthnInputElement', () => {
       const element = document.querySelector('lg-webauthn-input')!;
 
       expect(element.hidden).to.be.false();
-    });
-  });
-
-  context('input for platform authenticator', () => {
-    context('no passkey only restriction', () => {
-      beforeEach(() => {
-        document.body.innerHTML = `<lg-webauthn-input platform hidden></lg-webauthn-input>`;
-      });
-
-      it('becomes visible', () => {
-        const element = document.querySelector('lg-webauthn-input')!;
-
-        expect(element.hidden).to.be.false();
-      });
-    });
-
-    context('passkey supported only', () => {
-      context('device does not support passkey', () => {
-        context('unsupported passkey not shown', () => {
-          beforeEach(() => {
-            isWebauthnPasskeySupported.returns(false);
-            document.body.innerHTML = `<lg-webauthn-input platform passkey-supported-only hidden></lg-webauthn-input>`;
-          });
-
-          it('stays hidden', () => {
-            const element = document.querySelector('lg-webauthn-input')!;
-
-            expect(element.hidden).to.be.true();
-          });
-        });
-
-        context('unsupported passkey shown', () => {
-          beforeEach(() => {
-            isWebauthnPasskeySupported.returns(false);
-            document.body.innerHTML = `<lg-webauthn-input platform passkey-supported-only show-unsupported-passkey hidden></lg-webauthn-input>`;
-          });
-
-          it('becomes visible, with modifier class', () => {
-            const element = document.querySelector('lg-webauthn-input')!;
-
-            expect(element.hidden).to.be.false();
-            expect(element.classList.contains('webauthn-input--unsupported-passkey')).to.be.true();
-          });
-        });
-      });
-
-      context('device supports passkey', () => {
-        beforeEach(() => {
-          isWebauthnPasskeySupported.returns(true);
-          document.body.innerHTML = `<lg-webauthn-input platform passkey-supported-only hidden></lg-webauthn-input>`;
-        });
-
-        it('becomes visible', () => {
-          const element = document.querySelector('lg-webauthn-input')!;
-
-          expect(element.hidden).to.be.false();
-        });
-      });
     });
   });
 });

--- a/app/javascript/packages/webauthn/webauthn-input-element.ts
+++ b/app/javascript/packages/webauthn/webauthn-input-element.ts
@@ -2,27 +2,23 @@ import isWebauthnPasskeySupported from './is-webauthn-passkey-supported';
 
 export class WebauthnInputElement extends HTMLElement {
   connectedCallback() {
-    this.toggleVisibleIfSupported();
+    this.toggleVisibleIfPasskeySupported();
   }
 
   get isPlatform(): boolean {
     return this.hasAttribute('platform');
   }
 
-  get isOnlyPasskeySupported(): boolean {
-    return this.hasAttribute('passkey-supported-only');
-  }
-
   get showUnsupportedPasskey(): boolean {
     return this.hasAttribute('show-unsupported-passkey');
   }
 
-  isSupported(): boolean {
-    return !this.isPlatform || !this.isOnlyPasskeySupported || isWebauthnPasskeySupported();
-  }
+  toggleVisibleIfPasskeySupported() {
+    if (!this.hasAttribute('hidden')) {
+      return;
+    }
 
-  toggleVisibleIfSupported() {
-    if (this.isSupported()) {
+    if (isWebauthnPasskeySupported()) {
       this.hidden = false;
     } else if (this.showUnsupportedPasskey) {
       this.hidden = false;

--- a/spec/components/webauthn_input_component_spec.rb
+++ b/spec/components/webauthn_input_component_spec.rb
@@ -6,12 +6,7 @@ RSpec.describe WebauthnInputComponent, type: :component do
   subject(:rendered) { render_inline component }
 
   it 'renders element with expected attributes' do
-    element = rendered.css('lg-webauthn-input').first
-
-    expect(element.attr('hidden')).to be_present
-    expect(element.attr('platform')).to be_nil
-    expect(element.attr('passkey-supported-only')).to be_nil
-    expect(element.attr('show-unsupported-passkey')).to be_nil
+    expect(rendered).to have_css('lg-webauthn-input.js:not([show-unsupported-passkey])')
   end
 
   it 'exposes boolean alias for platform option' do
@@ -28,66 +23,63 @@ RSpec.describe WebauthnInputComponent, type: :component do
 
   context 'with platform option' do
     context 'with platform option false' do
-      let(:options) { { platform: false } }
+      let(:options) { super().merge(platform: false) }
 
-      it 'renders without platform attribute' do
-        expect(rendered).to have_css('lg-webauthn-input[hidden]:not([platform])', visible: false)
+      it 'renders as visible for js-enabled browsers' do
+        expect(rendered).to have_css('lg-webauthn-input.js:not([show-unsupported-passkey])')
       end
     end
 
     context 'with platform option true' do
-      let(:options) { { platform: true } }
+      let(:options) { super().merge(platform: true) }
 
-      it 'renders with platform attribute' do
-        expect(rendered).to have_css('lg-webauthn-input[hidden][platform]', visible: false)
+      it 'renders as visible for js-enabled browsers' do
+        expect(rendered).to have_css('lg-webauthn-input.js:not([show-unsupported-passkey])')
       end
-    end
-  end
 
-  context 'with passkey_supported_only option' do
-    context 'with passkey_supported_only option false' do
-      let(:options) { { passkey_supported_only: false } }
+      context 'with passkey_supported_only option' do
+        context 'with passkey_supported_only option false' do
+          let(:options) { super().merge(passkey_supported_only: false) }
 
-      it 'renders without passkey-supported-only attribute' do
-        expect(rendered).to have_css(
-          'lg-webauthn-input[hidden]:not([passkey-supported-only])',
-          visible: false,
-        )
-      end
-    end
+          it 'renders as visible for js-enabled browsers' do
+            expect(rendered).to have_css('lg-webauthn-input.js:not([show-unsupported-passkey])')
+          end
+        end
 
-    context 'with passkey_supported_only option true' do
-      let(:options) { { passkey_supported_only: true } }
+        context 'with passkey_supported_only option true' do
+          let(:options) { super().merge(passkey_supported_only: true) }
 
-      it 'renders with passkey-supported-only attribute' do
-        expect(rendered).to have_css(
-          'lg-webauthn-input[hidden][passkey-supported-only]',
-          visible: false,
-        )
-      end
-    end
-  end
+          it 'renders as hidden' do
+            expect(rendered).to have_css(
+              'lg-webauthn-input[hidden]:not([show-unsupported-passkey])',
+              visible: false,
+            )
+          end
 
-  context 'with show_unsupported_passkey option' do
-    context 'with show_unsupported_passkey option false' do
-      let(:options) { { show_unsupported_passkey: false } }
+          context 'with show_unsupported_passkey option' do
+            context 'with show_unsupported_passkey option false' do
+              let(:options) { super().merge(show_unsupported_passkey: false) }
 
-      it 'renders without show-unsupported-passkey attribute' do
-        expect(rendered).to have_css(
-          'lg-webauthn-input[hidden]:not([show-unsupported-passkey])',
-          visible: false,
-        )
-      end
-    end
+              it 'renders as hidden' do
+                expect(rendered).to have_css(
+                  'lg-webauthn-input[hidden]:not([show-unsupported-passkey])',
+                  visible: false,
+                )
+              end
+            end
 
-    context 'with show_unsupported_passkey option true' do
-      let(:options) { { show_unsupported_passkey: true } }
+            context 'with show_unsupported_passkey option true' do
+              let(:options) { super().merge(show_unsupported_passkey: true) }
 
-      it 'renders with show-unsupported-passkey attribute' do
-        expect(rendered).to have_css(
-          'lg-webauthn-input[hidden][show-unsupported-passkey]',
-          visible: false,
-        )
+              it 'renders with show-unsupported-passkey attribute' do
+                expect(rendered).to have_css(
+                  'lg-webauthn-input[hidden][show-unsupported-passkey]',
+                  visible: false,
+                )
+              end
+            end
+          end
+        end
       end
     end
   end
@@ -96,7 +88,7 @@ RSpec.describe WebauthnInputComponent, type: :component do
     let(:options) { super().merge(data: { foo: 'bar' }) }
 
     it 'renders with additional attributes' do
-      expect(rendered).to have_css('lg-webauthn-input[hidden][data-foo="bar"]', visible: false)
+      expect(rendered).to have_css('lg-webauthn-input[data-foo="bar"]')
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Improves `WebauthnInputComponent` to avoid handling visibility in JavaScript for simple cases where the input should be visible in all JavaScript-enabled browsers.

**Draft:**

- [ ] Finish PR template

## 📜 Testing Plan

TBD