### PR TITLE
LG-10385 Add new columns for in-person proofing pending

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -17,6 +17,11 @@ class Profile < ApplicationRecord
   scope(:active, -> { where(active: true) })
   scope(:verified, -> { where.not(verified_at: nil) })
 
+  has_one :establishing_in_person_enrollment,
+          -> { where(status: :establishing).order(created_at: :desc) },
+          class_name: 'InPersonEnrollment', foreign_key: :profile_id, inverse_of: :profile,
+          dependent: :destroy
+
   enum deactivation_reason: {
     password_reset: 1,
     encryption_error: 2,

--- a/db/primary_migrate/20230727195406_add_in_person_verification_pending_at_to_profiles.rb
+++ b/db/primary_migrate/20230727195406_add_in_person_verification_pending_at_to_profiles.rb
@@ -3,6 +3,5 @@ class AddInPersonVerificationPendingAtToProfiles < ActiveRecord::Migration[7.0]
 
   def change
     add_column :profiles, :in_person_verification_pending_at, :datetime
-    add_index :profiles, :in_person_verification_pending_at, algorithm: :concurrently
   end
 end

--- a/db/primary_migrate/20230727195406_add_in_person_verification_pending_at_to_profiles.rb
+++ b/db/primary_migrate/20230727195406_add_in_person_verification_pending_at_to_profiles.rb
@@ -1,0 +1,8 @@
+class AddInPersonVerificationPendingAtToProfiles < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :profiles, :in_person_verification_pending_at, :datetime
+    add_index :profiles, :in_person_verification_pending_at, algorithm: :concurrently
+  end
+end

--- a/db/primary_migrate/20230728203252_add_in_person_enrollment_pending_at_to_profiles.rb
+++ b/db/primary_migrate/20230728203252_add_in_person_enrollment_pending_at_to_profiles.rb
@@ -1,8 +1,0 @@
-class AddInPersonEnrollmentPendingAtToProfiles < ActiveRecord::Migration[7.0]
-  disable_ddl_transaction!
-
-  def change
-    add_column :profiles, :in_person_enrollment_pending_at, :datetime
-    add_index :profiles, :in_person_enrollment_pending_at, algorithm: :concurrently
-  end
-end

--- a/db/primary_migrate/20230728203252_add_in_person_enrollment_pending_at_to_profiles.rb
+++ b/db/primary_migrate/20230728203252_add_in_person_enrollment_pending_at_to_profiles.rb
@@ -1,0 +1,8 @@
+class AddInPersonEnrollmentPendingAtToProfiles < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :profiles, :in_person_enrollment_pending_at, :datetime
+    add_index :profiles, :in_person_enrollment_pending_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -451,7 +451,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
     t.index ["gpo_verification_pending_at"], name: "index_profiles_on_gpo_verification_pending_at"
-    t.index ["in_person_verification_pending_at"], name: "index_profiles_on_in_person_verification_pending_at"
     t.index ["name_zip_birth_year_signature"], name: "index_profiles_on_name_zip_birth_year_signature"
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"
     t.index ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_20_183509) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
-  enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
 
@@ -446,10 +445,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_183509) do
     t.datetime "fraud_rejection_at"
     t.datetime "gpo_verification_pending_at"
     t.integer "fraud_pending_reason"
+    t.datetime "in_person_verification_pending_at"
     t.index ["fraud_pending_reason"], name: "index_profiles_on_fraud_pending_reason"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
     t.index ["gpo_verification_pending_at"], name: "index_profiles_on_gpo_verification_pending_at"
+    t.index ["in_person_verification_pending_at"], name: "index_profiles_on_in_person_verification_pending_at"
     t.index ["name_zip_birth_year_signature"], name: "index_profiles_on_name_zip_birth_year_signature"
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"
     t.index ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_28_203252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -446,10 +446,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
     t.datetime "gpo_verification_pending_at"
     t.integer "fraud_pending_reason"
     t.datetime "in_person_verification_pending_at"
+    t.datetime "in_person_enrollment_pending_at"
     t.index ["fraud_pending_reason"], name: "index_profiles_on_fraud_pending_reason"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
     t.index ["gpo_verification_pending_at"], name: "index_profiles_on_gpo_verification_pending_at"
+    t.index ["in_person_enrollment_pending_at"], name: "index_profiles_on_in_person_enrollment_pending_at"
     t.index ["in_person_verification_pending_at"], name: "index_profiles_on_in_person_verification_pending_at"
     t.index ["name_zip_birth_year_signature"], name: "index_profiles_on_name_zip_birth_year_signature"
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_203252) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -447,12 +447,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_203252) do
     t.datetime "gpo_verification_pending_at"
     t.integer "fraud_pending_reason"
     t.datetime "in_person_verification_pending_at"
-    t.datetime "in_person_enrollment_pending_at"
     t.index ["fraud_pending_reason"], name: "index_profiles_on_fraud_pending_reason"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
     t.index ["gpo_verification_pending_at"], name: "index_profiles_on_gpo_verification_pending_at"
-    t.index ["in_person_enrollment_pending_at"], name: "index_profiles_on_in_person_enrollment_pending_at"
     t.index ["in_person_verification_pending_at"], name: "index_profiles_on_in_person_verification_pending_at"
     t.index ["name_zip_birth_year_signature"], name: "index_profiles_on_name_zip_birth_year_signature"
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema[7.0].define(version: 2023_07_28_203252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
 


### PR DESCRIPTION


## 🎫 Ticket

[LG-10382](https://cm-jira.usa.gov/browse/LG-10382)


## 🛠 Summary of changes

Created two new columns in IdV user's profile for in person verification:

`in_person_verification_pending_at` is a timestamp for when a profile gets "deactivated" for in person verification.

~`in_person_enrollment_pending_at` is a timestamp for when a user has a pending enrollment. This column is meant to~ We can use #user.establishing_in_person_enrollment to replace the `pending_profile&.proofing_components&.[]('document_check') == Idp::Constants::Vendors::USPS` for an in_person_enrollment and make it more explicit in a user's profile.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
