### PR TITLE
Fix partial sign-in homepage redirect for account creation

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -87,7 +87,7 @@ module Users
       if user_fully_authenticated?
         redirect_to signed_in_url
       elsif current_user
-        redirect_to login_two_factor_options_path
+        redirect_to user_two_factor_authentication_url
       end
     end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe Users::SessionsController, devise: true do
         stub_sign_in_before_2fa
         get :new
 
-        expect(response).to redirect_to login_two_factor_options_path
+        expect(response).to redirect_to user_two_factor_authentication_url
       end
     end
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -481,11 +481,11 @@ RSpec.feature 'Two Factor Authentication' do
   end
 
   describe 'clicking the logo image during 2fa process' do
-    it 'returns them to the home page' do
+    it 'prompts them to 2FA' do
       user = create(:user, :fully_registered)
       sign_in_user(user)
       click_link 'Login.gov'
-      expect(current_path).to eq login_two_factor_options_path
+      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: :sms)
     end
   end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature 'Sign in' do
     email = 'foo@bar.com'
     submit_form_with_valid_email(email)
     click_confirmation_link_in_email(email)
-    submit_form_with_valid_password_confirmation
+    submit_form_with_valid_password
     expect(page).to have_current_path(authentication_methods_setup_path)
     select_2fa_option('phone')
     fill_in :new_phone_form_phone, with: '2025551314'

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -333,7 +333,7 @@ RSpec.feature 'Sign Up' do
         visit sign_up_email_path
         submit_form_with_valid_email(email)
         click_confirmation_link_in_email(email)
-        submit_form_with_valid_password_confirmation
+        submit_form_with_valid_password
 
         expect(page).to have_current_path(authentication_methods_setup_path)
       end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -419,4 +419,31 @@ RSpec.feature 'Sign Up' do
     visit add_phone_path
     expect(page).to have_current_path add_phone_path
   end
+
+  describe 'visiting the homepage by clicking the logo image' do
+    context 'on the password confirmation screen' do
+      before do
+        confirm_email('test@test.com')
+      end
+
+      it 'returns them to the homepage' do
+        click_link APP_NAME, href: new_user_session_path
+
+        expect(current_path).to eq new_user_session_path
+      end
+    end
+
+    context 'on the MFA setup screen' do
+      before do
+        confirm_email('test@test.com')
+        submit_form_with_valid_password
+      end
+
+      it 'returns them to the MFA setup screen' do
+        click_link APP_NAME, href: new_user_session_path
+
+        expect(current_path).to eq authentication_methods_setup_path
+      end
+    end
+  end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -446,7 +446,7 @@ module Features
 
       expect_branded_experience
 
-      submit_form_with_valid_password_confirmation
+      submit_form_with_valid_password
 
       set_up_2fa_with_valid_phone
       skip_second_mfa_prompt
@@ -510,13 +510,7 @@ module Features
 
     def submit_form_with_valid_password(password = VALID_PASSWORD)
       fill_in t('forms.password'), with: password
-      click_button t('forms.buttons.continue')
-    end
-
-    def submit_form_with_valid_password_confirmation(password = VALID_PASSWORD)
-      fill_in t('forms.password'), with: password
       fill_in t('components.password_confirmation.confirm_label'), with: password
-
       click_button t('forms.buttons.continue')
     end
 
@@ -557,7 +551,7 @@ module Features
       find_link(t('links.create_account')).click
       submit_form_with_valid_email(email)
       click_confirmation_link_in_email(email)
-      submit_form_with_valid_password_confirmation
+      submit_form_with_valid_password
     end
 
     def register_user_with_authenticator_app(email = 'test@test.com')

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -5,7 +5,7 @@ module SpAuthHelper
     click_link t('links.create_account')
     submit_form_with_valid_email
     click_confirmation_link_in_email(email)
-    submit_form_with_valid_password_confirmation
+    submit_form_with_valid_password
     set_up_2fa_with_valid_phone
     visit sign_out_url
     User.find_with_email(email)


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue from https://github.com/18F/identity-idp/pull/8895 where the user would be redirected to their (empty) MFA configurations listing when either clicking the logo link or otherwise visiting the homepage after having only partially completed account creation, up to MFA selection.

This should also be more consistent with similar redirect behavior that exists in `ApplicationController#signed_in_url`:

https://github.com/18F/identity-idp/blob/a102eb1158f1adcaf99779ea33b5d62f2d84faca/app/controllers/application_controller.rb#L229

## 📜 Testing Plan

**Account Creation:**

1. Go to http://localhost:3000
2. Click Create an account
3. At any point in account creation, click the logo
4. Observe that you're redirected to where you might expect to be redirected
   - Visiting from password confirmation redirects to homepage
   - Visiting from MFA setup list redirects to MFA setup (this is what's being fixed)
   - Visiting from MFA setup for selected method redirects to MFA setup

**Partial Sign-in**

1. Go to http://localhost:3000
2. Submit username and password for an existing account
3. (If not prompted to MFA, click "Forget all browsers", confirm prompt, sign out, and start again)
4. When prompted to MFA, click the logo
5. Observe that you're redirected back to the MFA prompt

**Fully Signed-In**

1. Go to http://localhost:3000
2. Sign in and MFA if needed
3. Click the logo
5. Observe that you're redirected back to the account page

## 👀 Screenshots

Screenshot showing logo click result from MFA setup listing:

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/b90259ba-ce4e-4240-813d-64d0d507432e)|![image](https://github.com/18F/identity-idp/assets/1779930/86970fef-4c67-40c2-bb59-27b593b3e730)
