### PR TITLE
LG-10431 Add new columns for multi-region encrypted ciphertexts

### DIFF
--- a/db/primary_migrate/20230803143215_add_mr_chipertext_columns.rb
+++ b/db/primary_migrate/20230803143215_add_mr_chipertext_columns.rb
@@ -1,0 +1,9 @@
+class AddMrChipertextColumns < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :encrypted_password_digest_mr, :string
+    add_column :users, :encrypted_recovery_code_digest_mr, :string
+    add_column :profiles, :encrypted_pii_mr, :text
+    add_column :profiles, :encrypted_pii_recovery_mr, :text
+    add_column :usps_confirmations, :entry_mr, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_03_143215) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -447,6 +447,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
     t.datetime "gpo_verification_pending_at"
     t.integer "fraud_pending_reason"
     t.datetime "in_person_verification_pending_at"
+    t.text "encrypted_pii_mr"
+    t.text "encrypted_pii_recovery_mr"
     t.index ["fraud_pending_reason"], name: "index_profiles_on_fraud_pending_reason"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
@@ -603,6 +605,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
     t.datetime "encrypted_recovery_code_digest_generated_at", precision: nil
     t.datetime "suspended_at"
     t.datetime "reinstated_at"
+    t.string "encrypted_password_digest_mr"
+    t.string "encrypted_recovery_code_digest_mr"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
@@ -622,6 +626,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_195406) do
     t.text "entry", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.text "entry_mr", null: false
   end
 
   create_table "webauthn_configurations", force: :cascade do |t|


### PR DESCRIPTION
We are introducing a new KMS encryptor which uses multi-region capable keys. The encryptor will be phases in by copying single region ciphertexts into new columns for multi-region ciphertexts. This commit starts the process by adding the new multi-region columns.
