### PR TITLE
Hide doc capture tips from users

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -91,7 +91,7 @@ doc_auth_error_dpi_threshold: 290
 doc_auth_error_glare_threshold: 40
 doc_auth_error_sharpness_threshold: 40
 doc_auth_max_attempts: 5
-doc_auth_max_capture_attempts_before_tips: 20 
+doc_auth_max_capture_attempts_before_tips: 20
 doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_capture_request_valid_for_minutes: 15

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -91,7 +91,7 @@ doc_auth_error_dpi_threshold: 290
 doc_auth_error_glare_threshold: 40
 doc_auth_error_sharpness_threshold: 40
 doc_auth_max_attempts: 5
-doc_auth_max_capture_attempts_before_tips: 3
+doc_auth_max_capture_attempts_before_tips: 20 
 doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_capture_request_valid_for_minutes: 15


### PR DESCRIPTION

## 🎫 Ticket
[LG-10446](https://cm-jira.usa.gov/browse/LG-10446)


## 🛠 Summary of changes
- Prevent user from seeing document capture tips after they fail sdk image capture three times.


## 📜 Testing Plan
- [ ] Enable [local mobile development](https://github.com/18F/identity-idp/blob/main/docs/mobile.md)
- [ ] Make a local change to force sdk image capture failure (eg increase `glareThreshold` in `onAcuantImageCaptureSuccess` method to 100)
- [ ] Attempt to capture an image with the sdk three times
- [ ] After the third failed attempt, confirm that you are redirected to the native camera and do not see the Document Capture Tips


## 👀 Screenshots

Here is a screenshot of the page that we DON'T want the user to see
<details>
<summary>Document Capture Tips:</summary>
  
![Screen Shot 2023-07-24 at 2 18 41 PM](https://github.com/18F/identity-idp/assets/80347702/91ceb0ea-3879-4a54-b684-60f757737a10)

</details>
