### PR TITLE
LG-10373: Assistive technology reads "two" twice in authentication method setup

### DIFF
--- a/config/locales/mfa/en.yml
+++ b/config/locales/mfa/en.yml
@@ -7,8 +7,8 @@ en:
     additional_mfa_required:
       heading: Add another authentication method.
     info: Add another layer of security by selecting a multi-factor authentication
-      method. We recommend you select at least two different options in case
-      you lose one of your methods.
+      method. We recommend you select at least two different options in case you
+      lose one of your methods.
     second_method_warning:
       link: Add a second authentication method.
       text: You will have to delete your account and start over if you lose your only

--- a/config/locales/mfa/en.yml
+++ b/config/locales/mfa/en.yml
@@ -7,7 +7,7 @@ en:
     additional_mfa_required:
       heading: Add another authentication method.
     info: Add another layer of security by selecting a multi-factor authentication
-      method. We recommend you select at least (2) two different options in case
+      method. We recommend you select at least two different options in case
       you lose one of your methods.
     second_method_warning:
       link: Add a second authentication method.


### PR DESCRIPTION
## 🎫 Ticket

[LG-10373: Assistive technology reads "two" twice in authentication method setup](jira.usa.gov/browse/LG-10373)

## 🛠 Summary of changes

This PR fixes a bug where "two" is read twice by a screen reader. It will now be announced once.

## 📜 Testing Plan

With a screen reader of your choice

After logging on to [localhost:3000](localhost:3000)
- [ ] Create an account
- [ ] At "Authentication method setup" screen, turn on screen reader
- [ ] Navigate page contents

## 👀 Screenshots

https://github.com/18F/identity-idp/assets/17969963/1bf63838-2c61-460c-aeb1-fcb535fae44d

