### PR TITLE
Add tests to check for matching HTML tags across locales

### DIFF
--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -58,9 +58,9 @@ en:
         zipcode: Enter a 5 or 9 digit ZIP Code
     failure:
       attempts_html:
-        one: For security reasons, you have <strong>one attempt<strong> remaining to add
-          your ID online.
-        other: For security reasons, you have <strong>%{count} attempts<strong>
+        one: For security reasons, you have <strong>one attempt</strong> remaining to
+          add your ID online.
+        other: For security reasons, you have <strong>%{count} attempts</strong>
           remaining to add your ID online.
       button:
         try_online: Try again online
@@ -280,7 +280,7 @@ en:
       state_id:
         cancel_button: Exit %{app_name}
         explanation: |
-          Unfortunately, we’re experiencing technical difficulties 
+          Unfortunately, we’re experiencing technical difficulties
           with IDs from your state and are currently unable to verify your information.
         heading: We are working to resolve an error
         next_steps:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -130,7 +130,7 @@ fr:
             how_long_it_takes: Cette procédure prend typiquement 3 à 7 jours ouvrables.
           heading: Nous n’avons pas pu vous associer à ce numéro
           learn_more_link: 'Apprenez-en plus sur quel numéro de téléphone utiliser'
-          next_steps_html: 'Essayez <strtong>un autre<strong> numéro que vous utilisez
+          next_steps_html: 'Essayez <strong>un autre</strong> numéro que vous utilisez
             souvent et depuis longtemps. Il peut s’agir d’un numéro
             professionnel ou personnel.'
           try_again_button: 'Essayez un autre numéro'

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -32,12 +32,12 @@ fr:
           votre mot de passe. Ajoutez ensuite votre PIV/CAC à votre compte.</p>
           <p><strong>Vous n’avez pas de compte %{app_name}?</strong>
           %{create_account}</p>'
-        add_from_sign_in_html: '<strong> Instructions: </ strong> insérez votre PIV ou
-          votre CAC dans <strong> “AJOUTER PIV / CAC” </ strong>. Vous devez
-          <strong> choisir un certificat </ strong> (le bon en a probablement
-          votre nom) et <strong> saisir votre code confidentiel </ strong>
-          (votre code confidentiel a été créé lors de la configuration de votre
-          PIV / CAC). ).'
+        add_from_sign_in_html: '<strong> Instructions: </strong> insérez votre PIV ou
+          votre CAC dans <strong> “AJOUTER PIV / CAC” </strong>. Vous devez
+          <strong> choisir un certificat </strong> (le bon en a probablement
+          votre nom) et <strong> saisir votre code confidentiel </strong> (votre
+          code confidentiel a été créé lors de la configuration de votre PIV /
+          CAC). ).'
         already_associated_html: Veuillez choisir un certificat associé à une autre
           carte PIV/CAC ou contactez votre administrateur afin de vérifier que
           votre carte PIV/CAC est bien à jour. Si vous pensez que c’est une

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -198,7 +198,7 @@ en:
         help, please visit the %{app_name_html} %{help_link_html} or
         %{contact_link_html}.
       info_html: '<p>Your %{app_name} account was just used to sign in on a new
-        device.</p><br/> <p><strong>%{date}<br/>%{location}</strong></p>'
+        device.</p><br/><p><strong>%{date}<br/>%{location}</strong></p>'
       subject: New sign-in with your %{app_name} account
     password_changed:
       disavowal_link: reset your password

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -214,8 +214,7 @@ es:
       help_html: Si no realizó este cambio, %{disavowal_link_html}. Para más ayuda,
         visite el %{app_name_html} %{help_link_html} o el %{contact_link_html}.
       info_html: '<p>Su cuenta %{app_name} acaba de iniciar sesión en un nuevo
-        dispositivo.</p><br/><br/>
-        <p><strong>%{date}<br/>%{location}</strong></p>'
+        dispositivo.</p><br/><p><strong>%{date}<br/>%{location}</strong></p>'
       subject: Nuevo initio de sesion con su %{app_name} cuenta
     password_changed:
       disavowal_link: restablecer su contraseña
