### PR TITLE
LG-10511: Update copy for banner that notifies user they already tried to verify with a phone number

### DIFF
--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -83,6 +83,8 @@
               idv_gpo_path,
             ),
           ) %>
+    <% else %>
+      <%= t('idv.messages.phone.failed_number.try_again_html') %>
     <% end %>
   <% end %>
 

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -216,7 +216,7 @@ en:
           This is to help verify your identity.
         failed_number:
           alert_text: We couldn’t match you to this number.
-          gpo_alert_html: Try <strong>another</strong> number or %{link_html} instead.
+          gpo_alert_html: Try <strong>another</strong> number or %{link_html}.
           gpo_verify_link: verify by mail
           try_again_html: Try <strong>another</strong> number.
         rules:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -216,9 +216,9 @@ en:
           This is to help verify your identity.
         failed_number:
           alert_text: We couldn’t match you to this number.
-          gpo_alert_html: If you don’t have <strong>another</strong> number to try,
-            %{link_html} instead.
+          gpo_alert_html: Try <strong>another</strong> number or %{link_html} instead.
           gpo_verify_link: verify by mail
+          try_again_html: Try <strong>another</strong> number.
         rules:
           - Based in the United States (including U.S. territories)
           - Your primary number (the one you use the most often)

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -226,9 +226,9 @@ es:
           código único. Esto es para ayudar a verificar su identidad.
         failed_number:
           alert_text: No pudimos asociarlo a este número.
-          gpo_alert_html: Si no dispone de <strong>otro</strong> número de teléfono,
-            %{link_html}.
-          gpo_verify_link: realice la verificación por correo
+          gpo_alert_html: Pruebe con <strong>otro</strong> número o %{link_html}.
+          gpo_verify_link: verifique por correo
+          try_again_html: Pruebe con <strong>otro</strong> número.
         rules:
           - Con base en Estados Unidos (incluidos los territorios de EE.UU.)
           - Su número principal (el que utiliza con más frecuencia)

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -241,7 +241,7 @@ fr:
         failed_number:
           alert_text: Nous n’avons pas pu vous associer à ce numéro.
           gpo_alert_html: Essayez un <strong>autre</strong> numéro ou %{link_html}.
-          gpo_verify_link: vérifiez plutôt par courrier
+          gpo_verify_link: vérifiez par courrier
           try_again_html: Essayez un <strong>autre</strong> numéro.
         rules:
           - Basé aux Etats-Unis (y compris les territoires américains)

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -240,9 +240,9 @@ fr:
           code à usage unique. Ceci est pour aider à vérifier votre identité.
         failed_number:
           alert_text: Nous n’avons pas pu vous associer à ce numéro.
-          gpo_alert_html: Si vous n’avez pas <strong>d’autre</strong> numéro de téléphone
-            à essayer, %{link_html}.
+          gpo_alert_html: Essayez un <strong>autre</strong> numéro ou %{link_html}.
           gpo_verify_link: vérifiez plutôt par courrier
+          try_again_html: Essayez un <strong>autre</strong> numéro.
         rules:
           - Basé aux Etats-Unis (y compris les territoires américains)
           - Votre numéro principal (celui que vous utilisez le plus souvent)

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -163,6 +163,7 @@ RSpec.feature 'idv phone step', :js do
                 ),
               ),
             )
+            expect(page).to have_content(t('idv.messages.phone.failed_number.try_again_html'))
 
             click_idv_send_security_code
             click_on t('idv.failure.phone.warning.try_again_button')

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -163,7 +163,11 @@ RSpec.feature 'idv phone step', :js do
                 ),
               ),
             )
-            expect(page).to have_content(t('idv.messages.phone.failed_number.try_again_html'))
+            expect(page).to have_content(
+              strip_tags(
+                t('idv.messages.phone.failed_number.try_again_html'),
+              ),
+            )
 
             click_idv_send_security_code
             click_on t('idv.failure.phone.warning.try_again_button')


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-10511](https://cm-jira.usa.gov/browse/LG-10511)


## 🛠 Summary of changes
Update copy for alert that notifies users they are retrying a failed number during IDV phone step.

## 📜 Testing Plan
- [ ] Submit a number that fails phone verification step
- [ ] Try again and type the same number into the phone textfield

## 👀 Screenshots
<details>
<summary>Before:</summary>
<img width="654" alt="LG-9499-gpo-unavailable" src="https://github.com/18F/identity-idp/assets/1261794/3d99efa2-45e4-4aa3-a8c2-27d8ea1897c7">
<img width="654" alt="LG-9499-fra" src="https://github.com/18F/identity-idp/assets/1261794/6e41db28-80bf-4af2-8a59-2c2fb8793827">
<img width="649" alt="LG-9499-es" src="https://github.com/18F/identity-idp/assets/1261794/dacfc7ac-4964-4490-97de-b40fc35ffc92">
</details>

<details>
<summary>After:</summary>
<img width="635" alt="LG-10511-en" src="https://github.com/18F/identity-idp/assets/1261794/22cda3b3-26cf-426b-baa5-75ba20ae3d3b">
<img width="615" alt="LG-10511-fr" src="https://github.com/18F/identity-idp/assets/1261794/a76ede4e-8673-460e-9077-8fe5aafad4f3">
<img width="630" alt="LG-10511-es" src="https://github.com/18F/identity-idp/assets/1261794/80add727-e4e7-4144-bf27-b9a178656e14">
<img width="633" alt="LG-10511-fr-instead" src="https://github.com/18F/identity-idp/assets/1261794/fe4f13ea-dde6-4336-a76c-9a20e8938d82">
<img width="629" alt="LG-10511-es-instead" src="https://github.com/18F/identity-idp/assets/1261794/14280778-1c13-4d78-b6ec-8ecbf6dcad09">
<img width="641" alt="LG-10511-en-instead" src="https://github.com/18F/identity-idp/assets/1261794/230582af-695c-4b3f-8d58-bb3ab3ef8449">

</details>
