### PR TITLE
LG-10248: Send in-person proofing notifications based on the status update time

### DIFF
--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -194,6 +194,8 @@ RSpec.describe GetUspsProofingResultsJob do
   end
 
   before do
+    allow(IdentityConfig.store).
+      to(receive(:in_person_results_delay_in_hours).and_return(nil))
     allow(Rails).to receive(:cache).and_return(
       ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
     )
@@ -493,7 +495,7 @@ RSpec.describe GetUspsProofingResultsJob do
               end.to have_enqueued_mail(UserMailer, :in_person_deadline_passed).with(
                 params: { user: user, email_address: user.email_addresses.first },
                 args: [{ enrollment: pending_enrollment }],
-              ).on_queue(:default)
+              ).at(:no_wait).on_queue(:default)
               pending_enrollment.reload
               expect(pending_enrollment.deadline_passed_sent).to be true
               expect(job_analytics).to have_logged_event(
@@ -613,14 +615,12 @@ RSpec.describe GetUspsProofingResultsJob do
                 to(receive(:in_person_results_delay_in_hours).and_return(0))
               user = pending_enrollment.user
 
-              freeze_time do
-                expect do
-                  job.perform(Time.zone.now)
-                end.to have_enqueued_mail(UserMailer, :in_person_verified).with(
-                  params: { user: user, email_address: user.email_addresses.first },
-                  args: [{ enrollment: pending_enrollment }],
-                ).on_queue(:default)
-              end
+              expect do
+                job.perform(Time.zone.now)
+              end.to have_enqueued_mail(UserMailer, :in_person_verified).with(
+                params: { user: user, email_address: user.email_addresses.first },
+                args: [{ enrollment: pending_enrollment }],
+              ).at(:no_wait).on_queue(:default)
             end
           end
         end
@@ -642,10 +642,14 @@ RSpec.describe GetUspsProofingResultsJob do
           it 'logs details about the success' do
             allow(IdentityConfig.store).to receive(:in_person_send_proofing_notifications_enabled).
               and_return(true)
-            expect do
-              job.perform(Time.zone.now)
-            end.to have_enqueued_job(InPerson::SendProofingNotificationJob).
-              with(pending_enrollment.id).on_queue(:intentionally_delayed)
+            expected_wait_until = nil
+            freeze_time do
+              expected_wait_until = 1.hour.from_now
+              expect do
+                job.perform(Time.zone.now)
+              end.to have_enqueued_job(InPerson::SendProofingNotificationJob).
+                with(pending_enrollment.id).at(expected_wait_until).on_queue(:intentionally_delayed)
+            end
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
               'GetUspsProofingResultsJob: Enrollment status updated',
@@ -661,7 +665,7 @@ RSpec.describe GetUspsProofingResultsJob do
               enrollment_code: pending_enrollment.enrollment_code,
               service_provider: anything,
               timestamp: anything,
-              wait_until: nil,
+              wait_until: expected_wait_until,
               job_name: 'GetUspsProofingResultsJob',
             )
           end
@@ -682,7 +686,11 @@ RSpec.describe GetUspsProofingResultsJob do
           )
 
           it 'logs failure details' do
-            job.perform(Time.zone.now)
+            expected_wait_until = nil
+            freeze_time do
+              expected_wait_until = 1.hour.from_now
+              job.perform(Time.zone.now)
+            end
 
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
@@ -699,7 +707,7 @@ RSpec.describe GetUspsProofingResultsJob do
               enrollment_code: pending_enrollment.enrollment_code,
               service_provider: anything,
               timestamp: anything,
-              wait_until: nil,
+              wait_until: expected_wait_until,
               job_name: 'GetUspsProofingResultsJob',
             )
           end
@@ -720,7 +728,11 @@ RSpec.describe GetUspsProofingResultsJob do
           )
 
           it 'logs fraud failure details' do
-            job.perform(Time.zone.now)
+            expected_wait_until = nil
+            freeze_time do
+              expected_wait_until = 1.hour.from_now
+              job.perform(Time.zone.now)
+            end
 
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
@@ -738,7 +750,7 @@ RSpec.describe GetUspsProofingResultsJob do
               enrollment_code: pending_enrollment.enrollment_code,
               service_provider: anything,
               timestamp: anything,
-              wait_until: nil,
+              wait_until: expected_wait_until,
               job_name: 'GetUspsProofingResultsJob',
             )
           end
@@ -759,7 +771,11 @@ RSpec.describe GetUspsProofingResultsJob do
           )
 
           it 'logs a message about the unsupported ID' do
-            job.perform Time.zone.now
+            expected_wait_until = nil
+            freeze_time do
+              expected_wait_until = 1.hour.from_now
+              job.perform Time.zone.now
+            end
 
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(job_analytics).to have_logged_event(
@@ -777,7 +793,7 @@ RSpec.describe GetUspsProofingResultsJob do
               enrollment_code: pending_enrollment.enrollment_code,
               service_provider: anything,
               timestamp: anything,
-              wait_until: nil,
+              wait_until: expected_wait_until,
               job_name: 'GetUspsProofingResultsJob',
             )
           end
@@ -1138,10 +1154,12 @@ RSpec.describe GetUspsProofingResultsJob do
           it 'logs a message about enrollment with secondary ID' do
             allow(IdentityConfig.store).to receive(:in_person_send_proofing_notifications_enabled).
               and_return(true)
-            expect do
-              job.perform Time.zone.now
-            end.to have_enqueued_job(InPerson::SendProofingNotificationJob).
-              with(pending_enrollment.id).on_queue(:intentionally_delayed)
+            freeze_time do
+              expect do
+                job.perform Time.zone.now
+              end.to have_enqueued_job(InPerson::SendProofingNotificationJob).
+                with(pending_enrollment.id).at(1.hour.from_now).on_queue(:intentionally_delayed)
+            end
             expect(pending_enrollment.proofed_at).to eq(transaction_end_date_time)
             expect(pending_enrollment.profile.active).to eq(false)
             expect(job_analytics).to have_logged_event(

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -639,7 +639,7 @@ RSpec.describe GetUspsProofingResultsJob do
               request_passed_proofing_results_response,
           )
 
-          it 'logs details about the success' do
+          it 'invokes the SendProofingNotificationJob and logs details about the success' do
             allow(IdentityConfig.store).to receive(:in_person_send_proofing_notifications_enabled).
               and_return(true)
             expected_wait_until = nil


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10248](https://cm-jira.usa.gov/browse/LG-10248)

## 🛠 Summary of changes

- Send in-person proofing email and SMS based on the time we received a status update from USPS
- Minor nonfunctional refactoring of the job
- Minor test updates

## 📜 Testing Plan

- [ ] Enroll for in-person proofing
- [ ] Complete in-person step (at post office or simulated)
- [ ] Run proofing results job
- [ ] Verify that notifications are received one hour after results are received from USPS

Note that this may be more easily simulated for a local dev stack by using a command like the following:

```sh
bundle exec rails dev:random_in_person_users NUM_USERS='1' SCRYPT_COST='800$8$1$' ENROLLMENT_STATUS='pending'
```

The details of the associated jobs can be observed by [enabling the GoodJob dashboard](https://github.com/bensheldon/good_job/blob/main/README.md#dashboard) and [preserving job records](https://github.com/bensheldon/good_job/blob/main/README.md#monitor-and-preserve-worked-jobs).

This was tested locally by stubbing the proofer's API response using the `request_passed_proofing_results_response` fixture.