### PR TITLE
Remove sm-left-align custom CSS utility class

### DIFF
--- a/app/assets/stylesheets/utilities/_util.scss
+++ b/app/assets/stylesheets/utilities/_util.scss
@@ -14,12 +14,6 @@ html.js .no-js {
   transform: scale(0.7);
 }
 
-@include at-media('tablet') {
-  .sm-left-align {
-    text-align: left;
-  }
-}
-
 .half-center {
   margin: 0 auto;
   text-align: center;

--- a/app/views/accounts/_header.html.erb
+++ b/app/views/accounts/_header.html.erb
@@ -1,15 +1,15 @@
 <div class="grid-row flex-justify padding-y-2 tablet:padding-y-0 margin-bottom-4 bg-primary-lightest tablet:bg-transparent position-relative <% if presenter.showing_any_badges? %>padding-bottom-4<% end %>">
   <div class="grid-col-12 tablet:grid-col-auto">
-    <h1 class="margin-0 text-center sm-left-align">
-      <span class="text-normal tablet:display-none">
+    <h1 class="margin-0">
+      <div class="text-normal tablet:display-none text-center">
         <%= t('account.welcome') %>,
         <span class="text-bold text-wrap-anywhere">
           <%= presenter.header_personalization %>
         </span>
-      </span>
-      <span class="display-none tablet:display-inline">
+      </div>
+      <div class="display-none tablet:display-inline">
         <%= t('headings.account.login_info') %>
-      </span>
+      </div>
     </h1>
   </div>
   <div class="account-header__badges grid-col-12 tablet:grid-col-auto">

--- a/app/views/users/authorization_confirmation/new.html.erb
+++ b/app/views/users/authorization_confirmation/new.html.erb
@@ -6,23 +6,21 @@
   <%= render PageHeadingComponent.new.with_content(decorated_session.new_session_heading) %>
 <% end %>
 
-<div class='sm-left-align'>
-  <div class='margin-top-4'>
-    <div class='margin-left-1 margin-bottom-1 text-bold'>
-      <%= t('user_authorization_confirmation.currently_logged_in') %>
-    </div>
-    <div class='tablet:margin-left-1 tablet:margin-right-1' >
-      <ul class='margin-bottom-4 usa-list--unstyled border-bottom border-primary-light success-bullets requested-attributes'>
-        <li class='success-bullet border-top border-primary-light'>
-          <span class='text-bold'>
-            <%= t('help_text.requested_attributes.email') %>
-          </span>
-          <span class='padding-left-2'>
-            <%= @email %>
-          </span>
-        </li>
-      </ul>
-    </div>
+<div class='margin-top-4'>
+  <div class='margin-left-1 margin-bottom-1 text-bold'>
+    <%= t('user_authorization_confirmation.currently_logged_in') %>
+  </div>
+  <div class='tablet:margin-left-1 tablet:margin-right-1' >
+    <ul class='margin-bottom-4 usa-list--unstyled border-bottom border-primary-light success-bullets requested-attributes'>
+      <li class='success-bullet border-top border-primary-light'>
+        <span class='text-bold'>
+          <%= t('help_text.requested_attributes.email') %>
+        </span>
+        <span class='padding-left-2'>
+          <%= @email %>
+        </span>
+      </li>
+    </ul>
   </div>
 
   <div class='margin-top-4 text-center'>


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the `sm-left-align` CSS utility class.

**Why?**

- Reduce size of application stylesheet
- Remove legacy references to "sm" as referring to BassCSS breakpoints, now standardized toward "tablet" USWDS breakpoint token
- Simplify usage leveraging left text alignment as default behavior

Recommend reviewing with whitespace changes hidden: https://github.com/18F/identity-idp/pull/8917/files?w=1

## 📜 Testing Plan

Verify no regressions in the affected usage:

1. Account management page header
2. Authenticating with a partner when already signed-in

## 👀 Screenshots

There's not expected to be any visual effect of these changes. Below are screenshots noting the affected usage, which should be unaffected.

![Screen Shot 2023-08-01 at 3 16 16 PM](https://github.com/18F/identity-idp/assets/1779930/b5b1eef8-82ba-4a16-9a88-642a742b731b)

![Screen Shot 2023-08-01 at 3 16 19 PM](https://github.com/18F/identity-idp/assets/1779930/88942700-23dd-439c-a2c1-1226f6f5ab6d)

![Screen Shot 2023-08-01 at 3 20 11 PM](https://github.com/18F/identity-idp/assets/1779930/1bd27652-b753-4107-a50e-33959619f7f1)

