### PR TITLE
Start renaming skip_upload parameter

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -18,7 +18,7 @@ module Idv
     end
 
     def update
-      skip_to_capture if params[:skip_upload]
+      skip_to_capture if params[:skip_hybrid_handoff] || params[:skip_upload]
 
       result = Idv::ConsentForm.new.submit(consent_form_params)
 

--- a/app/controllers/idv/getting_started_controller.rb
+++ b/app/controllers/idv/getting_started_controller.rb
@@ -21,7 +21,7 @@ module Idv
 
     def update
       flow_session[:skip_upload_step] = true unless FeatureManagement.idv_allow_hybrid_flow?
-      skip_to_capture if params[:skip_upload]
+      skip_to_capture if params[:skip_hybrid_handoff] || params[:skip_upload]
 
       result = Idv::ConsentForm.new.submit(consent_form_params)
 

--- a/app/javascript/packs/document-capture-welcome.ts
+++ b/app/javascript/packs/document-capture-welcome.ts
@@ -2,8 +2,17 @@ import { isCameraCapableMobile } from '@18f/identity-device';
 
 if (isCameraCapableMobile()) {
   const form = document.querySelector<HTMLFormElement>('.js-consent-continue-form')!;
+
+  // Tell the backend that we're on a device that can take its own pictures, so we don't need
+  // to show the user the hybrid handoff screen.
   const input = document.createElement('input');
   input.type = 'hidden';
-  input.name = 'skip_upload';
+  input.name = 'skip_hybrid_handoff';
   form.appendChild(input);
+
+  // TEMP: Send skip_upload as well to account for 50/50 state during deploy
+  const compatibilityInput = document.createElement('input');
+  compatibilityInput.type = 'hidden';
+  compatibilityInput.name = 'skip_upload';
+  form.appendChild(compatibilityInput);
 }

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -99,11 +99,14 @@ RSpec.describe Idv::AgreementController do
 
     let(:skip_upload) { nil }
 
+    let(:skip_hybrid_handoff) { nil }
+
     let(:params) do
       {
         doc_auth: {
           ial2_consent_given: 1,
         },
+        skip_hybrid_handoff: skip_hybrid_handoff,
         skip_upload: skip_upload,
       }.compact
     end
@@ -129,6 +132,30 @@ RSpec.describe Idv::AgreementController do
 
     context 'skip_upload present in params' do
       let(:skip_upload) { '' }
+      it 'sets flow_path to standard' do
+        expect do
+          put :update, params: params
+        end.to change {
+          subject.idv_session.flow_path
+        }.from(nil).to('standard')
+      end
+
+      it 'sets flow_session[:skip_upload_step] to true' do
+        expect do
+          put :update, params: params
+        end.to change {
+          subject.flow_session[:skip_upload_step]
+        }.from(nil).to(true)
+      end
+
+      it 'redirects to hybrid handoff' do
+        put :update, params: params
+        expect(response).to redirect_to(idv_hybrid_handoff_url)
+      end
+    end
+
+    context 'skip_hybrid_handoff present in params' do
+      let(:skip_hybrid_handoff) { '' }
       it 'sets flow_path to standard' do
         expect do
           put :update, params: params

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -97,10 +97,58 @@ RSpec.describe Idv::AgreementController do
       }.merge(ab_test_args)
     end
 
+    let(:skip_upload) { nil }
+
+    let(:params) do
+      {
+        doc_auth: {
+          ial2_consent_given: 1,
+        },
+        skip_upload: skip_upload,
+      }.compact
+    end
+
     it 'sends analytics_submitted event with consent given' do
-      put :update, params: { doc_auth: { ial2_consent_given: 1 } }
+      put :update, params: params
 
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+    end
+
+    it 'does not set flow_path' do
+      expect do
+        put :update, params: params
+      end.not_to change {
+        subject.idv_session.flow_path
+      }.from(nil)
+    end
+
+    it 'redirects to hybrid handoff' do
+      put :update, params: params
+      expect(response).to redirect_to(idv_hybrid_handoff_url)
+    end
+
+    context 'skip_upload present in params' do
+      let(:skip_upload) { '' }
+      it 'sets flow_path to standard' do
+        expect do
+          put :update, params: params
+        end.to change {
+          subject.idv_session.flow_path
+        }.from(nil).to('standard')
+      end
+
+      it 'sets flow_session[:skip_upload_step] to true' do
+        expect do
+          put :update, params: params
+        end.to change {
+          subject.flow_session[:skip_upload_step]
+        }.from(nil).to(true)
+      end
+
+      it 'redirects to hybrid handoff' do
+        put :update, params: params
+        expect(response).to redirect_to(idv_hybrid_handoff_url)
+      end
     end
   end
 end

--- a/spec/controllers/idv/getting_started_controller_spec.rb
+++ b/spec/controllers/idv/getting_started_controller_spec.rb
@@ -106,11 +106,14 @@ RSpec.describe Idv::GettingStartedController do
 
     let(:skip_upload) { nil }
 
+    let(:skip_hybrid_handoff) { nil }
+
     let(:params) do
       {
         doc_auth: {
           ial2_consent_given: 1,
         },
+        skip_hybrid_handoff: skip_hybrid_handoff,
         skip_upload: skip_upload,
       }.compact
     end
@@ -156,6 +159,30 @@ RSpec.describe Idv::GettingStartedController do
 
     context 'skip_upload present in params' do
       let(:skip_upload) { '' }
+      it 'sets flow_path to standard' do
+        expect do
+          put :update, params: params
+        end.to change {
+          subject.idv_session.flow_path
+        }.from(nil).to('standard')
+      end
+
+      it 'sets flow_session[:skip_upload_step] to true' do
+        expect do
+          put :update, params: params
+        end.to change {
+          subject.flow_session[:skip_upload_step]
+        }.from(nil).to(true)
+      end
+
+      it 'redirects to hybrid handoff' do
+        put :update, params: params
+        expect(response).to redirect_to(idv_hybrid_handoff_url)
+      end
+    end
+
+    context 'skip_hybrid_handoff present in params' do
+      let(:skip_hybrid_handoff) { '' }
       it 'sets flow_path to standard' do
         expect do
           put :update, params: params


### PR DESCRIPTION
## 🎫 Ticket

_Kind of_ related to [LG-10402](https://cm-jira.usa.gov/browse/LG-10402)

## 🛠 Summary of changes

We've already renamed "upload" step of IdV to "hybrid handoff". This PR begins the process of renaming an internal parameter from `skip_upload` to `skip_hybrid_handoff`. To handle the 50/50 state during deployment, we'll temporarily send both `skip_upload` and `skip_hybrid_handoff` and let our controllers accept both. A future PR (to be merged after this is deployed) will fully remove support for `skip_upload`.

This PR also adds some test coverage for what happens when `skip_upload` or `skip_hybrid_handoff` is present–the details of this will change with work on LG-10402, but I wanted to capture it as it is here.

_Also_, since we're in the process of A/B testing a new unified "Getting Started" screen, this PR involves the same changes made to `AgreementController` and `GettingStartedController`.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
