### PR TITLE
Lg 10190 remove reproof at from profiles 1 of 2

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,4 +1,6 @@
 class Profile < ApplicationRecord
+  self.ignored_columns += %w[reproof_at]
+
   belongs_to :user
   # rubocop:disable Rails/InverseOf
   belongs_to :initiating_service_provider,

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Idv::ProfileMaker do
 
       expect(pii).to be_a Pii::Attributes
       expect(pii.first_name).to eq('Some')
-      expect(profile.reproof_at).to be_nil
     end
 
     context 'with deactivation reason' do


### PR DESCRIPTION
changelog: Internal, Maintenance, Remove unused database column

## 🎫 Ticket

[LG-10190](https://cm-jira.usa.gov/browse/LG-10190)
Profiles schema should not have "reproof_at" attribute

## 🛠 Summary of changes

This PR ignores the `reproof_at` column in the `Profile` class

- [ ] blocks #8816 

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] rspec ./spec/services/idv/profile_maker_spec.rb:19 # Idv::ProfileMaker#save_profile creates an inactive Profile with encrypted PII

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
