### PR TITLE
LG-10342 Add the ability to specify a key_id for the KMS Client

### DIFF
--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -25,6 +25,12 @@ module Encryption
     end
     # rubocop:enable Layout/LineLength
 
+    attr_reader :kms_key_id
+
+    def initialize(kms_key_id: IdentityConfig.store.aws_kms_key_id)
+      @kms_key_id = kms_key_id
+    end
+
     def encrypt(plaintext, encryption_context)
       KmsLogger.log(:encrypt, encryption_context)
       return encrypt_kms(plaintext, encryption_context) if FeatureManagement.use_kms?
@@ -69,7 +75,7 @@ module Encryption
 
       KMS_CLIENT_POOL.with do |client|
         client.encrypt(
-          key_id: IdentityConfig.store.aws_kms_key_id,
+          key_id: kms_key_id,
           plaintext: plaintext,
           encryption_context: encryption_context,
         ).ciphertext_blob

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -58,6 +58,8 @@ aws_http_retry_max_delay: 1
 aws_kms_key_id: alias/login-dot-gov-test-keymaker
 aws_kms_client_contextless_pool_size: 5
 aws_kms_client_multi_pool_size: 5
+aws_kms_multi_region_key_id: alias/login-dot-gov-keymaker-multi-region
+aws_kms_multi_region_write_enabled: false
 aws_logo_bucket: ''
 aws_region: 'us-west-2'
 backup_code_cost: '2000$8$1$'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -145,6 +145,8 @@ class IdentityConfig
     config.add(:aws_kms_client_contextless_pool_size, type: :integer)
     config.add(:aws_kms_client_multi_pool_size, type: :integer)
     config.add(:aws_kms_key_id, type: :string)
+    config.add(:aws_kms_multi_region_key_id, type: :string)
+    config.add(:aws_kms_multi_region_write_enabled, type: :boolean)
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)
     config.add(:backup_code_cost, type: :string)


### PR DESCRIPTION
We are migrating to a new KMS instance for encryption that supports multi-region keys. We will need to encrypt and decrypt ciphertexts with both the current single region key and the new multi-region key. To support that the KMS client will need to be able to be configured for one of the given keys.

This commit adds the ability to specify a key ID to use for the KMS client. To preserve the original behavior as the new key is being phased in the KMS client uses the old single region key if no key is specified.
