### PR TITLE
LG-10252 Finish renaming /verify/session/errors/throttled to /rate_limited

### DIFF
--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -40,7 +40,7 @@ module RateLimitConcern
     when :idv_resolution
       redirect_to idv_session_errors_failure_url
     when :idv_doc_auth
-      redirect_to idv_session_errors_throttled_url
+      redirect_to idv_session_errors_rate_limited_url
     when :proof_address
       redirect_to idv_phone_errors_failure_url
     when :proof_ssn

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -34,7 +34,7 @@ module Idv
       return unless flow_session && document_capture_session
 
       if rate_limiter.limited?
-        idv_session_errors_throttled_url
+        idv_session_errors_rate_limited_url
       elsif user_has_establishing_in_person_enrollment?
         idv_in_person_url
       end

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -37,7 +37,7 @@ class ImageUploadResponsePresenter
       json = { success: false, errors: errors, remaining_attempts: remaining_attempts }
       if remaining_attempts&.zero?
         if @form_response.extra[:flow_path] == 'standard'
-          json[:redirect] = idv_session_errors_throttled_url
+          json[:redirect] = idv_session_errors_rate_limited_url
         else # hybrid flow on mobile
           json[:redirect] = idv_hybrid_mobile_capture_complete_url
         end

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -66,7 +66,7 @@ module Idv
       end
 
       def rate_limited_url
-        idv_session_errors_throttled_url
+        idv_session_errors_rate_limited_url
       end
 
       # Ideally we would not have to re-implement the EffectiveUser mixin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -367,7 +367,6 @@ Rails.application.routes.draw do
       get '/session/errors/failure' => 'session_errors#failure'
       get '/session/errors/ssn_failure' => 'session_errors#ssn_failure'
       get '/session/errors/exception' => 'session_errors#exception'
-      get '/session/errors/throttled' => 'session_errors#rate_limited'
       get '/session/errors/rate_limited' => 'session_errors#rate_limited'
       get '/setup_errors', to: redirect('/please_call')
       get '/not_verified' => 'not_verified#show'
@@ -412,6 +411,7 @@ Rails.application.routes.draw do
       post '/confirmations' => 'personal_key#update'
       get '/doc_auth/:step', to: redirect('/verify/welcome')
       get '/doc_auth/link_sent/poll' => 'capture_doc_status#show'
+      get '/session/errors/throttled', to: redirect('/verify/session/errors/rate_limited')
     end
 
     # Old paths to GPO outside of IdV.

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'RateLimitConcern' do
 
         get :show
 
-        expect(response).to redirect_to idv_session_errors_throttled_url
+        expect(response).to redirect_to idv_session_errors_rate_limited_url
       end
     end
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Idv::DocumentCaptureController do
 
         get :show
 
-        expect(response).to redirect_to(idv_session_errors_throttled_url)
+        expect(response).to redirect_to(idv_session_errors_rate_limited_url)
       end
     end
   end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Idv::ImageUploadsController do
       end
 
       context 'when rate limited' do
-        let(:redirect_url) { idv_session_errors_throttled_url }
+        let(:redirect_url) { idv_session_errors_rate_limited_url }
         let(:error_json) do
           {
             success: false,

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe IdvController do
       it 'redirects to rate limited page' do
         get :index
 
-        expect(response).to redirect_to idv_session_errors_throttled_url
+        expect(response).to redirect_to idv_session_errors_rate_limited_url
       end
     end
 

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'document capture step', :js do
           )
           message = strip_tags(t('errors.doc_auth.rate_limited_text_html', timeout: timeout))
           expect(page).to have_content(message)
-          expect(page).to have_current_path(idv_session_errors_throttled_path)
+          expect(page).to have_current_path(idv_session_errors_rate_limited_path)
         end
       end
 

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       end
 
       perform_in_browser(:desktop) do
-        expect(page).to have_current_path(idv_session_errors_throttled_path, wait: 10)
+        expect(page).to have_current_path(idv_session_errors_rate_limited_path, wait: 10)
       end
     end
   end

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe ImageUploadResponsePresenter do
           success: false,
           result_failed: false,
           errors: [{ field: :limit, message: t('errors.doc_auth.rate_limited_heading') }],
-          redirect: idv_session_errors_throttled_url,
+          redirect: idv_session_errors_rate_limited_url,
           remaining_attempts: 0,
           ocr_pii: nil,
         }
@@ -244,7 +244,7 @@ RSpec.describe ImageUploadResponsePresenter do
             result_failed: false,
             errors: [{ field: :front, message: t('doc_auth.errors.not_a_file') }],
             hints: true,
-            redirect: idv_session_errors_throttled_url,
+            redirect: idv_session_errors_rate_limited_url,
             remaining_attempts: 0,
             ocr_pii: nil,
           }


### PR DESCRIPTION
Change /verify/session/errors/throttled route to /verify/session/errors/rate_limited

## 🎫 Ticket

[LG-10252](https://cm-jira.usa.gov/browse/LG-10078)

## 🛠 Summary of changes

This is a followup to #8886. Once that's deployed, this one can be merged, to cover the 50/50 state.