### PR TITLE
LG-0385 Write to in_person_verification_pending_at timestamp.

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -64,7 +64,7 @@ module IdvStepConcern
   def confirm_verify_info_step_complete
     return if idv_session.verify_info_step_complete?
 
-    if idv_session.in_person_enrollment?
+    if idv_session.pending_in_person_enrollment?
       redirect_to idv_in_person_verify_info_url
     else
       redirect_to idv_verify_info_url

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -21,9 +21,9 @@ class GpoVerifyForm
 
     if result
       pending_profile&.remove_gpo_deactivation_reason
-      if pending_profile&.pending_in_person_enrollment?
-        # note: pending_profile is not active here
-        pending_profile&.deactivate_for_in_person_verification_and_schedule_enrollment(pii)
+
+      if profile_has_pending_in_person_enrollment?
+        schedule_in_person_enrollment_and_deactivate_profile
       elsif fraud_check_failed && threatmetrix_enabled?
         pending_profile&.deactivate_for_fraud_review
       elsif fraud_check_failed
@@ -59,6 +59,15 @@ class GpoVerifyForm
     return if otp.blank? || pending_profile.blank?
 
     pending_profile.gpo_confirmation_codes.first_with_otp(otp)
+  end
+
+  def profile_has_pending_in_person_enrollment?
+    pending_profile&.pending_in_person_enrollment?
+  end
+
+  def schedule_in_person_enrollment_and_deactivate_profile
+    UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
+    pending_profile&.deactivate_for_in_person_verification
   end
 
   def which_letter

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -150,7 +150,8 @@ class Profile < ApplicationRecord
 
   def in_person_verification_pending?
     # note: deactivation reason will be replaced by timestamp column
-    deactivation_reason == 'in_person_verification_pending'
+    deactivation_reason == 'in_person_verification_pending' ||
+      in_person_verification_pending_at?
   end
 
   def deactivate_for_in_person_verification

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -123,6 +123,7 @@ class Profile < ApplicationRecord
         fraud_rejection_at: nil,
         fraud_pending_reason: nil,
         deactivation_reason: nil,
+        in_person_verification_pending_at: nil,
       )
       activate
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -150,8 +150,7 @@ class Profile < ApplicationRecord
 
   def in_person_verification_pending?
     # note: deactivation reason will be replaced by timestamp column
-    deactivation_reason == 'in_person_verification_pending' ||
-      in_person_verification_pending_at?
+    deactivation_reason == 'in_person_verification_pending'
   end
 
   def deactivate_for_in_person_verification

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -161,13 +161,6 @@ class Profile < ApplicationRecord
     end
   end
 
-  def deactivate_for_in_person_verification_and_schedule_enrollment(pii)
-    transaction do
-      UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)
-      deactivate(:in_person_verification_pending)
-    end
-  end
-
   def deactivate_for_gpo_verification
     update!(active: false, gpo_verification_pending_at: Time.zone.now)
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -152,6 +152,13 @@ class Profile < ApplicationRecord
     deactivation_reason == 'in_person_verification_pending'
   end
 
+  def deactivate_for_in_person_verification
+    transaction do
+      deactivate(:in_person_verification_pending) # to be deprecated
+      update!(active: false, in_person_verification_pending_at: Time.zone.now)
+    end
+  end
+
   def deactivate_for_in_person_verification_and_schedule_enrollment(pii)
     transaction do
       UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(user, pii)

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -6,24 +6,23 @@ module Idv
       applicant:,
       user:,
       user_password:,
-      initiating_service_provider: nil,
-      in_person_verification_pending: false
+      initiating_service_provider: nil
     )
       self.pii_attributes = Pii::Attributes.new_from_hash(applicant)
       self.user = user
       self.user_password = user_password
       self.initiating_service_provider = initiating_service_provider
-      self.in_person_verification_pending = in_person_verification_pending
     end
 
     def save_profile(
       fraud_pending_reason:,
       gpo_verification_needed:,
+      in_person_verification_needed:,
       deactivation_reason: nil
     )
       profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason)
       profile.initiating_service_provider = initiating_service_provider
