### PR TITLE
Move GPO i18n keys into IDV namespace

### DIFF
--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -7,27 +7,27 @@
       ) %>
 <% end %>
 
-<% title t('forms.verify_profile.title') %>
+<% title t('idv.gpo.title') %>
 
 <%= render AlertComponent.new(type: :info, class: 'margin-bottom-4', text_tag: 'div') do %>
   <p>
-    <%= t('forms.verify_profile.alert_info') %>
+    <%= t('idv.gpo.alert_info') %>
     <br>
     <%= render 'shared/address', address: @gpo_verify_form.pii %>
   </p>
   <p>
-    <%= t('forms.verify_profile.wrong_address') %>
-    <%= link_to t('forms.verify_profile.clear_and_start_over'), idv_confirm_start_over_path %>
+    <%= t('idv.gpo.wrong_address') %>
+    <%= link_to t('idv.gpo.clear_and_start_over'), idv_confirm_start_over_path %>
   </p>
 <% end %>
 
-<%= render PageHeadingComponent.new.with_content(t('forms.verify_profile.welcome_back')) %>
-<%= t('forms.verify_profile.welcome_back_description_html') %>
+<%= render PageHeadingComponent.new.with_content(t('idv.gpo.welcome_back')) %>
+<%= t('idv.gpo.welcome_back_description_html') %>
 <hr class="margin-y-4" />
-<h2><%= t('forms.verify_profile.title') %></h2>
+<h2><%= t('idv.gpo.title') %></h2>
 
 <p class="margin-bottom-1">
-  <%= t('forms.verify_profile.instructions') %>
+  <%= t('idv.gpo.instructions') %>
 </p>
 
 <%= simple_form_for(
@@ -46,9 +46,9 @@
             input_html: {
               value: @code,
             },
-            label: t('forms.verify_profile.name'),
+            label: t('idv.gpo.name'),
           ) %>
-      <%= f.submit t('forms.verify_profile.submit'), full_width: true, wide: false, class: 'display-block margin-top-5' %>
+      <%= f.submit t('idv.gpo.submit'), full_width: true, wide: false, class: 'display-block margin-top-5' %>
     </div>
   </div>
 <% end %>
@@ -57,7 +57,7 @@
   <%= link_to t('idv.messages.gpo.resend'), idv_gpo_path, class: 'display-block margin-bottom-2' %>
 <% end %>
 
-<%= link_to t('forms.verify_profile.return_to_profile'), account_path %>
+<%= link_to t('idv.gpo.return_to_profile'), account_path %>
 
 <div class="margin-top-2 padding-top-2 border-top border-primary-light">
   <%= link_to t('idv.messages.clear_and_start_over'), idv_confirm_start_over_path %>

--- a/app/views/idv/gpo_verify/rate_limited.html.erb
+++ b/app/views/idv/gpo_verify/rate_limited.html.erb
@@ -1,6 +1,6 @@
 <% title t('titles.verify_profile') %>
 
