### PR TITLE
Allow setting remembered device preference when logging in with backup codes (LG-10434)

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -1,12 +1,12 @@
 module RememberDeviceConcern
   extend ActiveSupport::Concern
 
-  def save_user_opted_remember_device_pref
-    cookies.encrypted[:user_opted_remember_device_preference] = params[:remember_device]
+  def save_user_opted_remember_device_pref(remember_device_preference)
+    cookies.encrypted[:user_opted_remember_device_preference] = remember_device_preference
   end
 
-  def save_remember_device_preference
-    return if params[:remember_device] != '1' && params[:remember_device] != 'true'
+  def save_remember_device_preference(remember_device_preference)
+    return if remember_device_preference != '1' && remember_device_preference != 'true'
     cookies.encrypted[:remember_device] = {
       value: RememberDeviceCookie.new(user_id: current_user.id, created_at: Time.zone.now).to_json,
       expires: remember_device_cookie_expiration,

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -85,9 +85,9 @@ module TwoFactorAuthenticatableMethods
     ).call
   end
 
-  def handle_remember_device
-    save_user_opted_remember_device_pref
-    save_remember_device_preference
+  def handle_remember_device_preference(remember_device_preference)
+    save_user_opted_remember_device_pref(remember_device_preference)
+    save_remember_device_preference(remember_device_preference)
   end
 
   # Method will be renamed in the next refactor.

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -61,6 +61,7 @@ module TwoFactorAuthentication
 
     def handle_result(result)
       if result.success?
+        handle_remember_device_preference(backup_code_params[:remember_device])
         handle_valid_verification_for_authentication_context(
           auth_method: TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
         )
@@ -72,7 +73,7 @@ module TwoFactorAuthentication
     end
 
     def backup_code_params
-      params.require(:backup_code_verification_form).permit :backup_code
+      params.require(:backup_code_verification_form).permit(:backup_code, :remember_device)
     end
 
     def handle_valid_backup_code

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -21,7 +21,7 @@ module TwoFactorAuthentication
       result = otp_verification_form.submit
       post_analytics(result)
       if result.success?
-        handle_remember_device
+        handle_remember_device_preference(params[:remember_device])
 
         if UserSessionContext.confirmation_context?(context)
           handle_valid_confirmation_otp

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -26,7 +26,7 @@ module TwoFactorAuthentication
         handle_valid_verification_for_authentication_context(
           auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,
         )
-        handle_remember_device
+        handle_remember_device_preference(params[:remember_device])
         redirect_to after_sign_in_path_for(current_user)
       else
         handle_invalid_otp(context: context, type: 'totp')

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -47,7 +47,7 @@ module TwoFactorAuthentication
           auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN,
         )
       end
-      handle_remember_device
+      handle_remember_device_preference(params[:remember_device])
       redirect_to after_sign_in_path_for(current_user)
     end
 

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -82,7 +82,7 @@ module Users
       handle_valid_verification_for_confirmation_context(
         auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,
       )
-      handle_remember_device
+      handle_remember_device_preference(params[:remember_device])
       flash[:success] = t('notices.totp_configured')
       user_session.delete(:new_totp_secret)
       redirect_to next_setup_path || after_mfa_setup_path

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -155,7 +155,7 @@ module Users
         platform_authenticator: form.platform_authenticator?,
         enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
       )
