### PR TITLE
Set Remember Device Expiration for AAL2 to 0 hours

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -275,7 +275,7 @@ reg_unconfirmed_email_max_attempts: 20
 reg_unconfirmed_email_window_in_minutes: 60
 reject_id_token_hint_in_logout: false
 remember_device_expiration_hours_aal_1: 720
-remember_device_expiration_hours_aal_2: 12
+remember_device_expiration_hours_aal_2: 0
 report_timeout: 0
 requests_per_ip_cidr_allowlist: ''
 requests_per_ip_limit: 300

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -218,6 +218,20 @@ test:
     ial: 2
     allow_prompt_login: true
 
+  'urn:gov:gsa:openidconnect:sp:server_ial1':
+    agency_id: 2
+    redirect_uris:
+      - 'http://localhost:7654/auth/result'
+      - 'https://example.com'
+      - 'http://www.example.com/test/oidc'
+    certs:
+      - 'saml_test_sp'
+    friendly_name: 'Test SP'
+    return_to_sp_url: 'https://example.com/'
+    assertion_consumer_logout_service_url: ''
+    ial: 1
+    allow_prompt_login: true
+
   'urn:gov:gsa:openidconnect:sp:server_two':
     agency_id: 2
     redirect_uris:

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -461,7 +461,7 @@ RSpec.describe SamlIdpController do
     end
 
     let(:xmldoc) { SamlResponseDoc.new('controller', 'response_assertion', response) }
-    let(:aal_level) { 2 }
+    let(:aal_level) { 0 }
     let(:ial2_settings) do
       saml_settings(
         overrides: {
@@ -934,7 +934,7 @@ RSpec.describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
-            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: true,
           })
 
@@ -1564,7 +1564,7 @@ RSpec.describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
-            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
           })
 
@@ -1931,8 +1931,8 @@ RSpec.describe SamlIdpController do
             expect(subject).to_not be_nil
           end
 
-          it 'has contents set to AAL2' do
-            expect(subject.content).to eq Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+          it 'has contents set to default AAL' do
+            expect(subject.content).to eq Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
           end
         end
       end
@@ -2056,7 +2056,7 @@ RSpec.describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
-            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
           })
         expect(@analytics).to receive(:track_event).with('SAML Auth', analytics_hash)
@@ -2094,7 +2094,7 @@ RSpec.describe SamlIdpController do
           with('SAML Auth Request', {
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
-            requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
           })
         expect(@analytics).to receive(:track_event).with('SAML Auth', analytics_hash)

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe ServiceProviderSessionDecorator do
         allow(sp).to receive(:default_aal).and_return(2)
       end
 
-      it { expect(subject.mfa_expiration_interval).to eq(12.hours) }
+      it { expect(subject.mfa_expiration_interval).to eq(0.hours) }
     end
 
     context 'with an IAL2 sp' do
@@ -213,7 +213,7 @@ RSpec.describe ServiceProviderSessionDecorator do
         allow(sp).to receive(:ial).and_return(2)
       end
 
-      it { expect(subject.mfa_expiration_interval).to eq(12.hours) }
+      it { expect(subject.mfa_expiration_interval).to eq(0.hours) }
     end
 
     context 'with an sp that is not AAL2 or IAL2' do

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -324,7 +324,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     context 'when the SP is in the AAMVA banlist' do
       it 'does not perform the state ID check' do
         allow(IdentityConfig.store).to receive(:aamva_sp_banlist_issuers).
-          and_return('["urn:gov:gsa:openidconnect:sp:server"]')
+          and_return("[\"#{OidcAuthHelper::OIDC_IAL1_ISSUER}\"]")
         user = create(:user, :fully_registered)
         expect_any_instance_of(Idv::Agent).
           to receive(:proof_resolution).

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'OpenID Connect' do
     visit_idp_from_ial1_oidc_sp
 
     cookie = cookies.find { |c| c.name == 'sp_issuer' }.value
