### PR TITLE
LG-8763 Log that a profile is pending on password reset

### DIFF
--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -235,6 +235,8 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           error_details: reset_password_error_details,
           user_id: user.uuid,
           profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -266,6 +268,8 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           error_details: password_short_error,
           user_id: user.uuid,
           profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
         }
 
         expect(@analytics).to receive(:track_event).
@@ -341,6 +345,8 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
             errors: {},
             user_id: user.uuid,
             profile_deactivated: false,
+            pending_profile_invalidated: false,
+            pending_profile_pending_reasons: '',
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -389,6 +395,8 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           errors: {},
           user_id: user.uuid,
           profile_deactivated: true,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -434,6 +442,8 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           errors: {},
           user_id: user.uuid,
           profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
         }
 
         expect(@analytics).to have_received(:track_event).


### PR DESCRIPTION
When a user resets their password it deactivates their active profile. We log that we do that.

Additionally, we invalidate any pending profiles which will encounter a encryption error when the user logs in. This commit adds logging to log that a pending profile is present and the reasons that it is pending so we can measure the impact of this behavior at password reset
