### PR TITLE
LG-10342 Encrypt password digests with multi-region key

### DIFF
--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -48,7 +48,9 @@ module Encryption
         scrypted_password, kms_encryption_context(user_uuid: user_uuid)
       )
       single_region_digest = PasswordDigest.new(
-        encrypted_password: single_region_encrypted_password, password_salt: salt, password_cost: cost,
+        encrypted_password: single_region_encrypted_password,
+        password_salt: salt,
+        password_cost: cost,
       ).to_s
 
       multi_region_digest = nil
@@ -57,7 +59,9 @@ module Encryption
           scrypted_password, kms_encryption_context(user_uuid: user_uuid)
         )
         multi_region_digest = PasswordDigest.new(
-          encrypted_password: multi_region_encrypted_password, password_salt: salt, password_cost: cost,
+          encrypted_password: multi_region_encrypted_password,
+          password_salt: salt,
+          password_cost: cost,
         ).to_s
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -401,6 +401,12 @@ RSpec.describe User do
 
         expect(user.encrypted_password_digest_multi_region).to_not be_blank
         expect(user.encrypted_password_digest_multi_region).to_not match(/test password/)
+
+        expect(
+          user.encrypted_password_digest,
+        ).to_not eq(
+          user.encrypted_password_digest_multi_region,
+        )
       end
     end
   end
@@ -441,6 +447,12 @@ RSpec.describe User do
 
         expect(user.encrypted_recovery_code_digest_multi_region).to_not be_blank
         expect(user.encrypted_recovery_code_digest_multi_region).to_not match(/test personal key/)
+
+        expect(
+          user.encrypted_recovery_code_digest,
+        ).to_not eq(
+          user.encrypted_recovery_code_digest_multi_region,
+        )
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -374,6 +374,86 @@ RSpec.describe User do
     end
   end
 
+  describe '#password=' do
+    it 'digests and saves the digested password' do
+      user = build(:user, password: nil)
+
+      user.password = 'test password'
+
+      expect(user.encrypted_password_digest).to_not be_blank
+      expect(user.encrypted_password_digest).to_not match(/test password/)
+
+      expect(user.encrypted_password_digest_multi_region).to be_nil
+    end
+
+    context 'with aws_kms_multi_region_write_enabled set to true' do
+      before do
+        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_write_enabled).and_return(true)
+      end
+
+      it 'digests and saves a single region and multi region password digests' do
+        user = build(:user, password: nil)
+
+        user.password = 'test password'
+
+        expect(user.encrypted_password_digest).to_not be_blank
+        expect(user.encrypted_password_digest).to_not match(/test password/)
+
+        expect(user.encrypted_password_digest_multi_region).to_not be_blank
+        expect(user.encrypted_password_digest_multi_region).to_not match(/test password/)
+      end
+    end
+  end
+
+  describe '#valid_password?' do
+    it 'returns true if the password matches the stored digest' do
+      user = build(:user, password: 'test password')
+
+      expect(user.valid_password?('test password')).to eq(true)
+      expect(user.valid_password?('wrong password')).to eq(false)
+    end
+  end
+
+  describe '#personal_key=' do
+    it 'digests and saves the digested personal key' do
+      user = build(:user, personal_key: nil)
+
+      user.personal_key = 'test personal key'
+
+      expect(user.encrypted_recovery_code_digest).to_not be_blank
+      expect(user.encrypted_recovery_code_digest).to_not match(/test personal key/)
+
+      expect(user.encrypted_recovery_code_digest_multi_region).to be_nil
+    end
+
+    context 'with aws_kms_multi_region_write_enabled set to true' do
+      before do
+        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_write_enabled).and_return(true)
+      end
+
+      it 'digests and saves a single region and multi region personal key digests' do
+        user = build(:user, personal_key: nil)
+
+        user.personal_key = 'test personal key'
+
+        expect(user.encrypted_recovery_code_digest).to_not be_blank
+        expect(user.encrypted_recovery_code_digest).to_not match(/test personal key/)
+
+        expect(user.encrypted_recovery_code_digest_multi_region).to_not be_blank
+        expect(user.encrypted_recovery_code_digest_multi_region).to_not match(/test personal key/)
+      end
+    end
+  end
+
+  describe '#valid_personal_key?' do
+    it 'returns true if the personal key matches the stored digest' do
+      user = build(:user, personal_key: 'test personal key')
+
+      expect(user.valid_personal_key?('test personal key')).to eq(true)
+      expect(user.valid_personal_key?('wrong personal key')).to eq(false)
+    end
+  end
+
   describe '#authenticatable_salt' do
     it 'returns the password salt' do
       user = create(:user)

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -87,7 +87,6 @@ RSpec.describe Encryption::PasswordVerifier do
           { 'user_uuid' => user_uuid, 'context' => 'password-digest' },
         ).and_return('single_region_kms_ciphertext')
 
