### PR TITLE
Ensure PIV/CAC authentications check rules of use

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -217,7 +217,8 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(_user)
-    service_provider_mfa_setup_url ||
+    accept_rules_of_use_url ||
+      service_provider_mfa_setup_url ||
       add_piv_cac_setup_url ||
       fix_broken_personal_key_url ||
       user_session.delete(:stored_location) ||
@@ -232,6 +233,10 @@ class ApplicationController < ActionController::Base
     return url_for_pending_profile_reason if user_has_pending_profile?
     return backup_code_reminder_url if user_needs_backup_code_reminder?
     account_url
+  end
+
+  def accept_rules_of_use_url
+    rules_of_use_path unless current_user.accepted_rules_of_use_still_valid?
   end
 
   def after_mfa_setup_path

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -83,6 +83,8 @@ module Users
     def next_step
       if ial_context.ial2_requested?
         capture_password_url
+      elsif !current_user.accepted_rules_of_use_still_valid?
+        rules_of_use_path
       else
         after_sign_in_path_for(current_user)
       end

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -145,6 +145,16 @@ RSpec.describe Users::PivCacLoginController do
             expect(controller.user_session[:decrypted_x509]).to eq session_info.to_json
           end
 
+          context 'when the user has not accepted the most recent terms of use' do
+            let(:user) do
+              build(:user, accepted_terms_at: IdentityConfig.store.rules_of_use_updated_at - 1.year)
+            end
+
+            it 'redirects to rules_of_use_path' do
+              expect(response).to redirect_to rules_of_use_path
+            end
+          end
+
           describe 'it handles the otp_context' do
             it 'tracks the user_marked_authed event' do
               expect(@analytics).to have_received(:track_event).with(


### PR DESCRIPTION
## 🛠 Summary of changes

Similar to #8836, this change enforces rules of use acceptance more consistently across the application (PIV/CAC login in this case).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
