### PR TITLE
Log when user is logged out after partially authenticating

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -87,6 +87,7 @@ module Users
       if user_fully_authenticated?
         redirect_to signed_in_url
       elsif current_user
+        analytics.partial_authentication_log_out
         sign_out
       end
     end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2949,6 +2949,13 @@ module AnalyticsEvents
     )
   end
 
+  def partial_authentication_log_out(**extra)
+    track_event(
+      'Partially authenticated user logged out',
+      **extra,
+    )
+  end
+
   # @param [Boolean] success
   # @param [Hash] errors
   # The user updated their password

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe Users::SessionsController, devise: true do
 
   describe 'GET /users/sign_in' do
     it 'clears the session when user is not yet 2fa-ed' do
+      stub_analytics
+      expect(@analytics).to receive(:track_event).with(
+        'Sign in page visited',
+        flash: nil,
+        stored_location: nil,
+      )
+      expect(@analytics).to receive(:track_event).with('Partially authenticated user logged out')
       sign_in_before_2fa
 
       get :new


### PR DESCRIPTION
## 🛠 Summary of changes

In #897 based on discussion in https://github.com/18F/identity-private/issues/1202, behavior was added to log out users who have successfully entered their email/password but not completed authentication when they go to the home page. This is usually caused by clicking the Login.gov logo on the 2FA screen (pictured below).

To better understand the impact, this PR adds an analytics event so that we can see how frequently this happens (and whether affected users log in soon after).

![image](https://github.com/18F/identity-idp/assets/1430443/1a53b0bc-553f-4ad6-970a-786307ccf03c)


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
