### PR TITLE
Fix capitalization for "Add Face or Touch Unlock"

### DIFF
--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -80,7 +80,7 @@ en:
       add_email: Add email address
       add_federal_id: Add federal employee ID
       add_phone_number: Add phone number
-      add_platform_authenticator: Add Face or Touch Unlock
+      add_platform_authenticator: Add face or touch unlock
       add_security_key: Add security key
       close: Close
       connected_accounts: Your connected accounts


### PR DESCRIPTION
## 🛠 Summary of changes

Updates capitalization of "Add Face or Touch Unlock" to be consistent with initial capitalization of other MFA methods, and consistent with lower-casing of "face or touch unlock" generally.

Before: "Add Face or Touch Unlock"
After: "Add face or touch unlock"

Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1691508095280409?thread_ts=1691446260.169989&cid=C01710KMYUB

## 📜 Testing Plan

1. Sign in to an account
2. From account dashboard, observe link "Add face or touch unlock"

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/8f94da6c-1778-430e-babe-5b5af4faeb2d)|![image](https://github.com/18F/identity-idp/assets/1779930/adba3eb9-2009-433a-b4fc-8c1011be2a25)
