### PR TITLE
LG-10252 Rename throttle translation tags

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -176,7 +176,7 @@ module Idv
         throttle_type: :idv_send_link,
       )
       message = I18n.t(
-        'errors.doc_auth.send_link_throttle',
+        'errors.doc_auth.send_link_limited',
         timeout: distance_of_time_in_words(
           Time.zone.now,
           [rate_limiter.expires_at, Time.zone.now].compact.max,

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -366,7 +366,7 @@ module Users
 
     def handle_too_many_confirmation_sends
       flash[:error] = t(
-        'errors.messages.phone_confirmation_throttled',
+        'errors.messages.phone_confirmation_limited',
         timeout: distance_of_time_in_words(
           Time.zone.now,
           [phone_confirmation_rate_limiter.expires_at, Time.zone.now].compact.max,

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -201,7 +201,7 @@ module Idv
       return unless document_capture_session
       return unless rate_limited?
 
-      errors.add(:limit, t('errors.doc_auth.throttled_heading'), type: :throttled)
+      errors.add(:limit, t('errors.doc_auth.rate_limited_heading'), type: :throttled)
     end
 
     def track_rate_limited

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -118,7 +118,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
                     pii: submissionError.pii,
                   })(ReviewIssuesStep)
                 : ReviewIssuesStep,
-            title: t('errors.doc_auth.throttled_heading'),
+            title: t('errors.doc_auth.rate_limited_heading'),
           },
         ] as FormStep[]
       ).concat(inPersonSteps)

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -103,7 +103,7 @@ function ReviewIssuesStep({
       return (
         <>
           <Warning
-            heading={t('errors.doc_auth.throttled_heading')}
+            heading={t('errors.doc_auth.rate_limited_heading')}
             actionText={t('idv.failure.button.warning')}
             actionOnClick={onWarningPageDismissed}
             location="doc_auth_review_issues"
@@ -137,7 +137,7 @@ function ReviewIssuesStep({
 
     return (
       <Warning
-        heading={t('errors.doc_auth.throttled_heading')}
+        heading={t('errors.doc_auth.rate_limited_heading')}
         actionText={t('idv.failure.button.try_online')}
         actionOnClick={onWarningPageDismissed}
         location="doc_auth_review_issues"
@@ -150,7 +150,7 @@ function ReviewIssuesStep({
           />
         }
       >
-        <h2>{t('errors.doc_auth.throttled_subheading')}</h2>
+        <h2>{t('errors.doc_auth.rate_limited_subheading')}</h2>
         {!!unknownFieldErrors &&
           unknownFieldErrors
             .filter((error) => !['front', 'back'].includes(error.field!))

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -61,7 +61,7 @@ module Idv
         redirect_to rate_limited_url
         DocAuth::Response.new(
           success: false,
-          errors: { limit: I18n.t('errors.doc_auth.throttled_heading') },
+          errors: { limit: I18n.t('errors.doc_auth.rate_limited_heading') },
         )
       end
 

--- a/app/views/idv/gpo_verify/throttled.html.erb
+++ b/app/views/idv/gpo_verify/throttled.html.erb
@@ -4,7 +4,7 @@
 
 <p>
   <%= t(
-        'errors.verify_profile.throttled',
+        'errors.verify_profile.rate_limited',
         timeout: distance_of_time_in_words(
           Time.zone.now,
           [@expires_at, Time.zone.now].compact.max,

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -1,6 +1,6 @@
 <%= render(
       'idv/shared/error',
-      heading: t('errors.doc_auth.throttled_heading'),
+      heading: t('errors.doc_auth.rate_limited_heading'),
       options: [
         {
           url: MarketingSite.contact_url,
@@ -11,7 +11,7 @@
     ) do %>
       <p>
         <%= t(
-              'errors.doc_auth.throttled_text_html',
+              'errors.doc_auth.rate_limited_text_html',
               timeout: distance_of_time_in_words(
                 Time.zone.now,
                 [@expires_at, Time.zone.now].compact.max,

--- a/app/views/users/verify_personal_key/throttled.html.erb
+++ b/app/views/users/verify_personal_key/throttled.html.erb
@@ -4,7 +4,7 @@
 
 <p>
   <%= t(
-        'errors.verify_personal_key.throttled',
+        'errors.verify_personal_key.rate_limited',
         timeout: distance_of_time_in_words(
           Time.zone.now,
           [@expires_at, Time.zone.now].compact.max,

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -29,9 +29,9 @@ en:
         before continuing. We sent you a link with instructions.
       send_link_throttle: You tried too many times, please try again in %{timeout}.
         You can also go back and choose to use your computer instead.
-      throttled_heading: We couldn’t verify your ID
-      throttled_subheading: Try taking new pictures
-      throttled_text_html: 'For your security, we limit the number of times you can
+      rate_limited_heading: We couldn’t verify your ID
+      rate_limited_subheading: Try taking new pictures
+      rate_limited_text_html: 'For your security, we limit the number of times you can
         attempt to verify a document online. <strong>Try again in
         %{timeout}.</strong>'
     general: Oops, something went wrong. Please try again.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -110,9 +110,9 @@ en:
       must_select_additional_option: Select an additional authentication method.
       must_select_option: Select an authentication method.
     verify_personal_key:
-      throttled: You tried too many times, please try again in %{timeout}.
+      rate_limited: You tried too many times, please try again in %{timeout}.
     verify_profile:
-      throttled: You tried too many times, please try again in %{timeout}.
+      rate_limited: You tried too many times, please try again in %{timeout}.
     webauthn_platform_setup:
       account_setup_error: We were unable to add face or touch unlock. Please try again or %{link}.
       already_registered: Face or touch unlock is already registered on this device.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -32,8 +32,8 @@ en:
       rate_limited_text_html: 'For your security, we limit the number of times you can
         attempt to verify a document online. <strong>Try again in
         %{timeout}.</strong>'
-      send_link_throttle: You tried too many times, please try again in %{timeout}.
-        You can also go back and choose to use your computer instead.
+      send_link_limited: You tried too many times, please try again in %{timeout}. You
+        can also go back and choose to use your computer instead.
     general: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You’ve entered too many incorrect passwords. You

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -71,7 +71,7 @@ en:
       personal_key_incorrect: Incorrect personal key
       phone_carrier: Sorry, we are unable to support that phone carrier at this time.
         Please select a different number and try again.
-      phone_confirmation_throttled: You tried too many times, please try again in %{timeout}.
+      phone_confirmation_limited: You tried too many times, please try again in %{timeout}.
       phone_duplicate: This account is already using the phone number you entered as
         an authenticator. Please use a different phone number.
       phone_required: Phone number is required

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -27,13 +27,13 @@ en:
       document_capture_cancelled: You have cancelled uploading photos of your ID on your phone.
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.
-      send_link_throttle: You tried too many times, please try again in %{timeout}.
-        You can also go back and choose to use your computer instead.
       rate_limited_heading: We couldn’t verify your ID
       rate_limited_subheading: Try taking new pictures
       rate_limited_text_html: 'For your security, we limit the number of times you can
         attempt to verify a document online. <strong>Try again in
         %{timeout}.</strong>'
+      send_link_throttle: You tried too many times, please try again in %{timeout}.
+        You can also go back and choose to use your computer instead.
     general: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You’ve entered too many incorrect passwords. You

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -75,7 +75,7 @@ es:
       personal_key_incorrect: La clave personal es incorrecta
       phone_carrier: Lo sentimos, no podemos admitir ese operador telefónico en este
         momento. Por favor, seleccione un número diferente e inténtelo de nuevo.
-      phone_confirmation_throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
+      phone_confirmation_limited: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
       phone_duplicate: Esta cuenta ya está utilizando el número de teléfono que
         ingresó como autenticador. Por favor, use un número de teléfono
         diferente.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -116,9 +116,9 @@ es:
       must_select_additional_option: Seleccione un método de autenticación adicional.
       must_select_option: Seleccione un método de autenticación.
     verify_personal_key:
-      throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
+      rate_limited: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
     verify_profile:
-      throttled: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
+      rate_limited: Lo intentaste muchas veces, vuelve a intentarlo en %{timeout}.
     webauthn_platform_setup:
       account_setup_error: No pudimos agregar el desbloqueo con la cara o con la
         huella digital. Inténtelo de nuevo o %{link}.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -33,7 +33,7 @@ es:
       rate_limited_text_html: 'Por su seguridad, limitamos el número de veces que
         puede intentar verificar un documento en línea. <strong>Inténtelo de
         nuevo en %{timeout}.</strong>'
-      send_link_throttle: Ha intentado demasiadas veces, por favor, inténtelo de nuevo
+      send_link_limited: Ha intentado demasiadas veces, por favor, inténtelo de nuevo
         en %{timeout}. También puede retroceder y elegir utilizar su computadora
         como alternativa.
     general: '¡Oops! Algo salió mal. Inténtelo de nuevo.'

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -28,14 +28,14 @@ es:
       document_capture_cancelled: Ha cancelado la carga de fotos de su identificación en este teléfono.
       phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
         antes de continuar. Te enviamos un enlace con instrucciones.
+      rate_limited_heading: No pudimos verificar la identificación
+      rate_limited_subheading: Intente tomar nuevas fotografías.
+      rate_limited_text_html: 'Por su seguridad, limitamos el número de veces que
+        puede intentar verificar un documento en línea. <strong>Inténtelo de
+        nuevo en %{timeout}.</strong>'
       send_link_throttle: Ha intentado demasiadas veces, por favor, inténtelo de nuevo
         en %{timeout}. También puede retroceder y elegir utilizar su computadora
         como alternativa.
-      rate_limited_heading: No pudimos verificar la identificación
-      rate_limited_subheading: Intente tomar nuevas fotografías.
-      rate_limited_text_html: 'Por su seguridad, limitamos el número de veces que puede
-        intentar verificar un documento en línea. <strong>Inténtelo de nuevo en
-        %{timeout}.</strong>'
     general: '¡Oops! Algo salió mal. Inténtelo de nuevo.'
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -31,9 +31,9 @@ es:
       send_link_throttle: Ha intentado demasiadas veces, por favor, inténtelo de nuevo
         en %{timeout}. También puede retroceder y elegir utilizar su computadora
         como alternativa.
-      throttled_heading: No pudimos verificar la identificación
-      throttled_subheading: Intente tomar nuevas fotografías.
-      throttled_text_html: 'Por su seguridad, limitamos el número de veces que puede
+      rate_limited_heading: No pudimos verificar la identificación
+      rate_limited_subheading: Intente tomar nuevas fotografías.
+      rate_limited_text_html: 'Por su seguridad, limitamos el número de veces que puede
         intentar verificar un documento en línea. <strong>Inténtelo de nuevo en
         %{timeout}.</strong>'
     general: '¡Oops! Algo salió mal. Inténtelo de nuevo.'

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -32,14 +32,14 @@ fr:
       phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des
         photos de votre identifiant avant de continuer. Nous vous avons envoyé
         un lien avec des instructions.
-      send_link_throttle: Vous avez essayé trop de fois, veuillez réessayer dans
-        %{timeout}. Vous pouvez également revenir en arrière et choisir
-        d’utiliser votre ordinateur à la place.
       rate_limited_heading: Nous n’avons pas pu vérifier votre identité
       rate_limited_subheading: Essayez de prendre de nouvelles photos.
       rate_limited_text_html: 'Pour votre sécurité, nous limitons le nombre de fois où
         vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
         réessayer dans %{timeout}.</strong>'
+      send_link_throttle: Vous avez essayé trop de fois, veuillez réessayer dans
+        %{timeout}. Vous pouvez également revenir en arrière et choisir
+        d’utiliser votre ordinateur à la place.
     general: Oups, une erreur s’est produite. Veuillez essayer de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.
     max_password_attempts_reached: Vous avez inscrit des mots de passe incorrects un

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -83,7 +83,7 @@ fr:
       phone_carrier: Nous nous excusons, car nous ne pouvons pas prendre en charge cet
         opérateur téléphonique pour le moment. Veuillez sélectionner un autre
         numéro puis réessayer.
-      phone_confirmation_throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
+      phone_confirmation_limited: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
       phone_duplicate: Ce compte utilise déjà le numéro de téléphone que vous avez
         entré en tant qu’authentificateur. Veuillez utiliser un numéro de
         téléphone différent.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -126,9 +126,9 @@ fr:
       must_select_additional_option: Sélectionnez une méthode d’authentification supplémentaire.
       must_select_option: Sélectionnez une méthode d’authentification.
     verify_personal_key:
-      throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
+      rate_limited: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
     verify_profile:
-      throttled: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
+      rate_limited: Vous avez essayé plusieurs fois, essayez à nouveau dans %{timeout}.
     webauthn_platform_setup:
       account_setup_error: Nous n’avons pas pu ajouter le déverrouillage facial ni le
         déverrouillage tactile. Veuillez réessayer ou %{link}.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -35,9 +35,9 @@ fr:
       send_link_throttle: Vous avez essayé trop de fois, veuillez réessayer dans
         %{timeout}. Vous pouvez également revenir en arrière et choisir
         d’utiliser votre ordinateur à la place.
-      throttled_heading: Nous n’avons pas pu vérifier votre identité
-      throttled_subheading: Essayez de prendre de nouvelles photos.
-      throttled_text_html: 'Pour votre sécurité, nous limitons le nombre de fois où
+      rate_limited_heading: Nous n’avons pas pu vérifier votre identité
+      rate_limited_subheading: Essayez de prendre de nouvelles photos.
+      rate_limited_text_html: 'Pour votre sécurité, nous limitons le nombre de fois où
         vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
         réessayer dans %{timeout}.</strong>'
     general: Oups, une erreur s’est produite. Veuillez essayer de nouveau.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -37,7 +37,7 @@ fr:
       rate_limited_text_html: 'Pour votre sécurité, nous limitons le nombre de fois où
         vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
         réessayer dans %{timeout}.</strong>'
-      send_link_throttle: Vous avez essayé trop de fois, veuillez réessayer dans
+      send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans
         %{timeout}. Vous pouvez également revenir en arrière et choisir
         d’utiliser votre ordinateur à la place.
     general: Oups, une erreur s’est produite. Veuillez essayer de nouveau.

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -42,7 +42,7 @@ en:
         sms_unsupported: The phone number entered doesn’t support text messaging. Try
           the Phone call option.
         temporary_failure: We are experiencing technical difficulties.  Please try again later.
-        throttled: That number is experiencing high message volume.  Please try again
+        rate_limited: That number is experiencing high message volume.  Please try again
           later.
         timeout: The server took too long to respond. Please try again.
         unknown_failure: We are experiencing technical difficulties.  Please try again later.

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -39,11 +39,11 @@ en:
         invalid_phone_number: The phone number entered is not valid.
         opt_out: The phone number entered has opted out of text messages.
         permanent_failure: The phone number entered is not valid.
+        rate_limited: That number is experiencing high message volume.  Please try again
+          later.
         sms_unsupported: The phone number entered doesn’t support text messaging. Try
           the Phone call option.
         temporary_failure: We are experiencing technical difficulties.  Please try again later.
-        rate_limited: That number is experiencing high message volume.  Please try again
-          later.
         timeout: The server took too long to respond. Please try again.
         unknown_failure: We are experiencing technical difficulties.  Please try again later.
         voice_unsupported: Invalid phone number. Check that you’ve entered the correct

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -40,12 +40,12 @@ es:
         opt_out: El número de teléfono ingresado ha sido excluido de los mensajes de
           texto.
         permanent_failure: El número de teléfono ingresado no es válido.
+        rate_limited: Ese número está experimentando un alto volumen de mensajes. Por
+          favor, inténtelo de nuevo más tarde.
         sms_unsupported: El número de teléfono ingresado no admite mensajes de texto.
           Pruebe la opción de llamada telefónica.
         temporary_failure: Estamos experimentando dificultades técnicas. Por favor,
           inténtelo de nuevo más tarde.
-        rate_limited: Ese número está experimentando un alto volumen de mensajes. Por
-          favor, inténtelo de nuevo más tarde.
         timeout: El servidor tardó demasiado en responder. Inténtalo de nuevo.
         unknown_failure: Estamos experimentando dificultades técnicas. Por favor,
           inténtelo de nuevo más tarde.

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -44,7 +44,7 @@ es:
           Pruebe la opción de llamada telefónica.
         temporary_failure: Estamos experimentando dificultades técnicas. Por favor,
           inténtelo de nuevo más tarde.
-        throttled: Ese número está experimentando un alto volumen de mensajes. Por
+        rate_limited: Ese número está experimentando un alto volumen de mensajes. Por
           favor, inténtelo de nuevo más tarde.
         timeout: El servidor tardó demasiado en responder. Inténtalo de nuevo.
         unknown_failure: Estamos experimentando dificultades técnicas. Por favor,

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -41,12 +41,12 @@ fr:
         invalid_phone_number: Le numéro de téléphone saisi n’est pas valide.
         opt_out: Le numéro de téléphone entré a désactivé les messages texte.
         permanent_failure: Le numéro de téléphone entré n’est pas valide.
+        rate_limited: Ce nombre connaît un volume de messages élevé. Veuillez réessayer
+          plus tard.
         sms_unsupported: Le numéro de téléphone saisi ne prend pas en charge les
           messages textuels. Veuillez essayer l’option d’appel téléphonique.
         temporary_failure: Nous rencontrons des difficultés techniques. Veuillez
           réessayer plus tard.
-        rate_limited: Ce nombre connaît un volume de messages élevé. Veuillez réessayer
-          plus tard.
         timeout: Le serveur a pris trop de temps pour répondre. Veuillez réessayer.
         unknown_failure: Nous rencontrons des difficultés techniques. Veuillez réessayer
           plus tard.

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -45,7 +45,7 @@ fr:
           messages textuels. Veuillez essayer l’option d’appel téléphonique.
         temporary_failure: Nous rencontrons des difficultés techniques. Veuillez
           réessayer plus tard.
-        throttled: Ce nombre connaît un volume de messages élevé. Veuillez réessayer
+        rate_limited: Ce nombre connaît un volume de messages élevé. Veuillez réessayer
           plus tard.
         timeout: Le serveur a pris trop de temps pour répondre. Veuillez réessayer.
         unknown_failure: Nous rencontrons des difficultés techniques. Veuillez réessayer

--- a/lib/telephony/errors.rb
+++ b/lib/telephony/errors.rb
@@ -70,8 +70,8 @@ module Telephony
 
   class ThrottledError < TelephonyError
     def friendly_error_message_key
-      # i18n-tasks-use t('telephony.error.friendly_message.throttled')
-      'telephony.error.friendly_message.throttled'
+      # i18n-tasks-use t('telephony.error.friendly_message.rate_limited')
+      'telephony.error.friendly_message.rate_limited'
     end
   end
 

--- a/lib/telephony/errors.rb
+++ b/lib/telephony/errors.rb
@@ -68,7 +68,7 @@ module Telephony
     end
   end
 
-  class ThrottledError < TelephonyError
+  class RateLimitedError < TelephonyError
     def friendly_error_message_key
       # i18n-tasks-use t('telephony.error.friendly_message.rate_limited')
       'telephony.error.friendly_message.rate_limited'

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -8,7 +8,7 @@ module Telephony
         'OPT_OUT' => OptOutError,
         'PERMANENT_FAILURE' => PermanentFailureError,
         'TEMPORARY_FAILURE' => TemporaryFailureError,
-        'THROTTLED' => ThrottledError,
+        'THROTTLED' => RateLimitedError,
         'TIMEOUT' => TimeoutError,
         'UNKNOWN_FAILURE' => UnknownFailureError,
       }.freeze

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -81,7 +81,7 @@ module Telephony
 
         error_message = "#{err.class}: #{err.message}"
         error_class = if err.is_a? Aws::PinpointSMSVoice::Errors::LimitExceededException
-                        Telephony::ThrottledError
+                        Telephony::RateLimitedError
                       elsif err.is_a? Aws::PinpointSMSVoice::Errors::TooManyRequestsException
                         Telephony::DailyLimitReachedError
                       else

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -249,10 +249,10 @@ RSpec.describe Idv::ImageUploadsController do
           'IdV: doc auth image upload form submitted',
           success: false,
           errors: {
-            limit: [I18n.t('errors.doc_auth.throttled_heading')],
+            limit: [I18n.t('errors.doc_auth.rate_limited_heading')],
           },
           error_details: {
-            limit: [I18n.t('errors.doc_auth.throttled_heading')],
+            limit: [I18n.t('errors.doc_auth.rate_limited_heading')],
           },
           user_id: user.uuid,
           attempts: IdentityConfig.store.doc_auth_max_attempts,

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -623,7 +623,7 @@ RSpec.describe Users::TwoFactorAuthenticationController do
 
           expect(flash[:error]).to eq(
             I18n.t(
-              'errors.messages.phone_confirmation_throttled',
+              'errors.messages.phone_confirmation_limited',
               timeout: timeout,
             ),
           )
@@ -676,7 +676,7 @@ RSpec.describe Users::TwoFactorAuthenticationController do
 
           expect(flash[:error]).to eq(
             I18n.t(
-              'errors.messages.phone_confirmation_throttled',
+              'errors.messages.phone_confirmation_limited',
               timeout: timeout,
             ),
           )

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'document capture step', :js do
           timeout = distance_of_time_in_words(
             RateLimiter.attempt_window_in_minutes(:idv_doc_auth).minutes,
           )
-          message = strip_tags(t('errors.doc_auth.throttled_text_html', timeout: timeout))
+          message = strip_tags(t('errors.doc_auth.rate_limited_text_html', timeout: timeout))
           expect(page).to have_content(message)
           expect(page).to have_current_path(idv_session_errors_throttled_path)
         end

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
       freeze_time do
         idv_send_link_max_attempts.times do
           expect(page).to_not have_content(
-            I18n.t('errors.doc_auth.send_link_throttle', timeout: timeout),
+            I18n.t('errors.doc_auth.send_link_limited', timeout: timeout),
           )
 
           fill_in :doc_auth_phone, with: '415-555-0199'
@@ -161,7 +161,7 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
         expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
         expect(page).to have_content(
           I18n.t(
-            'errors.doc_auth.send_link_throttle',
+            'errors.doc_auth.send_link_limited',
             timeout: timeout,
           ),
         )

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature 'Sign Up' do
     # whether it says '9 minutes' or '10 minutes' depends on how
     # slowly the test runs.
     throttled_message = I18n.t(
-      'errors.messages.phone_confirmation_throttled',
+      'errors.messages.phone_confirmation_limited',
       timeout: '(10|9) minutes',
     )
 

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Idv::ApiImageUploadForm do
         form.submit
 
         expect(form.valid?).to eq(false)
-        expect(form.errors[:limit]).to eq([I18n.t('errors.doc_auth.throttled_heading')])
+        expect(form.errors[:limit]).to eq([I18n.t('errors.doc_auth.rate_limited_heading')])
       end
     end
   end

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -55,7 +55,7 @@ describe('document-capture/components/review-issues-step', () => {
       </I18nContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.throttled_heading')).to.be.ok();
+    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
     expect(getByText('3 attempts', { selector: 'strong' })).to.be.ok();
     expect(getByText('remaining')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -89,7 +89,7 @@ describe('document-capture/components/review-issues-step', () => {
       </InPersonContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.throttled_heading')).to.be.ok();
+    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
     expect(getByText('3 attempts', { selector: 'strong' })).to.be.ok();
     expect(getByText('remaining')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -131,7 +131,7 @@ describe('document-capture/components/review-issues-step', () => {
       </I18nContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.throttled_heading')).to.be.ok();
+    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
     expect(getByText('One attempt remaining')).to.be.ok();
     expect(getByText('An unknown error occurred')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();

--- a/spec/lib/telephony/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/sms_sender_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Telephony::Pinpoint::SmsSender do
         response = subject.deliver(message: 'hello!', to: '+11234567890', country_code: 'US')
 
         expect(response.success?).to eq(false)
-        expect(response.error).to eq(Telephony::ThrottledError.new(raised_error_message))
+        expect(response.error).to eq(Telephony::RateLimitedError.new(raised_error_message))
         expect(response.extra[:delivery_status]).to eq('THROTTLED')
         expect(response.extra[:request_id]).to eq('fake-message-request-id')
       end

--- a/spec/lib/telephony/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/telephony/pinpoint/voice_sender_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Telephony::Pinpoint::VoiceSender do
           'Aws::PinpointSMSVoice::Errors::LimitExceededException: This is a test message'
 
         expect(response.success?).to eq(false)
-        expect(response.error).to eq(Telephony::ThrottledError.new(error_message))
+        expect(response.error).to eq(Telephony::RateLimitedError.new(error_message))
       end
     end
 

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ImageUploadResponsePresenter do
         FormResponse.new(
           success: false,
           errors: {
-            limit: t('errors.doc_auth.throttled_heading'),
+            limit: t('errors.doc_auth.rate_limited_heading'),
           },
         )
       end
@@ -113,7 +113,7 @@ RSpec.describe ImageUploadResponsePresenter do
         FormResponse.new(
           success: false,
           errors: {
-            limit: t('errors.doc_auth.throttled_heading'),
+            limit: t('errors.doc_auth.rate_limited_heading'),
           },
           extra: extra_attributes,
         )
@@ -123,7 +123,7 @@ RSpec.describe ImageUploadResponsePresenter do
         expected = {
           success: false,
           result_failed: false,
-          errors: [{ field: :limit, message: t('errors.doc_auth.throttled_heading') }],
+          errors: [{ field: :limit, message: t('errors.doc_auth.rate_limited_heading') }],
           redirect: idv_session_errors_throttled_url,
           remaining_attempts: 0,
           ocr_pii: nil,
@@ -141,7 +141,7 @@ RSpec.describe ImageUploadResponsePresenter do
           expected = {
             success: false,
             result_failed: false,
-            errors: [{ field: :limit, message: t('errors.doc_auth.throttled_heading') }],
+            errors: [{ field: :limit, message: t('errors.doc_auth.rate_limited_heading') }],
             redirect: idv_hybrid_mobile_capture_complete_url,
             remaining_attempts: 0,
             ocr_pii: nil,

--- a/spec/views/idv/session_errors/throttled.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/throttled.html.erb_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe 'idv/session_errors/throttled.html.erb' do
 
   context 'with liveness feature disabled' do
     it 'renders expected heading' do
-      expect(rendered).to have_text(t('errors.doc_auth.throttled_heading'))
+      expect(rendered).to have_text(t('errors.doc_auth.rate_limited_heading'))
     end
   end
 
   context 'with liveness feature enabled' do
     it 'renders expected heading' do
-      expect(rendered).to have_text(t('errors.doc_auth.throttled_heading'))
+      expect(rendered).to have_text(t('errors.doc_auth.rate_limited_heading'))
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10252](https://cm-jira.usa.gov/browse/LG-10252)

## 🛠 Summary of changes

As a followup to PR #8706, rename translation tags that contained 'throttle'.
And a stray ThrottledError under lib/telephony that I missed before.

## 📜 Testing Plan

Automated tests.
