### PR TITLE
LG-10438: Remove flow_session[:document_capture_session_uuid]

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -44,7 +44,7 @@ module IdvSession
   end
 
   def document_capture_session_uuid
-    idv_session.document_capture_session_uuid || flow_session[:document_capture_session_uuid]
+    idv_session.document_capture_session_uuid
   end
 
   def document_capture_session

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -12,7 +12,7 @@ module Idv
 
     def status
       @status ||= begin
-        if !flow_session || !document_capture_session
+        if !document_capture_session
           :unauthorized
         elsif document_capture_session.cancelled_at
           :gone
@@ -31,17 +31,13 @@ module Idv
     end
 
     def redirect_url
-      return unless flow_session && document_capture_session
+      return unless document_capture_session
 
       if rate_limiter.limited?
         idv_session_errors_rate_limited_url
       elsif user_has_establishing_in_person_enrollment?
         idv_in_person_url
       end
-    end
-
-    def flow_session
-      user_session['idv/doc_auth']
     end
 
     def session_result

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -56,7 +56,7 @@ module Idv
     end
 
     def document_capture_session_uuid
-      idv_session.document_capture_session_uuid || flow_session[:document_capture_session_uuid]
+      idv_session.document_capture_session_uuid
     end
 
     def rate_limiter

--- a/app/controllers/idv/getting_started_controller.rb
+++ b/app/controllers/idv/getting_started_controller.rb
@@ -55,7 +55,6 @@ module Idv
         user_id: current_user.id,
         issuer: sp_session[:issuer],
       )
-      flow_session[:document_capture_session_uuid] = document_capture_session.uuid
       idv_session.document_capture_session_uuid = document_capture_session.uuid
     end
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -62,8 +62,7 @@ module Idv
     end
 
     def send_link
-      session_uuid =
-        idv_session.document_capture_session_uuid || flow_session[:document_capture_session_uuid]
+      session_uuid = idv_session.document_capture_session_uuid
       update_document_capture_session_requested_at(session_uuid)
       Telephony.send_doc_auth_link(
         to: formatted_destination_phone,

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -42,7 +42,6 @@ module Idv
         user_id: current_user.id,
         issuer: sp_session[:issuer],
       )
-      flow_session[:document_capture_session_uuid] = document_capture_session.uuid
       idv_session.document_capture_session_uuid = document_capture_session.uuid
     end
 

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -9,8 +9,12 @@ RSpec.describe Idv::CaptureDocStatusController do
 
   describe '#show' do
     let(:document_capture_session) { DocumentCaptureSession.create!(user: user) }
-    let(:flow_session) { { document_capture_session_uuid: document_capture_session.uuid } }
-    let(:idv_session) { {} }
+    let(:flow_session) { {} }
+    let(:idv_session) do
+      {
+        document_capture_session_uuid: document_capture_session.uuid,
+      }
+    end
 
     before do
       allow_any_instance_of(Flow::BaseFlow).to receive(:flow_session).and_return(flow_session)
@@ -118,20 +122,6 @@ RSpec.describe Idv::CaptureDocStatusController do
 
         expect(response.status).to eq(200)
       end
-
-      context 'when document_capture_session_uuid is stored in idv_session' do
-        let(:flow_session) { {} }
-        let(:idv_session) do
-          {
-            document_capture_session_uuid: document_capture_session.uuid,
-          }
-        end
-        it 'returns success' do
-          get :show
-
-          expect(response.status).to eq(200)
-        end
-      end
     end
 
     context 'when capture succeeded with barcode attention' do
@@ -210,12 +200,12 @@ RSpec.describe Idv::CaptureDocStatusController do
         let(:result) { nil }
         let(:flow_session) do
           {
-            document_capture_session_uuid: document_capture_session.uuid,
+            had_barcode_attention_error: true,
           }
         end
         let(:idv_session) do
           {
-            had_barcode_attention_error: true,
+            document_capture_session_uuid: document_capture_session.uuid,
           }
         end
 

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -9,16 +9,9 @@ RSpec.describe Idv::CaptureDocStatusController do
 
   describe '#show' do
     let(:document_capture_session) { DocumentCaptureSession.create!(user: user) }
