### PR TITLE
Move SMS job to appropriate queue; remove redundant update

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -229,7 +229,6 @@ class GetUspsProofingResultsJob < ApplicationJob
         job_name: self.class.name,
       )
     enrollment.update(status_check_completed_at: Time.zone.now)
-    enrollment.update(status_check_completed_at: Time.zone.now)
   end
 
   def handle_expired_status_update(enrollment, response, response_message)
@@ -456,11 +455,10 @@ class GetUspsProofingResultsJob < ApplicationJob
     sms_delay_hours = IdentityConfig.store.in_person_results_delay_in_hours ||
                       DEFAULT_EMAIL_DELAY_IN_HOURS
     wait_until = enrollment.proofed_at + sms_delay_hours
-    if wait_until > Time.zone.now
-      InPerson::SendProofingNotificationJob.set(wait_until: wait_until).perform_later(enrollment.id)
-    else
-      InPerson::SendProofingNotificationJob.perform_later(enrollment.id)
-    end
+    InPerson::SendProofingNotificationJob.set(
+      wait_until: wait_until,
+      queue: :intentionally_delayed,
+    ).perform_later(enrollment.id)
   end
 
   def email_analytics_attributes(enrollment)

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -645,7 +645,7 @@ RSpec.describe GetUspsProofingResultsJob do
             expect do
               job.perform(Time.zone.now)
             end.to have_enqueued_job(InPerson::SendProofingNotificationJob).
-              with(pending_enrollment.id)
+              with(pending_enrollment.id).on_queue(:intentionally_delayed)
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: Enrollment status updated',
@@ -1141,7 +1141,7 @@ RSpec.describe GetUspsProofingResultsJob do
             expect do
               job.perform Time.zone.now
             end.to have_enqueued_job(InPerson::SendProofingNotificationJob).
-              with(pending_enrollment.id)
+              with(pending_enrollment.id).on_queue(:intentionally_delayed)
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(pending_enrollment.profile.active).to eq(false)
             expect(job_analytics).to have_logged_event(


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10248](https://cm-jira.usa.gov/browse/LG-10248)
- This is cleanup prior to implementation of the ticket.

## 🛠 Summary of changes

- Move the SMS notification job to the appropriate queue
  - This prevents a queue time alarm from being accidentally triggered.
- Remove redundant conditional for performing job
  - Jobs scheduled for the past get executed almost immediately.
- Remove redundant record update

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Enroll for in-person proofing
- [ ] Complete in-person step
- [ ] Run proofing results job
- [ ] Verify that notifications are received
  - Precise timing will vary until the original story is completed.

Note that this may be more easily simulated for a local dev stack by using a command like the following:

```sh
bundle exec rails dev:random_in_person_users NUM_USERS='1' SCRYPT_COST='800$8$1$' ENROLLMENT_STATUS='passed'
```
