### PR TITLE
Update phonelib dependencies to add support for newer area codes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,7 +447,7 @@ GEM
     pg (1.4.5)
     pg_query (2.2.0)
       google-protobuf (>= 3.19.2)
-    phonelib (0.6.54)
+    phonelib (0.8.2)
     pkcs11 (0.3.4)
     premailer (1.21.0)
       addressable

--- a/app/javascript/packages/phone-input/package.json
+++ b/app/javascript/packages/phone-input/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "dependencies": {
     "intl-tel-input": "^17.0.19",
-    "libphonenumber-js": "^1.10.11"
+    "libphonenumber-js": "^1.10.39"
   }
 }

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Idv::PhoneForm do
         let(:optional_params) { { delivery_methods: [:sms] } }
 
         it 'uses the user phone number as the initial phone value' do
-          expect(subject.phone).to eq('+1 787 234 5678')
+          expect(subject.phone).to eq('+1 787-234-5678')
         end
         it 'infers the country code from the user phone number' do
           expect(subject.international_code).to eq('PR')
@@ -125,7 +125,7 @@ RSpec.describe Idv::PhoneForm do
           }
         end
         it 'uses the previously submitted phone + and infers country' do
-          expect(subject.phone).to eq('+1 787 234 5678')
+          expect(subject.phone).to eq('+1 787-234-5678')
           expect(subject.international_code).to eq('PR')
         end
       end

--- a/spec/services/phone_formatter_spec.rb
+++ b/spec/services/phone_formatter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PhoneFormatter do
       phone = '+13065550100'
       formatted_phone = PhoneFormatter.format(phone)
 
-      expect(formatted_phone).to eq('+1 306 555 0100')
+      expect(formatted_phone).to eq('+1 306-555-0100')
     end
 
     it 'uses +1 as the default international code' do

--- a/yarn.lock
+++ b/yarn.lock
@@ -4457,10 +4457,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libphonenumber-js@^1.10.11:
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.11.tgz#0078756857bcc5c9dfe097123c6e04ea930e309b"
-  integrity sha512-ehoihx4HpRXO6FH/uJ0EnaEV4dVU+FDny+jv0S6k9JPyPsAIr0eXDAFvGRMBKE1daCtyHAaFSKCiuCxrOjVAzQ==
+libphonenumber-js@^1.10.39:
+  version "1.10.39"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.39.tgz#12dd512621c9ebb13402a694ac81dc78511cd982"
+  integrity sha512-iPMM/NbSNIrdwbr94rAOos6krB7snhfzEptmk/DJUtTPs+P9gOhZ1YXVPcRgjpp3jJByclfm/Igvz45spfJK7g==
 
 lightningcss-darwin-arm64@1.16.1:
   version "1.16.1"


### PR DESCRIPTION
## 🛠 Summary of changes

We received reports that valid US phone numbers were being rejected, and it is in part due to outdated phone validation libraries. This PR updates them.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