-      handle_remember_device
+      handle_remember_device_preference(params[:remember_device])
       if form.platform_authenticator?
         handle_valid_verification_for_confirmation_context(
           auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM,

--- a/app/views/partials/backup_code/_entry_fields.html.erb
+++ b/app/views/partials/backup_code/_entry_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="margin-bottom-4">
+<div class="margin-bottom-2">
   <%= f.input attribute_name,
               label: t('forms.two_factor.backup_code'),
               input_html: { autocapitalize: 'none',

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -12,6 +12,16 @@
       html: { autocomplete: 'off', method: :post },
     ) do |f| %>
   <%= render 'partials/backup_code/entry_fields', f: f, attribute_name: :backup_code %>
+  <%= f.input(
+        :remember_device,
+        as: :boolean,
+        label: t('forms.messages.remember_device'),
+        wrapper_html: { class: 'margin-top-2' },
+        input_html: {
+          class: 'usa-checkbox__input--bordered',
+          checked: @presenter.remember_device_box_checked?,
+        },
+      ) %>
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>
 

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
 
       context 'with remember_device in the params' do
         it 'saves an encrypted cookie' do
-          remember_device_cookie = instance_double(RememberDeviceCookie)
-          allow(remember_device_cookie).to receive(:to_json).and_return('asdf1234')
+          remember_device_cookie = instance_double(RememberDeviceCookie, to_json: 'asdf1234')
           allow(RememberDeviceCookie).to receive(:new).and_return(remember_device_cookie)
 
           stub_sign_in_before_2fa(user)

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -50,6 +50,27 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
         expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
       end
 
+      context 'with remember_device in the params' do
+        it 'saves an encrypted cookie' do
+          remember_device_cookie = instance_double(RememberDeviceCookie)
+          allow(remember_device_cookie).to receive(:to_json).and_return('asdf1234')
+          allow(RememberDeviceCookie).to receive(:new).and_return(remember_device_cookie)
+
+          stub_sign_in_before_2fa(user)
+          post(
+            :create,
+            params: {
+              backup_code_verification_form: {
+                backup_code: backup_codes.first,
+                remember_device: '1',
+              },
+            },
+          )
+
+          expect(cookies.encrypted[:remember_device]).to eq('asdf1234')
+        end
+      end
+
       it 'tracks the valid authentication event when there are exisitng codes' do
         freeze_time do
           stub_sign_in_before_2fa(user)

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -321,20 +321,28 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
 
       context 'with remember_device in the params' do
         it 'saves an encrypted cookie' do
-          remember_device_cookie = instance_double(RememberDeviceCookie)
-          allow(remember_device_cookie).to receive(:to_json).and_return('asdf1234')
-          allow(RememberDeviceCookie).to receive(:new).and_return(remember_device_cookie)
+          freeze_time do
+            expect(cookies.encrypted[:remember_device]).to eq nil
+            post(
+              :create,
+              params: {
+                code: subject.current_user.direct_otp,
+                otp_delivery_preference: 'sms',
+                remember_device: '1',
+              },
+            )
 
-          post(
-            :create,
-            params: {
-              code: subject.current_user.direct_otp,
-              otp_delivery_preference: 'sms',
-              remember_device: '1',
-            },
-          )
-
-          expect(cookies.encrypted[:remember_device]).to eq('asdf1234')
+            remember_device_cookie = RememberDeviceCookie.from_json(
+              cookies.encrypted[:remember_device],
+            )
+            expiration_interval = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
+            expect(
+              remember_device_cookie.valid_for_user?(
+                user: subject.current_user,
+                expiration_interval: expiration_interval,
+              ),
+            ).to eq true
+          end
         end
       end
 
@@ -674,20 +682,28 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
 
       context 'with remember_device in the params' do
         it 'saves an encrypted cookie' do
-          remember_device_cookie = instance_double(RememberDeviceCookie)
-          allow(remember_device_cookie).to receive(:to_json).and_return('asdf1234')
-          allow(RememberDeviceCookie).to receive(:new).and_return(remember_device_cookie)
+          freeze_time do
+            expect(cookies.encrypted[:remember_device]).to eq nil
+            post(
+              :create,
+              params: {
+                code: subject.current_user.direct_otp,
+                otp_delivery_preference: 'sms',
+                remember_device: '1',
+              },
+            )
 
-          post(
-            :create,
-            params: {
-              code: subject.current_user.direct_otp,
-              otp_delivery_preference: 'sms',
-              remember_device: '1',
-            },
-          )
-
-          expect(cookies.encrypted[:remember_device]).to eq('asdf1234')
+            remember_device_cookie = RememberDeviceCookie.from_json(
+              cookies.encrypted[:remember_device],
+            )
+            expiration_interval = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
+            expect(
+              remember_device_cookie.valid_for_user?(
+                user: subject.current_user,
+                expiration_interval: expiration_interval,
+              ),
+            ).to eq true
+          end
         end
       end
 

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature 'sign up with backup code' do
       expect(page).to \
         have_content t('two_factor_authentication.login_options.backup_code_info')
       visit login_two_factor_backup_code_path
+      uncheck(t('forms.messages.remember_device'))
       fill_in :backup_code_verification_form_backup_code, with: codes[index]
       click_on 'Submit'
       if index == BackupCodeGenerator::NUMBER_OF_CODES - 1


### PR DESCRIPTION
## 🛠 Summary of changes

Currently, we do not allow people to select a remembered device preference when logging in with backup codes. This PR adds the ability to do that.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
