### PR TITLE
Update ruby-jwt gem to fix OpenSSL 3.0 incompadibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,7 +363,7 @@ GEM
       railties (>= 6.0.0)
     json (2.6.3)
     jwe (0.4.0)
-    jwt (2.4.1)
+    jwt (2.7.1)
     knapsack (4.0.0)
       rake
     launchy (2.5.0)


### PR DESCRIPTION
This commit updates the JWT gem. Prior to this a few specs would raise this error when running with OpenSSL 3.0:

```
OpenSSL::PKey::PKeyError:
  rsa#set_key= is incompatible with OpenSSL 3.0
```

This commit upgrades the JWT gem to a version that does not use `#set_key=` in a way that is incompatible with OpenSSL 3.0
