### PR TITLE
Reduce active / pending profile down to a single current profile

### DIFF
--- a/app/controllers/idv/please_call_controller.rb
+++ b/app/controllers/idv/please_call_controller.rb
@@ -10,7 +10,7 @@ module Idv
 
     def show
       analytics.idv_please_call_visited
-      pending_at = current_user.fraud_review_pending_profile.fraud_review_pending_at
+      pending_at = current_user.current_profile.fraud_review_pending_at
       @call_by_date = pending_at + FRAUD_REVIEW_CONTACT_WITHIN_DAYS
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -315,9 +315,9 @@ class User < ApplicationRecord
     active_identities.find_by(service_provider: service_provider.issuer)
   end
 
-  # def active_or_pending_profile
-  #   active_profile || pending_profile
-  # end
+  def active_or_pending_profile
+    active_profile || pending_profile
+  end
 
   def identity_not_verified?
     !identity_verified?

--- a/app/services/fraud_review_checker.rb
+++ b/app/services/fraud_review_checker.rb
@@ -10,14 +10,15 @@ class FraudReviewChecker
   end
 
   def fraud_review_pending?
-    user&.fraud_review_pending_profile.present?
+    user&.fraud_review_pending?
   end
 
   def fraud_rejection?
-    user&.fraud_rejection_profile.present?
+    user&.fraud_rejection?
   end
 
   def fraud_review_eligible?
-    !!user&.fraud_review_pending_profile&.fraud_review_pending_at&.after?(30.days.ago)
+    return false unless fraud_review_pending?
+    !!user&.current_profile&.fraud_review_pending_at&.after?(30.days.ago)
   end
 end

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -154,7 +154,7 @@ class ActionAccount
         if !user.fraud_review_pending?
           log_texts << log_text[:no_pending]
         elsif FraudReviewChecker.new(user).fraud_review_eligible?
-          profile = user.fraud_review_pending_profile
+          profile = user.current_profile
           profile.reject_for_fraud(notify_user: true)
 
           log_texts << log_text[:rejected_for_fraud]
@@ -217,7 +217,7 @@ class ActionAccount
         if !user.fraud_review_pending?
           log_texts << log_text[:no_pending]
         elsif FraudReviewChecker.new(user).fraud_review_eligible?
-          profile = user.fraud_review_pending_profile
+          profile = user.current_profile
           profile.activate_after_passing_review
 
           if profile.active?

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -28,7 +28,7 @@ namespace :users do
       end
 
       if FraudReviewChecker.new(user).fraud_review_eligible?
-        profile = user.fraud_review_pending_profile
+        profile = user.current_profile
         profile.activate_after_passing_review
 
         if profile.active?
@@ -75,7 +75,7 @@ namespace :users do
       end
 
       if FraudReviewChecker.new(user).fraud_review_eligible?
-        profile = user.fraud_review_pending_profile
+        profile = user.current_profile
 
         profile.reject_for_fraud(notify_user: true)
         STDOUT.puts "User's profile has been deactivated due to fraud rejection."


### PR DESCRIPTION
Currently a user can an active profile while also have a pending profile. This covers an edge case where a user who has already undergone proofing is making a subsequent attmept. Maintaining the active profile while their subsequent profile is pending means they maintain an active verified account while completing out-of-band steps for their second profile.

This edge case should be relatively rare, but does introduce a lot of complexity to the application.

This commit removes the active and pending profile model in favor of using a `current_profile` that is the most recent profile. As a result, a user who undergoes proofing again with an active profile will have their active profile overwritten once their new profile is written.

This reduces the active profile vs current profile question down to a question of the state of the user's latest profile.
