### PR TITLE
Prompt users to accept rules of use when account was set up prior to rules of use change

### DIFF
--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -80,7 +80,11 @@ module SignUp
 
     def sign_in_and_redirect_user
       sign_in @user
-      redirect_to authentication_methods_setup_url
+      if current_user.accepted_rules_of_use_still_valid?
+        redirect_to authentication_methods_setup_url
+      else
+        redirect_to rules_of_use_url
+      end
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Currently, the rules of use check is only applied when submitting email address and password for an existing account. This change adds the check so that it also applies when initially setting an account password.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
