### PR TITLE
LG-9469: Update TOTP "What is?" URL to valid help center article

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -4,7 +4,6 @@ class MarketingSite
   BASE_URL = URI('https://www.login.gov').freeze
 
   HELP_CENTER_ARTICLES = %w[
-    creating-an-account/authentication-application
     get-started/authentication-options
     manage-your-account/personal-key
     trouble-signing-in/face-or-touch-unlock
@@ -55,13 +54,6 @@ class MarketingSite
 
   def self.help_url
     URI.join(BASE_URL, locale_segment, 'help/').to_s
-  end
-
-  def self.help_authentication_app_url
-    help_center_article_url(
-      category: 'creating-an-account',
-      article: 'authentication-application',
-    )
   end
 
   def self.security_url

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -4,7 +4,16 @@
 
 <p>
   <%= t('forms.totp_setup.totp_intro') %>
-  <%= new_tab_link_to(t('links.what_is_totp'), MarketingSite.help_authentication_app_url) %>
+  <%= new_tab_link_to(
+        t('links.what_is_totp'),
+        help_center_redirect_path(
+          category: 'get-started',
+          article: 'authentication-options',
+          article_anchor: 'authentication-application',
+          flow: :two_factor_authentication,
+          step: :totp_setup,
+        ),
+      ) %>
 </p>
 
 <%= simple_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -135,28 +135,6 @@ RSpec.describe MarketingSite do
     end
   end
 
-  describe '.help_authentication_app_url' do
-    subject(:url) { MarketingSite.help_authentication_app_url }
-
-    it_behaves_like 'a marketing site URL'
-
-    it 'points to the authentication app section of the help page' do
-      expect(url).to eq(
-        'https://www.login.gov/help/creating-an-account/authentication-application/',
-      )
-    end
-
-    context 'when the user has set their locale to :es' do
-      before { I18n.locale = :es }
-
-      it 'points to the authentication app section of the help page with the locale appended' do
-        expect(url).to eq(
-          'https://www.login.gov/es/help/creating-an-account/authentication-application/',
-        )
-      end
-    end
-  end
-
   describe '.help_center_article_url' do
     let(:category) {}
     let(:article) {}


### PR DESCRIPTION
## 🎫 Ticket

[LG-9469](https://cm-jira.usa.gov/browse/LG-9469)

## 🛠 Summary of changes

Updates the "What is an authenticator app?" on the TOTP enrollment screen to link to a better help center article.

* Before: https://login.gov/help/creating-an-account/authentication-application
   * Redirects to https://login.gov/help/get-started/overview/
* After: https://login.gov/help/get-started/authentication-options/#authentication-application 

## 📜 Testing Plan

1. Add an authenticator app to a new or existing account
2. Click "What is an authenticator app?" in the link text
3. Observe that you arrive at a page that describes what an authenticator app is

## 👀 Screenshots

There are no visual changes here, but including a screenshot to illustrate the affected link:

![Screenshot 2023-08-07 at 5 01 49 PM](https://github.com/18F/identity-idp/assets/1779930/00ea9b5b-a04a-48e2-aa02-7dd550c2edcc)

