### PR TITLE
LG-10384 - backfill in person verification pending at

### DIFF
--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -15,13 +15,21 @@ namespace :profiles do
 
     update_profiles = ENV['UPDATE_PROFILES'] == 'true'
 
-    profiles = Profile.where(deactivation_reason: 'in_person_verification_pending')
+    profiles = Profile.where(
+      deactivation_reason: 'in_person_verification_pending',
+      in_person_verification_pending_at: nil,
+    )
 
     profiles.each do |profile|
       timestamp = profile.in_person_enrollment.updated_at
 
       warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
-      profile.update!(in_person_verification_pending_at: timestamp) if update_profiles
+      if update_profiles
+        profile.update!(
+          in_person_verification_pending_at: timestamp,
+          deactivation_reason: nil,
+        )
+      end
     end
   end
 

--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -1,5 +1,5 @@
 namespace :profiles do
-  desc 'If a profile is in "in person pending" state, but does not have an in_person_verification_pending_at value, generate one.'
+  desc 'Backfill the in_person_verification_pending_at value column.'
 
   ##
   # Usage:
@@ -58,8 +58,10 @@ namespace :profiles do
   task validate_backfill_in_person_verification_pending_at: :environment do |_task, _args|
     ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
 
-    profiles = Profile.where(deactivation_reason: 'in_person_verification_pending',
-                             in_person_verification_pending_at: nil)
+    profiles = Profile.where(
+      deactivation_reason: 'in_person_verification_pending',
+      in_person_verification_pending_at: nil,
+    )
 
     warn "backfill_in_person_verification_pending_at left #{profiles.count} rows"
   end

--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -1,0 +1,66 @@
+namespace :profiles do
+  desc 'If a profile is in "in person pending" state, but does not have an in_person_verification_pending_at value, generate one.'
+
+  ##
+  # Usage:
+  #
+  # Print pending updates
+  # bundle exec rake profiles:backfill_in_person_verification_pending_at
+  #
+  # Commit updates
+  # bundle exec rake profiles:backfill_in_person_verification_pending_at UPDATE_PROFILES=true
+  #
+  task backfill_in_person_verification_pending_at: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    update_profiles = ENV['UPDATE_PROFILES'] == 'true'
+
+    profiles = Profile.where(deactivation_reason: 'in_person_verification_pending')
+
+    profiles.each do |profile|
+      timestamp = profile.in_person_enrollment.updated_at
+
+      warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
+      profile.update!(in_person_verification_pending_at: timestamp) if update_profiles
+    end
+  end
+
+  ##
+  # Usage:
+  #
+  # Rollback the above:
+  #
+  # export BACKFILL_OUTPUT='<backfill_output>'
+  # bundle exec rake profiles:rollback_backfill_in_person_verification_pending_at
+  #
+  task rollback_backfill_in_person_verification_pending_at: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    profile_data = ENV['BACKFILL_OUTPUT'].split("\n").map do |profile_row|
+      profile_row.split(',')
+    end
+
+    warn "Updating #{profile_data.count} records"
+    profile_data.each do |profile_datum|
+      profile_id, deactivation_reason, _timestamp = profile_datum
+      Profile.where(id: profile_id).update!(
+        in_person_verification_pending_at: nil,
+        deactivation_reason: deactivation_reason,
+      )
+      warn profile_id
+    end
+  end
+
+  ##
+  # Usage:
+  # bundle exec rake profiles:validate_backfill_in_person_verification_pending_at
+  #
+  task validate_backfill_in_person_verification_pending_at: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    profiles = Profile.where(deactivation_reason: 'in_person_verification_pending',
+                             in_person_verification_pending_at: nil)
+
+    warn "backfill_in_person_verification_pending_at left #{profiles.count} rows"
+  end
+end


### PR DESCRIPTION
Co-authored by: Alexander Bradley <alexander.bradley@gsa.gov>

## 🎫 [LG-10384](https://cm-jira.usa.gov/browse/LG-10384)

## 🛠 Summary of changes
Added a rake task to backfill the new `in_person_verification_pending_at` column

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create a user who is in the in-person flow. The file 
[document_classification_error.yml.txt](https://github.com/18F/identity-idp/files/12314963/document_classification_error.yml.txt)
must be used for the user's ID images in order to force in-person proofing.
- [ ] Bring up the rails console, find the user's profile, and set the `in_person_verification_pending_at` column to nil
- [ ] run the `backfill_in_person_verification_pending_at` task, and verify that it shows one user to be updated
- [ ] run the `validate_backfill_in_person_verification_pending_at` task, and verify that it shows 1 row
- [ ] run the `backfill_in_person_verification_pending_at` task with the UPDATE_PROFILES environment variable set, and verify that it shows 1 profile being updated.
- [ ] run the `validate_backfill_in_person_verification_pending_at` task, and verify that it shows 0 rows
- [ ] bring up the rails console and verify that the user has an `in_person_verification_pending_at` value
- [ ] run the `rollback_backfill_in_person_verification_pending_at` task, using the output from the backfill task
- [ ] run the `validate_backfill_in_person_verification_pending_at` task, and verify that it shows 1 row
- [ ] bring up the rails console and verify that the user does not have an `in_person_verification_pending_at` value