### PR TITLE
LG-10545: "Didn't get your letter?" screen

### DIFF
--- a/app/controllers/idv/gpo_verify_controller.rb
+++ b/app/controllers/idv/gpo_verify_controller.rb
@@ -19,10 +19,14 @@ module Idv
       @gpo_verify_form = GpoVerifyForm.new(user: current_user, pii: pii)
       @code = session[:last_gpo_confirmation_code] if FeatureManagement.reveal_gpo_code?
 
-      @user_can_request_another_gpo_code =
+      @should_prompt_user_to_request_another_letter =
         FeatureManagement.gpo_verification_enabled? &&
         !gpo_mail.mail_spammed? &&
         !gpo_mail.profile_too_old?
+
+      # GPO reminder emails include an "I did not receive my letter!" link that results in
+      # slightly different copy on this screen.
+      @user_did_not_receive_letter = !!params[:did_not_receive_letter]
 
       if pii_locked?
         redirect_to capture_password_url

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1029,8 +1029,16 @@ module AnalyticsEvents
 
   # @identity.idp.previous_event_name Account verification visited
   # GPO verification visited
-  def idv_gpo_verification_visited
-    track_event('IdV: GPO verification visited')
+  # @param [String,nil] source The source for the visit (i.e., "gpo_reminder_email").
+  def idv_gpo_verification_visited(
+    source: nil,
+    **extra
+  )
+    track_event(
+      'IdV: GPO verification visited',
+      source: source,
+      **extra,
+    )
   end
 
   # Tracks emails that are initiated during InPerson::EmailReminderJob

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -21,13 +21,13 @@
   </p>
 <% end %>
 
-<%= render PageHeadingComponent.new.with_content(t('idv.gpo.welcome_back')) %>
-<%= t('idv.gpo.welcome_back_description_html') %>
+<%= render PageHeadingComponent.new.with_content(t('idv.gpo.title')) %>
+<%= t('idv.gpo.intro_html') %>
 <hr class="margin-y-4" />
-<h2><%= t('idv.gpo.title') %></h2>
+<h2><%= t('idv.gpo.form.title') %></h2>
 
 <p class="margin-bottom-1">
-  <%= t('idv.gpo.instructions') %>
+  <%= t('idv.gpo.form.instructions') %>
 </p>
 
 <%= simple_form_for(
@@ -46,9 +46,9 @@
             input_html: {
               value: @code,
             },
-            label: t('idv.gpo.name'),
+            label: t('idv.gpo.form.otp_label'),
           ) %>
-      <%= f.submit t('idv.gpo.submit'), full_width: true, wide: false, class: 'display-block margin-top-5' %>
+      <%= f.submit t('idv.gpo.form.submit'), full_width: true, wide: false, class: 'display-block margin-top-5' %>
     </div>
   </div>
 <% end %>

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -7,7 +7,11 @@
       ) %>
 <% end %>
 
+<% if @user_did_not_receive_letter %>
+<% title t('idv.gpo.did_not_receive_letter.title') %>
+<% else %>
 <% title t('idv.gpo.title') %>
+<% end %>
 
 <%= render AlertComponent.new(type: :info, class: 'margin-bottom-4', text_tag: 'div') do %>
   <p>
@@ -21,13 +25,40 @@
   </p>
 <% end %>
 
-<%= render PageHeadingComponent.new.with_content(t('idv.gpo.title')) %>
-<%= t('idv.gpo.intro_html') %>
+<%= render PageHeadingComponent.new.with_content(
+      if @user_did_not_receive_letter
+        t('idv.gpo.did_not_receive_letter.title')
+      else
+        t('idv.gpo.title')
+      end,
+    ) %>
+
+<% if @user_did_not_receive_letter %>
+  <%= t(
+        'idv.gpo.did_not_receive_letter.intro_html',
+        request_new_letter_prompt: (
+          if @should_prompt_user_to_request_another_letter
+            t(
+              'idv.gpo.did_not_receive_letter.request_new_letter_prompt_html',
+              request_new_letter_link: link_to(t('idv.gpo.did_not_receive_letter.request_new_letter_link'), idv_gpo_path),
+            )
+          else
+            ''
+          end
+        ),
+      ) %>
+<% else %>
+  <%= t('idv.gpo.intro_html') %>
+<% end %>
 <hr class="margin-y-4" />
 <h2><%= t('idv.gpo.form.title') %></h2>
 
 <p class="margin-bottom-1">
