### PR TITLE
Remove expensive remembered device test

### DIFF
--- a/spec/features/remember_device/phone_spec.rb
+++ b/spec/features/remember_device/phone_spec.rb
@@ -42,26 +42,4 @@ RSpec.feature 'Remembering a phone' do
 
     it_behaves_like 'remember device'
   end
-
-  context 'identity verification', :js do
-    let(:user) { user_with_2fa }
-
-    before do
-      sign_in_user(user)
-      check t('forms.messages.remember_device')
-      fill_in_code_with_last_phone_otp
-      click_submit_default
-      visit idv_path
-      complete_all_doc_auth_steps
-      fill_out_phone_form_ok('2022603829')
-      choose_idv_otp_delivery_method_sms
-    end
-
-    it 'requires 2FA and does not offer the option to remember device' do
-      expect(current_path).to eq(idv_otp_verification_path)
-      expect(page).to_not have_content(
-        t('forms.messages.remember_device'),
-      )
-    end
-  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

This test was added in https://github.com/18F/identity-idp/pull/2063 and ensures that we do not include the remembered device checkbox does not appear on the phone screen in identity verification. At the time, it shared the same OTP verification screen as non-identity verification phone OTP verification actions. Since #2430, identity verification has had its own page and the risk of including an unintended element on the page is greatly reduced.

This PR removes the test.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
