### PR TITLE
Only use postgis adapter for primary database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,5 @@
 postgresql: &postgresql
-  adapter: postgis
+  adapter: postgresql
   encoding: utf8
   database: identity_idp_<%= Rails.env %>
   port: 5432
@@ -24,9 +24,11 @@ defaults: &defaults
 development:
   primary:
     <<: *defaults
+    adapter: postgis
     migrations_paths: db/primary_migrate
   read_replica:
     <<: *defaults
+    adapter: postgis
     replica: true
   worker_jobs:
     <<: *defaults
@@ -36,6 +38,7 @@ development:
 test:
   primary: &test
     <<: *defaults
+    adapter: postgis
     pool: 10
     checkout_timeout: 10
     database: <%= ENV['POSTGRES_DB'] || "identity_idp_test#{ENV['TEST_ENV_NUMBER']}" %>
@@ -44,6 +47,7 @@ test:
     migrations_paths: db/primary_migrate
   read_replica:
     <<: *test
+    adapter: postgis
     replica: true
   worker_jobs:
     <<: *test
@@ -76,6 +80,7 @@ test:
 production:
   primary:
     <<: *defaults
+    adapter: postgis
     database: <%= IdentityConfig.store.database_name %>
     username: <%= IdentityConfig.store.database_username %>
     host: <%= IdentityConfig.store.database_socket.present? ?  IdentityConfig.store.database_socket : IdentityConfig.store.database_host %>
@@ -88,6 +93,7 @@ production:
     migrations_paths: db/primary_migrate
   read_replica:
     <<: *defaults
+    adapter: postgis
     database: <%= IdentityConfig.store.database_name %>
     username: <%= IdentityConfig.store.database_readonly_username %>
     host: <%= IdentityConfig.store.database_read_replica_host %>


### PR DESCRIPTION
## 🛠 Summary of changes

We've been seeing some odd connection errors connecting to the worker database since #8536 ([NewRelic](https://onenr.io/0qwLvPlGkj5)). The major change was postgis adapter for connections to all databases, but since the worker database does not have `postgis` or use it, this PR changes it so the default connection is `postgresql` and the `postgis` databases override the `adapter.

This was tested in my sandbox.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
