### PR TITLE
LG-10342 Remove the last barcode error writes to flow_session

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -40,7 +40,6 @@ module Idv
       )
 
       if defined?(flow_session) && defined?(idv_session) # hybrid mobile does not have idv_session
-        flow_session[:had_barcode_read_failure] = response.attention_with_barcode?
         idv_session.had_barcode_read_failure = response.attention_with_barcode?
         if store_in_session
           flow_session[:pii_from_doc] ||= {}

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -81,7 +81,6 @@ module Idv
 
     def had_barcode_attention_result?
       if session_result
-        flow_session[:had_barcode_attention_error] = session_result.attention_with_barcode?
         idv_session.had_barcode_attention_error = session_result.attention_with_barcode?
       end
 

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -148,7 +148,6 @@ RSpec.describe Idv::CaptureDocStatusController do
         it 'assigns flow session values as having received attention result' do
           get :show
 
-          expect(flow_session[:had_barcode_attention_error]).to eq(true)
           expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(true)
         end
       end
@@ -167,7 +166,6 @@ RSpec.describe Idv::CaptureDocStatusController do
         it 'assigns flow session values as having received attention result' do
           get :show
 
-          expect(flow_session[:had_barcode_attention_error]).to eq(true)
           expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(true)
         end
       end
@@ -183,7 +181,6 @@ RSpec.describe Idv::CaptureDocStatusController do
         end
 
         before do
-          flow_session[:had_barcode_attention_error] = true
           idv_session[:had_barcode_attention_error] = true
           document_capture_session.update(ocr_confirmation_pending: false)
         end
@@ -191,7 +188,6 @@ RSpec.describe Idv::CaptureDocStatusController do
         it 'assigns flow session values as not having received attention result' do
           get :show
 
-          expect(flow_session[:had_barcode_attention_error]).to eq(false)
           expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(false)
         end
       end
@@ -201,7 +197,6 @@ RSpec.describe Idv::CaptureDocStatusController do
         let(:flow_session) do
           {
             document_capture_session_uuid: document_capture_session.uuid,
-            had_barcode_attention_error: true,
           }
         end
         let(:idv_session) do
@@ -224,7 +219,6 @@ RSpec.describe Idv::CaptureDocStatusController do
           it 'assigns flow session values as having received attention result' do
             get :show
 
-            expect(flow_session[:had_barcode_attention_error]).to eq(true)
             expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(true)
           end
         end
@@ -243,7 +237,6 @@ RSpec.describe Idv::CaptureDocStatusController do
           it 'assigns flow session values as having received attention result' do
             get :show
 
-            expect(flow_session[:had_barcode_attention_error]).to eq(true)
             expect(controller.user_session[:idv][:had_barcode_attention_error]).to eq(true)
           end
         end


### PR DESCRIPTION
We are phasing out `flow_session` after retiring the flow state machine. This commit is part of the effort related to that. Specifically it is removing the barcode read errors from flow session.

#8881 and #8889 started writing the barcode read error flags to the `idv_session`. #8925 started reading from `idv_session`. With those steps done and deployed it should be safe to stop writing the value to `flow_session` as a final step.