-  <%= t('idv.gpo.form.instructions') %>
+  <%= if @user_did_not_receive_letter
+        t('idv.gpo.did_not_receive_letter.instructions')
+      else
+        t('idv.gpo.instructions')
+      end %>%
 </p>
 
 <%= simple_form_for(
@@ -53,8 +84,10 @@
   </div>
 <% end %>
 
-<% if @user_can_request_another_gpo_code %>
-  <%= link_to t('idv.messages.gpo.resend'), idv_gpo_path, class: 'display-block margin-bottom-2' %>
+<% if @should_prompt_user_to_request_another_letter %>
+  <% unless @user_did_not_receive_letter %>
+    <%= link_to t('idv.messages.gpo.resend'), idv_gpo_path, class: 'display-block margin-bottom-2' %>
+  <% end %>
 <% end %>
 
 <%= link_to t('idv.gpo.return_to_profile'), account_path %>

--- a/app/views/idv/gpo_verify/index.html.erb
+++ b/app/views/idv/gpo_verify/index.html.erb
@@ -34,19 +34,16 @@
     ) %>
 
 <% if @user_did_not_receive_letter %>
-  <%= t(
-        'idv.gpo.did_not_receive_letter.intro_html',
-        request_new_letter_prompt: (
-          if @should_prompt_user_to_request_another_letter
-            t(
-              'idv.gpo.did_not_receive_letter.request_new_letter_prompt_html',
-              request_new_letter_link: link_to(t('idv.gpo.did_not_receive_letter.request_new_letter_link'), idv_gpo_path),
-            )
-          else
-            ''
-          end
-        ),
-      ) %>
+  <% if @should_prompt_user_to_request_another_letter %>
+    <%= t(
+          'idv.gpo.did_not_receive_letter.intro.request_new_letter_prompt_html',
+          request_new_letter_link: link_to(
+            t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
+            idv_gpo_path,
+          ),
+        ) %>
+  <% end %>
+    <%= t('idv.gpo.did_not_receive_letter.intro.be_patient_html') %>
 <% else %>
   <%= t('idv.gpo.intro_html') %>
 <% end %>
@@ -55,10 +52,10 @@
 
 <p class="margin-bottom-1">
   <%= if @user_did_not_receive_letter
-        t('idv.gpo.did_not_receive_letter.instructions')
+        t('idv.gpo.did_not_receive_letter.form.instructions')
       else
