### PR TITLE
LG-10252 Rename throttle analytics

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -108,13 +108,13 @@ module Idv
     def idv_failure_log_rate_limited(rate_limit_type)
       if rate_limit_type == :proof_ssn
         irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'multi-session')
-        analytics.throttler_rate_limit_triggered(
+        analytics.rate_limit_reached(
           throttle_type: :proof_ssn,
           step_name: STEP_NAME,
         )
       elsif rate_limit_type == :idv_resolution
         irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
-        analytics.throttler_rate_limit_triggered(
+        analytics.rate_limit_reached(
           throttle_type: :idv_resolution,
           step_name: STEP_NAME,
         )

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -107,13 +107,13 @@ module Idv
 
     def idv_failure_log_rate_limited(rate_limit_type)
       if rate_limit_type == :proof_ssn
-        irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'multi-session')
+        irs_attempts_api_tracker.idv_verification_rate_limited(limiter_context: 'multi-session')
         analytics.rate_limit_reached(
           limiter_type: :proof_ssn,
           step_name: STEP_NAME,
         )
       elsif rate_limit_type == :idv_resolution
-        irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
+        irs_attempts_api_tracker.idv_verification_rate_limited(limiter_context: 'single-session')
         analytics.rate_limit_reached(
           limiter_type: :idv_resolution,
           step_name: STEP_NAME,

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -109,13 +109,13 @@ module Idv
       if rate_limit_type == :proof_ssn
         irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'multi-session')
         analytics.rate_limit_reached(
-          throttle_type: :proof_ssn,
+          limiter_type: :proof_ssn,
           step_name: STEP_NAME,
         )
       elsif rate_limit_type == :idv_resolution
         irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: 'single-session')
         analytics.rate_limit_reached(
-          throttle_type: :idv_resolution,
+          limiter_type: :idv_resolution,
           step_name: STEP_NAME,
         )
       end

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -22,16 +22,16 @@ module RateLimitConcern
 
   def track_rate_limited_event(rate_limit_type)
     analytics_args = { limiter_type: rate_limit_type }
-    throttle_context = 'single-session'
+    limiter_context = 'single-session'
 
     if rate_limit_type == :proof_address
       analytics_args[:step_name] = :phone
     elsif rate_limit_type == :proof_ssn
       analytics_args[:step_name] = 'verify_info'
-      throttle_context = 'multi-session'
+      limiter_context = 'multi-session'
     end
 
-    irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: throttle_context)
+    irs_attempts_api_tracker.idv_verification_rate_limited(limiter_context: limiter_context)
     analytics.rate_limit_reached(**analytics_args)
   end
 

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -21,7 +21,7 @@ module RateLimitConcern
   end
 
   def track_rate_limited_event(rate_limit_type)
-    analytics_args = { throttle_type: rate_limit_type }
+    analytics_args = { limiter_type: rate_limit_type }
     throttle_context = 'single-session'
 
     if rate_limit_type == :proof_address

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -32,7 +32,7 @@ module RateLimitConcern
     end
 
     irs_attempts_api_tracker.idv_verification_rate_limited(throttle_context: throttle_context)
-    analytics.throttler_rate_limit_triggered(**analytics_args)
+    analytics.rate_limit_reached(**analytics_args)
   end
 
   def rate_limited_redirect(rate_limit_type)

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -98,7 +98,7 @@ module Idv
 
     def render_rate_limited
       irs_attempts_api_tracker.idv_gpo_verification_rate_limited