-<%= render PageHeadingComponent.new.with_content(t('forms.verify_profile.title')) %>
+<%= render PageHeadingComponent.new.with_content(t('idv.gpo.title')) %>
 
 <p>
   <%= t(

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -125,20 +125,6 @@ en:
       try_again: Use another phone number
     validation:
       required_checkbox: Please check this box to continue
-    verify_profile:
-      alert_info: 'We sent a letter with your one-time code to:'
-      clear_and_start_over: Clear your information and start over
-      instructions: Enter the 10-character code from the letter you received.
-      name: One-time code
-      return_to_profile: Return to your profile
-      submit: Confirm account
-      title: Confirm your account
-      welcome_back: Welcome back
-      welcome_back_description_html: '<p>If you have received your letter, please
-        enter your one-time code below. </p><p>If your letter hasn’t arrived
-        yet, please be patient as <strong>letters typically take 3 to 7 business
-        days to arrive</strong>. Thank you for your patience.</p>'
-      wrong_address: Not the right address?
     webauthn_delete:
       caution: If you remove your security key you won’t be able to use it to access
         your %{app_name} account.

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -132,20 +132,6 @@ es:
       try_again: Use otro número de teléfono.
     validation:
       required_checkbox: Marque esta casilla para continuar
-    verify_profile:
-      alert_info: 'Enviamos una carta con su código único a:'
-      clear_and_start_over: Borrar su información y empezar de nuevo
-      instructions: Introduzca el código de 10 caracteres de la carta que ha recibido.
-      name: Código único
-      return_to_profile: Regrese a su perfil
-      submit: Confirmar cuenta
-      title: Confirme su cuenta
-      welcome_back: Bienvenido de nuevo
-      welcome_back_description_html: '<p>Si ha recibido su carta, introduzca su código
-        único a continuación.</p> <p>Si su carta aún no ha llegado, tenga
-        paciencia, ya que las <strong>cartas suelen tardar de 3 a 7 días hábiles
-        en llegar</strong>. Gracias por su paciencia.</p>'
-      wrong_address: ¿La dirección no es correcta?
     webauthn_delete:
       caution: Si elimina su clave de seguridad, no podrá usarla para acceder a su
         cuenta %{app_name}.

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -134,22 +134,6 @@ fr:
       try_again: Utilisez un autre numéro de téléphone
     validation:
       required_checkbox: Veuillez cocher cette case pour continuer
-    verify_profile:
-      alert_info: 'Nous avons envoyé une lettre avec votre code à usage unique à:'
-      clear_and_start_over: Supprimez vos données et recommencez
-      instructions: Entrez le code à 10 caractères figurant sur la lettre que vous
-        avez reçue.
-      name: Code à usage unique
-      return_to_profile: Retourner à votre profil
-      submit: Confirmer le compte
-      title: Confirmez votre compte
-      welcome_back: Content de vous revoir
-      welcome_back_description_html: '<p>Si vous avez reçu votre lettre, veuillez
-        entrer votre code à usage unique ci-dessous. </p> <p>Si votre lettre
-        n’est pas encore arrivée, veuillez être patient car les <strong>lettres
-        prennent généralement entre trois à sept jours ouvrables pour
-        arriver</strong>. Nous vous remercions de votre patience.</p>'
-      wrong_address: Pas la bonne adresse?
     webauthn_delete:
       caution: Si vous supprimez votre clé de sécurité, vous ne pourrez plus
         l’utiliser pour accéder à votre compte %{app_name}.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -171,6 +171,20 @@ en:
       no_js_header: You must enable JavaScript to verify your identity.
       no_js_intro: '%{sp_name} needs you to verify your identity. You need to enable
         JavaScript to continue this process.'
+    gpo:
+      alert_info: 'We sent a letter with your one-time code to:'
+      clear_and_start_over: Clear your information and start over
+      instructions: Enter the 10-character code from the letter you received.
+      name: One-time code
+      return_to_profile: Return to your profile
+      submit: Confirm account
+      title: Confirm your account
+      welcome_back: Welcome back
+      welcome_back_description_html: '<p>If you have received your letter, please
+        enter your one-time code below. </p><p>If your letter hasn’t arrived
+        yet, please be patient as <strong>letters typically take 3 to 7 business
+        days to arrive</strong>. Thank you for your patience.</p>'
+      wrong_address: Not the right address?
     images:
       come_back_later: Letter with a check mark
     index:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -178,6 +178,20 @@ es:
       no_js_header: Debe habilitar JavaScript para verificar su identidad.
       no_js_intro: '%{sp_name} requiere que usted verifique su identidad. Debe
         habilitar JavaScript para continuar con este proceso.'
+    gpo:
+      alert_info: 'Enviamos una carta con su código único a:'
+      clear_and_start_over: Borrar su información y empezar de nuevo
+      instructions: Introduzca el código de 10 caracteres de la carta que ha recibido.
+      name: Código único
+      return_to_profile: Regrese a su perfil
+      submit: Confirmar cuenta
+      title: Confirme su cuenta
+      welcome_back: Bienvenido de nuevo
+      welcome_back_description_html: '<p>Si ha recibido su carta, introduzca su código
+        único a continuación.</p> <p>Si su carta aún no ha llegado, tenga
+        paciencia, ya que las <strong>cartas suelen tardar de 3 a 7 días hábiles
+        en llegar</strong>. Gracias por su paciencia.</p>'
+      wrong_address: ¿La dirección no es correcta?
     images:
       come_back_later: Carta con una marca de verificación
     index:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -186,6 +186,22 @@ fr:
       no_js_header: Vous devez activer JavaScript pour vérifier votre identité.
       no_js_intro: '%{sp_name} a besoin de vous pour vérifier votre identité. Vous
         devez activer JavaScript pour poursuivre ce processus.'
+    gpo:
+      alert_info: 'Nous avons envoyé une lettre avec votre code à usage unique à:'
+      clear_and_start_over: Supprimez vos données et recommencez
+      instructions: Entrez le code à 10 caractères figurant sur la lettre que vous
+        avez reçue.
+      name: Code à usage unique
+      return_to_profile: Retourner à votre profil
+      submit: Confirmer le compte
+      title: Confirmez votre compte
+      welcome_back: Content de vous revoir
+      welcome_back_description_html: '<p>Si vous avez reçu votre lettre, veuillez
+        entrer votre code à usage unique ci-dessous. </p> <p>Si votre lettre
+        n’est pas encore arrivée, veuillez être patient car les <strong>lettres
+        prennent généralement entre trois à sept jours ouvrables pour
+        arriver</strong>. Nous vous remercions de votre patience.</p>'
+      wrong_address: Pas la bonne adresse?
     images:
       come_back_later: Lettre avec un crochet
     index:

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe 'In Person Proofing', js: true do
       expect(page).not_to have_content(t('headings.account.verified_account'))
       click_on t('account.index.verification.reactivate_button')
       expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
-      click_button t('forms.verify_profile.submit')
+      click_button t('idv.gpo.submit')
 
       # personal key
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -83,8 +83,8 @@ RSpec.feature 'idv gpo otp verification step' do
       expect(page).to have_content t('idv.messages.gpo.resend')
 
       gpo_confirmation_code
-      fill_in t('forms.verify_profile.name'), with: otp
-      click_button t('forms.verify_profile.submit')
+      fill_in t('idv.gpo.name'), with: otp
+      click_button t('idv.gpo.submit')
 
       profile.reload
 
@@ -111,8 +111,8 @@ RSpec.feature 'idv gpo otp verification step' do
       expect(page).to have_content t('idv.messages.gpo.resend')
 
       gpo_confirmation_code
-      fill_in t('forms.verify_profile.name'), with: otp
-      click_button t('forms.verify_profile.submit')
+      fill_in t('idv.gpo.name'), with: otp
+      click_button t('idv.gpo.submit')
 
       expect(user.events.account_verified.size).to eq 1
       expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
@@ -123,11 +123,11 @@ RSpec.feature 'idv gpo otp verification step' do
     sign_in_live_with_2fa(user)
 
     expect(current_path).to eq idv_gpo_verify_path
-    expect(page).to have_content t('forms.verify_profile.alert_info')
-    expect(page).to have_content t('forms.verify_profile.wrong_address')
+    expect(page).to have_content t('idv.gpo.alert_info')
+    expect(page).to have_content t('idv.gpo.wrong_address')
     expect(page).to have_content '1 Secure Way'
 
-    click_on t('forms.verify_profile.clear_and_start_over')
+    click_on t('idv.gpo.clear_and_start_over')
 
     expect(current_path).to eq idv_confirm_start_over_path
 

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'idv gpo step' do
       complete_idv_and_return_to_gpo_step
       click_doc_auth_back_link
 
-      expect(page).to have_content(t('forms.verify_profile.title'))
+      expect(page).to have_content(t('idv.gpo.title'))
       expect(page).to have_current_path(idv_gpo_verify_path)
       expect_user_to_be_unverified(user)
     end
@@ -125,7 +125,7 @@ RSpec.feature 'idv gpo step' do
       fill_in 'Password', with: user_password
       click_continue
       visit root_path
-      click_on t('forms.verify_profile.return_to_profile')
+      click_on t('idv.gpo.return_to_profile')
       first(:link, t('links.sign_out')).click
     end
 
@@ -186,7 +186,7 @@ RSpec.feature 'idv gpo step' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(page).to have_content(t('forms.verify_profile.instructions'))
+      expect(page).to have_content(t('idv.gpo.instructions'))
     end
   end
 end

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -26,8 +26,8 @@ RSpec.feature 'verify profile with OTP' do
 
     scenario 'valid OTP' do
       sign_in_live_with_2fa(user)
-      fill_in t('forms.verify_profile.name'), with: otp
-      click_button t('forms.verify_profile.submit')
+      fill_in t('idv.gpo.name'), with: otp
+      click_button t('idv.gpo.submit')
       acknowledge_and_confirm_personal_key
 
       expect(page).to have_current_path(account_path)
@@ -37,8 +37,8 @@ RSpec.feature 'verify profile with OTP' do
       GpoConfirmationCode.first.update(code_sent_at: 11.days.ago)
 
       sign_in_live_with_2fa(user)
-      fill_in t('forms.verify_profile.name'), with: otp
-      click_button t('forms.verify_profile.submit')
+      fill_in t('idv.gpo.name'), with: otp
+      click_button t('idv.gpo.submit')
 
       expect(page).to have_content t('errors.messages.gpo_otp_expired')
       expect(current_path).to eq idv_gpo_verify_path
@@ -46,8 +46,8 @@ RSpec.feature 'verify profile with OTP' do
 
     scenario 'wrong OTP used' do
       sign_in_live_with_2fa(user)
-      fill_in t('forms.verify_profile.name'), with: 'the wrong code'
-      click_button t('forms.verify_profile.submit')
+      fill_in t('idv.gpo.name'), with: 'the wrong code'
+      click_button t('idv.gpo.submit')
 
       expect(current_path).to eq idv_gpo_verify_path
       expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -156,8 +156,8 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
       profile: User.find(user.id).pending_profile,
       otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
     )
