### PR TITLE
LG-10495 Extend hybrid_mobile_spec to include starting and ending at SP

### DIFF
--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -282,19 +282,6 @@ RSpec.describe 'Identity verification', :js do
     expect(page).to have_content(t('forms.personal_key_partial.acknowledgement.header'))
   end
 
-  def validate_idv_completed_page(user)
-    expect(user.identity_verified?).to be(true)
-    expect(current_path).to eq sign_up_completed_path
-    expect(page).to have_content t(
-      'titles.sign_up.completion_ial2',
-      sp: 'Test SP',
-    )
-  end
-
-  def validate_return_to_sp
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
-  end
-
   def try_to_skip_ahead_before_signing_in
     visit idv_review_path
     expect(current_path).to eq(root_path)

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
   include DocAuthHelper
 
   let(:phone_number) { '415-555-0199' }
+  let(:sp) { :oidc }
 
   before do
     allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
@@ -22,7 +23,9 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
     user = nil
 
     perform_in_browser(:desktop) do
-      user = sign_in_and_2fa_user
+      visit_idp_from_sp_with_ial2(sp)
+      user = sign_up_and_2fa_ial1_user
+
       complete_doc_auth_steps_before_hybrid_handoff_step
       clear_and_fill_in(:doc_auth_phone, phone_number)
       click_send_link
@@ -81,8 +84,10 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
 
       acknowledge_and_confirm_personal_key
 
-      expect(page).to have_current_path(account_path)
-      expect(page).to have_content(t('headings.account.verified_account'))
+      validate_idv_completed_page(user)
+      click_agree_and_continue
+
+      validate_return_to_sp
     end
   end
 

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -184,4 +184,17 @@ module IdvHelper
     end
     visit_saml_authn_request_url(overrides: saml_overrides)
   end
+
+  def validate_idv_completed_page(user)
+    expect(user.identity_verified?).to be(true)
+    expect(current_path).to eq sign_up_completed_path
+    expect(page).to have_content t(
+      'titles.sign_up.completion_ial2',
+      sp: 'Test SP',
+    )
+  end
+
+  def validate_return_to_sp
+    expect(current_url).to start_with('http://localhost:7654/auth/result')
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10495](https://cm-jira.usa.gov/browse/LG-10495)

## 🛠 Summary of changes

End to end specs help us validate that profile changes will not break IdV in production. Extend hybrid_mobile IdV spec to include starting and ending at the Service Provider

Move `validate_idv_completed_page(user)` and `validate_return_to_sp` to idv_helper

## 📜 Testing Plan

Automated tests.