### PR TITLE
LG-10126: SendProofingNotificationJob refactor

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -212,6 +212,8 @@ class GetUspsProofingResultsJob < ApplicationJob
       status_check_completed_at: Time.zone.now,
     )
 
+    # send SMS and email
+    send_enrollment_status_sms_notification(enrollment: enrollment)
     send_failed_email(enrollment.user, enrollment)
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
       **email_analytics_attributes(enrollment),
@@ -373,6 +375,8 @@ class GetUspsProofingResultsJob < ApplicationJob
       proofed_at: proofed_at,
       status_check_completed_at: Time.zone.now,
     )
+    # send SMS and email
+    send_enrollment_status_sms_notification(enrollment: enrollment)
     send_failed_email(enrollment.user, enrollment)
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
       **email_analytics_attributes(enrollment),

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -245,8 +245,10 @@ class GetUspsProofingResultsJob < ApplicationJob
       status: :expired,
       status_check_completed_at: Time.zone.now,
     )
-    # destroy phone number for expired
+
+    # destroy phone number for expired enrollments
     enrollment.notification_phone_configuration&.destroy
+
     begin
       send_deadline_passed_email(enrollment.user, enrollment) unless enrollment.deadline_passed_sent
     rescue StandardError => err
@@ -310,6 +312,9 @@ class GetUspsProofingResultsJob < ApplicationJob
       proofed_at: proofed_at,
       status_check_completed_at: Time.zone.now,
     )
+
+    # send SMS and email
+    send_enrollment_status_sms_notification(enrollment: enrollment)
     if response['fraudSuspected']
       send_failed_fraud_email(enrollment.user, enrollment)
       analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
@@ -343,6 +348,9 @@ class GetUspsProofingResultsJob < ApplicationJob
       proofed_at: proofed_at,
       status_check_completed_at: Time.zone.now,
     )
+
+    # send SMS and email
+    send_enrollment_status_sms_notification(enrollment: enrollment)
     send_verified_email(enrollment.user, enrollment)
     analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
       **email_analytics_attributes(enrollment),
@@ -394,9 +402,6 @@ class GetUspsProofingResultsJob < ApplicationJob
     else
       handle_unsupported_status(enrollment, response)
     end
-
-    # invoke job to send sms notification
-    send_enrollment_status_sms_notification(enrollment: enrollment)
   end
 
   def send_verified_email(user, enrollment)

--- a/app/jobs/in_person/send_proofing_notification_job.rb
+++ b/app/jobs/in_person/send_proofing_notification_job.rb
@@ -45,6 +45,14 @@ module InPerson
       enrollment.update(notification_sent_at: Time.zone.now) if response.success?
 
       log_job_completed(enrollment: enrollment)
+    rescue StandardError => err
+      analytics(user: enrollment&.user || AnonymousUser.new).
+        idv_in_person_send_proofing_notification_job_exception(
+          enrollment_code: enrollment&.code,
+          enrollment_id: enrollment_id,
+          exception_class: err.class.to_s,
+          exception_message: err.message,
+        )
     end
 
     private

--- a/app/jobs/in_person/send_proofing_notification_job.rb
+++ b/app/jobs/in_person/send_proofing_notification_job.rb
@@ -12,8 +12,9 @@ module InPerson
           include: [:notification_phone_configuration, :user],
         )
         return unless enrollment
-        # skip when enrollment status not success/failed/expired and no phone configured
-        if enrollment.skip_notification_sent_at_set?
+
+        # skip when enrollment status not success/failed/expired or no phone configured
+        if !enrollment.eligible_for_notification?
           # log event
           analytics(user: enrollment.user).
             idv_in_person_usps_proofing_results_notification_job_skipped(
@@ -22,6 +23,7 @@ module InPerson
             )
           return
         end
