### PR TITLE
LG-10285: Fix unexpected sign out with phone reauthentication in account management

### DIFF
--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -61,9 +61,15 @@ RSpec.feature 'Changing authentication factor' do
         visit manage_password_path
         complete_2fa_confirmation_without_entering_otp
 
+        # Canceling from MFA prompt
+        click_on t('links.cancel')
+        expect(current_path).to eq account_path
+
+        # Canceling from MFA selection
+        visit manage_password_path
+        complete_2fa_confirmation_without_entering_otp
         click_on t('two_factor_authentication.login_options_link_text')
         click_on t('links.cancel')
-
         expect(current_path).to eq account_path
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10285](https://cm-jira.usa.gov/browse/LG-10285)

## 🛠 Summary of changes

Fixes an issue where a user is unexpected signed out if they click "Cancel" when prompted for OTP during account management reauthentication.

**Draft:**

- [ ] Implement the fix

## 📜 Testing Plan

1. Create or sign in to an account with phone as MFA method
2. Once signed in, wait 2 minutes until the last time you were prompted for OTP code
3. If you were not prompted for OTP during sign-in, you may not need to wait
4. On the account dashboard, add a new MFA method (e.g. click "Add phone number")
5. You should be prompted to re-authenticate method ("Select your authentication method")
6. Ensure "Text message" is selected and click "Continue"
7. Click "Cancel"
8. Observe that you are redirected to the homepage
