### PR TITLE
Do not log user out when accessing root url while partially authenticated

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -87,8 +87,7 @@ module Users
       if user_fully_authenticated?
         redirect_to signed_in_url
       elsif current_user
-        analytics.partial_authentication_log_out
-        sign_out
+        redirect_to login_two_factor_options_path
       end
     end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2976,13 +2976,6 @@ module AnalyticsEvents
     )
   end
 
-  def partial_authentication_log_out(**extra)
-    track_event(
-      'Partially authenticated user logged out',
-      **extra,
-    )
-  end
-
   # @param [Boolean] success
   # @param [Hash] errors
   # The user updated their password

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -4,23 +4,6 @@ RSpec.describe Users::SessionsController, devise: true do
   include ActionView::Helpers::DateHelper
   let(:mock_valid_site) { 'http://example.com' }
 
-  describe 'GET /users/sign_in' do
-    it 'clears the session when user is not yet 2fa-ed' do
-      stub_analytics
-      expect(@analytics).to receive(:track_event).with(
-        'Sign in page visited',
-        flash: nil,
-        stored_location: nil,
-      )
-      expect(@analytics).to receive(:track_event).with('Partially authenticated user logged out')
-      sign_in_before_2fa
-
-      get :new
-
-      expect(controller.current_user).to be nil
-    end
-  end
-
   describe 'GET /logout' do
     it 'tracks a logout event' do
       stub_analytics
@@ -464,13 +447,11 @@ RSpec.describe Users::SessionsController, devise: true do
     end
 
     context 'with current user' do
-      it 'logs the user out' do
+      it 'redirects to 2FA' do
         stub_sign_in_before_2fa
-        subject.session[:logged_in] = true
         get :new
 
-        expect(request.path).to eq root_path
-        expect(subject.session[:logged_in]).to be_nil
+        expect(response).to redirect_to login_two_factor_options_path
       end
     end
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -494,7 +494,7 @@ RSpec.feature 'Two Factor Authentication' do
       user = create(:user, :fully_registered)
       sign_in_user(user)
       click_link 'Login.gov'
-      expect(current_path).to eq root_path
+      expect(current_path).to eq login_two_factor_options_path
     end
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

In https://github.com/18F/identity-idp/pull/897, we made the change to log a user out if they went to the root URL while partially authenticated (typically precipitated by clicking the logo at an MFA screen). In gathering some analytics from #8838, it seems as though many users are unintentionally being logged out. Around 50% of users that were logged out in this manner re-authenticated shortly after. Further discussion can be found [here](https://gsa-tts.slack.com/archives/C01710KMYUB/p1690214951246489).

This PR changes the redirect to go to MFA selection.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->
