### PR TITLE
Remove legacy/outdated help center URLs

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -4,11 +4,9 @@ class MarketingSite
   BASE_URL = URI('https://www.login.gov').freeze
 
   HELP_CENTER_ARTICLES = %w[
-    authentication-methods/which-authentication-method-should-i-use
     creating-an-account/authentication-application
     get-started/authentication-options
     manage-your-account/personal-key
-    signing-in/what-is-a-hardware-security-key
     trouble-signing-in/face-or-touch-unlock
     verify-your-identity/accepted-state-issued-identification
     verify-your-identity/how-to-add-images-of-your-state-issued-id

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -66,20 +66,6 @@ class MarketingSite
     )
   end
 
-  def self.help_which_authentication_method_url
-    help_center_article_url(
-      category: 'authentication-methods',
-      article: 'which-authentication-method-should-i-use',
-    )
-  end
-
-  def self.help_hardware_security_key_url
-    help_center_article_url(
-      category: 'signing-in',
-      article: 'what-is-a-hardware-security-key',
-    )
-  end
-
   def self.security_url
     URI.join(BASE_URL, locale_segment, 'security/').to_s
   end

--- a/app/views/user_mailer/please_reset_password.html.erb
+++ b/app/views/user_mailer/please_reset_password.html.erb
@@ -19,6 +19,6 @@
 <p>
   <%= link_to(
         t('user_mailer.please_reset_password.learn_more_link_text'),
-        MarketingSite.help_which_authentication_method_url,
+        MarketingSite.help_center_article_url(category: 'get-started', article: 'authentication-options'),
       ) %>
 </p>


### PR DESCRIPTION
## 🛠 Summary of changes

Removes `MarketingSite` URL helpers for two outdated URLs which predate the brochure site redesign:

1. `MarketingSite.help_hardware_security_key_url`
   - URL: https://www.login.gov/help/signing-in/what-is-a-hardware-security-key/
   - The above URL 404s, but fortunately this helper was not used anywhere in the application
   - Follow-up to see if the URL was valid at any point and should have a redirect established in `identity-site`
2. `MarketingSite.help_which_authentication_method_url`
   - URL: https://www.login.gov/help/authentication-methods/which-authentication-method-should-i-use/
   - Updated URL: https://www.login.gov/help/get-started/authentication-options/

`help_authentication_app_url` should also be updated, but this will be handled in LG-9469.

## 📜 Testing Plan

1. Go to http://localhost:3000/rails/mailers/user_mailer/please_reset_password
2. Click "Learn more about your options"
3. Observe that you're redirected to [the "Authentication options" Help Center article](https://www.login.gov/help/get-started/authentication-options/)