### PR TITLE
LG-10126: For notification phone configurations; handle expired enrollments outside of jobs

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -247,9 +247,6 @@ class GetUspsProofingResultsJob < ApplicationJob
       status_check_completed_at: Time.zone.now,
     )
 
-    # destroy phone number for expired enrollments
-    enrollment.notification_phone_configuration&.destroy
-
     begin
       send_deadline_passed_email(enrollment.user, enrollment) unless enrollment.deadline_passed_sent
     rescue StandardError => err

--- a/app/jobs/in_person/send_proofing_notification_job.rb
+++ b/app/jobs/in_person/send_proofing_notification_job.rb
@@ -26,12 +26,6 @@ module InPerson
           enrollment_code: enrollment.enrollment_code,
           enrollment_id: enrollment.id,
         )
-      if enrollment.expired?
-        # no sending message for expired status
-        enrollment.notification_phone_configuration&.destroy
-        log_job_completed(enrollment: enrollment)
-        return
-      end
 
       # send notification and log result when success or failed
       phone = enrollment.notification_phone_configuration.formatted_phone

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -11,13 +11,20 @@ class InPersonEnrollment < ApplicationRecord
 
   has_one :notification_phone_configuration, dependent: :destroy, inverse_of: :in_person_enrollment
 
+  STATUS_ESTABLISHING = 'establishing'
+  STATUS_PENDING = 'pending'
+  STATUS_PASSED = 'passed'
+  STATUS_FAILED = 'failed'
+  STATUS_EXPIRED = 'expired'
+  STATUS_CANCELLED = 'cancelled'
+
   enum status: {
-    establishing: 0,
-    pending: 1,
-    passed: 2,
-    failed: 3,
-    expired: 4,
-    cancelled: 5,
+    STATUS_ESTABLISHING.to_sym => 0,
+    STATUS_PENDING.to_sym => 1,
+    STATUS_PASSED.to_sym => 2,
+    STATUS_FAILED.to_sym => 3,
+    STATUS_EXPIRED.to_sym => 4,
+    STATUS_CANCELLED.to_sym => 5,
   }
 
   validate :profile_belongs_to_user
@@ -148,7 +155,7 @@ class InPersonEnrollment < ApplicationRecord
   end
 
   def enrollment_will_be_cancelled?
-    status_change_to_be_saved&.last == 'cancelled'
+    status_change_to_be_saved&.last == STATUS_CANCELLED
   end
 
   def set_unique_id

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -141,21 +141,20 @@ class InPersonEnrollment < ApplicationRecord
   end
 
   def eligible_for_notification?
-    self.notification_phone_configuration.present? &&
-      (self.passed? || self.failed? || self.expired?)
+    self.notification_phone_configuration.present? && (self.passed? || self.failed?)
   end
 
   private
 
   def on_status_updated
-    if enrollment_will_be_cancelled? && notification_phone_configuration.present?
+    if enrollment_will_be_cancelled_or_expired? && notification_phone_configuration.present?
       notification_phone_configuration.destroy!
     end
     self.status_updated_at = Time.zone.now
   end
 
-  def enrollment_will_be_cancelled?
-    status_change_to_be_saved&.last == STATUS_CANCELLED
+  def enrollment_will_be_cancelled_or_expired?
+    [STATUS_CANCELLED, STATUS_EXPIRED].include? status_change_to_be_saved&.last
   end
 
   def set_unique_id

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Idv::CancellationsController do
           delete :destroy
 
           pending_enrollment.reload