-
         expect(multi_region_kms_client).to receive(:encrypt).with(
           encoded_scrypt_password,
           { 'user_uuid' => user_uuid, 'context' => 'password-digest' },

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -40,22 +40,74 @@ RSpec.describe Encryption::PasswordVerifier do
         and_return('scrypted')
       expect(SCrypt::Password).to receive(:new).with('scrypted').and_return(scrypt_password)
 
-      kms_client = Encryption::KmsClient.new
+      kms_client = subject.send(:single_region_kms_client)
       expect(kms_client).to receive(:encrypt).with(
         encoded_scrypt_password,
         { 'user_uuid' => user_uuid, 'context' => 'password-digest' },
       ).and_return('kms_ciphertext')
-      expect(Encryption::KmsClient).to receive(:new).and_return(kms_client)
 
-      result = subject.create_digest_pair(
+      digest_pair = subject.create_digest_pair(
         password: password, user_uuid: user_uuid,
-      ).single_region_ciphertext
+      )
 
-      expect(JSON.parse(result, symbolize_names: true)).to eq(
+      expect(JSON.parse(digest_pair.single_region_ciphertext, symbolize_names: true)).to eq(
         password_salt: salt,
         password_cost: IdentityConfig.store.scrypt_cost,
         encrypted_password: 'kms_ciphertext',
       )
+      expect(digest_pair.multi_region_ciphertext).to eq(nil)
+    end
+
+    context 'with aws_kms_multi_region_write_enabled set to true' do
+      before do
+        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_write_enabled).and_return(true)
+      end
+
+      it 'creates a single region and multi region password digest' do
+        scrypt_password = double(SCrypt::Password, digest: 'scrypted_password')
+        encoded_scrypt_password = Base64.strict_encode64('scrypted_password')
+
+        expect(SCrypt::Engine).to receive(:hash_secret).
+          with(password, instance_of(String), 32).
+          and_return('scrypted')
+        expect(SCrypt::Password).to receive(:new).with('scrypted').and_return(scrypt_password)
+
+        single_region_kms_client = subject.send(:single_region_kms_client)
+        multi_region_kms_client = subject.send(:multi_region_kms_client)
+
+        expect(single_region_kms_client.kms_key_id).to eq(
+          IdentityConfig.store.aws_kms_key_id,
+        )
+        expect(multi_region_kms_client.kms_key_id).to eq(
+          IdentityConfig.store.aws_kms_multi_region_key_id,
+        )
+
+        expect(single_region_kms_client).to receive(:encrypt).with(
+          encoded_scrypt_password,
+          { 'user_uuid' => user_uuid, 'context' => 'password-digest' },
+        ).and_return('single_region_kms_ciphertext')
+
+
+        expect(multi_region_kms_client).to receive(:encrypt).with(
+          encoded_scrypt_password,
+          { 'user_uuid' => user_uuid, 'context' => 'password-digest' },
+        ).and_return('multi_regionn_kms_ciphertext')
+
+        digest_pair = subject.create_digest_pair(
+          password: password, user_uuid: user_uuid,
+        )
+
+        expect(JSON.parse(digest_pair.single_region_ciphertext, symbolize_names: true)).to match(
+          password_salt: instance_of(String),
+          password_cost: IdentityConfig.store.scrypt_cost,
+          encrypted_password: 'single_region_kms_ciphertext',
+        )
+        expect(JSON.parse(digest_pair.multi_region_ciphertext, symbolize_names: true)).to match(
+          password_salt: instance_of(String),
+          password_cost: IdentityConfig.store.scrypt_cost,
+          encrypted_password: 'multi_regionn_kms_ciphertext',
+        )
+      end
     end
   end
 

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Encryption::PasswordVerifier do
         expect(multi_region_kms_client).to receive(:encrypt).with(
           encoded_scrypt_password,
           { 'user_uuid' => user_uuid, 'context' => 'password-digest' },
-        ).and_return('multi_regionn_kms_ciphertext')
+        ).and_return('multi_region_kms_ciphertext')
 
         digest_pair = subject.create_digest_pair(
           password: password, user_uuid: user_uuid,
@@ -104,7 +104,7 @@ RSpec.describe Encryption::PasswordVerifier do
         expect(JSON.parse(digest_pair.multi_region_ciphertext, symbolize_names: true)).to match(
           password_salt: instance_of(String),
           password_cost: IdentityConfig.store.scrypt_cost,
-          encrypted_password: 'multi_regionn_kms_ciphertext',
+          encrypted_password: 'multi_region_kms_ciphertext',
         )
       end
     end


### PR DESCRIPTION
We are working on migrating to a KMS key that supports encryption and decryption across regions. To enable this move we are changing the application to encrypt PII and passwords with both a multi-region and single-region key during the migraiton.

This commit changes the app to encrypt passwords with the single-region key and the multi-region key when the `aws_kms_multi_region_write_enabled` flag is set.
