### PR TITLE
LG-10342 Introduce ciphertext pair for managing single and multi-region KMS ciphertexts

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -212,7 +212,7 @@ class Profile < ApplicationRecord
     )
 
     decrypted_recovery_json = encryptor.decrypt(
-      encrypted_pii_recovery_ciphertext_pair, user_uuid: user.uuid,
+      encrypted_pii_recovery_ciphertext_pair, user_uuid: user.uuid
     )
     return nil if JSON.parse(decrypted_recovery_json).nil?
     Pii::Attributes.new_from_json(decrypted_recovery_json)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -192,14 +192,28 @@ class Profile < ApplicationRecord
 
   def decrypt_pii(password)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-    decrypted_json = encryptor.decrypt(encrypted_pii, user_uuid: user.uuid)
+
+    encrypted_pii_ciphertext_pair = Encryption::RegionalCiphertextPair.new(
+      single_region_ciphertext: encrypted_pii,
+      multi_region_ciphertext: encrypted_pii_multi_region,
+    )
+
+    decrypted_json = encryptor.decrypt(encrypted_pii_ciphertext_pair, user_uuid: user.uuid)
     Pii::Attributes.new_from_json(decrypted_json)
   end
 
   # @return [Pii::Attributes]
   def recover_pii(personal_key)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(personal_key)
-    decrypted_recovery_json = encryptor.decrypt(encrypted_pii_recovery, user_uuid: user.uuid)
+
+    encrypted_pii_recovery_ciphertext_pair = Encryption::RegionalCiphertextPair.new(
+      single_region_ciphertext: encrypted_pii_recovery,
+      multi_region_ciphertext: encrypted_pii_recovery_multi_region,
+    )
+
+    decrypted_recovery_json = encryptor.decrypt(
+      encrypted_pii_recovery_ciphertext_pair, user_uuid: user.uuid,
+    )
     return nil if JSON.parse(decrypted_recovery_json).nil?
     Pii::Attributes.new_from_json(decrypted_recovery_json)
   end
@@ -209,7 +223,9 @@ class Profile < ApplicationRecord
     encrypt_ssn_fingerprint(pii)
     encrypt_compound_pii_fingerprint(pii)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-    self.encrypted_pii = encryptor.encrypt(pii.to_json, user_uuid: user.uuid)
+    self.encrypted_pii, self.encrypted_pii_multi_region = encryptor.encrypt(
+      pii.to_json, user_uuid: user.uuid
+    )
     encrypt_recovery_pii(pii)
   end
 
@@ -219,7 +235,9 @@ class Profile < ApplicationRecord
     encryptor = Encryption::Encryptors::PiiEncryptor.new(
       personal_key_generator.normalize(personal_key),
     )
-    self.encrypted_pii_recovery = encryptor.encrypt(pii.to_json, user_uuid: user.uuid)
+    self.encrypted_pii_recovery, self.encrypted_pii_recovery_multi_region = encryptor.encrypt(
+      pii.to_json, user_uuid: user.uuid
+    )
     @personal_key = personal_key
   end
 

--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -47,10 +47,16 @@ module Encryption
         kms_encrypted_ciphertext = kms_client.encrypt(
           aes_encrypted_ciphertext, kms_encryption_context(user_uuid: user_uuid)
         )
-        Ciphertext.new(kms_encrypted_ciphertext, salt, cost).to_s
+
+        RegionalCiphertextPair.new(
+          single_region_ciphertext: Ciphertext.new(kms_encrypted_ciphertext, salt, cost).to_s,
+          multi_region_ciphertext: nil,
+        )
       end
 
-      def decrypt(ciphertext_string, user_uuid: nil)
+      def decrypt(ciphertext_pair, user_uuid: nil)
+        ciphertext_string = ciphertext_pair.single_region_ciphertext
+
         ciphertext = Ciphertext.parse_from_string(ciphertext_string)
         aes_encrypted_ciphertext = kms_client.decrypt(
           ciphertext.encrypted_data, kms_encryption_context(user_uuid: user_uuid)

--- a/app/services/encryption/regional_ciphertext_pair.rb
+++ b/app/services/encryption/regional_ciphertext_pair.rb
@@ -1,0 +1,7 @@
+Encryption::RegionalCiphertextPair = RedactedStruct.new(
+  :single_region_ciphertext, :multi_region_ciphertext, keyword_init: true
+) do
+  def to_ary
+    [single_region_ciphertext, multi_region_ciphertext]
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1059,13 +1059,18 @@ RSpec.describe User do
       let(:personal_key) { RandomPhrase.new(num_words: 4).to_s }
 
       before do
+        encrypted_pii_recovery, encrypted_pii_recovery_multi_region =
+          Encryption::Encryptors::PiiEncryptor.new(
+            personal_key,
+          ).encrypt('null', user_uuid: user.uuid).single_region_ciphertext
+
         create(
           :profile,
           user: user,
           active: true,
           verified_at: Time.zone.now,
-          encrypted_pii_recovery: Encryption::Encryptors::PiiEncryptor.new(personal_key).
-            encrypt('null', user_uuid: user.uuid),
+          encrypted_pii_recovery: encrypted_pii_recovery,
+          encrypted_pii_recovery_multi_region: encrypted_pii_recovery_multi_region,
         )
       end
 

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -214,9 +214,13 @@ RSpec.shared_examples 'signing in as proofed account with broken personal key' d
       user.update(encrypted_recovery_code_digest_generated_at: nil)
     when :encrypted_data_too_short
       personal_key = RandomPhrase.new(num_words: 4).to_s
+      encrypted_pii_recovery, encrypted_pii_recovery_multi_region =
+        Encryption::Encryptors::PiiEncryptor.new(
+          personal_key,
+        ).encrypt('null', user_uuid: user.uuid)
       user.active_profile.update(
-        encrypted_pii_recovery: Encryption::Encryptors::PiiEncryptor.new(personal_key).
-          encrypt('null', user_uuid: user.uuid),
+        encrypted_pii_recovery: encrypted_pii_recovery,
+        encrypted_pii_recovery_multi_region: encrypted_pii_recovery_multi_region,
       )
     else
       raise "unknown scenario #{scenario}"


### PR DESCRIPTION
We are working on migrating to a new KMS key that has multi-region capabilities. Migrating to this new key will require storing both single region and multi-region ciphertexts in the database. Moreover, the inner layer of these ciphertexts is expected to match so we cannot have 2 encryptors, 1 with the new key and 1 with the old.

This commit introduces a `RegionalCiphertextPair` struct. It is intended to be returned from the `PiiEncryptor` and eventually the `PasswordVerifier`.

Consumers of the `PiiEncryptor#encrypt` methods can break up the `RegionalCiphertextPair` and store the single region and multi-region ciphertexts independently. On decryption the ciphertext pair can be reconstructed and used as the argument to `PiiEncryptor#decrypt`.