### PR TITLE
Hardcode chromedriver version until we get an upgrade that works

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,7 +96,11 @@ RSpec.configure do |config|
     default_url_options = ApplicationController.default_url_options.merge(host: server_domain)
     self.default_url_options = default_url_options
     allow(Rails.application.routes).to receive(:default_url_options).and_return(default_url_options)
-    Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+    # temporary fix for local development feature tests
+    # remove when we get a new working version of Chromedriver
+    if ENV['CI'] != 'true'
+      Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+    end
   end
 
   config.before(:each, type: :controller) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,11 +96,6 @@ RSpec.configure do |config|
     default_url_options = ApplicationController.default_url_options.merge(host: server_domain)
     self.default_url_options = default_url_options
     allow(Rails.application.routes).to receive(:default_url_options).and_return(default_url_options)
-    # temporary fix for local development feature tests
-    # remove when we get a new working version of Chromedriver
-    if ENV['CI'] != 'true'
-      Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-    end
   end
 
   config.before(:each, type: :controller) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,6 +96,7 @@ RSpec.configure do |config|
     default_url_options = ApplicationController.default_url_options.merge(host: server_domain)
     self.default_url_options = default_url_options
     allow(Rails.application.routes).to receive(:default_url_options).and_return(default_url_options)
+    Webdrivers::Chromedriver.required_version = '114.0.5735.90'
   end
 
   config.before(:each, type: :controller) do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,6 +3,12 @@ require 'rack_session_access/capybara'
 require 'webdrivers/chromedriver'
 require 'selenium/webdriver'
 
+# temporary fix for local development feature tests
+# remove when we get a new working version of Chromedriver
+if ENV['CI'] != 'true'
+  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+end
+
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--headless') if !ENV['SHOW_BROWSER']


### PR DESCRIPTION
Chromedriver versions are behind Chrome, so we need to hardcode the version until Chromedriver catches up.

This is affecting more and more devs who want to run feature specs, and it's a hassle to keep an edited rails_helper.rb around without committing it. We can revert this when we get a version of Chromedriver that works.

ETA: Looks like we need to upgrade the version of Chrome that CI uses to make this work. Is that an option?