### PR TITLE
Exempt "InvalidStateError" from WebAuthn error tracking

### DIFF
--- a/app/javascript/packages/webauthn/is-expected-error.ts
+++ b/app/javascript/packages/webauthn/is-expected-error.ts
@@ -1,10 +1,17 @@
 /**
- * Set of expected DOM exceptions, which occur based on some user behavior that is not noteworthy,
- * such as declining permissions or timeout due to inactivity.
+ * Set of expected DOM exceptions, which occur based on some user behavior that is not noteworthy:
+ *
+ * - Declining permissions
+ * - Timeout due to inactivity
+ * - Invalid state such as duplicate key enrollment
  *
  * @see https://webidl.spec.whatwg.org/#idl-DOMException
  */
-const EXPECTED_DOM_EXCEPTIONS: Set<string> = new Set(['NotAllowedError', 'TimeoutError']);
+const EXPECTED_DOM_EXCEPTIONS: Set<string> = new Set([
+  'NotAllowedError',
+  'TimeoutError',
+  'InvalidStateError',
+]);
 
 const isExpectedWebauthnError = (error: Error): boolean =>
   error instanceof DOMException && EXPECTED_DOM_EXCEPTIONS.has(error.name);


### PR DESCRIPTION
## 🎫 Ticket

Addendum for [LG-10457](https://cm-jira.usa.gov/browse/LG-10457)

## 🛠 Summary of changes

Revises the exception set for allowable errors introduced in #8859's error tracking to also allow `InvalidStateError`. After testing this in a live environment, it was observed that `InvalidStateError` frequently may occur when a user attempts to enroll an authenticator that's already been registered.

## 📜 Testing Plan

1. Create an account with security key
2. Add a security key from account dashboard
3. In browser DevTools console, add a breakpoint at https://github.com/18F/identity-idp/blob/93ecd59205910b19e72e56a59a90537387d73d2d/app/javascript/packages/analytics/index.ts#L34
4. Assuming it's the same security key, observe breakpoint is not triggered
