### PR TITLE
LG-10402: Finish renaming skip_upload_step

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -46,7 +46,6 @@ module Idv
     end
 
     def skip_to_capture
-      flow_session[:skip_upload_step] = true
       idv_session.flow_path = 'standard'
 
       # Store that we're skipping hybrid handoff so if the user

--- a/app/controllers/idv/getting_started_controller.rb
+++ b/app/controllers/idv/getting_started_controller.rb
@@ -65,7 +65,6 @@ module Idv
     end
 
     def skip_to_capture
-      flow_session[:skip_upload_step] = true
       idv_session.flow_path = 'standard'
 
       # Store that we're skipping hybrid handoff so if the user

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -199,9 +199,6 @@ module Idv
       if idv_session.skip_hybrid_handoff?
         # We previously skipped hybrid handoff. Keep doing that.
         idv_session.flow_path = 'standard'
-      elsif flow_session[:skip_upload_step]
-        # TEMP: Will be removing :skip_upload_step in future commit
-        idv_session.flow_path = 'standard'
       end
 
       if !FeatureManagement.idv_allow_hybrid_flow?
@@ -224,9 +221,7 @@ module Idv
       # If we previously skipped hybrid handoff for the user (because they're on a mobile
       # device with a camera), skip it _again_ here.
 
-      if flow_session[:skip_upload_step]
-        idv_session.flow_path = 'standard'
-      elsif idv_session.skip_hybrid_handoff?
+      if idv_session.skip_hybrid_handoff?
         idv_session.flow_path = 'standard'
       else
         idv_session.flow_path = nil

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -644,7 +644,7 @@ module AnalyticsEvents
   end
 
   # User has consented to share information with document upload and may
-  # view the "hybrid handoff" step next unless "skip_upload" param is true
+  # view the "hybrid handoff" step next unless "skip_hybrid_handoff" param is true
   def idv_doc_auth_agreement_submitted(**extra)
     track_event('IdV: doc auth agreement submitted', **extra)
   end

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -80,4 +80,4 @@
   </div>
 </div>
 
-<%= render 'idv/doc_auth/cancel', step: 'upload' %>
+<%= render 'idv/doc_auth/cancel', step: 'hybrid_handoff' %>

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -137,14 +137,6 @@ RSpec.describe Idv::AgreementController do
         }.from(nil).to('standard')
       end
 
-      it 'sets flow_session[:skip_upload_step] to true' do
-        expect do
-          put :update, params: params
-        end.to change {
-          subject.flow_session[:skip_upload_step]
-        }.from(nil).to(true)
-      end
-
       it 'redirects to hybrid handoff' do
         put :update, params: params
         expect(response).to redirect_to(idv_hybrid_handoff_url)

--- a/spec/controllers/idv/getting_started_controller_spec.rb
+++ b/spec/controllers/idv/getting_started_controller_spec.rb
@@ -164,14 +164,6 @@ RSpec.describe Idv::GettingStartedController do
         }.from(nil).to('standard')
       end
 
-      it 'sets flow_session[:skip_upload_step] to true' do
-        expect do
-          put :update, params: params
-        end.to change {
-          subject.flow_session[:skip_upload_step]
-        }.from(nil).to(true)
-      end
-
       it 'redirects to hybrid handoff' do
         put :update, params: params
         expect(response).to redirect_to(idv_hybrid_handoff_url)

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -125,18 +125,6 @@ RSpec.describe Idv::HybridHandoffController do
         expect(response).to render_template :show
       end
 
-      context 'skip_upload_step is set on flow_session' do
-        before do
-          subject.user_session['idv/doc_auth'][:skip_upload_step] = true
-        end
-        it 'redirects to document_capture' do
-          subject.idv_session.flow_path = 'standard'
-          get :show, params: { redo: true }
-
-          expect(response).to redirect_to(idv_document_capture_url)
-        end
-      end
-
       context 'idv_session.skip_hybrid_handoff? is true' do
         before do
           subject.idv_session.skip_hybrid_handoff = true
@@ -165,13 +153,6 @@ RSpec.describe Idv::HybridHandoffController do
       it 'redirects the user straight to document capture' do
         get :show
         expect(response).to redirect_to(idv_document_capture_url)
-      end
-      it 'does not set flow_session[:skip_upload_step]' do
-        expect do
-          get :show
-        end.not_to change {
-          subject.flow_session[:skip_upload_step]
-        }.from(nil)
       end
       it 'does not set idv_session.skip_hybrid_handoff' do
         expect do


### PR DESCRIPTION
#8894 started writing `skip_hybrid_handoff` to `IdvSession` alongside `flow_session[:skip_upload_step]`. This PR removes references to `flow_session[:skip_upload_step]`. It will be safe to merge once #8894 has been deployed.

## 🎫 Ticket

[LG-10402](https://cm-jira.usa.gov/browse/LG-10402)