-    let(:flow_session) { {} }
-    let(:idv_session) do
-      {
-        document_capture_session_uuid: document_capture_session.uuid,
-      }
-    end
+    let(:idv_session) { { document_capture_session_uuid: document_capture_session.uuid } }
 
     before do
-      allow_any_instance_of(Flow::BaseFlow).to receive(:flow_session).and_return(flow_session)
-      controller.user_session['idv/doc_auth'] = flow_session if user
       controller.user_session[:idv] = idv_session if user
     end
 
@@ -32,19 +25,7 @@ RSpec.describe Idv::CaptureDocStatusController do
       end
     end
 
-    context 'when flow session expires' do
-      let(:flow_session) { nil }
-      let(:idv_session) { nil }
-
-      it 'returns unauthorized' do
-        get :show
-
-        expect(response.status).to eq(401)
-      end
-    end
-
     context 'when session does not exist' do
-      let(:flow_session) { {} }
       let(:idv_session) { {} }
 
       it 'returns unauthorized' do
@@ -149,7 +130,7 @@ RSpec.describe Idv::CaptureDocStatusController do
           expect(response.status).to eq(202)
         end
 
-        it 'assigns flow session values as having received attention result' do
+        it 'assigns idv session values as having received attention result' do
           get :show
 
           expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(true)
@@ -167,7 +148,7 @@ RSpec.describe Idv::CaptureDocStatusController do
           expect(response.status).to eq(200)
         end
 
-        it 'assigns flow session values as having received attention result' do
+        it 'assigns idv session values as having received attention result' do
           get :show
 
           expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(true)
@@ -189,7 +170,7 @@ RSpec.describe Idv::CaptureDocStatusController do
           document_capture_session.update(ocr_confirmation_pending: false)
         end
 
-        it 'assigns flow session values as not having received attention result' do
+        it 'assigns idv session values as not having received attention result' do
           get :show
 
           expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(false)
@@ -198,14 +179,10 @@ RSpec.describe Idv::CaptureDocStatusController do
 
       context 'when loaded result expires but session was already marked with attention result' do
         let(:result) { nil }
-        let(:flow_session) do
-          {
-            had_barcode_attention_error: true,
-          }
-        end
         let(:idv_session) do
           {
             document_capture_session_uuid: document_capture_session.uuid,
+            had_barcode_attention_error: true,
           }
         end
 
@@ -220,7 +197,7 @@ RSpec.describe Idv::CaptureDocStatusController do
             expect(response.status).to eq(202)
           end
 
-          it 'assigns flow session values as having received attention result' do
+          it 'assigns idv session values as having received attention result' do
             get :show
 
             expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(true)
@@ -238,7 +215,7 @@ RSpec.describe Idv::CaptureDocStatusController do
             expect(response.status).to eq(200)
           end
 
-          it 'assigns flow session values as having received attention result' do
+          it 'assigns idv session values as having received attention result' do
             get :show
 
             expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(true)

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Idv::DocumentCaptureController do
   let(:threatmetrix_session_id) { 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0' }
 
   let(:flow_session) do
-    { document_capture_session_uuid: document_capture_session_uuid,
-      threatmetrix_session_id: threatmetrix_session_id }
+    { threatmetrix_session_id: threatmetrix_session_id }
   end
 
   let(:user) { create(:user) }
@@ -22,6 +21,7 @@ RSpec.describe Idv::DocumentCaptureController do
     stub_sign_in(user)
     stub_analytics
     subject.idv_session.flow_path = 'standard'
+    subject.idv_session.document_capture_session_uuid = document_capture_session_uuid
     subject.user_session['idv/doc_auth'] = flow_session
 
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
@@ -135,25 +135,6 @@ RSpec.describe Idv::DocumentCaptureController do
         get :show
 
         expect(response).to redirect_to(idv_session_errors_rate_limited_url)
-      end
-    end
-
-    context 'document_capture_session_uuid is stored in idv_session' do
-      let(:flow_session) { { threatmetrix_session_id: threatmetrix_session_id } }
-      before do
-        subject.idv_session.document_capture_session_uuid = document_capture_session_uuid
-      end
-      it 'renders the show template' do
-        expect(subject).to receive(:render).with(
-          :show,
-          locals: hash_including(
-            document_capture_session_uuid: document_capture_session_uuid,
-          ),
-        ).and_call_original
-
-        get :show
-
-        expect(response).to render_template :show
       end
     end
   end

--- a/spec/controllers/idv/getting_started_controller_spec.rb
+++ b/spec/controllers/idv/getting_started_controller_spec.rb
@@ -121,21 +121,9 @@ RSpec.describe Idv::GettingStartedController do
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
-    it 'creates a document capture session and stores it in flow_session' do
-      expect { put :update, params: params }.
-        to change { subject.user_session['idv/doc_auth'][:document_capture_session_uuid] }.from(nil)
-    end
-
-    it 'creates a document capture session and stores it in idv_session' do
+    it 'creates a document capture session' do
       expect { put :update, params: params }.
         to change { subject.idv_session.document_capture_session_uuid }.from(nil)
-    end
-
-    it 'sets flow_session and idv_session document_capture_session_uuid to same value' do
-      put :update, params: params
-      expect(subject.user_session['idv/doc_auth'][:document_capture_session_uuid]).to eql(
-        subject.idv_session.document_capture_session_uuid,
-      )
     end
 
     context 'with previous establishing in-person enrollments' do

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -193,6 +193,8 @@ RSpec.describe Idv::HybridHandoffController do
         }
       end
 
