### PR TITLE
LG-10342 Use the `RegionalCiphertextPair` struct for password verification

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -22,7 +22,7 @@ module UserAccessKeyOverrides
     @password = new_password
     return if @password.blank?
     self.encrypted_password_digest, self.encrypted_password_digest_multi_region =
-      Encryption::PasswordVerifier.new.digest_pair(
+      Encryption::PasswordVerifier.new.create_digest_pair(
         password: @password,
         user_uuid: uuid || generate_uuid,
       )
@@ -47,7 +47,7 @@ module UserAccessKeyOverrides
     @personal_key = new_personal_key
     return if new_personal_key.blank?
     self.encrypted_recovery_code_digest, self.encrypted_recovery_code_digest_multi_region =
-      Encryption::PasswordVerifier.new.digest_pair(
+      Encryption::PasswordVerifier.new.create_digest_pair(
         password: new_personal_key,
         user_uuid: uuid || generate_uuid,
       )

--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -34,7 +34,7 @@ module Encryption
       @kms_client = KmsClient.new
     end
 
-    def digest_pair(password:, user_uuid:)
+    def create_digest_pair(password:, user_uuid:)
       salt = SecureRandom.hex(32)
       cost = IdentityConfig.store.scrypt_cost
       encrypted_password = encrypt_password(

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Encryption::PasswordVerifier do
     end
   end
 
-  describe '#digest_pair' do
+  describe '#create_digest_pair' do
     it 'creates a digest from the password' do
       salt = '1' * 64 # 32 hex encoded bytes is 64 characters
       # The newrelic_rpm gem added a call to `SecureRandom.hex(8)` in
@@ -47,7 +47,7 @@ RSpec.describe Encryption::PasswordVerifier do
       ).and_return('kms_ciphertext')
       expect(Encryption::KmsClient).to receive(:new).and_return(kms_client)
 
-      result = subject.digest_pair(
+      result = subject.create_digest_pair(
         password: password, user_uuid: user_uuid,
       ).single_region_ciphertext
 
@@ -61,7 +61,7 @@ RSpec.describe Encryption::PasswordVerifier do
 
   describe '#verify' do
     it 'returns true if the password does match' do
-      digest_pair = subject.digest_pair(password: password, user_uuid: user_uuid)
+      digest_pair = subject.create_digest_pair(password: password, user_uuid: user_uuid)
 
       result = subject.verify(digest_pair: digest_pair, password: password, user_uuid: user_uuid)
 
@@ -69,7 +69,7 @@ RSpec.describe Encryption::PasswordVerifier do
     end
 
     it 'returns false if the password does not match' do
-      digest_pair = subject.digest_pair(password: password, user_uuid: user_uuid)
+      digest_pair = subject.create_digest_pair(password: password, user_uuid: user_uuid)
 
       result = subject.verify(digest_pair: digest_pair, password: 'qwerty', user_uuid: user_uuid)
 
@@ -123,7 +123,7 @@ RSpec.describe Encryption::PasswordVerifier do
     end
 
     it 'returns false if the digest is fresh' do
-      digest = subject.digest_pair(
+      digest = subject.create_digest_pair(
         password: password, user_uuid: user_uuid,
       ).single_region_ciphertext
 


### PR DESCRIPTION
PR #8933 introduced a struct for tracking ciphertexts while we migrate from using a single region key to a multi-region capable key. In that PR the pattern was applied to PII encryption. This commit applies it to password verification.