-          expect(pending_enrollment.status).to eq('cancelled')
+          expect(pending_enrollment.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
           expect(user.reload.pending_in_person_enrollment).to be_blank
         end
 
@@ -249,7 +249,7 @@ RSpec.describe Idv::CancellationsController do
           delete :destroy
 
           establishing_enrollment.reload
-          expect(establishing_enrollment.status).to eq('cancelled')
+          expect(establishing_enrollment.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
           expect(InPersonEnrollment.where(user: user, status: :establishing).count).to eq(0)
         end
 

--- a/spec/controllers/idv/getting_started_controller_spec.rb
+++ b/spec/controllers/idv/getting_started_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Idv::GettingStartedController do
       it 'cancels all previous establishing enrollments' do
         put :update, params: { doc_auth: { ial2_consent_given: 1 } }
 
-        expect(enrollment.reload.status).to eq('cancelled')
+        expect(enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
         expect(user.establishing_in_person_enrollment).to be_blank
       end
     end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe Idv::ReviewController do
 
             enrollment.reload
 
-            expect(enrollment.status).to eq('pending')
+            expect(enrollment.status).to eq(InPersonEnrollment::STATUS_PENDING)
             expect(enrollment.user_id).to eq(user.id)
             expect(enrollment.enrollment_code).to be_a(String)
             expect(enrollment.profile).to eq(user.profiles.last)
@@ -451,7 +451,7 @@ RSpec.describe Idv::ReviewController do
 
               expect(InPersonEnrollment.count).to be(1)
               enrollment = InPersonEnrollment.where(user_id: user.id).first
-              expect(enrollment.status).to eq('establishing')
+              expect(enrollment.status).to eq(InPersonEnrollment::STATUS_ESTABLISHING)
               expect(enrollment.user_id).to eq(user.id)
               expect(enrollment.enrollment_code).to be_nil
             end
@@ -481,7 +481,7 @@ RSpec.describe Idv::ReviewController do
 
               expect(InPersonEnrollment.count).to be(1)
               enrollment = InPersonEnrollment.where(user_id: user.id).first
-              expect(enrollment.status).to eq('establishing')
+              expect(enrollment.status).to eq(InPersonEnrollment::STATUS_ESTABLISHING)
               expect(enrollment.user_id).to eq(user.id)
               expect(enrollment.enrollment_code).to be_nil
             end
@@ -499,7 +499,7 @@ RSpec.describe Idv::ReviewController do
 
               enrollment.reload
 
-              expect(enrollment.status).to eq('pending')
+              expect(enrollment.status).to eq(InPersonEnrollment::STATUS_PENDING)
               expect(enrollment.user_id).to eq(user.id)
               expect(enrollment.enrollment_code).to be_a(String)
               expect(enrollment.profile).to eq(user.profiles.last)
@@ -551,7 +551,7 @@ RSpec.describe Idv::ReviewController do
 
               expect(InPersonEnrollment.count).to be(1)
               enrollment = InPersonEnrollment.where(user_id: user.id).first
-              expect(enrollment.status).to eq('establishing')
+              expect(enrollment.status).to eq(InPersonEnrollment::STATUS_ESTABLISHING)
               expect(enrollment.user_id).to eq(user.id)
               expect(enrollment.enrollment_code).to be_nil
             end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Idv::SessionsController do
         delete :destroy
 
         pending_enrollment.reload
-        expect(pending_enrollment.status).to eq('cancelled')
+        expect(pending_enrollment.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
         expect(user.reload.pending_in_person_enrollment).to be_blank
       end
 
@@ -117,7 +117,7 @@ RSpec.describe Idv::SessionsController do
         delete :destroy
 
         establishing_enrollment.reload
-        expect(establishing_enrollment.status).to eq('cancelled')
+        expect(establishing_enrollment.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
         expect(InPersonEnrollment.where(user: user, status: :establishing).count).to eq(0)
       end
     end

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Idv::WelcomeController do
       it 'cancels all previous establishing enrollments' do
         put :update
 
-        expect(enrollment.reload.status).to eq('cancelled')
+        expect(enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
         expect(user.establishing_in_person_enrollment).to be_blank
       end
     end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe GpoVerifyForm do
 
           enrollment.reload
 
-          expect(enrollment.status).to eq('pending')
+          expect(enrollment.status).to eq(InPersonEnrollment::STATUS_PENDING)
           expect(enrollment.user_id).to eq(user.id)
           expect(enrollment.enrollment_code).to be_a(String)
         end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -629,7 +629,7 @@ RSpec.describe GetUspsProofingResultsJob do
             'enrollment_with_a_status_update',
             passed: true,
             email_type: 'Success',
-            enrollment_status: 'passed',
+            enrollment_status: InPersonEnrollment::STATUS_PASSED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
               request_passed_proofing_results_response,
           )
@@ -675,7 +675,7 @@ RSpec.describe GetUspsProofingResultsJob do
             'enrollment_with_a_status_update',
             passed: false,
             email_type: 'Failed',
-            enrollment_status: 'failed',
+            enrollment_status: InPersonEnrollment::STATUS_FAILED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
               request_failed_proofing_results_response,
           )
@@ -717,7 +717,7 @@ RSpec.describe GetUspsProofingResultsJob do
             'enrollment_with_a_status_update',
             passed: false,
             email_type: 'Failed fraud suspected',
-            enrollment_status: 'failed',
+            enrollment_status: InPersonEnrollment::STATUS_FAILED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
               request_failed_suspected_fraud_proofing_results_response,
           )
@@ -760,7 +760,7 @@ RSpec.describe GetUspsProofingResultsJob do
             'enrollment_with_a_status_update',
             passed: false,
             email_type: 'Failed unsupported ID type',
-            enrollment_status: 'failed',
+            enrollment_status: InPersonEnrollment::STATUS_FAILED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
               request_passed_proofing_unsupported_id_results_response,
           )
@@ -803,7 +803,7 @@ RSpec.describe GetUspsProofingResultsJob do
             'enrollment_with_a_status_update',
             passed: false,
             email_type: 'deadline passed',
-            enrollment_status: 'expired',
+            enrollment_status: InPersonEnrollment::STATUS_EXPIRED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
               request_expired_proofing_results_response,
           )
@@ -833,7 +833,7 @@ RSpec.describe GetUspsProofingResultsJob do
             it 'treats the enrollment as incomplete' do
               job.perform(Time.zone.now)
 
-              expect(pending_enrollment.status).to eq('pending')
+              expect(pending_enrollment.status).to eq(InPersonEnrollment::STATUS_PENDING)
               # we pass the expiration message to analytics
               expect(job_analytics).to have_logged_event(
                 'GetUspsProofingResultsJob: Enrollment incomplete',
@@ -855,7 +855,7 @@ RSpec.describe GetUspsProofingResultsJob do
             'enrollment_with_a_status_update',
             passed: false,
             email_type: 'deadline passed',
-            enrollment_status: 'expired',
+            enrollment_status: InPersonEnrollment::STATUS_EXPIRED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
               request_unexpected_expired_proofing_results_response,
           )
@@ -1141,7 +1141,7 @@ RSpec.describe GetUspsProofingResultsJob do
             'enrollment_with_a_status_update',
             passed: false,
             email_type: 'Failed unsupported secondary ID',
-            enrollment_status: 'failed',
+            enrollment_status: InPersonEnrollment::STATUS_FAILED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
               request_passed_proofing_secondary_id_type_results_response,
           )

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -97,15 +97,13 @@ RSpec.describe InPerson::SendProofingNotificationJob do
       end
       context 'enrollment has an unsupported status' do
         it 'returns without doing anything' do