+
         analytics(user: enrollment.user).
           idv_in_person_usps_proofing_results_notification_job_started(
             enrollment_code: enrollment.enrollment_code,

--- a/app/jobs/in_person/send_proofing_notification_job.rb
+++ b/app/jobs/in_person/send_proofing_notification_job.rb
@@ -16,7 +16,7 @@ module InPerson
         analytics(user: enrollment&.user || AnonymousUser.new).
           idv_in_person_send_proofing_notification_job_skipped(
             enrollment_code: enrollment&.enrollment_code,
-            enrollment_id: enrollment&.id,
+            enrollment_id: enrollment_id,
           )
         return
       end

--- a/app/jobs/in_person/send_proofing_notification_job.rb
+++ b/app/jobs/in_person/send_proofing_notification_job.rb
@@ -14,7 +14,7 @@ module InPerson
 
       if enrollment.nil? || !enrollment.eligible_for_notification?
         analytics(user: enrollment&.user || AnonymousUser.new).
-          idv_in_person_usps_proofing_results_notification_job_skipped(
+          idv_in_person_send_proofing_notification_job_skipped(
             enrollment_code: enrollment&.enrollment_code,
             enrollment_id: enrollment&.id,
           )
@@ -22,7 +22,7 @@ module InPerson
       end
 
       analytics(user: enrollment.user).
-        idv_in_person_usps_proofing_results_notification_job_started(
+        idv_in_person_send_proofing_notification_job_started(
           enrollment_code: enrollment.enrollment_code,
           enrollment_id: enrollment.id,
         )
@@ -51,14 +51,14 @@ module InPerson
 
     def log_job_completed(enrollment:)
       analytics(user: enrollment.user).
-        idv_in_person_usps_proofing_results_notification_job_completed(
+        idv_in_person_send_proofing_notification_job_completed(
           enrollment_code: enrollment.enrollment_code, enrollment_id: enrollment.id,
         )
     end
 
     def handle_telephony_response(enrollment:, phone:, telephony_response:)
       analytics(user: enrollment.user).
-        idv_in_person_usps_proofing_results_notification_sent_attempted(
+        idv_in_person_send_proofing_notification_attempted(
           success: telephony_response.success?,
           enrollment_code: enrollment.enrollment_code,
           enrollment_id: enrollment.id,

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -133,8 +133,9 @@ class InPersonEnrollment < ApplicationRecord
     end
   end
 
-  def skip_notification_sent_at_set?
-    !notification_phone_configuration.present? || (!self.passed? && !self.failed? && !self.expired?)
+  def eligible_for_notification?
+    self.notification_phone_configuration.present? &&
+      (self.passed? || self.failed? || self.expired?)
   end
 
   private

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1787,7 +1787,7 @@ module AnalyticsEvents
     **extra
   )
     track_event(
-      'GetUspsProofingResultsJob: Exception raised',
+      'SendProofingNotificationJob: Exception raised',
       enrollment_code: enrollment_code,
       enrollment_id: enrollment_id,
       exception_class: exception_class,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1726,9 +1726,11 @@ module AnalyticsEvents
   # @param [String] enrollment_code enrollment_code
   # @param [String] enrollment_id enrollment_id
   # @param [Hash] extra extra information
-  def idv_in_person_usps_proofing_results_notification_job_completed(enrollment_code:,
-                                                                     enrollment_id:,
-                                                                     **extra)
+  def idv_in_person_send_proofing_notification_job_completed(
+    enrollment_code:,
+    enrollment_id:,
+    **extra
+  )
     track_event(
       'SendProofingNotificationAndDeletePhoneNumberJob: job completed',
       enrollment_code: enrollment_code,
@@ -1741,7 +1743,7 @@ module AnalyticsEvents
   # @param [String] enrollment_code enrollment_code
   # @param [String] enrollment_id enrollment_id
   # @param [Hash] extra extra information
-  def idv_in_person_usps_proofing_results_notification_job_skipped(
+  def idv_in_person_send_proofing_notification_job_skipped(
     enrollment_code:,
     enrollment_id:,
     **extra
@@ -1758,9 +1760,11 @@ module AnalyticsEvents
   # @param [String] enrollment_code enrollment_code
   # @param [String] enrollment_id enrollment_id
   # @param [Hash] extra extra information
-  def idv_in_person_usps_proofing_results_notification_job_started(enrollment_code:,
-                                                                   enrollment_id:,
-                                                                   **extra)
+  def idv_in_person_send_proofing_notification_job_started(
+    enrollment_code:,
+    enrollment_id:,
+    **extra
+  )
     track_event(
       'SendProofingNotificationAndDeletePhoneNumberJob: job started',
       enrollment_code: enrollment_code,
@@ -1775,7 +1779,7 @@ module AnalyticsEvents
   # @param [String] enrollment_id enrollment_id
   # @param [Hash] telephony_response response from Telephony gem
   # @param [Hash] extra extra information
-  def idv_in_person_usps_proofing_results_notification_sent_attempted(
+  def idv_in_person_send_proofing_notification_attempted(
     success:,
     enrollment_code:,
     enrollment_id:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1773,6 +1773,29 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks exceptions that are raised when running InPerson::SendProofingNotificationJob
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  # @param [Hash] extra extra information
+  def idv_in_person_send_proofing_notification_job_exception(
+    enrollment_code:,
+    enrollment_id:,
+    exception_class: nil,
+    exception_message: nil,
+    **extra
+  )
+    track_event(
+      'GetUspsProofingResultsJob: Exception raised',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
   # Track sms notification attempt
   # @param [boolean] success sms notification successful or not
   # @param [String] enrollment_code enrollment_code

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1464,6 +1464,103 @@ module AnalyticsEvents
     )
   end
 
+  # Track sms notification attempt
+  # @param [boolean] success sms notification successful or not
+  # @param [String] enrollment_code enrollment_code
+  # @param [String] enrollment_id enrollment_id
+  # @param [Hash] telephony_response response from Telephony gem
+  # @param [Hash] extra extra information
+  def idv_in_person_send_proofing_notification_attempted(
+    success:,
+    enrollment_code:,
+    enrollment_id:,
+    telephony_response:,
+    **extra
+  )
+    track_event(
+      'IdV: in person notification SMS send attempted',
+      success: success,
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      telephony_response: telephony_response,
+      **extra,
+    )
+  end
+
+  # Track sms notification job completion
+  # @param [String] enrollment_code enrollment_code
+  # @param [String] enrollment_id enrollment_id
+  # @param [Hash] extra extra information
+  def idv_in_person_send_proofing_notification_job_completed(
+    enrollment_code:,
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      'SendProofingNotificationAndDeletePhoneNumberJob: job completed',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
+
+  # Tracks exceptions that are raised when running InPerson::SendProofingNotificationJob
+  # @param [String] enrollment_code
+  # @param [String] enrollment_id
+  # @param [String] exception_class
+  # @param [String] exception_message
+  # @param [Hash] extra extra information
+  def idv_in_person_send_proofing_notification_job_exception(
+    enrollment_code:,
+    enrollment_id:,
+    exception_class: nil,
+    exception_message: nil,
+    **extra
+  )
+    track_event(
+      'SendProofingNotificationJob: Exception raised',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
+  # Track sms notification job skipped
+  # @param [String] enrollment_code enrollment_code
+  # @param [String] enrollment_id enrollment_id
+  # @param [Hash] extra extra information
+  def idv_in_person_send_proofing_notification_job_skipped(
+    enrollment_code:,
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      'SendProofingNotificationAndDeletePhoneNumberJob: job skipped',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
+
+  # Track sms notification job started
+  # @param [String] enrollment_code enrollment_code
+  # @param [String] enrollment_id enrollment_id
+  # @param [Hash] extra extra information
+  def idv_in_person_send_proofing_notification_job_started(
+    enrollment_code:,
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      'SendProofingNotificationAndDeletePhoneNumberJob: job started',
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
+      **extra,
+    )
+  end
+
   # @param [String] flow_path Document capture path ("hybrid" or "standard")
   # The user submitted the in person proofing switch_back step
   def idv_in_person_switch_back_submitted(flow_path:, **extra)
@@ -1718,103 +1815,6 @@ module AnalyticsEvents
       minutes_since_established: minutes_since_established,
       response_message: response_message,
       reason: reason,
-      **extra,
-    )
-  end
-
-  # Track sms notification job completion
-  # @param [String] enrollment_code enrollment_code
-  # @param [String] enrollment_id enrollment_id
-  # @param [Hash] extra extra information
-  def idv_in_person_send_proofing_notification_job_completed(
-    enrollment_code:,
-    enrollment_id:,
-    **extra
-  )
-    track_event(
-      'SendProofingNotificationAndDeletePhoneNumberJob: job completed',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      **extra,
-    )
-  end
-
-  # Track sms notification job skipped
-  # @param [String] enrollment_code enrollment_code
-  # @param [String] enrollment_id enrollment_id
-  # @param [Hash] extra extra information
-  def idv_in_person_send_proofing_notification_job_skipped(
-    enrollment_code:,
-    enrollment_id:,
-    **extra
-  )
-    track_event(
-      'SendProofingNotificationAndDeletePhoneNumberJob: job skipped',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      **extra,
-    )
-  end
-
-  # Track sms notification job started
-  # @param [String] enrollment_code enrollment_code
-  # @param [String] enrollment_id enrollment_id
-  # @param [Hash] extra extra information
-  def idv_in_person_send_proofing_notification_job_started(
-    enrollment_code:,
-    enrollment_id:,
-    **extra
-  )
-    track_event(
-      'SendProofingNotificationAndDeletePhoneNumberJob: job started',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      **extra,
-    )
-  end
-
-  # Tracks exceptions that are raised when running InPerson::SendProofingNotificationJob
-  # @param [String] enrollment_code
-  # @param [String] enrollment_id
-  # @param [String] exception_class
-  # @param [String] exception_message
-  # @param [Hash] extra extra information
-  def idv_in_person_send_proofing_notification_job_exception(
-    enrollment_code:,
-    enrollment_id:,
-    exception_class: nil,
-    exception_message: nil,
-    **extra
-  )
-    track_event(
-      'SendProofingNotificationJob: Exception raised',
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      exception_class: exception_class,
-      exception_message: exception_message,
-      **extra,
-    )
-  end
-
-  # Track sms notification attempt
-  # @param [boolean] success sms notification successful or not
-  # @param [String] enrollment_code enrollment_code
-  # @param [String] enrollment_id enrollment_id
-  # @param [Hash] telephony_response response from Telephony gem
-  # @param [Hash] extra extra information
-  def idv_in_person_send_proofing_notification_attempted(
-    success:,
-    enrollment_code:,
-    enrollment_id:,
-    telephony_response:,
-    **extra
-  )
-    track_event(
-      'IdV: in person notification SMS send attempted',
-      success: success,
-      enrollment_code: enrollment_code,
-      enrollment_id: enrollment_id,
-      telephony_response: telephony_response,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1773,13 +1773,13 @@ module AnalyticsEvents
   # @param [boolean] success sms notification successful or not
   # @param [String] enrollment_code enrollment_code
   # @param [String] enrollment_id enrollment_id
-  # @param [Telephony::Response] telephony_result
+  # @param [Hash] telephony_response response from Telephony gem
   # @param [Hash] extra extra information
   def idv_in_person_usps_proofing_results_notification_sent_attempted(
     success:,
     enrollment_code:,
     enrollment_id:,
-    telephony_result:,
+    telephony_response:,
     **extra
   )
     track_event(
@@ -1787,7 +1787,7 @@ module AnalyticsEvents
       success: success,
       enrollment_code: enrollment_code,
       enrollment_id: enrollment_id,
-      telephony_result: telephony_result,
+      telephony_response: telephony_response,
       **extra,
     )
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -139,7 +139,6 @@ in_person_email_reminder_early_benchmark_in_days: 11
 in_person_email_reminder_final_benchmark_in_days: 1
 in_person_email_reminder_late_benchmark_in_days: 4
 in_person_proofing_enabled: false
-in_person_send_proofing_notifications_enabled: false
 in_person_enrollment_validity_in_days: 30
 in_person_enrollments_ready_job_email_body_pattern: '\A\s*(?<enrollment_code>\d{16})\s*\Z'
 in_person_enrollments_ready_job_cron: '0/10 * * * *'

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -185,6 +185,23 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           expect(passed_enrollment.reload.notification_sent_at).to be_nil
         end
       end
+      context 'when an exception is raised' do
+        it 'logs the exception details' do
+          allow(InPersonEnrollment).
+            to receive(:find_by).
+            and_raise(ActiveRecord::DatabaseConnectionError)
+
+          job.perform(passed_enrollment.id)
+
+          expect(analytics).to have_logged_event(
+            'GetUspsProofingResultsJob: Exception raised',
+            enrollment_code: nil,
+            enrollment_id: passed_enrollment.id,
+            exception_class: 'ActiveRecord::DatabaseConnectionError',
+            exception_message: 'Database connection error',
+          )
+        end
+      end
     end
   end
 end

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -83,13 +83,25 @@ RSpec.describe InPerson::SendProofingNotificationJob do
     context 'ipp and job enabled' do
       let(:in_person_proofing_enabled) { true }
       let(:in_person_send_proofing_notifications_enabled) { true }
+      context 'enrollment does not exist' do
+        it 'returns without doing anything' do
+          bad_id = (InPersonEnrollment.all.pluck(:id).max || 0) + 1
+          expect(analytics).not_to receive(
+            :idv_in_person_usps_proofing_results_notification_job_started,
+          )
+          expect(analytics).to receive(
+            :idv_in_person_usps_proofing_results_notification_job_skipped,
+          )
+          job.perform(bad_id)
+        end
+      end
       context 'without notification phone notification' do
         it 'returns without doing anything' do
           expect(analytics).not_to receive(
             :idv_in_person_usps_proofing_results_notification_job_started,
           )
           expect(analytics).to receive(
-            :idv_in_person_usps_proofing_results_notification_job_completed,
+            :idv_in_person_usps_proofing_results_notification_job_skipped,
           )
           job.perform(passed_enrollment_without_notification.id)
         end

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           job.perform(passed_enrollment.id)
 
           expect(analytics).to have_logged_event(
-            'GetUspsProofingResultsJob: Exception raised',
+            'SendProofingNotificationJob: Exception raised',
             enrollment_code: nil,
             enrollment_id: passed_enrollment.id,
             exception_class: 'ActiveRecord::DatabaseConnectionError',

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe InPerson::SendProofingNotificationJob do
       let(:in_person_send_proofing_notifications_enabled) { true }
       it 'returns without doing anything' do
         expect(analytics).not_to receive(
-          :idv_in_person_usps_proofing_results_notification_job_started,
+          :idv_in_person_send_proofing_notification_job_started,
         )
         expect(analytics).not_to receive(
-          :idv_in_person_usps_proofing_results_notification_job_completed,
+          :idv_in_person_send_proofing_notification_job_completed,
         )
         expect(job).not_to receive(:poll)
         expect(job).not_to receive(:process_batch)
@@ -70,10 +70,10 @@ RSpec.describe InPerson::SendProofingNotificationJob do
       let(:in_person_send_proofing_notifications_enabled) { false }
       it 'returns without doing anything' do
         expect(analytics).not_to receive(
-          :idv_in_person_usps_proofing_results_notification_job_started,
+          :idv_in_person_send_proofing_notification_job_started,
         )
         expect(analytics).not_to receive(
-          :idv_in_person_usps_proofing_results_notification_job_completed,
+          :idv_in_person_send_proofing_notification_job_completed,
         )
         expect(job).not_to receive(:poll)
         expect(job).not_to receive(:process_batch)
@@ -87,10 +87,10 @@ RSpec.describe InPerson::SendProofingNotificationJob do
         it 'returns without doing anything' do
           bad_id = (InPersonEnrollment.all.pluck(:id).max || 0) + 1
           expect(analytics).not_to receive(
-            :idv_in_person_usps_proofing_results_notification_job_started,
+            :idv_in_person_send_proofing_notification_job_started,
           )
           expect(analytics).to receive(
-            :idv_in_person_usps_proofing_results_notification_job_skipped,
+            :idv_in_person_send_proofing_notification_job_skipped,
           )
           job.perform(bad_id)
         end
@@ -98,10 +98,10 @@ RSpec.describe InPerson::SendProofingNotificationJob do
       context 'without notification phone notification' do
         it 'returns without doing anything' do
           expect(analytics).not_to receive(
-            :idv_in_person_usps_proofing_results_notification_job_started,
+            :idv_in_person_send_proofing_notification_job_started,
           )
           expect(analytics).to receive(
-            :idv_in_person_usps_proofing_results_notification_job_skipped,
+            :idv_in_person_send_proofing_notification_job_skipped,
           )
           job.perform(passed_enrollment_without_notification.id)
         end
@@ -113,13 +113,13 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           freeze_time do
             now = Time.zone.now
             expect(analytics).to receive(
-              :idv_in_person_usps_proofing_results_notification_job_started,
+              :idv_in_person_send_proofing_notification_job_started,
             )
             expect(analytics).to receive(
-              :idv_in_person_usps_proofing_results_notification_job_completed,
+              :idv_in_person_send_proofing_notification_job_completed,
             )
             expect(analytics).to receive(
-              :idv_in_person_usps_proofing_results_notification_sent_attempted,
+              :idv_in_person_send_proofing_notification_attempted,
             )
             expect(passed_enrollment.reload.notification_sent_at).to be_nil
 
@@ -134,13 +134,13 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           freeze_time do
             now = Time.zone.now
             expect(analytics).to receive(
-              :idv_in_person_usps_proofing_results_notification_job_started,
+              :idv_in_person_send_proofing_notification_job_started,
             )
             expect(analytics).to receive(
-              :idv_in_person_usps_proofing_results_notification_job_completed,
+              :idv_in_person_send_proofing_notification_job_completed,
             )
             expect(analytics).to receive(
-              :idv_in_person_usps_proofing_results_notification_sent_attempted,
+              :idv_in_person_send_proofing_notification_attempted,
             )
             job.perform(failing_enrollment.id)
             expect(failing_enrollment.reload.notification_sent_at).to eq(now)
@@ -151,13 +151,13 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           allow(Telephony).to receive(:send_notification).and_return(sms_success_response)
           freeze_time do
             expect(analytics).to receive(
-              :idv_in_person_usps_proofing_results_notification_job_started,
+              :idv_in_person_send_proofing_notification_job_started,
             )
             expect(analytics).to receive(
-              :idv_in_person_usps_proofing_results_notification_job_completed,
+              :idv_in_person_send_proofing_notification_job_completed,
             )
             expect(analytics).not_to receive(
-              :idv_in_person_usps_proofing_results_notification_sent_attempted,
+              :idv_in_person_send_proofing_notification_attempted,
             )
             job.perform(expired_enrollment.id)
             expect(expired_enrollment.reload.notification_sent_at).to be_nil
@@ -170,7 +170,7 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           allow(Telephony).to receive(:send_notification).and_return(sms_opt_out_response)
 
           expect(analytics).to receive(
-            :idv_in_person_usps_proofing_results_notification_sent_attempted,
+            :idv_in_person_send_proofing_notification_attempted,
           )
           job.perform(passed_enrollment.id)
           expect(passed_enrollment.reload.notification_sent_at).to be_nil
@@ -179,7 +179,7 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           allow(Telephony).to receive(:send_notification).and_return(sms_failure_response)
 
           expect(analytics).to receive(
-            :idv_in_person_usps_proofing_results_notification_sent_attempted,
+            :idv_in_person_send_proofing_notification_attempted,
           )
           job.perform(passed_enrollment.id)
           expect(passed_enrollment.reload.notification_sent_at).to be_nil

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -389,9 +389,12 @@ RSpec.describe InPersonEnrollment, type: :model do
     end
   end
 
-  describe 'skip_notification_sent_at_set?' do
+  describe 'eligible_for_notification?' do
     let(:passed_enrollment) do
       create(:in_person_enrollment, :passed, :with_notification_phone_configuration)
+    end
+    let(:failed_enrollment) do
+      create(:in_person_enrollment, :failed, :with_notification_phone_configuration)
     end
     let(:expired_enrollment) do
       create(:in_person_enrollment, :expired, :with_notification_phone_configuration)
@@ -406,14 +409,16 @@ RSpec.describe InPersonEnrollment, type: :model do
       create(:in_person_enrollment, :failed)
     end
 
-    it 'returns false when status of passed/failed/expired and notification configuration' do
-      expect(passed_enrollment.skip_notification_sent_at_set?).to eq(false)
-      expect(expired_enrollment.skip_notification_sent_at_set?).to eq(false)
+    it 'returns true when status of passed/failed/expired and notification configuration' do
+      expect(passed_enrollment.eligible_for_notification?).to eq(true)
+      expect(failed_enrollment.eligible_for_notification?).to eq(true)
+      expect(expired_enrollment.eligible_for_notification?).to eq(true)
     end
+
     it 'returns false when status of incomplete or without notification configuration' do
-      expect(incomplete_enrollment.skip_notification_sent_at_set?).to eq(true)
-      expect(passed_enrollment_without_notification.skip_notification_sent_at_set?).to eq(true)
-      expect(failed_enrollment_without_notification.skip_notification_sent_at_set?).to eq(true)
+      expect(incomplete_enrollment.eligible_for_notification?).to eq(false)
+      expect(passed_enrollment_without_notification.eligible_for_notification?).to eq(false)
+      expect(failed_enrollment_without_notification.eligible_for_notification?).to eq(false)
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-10126](https://cm-jira.usa.gov/browse/LG-10126)

## 🛠 Summary of changes

Follow-up to #8772, refactors related to the implementation of `SendProofingNotificationJob`.

The only functional changes:
- Only invokes the job when we get a pass/fail from the USPS API
- Log notification job 'skipped' when the enrollment can't be found (instead of 'completed')
- Capture exceptions and log them with a new analytics event
- Converts telephony response to a hash before logging it
