### PR TITLE
WIP: Make have_logged_event fail if an event is logged more than once

### DIFF
--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -121,7 +121,7 @@ RSpec::Matchers.define :have_logged_event do |event, attributes_matcher|
   failure_message do |actual|
     matching_events = actual.events[event]
 
-    if matching_events&.length.to_i > 1 && !allow_multiple_events?
+    if matching_events&.length.to_i > 1 && expect_only_one_event?
       <<~MESSAGE
         FakeAnalytics received too many #{event} events.
         expected: 1
@@ -134,8 +134,7 @@ RSpec::Matchers.define :have_logged_event do |event, attributes_matcher|
             at #{first_relevant_backtrace_line(event[:backtrace])}:
             #{event[:attributes].pretty_inspect.split("\n").map { |line| "  #{line}" }.join("\n")},
           EVENT
-        end.
-        join("\n\n")}
+        end.join("\n\n")}
 
       MESSAGE
     elsif matching_events&.length == 1 && attributes_matcher.instance_of?(Hash)
@@ -187,8 +186,8 @@ RSpec::Matchers.define :have_logged_event do |event, attributes_matcher|
     )
   end
 
-  def allow_multiple_events?
-    !!@allow_multiple_events
+  def expect_only_one_event?
+    !@allow_multiple_events
   end
 
   def first_relevant_backtrace_line(backtrace)

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -133,11 +133,13 @@ RSpec::Matchers.define :have_logged_event do |event, attributes_matcher|
       # attributes
       expected = attributes_matcher
       actual = matching_events.first
-      message = "Expected that FakeAnalytics would have received matching event #{event}\n"
-      message += "expected: #{expected}\n"
-      message += "     got: #{actual}\n\n"
-      message += "Diff:#{differ.diff(actual, expected)}"
-      message
+      <<~MESSAGE
+        Expected that FakeAnalytics would have received matching event #{event}
+        expected: #{expected}
+             got: #{actual}
+
+        Diff:#{differ.diff(actual, expected)}
+      MESSAGE
     elsif matching_events&.length == 1 &&
           attributes_matcher.instance_of?(RSpec::Matchers::BuiltIn::Include)
       # We found one matching event and an `include` matcher. Let's show the user a diff of the
@@ -146,14 +148,15 @@ RSpec::Matchers.define :have_logged_event do |event, attributes_matcher|
       actual_attrs = matching_events.first
       actual_compared = actual_attrs.slice(*expected.keys)
       actual_ignored = actual_attrs.except(*expected.keys)
-      message = "Expected that FakeAnalytics would have received matching event #{event}"
-      message += "expected: include #{expected}\n"
-      message += "     got: #{actual_attrs}\n\n"
-      message += "Diff:#{differ.diff(actual_compared, expected)}\n"
-      message += "Attributes ignored by the include matcher:#{differ.diff(
-        actual_ignored, {}
-      )}"
-      message
+
+      <<~MESSAGE
+        Expected that FakeAnalytics would have received matching event #{event}
+        expected: include #{expected}
+             got: #{actual_attrs}
+
+        Diff:#{differ.diff(actual_compared, expected)}
+        Attributes ignored by the include matcher:#{differ.diff(actual_ignored, {})}
+      MESSAGE
     else
       <<~MESSAGE
         Expected that FakeAnalytics would have received event #{event.inspect}

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -104,6 +104,8 @@ RSpec::Matchers.define :have_logged_event do |event, attributes_matcher|
     else
       expect(actual.events[event]).to include(match(attributes_matcher))
     end
+
+    expect(actual.events).to have_length(1)
   end
 
   failure_message do |actual|

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -105,7 +105,7 @@ RSpec::Matchers.define :have_logged_event do |event, attributes_matcher|
       expect(actual.events[event]).to include(match(attributes_matcher))
     end
 
-    expect(actual.events).to have_length(1)
+    expect(actual.events[event]).to have_attributes(size: 1)
   end
 
   failure_message do |actual|


### PR DESCRIPTION
I was noticing while working on some feature tests that it seemed like some screens were logging events more than once. Our `have_logged_event` Rspec matcher was just checking _that_ the event was logged, but not how many times.

This PR updates the `have_logged_event` to fail if more than one event was logged. To revert to the old behavior, you'd add `.at_least_once`:

```ruby
expect(analytics).to have_logged_event('my cool event').at_least_once
```

Marking this draft for now, since there's a few specs this broke and I still need to figure some stuff out.