### PR TITLE
LG-10303: Update CORS regex to permit Federalist preview site origins

### DIFF
--- a/lib/identity_cors.rb
+++ b/lib/identity_cors.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class IdentityCors
-  FEDERALIST_REGEX = %r{\Ahttps://federalist-[0-9a-f-]+\.sites\.pages\.cloud\.gov\z}
+  FEDERALIST_REGEX = %r{\Ahttps://federalist-[0-9a-f-]+(\.sites)?\.pages\.cloud\.gov\z}
   STATIC_SITE_ALLOWED_ORIGINS = [
     'https://www.login.gov',
     'https://login.gov',

--- a/spec/requests/api_cors_spec.rb
+++ b/spec/requests/api_cors_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
       end
     end
 
+    context 'origin is legacy federalist preview domain' do
+      let(:http_origin) { 'https://federalist-abcdef.pages.cloud.gov' }
+
+      it 'allows origin' do
+        aggregate_failures do
+          expect(response['Access-Control-Allow-Origin']).to eq(http_origin)
+          expect(response['Access-Control-Allow-Methods']).to eq('GET')
+        end
+      end
+    end
+
     context 'origin is federalist preview' do
       let(:http_origin) { 'https://federalist-abcdef.sites.pages.cloud.gov' }
 


### PR DESCRIPTION
## 🎫 Ticket

Previously:
<img width="1226" alt="image" src="https://github.com/18F/identity-idp/assets/5004319/e1ce476d-a864-45fa-bbbf-4fa24336f7f7">

Now:
<img width="1190" alt="image" src="https://github.com/18F/identity-idp/assets/5004319/32b2c6be-eb80-47de-bd44-54a3e1e4d12b">


## 🛠 Summary of changes

Seems like:

1) Forward slashes needed to be escaped
2) .sites needed to be included

In order to pattern match the identity-site preview links. Example preview link: https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/wmg/configure-address-search-urls/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

## 📜 Testing Plan

- [x] Working on adding a test to identity_cors_spec
