### PR TITLE
LG-10289: Fix cropping error message

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -504,8 +504,10 @@ function AcuantCapture(
               );
 
               refreshAcuantFailureCookie();
-            } else {
+            } else if (error === 'Camera not supported.') {
               setOwnErrorMessage(t('doc_auth.errors.camera.failed'));
+            } else {
+              setOwnErrorMessage(t('errors.general'));
             }
 
             setIsCapturingEnvironment(false);

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -288,6 +288,35 @@ describe('document-capture/components/acuant-capture', () => {
       expect(document.activeElement).to.equal(button);
     });
 
+    it('shows a generic error if camera starts but cropping error occurs', async () => {
+      const trackEvent = sinon.spy();
+      const { container, getByLabelText, findByText } = render(
+        <AnalyticsContext.Provider value={{ trackEvent }}>
+          <DeviceContext.Provider value={{ isMobile: true }}>
+            <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+              <AcuantCapture label="Image" name="test" />
+            </AcuantContextProvider>
+          </DeviceContext.Provider>
+        </AnalyticsContext.Provider>,
+      );
+
+      initialize({
+        start: sinon.stub().callsArgWithAsync(1, undefined, 'start-fail-code'),
+      });
+
+      const button = getByLabelText('Image');
+      await userEvent.click(button);
+      await findByText('errors.general');
+
+      expect(window.AcuantCameraUI.end).to.have.been.calledOnce();
+      expect(container.querySelector('.full-screen')).to.be.null();
+      expect(trackEvent).to.have.been.calledWith('IdV: Image capture failed', {
+        field: 'test',
+        error: 'Cropping failure',
+      });
+      expect(document.activeElement).to.equal(button);
+    });
+
     it('shows sequence break error', async () => {
       const trackEvent = sinon.spy();
       const { container, getByLabelText, findByText } = render(


### PR DESCRIPTION
## 🎫 Ticket

[LG-10289](https://cm-jira.usa.gov/browse/LG-10289)

## 🛠 Summary of changes

Before this change, when the camera cropping failed in the SDK, the user
would get a `Camera failed to start, please try again.` error message.

This is confusing because to get to the cropping failure, the user's
camera would have had to start. In the case of a cropping error, we want
to give a general error message instead.

## 📜 Testing Plan

- [ ] Follow the flow through to the upload image section.
- [ ] When uploading an image, upload it in such a way that you cause a cropping error.
- [ ] Make sure that the error message you see is "Oops, something went wrong. Please try again." and **not** "Camera failed to start, please try again."
