### PR TITLE
Fix Rubocop namespace deprecation

### DIFF
--- a/spec/bin/oncall/email-deliveries_spec.rb
+++ b/spec/bin/oncall/email-deliveries_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe EmailDeliveries do
         and_return(instance_double('Reporting::CloudwatchClient', fetch: email_events))
     end
 
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     let(:events_log) do
       [
         { '@timestamp' => '2023-01-01 00:00:01', 'user_id' => 'abc123', 'ses_message_id' => 'message-1' },
@@ -71,7 +71,7 @@ RSpec.describe EmailDeliveries do
         { '@timestamp' => '2023-01-01 00:00:04', 'ses_message_id' => 'message-2', 'event_type' => 'Bounce' },
       ]
     end
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
 
     it 'prints a table of events by message ID' do
       run


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a small warning that we're seeing when running rubocop:

```
spec/bin/oncall/email-deliveries_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
spec/bin/oncall/email-deliveries_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