-          freeze_time do
-            expect(analytics).not_to receive(
-              :idv_in_person_send_proofing_notification_job_started,
-            )
-            expect(analytics).to receive(
-              :idv_in_person_send_proofing_notification_job_skipped,
-            )
-            job.perform(expired_enrollment.id)
-          end
+          expect(analytics).not_to receive(
+            :idv_in_person_send_proofing_notification_job_started,
+          )
+          expect(analytics).to receive(
+            :idv_in_person_send_proofing_notification_job_skipped,
+          )
+          job.perform(expired_enrollment.id)
         end
       end
       context 'without notification phone notification' do

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -95,6 +95,19 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           job.perform(bad_id)
         end
       end
+      context 'enrollment has an unsupported status' do
+        it 'returns without doing anything' do
+          freeze_time do
+            expect(analytics).not_to receive(
+              :idv_in_person_send_proofing_notification_job_started,
+            )
+            expect(analytics).to receive(
+              :idv_in_person_send_proofing_notification_job_skipped,
+            )
+            job.perform(expired_enrollment.id)
+          end
+        end
+      end
       context 'without notification phone notification' do
         it 'returns without doing anything' do
           expect(analytics).not_to receive(
@@ -145,23 +158,6 @@ RSpec.describe InPerson::SendProofingNotificationJob do
             job.perform(failing_enrollment.id)
             expect(failing_enrollment.reload.notification_sent_at).to eq(now)
             expect(failing_enrollment.reload.notification_phone_configuration).to be_nil
-          end
-        end
-        it 'sends no notification and phone removed when enrollment expired' do
-          allow(Telephony).to receive(:send_notification).and_return(sms_success_response)
-          freeze_time do
-            expect(analytics).to receive(
-              :idv_in_person_send_proofing_notification_job_started,
-            )
-            expect(analytics).to receive(
-              :idv_in_person_send_proofing_notification_job_completed,
-            )
-            expect(analytics).not_to receive(
-              :idv_in_person_send_proofing_notification_attempted,
-            )
-            job.perform(expired_enrollment.id)
-            expect(expired_enrollment.reload.notification_sent_at).to be_nil
-            expect(expired_enrollment.reload.notification_phone_configuration).to be_nil
           end
         end
       end

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'dev rake tasks' do
       # Spot check attributes on last record
       last_record = InPersonEnrollment.last
       expect(last_record.attributes).to include(
-        'status' => 'pending',
+        'status' => InPersonEnrollment::STATUS_PENDING,
         'enrollment_established_at' => respond_to(:to_date),
         'unique_id' => an_instance_of(String),
         'enrollment_code' => an_instance_of(String),
@@ -172,7 +172,7 @@ RSpec.describe 'dev rake tasks' do
       # Spot check attributes on last record
       last_record = InPersonEnrollment.last
       expect(last_record.attributes).to include(
-        'status' => 'pending',
+        'status' => InPersonEnrollment::STATUS_PENDING,
         'enrollment_established_at' => respond_to(:to_date),
         'unique_id' => an_instance_of(String),
         'enrollment_code' => an_instance_of(String),
@@ -182,7 +182,7 @@ RSpec.describe 'dev rake tasks' do
     end
 
     it 'can create establishing enrollments' do
-      ENV['ENROLLMENT_STATUS'] = 'establishing'
+      ENV['ENROLLMENT_STATUS'] = InPersonEnrollment::STATUS_ESTABLISHING
 
       expect(User.count).to eq 0
       expect(InPersonEnrollment.count).to eq 0
@@ -197,13 +197,13 @@ RSpec.describe 'dev rake tasks' do
       # Spot check attributes on last record
       last_record = InPersonEnrollment.last
       expect(last_record.attributes).to include(
-        'status' => 'establishing',
+        'status' => InPersonEnrollment::STATUS_ESTABLISHING,
       )
       expect(last_record.profile).to be_nil
     end
 
     it 'can create cancelled enrollments' do
-      ENV['ENROLLMENT_STATUS'] = 'cancelled'
+      ENV['ENROLLMENT_STATUS'] = InPersonEnrollment::STATUS_CANCELLED
 
       expect(User.count).to eq 0
       expect(InPersonEnrollment.count).to eq 0
@@ -218,13 +218,13 @@ RSpec.describe 'dev rake tasks' do
       # Spot check attributes on last record
       last_record = InPersonEnrollment.last
       expect(last_record.attributes).to include(
-        'status' => 'cancelled',
+        'status' => InPersonEnrollment::STATUS_CANCELLED,
       )
       expect(last_record.profile).to be_nil
     end
 
     it 'can create expired enrollments' do
-      ENV['ENROLLMENT_STATUS'] = 'expired'
+      ENV['ENROLLMENT_STATUS'] = InPersonEnrollment::STATUS_EXPIRED
 
       expect(User.count).to eq 0
       expect(InPersonEnrollment.count).to eq 0
@@ -239,7 +239,7 @@ RSpec.describe 'dev rake tasks' do
       # Spot check attributes on last record
       last_record = InPersonEnrollment.last
       expect(last_record.attributes).to include(
-        'status' => 'expired',
+        'status' => InPersonEnrollment::STATUS_EXPIRED,
         'enrollment_established_at' => respond_to(:to_date),
         'unique_id' => an_instance_of(String),
         'enrollment_code' => an_instance_of(String),
@@ -249,7 +249,7 @@ RSpec.describe 'dev rake tasks' do
     end
 
     it 'can create failed enrollments' do
-      ENV['ENROLLMENT_STATUS'] = 'failed'
+      ENV['ENROLLMENT_STATUS'] = InPersonEnrollment::STATUS_FAILED
 
       expect(User.count).to eq 0
       expect(InPersonEnrollment.count).to eq 0
@@ -264,7 +264,7 @@ RSpec.describe 'dev rake tasks' do
       # Spot check attributes on last record
       last_record = InPersonEnrollment.last
       expect(last_record.attributes).to include(
-        'status' => 'failed',
+        'status' => InPersonEnrollment::STATUS_FAILED,
         'enrollment_established_at' => respond_to(:to_date),
         'unique_id' => an_instance_of(String),
         'enrollment_code' => an_instance_of(String),
@@ -274,7 +274,7 @@ RSpec.describe 'dev rake tasks' do
     end
 
     it 'can create passed enrollments' do
-      ENV['ENROLLMENT_STATUS'] = 'passed'
+      ENV['ENROLLMENT_STATUS'] = InPersonEnrollment::STATUS_PASSED
 
       expect(User.count).to eq 0
       expect(InPersonEnrollment.count).to eq 0
@@ -289,7 +289,7 @@ RSpec.describe 'dev rake tasks' do
       # Spot check attributes on last record
       last_record = InPersonEnrollment.last
       expect(last_record.attributes).to include(
-        'status' => 'passed',
+        'status' => InPersonEnrollment::STATUS_PASSED,
         'enrollment_established_at' => respond_to(:to_date),
         'unique_id' => an_instance_of(String),
         'enrollment_code' => an_instance_of(String),
@@ -316,7 +316,7 @@ RSpec.describe 'dev rake tasks' do
       # Spot check attributes on last record
       last_record = InPersonEnrollment.last
       expect(last_record.attributes).to include(
-        'status' => 'pending',
+        'status' => InPersonEnrollment::STATUS_PENDING,
         'enrollment_established_at' => respond_to(:to_date),
         'unique_id' => an_instance_of(String),
 

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe InPersonEnrollment, type: :model do
     end
 
     it 'returns nil if enrollment has not been established' do
-      enrollment.status = 'establishing'
+      enrollment.status = InPersonEnrollment::STATUS_ESTABLISHING
       enrollment.enrollment_established_at = nil
 
       expect(enrollment.minutes_since_established).to eq(nil)

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -412,11 +412,11 @@ RSpec.describe InPersonEnrollment, type: :model do
     it 'returns true when status of passed/failed/expired and notification configuration' do
       expect(passed_enrollment.eligible_for_notification?).to eq(true)
       expect(failed_enrollment.eligible_for_notification?).to eq(true)
-      expect(expired_enrollment.eligible_for_notification?).to eq(true)
     end
 
-    it 'returns false when status of incomplete or without notification configuration' do
+    it 'returns false when status of incomplete, expired, or without notification configuration' do
       expect(incomplete_enrollment.eligible_for_notification?).to eq(false)
+      expect(expired_enrollment.eligible_for_notification?).to eq(false)
       expect(passed_enrollment_without_notification.eligible_for_notification?).to eq(false)
       expect(failed_enrollment_without_notification.eligible_for_notification?).to eq(false)
     end
@@ -446,6 +446,22 @@ RSpec.describe InPersonEnrollment, type: :model do
 
         expect(enrollment.notification_phone_configuration).to eq(nil)
       end
+    end
+  end
+
+  describe 'enrollment expires' do
+    it 'deletes the notification phone number' do
+      enrollment = create(
+        :in_person_enrollment, :establishing, :with_notification_phone_configuration
+      )
+      config_id = enrollment.notification_phone_configuration.id
+      expect(NotificationPhoneConfiguration.find_by({ id: config_id })).to_not eq(nil)
+
+      enrollment.expired!
+      enrollment.reload
+
+      expect(enrollment.notification_phone_configuration).to eq(nil)
+      expect(NotificationPhoneConfiguration.find_by({ id: config_id })).to eq(nil)
     end
   end
 end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
       it 'sets enrollment status to pending and sets established at date and unique id' do
         subject.schedule_in_person_enrollment(user, pii)
 
-        expect(user.in_person_enrollments.first.status).to eq('pending')
+        expect(user.in_person_enrollments.first.status).to eq(InPersonEnrollment::STATUS_PENDING)
         expect(user.in_person_enrollments.first.enrollment_established_at).to_not be_nil
         expect(user.in_person_enrollments.first.unique_id).to_not be_nil
       end


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-10126](https://cm-jira.usa.gov/browse/LG-10126)

## 🛠 Summary of changes

Has the `InPersonEnrollment` model delete `NotificationPhoneConfiguration` associated with enrollments when they expire, rather than relying on the `GetUspsProofingResultsJob` or the `SendProofingNotificationJob` to delete them. (see d67c9031eb61ff522acd766540d8b4f1ad7f991e)

Also starts using constants to refer to the in person enrollment states, for clarity when reading and writing code. (see c0e725d0d1cc1c5574d99895eaf8c1c124fb90d5)
