### PR TITLE
Ensure phone ownership is compared reliably when validating phone numbers

### DIFF
--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -131,7 +131,9 @@ module Idv
     end
 
     def user_phone?(phone)
-      MfaContext.new(user).phone_configurations.any? { |config| config.phone == phone }
+      MfaContext.new(user).phone_configurations.any? do |config|
+        PhoneFormatter.format(config.phone) == phone
+      end
     end
 
     def extra_analytics_attributes


### PR DESCRIPTION
## 🛠 Summary of changes

This fixes a small non-production-impacting bug where if a user is using a phone in a country where we do not support unregistered numbers, they may be denied due to inconsistent formatting when comparing numbers. This PR ensures they are compared with the same format, similar to how we do [here](https://github.com/18F/identity-idp/blob/5ba3ded47ee1bb997a0caf62263accfa6fffcad0/app/forms/new_phone_form.rb#L120-L122).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