-    fill_in t('forms.verify_profile.name'), with: otp
-    click_button t('forms.verify_profile.submit')
+    fill_in t('idv.gpo.name'), with: otp
+    click_button t('idv.gpo.submit')
   end
 
   def complete_come_back_later

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -8,8 +8,8 @@ RSpec.shared_examples 'gpo otp verification' do
     expect(page).to have_content t('idv.messages.gpo.resend')
 
     gpo_confirmation_code
-    fill_in t('forms.verify_profile.name'), with: otp
-    click_button t('forms.verify_profile.submit')
+    fill_in t('idv.gpo.name'), with: otp
+    click_button t('idv.gpo.submit')
 
     profile.reload
 
@@ -30,8 +30,8 @@ RSpec.shared_examples 'gpo otp verification' do
     sign_in_live_with_2fa(user)
 
     gpo_confirmation_code.update(code_sent_at: 11.days.ago)
-    fill_in t('forms.verify_profile.name'), with: otp
-    click_button t('forms.verify_profile.submit')
+    fill_in t('idv.gpo.name'), with: otp
+    click_button t('idv.gpo.submit')
 
     expect(current_path).to eq idv_gpo_verify_path
     expect(page).to have_content t('errors.messages.gpo_otp_expired')


### PR DESCRIPTION
These keys were at `forms.verify_profile`, but relate entirely to the GPO experience. I'd like to move them to `idv.gpo` in preparation for tackling [LG-10545](https://cm-jira.usa.gov/browse/LG-10545)
