### PR TITLE
LG-10442: Fix required MFA redirect for platform authenticator

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -360,6 +360,8 @@ class ApplicationController < ActionController::Base
 
     if TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled? && !mobile?
       login_two_factor_piv_cac_url
+    elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).platform_enabled?
+      login_two_factor_webauthn_url(platform: true)
     elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).enabled?
       login_two_factor_webauthn_url
     else

--- a/spec/features/openid_connect/phishing_resistant_required_spec.rb
+++ b/spec/features/openid_connect/phishing_resistant_required_spec.rb
@@ -18,12 +18,40 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
     end
 
     context 'user has phishing-resistant auth configured' do
-      it 'sends user to authenticate with phishing-resistant auth' do
-        sign_in_before_2fa(user_with_phishing_resistant_2fa)
+      context 'with piv cac configured' do
+        let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
-        visit login_two_factor_path(otp_delivery_preference: 'sms')
-        expect(current_url).to eq(login_two_factor_webauthn_url)
+        it 'sends user to authenticate with piv cac' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_piv_cac_url)
+        end
+      end
+
+      context 'with webauthn configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn) }
+
+        it 'sends user to authenticate with webauthn' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url)
+        end
+      end
+
+      context 'with webauthn platform configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
+
+        it 'sends user to authenticate with webauthn platform' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+        end
       end
 
       it 'does not allow an already signed in user to bypass phishing-resistant auth' do
@@ -50,12 +78,40 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
     end
 
     context 'user has phishing-resistant auth configured' do
-      it 'sends user to authenticate with phishing-resistant auth' do
-        sign_in_before_2fa(user_with_phishing_resistant_2fa)
+      context 'with piv cac configured' do
+        let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
-        visit login_two_factor_path(otp_delivery_preference: 'sms')
-        expect(current_url).to eq(login_two_factor_webauthn_url)
+        it 'sends user to authenticate with piv cac' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_piv_cac_url)
+        end
+      end
+
+      context 'with webauthn configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn) }
+
+        it 'sends user to authenticate with webauthn' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url)
+        end
+      end
+
+      context 'with webauthn platform configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
+
+        it 'sends user to authenticate with webauthn platform' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+        end
       end
 
       it 'does not allow an already signed in user to bypass phishing-resistant auth' do
@@ -97,12 +153,40 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
     end
 
     context 'user has phishing-resistant auth configured' do
-      it 'sends user to authenticate with phishing-resistant auth' do
-        sign_in_before_2fa(user_with_phishing_resistant_2fa)
-        visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
-        visit login_two_factor_path(otp_delivery_preference: 'sms')
+      context 'with piv cac configured' do
+        let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        expect(current_url).to eq(login_two_factor_webauthn_url)
+        it 'sends user to authenticate with piv cac' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_piv_cac_url)
+        end
+      end
+
+      context 'with webauthn configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn) }
+
+        it 'sends user to authenticate with webauthn' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url)
+        end
+      end
+
+      context 'with webauthn platform configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
+
+        it 'sends user to authenticate with webauthn platform' do
+          sign_in_before_2fa(user)
+
+          visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+        end
       end
 
       it 'does not allow an already signed in user to bypass phishing-resistant auth' do

--- a/spec/features/saml/phishing_resistant_required_spec.rb
+++ b/spec/features/saml/phishing_resistant_required_spec.rb
@@ -21,16 +21,55 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
     end
 
     context 'user has phishing-resistant auth configured' do