-    expect(cookie).to eq(OidcAuthHelper::OIDC_ISSUER)
+    expect(cookie).to eq(OidcAuthHelper::OIDC_IAL1_ISSUER)
   end
 
   it 'receives an ID token with a kid that matches the certs endpooint' do

--- a/spec/features/remember_device/session_expiration_spec.rb
+++ b/spec/features/remember_device/session_expiration_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'signing in with remember device and idling on the sign in page' 
     first(:link, t('links.sign_out')).click
 
     IdentityLinker.new(
-      user, build(:service_provider, issuer: 'urn:gov:gsa:openidconnect:sp:server')
+      user, build(:service_provider, issuer: OidcAuthHelper::OIDC_IAL1_ISSUER)
     ).link_identity(verified_attributes: %w[email])
 
     visit_idp_from_sp_with_ial1(:oidc)

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -115,7 +115,7 @@ RSpec.feature 'remember device sp expiration' do
   before do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(1000)
 
-    ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:sp:server').update!(
+    ServiceProvider.find_by(issuer: OidcAuthHelper::OIDC_IAL1_ISSUER).update!(
       default_aal: aal,
       ial: ial,
     )

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
+# rubocop:disable Layout/LineLength
 RSpec.shared_examples 'expiring remember device for an sp config' do |expiration_time, protocol, aal|
+  # rubocop:enable Layout/LineLength
   before do
     user # Go through the signup flow and remember user before visiting SP
   end

--- a/spec/features/reports/sp_active_users_report_spec.rb
+++ b/spec/features/reports/sp_active_users_report_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'sp active users report' do
     click_agree_and_continue
     expect(current_url).to start_with('http://localhost:7654/auth/result')
 
