### PR TITLE
Implement current_profile relation on user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -251,15 +251,7 @@ class ApplicationController < ActionController::Base
 
   def user_needs_to_reactivate_account?
     return false if current_user.password_reset_profile.blank?
-    return false if pending_profile_newer_than_password_reset_profile?
     sp_session[:ial2] == true
-  end
-
-  def pending_profile_newer_than_password_reset_profile?
-    return false if current_user.pending_profile.blank?
-    return false if current_user.password_reset_profile.blank?
-    current_user.pending_profile.created_at >
-      current_user.password_reset_profile.updated_at
   end
 
   def invalid_auth_token(_exception)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -47,7 +47,19 @@ class Profile < ApplicationRecord
     gpo_verification_pending_at.present?
   end
 
+  def pending?
+    pending_reasons.any?
+  end
+
   def pending_reasons
+    ##
+    # If profiles have been deactivated because of verification_cancelled or encryption_error
+    # or password reset then they are no longer pending and thus have no pending reasons
+    #
+    if deactivation_reason.present? && deactivation_reason != 'in_person_verification_pending'
+      return []
+    end
+
     [
       *(:gpo_verification_pending if gpo_verification_pending?),
       *(:fraud_check_pending if has_fraud_deactivation_reason?),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,11 @@ class User < ApplicationRecord
   # rubocop:enable Rails/HasManyOrHasOneDependent
   has_many :agency_identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
+  has_one :current_profile,
+          -> { order(created_at: :desc) },
+          class_name: 'Profile',
+          dependent: :destroy,
+          inverse_of: :user
   has_one :account_reset_request, dependent: :destroy
   has_many :phone_configurations, dependent: :destroy, inverse_of: :user
   has_many :email_addresses, dependent: :destroy, inverse_of: :user
@@ -59,12 +64,6 @@ class User < ApplicationRecord
           -> { where(status: :establishing).order(created_at: :desc) },
           class_name: 'InPersonEnrollment', foreign_key: :user_id, inverse_of: :user,
           dependent: :destroy
-
-  has_one :current_profile,
-          -> { order(created_at: :desc) },
-          class_name: 'Profile',
-          dependent: :destroy,
-          inverse_of: :user
 
   attr_accessor :asserted_attributes, :email
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,7 +145,7 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    current_profile if current_profile&.pending_reasons&.any?
+    current_profile if current_profile&.pending?
   end
 
   def gpo_verification_pending_profile

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature 'idv gpo otp verification step' do
   let(:profile) do
     create(
       :profile,
-      deactivation_reason: 3,
       gpo_verification_pending_at: 2.days.ago,
       pii: {
         address1: '1 Secure Way',

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'idv gpo step' do
       # complete verification: end to end gpo test
       complete_gpo_verification(user)
 
-      expect(user.identity_verified?).to be(true)
+      expect(user.reload.identity_verified?).to be(true)
 
       expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
     end

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'dev rake tasks' do
       expect(User.count).to eq 10
       verified_user.reload
       expect(verified_user.updated_at).to eq(verified_user_updated_at)
-      expect(verified_user.active_profile).to be(verified_user_profile)
+      expect(verified_user.active_profile).to eq(verified_user_profile)
 
       unverified_user = User.last
       expect(unverified_user.active_profile).to be_nil
@@ -99,7 +99,7 @@ RSpec.describe 'dev rake tasks' do
 
       verified_user.reload
       expect(verified_user.updated_at).to eq(verified_user_updated_at)
-      expect(verified_user.active_profile).to be(verified_user_profile)
+      expect(verified_user.active_profile).to eq(verified_user_profile)
     end
   end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -48,19 +48,47 @@ RSpec.describe Profile do
 
   # TODO
   describe '#pending?' do
-    it 'returns false if the profile has no pending reasons'
+    it 'returns false if the profile has no pending reasons' do
+      profile = create(:profile, :verified)
 
-    it 'returns true if the profile is GPO pending'
+      expect(profile.pending?).to eq(false)
+    end
 
-    it 'returns true if the profile is in-person pending'
+    it 'returns true if the profile is GPO pending' do
+      profile = create(:profile, :verify_by_mail_pending)
 
-    it 'returns true if the user if fraud review pending'
+      expect(profile.pending?).to eq(true)
+    end
 
-    it 'returns false if the user cancelled verification'
+    it 'returns true if the profile is in-person pending' do
+      profile = create(:profile, :in_person_verification_pending)
 
-    it 'returns false if a pending profile was deactivate for an encryption error'
+      expect(profile.pending?).to eq(true)
+    end
 
-    it 'returns false if a profile is pending password reset'
+    it 'returns true if the user if fraud review pending' do
+      profile = create(:profile, :fraud_review_pending)
+
+      expect(profile.pending?).to eq(true)
+    end
+
+    it 'returns false if the user cancelled verification' do
+      profile = create(:profile, :verification_cancelled, :verify_by_mail_pending)
+
+      expect(profile.pending?).to eq(false)
+    end
+
+    it 'returns false if a pending profile was deactivate for an encryption error' do
+      profile = create(:profile, :encryption_error, :verify_by_mail_pending)
+
+      expect(profile.pending?).to eq(false)
+    end
+
+    it 'returns false if a profile is pending password reset' do
+      profile = create(:profile, :password_reset)
+
+      expect(profile.pending?).to eq(false)
+    end
   end
 
   describe '#pending_in_person_enrollment?' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -46,6 +46,23 @@ RSpec.describe Profile do
     end
   end
 
+  # TODO
+  describe '#pending?' do
+    it 'returns false if the profile has no pending reasons'
+
+    it 'returns true if the profile is GPO pending'
+
+    it 'returns true if the profile is in-person pending'
+
+    it 'returns true if the user if fraud review pending'
+
+    it 'returns false if the user cancelled verification'
+
+    it 'returns false if a pending profile was deactivate for an encryption error'
+
+    it 'returns false if a profile is pending password reset'
+  end
+
   describe '#pending_in_person_enrollment?' do
     it 'returns true if the document_check component is usps' do
       profile = create(:profile, proofing_components: { document_check: 'usps' })

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -97,6 +97,7 @@ RSpec.configure do |config|
     self.default_url_options = default_url_options
     allow(Rails.application.routes).to receive(:default_url_options).and_return(default_url_options)
   end
+
   config.before(:each, type: :controller) do
     @request.host = IdentityConfig.store.domain_name
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -98,6 +98,8 @@ RSpec.configure do |config|
     allow(Rails.application.routes).to receive(:default_url_options).and_return(default_url_options)
   end
 
+  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+
   config.before(:each, type: :controller) do
     @request.host = IdentityConfig.store.domain_name
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -98,8 +98,6 @@ RSpec.configure do |config|
     allow(Rails.application.routes).to receive(:default_url_options).and_return(default_url_options)
   end
 
-  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-
   config.before(:each, type: :controller) do
     @request.host = IdentityConfig.store.domain_name
   end

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -198,7 +198,8 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
   end
 
   def expect_successful_saml_handoff
-    profile_phone = user.active_profile.decrypt_pii(Features::SessionHelper::VALID_PASSWORD).phone
+    decrypted_pii = user.reload.active_profile.decrypt_pii(Features::SessionHelper::VALID_PASSWORD)
+    profile_phone = decrypted_pii.phone
     xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
 
     expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(xmldoc.uuid)


### PR DESCRIPTION
This commit adds a more conservative approach to #8866.

That PR investigated what it would take to fully re-implment the pending/active/password_reset profile tooling to ensure those always returned the same profile. There are some pretty large changes that come along with that.

This commit simplifies things by keeping the interface that fetches those profiles on the user. It changes the implmentation so they only return a profile if it is the most recent profile.