-      it 'sends user to authenticate with phishing-resistant auth' do
-        sign_in_before_2fa(user_with_phishing_resistant_2fa)
-        visit_saml_authn_request_url(
-          overrides: {
-            issuer: sp1_issuer,
-            authn_context: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
-          },
-        )
-        visit login_two_factor_path(otp_delivery_preference: 'sms')
-        expect(current_url).to eq(login_two_factor_webauthn_url)
+      context 'with piv cac configured' do
+        let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
+
+        it 'sends user to authenticate with piv cac' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: sp1_issuer,
+              authn_context: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_piv_cac_url)
+        end
+      end
+
+      context 'with webauthn configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn) }
+
+        it 'sends user to authenticate with webauthn' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: sp1_issuer,
+              authn_context: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url)
+        end
+      end
+
+      context 'with webauthn platform configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
+
+        it 'sends user to authenticate with webauthn platform' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: sp1_issuer,
+              authn_context: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+        end
       end
     end
   end
@@ -52,15 +91,52 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
     end
 
     context 'user has phishing-resistant auth configured' do
-      it 'sends user to authenticate with phishing-resistant auth' do
-        sign_in_before_2fa(user_with_phishing_resistant_2fa)
-        visit_saml_authn_request_url(
-          overrides: {
-            issuer: sp1_issuer, authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
-          },
-        )
-        visit login_two_factor_path(otp_delivery_preference: 'sms')
-        expect(current_url).to eq(login_two_factor_webauthn_url)
+      context 'with piv cac configured' do
+        let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
+
+        it 'sends user to authenticate with piv cac' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: sp1_issuer, authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_piv_cac_url)
+        end
+      end
+
+      context 'with webauthn configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn) }
+
+        it 'sends user to authenticate with webauthn' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: sp1_issuer, authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url)
+        end
+      end
+
+      context 'with webauthn platform configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
+
+        it 'sends user to authenticate with webauthn platform' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: sp1_issuer, authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+        end
       end
     end
   end
@@ -82,15 +158,52 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
     end
 
     context 'user has phishing-resistant auth configured' do
-      it 'sends user to authenticate with phishing-resistant auth' do
-        sign_in_before_2fa(user_with_phishing_resistant_2fa)
-        visit_saml_authn_request_url(
-          overrides: {
-            issuer: aal3_issuer, authn_context: nil
-          },
-        )
-        visit login_two_factor_path(otp_delivery_preference: 'sms')
-        expect(current_url).to eq(login_two_factor_webauthn_url)
+      context 'with piv cac configured' do
+        let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
+
+        it 'sends user to authenticate with piv cac' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: aal3_issuer, authn_context: nil
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_piv_cac_url)
+        end
+      end
+
+      context 'with webauthn configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn) }
+
+        it 'sends user to authenticate with webauthn' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: aal3_issuer, authn_context: nil
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url)
+        end
+      end
+
+      context 'with webauthn platform configured' do
+        let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
+
+        it 'sends user to authenticate with webauthn platform' do
+          sign_in_before_2fa(user)
+
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: aal3_issuer, authn_context: nil
+            },
+          )
+          visit login_two_factor_path(otp_delivery_preference: 'sms')
+          expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+        end
       end
 
       it 'does not allow an already signed in user to bypass phishing-resistant auth' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-10442](https://cm-jira.usa.gov/browse/LG-10442)

## 🛠 Summary of changes

Fixes the behavior of the redirect logic for a partner requesting phishing-resistant MFAs to account for a user which has Face or Touch Unlock configured. Previously, the user would be redirected to authenticate with Security Key which, when combined with the changes introduced in #8795, would prevent the user from being able to successfully authenticate.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create an account
3. At MFA setup, select Face or Touch Unlock
   - You can select multiple MFA, but avoid Security Key and PIV as your second MFA method for the purpose of this bug
4. Complete account creation
5. Click "Forget all browsers" in account sidebar and confirm prompt
6. Sign out
7. With [sample RP application](https://github.com/18f/identity-oidc-sinatra) running in a separate terminal process, go to http://localhost:9292/?aal=2-phishing_resistant
8. Click "Sign in"
9. Sign in to the account created previously

**Before:** You are prompted for a Security Key, but you cannot complete this step because you don't have a Face/Touch Unlock credential configured.

**After:** You are prompted for your Face/Touch Unlock credential.
