### PR TITLE
Remove octokit, rails-erd, and binding_of_caller from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,6 @@ gem 'zxcvbn', '0.1.9'
 
 group :development do
   gem 'better_errors', '>= 2.5.1'
-  gem 'binding_of_caller'
   gem 'derailed_benchmarks'
   gem 'guard-rspec', require: false
   gem 'irb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,8 +199,6 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindata (2.4.14)
-    binding_of_caller (1.0.0)
-      debug_inspector (>= 0.0.1)
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     brakeman (6.0.1)
@@ -241,7 +239,6 @@ GEM
       railties (>= 6.0.0)
     date (3.3.3)
     dead_end (4.0.0)
-    debug_inspector (1.1.0)
     derailed_benchmarks (2.1.2)
       benchmark-ips (~> 2)
       dead_end
@@ -732,7 +729,6 @@ DEPENDENCIES
   barby (~> 0.6.8)
   base32-crockford
   better_errors (>= 2.5.1)
-  binding_of_caller
   bootsnap (~> 1.0)
   brakeman
   browser


### PR DESCRIPTION
## 🛠 Summary of changes

We removed the code that used `octokit` in #5038, but the dependency is still installed in development. This PR removes it.

`rails-erd` was added in #625, but the documentation was removed in #4960.

`binding_of_caller` has been around since #1, and has not been used for some time as far as I can tell 🙂 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