-        t('idv.gpo.instructions')
-      end %>%
+        t('idv.gpo.form.instructions')
+      end %>
 </p>
 
 <%= simple_form_for(

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -175,21 +175,21 @@ en:
       alert_info: 'We sent a letter with your one-time code to:'
       clear_and_start_over: Clear your information and start over
       did_not_receive_letter:
-        instructions: If you have your letter, enter the 10-character code from the
-          letter you received.
-        intro_html: '<p>%{request_new_letter_prompt}Please note that <strong>letters
-          typically take 3 to 7 business days to arrive</strong>. Thank you for
-          your patience.</p>'
-        request_new_letter_link: request a new letter
-        request_new_letter_prompt_html: If you haven’t received your letter, you may
-          %{request_new_letter_link}.
+        form:
+          instructions: If you have your letter, enter the 10-character code from the
+            letter you received.
+        intro:
+          be_patient_html: Please note that <strong>letters typically take 3 to 7 business
+            days to arrive</strong>. Thank you for your patience.
+          request_new_letter_link: request a new letter
+          request_new_letter_prompt_html: If you haven’t received your letter, you may
+            <span>%{request_new_letter_link}</span>.
         title: Didn’t get your letter?
       form:
         instructions: Enter the 10-character code from the letter you received.
         otp_label: One-time code
         submit: Confirm account
         title: Confirm your account
-      instructions: Enter the 10-character code from the letter you received.
       intro_html: '<p>If you have received your letter, please enter your one-time
         code below. </p><p>If your letter hasn’t arrived yet, please be patient
         as <strong>letters typically take 3 to 7 business days to

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -174,11 +174,22 @@ en:
     gpo:
       alert_info: 'We sent a letter with your one-time code to:'
       clear_and_start_over: Clear your information and start over
+      did_not_receive_letter:
+        instructions: If you have your letter, enter the 10-character code from the
+          letter you received.
+        intro_html: '<p>%{request_new_letter_prompt}Please note that <strong>letters
+          typically take 3 to 7 business days to arrive</strong>. Thank you for
+          your patience.</p>'
+        request_new_letter_link: request a new letter
+        request_new_letter_prompt_html: If you haven’t received your letter, you may
+          %{request_new_letter_link}.
+        title: Didn’t get your letter?
       form:
         instructions: Enter the 10-character code from the letter you received.
         otp_label: One-time code
         submit: Confirm account
         title: Confirm your account
+      instructions: Enter the 10-character code from the letter you received.
       intro_html: '<p>If you have received your letter, please enter your one-time
         code below. </p><p>If your letter hasn’t arrived yet, please be patient
         as <strong>letters typically take 3 to 7 business days to

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -174,16 +174,17 @@ en:
     gpo:
       alert_info: 'We sent a letter with your one-time code to:'
       clear_and_start_over: Clear your information and start over
-      instructions: Enter the 10-character code from the letter you received.
-      name: One-time code
+      form:
+        instructions: Enter the 10-character code from the letter you received.
+        otp_label: One-time code
+        submit: Confirm account
+        title: Confirm your account
+      intro_html: '<p>If you have received your letter, please enter your one-time
+        code below. </p><p>If your letter hasn’t arrived yet, please be patient
+        as <strong>letters typically take 3 to 7 business days to
+        arrive</strong>. Thank you for your patience.</p>'
       return_to_profile: Return to your profile
-      submit: Confirm account
-      title: Confirm your account
-      welcome_back: Welcome back
-      welcome_back_description_html: '<p>If you have received your letter, please
-        enter your one-time code below. </p><p>If your letter hasn’t arrived
-        yet, please be patient as <strong>letters typically take 3 to 7 business
-        days to arrive</strong>. Thank you for your patience.</p>'
+      title: Welcome back
       wrong_address: Not the right address?
     images:
       come_back_later: Letter with a check mark

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -181,6 +181,15 @@ es:
     gpo:
       alert_info: 'Enviamos una carta con su código único a:'
       clear_and_start_over: Borrar su información y empezar de nuevo
+      did_not_receive_letter:
+        instructions: Si ya tiene su carta, introduzca el código de 10 caracteres de la
+          carta que recibió.
+        intro_html: '<p>%{request_new_letter_prompt} Tenga en cuenta que las cartas
+          <strong>suelen tardar entre 3 y 7 días laborables en llegar</strong>.
+          Gracias por su paciencia.</p>'
+        request_new_letter_link: solicitar una nueva
+        request_new_letter_prompt_html: Si no ha recibido su carta, puede %{request_new_letter_link}.
+        title: ¿No recibió su carta?
       form:
         instructions: Introduzca el código de 10 caracteres de la carta que ha recibido.
         otp_label: Código único

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -182,13 +182,15 @@ es:
       alert_info: 'Enviamos una carta con su código único a:'
       clear_and_start_over: Borrar su información y empezar de nuevo
       did_not_receive_letter:
-        instructions: Si ya tiene su carta, introduzca el código de 10 caracteres de la
-          carta que recibió.
-        intro_html: '<p>%{request_new_letter_prompt} Tenga en cuenta que las cartas
-          <strong>suelen tardar entre 3 y 7 días laborables en llegar</strong>.
-          Gracias por su paciencia.</p>'
-        request_new_letter_link: solicitar una nueva
-        request_new_letter_prompt_html: Si no ha recibido su carta, puede %{request_new_letter_link}.
+        form:
+          instructions: Si ya tiene su carta, introduzca el código de 10 caracteres de la
+            carta que recibió.
+        intro:
+          be_patient_html: Tenga en cuenta que las cartas <strong>suelen tardar entre 3 y
+            7 días laborables en llegar</strong>. Gracias por su paciencia.
+          request_new_letter_link: solicitar una nueva
+          request_new_letter_prompt_html: Si no ha recibido su carta, puede
+            <span>%{request_new_letter_link}</span>.
         title: ¿No recibió su carta?
       form:
         instructions: Introduzca el código de 10 caracteres de la carta que ha recibido.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -181,16 +181,17 @@ es:
     gpo:
       alert_info: 'Enviamos una carta con su código único a:'
       clear_and_start_over: Borrar su información y empezar de nuevo
-      instructions: Introduzca el código de 10 caracteres de la carta que ha recibido.
-      name: Código único
+      form:
+        instructions: Introduzca el código de 10 caracteres de la carta que ha recibido.
+        otp_label: Código único
+        submit: Confirmar cuenta
+        title: Confirme su cuenta
+      intro_html: '<p>Si ha recibido su carta, introduzca su código único a
+        continuación.</p> <p>Si su carta aún no ha llegado, tenga paciencia, ya
+        que las <strong>cartas suelen tardar de 3 a 7 días hábiles en
+        llegar</strong>. Gracias por su paciencia.</p>'
       return_to_profile: Regrese a su perfil
-      submit: Confirmar cuenta
-      title: Confirme su cuenta
-      welcome_back: Bienvenido de nuevo
-      welcome_back_description_html: '<p>Si ha recibido su carta, introduzca su código
-        único a continuación.</p> <p>Si su carta aún no ha llegado, tenga
-        paciencia, ya que las <strong>cartas suelen tardar de 3 a 7 días hábiles
-        en llegar</strong>. Gracias por su paciencia.</p>'
+      title: Bienvenido de nuevo
       wrong_address: ¿La dirección no es correcta?
     images:
       come_back_later: Carta con una marca de verificación

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -190,14 +190,16 @@ fr:
       alert_info: 'Nous avons envoyé une lettre avec votre code à usage unique à:'
       clear_and_start_over: Supprimez vos données et recommencez
       did_not_receive_letter:
-        instructions: Si vous avez reçu votre lettre, veuillez entrer le code à 10
-          caractères figurant sur la lettre que vous avez reçue.
-        intro_html: '<p>%{request_new_letter_prompt} Veuillez noter que les lettres
-          prennent <strong>généralement entre trois à sept jours ouvrables pour
-          arriver</strong>. Nous vous remercions de votre patience.</p>'
-        request_new_letter_link: demander une nouvelle
-        request_new_letter_prompt_html: Si votre lettre n’est pas encore arrivée, vous
-          pouvez en %{request_new_letter_link}.
+        form:
+          instructions: Si vous avez reçu votre lettre, veuillez entrer le code à 10
+            caractères figurant sur la lettre que vous avez reçue.
+        intro:
+          be_patient_html: 'Veuillez noter que les lettres prennent <strong>généralement
+            entre trois à sept jours ouvrables pour arriver</strong>. Nous vous
+            remercions de votre patience.'
+          request_new_letter_link: demander une nouvelle
+          request_new_letter_prompt_html: Si votre lettre n’est pas encore arrivée, vous
+            pouvez en <span>%{request_new_letter_link}</span>.
         title: N’avez-vous pas reçu votre lettre?
       form:
         instructions: Entrez le code à 10 caractères figurant sur la lettre que vous

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -189,6 +189,16 @@ fr:
     gpo:
       alert_info: 'Nous avons envoyé une lettre avec votre code à usage unique à:'
       clear_and_start_over: Supprimez vos données et recommencez
+      did_not_receive_letter:
+        instructions: Si vous avez reçu votre lettre, veuillez entrer le code à 10
+          caractères figurant sur la lettre que vous avez reçue.
+        intro_html: '<p>%{request_new_letter_prompt} Veuillez noter que les lettres
+          prennent <strong>généralement entre trois à sept jours ouvrables pour
+          arriver</strong>. Nous vous remercions de votre patience.</p>'
+        request_new_letter_link: demander une nouvelle
+        request_new_letter_prompt_html: Si votre lettre n’est pas encore arrivée, vous
+          pouvez en %{request_new_letter_link}.
+        title: N’avez-vous pas reçu votre lettre?
       form:
         instructions: Entrez le code à 10 caractères figurant sur la lettre que vous
           avez reçue.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -189,18 +189,19 @@ fr:
     gpo:
       alert_info: 'Nous avons envoyé une lettre avec votre code à usage unique à:'
       clear_and_start_over: Supprimez vos données et recommencez
-      instructions: Entrez le code à 10 caractères figurant sur la lettre que vous
-        avez reçue.
-      name: Code à usage unique
+      form:
+        instructions: Entrez le code à 10 caractères figurant sur la lettre que vous
+          avez reçue.
+        otp_label: Code à usage unique
+        submit: Confirmer le compte
+        title: Confirmez votre compte
+      intro_html: '<p>Si vous avez reçu votre lettre, veuillez entrer votre code à
+        usage unique ci-dessous. </p> <p>Si votre lettre n’est pas encore
+        arrivée, veuillez être patient car les <strong>lettres prennent
+        généralement entre trois à sept jours ouvrables pour arriver</strong>.
+        Nous vous remercions de votre patience.</p>'
       return_to_profile: Retourner à votre profil
-      submit: Confirmer le compte
-      title: Confirmez votre compte
-      welcome_back: Content de vous revoir
-      welcome_back_description_html: '<p>Si vous avez reçu votre lettre, veuillez
-        entrer votre code à usage unique ci-dessous. </p> <p>Si votre lettre
-        n’est pas encore arrivée, veuillez être patient car les <strong>lettres
-        prennent généralement entre trois à sept jours ouvrables pour
-        arriver</strong>. Nous vous remercions de votre patience.</p>'
+      title: Content de vous revoir
       wrong_address: Pas la bonne adresse?
     images:
       come_back_later: Lettre avec un crochet

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Idv::GpoVerifyController do
   let(:proofing_components) { nil }
   let(:threatmetrix_enabled) { false }
   let(:gpo_enabled) { true }
+  let(:params) { nil }
 
   before do
     stub_analytics
@@ -40,7 +41,7 @@ RSpec.describe Idv::GpoVerifyController do
 
   describe '#index' do
     subject(:action) do
-      get(:index)
+      get(:index, params: params)
     end
 
     context 'user has pending profile' do
@@ -53,9 +54,9 @@ RSpec.describe Idv::GpoVerifyController do
         expect(response).to render_template('idv/gpo_verify/index')
       end
 
-      it 'sets @user_can_request_another_gpo_code to true' do
+      it 'sets @should_prompt_user_to_request_another_letter to true' do
         action
-        expect(assigns(:user_can_request_another_gpo_code)).to eql(true)
+        expect(assigns(:should_prompt_user_to_request_another_letter)).to eql(true)
       end
 
       it 'shows rate limited page if user is rate limited' do
@@ -68,9 +69,21 @@ RSpec.describe Idv::GpoVerifyController do
 
       context 'but that profile is > 30 days old' do
         let(:profile_created_at) { 31.days.ago }
-        it 'sets @user_can_request_another_gpo_code to false' do
+        it 'sets @should_prompt_user_to_request_another_letter to false' do
           action
-          expect(assigns(:user_can_request_another_gpo_code)).to eql(false)
+          expect(assigns(:should_prompt_user_to_request_another_letter)).to eql(false)
+        end
+      end
+
+      context 'user clicked a "i did not receive my letter" link' do
+        let(:params) do
+          {
+            did_not_receive_letter: 1,
+          }
+        end
+        it 'sets @user_did_not_receive_letter to true' do
+          action
+          expect(assigns(:user_did_not_receive_letter)).to eql(true)
         end
       end
     end

--- a/spec/controllers/idv/gpo_verify_controller_spec.rb
+++ b/spec/controllers/idv/gpo_verify_controller_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe Idv::GpoVerifyController do
     context 'user has pending profile' do
       it 'renders page' do
         controller.user_session[:decrypted_pii] = { address1: 'Address1' }.to_json
-        expect(@analytics).to receive(:track_event).with('IdV: GPO verification visited')
+        expect(@analytics).to receive(:track_event).with(
+          'IdV: GPO verification visited',
+          source: nil,
+        )
 
         action
 
@@ -90,6 +93,13 @@ RSpec.describe Idv::GpoVerifyController do
           action
           expect(assigns(:user_did_not_receive_letter)).to eql(true)
         end
+        it 'augments analytics event' do
+          action
+          expect(@analytics).to have_logged_event(
+            'IdV: GPO verification visited',
+            source: 'gpo_reminder_email',
+          )
+        end
       end
     end
 
@@ -111,6 +121,7 @@ RSpec.describe Idv::GpoVerifyController do
       it 'renders rate limited page' do
         expect(@analytics).to receive(:track_event).with(
           'IdV: GPO verification visited',
+          source: nil,
         ).once
         expect(@analytics).to receive(:track_event).with(
           'Rate Limit Reached',

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe 'In Person Proofing', js: true do
       expect(page).not_to have_content(t('headings.account.verified_account'))
       click_on t('account.index.verification.reactivate_button')
       expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
-      click_button t('idv.gpo.submit')
+      click_button t('idv.gpo.form.submit')
 
       # personal key
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -77,9 +77,15 @@ RSpec.feature 'idv gpo otp verification step' do
 
   context 'coming from an "I did not receive my letter" link in a reminder email' do
     it 'renders an alternate ui', :js do
-      visit idv_gpo_url(did_not_receive_letter: 1)
-      expect(current_path).to eql(root_path)
-      sign_in_and_2fa_user
+      visit idv_gpo_verify_url(did_not_receive_letter: 1)
+      expect(current_path).to eql(new_user_session_path)
+
+      fill_in_credentials_and_submit(user.email, user.password)
+      continue_as(user.email, user.password)
+      uncheck(t('forms.messages.remember_device'))
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
       expect(current_path).to eq idv_gpo_verify_path
       expect(page).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
     end

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -75,6 +75,16 @@ RSpec.feature 'idv gpo otp verification step' do
     end
   end
 
+  context 'coming from an "I did not receive my letter" link in a reminder email' do
+    it 'renders an alternate ui', :js do
+      visit idv_gpo_url(did_not_receive_letter: 1)
+      expect(current_path).to eql(root_path)
+      sign_in_and_2fa_user
+      expect(current_path).to eq idv_gpo_verify_path
+      expect(page).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
+    end
+  end
+
   context 'with gpo personal key after verification' do
     it 'shows the user a personal key after verification' do
       sign_in_live_with_2fa(user)

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -83,8 +83,8 @@ RSpec.feature 'idv gpo otp verification step' do
       expect(page).to have_content t('idv.messages.gpo.resend')
 
       gpo_confirmation_code
-      fill_in t('idv.gpo.name'), with: otp
-      click_button t('idv.gpo.submit')
+      fill_in t('idv.gpo.form.otp_label'), with: otp
+      click_button t('idv.gpo.form.submit')
 
       profile.reload
 
@@ -111,8 +111,8 @@ RSpec.feature 'idv gpo otp verification step' do
       expect(page).to have_content t('idv.messages.gpo.resend')
 
       gpo_confirmation_code
-      fill_in t('idv.gpo.name'), with: otp
-      click_button t('idv.gpo.submit')
+      fill_in t('idv.gpo.form.otp_label'), with: otp
+      click_button t('idv.gpo.form.submit')
 
       expect(user.events.account_verified.size).to eq 1
       expect(page).to_not have_content(t('account.index.verification.reactivate_button'))

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -186,7 +186,7 @@ RSpec.feature 'idv gpo step' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(page).to have_content(t('idv.gpo.instructions'))
+      expect(page).to have_content(t('idv.gpo.form.instructions'))
     end
   end
 end

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -26,8 +26,8 @@ RSpec.feature 'verify profile with OTP' do
 
     scenario 'valid OTP' do
       sign_in_live_with_2fa(user)
-      fill_in t('idv.gpo.name'), with: otp
-      click_button t('idv.gpo.submit')
+      fill_in t('idv.gpo.form.otp_label'), with: otp
+      click_button t('idv.gpo.form.submit')
       acknowledge_and_confirm_personal_key
 
       expect(page).to have_current_path(account_path)
@@ -37,8 +37,8 @@ RSpec.feature 'verify profile with OTP' do
       GpoConfirmationCode.first.update(code_sent_at: 11.days.ago)
 
       sign_in_live_with_2fa(user)
-      fill_in t('idv.gpo.name'), with: otp
-      click_button t('idv.gpo.submit')
+      fill_in t('idv.gpo.form.otp_label'), with: otp
+      click_button t('idv.gpo.form.submit')
 
       expect(page).to have_content t('errors.messages.gpo_otp_expired')
       expect(current_path).to eq idv_gpo_verify_path
@@ -46,8 +46,8 @@ RSpec.feature 'verify profile with OTP' do
 
     scenario 'wrong OTP used' do
       sign_in_live_with_2fa(user)
-      fill_in t('idv.gpo.name'), with: 'the wrong code'
-      click_button t('idv.gpo.submit')
+      fill_in t('idv.gpo.form.otp_label'), with: 'the wrong code'
+      click_button t('idv.gpo.form.submit')
 
       expect(current_path).to eq idv_gpo_verify_path
       expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -156,8 +156,8 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
       profile: User.find(user.id).pending_profile,
       otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
     )
-    fill_in t('idv.gpo.name'), with: otp
-    click_button t('idv.gpo.submit')
+    fill_in t('idv.gpo.form.otp_label'), with: otp
+    click_button t('idv.gpo.form.submit')
   end
 
   def complete_come_back_later

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -8,8 +8,8 @@ RSpec.shared_examples 'gpo otp verification' do
     expect(page).to have_content t('idv.messages.gpo.resend')
 
     gpo_confirmation_code
-    fill_in t('idv.gpo.name'), with: otp
-    click_button t('idv.gpo.submit')
+    fill_in t('idv.gpo.form.otp_label'), with: otp
+    click_button t('idv.gpo.form.submit')
 
     profile.reload
 
@@ -30,8 +30,8 @@ RSpec.shared_examples 'gpo otp verification' do
     sign_in_live_with_2fa(user)
 
     gpo_confirmation_code.update(code_sent_at: 11.days.ago)
-    fill_in t('idv.gpo.name'), with: otp
-    click_button t('idv.gpo.submit')
+    fill_in t('idv.gpo.form.otp_label'), with: otp
+    click_button t('idv.gpo.form.submit')
 
     expect(current_path).to eq idv_gpo_verify_path
     expect(page).to have_content t('errors.messages.gpo_otp_expired')

--- a/spec/views/idv/gpo_verify/index.html.erb_spec.rb
+++ b/spec/views/idv/gpo_verify/index.html.erb_spec.rb
@@ -9,31 +9,101 @@ RSpec.describe 'idv/gpo_verify/index.html.erb' do
     {}
   end
 
+  let(:should_prompt_user_to_request_another_letter) { true }
+
+  let(:user_did_not_receive_letter) { false }
+
   before do
     allow(view).to receive(:step_indicator_steps).and_return({})
+
     @gpo_verify_form = GpoVerifyForm.new(
       user: user,
       pii: pii,
       otp: '1234',
     )
+
+    @should_prompt_user_to_request_another_letter = should_prompt_user_to_request_another_letter
+    @user_did_not_receive_letter = user_did_not_receive_letter
+
+    render
   end
 
   context 'user is allowed to request another GPO letter' do
-    before do
-      @user_can_request_another_gpo_code = true
-      render
-    end
     it 'includes the send another letter link' do
       expect(rendered).to have_link(t('idv.messages.gpo.resend'), href: idv_gpo_path)
     end
   end
+
   context 'user is NOT allowed to request another GPO letter' do
-    before do
-      @user_can_request_another_gpo_code = false
-      render
-    end
+    let(:should_prompt_user_to_request_another_letter) { false }
     it 'does not include the send another letter link' do
       expect(rendered).not_to have_link(t('idv.messages.gpo.resend'), href: idv_gpo_path)
+    end
+  end
+
+  context 'user clicked an "i didn\'t get my letter" link in an email' do
+    let(:user_did_not_receive_letter) { true }
+
+    it 'uses a special title' do
+      expect(rendered).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
+    end
+
+    it 'has a special intro paragraph' do
+      expect(rendered).to have_css(
+        'p',
+        text: strip_tags(
+          t(
+            'idv.gpo.did_not_receive_letter.intro_html',
+            request_new_letter_prompt: t(
+              'idv.gpo.did_not_receive_letter.request_new_letter_prompt_html',
+              request_new_letter_link: t('idv.gpo.did_not_receive_letter.request_new_letter_link'),
+            ),
+          ),
+        ),
+      )
+    end
+
+    it 'links to requesting a new letter' do
+      expect(rendered).to have_link(
+        t('idv.gpo.did_not_receive_letter.request_new_letter_link'),
+        href: idv_gpo_path,
+      )
+    end
+
+    it 'has a special prompt to enter the otp' do
+      expect(rendered).to have_content(
+        t('idv.gpo.did_not_receive_letter.instructions'),
+      )
+    end
+
+    it 'does not link to requesting a new letter at the bottom of the page' do
+      expect(rendered).not_to have_link(
+        t('idv.messages.gpo.resend'),
+        href: idv_gpo_path,
+      )
+    end
+
+    context 'user is NOT allowed to request another GPO letter' do
+      let(:should_prompt_user_to_request_another_letter) { false }
+
+      it 'has special intro but does not prompt to request new letter' do
+        expect(rendered).to have_css(
+          'p',
+          text: strip_tags(
+            t(
+              'idv.gpo.did_not_receive_letter.intro_html',
+              request_new_letter_prompt: '',
+            ),
+          ),
+        )
+      end
+
+      it 'does not link to requesting a new letter' do
+        expect(rendered).not_to have_link(
+          t('idv.gpo.did_not_receive_letter.request_new_letter_link'),
+          href: idv_gpo_path,
+        )
+      end
     end
   end
 end

--- a/spec/views/idv/gpo_verify/index.html.erb_spec.rb
+++ b/spec/views/idv/gpo_verify/index.html.erb_spec.rb
@@ -49,30 +49,30 @@ RSpec.describe 'idv/gpo_verify/index.html.erb' do
     end
 
     it 'has a special intro paragraph' do
-      expect(rendered).to have_css(
-        'p',
-        text: strip_tags(
+      expect(rendered).to have_content(
+        strip_tags(
           t(
-            'idv.gpo.did_not_receive_letter.intro_html',
-            request_new_letter_prompt: t(
-              'idv.gpo.did_not_receive_letter.request_new_letter_prompt_html',
-              request_new_letter_link: t('idv.gpo.did_not_receive_letter.request_new_letter_link'),
-            ),
+            'idv.gpo.did_not_receive_letter.intro.request_new_letter_prompt_html',
+            request_new_letter_link:
+              t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
           ),
         ),
+      )
+      expect(rendered).to have_content(
+        strip_tags(t('idv.gpo.did_not_receive_letter.intro.be_patient_html')),
       )
     end
 
     it 'links to requesting a new letter' do
       expect(rendered).to have_link(
-        t('idv.gpo.did_not_receive_letter.request_new_letter_link'),
+        t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
         href: idv_gpo_path,
       )
     end
 
     it 'has a special prompt to enter the otp' do
       expect(rendered).to have_content(
-        t('idv.gpo.did_not_receive_letter.instructions'),
+        t('idv.gpo.did_not_receive_letter.form.instructions'),
       )
     end
 
@@ -86,21 +86,15 @@ RSpec.describe 'idv/gpo_verify/index.html.erb' do
     context 'user is NOT allowed to request another GPO letter' do
       let(:should_prompt_user_to_request_another_letter) { false }
 
-      it 'has special intro but does not prompt to request new letter' do
-        expect(rendered).to have_css(
-          'p',
-          text: strip_tags(
-            t(
-              'idv.gpo.did_not_receive_letter.intro_html',
-              request_new_letter_prompt: '',
-            ),
-          ),
+      it 'still has a special intro' do
+        expect(rendered).to have_content(
+          strip_tags(t('idv.gpo.did_not_receive_letter.intro.be_patient_html')),
         )
       end
 
       it 'does not link to requesting a new letter' do
         expect(rendered).not_to have_link(
-          t('idv.gpo.did_not_receive_letter.request_new_letter_link'),
+          t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
           href: idv_gpo_path,
         )
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10545](https://cm-jira.usa.gov/browse/LG-10545)

## 🛠 Summary of changes

Add a screen that provides more assistance to users who haven't received their OTP via USPS after a decent chunk of time.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Run through IdV, choosing the GPO flow.
- [x] Verify that you see the "Welcome back" screen as normal when you go to enter your OTP.
- [x] When you get to the "welcome back" screen, add `?did_not_receive_letter=1` to the URL
- [x] Verify that you get the new "Didn't get your letter?" screen (pictured below)
- [x] Log out
- [x] Attempt to access `/verify/by_mail?did_not_receive_letter=1`
- [x] Check that you are prompted to sign in, and that after auth you see the new "Didn't get your letter?" screen (pictured below)
- [x] Verify that the `'IdV: GPO verification visited'` analytics event includes `source: "gpo_reminder_email"`.

## 👀 Screenshots

<details>

<summary>English</summary>

![verify-by_mail-en](https://github.com/18F/identity-idp/assets/364697/31313c14-f593-4de9-a4e3-559b5ea09363)

</details>

<details>

<summary>French</summary>

![verify-by_mail-fr](https://github.com/18F/identity-idp/assets/364697/6f324f7b-553c-4f2f-8c4e-b052ddc17d85)

</details>

<details>

<summary>Spanish</summary>

![verify-by_mail-es](https://github.com/18F/identity-idp/assets/364697/abf35b22-1653-4389-b33d-c04fbddf818e)

</details>