-    results = [{ issuer: 'urn:gov:gsa:openidconnect:sp:server_ial1',
+    results = [{ issuer: OidcAuthHelper::OIDC_IAL1_ISSUER,
                  app_id: nil,
                  total_ial1_active: 1,
                  total_ial2_active: 0 }].to_json

--- a/spec/features/reports/sp_active_users_report_spec.rb
+++ b/spec/features/reports/sp_active_users_report_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'sp active users report' do
     click_agree_and_continue
     expect(current_url).to start_with('http://localhost:7654/auth/result')
 
-    results = [{ issuer: 'urn:gov:gsa:openidconnect:sp:server',
+    results = [{ issuer: 'urn:gov:gsa:openidconnect:sp:server_ial1',
                  app_id: nil,
                  total_ial1_active: 1,
                  total_ial2_active: 0 }].to_json

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -340,6 +340,7 @@ RSpec.feature 'saml api' do
 
           # log in for second time
           fill_in_credentials_and_submit(user.email, user.password)
+          fill_in_code_with_last_phone_otp
           click_submit_default_twice
 
           xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
@@ -408,7 +409,7 @@ RSpec.feature 'saml api' do
       expect(fake_analytics.events['SAML Auth Request']).to eq(
         [{ requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
            service_provider: 'http://localhost:3000',
-           requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+           requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
            force_authn: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
@@ -467,7 +468,7 @@ RSpec.feature 'saml api' do
       expect(fake_analytics.events['SAML Auth Request']).to eq(
         [{ requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
            service_provider: 'http://localhost:3000',
-           requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+           requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
            force_authn: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2

--- a/spec/features/sign_in/banned_users_spec.rb
+++ b/spec/features/sign_in/banned_users_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Banning users for an SP' do
   include SamlAuthHelper
+  include OidcAuthHelper
 
   context 'a user is banned from all SPs' do
     it 'does not let the user sign in to any SP' do
@@ -45,7 +46,7 @@ RSpec.feature 'Banning users for an SP' do
     it 'bans the user from signing in to the banned SP but allows other sign ins' do
       user = create(:user, :fully_registered)
 
-      SignInRestriction.create(user: user, service_provider: 'urn:gov:gsa:openidconnect:sp:server')
+      SignInRestriction.create(user: user, service_provider: OidcAuthHelper::OIDC_IAL1_ISSUER)
 
       sign_in_live_with_2fa(user)
       expect(current_path).to eq(account_path)

--- a/spec/features/sign_in/remember_device_default_spec.rb
+++ b/spec/features/sign_in/remember_device_default_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Remember device checkbox' do
 
     it 'does not have remember device checked' do
       user = create(:user, :fully_registered)
-      visit_idp_from_sp_with_ial1(:oidc)
+      visit_idp_from_sp_with_ial1_aal2(:oidc)
       fill_in_credentials_and_submit(user.email, user.password)
       expect(page).to_not have_checked_field t('forms.messages.remember_device')
     end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -389,7 +389,7 @@ RSpec.feature 'Sign Up' do
   end
 
   it 'does not show the remember device option as the default when the SP is AAL2' do
-    ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:sp:server').update!(
+    ServiceProvider.find_by(issuer: OidcAuthHelper::OIDC_IAL1_ISSUER).update!(
       default_aal: 2,
     )
     visit_idp_from_sp_with_ial1(:oidc)

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -1,5 +1,6 @@
 module OidcAuthHelper
   OIDC_ISSUER = 'urn:gov:gsa:openidconnect:sp:server'.freeze
+  OIDC_IAL1_ISSUER = 'urn:gov:gsa:openidconnect:sp:server_ial1'.freeze
   OIDC_AAL3_ISSUER = 'urn:gov:gsa:openidconnect:sp:server_requiring_aal3'.freeze
 
   def sign_in_oidc_user(user)
@@ -57,7 +58,7 @@ module OidcAuthHelper
   def ial1_params(prompt: nil,
                   state: SecureRandom.hex,
                   nonce: SecureRandom.hex,
-                  client_id: OIDC_ISSUER,
+                  client_id: OIDC_IAL1_ISSUER,
                   tid: nil)
     ial1_params = {
       client_id: client_id,

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -241,7 +241,7 @@ module SamlAuthHelper
       )
     elsif sp == :oidc
       @state = SecureRandom.hex
-      @client_id = 'urn:gov:gsa:openidconnect:sp:server'
+      @client_id = OidcAuthHelper::OIDC_IAL1_ISSUER
       @nonce = SecureRandom.hex
       visit_idp_from_oidc_sp_with_ial1(state: @state, client_id: @client_id, nonce: @nonce)
     end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -41,7 +41,7 @@ module SamlAuthHelper
 
   def request_authn_contexts
     [
-      Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+      Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
       Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
     ]
   end

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples 'remember device' do
 
   it 'redirects to an SP from the sign in page' do
     oidc_url = openid_connect_authorize_url(
-      client_id: 'urn:gov:gsa:openidconnect:sp:server',
+      client_id: OidcAuthHelper::OIDC_IAL1_ISSUER,
       response_type: 'code',
       acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
       scope: 'openid email',
@@ -51,7 +51,7 @@ RSpec.shared_examples 'remember device' do
     user = remember_device_and_sign_out_user
 
     IdentityLinker.new(
-      user, build(:service_provider, issuer: 'urn:gov:gsa:openidconnect:sp:server')
+      user, build(:service_provider, issuer: OidcAuthHelper::OIDC_IAL1_ISSUER)
     ).link_identity(verified_attributes: %w[email])
 
     visit oidc_url


### PR DESCRIPTION
## 🛠 Summary of changes

This change was made across our live environments a few months ago ([thread](https://gsa-tts.slack.com/archives/C0NGESUN5/p1675886655627409)), but I never followed up to make it consistent everywhere. This PR changes the default to zero.

[EDIT]
There was quite a bit of testing that assumed different behaviors of AAL2/remembered device, so this PR also applies some changes to hopefully make those easier to maintain going forward. Test coverage difference between this PR and main does not show a reduction (in line or branch-based), which isn't conclusive that we haven't lost certain permutations of some behavior being tested, but is sufficient for me to move forward with the changes.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
