### PR TITLE
Add "count distinct" option to CloudWatch query script

### DIFF
--- a/bin/query-cloudwatch
+++ b/bin/query-cloudwatch
@@ -40,8 +40,9 @@ class QueryCloudwatch
 
   def run(stdout: STDOUT)
     if config.count_distinct
-      result = fetch
-      stdout.puts result
+      values = {}
+      fetch { |row| values[row[config.count_distinct]] = true }
+      stdout.puts values.size
     else
       fetch { |row| stdout.puts format_response(row) }
     end
@@ -79,7 +80,7 @@ class QueryCloudwatch
       log_group_name: config.group,
       progress: config.progress,
       slice_interval: config.slice,
-      **config.to_h.slice(:wait_duration, :count_distinct).compact,
+      **config.to_h.slice(:wait_duration).compact,
     )
   end
 
@@ -244,6 +245,15 @@ class QueryCloudwatch
       else
         config.query = stdin.read
       end
+    end
+
+    if config.count_distinct
+      config.complete = true
+      config.query = [
+        config.query,
+        "| stats count(*) by #{config.count_distinct}",
+        "| limit #{Reporting::CloudwatchClient::MAX_RESULTS_LIMIT}",
+      ].join("\n")
     end
 
     if !errors.empty?

--- a/bin/query-cloudwatch
+++ b/bin/query-cloudwatch
@@ -69,6 +69,7 @@ class QueryCloudwatch
       query: config.query,
       from: config.from,
       to: config.to,
+      &block
     )
   end
 

--- a/bin/query-cloudwatch
+++ b/bin/query-cloudwatch
@@ -28,6 +28,7 @@ class QueryCloudwatch
     :complete,
     :progress,
     :wait_duration,
+    :count_distinct,
     keyword_init: true,
   )
 
@@ -38,12 +39,11 @@ class QueryCloudwatch
   end
 
   def run(stdout: STDOUT)
-    cloudwatch_client.fetch(
-      query: config.query,
-      from: config.from,
-      to: config.to,
-    ) do |row|
-      stdout.puts format_response(row)
+    if config.count_distinct
+      result = fetch
+      stdout.puts result
+    else
+      fetch { |row| stdout.puts format_response(row) }
     end
   rescue Interrupt
     # catch interrupts (ctrl-c) and directly exit, this skips printing the backtrace
@@ -64,13 +64,21 @@ class QueryCloudwatch
     end
   end
 
+  def fetch(&block)
+    cloudwatch_client.fetch(
+      query: config.query,
+      from: config.from,
+      to: config.to,
+    )
+  end
+
   def cloudwatch_client
     @cloudwatch_client ||= Reporting::CloudwatchClient.new(
       ensure_complete_logs: config.complete,
       log_group_name: config.group,
       progress: config.progress,
       slice_interval: config.slice,
-      **config.to_h.slice(:wait_duration).compact,
+      **config.to_h.slice(:wait_duration, :count_distinct).compact,
     )
   end
 
@@ -84,6 +92,7 @@ class QueryCloudwatch
       to: now,
       complete: false,
       progress: true,
+      count_distinct: nil,
     )
 
     # rubocop:disable Metrics/BlockLength
@@ -202,6 +211,10 @@ class QueryCloudwatch
 
       opts.on('--[no-]progress', 'whether or not show a progress bar, defaults to on') do |progress|
         config.progress = progress
+      end
+
+      opts.on('--count-distinct FIELD', 'get distinct count for given field') do |count_distinct|
+        config.count_distinct = count_distinct
       end
 
       opts.on('-h', '--help', 'Prints this help') do

--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -8,11 +8,7 @@ module Reporting
     DEFAULT_WAIT_DURATION = 3
     MAX_RESULTS_LIMIT = 10_000
 
-    attr_reader :num_threads,
-                :wait_duration,
-                :slice_interval,
-                :logger,
-                :log_group_name
+    attr_reader :num_threads, :wait_duration, :slice_interval, :logger, :log_group_name
 
     # @param [Boolean] ensure_complete_logs when true, will detect when queries return exactly
     #  10,000 rows (Cloudwatch Insights max limit) and then recursively split the query window into

--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -8,7 +8,12 @@ module Reporting
     DEFAULT_WAIT_DURATION = 3
     MAX_RESULTS_LIMIT = 10_000
 