-      if in_person_verification_pending
+      if in_person_verification_needed
         profile.deactivation_reason = :in_person_verification_pending
       end
       profile.encrypt_pii(pii_attributes, user_password)

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -22,9 +22,7 @@ module Idv
     )
       profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason)
       profile.initiating_service_provider = initiating_service_provider
-      if in_person_verification_needed
-        profile.deactivation_reason = :in_person_verification_pending
-      end
+      profile.deactivate_for_in_person_verification if in_person_verification_needed
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
       profile.fraud_pending_reason = fraud_pending_reason

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -45,7 +45,6 @@ module Idv
       :user_password,
       :phone_confirmed,
       :initiating_service_provider,
-      :in_person_verification_pending,
     )
     attr_writer :pii_attributes
   end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -102,7 +102,7 @@ module Idv
     end
 
     def associate_in_person_enrollment_with_profile
-      return unless in_person_enrollment? && current_user.establishing_in_person_enrollment
+      return unless pending_in_person_enrollment? && current_user.establishing_in_person_enrollment
       current_user.establishing_in_person_enrollment.update(profile: profile)
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -56,6 +56,7 @@ module Idv
       profile = profile_maker.save_profile(
         fraud_pending_reason: threatmetrix_fraud_pending_reason,
         gpo_verification_needed: gpo_verification_needed?,
+        in_person_verification_needed: in_person_enrollment?,
       )
 
       profile.activate unless profile.reason_not_to_activate
@@ -237,7 +238,6 @@ module Idv
         user: current_user,
         user_password: user_password,
         initiating_service_provider: service_provider,
-        in_person_verification_pending: in_person_enrollment?,
       )
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -56,7 +56,7 @@ module Idv
       profile = profile_maker.save_profile(
         fraud_pending_reason: threatmetrix_fraud_pending_reason,
         gpo_verification_needed: gpo_verification_needed?,
-        in_person_verification_needed: in_person_enrollment?,
+        in_person_verification_needed: pending_in_person_enrollment?,
       )
 
       profile.activate unless profile.reason_not_to_activate
@@ -72,7 +72,7 @@ module Idv
         move_pii_to_user_session
       elsif address_verification_mechanism == 'gpo'
         create_gpo_entry
-      elsif in_person_enrollment?
+      elsif pending_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
           current_user,
           pii,
@@ -138,7 +138,7 @@ module Idv
       failed_phone_step_numbers << phone_e164 if !failed_phone_step_numbers.include?(phone_e164)
     end
 
-    def in_person_enrollment?
+    def pending_in_person_enrollment?
       current_user.proofing_component&.document_check == Idp::Constants::Vendors::USPS
     end
 

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Idv::PersonalKeyController do
     profile = profile_maker.save_profile(
       fraud_pending_reason: nil,
       gpo_verification_needed: false,
+      in_person_verification_needed: false,
     )
     idv_session.pii = profile_maker.pii_attributes
     idv_session.profile_id = profile.id

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
 
     trait :in_person_verification_pending do
       deactivation_reason { :in_person_verification_pending }
+      in_person_verification_pending_at { 15.days.ago }
     end
 
     trait :fraud_pending_reason do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -725,6 +725,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq 'in_person_verification_pending' # to change
       expect(profile.fraud_review_pending?).to eq(true) # to change
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to_not be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -735,6 +736,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil # changed
       expect(profile.fraud_review_pending?).to eq(false) # changed
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -902,6 +902,30 @@ RSpec.describe Profile do
 
   # TODO: does deactivating make sense for a non-active profile? Should we prevent it?
   # TODO: related: should we test against an active profile here?
