### PR TITLE
Fix 500 Error: Create Account with Suspended User Email Using "+" sign

### DIFF
--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -38,7 +38,7 @@
   <% if FeatureManagement.enable_load_testing_mode? %>
     <%= link_to(
           'CONFIRM NOW',
-          sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),
+          sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email)&.confirmation_token),
           id: 'confirm-now',
         ) %>
   <% end %>

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -35,10 +35,10 @@
   </p>
   <p><%= t('devise.registrations.close_window') %></p>
 
-  <% if FeatureManagement.enable_load_testing_mode? %>
+  <% if FeatureManagement.enable_load_testing_mode? && EmailAddress.find_with_email(email) %>
     <%= link_to(
           'CONFIRM NOW',
-          sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email)&.confirmation_token),
+          sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),
           id: 'confirm-now',
         ) %>
   <% end %>

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -25,7 +25,7 @@
 <p><%= t('notices.use_diff_email.text_html', link_html: link_to(t('notices.use_diff_email.link'), add_email_path)) %></p>
 <p><%= t('devise.registrations.close_window') %></p>
 
-<% if FeatureManagement.enable_load_testing_mode? %>
+<% if FeatureManagement.enable_load_testing_mode? && EmailAddress.find_with_email(email) %>
   <%= link_to(
         'CONFIRM NOW',
         sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),

--- a/spec/views/sign_up/emails/show.html.erb_spec.rb
+++ b/spec/views/sign_up/emails/show.html.erb_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe 'sign_up/emails/show.html.erb' do
   context 'when email address not found' do
     before do
       allow(FeatureManagement).to receive(:enable_load_testing_mode?).and_return(true)
-      allow(EmailAddress).to receive(:find_with_email).with(email).and_return(nil)
 
       render
     end

--- a/spec/views/sign_up/emails/show.html.erb_spec.rb
+++ b/spec/views/sign_up/emails/show.html.erb_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe 'sign_up/emails/show.html.erb' do
   context 'when enable_load_testing_mode? is true and email address found' do
     before do
       allow(FeatureManagement).to receive(:enable_load_testing_mode?).and_return(true)
-      email_address = instance_double(EmailAddress, confirmation_token: 'some_token')
-      allow(EmailAddress).to receive(:find_with_email).with(email).and_return(email_address)
+      create(:email_address, confirmation_token: 'some_token', email: email)
 
       render
     end

--- a/spec/views/users/emails/verify.html.erb_spec.rb
+++ b/spec/views/users/emails/verify.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'sign_up/emails/show.html.erb' do
+RSpec.describe 'users/emails/verify.html.erb' do
   let(:email) { 'foo@bar.com' }
   before do
     allow(view).to receive(:email).and_return(email)

--- a/spec/views/users/emails/verify.html.erb_spec.rb
+++ b/spec/views/users/emails/verify.html.erb_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe 'users/emails/verify.html.erb' do
   context 'when email address not found' do
     before do
       allow(FeatureManagement).to receive(:enable_load_testing_mode?).and_return(true)
-      allow(EmailAddress).to receive(:find_with_email).with(email).and_return(nil)
 
       render
     end

--- a/spec/views/users/emails/verify.html.erb_spec.rb
+++ b/spec/views/users/emails/verify.html.erb_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe 'users/emails/verify.html.erb' do
   context 'when enable_load_testing_mode? is true and email address found' do
     before do
       allow(FeatureManagement).to receive(:enable_load_testing_mode?).and_return(true)
-      email_address = instance_double(EmailAddress, confirmation_token: 'some_token')
-      allow(EmailAddress).to receive(:find_with_email).with(email).and_return(email_address)
+      create(:email_address, confirmation_token: 'some_token', email: email)
 
       render
     end


### PR DESCRIPTION
![image](https://github.com/18F/identity-idp/assets/109746710/50a58dee-cbc9-4536-824e-2a7b99c4c573)