-    attr_reader :num_threads, :wait_duration, :slice_interval, :logger, :log_group_name
+    attr_reader :num_threads,
+                :wait_duration,
+                :slice_interval,
+                :logger,
+                :log_group_name,
+                :count_distinct
 
     # @param [Boolean] ensure_complete_logs when true, will detect when queries return exactly
     #  10,000 rows (Cloudwatch Insights max limit) and then recursively split the query window into
@@ -27,7 +32,8 @@ module Reporting
       slice_interval: 1.day,
       logger: nil,
       progress: true,
-      log_group_name: 'prod_/srv/idp/shared/log/events.log'
+      log_group_name: 'prod_/srv/idp/shared/log/events.log',
+      count_distinct: nil
     )
       @ensure_complete_logs = ensure_complete_logs
       @num_threads = num_threads
@@ -36,6 +42,7 @@ module Reporting
       @logger = logger
       @progress = progress
       @log_group_name = log_group_name
+      @count_distinct = count_distinct
     end
 
     # Either both (from, to) or time_slices must be provided
@@ -73,6 +80,15 @@ module Reporting
           format: 'Querying log slices %j%% [%c/%C] |%B| %a',
           output: @progress.respond_to?(:fileno) ? @progress : STDERR,
         )
+      end
+
+      if count_distinct
+        @ensure_complete_logs = true
+        query = [
+          query,
+          "| stats count(*) by #{count_distinct}",
+          "| limit #{MAX_RESULTS_LIMIT}",
+        ].join("\n")
       end
 
       log(:debug, "starting query, queue_size=#{queue.length} num_threads=#{num_threads}")
@@ -143,6 +159,10 @@ module Reporting
 
       @progress_bar&.finish
 
+      if count_distinct
+        results = results.sum
+      end
+
       results
     ensure
       threads&.each(&:kill)
@@ -205,9 +225,13 @@ module Reporting
     # @param [Array<Array<Aws::CloudWatchLogs::Types::ResultField>>] results
     # @return [Array<Hash>]
     def parse_results(results)
-      results.map do |row|
-        row.map { |cell| [cell.field, cell.value] }.to_h.tap do |h|
-          h.delete('@ptr') # just noise
+      if count_distinct
+        [results.size]
+      else
+        results.map do |row|
+          row.map { |cell| [cell.field, cell.value] }.to_h.tap do |h|
+            h.delete('@ptr') # just noise
+          end
         end
       end
     end

--- a/spec/bin/query-cloudwatch_spec.rb
+++ b/spec/bin/query-cloudwatch_spec.rb
@@ -159,6 +159,15 @@ RSpec.describe QueryCloudwatch do
       end
     end
 
+    context 'with --count-distinct' do
+      let(:argv) { required_parameters + %w[--count-distinct properties.user_id] }
+
+      it 'assigns the slice duration' do
+        config = parse!
+        expect(config.count_distinct).to eq('properties.user_id')
+      end
+    end
+
     def build_stdin_without_query
       StringIO.new.tap do |io|
         allow(io).to receive(:tty?).and_return(true)
@@ -172,6 +181,7 @@ RSpec.describe QueryCloudwatch do
 
   describe '#run' do
     let(:format) { :csv }
+    let(:count_distinct) { nil }
     let(:config) do
       QueryCloudwatch::Config.new(
         group: 'foobar',
@@ -182,6 +192,7 @@ RSpec.describe QueryCloudwatch do
         wait_duration: 0,
         query: 'fields @timestamp, @message',
         format: format,
+        count_distinct: count_distinct,
       )
     end
     let(:query_cloudwatch) { QueryCloudwatch.new(config) }
@@ -230,6 +241,15 @@ RSpec.describe QueryCloudwatch do
           {"@timestamp":"timestamp-1","@message":"message-1"}
           {"@timestamp":"timestamp-2","@message":"message-2"}
         STR
+      end
+    end
+
+    context 'with count distinct' do
+      let(:count_distinct) { '@message' }
+
+      it 'outputs sum count' do
+        run
+        expect(stdout.string.strip).to eq '2'
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-7708](https://cm-jira.usa.gov/browse/LG-7708)

## 🛠 Summary of changes

Adds new `--count-distinct` option to `bin/query-cloudwatch` to help produce a total distinct count from a query that may need to be stitched together with the `--complete` functionality.

## 📜 Testing Plan

Example usage:

```
bin/query-cloudwatch --from 1h --env int --app idp --log events.log --count-distinct properties.user_id --query "filter name = 'Multi-Factor Authentication' and properties.event_properties.success = 1"
```