### PR TITLE
Remove reference to dropped profiles.reproof_at database column

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,4 @@
 class Profile < ApplicationRecord
-  self.ignored_columns += %w[reproof_at]
-
   belongs_to :user
   # rubocop:disable Rails/InverseOf
   belongs_to :initiating_service_provider,


### PR DESCRIPTION
## 🛠 Summary of changes

Follow-up to #8816/#8831 which removed the `reproof_at` column. This PR removes the `ignored_columns` call since the column has been dropped.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
