### PR TITLE
LG-10457: Track unexpected WebAuthn errors

### DIFF
--- a/app/javascript/packages/webauthn/index.ts
+++ b/app/javascript/packages/webauthn/index.ts
@@ -1,6 +1,7 @@
 export { default as enrollWebauthnDevice } from './enroll-webauthn-device';
 export { default as extractCredentials } from './extract-credentials';
 export { default as verifyWebauthnDevice } from './verify-webauthn-device';
+export { default as isExpectedWebauthnError } from './is-expected-error';
 export * from './converters';
 
 export type { VerifyCredentialDescriptor } from './verify-webauthn-device';

--- a/app/javascript/packages/webauthn/is-expected-error.spec.ts
+++ b/app/javascript/packages/webauthn/is-expected-error.spec.ts
@@ -8,7 +8,14 @@ describe('isExpectedWebauthnError', () => {
     expect(result).to.be.false();
   });
 
-  it('returns true for instance of DOMException', () => {
+  it('returns false for instance of DOMException of an unexpected name', () => {
+    const error = new DOMException('', 'UnknownError');
+    const result = isExpectedWebauthnError(error);
+
+    expect(result).to.be.false();
+  });
+
+  it('returns true for instance of DOMException of an expected name', () => {
     const error = new DOMException('', 'NotAllowedError');
     const result = isExpectedWebauthnError(error);
 

--- a/app/javascript/packages/webauthn/is-expected-error.spec.ts
+++ b/app/javascript/packages/webauthn/is-expected-error.spec.ts
@@ -1,0 +1,17 @@
+import isExpectedWebauthnError from './is-expected-error';
+
+describe('isExpectedWebauthnError', () => {
+  it('returns false for any error other than DOMException', () => {
+    const error = new TypeError();
+    const result = isExpectedWebauthnError(error);
+
+    expect(result).to.be.false();
+  });
+
+  it('returns true for instance of DOMException', () => {
+    const error = new DOMException('', 'NotAllowedError');
+    const result = isExpectedWebauthnError(error);
+
+    expect(result).to.be.true();
+  });
+});

--- a/app/javascript/packages/webauthn/is-expected-error.ts
+++ b/app/javascript/packages/webauthn/is-expected-error.ts
@@ -1,0 +1,3 @@
+const isExpectedWebauthnError = (error: Error): boolean => error instanceof DOMException;
+
+export default isExpectedWebauthnError;

--- a/app/javascript/packages/webauthn/is-expected-error.ts
+++ b/app/javascript/packages/webauthn/is-expected-error.ts
@@ -1,3 +1,12 @@
-const isExpectedWebauthnError = (error: Error): boolean => error instanceof DOMException;
+/**
+ * Set of expected DOM exceptions, which occur based on some user behavior that is not noteworthy,
+ * such as declining permissions or timeout due to inactivity.
+ *
+ * @see https://webidl.spec.whatwg.org/#idl-DOMException
+ */
+const EXPECTED_DOM_EXCEPTIONS: Set<string> = new Set(['NotAllowedError', 'TimeoutError']);
+
+const isExpectedWebauthnError = (error: Error): boolean =>
+  error instanceof DOMException && EXPECTED_DOM_EXCEPTIONS.has(error.name);
 
 export default isExpectedWebauthnError;

--- a/app/javascript/packages/webauthn/webauthn-verify-button-element.ts
+++ b/app/javascript/packages/webauthn/webauthn-verify-button-element.ts
@@ -1,5 +1,7 @@
+import { trackError } from '@18f/identity-analytics';
 import verifyWebauthnDevice from './verify-webauthn-device';
 import type { VerifyCredentialDescriptor } from './verify-webauthn-device';
+import isExpectedWebauthnError from './is-expected-error';
 
 export interface WebauthnVerifyButtonDataset extends DOMStringMap {
   credentials: string;
@@ -50,6 +52,10 @@ class WebauthnVerifyButtonElement extends HTMLElement {
       this.setInputValue('client_data_json', result.clientDataJSON);
       this.setInputValue('signature', result.signature);
     } catch (error) {
+      if (!isExpectedWebauthnError(error)) {
+        trackError(error);
+      }
+
       this.setInputValue('webauthn_error', error.name);
     }
 

--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -1,4 +1,10 @@
-import { enrollWebauthnDevice, extractCredentials, longToByteArray } from '@18f/identity-webauthn';
+import {
+  enrollWebauthnDevice,
+  extractCredentials,
+  isExpectedWebauthnError,
+  longToByteArray,
+} from '@18f/identity-webauthn';
+import { trackError } from '@18f/identity-analytics';
 import { forceRedirect } from '@18f/identity-url';
 import type { Navigate } from '@18f/identity-url';
 
@@ -64,7 +70,13 @@ function webauthn() {
           result.transports.join();
         (document.getElementById('webauthn_form') as HTMLFormElement).submit();
       })
-      .catch((err) => reloadWithError(err.name, { force: true }));
+      .catch((error: Error) => {
+        if (!isExpectedWebauthnError(error)) {
+          trackError(error);
+        }
+
+        reloadWithError(error.name, { force: true });
+      });
   });
 }
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-10457](https://cm-jira.usa.gov/browse/LG-10457)

## 🛠 Summary of changes

Adds error tracking for "unexpected" errors that occur during WebAuthn enrollment or authentication. An unexpected error is one not occurring as an outcome of the WebAuthn API ceremony, but rather may point to errors in our own code.

See Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1690308232479249

## 📜 Testing Plan

**Test expected errors:**

Add a breakpoint to `trackError`:

```diff
diff --git a/app/javascript/packages/analytics/index.ts b/app/javascript/packages/analytics/index.ts
index 1f0f43d4c..ee31274f3 100644
--- a/app/javascript/packages/analytics/index.ts
+++ b/app/javascript/packages/analytics/index.ts
@@ -33,2 +33,3 @@ export function trackEvent(event: string, payload?: object) {
 export function trackError(error: Error) {
+  debugger;
   (globalThis as typeof globalThis & NewRelicGlobals).newrelic?.noticeError(error);
```

Create or sign in to an account with Face or Touch Unlock, cancel the ceremony, and observe that the breakpoint is not triggered.

**Test unexpected errors:**

Keep the above breakpoint, and add some artificial errors:

```diff
diff --git a/app/javascript/packages/webauthn/enroll-webauthn-device.ts b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
index 4d4c19e19..2eb4f53eb 100644
--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -30,2 +30,3 @@ async function enrollWebauthnDevice({
 }: EnrollOptions): Promise<EnrollResult> {
+  throw new Error();
   const credential = (await navigator.credentials.create({
diff --git a/app/javascript/packages/webauthn/verify-webauthn-device.ts b/app/javascript/packages/webauthn/verify-webauthn-device.ts
index ee39c2016..c2fa3d501 100644
--- a/app/javascript/packages/webauthn/verify-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/verify-webauthn-device.ts
@@ -36,2 +36,3 @@ async function verifyWebauthnDevice({
 }: VerifyOptions): Promise<VerifyResult> {
+  throw new Error();
   const credential = (await navigator.credentials.get({
```

Create or sign in to an account with Face or Touch Unlock, and observe that the breakpoint is triggered when initiating the WebAuthn ceremony.