+  describe 'deactivate_for_in_person_verification' do
+    it 'deactivates a profile for in_person_verification' do
+      profile = create(:profile, user: user)
+
+      expect(profile.activated_at).to be_nil
+      expect(profile.active).to eq(false)
+      expect(profile.deactivation_reason).to be_nil # to change
+      expect(profile.fraud_review_pending?).to eq(false)
+      expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.initiating_service_provider).to be_nil
+      expect(profile.verified_at).to be_nil
+
+      profile.deactivate_for_in_person_verification
+
+      expect(profile.activated_at).to be_nil
+      expect(profile.active).to eq(false)
+      expect(profile.deactivation_reason).to eq('in_person_verification_pending') # changed
+      expect(profile.fraud_review_pending?).to eq(false)
+      expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.initiating_service_provider).to be_nil
+      expect(profile.verified_at).to be_nil
+    end
+  end
+
   describe '#deactivate_for_in_person_verification_and_schedule_enrollment' do
     it 'sets deactivation reason to in_person_verification_pending' do
       profile = create(:profile, user: user)

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -928,30 +928,6 @@ RSpec.describe Profile do
     end
   end
 
-  describe '#deactivate_for_in_person_verification_and_schedule_enrollment' do
-    it 'sets deactivation reason to in_person_verification_pending' do
-      profile = create(:profile, user: user)
-
-      expect(profile.activated_at).to be_nil
-      expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to be_nil # to change
-      expect(profile.fraud_review_pending?).to eq(false)
-      expect(profile.gpo_verification_pending_at).to be_nil
-      expect(profile.initiating_service_provider).to be_nil
-      expect(profile.verified_at).to be_nil
-
-      profile.deactivate_for_in_person_verification_and_schedule_enrollment(pii)
-
-      expect(profile.activated_at).to be_nil
-      expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to eq('in_person_verification_pending') # changed
-      expect(profile.fraud_review_pending?).to eq(false)
-      expect(profile.gpo_verification_pending_at).to be_nil
-      expect(profile.initiating_service_provider).to be_nil
-      expect(profile.verified_at).to be_nil
-    end
-  end
-
   # TODO: does deactivating make sense for a non-active profile? Should we prevent it?
   # TODO: related: should we test against an active profile here?
   describe '#deactivate_for_gpo_verification' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -238,6 +238,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -248,6 +249,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
 
@@ -262,6 +264,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -272,6 +275,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
 
@@ -292,6 +296,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -301,6 +306,7 @@ RSpec.describe Profile do
       expect(active_profile.deactivation_reason).to be_nil
       expect(active_profile.fraud_review_pending?).to eq(false)
       expect(active_profile.gpo_verification_pending_at).to be_nil
+      expect(active_profile.in_person_verification_pending_at).to be_nil
       expect(active_profile.initiating_service_provider).to be_nil
       expect(active_profile.verified_at).to be_present
 
@@ -313,6 +319,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
 
@@ -322,6 +329,7 @@ RSpec.describe Profile do
       expect(active_profile.deactivation_reason).to be_nil
       expect(active_profile.fraud_review_pending?).to eq(false)
       expect(active_profile.gpo_verification_pending_at).to be_nil
+      expect(active_profile.in_person_verification_pending_at).to be_nil
       expect(active_profile.initiating_service_provider).to be_nil
 
       # !!! a user can have multiple verified profiles
@@ -338,6 +346,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present
 
@@ -348,6 +357,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
     end
@@ -365,6 +375,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -375,6 +386,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
     end
@@ -387,6 +399,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -397,6 +410,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
     end
@@ -416,6 +430,7 @@ RSpec.describe Profile do
         expect(profile.deactivation_reason).to be_nil
         expect(profile.fraud_review_pending?).to eq(false)
         expect(profile.gpo_verification_pending_at).to be_present
+        expect(profile.in_person_verification_pending_at).to be_nil
         expect(profile.initiating_service_provider).to be_nil
         expect(profile.verified_at).to be_nil
 
@@ -429,6 +444,7 @@ RSpec.describe Profile do
         expect(profile.deactivation_reason).to be_nil
         expect(profile.fraud_review_pending?).to eq(false)
         expect(profile.gpo_verification_pending_at).to be_present
