### PR TITLE
LG 10372 Shorten Fieldset for MFA option setup

### DIFF
--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -50,10 +50,6 @@ class TwoFactorOptionsPresenter
     end
   end
 
-  def form_legend
-    t('two_factor_authentication.form_legend')
-  end
-
   def show_skip_additional_mfa_link?
     @show_skip_additional_mfa_link
   end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -50,6 +50,10 @@ class TwoFactorOptionsPresenter
     end
   end
 
+  def form_legend 
+    t('two_factor_authentication.form_legend')
+  end
+
   def show_skip_additional_mfa_link?
     @show_skip_additional_mfa_link
   end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -50,7 +50,7 @@ class TwoFactorOptionsPresenter
     end
   end
 
-  def form_legend 
+  def form_legend
     t('two_factor_authentication.form_legend')
   end
 

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -20,7 +20,7 @@
                     url: authentication_methods_setup_path do |f| %>
   <div class="margin-bottom-4">
     <fieldset class="margin-0 padding-0 border-0">
-      <legend class="margin-bottom-2 usa-sr-only"><%= @presenter.intro %></legend>
+      <legend class="margin-bottom-2 usa-sr-only"><%= @presenter.form_legend %></legend>
       <%= hidden_field_tag 'two_factor_options_form[selection][]', nil %>
       <% @presenter.options.each do |option| %>
         <%= render(option) do %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -20,7 +20,9 @@
                     url: authentication_methods_setup_path do |f| %>
   <div class="margin-bottom-4">
     <fieldset class="margin-0 padding-0 border-0">
-      <legend class="margin-bottom-2 usa-sr-only"><%= @presenter.form_legend %></legend>
+      <legend class="margin-bottom-2 usa-sr-only">
+        <%= t('two_factor_authentication.form_legend') %>
+      </legend>
       <%= hidden_field_tag 'two_factor_options_form[selection][]', nil %>
       <% @presenter.options.each do |option| %>
         <%= render(option) do %>

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -30,6 +30,7 @@ en:
         </strong>If you have access to another device, such as a phone, protect
         your account with another authentication method.
     choose_another_option: '‹ Choose another authentication method'
+    form_legend: Choose your authentication methods
     header_text: Enter your one-time code
     important_alert_icon: important alert icon
     invalid_backup_code: That backup code is invalid.

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -30,6 +30,7 @@ es:
         </strong>Si tiene acceso a otro dispositivo, como un celular, proteja su
         cuenta mediante otro método de autenticación.
     choose_another_option: '‹ Elige otra opción de seguridad'
+    form_legend: Elija sus métodos de autenticación
     header_text: Introduzca su código único
     important_alert_icon: ícono de aviso importante
     invalid_backup_code: Esa código de respaldo no es válida.

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -31,6 +31,7 @@ fr:
         téléphone, protégez votre compte à l’aide d’une autre méthode
         d’authentification.
     choose_another_option: '‹ Choisissez une autre option de sécurité'
+    form_legend: Choisissez vos méthodes d'authentification
     header_text: Entrez votre code à usage unique
     important_alert_icon: Icône d’alerte importante
     invalid_backup_code: Ce code de sauvegarde est invalide.

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -31,7 +31,7 @@ fr:
         téléphone, protégez votre compte à l’aide d’une autre méthode
         d’authentification.
     choose_another_option: '‹ Choisissez une autre option de sécurité'
-    form_legend: Choisissez vos méthodes d'authentification
+    form_legend: Choisissez vos méthodes d’authentification
     header_text: Entrez votre code à usage unique
     important_alert_icon: Icône d’alerte importante
     invalid_backup_code: Ce code de sauvegarde est invalide.


### PR DESCRIPTION


<!-- Uncomment and update the sections you need for your PR! -->
 
## 🎫 Ticket

Link to the relevant ticket.
[LG-10372](https://cm-jira.usa.gov/browse/LG-10372)


## 🛠 Summary of changes

Adds a new method to insert a more concise legend to the MFA option form correcting screen reader experience that was displaying a redundant description of the form as a copy of the intro text above.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create a new account
- [ ] On the Authentication method setup page: view page source or inspect the form with browser dev tools
- [ ] Legend tag should now be: 
`en: <legend class="margin-bottom-2 usa-sr-only">Choose your authentication methods</legend>`
`fr: <legend class="margin-bottom-2 usa-sr-only">Elija sus métodos de autenticación</legend>`
`sp: <legend class="margin-bottom-2 usa-sr-only">Choisissez vos méthodes d'authentification</legend>`


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
