### PR TITLE
Handle unexpected ArcGIS response body

### DIFF
--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -31,12 +31,12 @@ module Idv
 
       def report_errors(error)
         remapped_error = case error
-        when Faraday::Error,
-             ActionController::InvalidAuthenticityToken
-          :unprocessable_entity
-        else
-          :internal_server_error
-        end
+                         when Faraday::Error,
+                              ActionController::InvalidAuthenticityToken
+                           :unprocessable_entity
+                         else
+                           :internal_server_error
+                         end
 
         errors = if error.respond_to?(:response_body)
                    error.response_body && error.response_body[:details]

--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -44,13 +44,17 @@ module Idv
 
         errors ||= 'ArcGIS error performing operation'
 
+        response_status_code = if error.respond_to?(:response_status)
+                                 error.response_status
+                               end
+
         analytics.idv_in_person_locations_searched(
           success: false,
           errors: errors,
           api_status_code: Rack::Utils.status_code(remapped_error),
           exception_class: error.class,
           exception_message: error.message,
-          response_status_code: error.respond_to?(:response_status) && error.response_status,
+          response_status_code: response_status_code,
         )
 
         analytics.idv_arcgis_request_failure(
@@ -59,7 +63,7 @@ module Idv
           exception_message: error.message,
           response_body_present: error.respond_to?(:response_body) && error.response_body.present?,
           response_body: error.respond_to?(:response_body) && error.response_body,
-          response_status_code: error.respond_to?(:response_status) && error.response_status,
+          response_status_code: response_status_code,
         )
         render json: [], status: remapped_error
       end

--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -44,17 +44,13 @@ module Idv
 
         errors ||= 'ArcGIS error performing operation'
 
-        response_status_code = if error.respond_to?(:response_status)
-                                 error.response_status
-                               end
-
         analytics.idv_in_person_locations_searched(
           success: false,
           errors: errors,
           api_status_code: Rack::Utils.status_code(remapped_error),
           exception_class: error.class,
           exception_message: error.message,
-          response_status_code: response_status_code,
+          response_status_code: error.try(:response_status),
         )
 
         analytics.idv_arcgis_request_failure(
@@ -63,7 +59,7 @@ module Idv
           exception_message: error.message,
           response_body_present: error.respond_to?(:response_body) && error.response_body.present?,
           response_body: error.respond_to?(:response_body) && error.response_body,
-          response_status_code: response_status_code,
+          response_status_code: error.try(:response_status),
         )
         render json: [], status: remapped_error
       end

--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -39,7 +39,7 @@ module Idv
                          end
 
         errors = if error.respond_to?(:response_body)
-                   error.response_body && error.response_body[:details]
+                   error.response_body.is_a?(Hash) && error.response_body[:details]
                  end
 
         errors ||= 'ArcGIS error performing operation'

--- a/app/controllers/idv/in_person/address_search_controller.rb
+++ b/app/controllers/idv/in_person/address_search_controller.rb
@@ -33,7 +33,7 @@ module Idv
         remapped_error = case error
         when Faraday::Error,
              ActionController::InvalidAuthenticityToken
-          :bad_request
+          :unprocessable_entity
         else
           :internal_server_error
         end

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -63,12 +63,12 @@ module Idv
 
       def handle_error(err)
         remapped_error = case err
-        when ActionController::InvalidAuthenticityToken,
-             Faraday::Error
-          :unprocessable_entity
-        else
-          :internal_server_error
-        end
+                         when ActionController::InvalidAuthenticityToken,
+                              Faraday::Error
+                           :unprocessable_entity
+                         else
+                           :internal_server_error
+                         end
 
         analytics.idv_in_person_locations_request_failure(
           api_status_code: Rack::Utils.status_code(remapped_error),

--- a/spec/controllers/idv/in_person/address_search_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_search_controller_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Idv::InPerson::AddressSearchController do
           result_total: 0,
           exception_class: StandardError,
           exception_message: 'error',
-          response_status_code: false,
+          response_status_code: nil,
         )
       end
 
@@ -223,7 +223,7 @@ RSpec.describe Idv::InPerson::AddressSearchController do
           api_status_code: 500,
           exception_class: StandardError,
           exception_message: 'error',
-          response_status_code: false,
+          response_status_code: nil,
           response_body_present: false,
           response_body: false,
         )

--- a/spec/controllers/idv/in_person/address_search_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_search_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Idv::InPerson::AddressSearchController do
           expect(addresses.length).to eq 0
           expect(@analytics).to have_logged_event(
             'IdV: in person proofing location search submitted',
-            api_status_code: 400,
+            api_status_code: 422,
             success: false,
             errors: 'request is too many characters',
             result_total: 0,
@@ -106,7 +106,7 @@ RSpec.describe Idv::InPerson::AddressSearchController do
 
       it 'gets an empty pilot response' do
         response = get :index
-        expect(response.status).to eq(400)
+        expect(response.status).to eq(422)
         addresses = JSON.parse(response.body)
         expect(addresses.length).to eq 0
       end
@@ -115,7 +115,7 @@ RSpec.describe Idv::InPerson::AddressSearchController do
         response
         expect(@analytics).to have_logged_event(
           'IdV: in person proofing location search submitted',
-          api_status_code: 400,
+          api_status_code: 422,
           success: false,
           errors: 'ArcGIS error performing operation',
           result_total: 0,
@@ -137,7 +137,7 @@ RSpec.describe Idv::InPerson::AddressSearchController do
 
       it 'returns an error code' do
         response = get :index
-        expect(response.status).to eq(400)
+        expect(response.status).to eq(422)
         addresses = JSON.parse(response.body)
         expect(addresses.length).to eq 0
 
@@ -157,7 +157,7 @@ RSpec.describe Idv::InPerson::AddressSearchController do
         response
         expect(@analytics).to have_logged_event(
           'IdV: in person proofing location search submitted',
-          api_status_code: 400,
+          api_status_code: 422,
           success: false,
           errors: 'ArcGIS error performing operation',
           result_total: 0,


### PR DESCRIPTION
## 🛠 Summary of changes

Handles an unexpected response body from the ArcGIS service.

Also:

- raises a `422` instead of a `400` for most errors in `Idv::InPerson::AddressSearchController`, to stay consistent with `Idv::InPerson::UspsLocationsController` – ac417381e2777e4acf9051bfeb70a8a2fbd67df3
- adds a missing test – 45e1df64897ba6e077515197c130931ca6088f81

## 📔 Notes

- [NewRelic error](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=43200000&filters=%28domain%20IN%20%28%27APM%27%2C%20%27EXT%27%29%20AND%20type%20IN%20%28%27APPLICATION%27%2C%20%27SERVICE%27%29%29&state=d78d8d16-0d2e-429c-af31-c26792923bba)
- [Slack thread](https://gsa-tts.slack.com/archives/C03FA4VBN76/p1691535543563699)