@@ -256,11 +255,12 @@ es:
         %{app_name}</a></strong> y asegúrese de reconocer toda la información en
         la página de su cuenta, incluidos los métodos que utiliza para la
         autenticación de dos factores, como el número de teléfono, la aplicación
-        de autenticación, o la clave de seguridad.</li><li><strong>En la página
-        de su cuenta %{app_name}, solicite una nueva clave personal.</strong>
-        Recuerde, nunca lo comparta a menos que lo esté utilizando para iniciar
-        sesión en un sitio web de confianza que utiliza
-        %{app_name}.</li></ol></p><br>Gracias,<br>El equipo de %{app_name}
+        de autenticación, o la clave de seguridad.</li><li><strong>En <a
+        href="%{account_url}">la página de su cuenta %{app_name}</a>, solicite
+        una nueva clave personal.</strong> Recuerde, nunca lo comparta a menos
+        que lo esté utilizando para iniciar sesión en un sitio web de confianza
+        que utiliza %{app_name}.</li></ol></p><br>Gracias,<br>El equipo de
+        %{app_name}
       intro: Clave personal utilizada para iniciar sesión
       subject: Alerta de seguridad de cuenta
     phone_added:

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -219,7 +219,7 @@ fr:
         Pour plus d’aide, veuillez visiter le %{help_link_html} de
         %{app_name_html} ou %{contact_link_html}.
       info_html: '<p>Votre compte %{app_name} a été connecté sur un nouvel
-        appareil.</p><br/><br/> <p><strong>%{date}<br/>%{location}</strong></p>'
+        appareil.</p><br/><p><strong>%{date}<br/>%{location}</strong></p>'
       subject: Nouvelle connexion avec votre compte %{app_name}
     password_changed:
       disavowal_link: réinitialiser votre mot de passe
@@ -265,10 +265,10 @@ fr:
         informations de la page de votre compte, y compris les méthodes que vous
         utilisez pour l’authentification à deux facteurs, telles que le numéro
         de téléphone, l’application d’authentification ou la clé de
-        sécurité.</li><li><strong>Sur la page de votre compte %{app_name},
-        demandez une nouvelle clé personnelle.</strong> N’oubliez pas de ne
-        jamais le partager à moins que vous ne l’utilisiez pour vous connecter à
-        un site Web de confiance utilisant
+        sécurité.</li><li><strong>Sur <a href="%{account_url}">la page de votre
+        compte %{app_name}</a>, demandez une nouvelle clé personnelle.</strong>
+        N’oubliez pas de ne jamais le partager à moins que vous ne l’utilisiez
+        pour vous connecter à un site Web de confiance utilisant
         %{app_name}.</li></ol></p><br>Merci,<br>L’équipe %{app_name}
       intro: La clé personnelle utilisée pour vous connecter
       subject: Alerte de sécurité du compte

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -107,6 +107,18 @@ RSpec.describe 'I18n' do
     expect(missing_interpolation_argument_keys).to be_empty
   end
 
+  it 'has matching HTML tags' do
+    i18n.data[i18n.base_locale].select_keys do |key, _node|
+      if key.start_with?('i18n.transliterate.rule.') || i18n.t(key).is_a?(Array) || i18n.t(key).nil?
+        next
+      end
+
+      html_unique_tags = i18n.locales.map { |locale| i18n.t(key, locale)&.scan(/<.+?>/) }.uniq
+
+      expect(html_unique_tags.size).to eq(1), "HTML tag mismatch for key #{key}"
+    end
+  end
+
   root_dir = File.expand_path(File.join(File.dirname(__FILE__), '../'))
 
   Dir[File.join(root_dir, '/config/locales/**')].sort.each do |group_path|


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a test case which checks for matching sets of HTML tags across all locales for a given string key, and resolves current issues.

See discussion: https://github.com/18F/identity-idp/pull/8837#discussion_r1272582933

## 📜 Testing Plan

```
rspec spec/i18n_spec.rb
```

Confirm no regressions in affected string usage.