### PR TITLE
LG-10439 Read barcode read error values from the session

### DIFF
--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -85,7 +85,7 @@ module Idv
         idv_session.had_barcode_attention_error = session_result.attention_with_barcode?
       end
 
-      flow_session[:had_barcode_attention_error]
+      idv_session.had_barcode_attention_error
     end
 
     def idv_session

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -16,7 +16,7 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('verify', :view, true)
 
-      @had_barcode_read_failure = flow_session[:had_barcode_read_failure]
+      @had_barcode_read_failure = idv_session.had_barcode_read_failure
       process_async_state(load_async_state)
     end
 

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -26,25 +26,6 @@ module Idv
         ProofingComponent.create_or_find_by(user: current_user).update(component_attributes)
       end
 
-      # @param [DocAuth::Response,
-      #   DocumentCaptureSessionAsyncResult,
-      #   DocumentCaptureSessionResult] response
-      def extract_pii_from_doc(response, store_in_session: false)
-        pii_from_doc = response.pii_from_doc.merge(
-          uuid: effective_user.uuid,
-          phone: effective_user.phone_configurations.take&.phone,
-          uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
-        )
-
-        flow_session[:had_barcode_read_failure] = response.attention_with_barcode?
-        if store_in_session
-          flow_session[:pii_from_doc] ||= {}
-          flow_session[:pii_from_doc].merge!(pii_from_doc)
-          idv_session.delete('applicant')
-        end
-        track_document_state(pii_from_doc[:state])
-      end
-
       def user_id_from_token
         flow_session[:doc_capture_user_id]
       end


### PR DESCRIPTION
We are working on removing the flags that indicate a barcode read error from the `flow_session` and adding them to `idv_session` instead.

The work to write the values to `idv_session` was handled in #8881 and #8889. That has been deployed so it is not safe to start reading the values from `idv_session`. A future commit will stop writing them to `flow_session`.