+      let(:document_capture_session_uuid) { '09228b6d-dd39-4925-bf82-b69104095517' }
+
       it 'sends analytics_submitted event for hybrid' do
         put :update, params: params
 
@@ -200,40 +202,18 @@ RSpec.describe Idv::HybridHandoffController do
         expect(@analytics).to have_logged_event(analytics_name, analytics_args)
       end
 
-      context 'document_capture_session_uuid in flow_session' do
-        let(:document_capture_session_uuid) { '09228b6d-dd39-4925-bf82-b69104095517' }
-
-        before do
-          subject.flow_session[:document_capture_session_uuid] = document_capture_session_uuid
-        end
-
-        it 'sends a doc auth link' do
-          expect(Telephony).to receive(:send_doc_auth_link).with(
-            hash_including(
-              link: a_string_including(document_capture_session_uuid),
-            ),
-          ).and_call_original
-
-          put :update, params: params
-        end
+      before do
+        subject.idv_session.document_capture_session_uuid = document_capture_session_uuid
       end
 
-      context 'document_capture_session_uuid in idv_session' do
-        let(:document_capture_session_uuid) { '09228b6d-dd39-4925-bf82-b69104095517' }
+      it 'sends a doc auth link' do
+        expect(Telephony).to receive(:send_doc_auth_link).with(
+          hash_including(
+            link: a_string_including(document_capture_session_uuid),
+          ),
+        ).and_call_original
 
-        before do
-          subject.idv_session.document_capture_session_uuid = document_capture_session_uuid
-        end
-
-        it 'sends a doc auth link' do
-          expect(Telephony).to receive(:send_doc_auth_link).with(
-            hash_including(
-              link: a_string_including(document_capture_session_uuid),
-            ),
-          ).and_call_original
-
-          put :update, params: params
-        end
+        put :update, params: params
       end
     end
 

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -107,21 +107,9 @@ RSpec.describe Idv::WelcomeController do
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
-    it 'creates a document capture session and stores it in flow_session' do
-      expect { put :update }.
-        to change { subject.user_session['idv/doc_auth'][:document_capture_session_uuid] }.from(nil)
-    end
-
-    it 'creates a document capture session and stores it in idv_session' do
+    it 'creates a document capture session' do
       expect { put :update }.
         to change { subject.idv_session.document_capture_session_uuid }.from(nil)
-    end
-
-    it 'sets flow_session and idv_session document_capture_session_uuid to same value' do
-      put :update
-      expect(subject.user_session['idv/doc_auth'][:document_capture_session_uuid]).to eql(
-        subject.idv_session.document_capture_session_uuid,
-      )
     end
 
     context 'with previous establishing in-person enrollments' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-10438](https://cm-jira.usa.gov/browse/LG-10438)

## 🛠 Summary of changes

Remove references to `flow_session[:document_capture_session_uuid]` after the variable was moved to `idv_session` in #8906.