+        expect(profile.in_person_verification_pending_at).to be_nil
         expect(profile.initiating_service_provider).to be_nil
         expect(profile.verified_at).to be_nil
 
@@ -443,6 +459,7 @@ RSpec.describe Profile do
         expect(profile.deactivation_reason).to be_nil
         expect(profile.fraud_review_pending?).to eq(true)
         expect(profile.gpo_verification_pending_at).to be_nil
+        expect(profile.in_person_verification_pending_at).to be_nil
         expect(profile.initiating_service_provider).to be_nil
         expect(profile.verified_at).to be_nil
 
@@ -456,6 +473,7 @@ RSpec.describe Profile do
         expect(profile.deactivation_reason).to be_nil
         expect(profile.fraud_review_pending?).to eq(true)
         expect(profile.gpo_verification_pending_at).to be_nil
+        expect(profile.in_person_verification_pending_at).to be_nil
         expect(profile.initiating_service_provider).to be_nil
         expect(profile.verified_at).to be_nil
 
@@ -470,6 +488,7 @@ RSpec.describe Profile do
         expect(profile.deactivation_reason).to be_nil
         expect(profile.fraud_review_pending?).to eq(false)
         expect(profile.gpo_verification_pending_at).to be_nil
+        expect(profile.in_person_verification_pending_at).to be_nil
         expect(profile.initiating_service_provider).to be_nil
         expect(profile.verified_at).to be_nil
 
@@ -483,6 +502,7 @@ RSpec.describe Profile do
         expect(profile.deactivation_reason).to be_nil
         expect(profile.fraud_review_pending?).to eq(false)
         expect(profile.gpo_verification_pending_at).to be_nil
+        expect(profile.in_person_verification_pending_at).to be_nil
         expect(profile.initiating_service_provider).to be_nil
         expect(profile.verified_at).to be_nil
 
@@ -512,6 +532,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil # to change
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present
 
@@ -522,6 +543,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq('password_reset') # changed
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
 
       # !!! does a deactivated verified profile remain verified?
@@ -541,6 +563,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_present # to change
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -551,6 +574,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil # changed
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -575,6 +599,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq 'password_reset' # will change but shouldn't
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -586,6 +611,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil # !!! changed
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
     end
@@ -604,6 +630,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq 'password_reset' # to change
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to eq verified_at
 
@@ -614,6 +641,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil # changed
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to eq verified_at
     end
@@ -632,6 +660,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq('password_reset') # to change
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -645,6 +674,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil # changed
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -663,6 +693,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq 'encryption_error'
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -673,6 +704,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq 'encryption_error'
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
     end
@@ -691,6 +723,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq('password_reset')
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -703,6 +736,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq('password_reset')
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -761,6 +795,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq('in_person_verification_pending')
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_present
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -773,6 +808,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq('in_person_verification_pending')
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_present
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -790,6 +826,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(true) # to change
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -800,6 +837,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false) # changed
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
 
@@ -866,6 +904,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(true) # to change
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -880,6 +919,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false) # changed
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
 
@@ -913,6 +953,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil # to change
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -923,6 +964,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq('in_person_verification_pending') # changed
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_present # changed
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
     end
@@ -939,6 +981,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil # to change
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -949,6 +992,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_present # changed
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -968,6 +1012,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false) # to change
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
@@ -979,6 +1024,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(true) # changed
       expect(profile.gpo_verification_pending_at).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -759,7 +759,7 @@ RSpec.describe Profile do
       expect(profile.deactivation_reason).to eq 'in_person_verification_pending' # to change
       expect(profile.fraud_review_pending?).to eq(true) # to change
       expect(profile.gpo_verification_pending_at).to be_nil
-      expect(profile.in_person_verification_pending_at).to_not be_nil
+      expect(profile.in_person_verification_pending_at).to be_present
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil # to change
 
