### PR TITLE
LG-10150: Improve error message for canceled security key

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -63,7 +63,7 @@ module TwoFactorAuthentication
         redirect_to login_two_factor_webauthn_url(platform: 'true')
       else
         flash[:error] = t(
-          'two_factor_authentication.webauthn_error.connect_html',
+          'two_factor_authentication.webauthn_error.connect',
           link: view_context.link_to(
             t('two_factor_authentication.webauthn_error.additional_methods_link'),
             login_two_factor_options_path,

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -62,7 +62,13 @@ module TwoFactorAuthentication
         )
         redirect_to login_two_factor_webauthn_url(platform: 'true')
       else
-        flash[:error] = t('errors.general')
+        flash[:error] = t(
+          'two_factor_authentication.webauthn_error.connect_html',
+          link: view_context.link_to(
+            t('two_factor_authentication.webauthn_error.additional_methods_link'),
+            login_two_factor_options_path,
+          ),
+        )
         redirect_to login_two_factor_webauthn_url
       end
     end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -63,8 +63,8 @@ module TwoFactorAuthentication
         redirect_to login_two_factor_webauthn_url(platform: 'true')
       else
         flash[:error] = t(
-          'two_factor_authentication.webauthn_error.connect',
-          link: view_context.link_to(
+          'two_factor_authentication.webauthn_error.connect_html',
+          link_html: view_context.link_to(
             t('two_factor_authentication.webauthn_error.additional_methods_link'),
             login_two_factor_options_path,
           ),

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -193,8 +193,8 @@ module Users
         flash[:error] = t('errors.webauthn_platform_setup.general_error')
       else
         flash[:error] = t(
-          'errors.webauthn_setup.general_error',
-          link: view_context.link_to(
+          'errors.webauthn_setup.general_error_html',
+          link_html: view_context.link_to(
             t('errors.webauthn_setup.additional_methods_link'),
             authentication_methods_setup_path,
           ),

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -193,7 +193,7 @@ module Users
         flash[:error] = t('errors.webauthn_platform_setup.general_error')
       else
         flash[:error] = t(
-          'errors.webauthn_setup.general_error_html',
+          'errors.webauthn_setup.general_error',
           link: view_context.link_to(
             t('errors.webauthn_setup.additional_methods_link'),
             authentication_methods_setup_path,

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -99,8 +99,7 @@ module Users
       @presenter = SetupPresenter.new(
         current_user: current_user,
         user_fully_authenticated: user_fully_authenticated?,
-        user_opted_remember_device_cookie:
-                                                  user_opted_remember_device_cookie,
+        user_opted_remember_device_cookie: user_opted_remember_device_cookie,
         remember_device_default: remember_device_default,
       )
     end
@@ -193,7 +192,13 @@ module Users
       elsif form.platform_authenticator?
         flash[:error] = t('errors.webauthn_platform_setup.general_error')
       else
-        flash[:error] = t('errors.webauthn_setup.general_error')
+        flash[:error] = t(
+          'errors.webauthn_setup.general_error_html',
+          link: view_context.link_to(
+            t('errors.webauthn_setup.additional_methods_link'),
+            authentication_methods_setup_path,
+          ),
+        )
       end
       render :new
     end

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -192,13 +192,7 @@ module Users
       elsif form.platform_authenticator?
         flash[:error] = t('errors.webauthn_platform_setup.general_error')
       else
-        flash[:error] = t(
-          'errors.webauthn_setup.general_error_html',
-          link_html: view_context.link_to(
-            t('errors.webauthn_setup.additional_methods_link'),
-            authentication_methods_setup_path,
-          ),
-        )
+        flash[:error] = 'todo remove'
       end
       render :new
     end

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -192,7 +192,10 @@ module Users
       elsif form.platform_authenticator?
         flash[:error] = t('errors.webauthn_platform_setup.general_error')
       else
-        flash[:error] = 'todo remove'
+        flash[:error] = t(
+          'errors.webauthn_setup.general_error_html',
+          link_html: t('errors.webauthn_setup.additional_methods_link'),
+        )
       end
       render :new
     end

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -67,8 +67,8 @@ class WebauthnVisitForm
       I18n.t('errors.webauthn_setup.not_supported')
     else
       I18n.t(
-        'errors.webauthn_setup.general_error',
-        link: link_to(
+        'errors.webauthn_setup.general_error_html',
+        link_html: link_to(
           I18n.t('errors.webauthn_setup.additional_methods_link'),
           authentication_methods_setup_path,
         ),

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -24,6 +24,16 @@ class WebauthnVisitForm
     @platform_authenticator
   end
 
+  def current_mfa_setup_path
+    if mfa_user.two_factor_enabled? && in_mfa_selection_flow
+      second_mfa_setup_path
+    elsif mfa_user.two_factor_enabled?
+      account_path
+    else
+      authentication_methods_setup_path
+    end
+  end
+
   private
 
   def check_params(params)
@@ -45,17 +55,7 @@ class WebauthnVisitForm
     when NOT_SUPPORTED_ERROR
       I18n.t('errors.webauthn_platform_setup.not_supported')
     else
-      if in_mfa_selection_flow
-        I18n.t(
-          'errors.webauthn_platform_setup.account_setup_error',
-          link: link_to(
-            I18n.t('errors.webauthn_platform_setup.choose_another_method'),
-            authentication_methods_setup_path,
-          ),
-        )
-      else
-        I18n.t('errors.webauthn_platform_setup.general_error')
-      end
+      webauthn_platform_general_error
     end
   end
 
@@ -66,14 +66,28 @@ class WebauthnVisitForm
     when NOT_SUPPORTED_ERROR
       I18n.t('errors.webauthn_setup.not_supported')
     else
-      I18n.t(
-        'errors.webauthn_setup.general_error_html',
-        link_html: link_to(
-          I18n.t('errors.webauthn_setup.additional_methods_link'),
-          authentication_methods_setup_path,
-        ),
-      )
+      webauthn_general_error
     end
+  end
+
+  def webauthn_platform_general_error
+    I18n.t(
+      'errors.webauthn_platform_setup.account_setup_error',
+      link: link_to(
+        I18n.t('errors.webauthn_platform_setup.choose_another_method'),
+        current_mfa_setup_path,
+      ),
+    )
+  end
+
+  def webauthn_general_error
+    I18n.t(
+      'errors.webauthn_setup.general_error_html',
+      link_html: link_to(
+        I18n.t('errors.webauthn_setup.additional_methods_link'),
+        current_mfa_setup_path,
+      ),
+    )
   end
 
   def mfa_user

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -68,10 +68,7 @@ class WebauthnVisitForm
     else
       I18n.t(
         'errors.webauthn_setup.general_error_html',
-        link_html: link_to(
-          I18n.t('errors.webauthn_setup.additional_methods_link'),
-          authentication_methods_setup_path,
-        ),
+        link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
       )
     end
   end

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -71,23 +71,37 @@ class WebauthnVisitForm
   end
 
   def webauthn_platform_general_error
-    I18n.t(
-      'errors.webauthn_platform_setup.account_setup_error',
-      link: link_to(
-        I18n.t('errors.webauthn_platform_setup.choose_another_method'),
-        current_mfa_setup_path,
-      ),
-    )
+    if current_mfa_setup_path == account_path
+      I18n.t(
+        'errors.webauthn_platform_setup.account_setup_error',
+        link: I18n.t('errors.webauthn_platform_setup.choose_another_method'),
+      )
+    else
+      I18n.t(
+        'errors.webauthn_platform_setup.account_setup_error',
+        link: link_to(
+          I18n.t('errors.webauthn_platform_setup.choose_another_method'),
+          current_mfa_setup_path,
+        ),
+      )
+    end
   end
 
   def webauthn_general_error
-    I18n.t(
-      'errors.webauthn_setup.general_error_html',
-      link_html: link_to(
-        I18n.t('errors.webauthn_setup.additional_methods_link'),
-        current_mfa_setup_path,
-      ),
-    )
+    if current_mfa_setup_path == account_path
+      I18n.t(
+        'errors.webauthn_setup.general_error_html',
+        link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
+      )
+    else
+      I18n.t(
+        'errors.webauthn_setup.general_error_html',
+        link_html: link_to(
+          I18n.t('errors.webauthn_setup.additional_methods_link'),
+          current_mfa_setup_path,
+        ),
+      )
+    end
   end
 
   def mfa_user

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -67,7 +67,7 @@ class WebauthnVisitForm
       I18n.t('errors.webauthn_setup.not_supported')
     else
       I18n.t(
-        'errors.webauthn_setup.general_error_html',
+        'errors.webauthn_setup.general_error',
         link: link_to(
           I18n.t('errors.webauthn_setup.additional_methods_link'),
           authentication_methods_setup_path,

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -68,7 +68,10 @@ class WebauthnVisitForm
     else
       I18n.t(
         'errors.webauthn_setup.general_error_html',
-        link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
+        link_html: link_to(
+          I18n.t('errors.webauthn_setup.additional_methods_link'),
+          authentication_methods_setup_path,
+        ),
       )
     end
   end

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -66,7 +66,13 @@ class WebauthnVisitForm
     when NOT_SUPPORTED_ERROR
       I18n.t('errors.webauthn_setup.not_supported')
     else
-      I18n.t('errors.webauthn_setup.general_error')
+      I18n.t(
+        'errors.webauthn_setup.general_error_html',
+        link: link_to(
+          I18n.t('errors.webauthn_setup.additional_methods_link'),
+          authentication_methods_setup_path,
+        ),
+      )
     end
   end
 

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -135,7 +135,7 @@ en:
         security key. Please make sure your device is listed at
         https://fidoalliance.org/certification/fido-certified-products/ and if
         you believe this is our error, please contact at %{link}.
-      general_error: We were unable to add security key. Please try again or %{link}.
+      general_error_html: We were unable to add security key. Please try again or %{link_html}.
       not_supported: Sorry, your browser does not support FIDO security keys. The
         latest versions of Chrome, Firefox, Edge, and Safari support FIDO
         security keys.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -129,12 +129,13 @@ en:
         support FIDO platform authenticators.
       unique_name: That name is already taken. Please choose a different name.
     webauthn_setup:
+      additional_methods_link: choose another authentication method
       already_registered: Security key already registered. Please try a different security key.
       attestation_error: Sorry, but your security key doesn’t appear to be a FIDO
         security key. Please make sure your device is listed at
         https://fidoalliance.org/certification/fido-certified-products/ and if
         you believe this is our error, please contact at %{link}.
-      general_error: There was an error adding your hardware security key. Please try again.
+      general_error_html: We were unable to add security key. Please try again or %{link}.
       not_supported: Sorry, your browser does not support FIDO security keys. The
         latest versions of Chrome, Firefox, Edge, and Safari support FIDO
         security keys.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -135,7 +135,7 @@ en:
         security key. Please make sure your device is listed at
         https://fidoalliance.org/certification/fido-certified-products/ and if
         you believe this is our error, please contact at %{link}.
-      general_error_html: We were unable to add security key. Please try again or %{link}.
+      general_error: We were unable to add security key. Please try again or %{link}.
       not_supported: Sorry, your browser does not support FIDO security keys. The
         latest versions of Chrome, Firefox, Edge, and Safari support FIDO
         security keys.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -135,7 +135,7 @@ en:
         security key. Please make sure your device is listed at
         https://fidoalliance.org/certification/fido-certified-products/ and if
         you believe this is our error, please contact at %{link}.
-      general_error_html: We were unable to add security key. Please try again or %{link_html}.
+      general_error_html: We were unable to add the security key. Please try again or %{link_html}.
       not_supported: Sorry, your browser does not support FIDO security keys. The
         latest versions of Chrome, Firefox, Edge, and Safari support FIDO
         security keys.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -147,8 +147,8 @@ es:
         https://fidoalliance.org/certification/fido-certified-products/. Si
         considera que se trata de un error nuestro, póngase en contacto con
         %{link}.
-      general_error_html: No hemos podido añadir la clave de seguridad. Inténtelo de
-        nuevo o %{link}.
+      general_error: No hemos podido añadir la clave de seguridad. Inténtelo de nuevo
+        o %{link}.
       not_supported: Lo sentimos, su navegador no admite las claves de seguridad FIDO.
         Las últimas versiones de Chrome, Firefox, Edge y Safari son compatibles
         con las claves de seguridad FIDO.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -147,8 +147,8 @@ es:
         https://fidoalliance.org/certification/fido-certified-products/. Si
         considera que se trata de un error nuestro, póngase en contacto con
         %{link}.
-      general_error: No hemos podido añadir la clave de seguridad. Inténtelo de nuevo
-        o %{link}.
+      general_error_html: No hemos podido añadir la clave de seguridad. Inténtelo de
+        nuevo o %{link_html}.
       not_supported: Lo sentimos, su navegador no admite las claves de seguridad FIDO.
         Las últimas versiones de Chrome, Firefox, Edge y Safari son compatibles
         con las claves de seguridad FIDO.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -138,6 +138,7 @@ es:
       unique_name: Ese nombre de dispositivo ha sido utilizado. Por favor, seleccione
         un nombre de dispositivo diferente.
     webauthn_setup:
+      additional_methods_link: elija otro método de autenticación
       already_registered: Clave de seguridad ya registrada. Por favor, intente una
         clave de seguridad diferente.
       attestation_error: Lo sentimos, pero su clave de seguridad no parece ser una
@@ -146,8 +147,8 @@ es:
         https://fidoalliance.org/certification/fido-certified-products/. Si
         considera que se trata de un error nuestro, póngase en contacto con
         %{link}.
-      general_error: Hubo un error al agregar su clave de seguridad de hardware.
-        Inténtalo de nuevo.
+      general_error_html: No hemos podido añadir la clave de seguridad. Inténtelo de
+        nuevo o %{link}.
       not_supported: Lo sentimos, su navegador no admite las claves de seguridad FIDO.
         Las últimas versiones de Chrome, Firefox, Edge y Safari son compatibles
         con las claves de seguridad FIDO.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -157,7 +157,7 @@ fr:
         https://fidoalliance.org/certification/fido-certified-products/. Si vous
         pensez qu’il s’agit d’une erreur de notre part, veuillez contacter
         %{link}.
-      general_error_html: Nous n’avons pas pu ajouter la clé de sécurité. Veuillez
+      general_error: Nous n’avons pas pu ajouter la clé de sécurité. Veuillez
         réessayer ou %{link}.
       not_supported: Désolé, votre navigateur ne supporte pas les clés de sécurité
         FIDO. Les dernières versions de Chrome, Firefox, Edge et Safari prennent

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -157,8 +157,8 @@ fr:
         https://fidoalliance.org/certification/fido-certified-products/. Si vous
         pensez qu’il s’agit d’une erreur de notre part, veuillez contacter
         %{link}.
-      general_error: Nous n’avons pas pu ajouter la clé de sécurité. Veuillez
-        réessayer ou %{link}.
+      general_error_html: Nous n’avons pas pu ajouter la clé de sécurité. Veuillez
+        réessayer ou %{link_html}.
       not_supported: Désolé, votre navigateur ne supporte pas les clés de sécurité
         FIDO. Les dernières versions de Chrome, Firefox, Edge et Safari prennent
         en charge les clés de sécurité FIDO.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -149,6 +149,7 @@ fr:
       unique_name: Ce nom d’appareil a été utilisé. Veuillez sélectionner un autre nom
         d’appareil.
     webauthn_setup:
+      additional_methods_link: choisir une autre méthode d’authentification
       already_registered: Clé de sécurité déjà enregistrée. Veuillez essayer une clé
         de sécurité différente.
       attestation_error: Désolé, votre clé de sécurité ne semble pas être une clé de
@@ -156,8 +157,8 @@ fr:
         https://fidoalliance.org/certification/fido-certified-products/. Si vous
         pensez qu’il s’agit d’une erreur de notre part, veuillez contacter
         %{link}.
-      general_error: Une erreur s’est produite lors de l’ajout de votre clé de
-        sécurité physique. Veuillez réessayer.
+      general_error_html: Nous n’avons pas pu ajouter la clé de sécurité. Veuillez
+        réessayer ou %{link}.
       not_supported: Désolé, votre navigateur ne supporte pas les clés de sécurité
         FIDO. Les dernières versions de Chrome, Firefox, Edge et Safari prennent
         en charge les clés de sécurité FIDO.

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -180,7 +180,7 @@ en:
     webauthn_authenticating: Authenticating your credentials…
     webauthn_error:
       additional_methods_link: choose another authentication method
-      connect: We were unable to connect security key. Please try again or %{link}.
+      connect_html: We were unable to connect security key. Please try again or %{link_html}.
       try_again: Face or touch unlock was unsuccessful. Please try again or %{link}.
     webauthn_header_text: Connect your security key
     webauthn_platform_header_text: Use face or touch unlock

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -180,7 +180,7 @@ en:
     webauthn_authenticating: Authenticating your credentials…
     webauthn_error:
       additional_methods_link: choose another authentication method
-      connect_html: We were unable to connect security key. Please try again or %{link}.
+      connect: We were unable to connect security key. Please try again or %{link}.
       try_again: Face or touch unlock was unsuccessful. Please try again or %{link}.
     webauthn_header_text: Connect your security key
     webauthn_platform_header_text: Use face or touch unlock

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -180,7 +180,8 @@ en:
     webauthn_authenticating: Authenticating your credentials…
     webauthn_error:
       additional_methods_link: choose another authentication method
-      connect_html: We were unable to connect security key. Please try again or %{link_html}.
+      connect_html: We were unable to connect the security key. Please try again or
+        %{link_html}.
       try_again: Face or touch unlock was unsuccessful. Please try again or %{link}.
     webauthn_header_text: Connect your security key
     webauthn_platform_header_text: Use face or touch unlock

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -180,6 +180,7 @@ en:
     webauthn_authenticating: Authenticating your credentials…
     webauthn_error:
       additional_methods_link: choose another authentication method
+      connect_html: We were unable to connect security key. Please try again or %{link}.
       try_again: Face or touch unlock was unsuccessful. Please try again or %{link}.
     webauthn_header_text: Connect your security key
     webauthn_platform_header_text: Use face or touch unlock

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -192,6 +192,8 @@ es:
     webauthn_authenticating: Autenticando sus credenciales…
     webauthn_error:
       additional_methods_link: elija otro método de autenticación
+      connect_html: No hemos podido conectar la clave de seguridad. Por favor,
+        inténtelo de nuevo o %{link}.
       try_again: El desbloqueo facial o táctil no fue exitoso. Por favor, inténtelo de
         nuevo o %{link}.
     webauthn_header_text: Conecte su llave de seguridad

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -192,8 +192,8 @@ es:
     webauthn_authenticating: Autenticando sus credenciales…
     webauthn_error:
       additional_methods_link: elija otro método de autenticación
-      connect_html: No hemos podido conectar la clave de seguridad. Por favor,
-        inténtelo de nuevo o %{link}.
+      connect: No hemos podido conectar la clave de seguridad. Por favor, inténtelo de
+        nuevo o %{link}.
       try_again: El desbloqueo facial o táctil no fue exitoso. Por favor, inténtelo de
         nuevo o %{link}.
     webauthn_header_text: Conecte su llave de seguridad

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -192,8 +192,8 @@ es:
     webauthn_authenticating: Autenticando sus credenciales…
     webauthn_error:
       additional_methods_link: elija otro método de autenticación
-      connect: No hemos podido conectar la clave de seguridad. Por favor, inténtelo de
-        nuevo o %{link}.
+      connect_html: No hemos podido conectar la clave de seguridad. Por favor,
+        inténtelo de nuevo o %{link_html}.
       try_again: El desbloqueo facial o táctil no fue exitoso. Por favor, inténtelo de
         nuevo o %{link}.
     webauthn_header_text: Conecte su llave de seguridad

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -200,6 +200,8 @@ fr:
     webauthn_authenticating: Authentification de vos informations d’identification…
     webauthn_error:
       additional_methods_link: choisir une autre méthode d’authentification
+      connect_html: Nous n’avons pas pu connecter la clé de sécurité. Veuillez
+        réessayer ou %{link}.
       try_again: Le déverrouillage facial ou tactile n’a pas fonctionné. Veuillez
         réessayer ou %{link}.
     webauthn_header_text: Connectez votre clé de sécurité

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -200,8 +200,8 @@ fr:
     webauthn_authenticating: Authentification de vos informations d’identification…
     webauthn_error:
       additional_methods_link: choisir une autre méthode d’authentification
-      connect_html: Nous n’avons pas pu connecter la clé de sécurité. Veuillez
-        réessayer ou %{link}.
+      connect: Nous n’avons pas pu connecter la clé de sécurité. Veuillez réessayer ou
+        %{link}.
       try_again: Le déverrouillage facial ou tactile n’a pas fonctionné. Veuillez
         réessayer ou %{link}.
     webauthn_header_text: Connectez votre clé de sécurité

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -200,8 +200,8 @@ fr:
     webauthn_authenticating: Authentification de vos informations d’identification…
     webauthn_error:
       additional_methods_link: choisir une autre méthode d’authentification
-      connect: Nous n’avons pas pu connecter la clé de sécurité. Veuillez réessayer ou
-        %{link}.
+      connect_html: Nous n’avons pas pu connecter la clé de sécurité. Veuillez
+        réessayer ou %{link_html}.
       try_again: Le déverrouillage facial ou tactile n’a pas fonctionné. Veuillez
         réessayer ou %{link}.
     webauthn_header_text: Connectez votre clé de sécurité

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'webauthn management' do
 
   def expect_webauthn_setup_error
     expect(page).to have_content t(
-      'errors.webauthn_setup.general_error',
-      link: t('errors.webauthn_setup.additional_methods_link'),
+      'errors.webauthn_setup.general_error_html',
+      link_html: t('errors.webauthn_setup.additional_methods_link'),
     )
     expect(current_path).to eq webauthn_setup_path
   end

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'webauthn management' do
 
   def expect_webauthn_setup_error
     expect(page).to have_content t(
-      'errors.webauthn_setup.general_error_html',
+      'errors.webauthn_setup.general_error',
       link: t('errors.webauthn_setup.additional_methods_link'),
     )
     expect(current_path).to eq webauthn_setup_path

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe 'webauthn management' do
   end
 
   def expect_webauthn_setup_error
-    expect(page).to have_content t('errors.webauthn_setup.general_error')
+    expect(page).to have_content t(
+      'errors.webauthn_setup.general_error_html',
+      link: t('errors.webauthn_setup.additional_methods_link'),
+    )
     expect(current_path).to eq webauthn_setup_path
   end
 

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'webauthn sign in' do
   let(:user) { create(:user, :with_webauthn, with: { credential_id:, credential_public_key: }) }
   let(:general_error) do
     t(
-      'two_factor_authentication.webauthn_error.connect_html',
+      'two_factor_authentication.webauthn_error.connect',
       link: t('two_factor_authentication.webauthn_error.additional_methods_link'),
     )
   end

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -8,6 +8,12 @@ RSpec.feature 'webauthn sign in' do
   end
 
   let(:user) { create(:user, :with_webauthn, with: { credential_id:, credential_public_key: }) }
+  let(:general_error) do
+    t(
+      'two_factor_authentication.webauthn_error.connect_html',
+      link: t('two_factor_authentication.webauthn_error.additional_methods_link'),
+    )
+  end
 
   it 'allows the user to sign in if webauthn is successful' do
     mock_webauthn_verification_challenge
@@ -24,7 +30,7 @@ RSpec.feature 'webauthn sign in' do
     sign_in_user(user)
     mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
 
-    expect(page).to have_content(t('errors.general'))
+    expect(page).to have_content(general_error)
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 
@@ -34,7 +40,7 @@ RSpec.feature 'webauthn sign in' do
     sign_in_user(user)
     mock_cancelled_webauthn_authentication { click_webauthn_authenticate_button }
 
-    expect(page).to have_content(t('errors.general'))
+    expect(page).to have_content(general_error)
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 
@@ -44,11 +50,11 @@ RSpec.feature 'webauthn sign in' do
     sign_in_user(user)
     mock_cancelled_webauthn_authentication { click_webauthn_authenticate_button }
 
-    expect(page).to have_content(t('errors.general'))
+    expect(page).to have_content(general_error)
 
     mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
 
-    expect(page).to_not have_content(t('errors.general'))
+    expect(page).to_not have_content(general_error)
   end
 
   it 'maintains correct platform attachment content if cancelled', :js do

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -10,8 +10,8 @@ RSpec.feature 'webauthn sign in' do
   let(:user) { create(:user, :with_webauthn, with: { credential_id:, credential_public_key: }) }
   let(:general_error) do
     t(
-      'two_factor_authentication.webauthn_error.connect',
-      link: t('two_factor_authentication.webauthn_error.additional_methods_link'),
+      'two_factor_authentication.webauthn_error.connect_html',
+      link_html: t('two_factor_authentication.webauthn_error.additional_methods_link'),
     )
   end
 

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -18,8 +18,8 @@ RSpec.feature 'webauthn sign up' do
 
   def expect_webauthn_setup_error
     expect(page).to have_content t(
-      'errors.webauthn_setup.general_error',
-      link: t('errors.webauthn_setup.additional_methods_link'),
+      'errors.webauthn_setup.general_error_html',
+      link_html: t('errors.webauthn_setup.additional_methods_link'),
     )
     expect(page).to have_current_path(webauthn_setup_path)
   end

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -17,7 +17,10 @@ RSpec.feature 'webauthn sign up' do
   end
 
   def expect_webauthn_setup_error
-    expect(page).to have_content t('errors.webauthn_setup.general_error')
+    expect(page).to have_content t(
+      'errors.webauthn_setup.general_error_html',
+      link: t('errors.webauthn_setup.additional_methods_link'),
+    )
     expect(page).to have_current_path(webauthn_setup_path)
   end
 

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'webauthn sign up' do
 
   def expect_webauthn_setup_error
     expect(page).to have_content t(
-      'errors.webauthn_setup.general_error_html',
+      'errors.webauthn_setup.general_error',
       link: t('errors.webauthn_setup.additional_methods_link'),
     )
     expect(page).to have_current_path(webauthn_setup_path)

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe WebauthnVisitForm do
       it 'returns FormResponse with success: false with an unrecognized error' do
         params = { error: 'foo' }
         general_error = t(
-          'errors.webauthn_setup.general_error',
-          link: link_to(
+          'errors.webauthn_setup.general_error_html',
+          link_html: link_to(
             t('errors.webauthn_setup.additional_methods_link'),
             authentication_methods_setup_path,
           ),

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -6,13 +6,15 @@ RSpec.describe WebauthnVisitForm do
 
   let(:user) { build(:user) }
   let(:url_options) { {} }
-  let(:subject) do
+  let(:in_mfa_selection_flow) { true }
+  let(:form) do
     WebauthnVisitForm.new(
       user: user,
       url_options:,
-      in_mfa_selection_flow: true,
+      in_mfa_selection_flow: in_mfa_selection_flow,
     )
   end
+  subject { form }
 
   describe '#submit' do
     it 'returns FormResponse with success: true if there are no errors' do
@@ -124,19 +126,18 @@ RSpec.describe WebauthnVisitForm do
           )
         end
 
-        context 'when a user is not in mfa selection' do
-          let(:subject) do
-            WebauthnVisitForm.new(
-              user: user,
-              url_options: {},
-              in_mfa_selection_flow: false,
-            )
-          end
+        context 'with two_factor_enabled' do
+          let(:in_mfa_selection_flow) { false }
+          let(:user) { create(:user, :with_phone) }
 
           it 'returns FormResponse with success: false with an unrecognized error' do
             params = { error: 'foo', platform: 'true' }
             errors = { foo: [I18n.t(
-              'errors.webauthn_platform_setup.general_error',
+              'errors.webauthn_platform_setup.account_setup_error',
+              link: link_to(
+                I18n.t('errors.webauthn_platform_setup.choose_another_method'),
+                account_path,
+              ),
             )] }
 
             expect(subject.submit(params).to_h).to include(
@@ -161,6 +162,27 @@ RSpec.describe WebauthnVisitForm do
       let(:params) { { platform: 'true' } }
 
       it { expect(subject.platform_authenticator?).to eq(true) }
+    end
+  end
+
+  describe '#current_mfa_setup_path' do
+    subject { form.current_mfa_setup_path }
+
+    context 'with two_factor_enabled and in_mfa_selection_flow' do
+      let(:user) { create(:user, :with_phone) }
+
+      it { is_expected.to eq(second_mfa_setup_path) }
+    end
+
+    context 'with two_factor_enabled' do
+      let(:user) { create(:user, :with_phone) }
+      let(:in_mfa_selection_flow) { false }
+
+      it { is_expected.to eq(account_path) }
+    end
+
+    context 'with no prior mfa enabled' do
+      it { is_expected.to eq(authentication_methods_setup_path) }
     end
   end
 end

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -66,7 +66,10 @@ RSpec.describe WebauthnVisitForm do
         params = { error: 'foo' }
         general_error = t(
           'errors.webauthn_setup.general_error_html',
-          link_html: t('errors.webauthn_setup.additional_methods_link'),
+          link_html: link_to(
+            t('errors.webauthn_setup.additional_methods_link'),
+            authentication_methods_setup_path,
+          ),
         )
         errors = {
           foo: [general_error],

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -66,10 +66,7 @@ RSpec.describe WebauthnVisitForm do
         params = { error: 'foo' }
         general_error = t(
           'errors.webauthn_setup.general_error_html',
-          link_html: link_to(
-            t('errors.webauthn_setup.additional_methods_link'),
-            authentication_methods_setup_path,
-          ),
+          link_html: t('errors.webauthn_setup.additional_methods_link'),
         )
         errors = {
           foo: [general_error],

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -134,10 +134,7 @@ RSpec.describe WebauthnVisitForm do
             params = { error: 'foo', platform: 'true' }
             errors = { foo: [I18n.t(
               'errors.webauthn_platform_setup.account_setup_error',
-              link: link_to(
-                I18n.t('errors.webauthn_platform_setup.choose_another_method'),
-                account_path,
-              ),
+              link: I18n.t('errors.webauthn_platform_setup.choose_another_method'),
             )] }
 
             expect(subject.submit(params).to_h).to include(

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -64,7 +64,16 @@ RSpec.describe WebauthnVisitForm do
 
       it 'returns FormResponse with success: false with an unrecognized error' do
         params = { error: 'foo' }
-        errors = { foo: [I18n.t('errors.webauthn_setup.general_error')] }
+        general_error = t(
+          'errors.webauthn_setup.general_error_html',
+          link: link_to(
+            t('errors.webauthn_setup.additional_methods_link'),
+            authentication_methods_setup_path,
+          ),
+        )
+        errors = {
+          foo: [general_error],
+        }
 
         expect(subject.submit(params).to_h).to include(
           success: false,

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe WebauthnVisitForm do
       it 'returns FormResponse with success: false with an unrecognized error' do
         params = { error: 'foo' }
         general_error = t(
-          'errors.webauthn_setup.general_error_html',
+          'errors.webauthn_setup.general_error',
           link: link_to(
             t('errors.webauthn_setup.additional_methods_link'),
             authentication_methods_setup_path,

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -48,8 +48,8 @@ module WebAuthnHelper
 
   def mock_cancelled_webauthn_authentication
     webauthn_general_error = t(
-      'two_factor_authentication.webauthn_error.connect',
-      link: t('two_factor_authentication.webauthn_error.additional_methods_link'),
+      'two_factor_authentication.webauthn_error.connect_html',
+      link_html: t('two_factor_authentication.webauthn_error.additional_methods_link'),
     )
 
     if javascript_enabled?

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -48,7 +48,7 @@ module WebAuthnHelper
 
   def mock_cancelled_webauthn_authentication
     webauthn_general_error = t(
-      'two_factor_authentication.webauthn_error.connect_html',
+      'two_factor_authentication.webauthn_error.connect',
       link: t('two_factor_authentication.webauthn_error.additional_methods_link'),
     )
 

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -47,6 +47,11 @@ module WebAuthnHelper
   end
 
   def mock_cancelled_webauthn_authentication
+    webauthn_general_error = t(
+      'two_factor_authentication.webauthn_error.connect_html',
+      link: t('two_factor_authentication.webauthn_error.additional_methods_link'),
+    )
+
     if javascript_enabled?
       page.evaluate_script(<<~JS)
         navigator.credentials.get = () => Promise.reject(new DOMException('', 'NotAllowedError'));
@@ -68,7 +73,7 @@ module WebAuthnHelper
           wait: 5,
         )
       else
-        expect(page).to have_content(t('errors.general'), wait: 5)
+        expect(page).to have_content(webauthn_general_error, wait: 5)
       end
     else
       yield


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-10150](https://cm-jira.usa.gov/browse/LG-10150)

Note: we may want to improve the English text further. Please see the latest comments on the Jira ticket.

## 🛠 Summary of changes

Error messages related to using a security key as a MFA option have been changed at two locations: during registration and login.

The two locations where the error messages can be encountered are:
- `/webauthn_setup` (registration)
- `/login/two_factor/webauthn` (login)


## 📜 Testing Plan

To get the error messages to display, cancel the security key process (ceremony) during registration or login at the two locations listed above.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
