### PR TITLE
LG-10484: Add uuid-export in data-pull script

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -231,8 +231,8 @@ class DataPull
           else
             scope
           end
-        end.flat_map do |user|
-          user.identities.map do |identity|
+        end.each do |user|
+          user.identities.each do |identity|
             uuids << user.uuid
             external_uuid = user.agency_identities&.find do |a_i|
                               a_i.agency == identity.service_provider_record.agency

--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -40,6 +40,8 @@ class DataPull
 
         * #{basename} profile-summary uuid1 uuid2
 
+        * #{basename} uuid-export uuid1 uuid2 --requesting-issuer ABC:DEF:GHI
+
       Options:
     EOS
   end
@@ -55,6 +57,7 @@ class DataPull
       'email-lookup' => EmailLookup,
       'ig-request' => InspectorGeneralRequest,
       'profile-summary' => ProfileSummary,
+      'uuid-export' => UuidExport,
     }[name]
   end
 
@@ -207,6 +210,51 @@ class DataPull
       ScriptBase::Result.new(
         subtask: 'profile-summary',
         uuids: users.map(&:uuid),
+        table:,
+      )
+    end
+  end
+
+  class UuidExport
+    def run(args:, config:)
+      login_uuids = args
+
+      uuids = []
+      table = []
+      table << %w[login_uuid agency issuer external_uuid]
+
+      User.includes(:agency_identities, identities: { service_provider_record: :agency }).
+        where(uuid: login_uuids).
+        then do |scope|
+          if config.requesting_issuers.present?
+            scope.where(service_provider_record: { issuer: config.requesting_issuers })
+          else
+            scope
+          end
+        end.flat_map do |user|
+          user.identities.map do |identity|
+            uuids << user.uuid
+            external_uuid = user.agency_identities&.find do |a_i|
+                              a_i.agency == identity.service_provider_record.agency
+                            end&.uuid || identity.uuid
+            table << [
+              user.uuid,
+              identity.service_provider_record.agency&.name,
+              identity.service_provider_record.issuer,
+              external_uuid,
+            ]
+          end
+        end
+
+      if config.include_missing?
+        (login_uuids - uuids.uniq).each do |missing_uuid|
+          table << [missing_uuid, '[NOT FOUND]', '[NOT FOUND]', '[NOT FOUND]']
+        end
+      end
+
+      ScriptBase::Result.new(
+        subtask: 'uuid-export',
+        uuids: uuids.uniq,
         table:,
       )
     end

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -271,4 +271,74 @@ RSpec.describe DataPull do
       end
     end
   end
+
+  describe DataPull::UuidExport do
+    subject(:subtask) { DataPull::UuidExport.new }
+
+    let(:user1) { create(:user, :fully_registered) }
+    let(:user2) { create(:user, :fully_registered) }
+
+    let(:agency) { create(:agency) }
+    let(:service_provider) { create(:service_provider, agency_id: agency.id) }
+    let(:other_sp) { create(:service_provider, active: true, agency_id: agency.id) }
+
+    let(:identity) do
+      create(:service_provider_identity, service_provider: service_provider.issuer, user: user1)
+    end
+    let(:other_identity) do
+      create(:service_provider_identity, service_provider: other_sp.issuer, user: user2)
+    end
+
+    let(:agency_identity) do
+      create(:agency_identity, agency: agency, user: user1, uuid: identity.uuid)
+    end
+    let(:other_agency_identity) do
+      create(:agency_identity, agency: agency, user: user2, uuid: other_identity.uuid)
+    end
+
+    let(:args) { [user1.uuid, user2.uuid, 'does-not-exist'] }
+    let(:include_missing) { true }
+    subject(:result) { subtask.run(args: args, config: config) }
+
+    describe '#run' do
+      context 'without requesting issuers' do
+        let(:config) { ScriptBase::Config.new(include_missing: include_missing) }
+
+        it 'return partner UUIDs for all apps', aggregate_failures: true do
+          expected_table = [
+            ['login_uuid', 'agency', 'issuer', 'external_uuid'],
+            [user1.uuid, agency.name, service_provider.issuer, agency_identity.uuid],
+            [user2.uuid, agency.name, other_sp.issuer, other_agency_identity.uuid],
+            ['does-not-exist', '[NOT FOUND]', '[NOT FOUND]', '[NOT FOUND]'],
+          ]
+
+          expect(result.table).to eq(expected_table)
+          expect(result.subtask).to eq('uuid-export')
+          expect(result.uuids).to match_array([user1.uuid, user2.uuid])
+        end
+      end
+
+      context 'with requesting issuers' do
+        let(:config) do
+          ScriptBase::Config.new(
+            include_missing: include_missing,
+            requesting_issuers: [service_provider.issuer],
+          )
+        end
+
+        it 'return partner UUIDs for just provided app', aggregate_failures: true do
+          expected_table = [
+            ['login_uuid', 'agency', 'issuer', 'external_uuid'],
+            [user1.uuid, agency.name, service_provider.issuer, agency_identity.uuid],
+            [user2.uuid, '[NOT FOUND]', '[NOT FOUND]', '[NOT FOUND]'],
+            ['does-not-exist', '[NOT FOUND]', '[NOT FOUND]', '[NOT FOUND]'],
+          ]
+
+          expect(result.table).to eq(expected_table)
+          expect(result.subtask).to eq('uuid-export')
+          expect(result.uuids).to match_array([user1.uuid])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION

## 🎫 Ticket
https://cm-jira.usa.gov/browse/LG-10484

## 🛠 Summary of changes

Update the data-pull script in the IDP so that we can get the external partner UUIDs for a user

## 👀 Screenshots
![image](https://github.com/18F/identity-idp/assets/109746710/bc97b4c1-dfac-4023-9668-ab12a556f876)