-      analytics.throttler_rate_limit_triggered(
+      analytics.rate_limit_reached(
         throttle_type: :verify_gpo_key,
       )
 

--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -99,7 +99,7 @@ module Idv
     def render_rate_limited
       irs_attempts_api_tracker.idv_gpo_verification_rate_limited
       analytics.rate_limit_reached(
-        throttle_type: :verify_gpo_key,
+        limiter_type: :verify_gpo_key,
       )
 
       @expires_at = rate_limiter.expires_at

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -172,7 +172,7 @@ module Idv
     end
 
     def rate_limited_failure
-      analytics.throttler_rate_limit_triggered(
+      analytics.rate_limit_reached(
         throttle_type: :idv_send_link,
       )
       message = I18n.t(

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -173,7 +173,7 @@ module Idv
 
     def rate_limited_failure
       analytics.rate_limit_reached(
-        throttle_type: :idv_send_link,
+        limiter_type: :idv_send_link,
       )
       message = I18n.t(
         'errors.doc_auth.send_link_limited',

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -52,7 +52,7 @@ module Idv
     def track_event(type:)
       attributes = { type: type }
       if type == :failure
-        attributes[:throttle_expires_at] = @expires_at
+        attributes[:limiter_expires_at] = @expires_at
       else
         attributes[:remaining_attempts] = @remaining_attempts
       end

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -54,7 +54,7 @@ module Users
 
     def render_rate_limited
       analytics.rate_limit_reached(
-        throttle_type: :verify_personal_key,
+        limiter_type: :verify_personal_key,
       )
 
       irs_attempts_api_tracker.personal_key_reactivation_rate_limited

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -53,7 +53,7 @@ module Users
     end
 
     def render_rate_limited
-      analytics.throttler_rate_limit_triggered(
+      analytics.rate_limit_reached(
         throttle_type: :verify_personal_key,
       )
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -205,7 +205,7 @@ module Idv
     end
 
     def track_rate_limited
-      analytics.throttler_rate_limit_triggered(throttle_type: :idv_doc_auth)
+      analytics.rate_limit_reached(throttle_type: :idv_doc_auth)
       irs_attempts_api_tracker.idv_document_upload_rate_limited
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -205,7 +205,7 @@ module Idv
     end
 
     def track_rate_limited
-      analytics.rate_limit_reached(throttle_type: :idv_doc_auth)
+      analytics.rate_limit_reached(limiter_type: :idv_doc_auth)
       irs_attempts_api_tracker.idv_document_upload_rate_limited
     end
 

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -114,7 +114,7 @@ class RegisterUserEmailForm
       email_already_exists: email_taken?,
       user_id: user.uuid || existing_user.uuid,
       domain_name: email&.split('@')&.last,
-      throttled: @rate_limited,
+      rate_limited: @rate_limited,
     }
   end
 

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -124,7 +124,7 @@ class RegisterUserEmailForm
     @rate_limited = rate_limiter.limited?
 
     if @rate_limited
-      @analytics.throttler_rate_limit_triggered(
+      @analytics.rate_limit_reached(
         throttle_type: :reg_unconfirmed_email,
       )
       @attempts_tracker.user_registration_email_submission_rate_limited(
@@ -141,7 +141,7 @@ class RegisterUserEmailForm
     @rate_limited = rate_limiter.limited?
 
     if @rate_limited
-      @analytics.throttler_rate_limit_triggered(
+      @analytics.rate_limit_reached(
         throttle_type: :reg_confirmed_email,
       )
       @attempts_tracker.user_registration_email_submission_rate_limited(

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -125,7 +125,7 @@ class RegisterUserEmailForm
 
     if @rate_limited
       @analytics.rate_limit_reached(
-        throttle_type: :reg_unconfirmed_email,
+        limiter_type: :reg_unconfirmed_email,
       )
       @attempts_tracker.user_registration_email_submission_rate_limited(
         email: email, email_already_registered: false,
@@ -142,7 +142,7 @@ class RegisterUserEmailForm
 
     if @rate_limited
       @analytics.rate_limit_reached(
-        throttle_type: :reg_confirmed_email,
+        limiter_type: :reg_confirmed_email,
       )
       @attempts_tracker.user_registration_email_submission_rate_limited(
         email: email, email_already_registered: true,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3644,11 +3644,11 @@ module AnalyticsEvents
   end
 
   # Tracks when a user triggered a rate limit throttle
-  # @param [String] throttle_type
-  def rate_limit_reached(throttle_type:, **extra)
+  # @param [String] limiter_type
+  def rate_limit_reached(limiter_type:, **extra)
     track_event(
       'Rate Limit Reached',
-      throttle_type: throttle_type,
+      limiter_type: limiter_type,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3235,6 +3235,17 @@ module AnalyticsEvents
     track_event('Proofing Document Result Missing')
   end
 
+  # Tracks when a user triggered a rate limiter
+  # @param [String] limiter_type
+  # @identity.idp.previous_event_name Throttler Rate Limit Triggered
+  def rate_limit_reached(limiter_type:, **extra)
+    track_event(
+      'Rate Limit Reached',
+      limiter_type: limiter_type,
+      **extra,
+    )
+  end
+
   # Rate limit triggered
   # @param [String] type
   def rate_limit_triggered(type:, **extra)
@@ -3641,17 +3652,6 @@ module AnalyticsEvents
         success: success,
         **extra,
       },
-    )
-  end
-
-  # Tracks when a user triggered a rate limiter
-  # @param [String] limiter_type
-  # @identity.idp.previous_event_name Throttler Rate Limit Triggered
-  def rate_limit_reached(limiter_type:, **extra)
-    track_event(
-      'Rate Limit Reached',
-      limiter_type: limiter_type,
-      **extra,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -671,7 +671,7 @@ module AnalyticsEvents
   end
 
   # @param [String] step_name which step the user was on
-  # @param [Integer] remaining_attempts how many attempts the user has left before we throttle them
+  # @param [Integer] remaining_attempts how many attempts the user has left before we rate limit them
   # The user visited an error page due to an encountering an exception talking to a proofing vendor
   def idv_doc_auth_exception_visited(step_name:, remaining_attempts:, **extra)
     track_event(
@@ -2152,14 +2152,14 @@ module AnalyticsEvents
   end
 
   # @param ['warning','jobfail','failure'] type
-  # @param [Time] throttle_expires_at when the throttle expires
+  # @param [Time] limiter_expires_at when the rate limit expires
   # @param [Integer] remaining_attempts number of attempts remaining
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # When a user gets an error during the phone finder flow of IDV
   def idv_phone_error_visited(
     type:,
     proofing_components: nil,
-    throttle_expires_at: nil,
+    limiter_expires_at: nil,
     remaining_attempts: nil,
     **extra
   )
@@ -2168,7 +2168,7 @@ module AnalyticsEvents
       {
         type: type,
         proofing_components: proofing_components,
-        throttle_expires_at: throttle_expires_at,
+        limiter_expires_at: limiter_expires_at,
         remaining_attempts: remaining_attempts,
         **extra,
       }.compact,
@@ -3643,7 +3643,7 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when a user triggered a rate limit throttle
+  # Tracks when a user triggered a rate limiter
   # @param [String] limiter_type
   def rate_limit_reached(limiter_type:, **extra)
     track_event(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3645,6 +3645,7 @@ module AnalyticsEvents
 
   # Tracks when a user triggered a rate limiter
   # @param [String] limiter_type
+  # @identity.idp.previous_event_name Throttler Rate Limit Triggered
   def rate_limit_reached(limiter_type:, **extra)
     track_event(
       'Rate Limit Reached',

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -671,7 +671,8 @@ module AnalyticsEvents
   end
 
   # @param [String] step_name which step the user was on
-  # @param [Integer] remaining_attempts how many attempts the user has left before we rate limit them
+  # @param [Integer] remaining_attempts how many attempts the user has left before
+  #                  we rate limit them
   # The user visited an error page due to an encountering an exception talking to a proofing vendor
   def idv_doc_auth_exception_visited(step_name:, remaining_attempts:, **extra)
     track_event(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3645,7 +3645,7 @@ module AnalyticsEvents
 
   # Tracks when a user triggered a rate limit throttle
   # @param [String] throttle_type
-  def throttler_rate_limit_triggered(throttle_type:, **extra)
+  def rate_limit_reached(throttle_type:, **extra)
     track_event(
       'Rate Limit Reached',
       throttle_type: throttle_type,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3873,14 +3873,14 @@ module AnalyticsEvents
 
   # Tracks when user submits registration email
   # @param [Boolean] success
-  # @param [Boolean] throttled
+  # @param [Boolean] rate_limited
   # @param [Hash] errors
   # @param [Hash] error_details
   # @param [String] user_id
   # @param [String] domain_name
   def user_registration_email(
     success:,
-    throttled:,
+    rate_limited:,
     errors:,
     error_details: nil,
     user_id: nil,
@@ -3891,7 +3891,7 @@ module AnalyticsEvents
       'User Registration: Email Submitted',
       {
         success: success,
-        throttled: throttled,
+        rate_limited: rate_limited,
         errors: errors,
         error_details: error_details,
         user_id: user_id,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3647,7 +3647,7 @@ module AnalyticsEvents
   # @param [String] throttle_type
   def throttler_rate_limit_triggered(throttle_type:, **extra)
     track_event(
-      'Throttler Rate Limit Triggered',
+      'Rate Limit Reached',
       throttle_type: throttle_type,
       **extra,
     )

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -121,7 +121,7 @@ module Idv
 
     def rate_limited_result
       @attempts_tracker.idv_phone_otp_sent_rate_limited
-      @analytics.throttler_rate_limit_triggered(throttle_type: :proof_address, step_name: :phone)
+      @analytics.rate_limit_reached(throttle_type: :proof_address, step_name: :phone)
       FormResponse.new(success: false)
     end
 

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -121,7 +121,7 @@ module Idv
 
     def rate_limited_result
       @attempts_tracker.idv_phone_otp_sent_rate_limited
-      @analytics.rate_limit_reached(throttle_type: :proof_address, step_name: :phone)
+      @analytics.rate_limit_reached(limiter_type: :proof_address, step_name: :phone)
       FormResponse.new(success: false)
     end
 

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -54,7 +54,7 @@ module Idv
       end
 
       def rate_limited_response
-        @flow.analytics.throttler_rate_limit_triggered(
+        @flow.analytics.rate_limit_reached(
           throttle_type: :idv_doc_auth,
         )
         @flow.irs_attempts_api_tracker.idv_document_upload_rate_limited

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -55,7 +55,7 @@ module Idv
 
       def rate_limited_response
         @flow.analytics.rate_limit_reached(
-          throttle_type: :idv_doc_auth,
+          limiter_type: :idv_doc_auth,
         )
         @flow.irs_attempts_api_tracker.idv_document_upload_rate_limited
         redirect_to rate_limited_url

--- a/app/services/irs_attempts_api/tracker_events.rb
+++ b/app/services/irs_attempts_api/tracker_events.rb
@@ -297,12 +297,12 @@ module IrsAttemptsApi
       )
     end
 
-    # @param [String] throttle_context - Either single-session or multi-session
+    # @param [String] limiter_context - Either single-session or multi-session
     # Track when idv verification is rate limited during idv flow
-    def idv_verification_rate_limited(throttle_context:)
+    def idv_verification_rate_limited(limiter_context:)
       track_event(
         :idv_verification_rate_limited,
-        throttle_context: throttle_context,
+        limiter_context: limiter_context,
       )
     end
 

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -24,7 +24,7 @@ RequestPasswordReset = RedactedStruct.new(
     rate_limiter = RateLimiter.new(user: user, rate_limit_type: :reset_password_email)
     rate_limiter.increment!
     if rate_limiter.limited?
-      analytics.throttler_rate_limit_triggered(throttle_type: :reset_password_email)
+      analytics.rate_limit_reached(throttle_type: :reset_password_email)
       irs_attempts_api_tracker.forgot_password_email_rate_limited(email: email)
     elsif user.suspended?
       UserMailer.with(

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -24,7 +24,7 @@ RequestPasswordReset = RedactedStruct.new(
     rate_limiter = RateLimiter.new(user: user, rate_limit_type: :reset_password_email)
     rate_limiter.increment!
     if rate_limiter.limited?
-      analytics.rate_limit_reached(throttle_type: :reset_password_email)
+      analytics.rate_limit_reached(limiter_type: :reset_password_email)
       irs_attempts_api_tracker.forgot_password_email_rate_limited(email: email)
     elsif user.suspended?
       UserMailer.with(

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Idv::GpoVerifyController do
           'IdV: GPO verification visited',
         ).once
         expect(@analytics).to receive(:track_event).with(
-          'Throttler Rate Limit Triggered',
+          'Rate Limit Reached',
           throttle_type: :verify_gpo_key,
         ).once
 
@@ -350,7 +350,7 @@ RSpec.describe Idv::GpoVerifyController do
           ).exactly(max_attempts).times
 
           expect(@analytics).to receive(:track_event).with(
-            'Throttler Rate Limit Triggered',
+            'Rate Limit Reached',
             throttle_type: :verify_gpo_key,
           ).once
 

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Idv::GpoVerifyController do
         ).once
         expect(@analytics).to receive(:track_event).with(
           'Rate Limit Reached',
-          throttle_type: :verify_gpo_key,
+          limiter_type: :verify_gpo_key,
         ).once
 
         action
@@ -351,7 +351,7 @@ RSpec.describe Idv::GpoVerifyController do
 
           expect(@analytics).to receive(:track_event).with(
             'Rate Limit Reached',
-            throttle_type: :verify_gpo_key,
+            limiter_type: :verify_gpo_key,
           ).once
 
           expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_rate_limited).once

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -521,7 +521,7 @@ RSpec.describe Idv::PhoneController do
 
         it 'tracks rate limited event' do
           expect(@analytics).to have_logged_event(
-            'Throttler Rate Limit Triggered',
+            'Rate Limit Reached',
             {
               throttle_type: :proof_address,
               step_name: :phone,

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -523,7 +523,7 @@ RSpec.describe Idv::PhoneController do
           expect(@analytics).to have_logged_event(
             'Rate Limit Reached',
             {
-              throttle_type: :proof_address,
+              limiter_type: :proof_address,
               step_name: :phone,
             },
           )

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Idv::PhoneErrorsController do
           expect(@analytics).to have_received(:track_event).with(
             'IdV: phone error visited',
             type: action,
-            throttle_expires_at: attempted_at + rate_limit_window,
+            limiter_expires_at: attempted_at + rate_limit_window,
           )
         end
       end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Idv::VerifyInfoController do
 
       it 'logs the correct attempts event' do
         expect(@irs_attempts_api_tracker).to receive(:idv_verification_rate_limited).
-          with({ throttle_context: 'multi-session' })
+          with({ limiter_context: 'multi-session' })
 
         get :show
       end
@@ -164,7 +164,7 @@ RSpec.describe Idv::VerifyInfoController do
 
       it 'logs the correct attempts event' do
         expect(@irs_attempts_api_tracker).to receive(:idv_verification_rate_limited).
-          with({ throttle_context: 'single-session' })
+          with({ limiter_context: 'single-session' })
 
         get :show
       end
@@ -431,7 +431,7 @@ RSpec.describe Idv::VerifyInfoController do
 
       it 'logs the correct attempts event' do
         expect(@irs_attempts_api_tracker).to receive(:idv_verification_rate_limited).
-          with({ throttle_context: 'multi-session' })
+          with({ limiter_context: 'multi-session' })
 
         put :update
       end
@@ -453,7 +453,7 @@ RSpec.describe Idv::VerifyInfoController do
 
       it 'logs the correct attempts event' do
         expect(@irs_attempts_api_tracker).to receive(:idv_verification_rate_limited).
-          with({ throttle_context: 'single-session' })
+          with({ limiter_context: 'single-session' })
 
         put :update
       end

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe IdvController do
       it 'logs appropriate attempts event' do
         stub_attempts_tracker
         expect(@irs_attempts_api_tracker).to receive(:idv_verification_rate_limited).
-          with({ throttle_context: 'single-session' })
+          with({ limiter_context: 'single-session' })
 
         get :index
       end

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
 
         analytics_hash = {
           success: true,
-          throttled: false,
+          rate_limited: false,
           errors: {},
           email_already_exists: false,
           user_id: user.uuid,
@@ -128,7 +128,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
 
       analytics_hash = {
         success: true,
-        throttled: false,
+        rate_limited: false,
         errors: {},
         email_already_exists: true,
         user_id: existing_user.uuid,
@@ -154,7 +154,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
 
       analytics_hash = {
         success: false,
-        throttled: false,
+        rate_limited: false,
         errors: { email: [t('valid_email.validations.email.invalid')] },
         error_details: { email: [:invalid] },
         email_already_exists: false,

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -485,7 +485,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: true,
-          throttled: false,
+          rate_limited: false,
           errors: {},
           email_already_exists: false,
           user_id: User.find_with_email(email).uuid,

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Users::VerifyPersonalKeyController do
           'Personal key reactivation: Personal key form visited',
         ).once
         expect(@analytics).to receive(:track_event).with(
-          'Throttler Rate Limit Triggered',
+          'Rate Limit Reached',
           throttle_type: :verify_personal_key,
         ).once
 
@@ -168,7 +168,7 @@ RSpec.describe Users::VerifyPersonalKeyController do
           pii_like_keypaths: pii_like_keypaths_errors,
         ).once
         expect(@analytics).to receive(:track_event).with(
-          'Throttler Rate Limit Triggered',
+          'Rate Limit Reached',
           throttle_type: :verify_personal_key,
         ).once
 

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Users::VerifyPersonalKeyController do
         ).once
         expect(@analytics).to receive(:track_event).with(
           'Rate Limit Reached',
-          throttle_type: :verify_personal_key,
+          limiter_type: :verify_personal_key,
         ).once
 
         expect(@irs_attempts_api_tracker).to receive(:personal_key_reactivation_rate_limited)
@@ -169,7 +169,7 @@ RSpec.describe Users::VerifyPersonalKeyController do
         ).once
         expect(@analytics).to receive(:track_event).with(
           'Rate Limit Reached',
-          throttle_type: :verify_personal_key,
+          limiter_type: :verify_personal_key,
         ).once
 
         expect(@irs_attempts_api_tracker).to receive(:personal_key_reactivation_rate_limited).once

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature 'document capture step', :js do
       it 'logs the rate limited analytics event for doc_auth' do
         attach_and_submit_images
         expect(fake_analytics).to have_logged_event(
-          'Throttler Rate Limit Triggered',
+          'Rate Limit Reached',
           throttle_type: :idv_doc_auth,
         )
       end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'document capture step', :js do
         attach_and_submit_images
         expect(fake_analytics).to have_logged_event(
           'Rate Limit Reached',
-          throttle_type: :idv_doc_auth,
+          limiter_type: :idv_doc_auth,
         )
       end
 

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -167,7 +167,7 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
         )
       end
       expect(fake_analytics).to have_logged_event(
-        'Throttler Rate Limit Triggered',
+        'Rate Limit Reached',
         throttle_type: :idv_send_link,
       )
 

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -168,7 +168,7 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
       end
       expect(fake_analytics).to have_logged_event(
         'Rate Limit Reached',
-        throttle_type: :idv_send_link,
+        limiter_type: :idv_send_link,
       )
 
       # Manual expiration is needed for now since the RateLimiter uses

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -148,7 +148,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     # proof_ssn_max_attempts is 10, vs 5 for resolution, so it doesn't get triggered
     it 'rate limits resolution and continues when it expires' do
       expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited).at_least(1).times.
-        with({ throttle_context: 'single-session' })
+        with({ limiter_context: 'single-session' })
 
       (max_resolution_attempts - 2).times do
         click_idv_continue
@@ -211,7 +211,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
 
     it 'rate limits ssn and continues when it expires' do
       expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited).at_least(1).times.
-        with({ throttle_context: 'multi-session' })
+        with({ limiter_context: 'multi-session' })
       click_idv_continue
       expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
       expect(fake_analytics).to have_logged_event(

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -165,7 +165,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       click_idv_continue
       expect(page).to have_current_path(idv_session_errors_failure_path)
       expect(fake_analytics).to have_logged_event(
-        'Throttler Rate Limit Triggered',
+        'Rate Limit Reached',
         throttle_type: :idv_resolution,
         step_name: 'verify_info',
       )
@@ -215,7 +215,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       click_idv_continue
       expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
       expect(fake_analytics).to have_logged_event(
-        'Throttler Rate Limit Triggered',
+        'Rate Limit Reached',
         throttle_type: :proof_ssn,
         step_name: 'verify_info',
       )
@@ -248,7 +248,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
 
       expect(page).to have_current_path(idv_phone_path)
       expect(fake_analytics).not_to have_logged_event(
-        'Throttler Rate Limit Triggered',
+        'Rate Limit Reached',
         throttle_type: :proof_ssn,
         step_name: 'verify_info',
       )

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -166,7 +166,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       expect(page).to have_current_path(idv_session_errors_failure_path)
       expect(fake_analytics).to have_logged_event(
         'Rate Limit Reached',
-        throttle_type: :idv_resolution,
+        limiter_type: :idv_resolution,
         step_name: 'verify_info',
       )
 
@@ -216,7 +216,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
       expect(fake_analytics).to have_logged_event(
         'Rate Limit Reached',
-        throttle_type: :proof_ssn,
+        limiter_type: :proof_ssn,
         step_name: 'verify_info',
       )
 
@@ -249,7 +249,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       expect(page).to have_current_path(idv_phone_path)
       expect(fake_analytics).not_to have_logged_event(
         'Rate Limit Reached',
-        throttle_type: :proof_ssn,
+        limiter_type: :proof_ssn,
         step_name: 'verify_info',
       )
     end

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe RegisterUserEmailForm do
       let(:extra_params) do
         {
           email_already_exists: true,
-          throttled: false,
+          rate_limited: false,
           user_id: existing_user.uuid,
           domain_name: email_domain,
         }
@@ -147,7 +147,7 @@ RSpec.describe RegisterUserEmailForm do
       let(:extra_params) do
         {
           email_already_exists: true,
-          throttled: false,
+          rate_limited: false,
           user_id: existing_user.uuid,
           domain_name: email_domain,
         }
@@ -218,7 +218,7 @@ RSpec.describe RegisterUserEmailForm do
         submit_form = subject.submit(email: unregistered_email_address, terms_accepted: '1')
         extra = {
           email_already_exists: false,
-          throttled: false,
+          rate_limited: false,
           user_id: User.find_with_email(unregistered_email_address).uuid,
           domain_name: email_domain,
         }
@@ -250,7 +250,7 @@ RSpec.describe RegisterUserEmailForm do
 
         extra = {
           email_already_exists: false,
-          throttled: false,
+          rate_limited: false,
           user_id: anonymous_uuid,
           domain_name: invalid_email,
         }
@@ -269,7 +269,7 @@ RSpec.describe RegisterUserEmailForm do
 
         extra = {
           email_already_exists: false,
-          throttled: false,
+          rate_limited: false,
           user_id: anonymous_uuid,
           domain_name: 'çà.com',
         }
@@ -292,7 +292,7 @@ RSpec.describe RegisterUserEmailForm do
 
         extra = {
           email_already_exists: true,
-          throttled: false,
+          rate_limited: false,
           user_id: email_address.user.uuid,
           domain_name: blocked_domain,
         }
@@ -341,7 +341,7 @@ RSpec.describe RegisterUserEmailForm do
         extra = {
           domain_name: email_domain,
           email_already_exists: false,
-          throttled: false,
+          rate_limited: false,
           user_id: User.find_with_email(unregistered_email_address).uuid,
         }
 
@@ -367,7 +367,7 @@ RSpec.describe RegisterUserEmailForm do
         extra = {
           domain_name: email_domain,
           email_already_exists: false,
-          throttled: false,
+          rate_limited: false,
           user_id: User.find_with_email(unregistered_email_address).uuid,
         }
 
@@ -385,7 +385,7 @@ RSpec.describe RegisterUserEmailForm do
         extra = {
           domain_name: email_domain,
           email_already_exists: false,
-          throttled: false,
+          rate_limited: false,
           user_id: anonymous_uuid,
         }
 
@@ -406,7 +406,7 @@ RSpec.describe RegisterUserEmailForm do
         extra = {
           domain_name: email_domain,
           email_already_exists: true,
-          throttled: false,
+          rate_limited: false,
           user_id: email_address.user.uuid,
         }
 
@@ -424,7 +424,7 @@ RSpec.describe RegisterUserEmailForm do
         extra = {
           domain_name: email_domain,
           email_already_exists: false,
-          throttled: false,
+          rate_limited: false,
           user_id: anonymous_uuid,
         }
         submit_form = subject.submit(

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(analytics).to have_logged_event(
           'Rate Limit Reached',
-          throttle_type: :reg_confirmed_email,
+          limiter_type: :reg_confirmed_email,
         )
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(analytics).to have_logged_event(
           'Rate Limit Reached',
-          throttle_type: :reg_unconfirmed_email,
+          limiter_type: :reg_unconfirmed_email,
         )
       end
     end

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe RegisterUserEmailForm do
         end
 
         expect(analytics).to have_logged_event(
-          'Throttler Rate Limit Triggered',
+          'Rate Limit Reached',
           throttle_type: :reg_confirmed_email,
         )
       end
@@ -187,7 +187,7 @@ RSpec.describe RegisterUserEmailForm do
         end
 
         expect(analytics).to have_logged_event(
-          'Throttler Rate Limit Triggered',
+          'Rate Limit Reached',
           throttle_type: :reg_unconfirmed_email,
         )
       end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe RequestPasswordReset do
 
         expect(analytics).to have_logged_event(
           'Rate Limit Reached',
-          throttle_type: :reset_password_email,
+          limiter_type: :reset_password_email,
         )
         expect(irs_attempts_api_tracker).to have_received(:forgot_password_email_rate_limited).with(
           email: email,

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe RequestPasswordReset do
           to_not(change { user.reload.reset_password_token })
 
         expect(analytics).to have_logged_event(
-          'Throttler Rate Limit Triggered',
+          'Rate Limit Reached',
           throttle_type: :reset_password_email,
         )
         expect(irs_attempts_api_tracker).to have_received(:forgot_password_email_rate_limited).with(


### PR DESCRIPTION
## 🎫 Ticket

[LG-10252](https://cm-jira.usa.gov/browse/LG-10252)

## 🛠 Summary of changes

- As a followup to PR #8706, rename analytics events and arguments that contain 'throttle'.
  - Event `Throttler Rate Limit Triggered` is now `Rate Limit Reached`.
- Also rename irs_attempts_api argument `throttle_context` to `limiter_context`

NOTE:
- This requires coordination with a devops terraform deploy to change any dashboards that use these events
  - Searched in identity-devops repo, but it only refers to the rack_attack event `Rate Limit Triggered`, which is separate from the one renamed here.
- Check with @ThatSpaceGuy about change to irs_attempts_api 
  - @zachmargolis confirmed that it's not a problem.
- Notify Rodolfo Ornelas of analytics changes.

## 📜 Testing Plan

Automated tests.