@@ -909,8 +909,8 @@ RSpec.describe Profile do
       expect(profile.verified_at).to be_nil # to change
 
       expect(profile).to_not be_active
-      expect(profile.fraud_review_pending_at).to_not be_nil
-      expect(profile.fraud_pending_reason).to_not be_nil
+      expect(profile.fraud_review_pending_at).to be_present
+      expect(profile.fraud_pending_reason).to be_present
 
       profile.activate_after_fraud_review_unnecessary
 

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Idv::ProfileMaker do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to eq('in_person_verification_pending')
+        expect(profile.in_person_verification_pending_at).to_not be_nil
         expect(profile.fraud_review_pending?).to eq(false)
         expect(profile.gpo_verification_pending_at.present?).to eq(false)
         expect(profile.initiating_service_provider).to eq(nil)

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Idv::ProfileMaker do
     let(:user) { create(:user, :fully_registered) }
     let(:user_password) { user.password }
     let(:initiating_service_provider) { nil }
-    let(:in_person_verification_pending) { false }
 
     subject do
       described_class.new(
@@ -14,7 +13,6 @@ RSpec.describe Idv::ProfileMaker do
         user: user,
         user_password: user_password,
         initiating_service_provider: initiating_service_provider,
-        in_person_verification_pending: in_person_verification_pending,
       )
     end
 
@@ -23,6 +21,7 @@ RSpec.describe Idv::ProfileMaker do
       profile = subject.save_profile(
         fraud_pending_reason: nil,
         gpo_verification_needed: false,
+        in_person_verification_needed: false,
       )
       pii = subject.pii_attributes
 
@@ -44,6 +43,7 @@ RSpec.describe Idv::ProfileMaker do
           fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: :encryption_error,
+          in_person_verification_needed: false,
         )
 
         expect(profile.activated_at).to be_nil
@@ -62,6 +62,7 @@ RSpec.describe Idv::ProfileMaker do
           fraud_pending_reason: 'threatmetrix_review',
           gpo_verification_needed: false,
           deactivation_reason: nil,
+          in_person_verification_needed: false,
         )
 
         expect(profile.activated_at).to be_nil
@@ -80,6 +81,7 @@ RSpec.describe Idv::ProfileMaker do
           fraud_pending_reason: nil,
           gpo_verification_needed: true,
           deactivation_reason: nil,
+          in_person_verification_needed: false,
         )
 
         expect(profile.activated_at).to be_nil
@@ -92,12 +94,32 @@ RSpec.describe Idv::ProfileMaker do
       end
     end
 
+    context 'with in_person_verification_needed' do
+      it 'deactivates a profile for in person verification' do
+        profile = subject.save_profile(
+          fraud_pending_reason: nil,
+          gpo_verification_needed: false,
+          deactivation_reason: nil,
+          in_person_verification_needed: true,
+        )
+
+        expect(profile.activated_at).to be_nil
+        expect(profile.active).to eq(false)
+        expect(profile.deactivation_reason).to eq('in_person_verification_pending')
+        expect(profile.fraud_review_pending?).to eq(false)
+        expect(profile.gpo_verification_pending_at.present?).to eq(false)
+        expect(profile.initiating_service_provider).to eq(nil)
+        expect(profile.verified_at).to be_nil
+      end
+    end
+
     context 'as active' do
       it 'creates an active profile' do
         profile = subject.save_profile(
           fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: nil,
+          in_person_verification_needed: false,
         )
 
         expect(profile.activated_at).to be_nil
@@ -118,6 +140,7 @@ RSpec.describe Idv::ProfileMaker do
           fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: nil,
+          in_person_verification_needed: false,
         )
 
         expect(profile.activated_at).to be_nil


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-10383](https://cm-jira.usa.gov/browse/LG-10383)


## 🛠 Summary of changes

We are deprecating the `profile#deactivation_reason(:in_person_verification_pending)` enum for a in_person_verification_pending_at timestamp. This PR will write to both for now until we complete a backfill to add timestamps to all users who are undergoing in person verification.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
