### PR TITLE
LG-10121 remove verified_at from users who have not finished verification.

### DIFF
--- a/lib/tasks/remove_verified_at_for_non_verified.rake
+++ b/lib/tasks/remove_verified_at_for_non_verified.rake
@@ -1,0 +1,65 @@
+namespace :profiles do
+  desc 'Remove verified_at if a profile is gpo or fraud pending'
+
+  ##
+  # Usage:
+  #
+  # Print errant profiles
+  # bundle exec rake profiles:remove_errant_verified_at _from_profiles
+  #
+  # Commit updates
+  # bundle exec rake profiles:remove_errant_verified_at _from_profiles UPDATE_PROFILES=true
+  #
+  task remove_verified_at_from_non_verified_profiles: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    update_profiles = ENV['UPDATE_PROFILES'] == 'true'
+
+    profiles = Profile.where('verified_at IS NOT NULL').
+      where('fraud_review_pending_at IS NOT NULL OR gpo_verification_pending_at IS NOT NULL')
+
+    profiles.each do |profile|
+      warn "#{profile.id},#{profile.verified_at}, #{profile.user.uuid}"
+      profile.update!(verified_at: nil) if update_profiles
+    end
+  end
+
+  ##
+  # Usage:
+  #
+  # Rollback the above:
+  #
+  # export BACKFILL_OUTPUT='<backfill_output>'
+  # bundle exec rake profiles:rollback_remove_verified_at_from_non_verified_profiles
+  #
+  task rollback_remove_verified_at_from_non_verified_profiles: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    profiles = ENV['VERIFIED_OUTPUT']
+
+    profiles.split("\n").map do |profile_row|
+      profile_id, profile_verified_at = profile_row.split(',', 2)
+
+      warn "Updating #{profiles.count} records"
+      Profile.find(profile_id).update(verified_at: profile_verified_at)
+    end
+  end
+
+  ##
+  # Usage:
+  # bundle exec rake profiles:validate_remove_verified_at_from_non_verified_profiles
+  #
+  task validate_remove_verified_at_from_non_verified_profiles: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    profiles = Profile.where(
+      verified_at: nil,
+    ).where('fraud_review_pending_at IS NOT NULL OR gpo_verification_pending_at IS NOT NULL')
+
+    if profiles.empty?
+      warn 'remove errant verified_at from profiles was successful'
+    else
+      warn "remove errant verified_at from profiles left #{profiles.count} rows"
+    end
+  end
+end

--- a/lib/tasks/remove_verified_at_for_non_verified.rake
+++ b/lib/tasks/remove_verified_at_for_non_verified.rake
@@ -5,7 +5,7 @@ namespace :profiles do
   # Usage:
   #
   # Print errant profiles
-  # bundle exec rake profiles:remove_verified_at_from_non_verified_profiles_profiles
+  # bundle exec rake profiles:remove_verified_at_from_non_verified_profiles
   #
   # Commit updates
   # bundle exec rake profiles:remove_verified_at_from_non_verified_profiles UPDATE_PROFILES=true

--- a/lib/tasks/remove_verified_at_for_non_verified.rake
+++ b/lib/tasks/remove_verified_at_for_non_verified.rake
@@ -60,9 +60,9 @@ namespace :profiles do
         gpo_verification_pending_at IS NOT NULL')
 
     if profiles.empty?
-      warn 'remove errant verified_at from profiles was successful'
+      warn 'remove verified_at from profiles that were not verified was successful'
     else
-      warn "remove errant verified_at from profiles left #{profiles.count} rows"
+      warn "remove verified_at from profiles that were not verified left #{profiles.count} rows"
     end
   end
 end

--- a/lib/tasks/remove_verified_at_for_non_verified.rake
+++ b/lib/tasks/remove_verified_at_for_non_verified.rake
@@ -1,14 +1,14 @@
 namespace :profiles do
-  desc 'Remove verified_at if a profile is gpo or fraud pending'
+  desc 'Remove verified_at if a profile is gpo, fraud pending or fraud rejected'
 
   ##
   # Usage:
   #
   # Print errant profiles
-  # bundle exec rake profiles:remove_errant_verified_at _from_profiles
+  # bundle exec rake profiles:remove_verified_at_from_non_verified_profiles_profiles
   #
   # Commit updates
-  # bundle exec rake profiles:remove_errant_verified_at _from_profiles UPDATE_PROFILES=true
+  # bundle exec rake profiles:remove_verified_at_from_non_verified_profiles UPDATE_PROFILES=true
   #
   task remove_verified_at_from_non_verified_profiles: :environment do |_task, _args|
     ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
@@ -16,7 +16,8 @@ namespace :profiles do
     update_profiles = ENV['UPDATE_PROFILES'] == 'true'
 
     profiles = Profile.where('verified_at IS NOT NULL').
-      where('fraud_review_pending_at IS NOT NULL OR gpo_verification_pending_at IS NOT NULL')
+      where('fraud_review_pending_at IS NOT NULL OR fraud_rejection_at IS NOT NULL OR
+        gpo_verification_pending_at IS NOT NULL')
 
     profiles.each do |profile|
       warn "#{profile.id},#{profile.verified_at}, #{profile.user.uuid}"
@@ -37,10 +38,11 @@ namespace :profiles do
 
     profiles = ENV['VERIFIED_OUTPUT']
 
+    warn "Updating #{profiles.count} records"
+
     profiles.split("\n").map do |profile_row|
       profile_id, profile_verified_at = profile_row.split(',', 2)
 
-      warn "Updating #{profiles.count} records"
       Profile.find(profile_id).update(verified_at: profile_verified_at)
     end
   end
@@ -54,7 +56,8 @@ namespace :profiles do
 
     profiles = Profile.where(
       verified_at: nil,
-    ).where('fraud_review_pending_at IS NOT NULL OR gpo_verification_pending_at IS NOT NULL')
+    ).where('fraud_review_pending_at IS NOT NULL OR fraud_rejection_at IS NOT NULL OR
+        gpo_verification_pending_at IS NOT NULL')
 
     if profiles.empty?
       warn 'remove errant verified_at from profiles was successful'


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-10121](https://cm-jira.usa.gov/browse/LG-10121)


## 🛠 Summary of changes

You can see the in-depth roll plan for this in [ROLL-0017](https://docs.google.com/document/d/1-R60EoEy0o3N_aZumirS4iv1EX4ozU4dILGZsq9wJ0I/edit?pli=1#heading=h.hszo4s1dz96d)

We found out that there were profiles that had the verified_at field populated when they shouldn’t. These profiles still had a gpo_verification_pending_at or fraud_review_pending_at timestamp meaning that they haven’t completed verification yet. This roll plan removes the verified_at attribute from those profiles.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
