### PR TITLE
LG-10439 Add `had_barcode_read_failure` to `idv_session`

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -39,8 +39,9 @@ module Idv
         uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
       )
 
-      if defined?(flow_session) # hybrid mobile does not have flow_session
+      if defined?(flow_session) && defined?(idv_session) # hybrid mobile does not have idv_session
         flow_session[:had_barcode_read_failure] = response.attention_with_barcode?
+        idv_session.had_barcode_read_failure = response.attention_with_barcode?
         if store_in_session
           flow_session[:pii_from_doc] ||= {}
           flow_session[:pii_from_doc].merge!(pii_from_doc)

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -6,6 +6,7 @@ module Idv
       flow_path
       go_back_path
       gpo_code_verified
+      had_barcode_read_failure
       idv_consent_given
       idv_phone_step_document_capture_session_uuid
       personal_key

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -118,14 +118,6 @@ module Idv
         :idv_verify_step_document_capture_session_uuid
       end
 
-      def track_document_state(state)
-        return unless IdentityConfig.store.state_tracking_enabled && state
-        doc_auth_log = DocAuthLog.find_by(user_id: user_id)
-        return unless doc_auth_log
-        doc_auth_log.state = state
-        doc_auth_log.save!
-      end
-
       delegate :idv_session, :session, :flow_path, to: :@flow
     end
   end

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -18,23 +18,6 @@ locals:
   <!-- Needed by form steps wait javascript -->
 </div>
 
-<% if @had_barcode_read_failure %>
-  <%= render AlertComponent.new(
-        type: :warning,
-        class: 'margin-bottom-4',
-        text_tag: 'div',
-      ) do %>
-    <%= t(
-          'doc_auth.headings.capture_scan_warning_html',
-          link_html: link_to(
-            t('doc_auth.headings.capture_scan_warning_link'),
-            idv_hybrid_handoff_url(redo: true),
-            'aria-label': t('doc_auth.headings.capture_scan_warning_link'),
-          ),
-        ) %>
-  <% end %>
-<% end %>
-
 <% title t('titles.idv.verify_info') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>


### PR DESCRIPTION
We are working to retire `flow_session` as part of retiring FSM and restoring the back button functionality.

This commit starts to move one of the properties, `had_barcode_read_failure`, into `idv_session`. Another commit will be necessary to start reading from the `idv_session` and then a final commit to stop writing to `flow_session`.
