### PR TITLE
LG-10337: Update error message when doc classification ≠ state ID

### DIFF
--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -125,6 +125,10 @@ module DocAuth
           !!doc_auth_result
         end
 
+        def doc_type_supported?
+          !doc_class_name.present? || ID_TYPE_SLUGS.key?(doc_class_name) || doc_class_name == 'Unknown'
+        end
+
         private
 
         def response_info
@@ -147,6 +151,7 @@ module DocAuth
             portrait_match_results: true_id_product[:PORTRAIT_MATCH_RESULT],
             image_metrics: parse_image_metrics,
             address_line2_present: !pii_from_doc[:address2].blank?,
+            classification_info: classification_info,
           }
         end
 
@@ -180,6 +185,23 @@ module DocAuth
 
         def doc_auth_result_unknown?
           doc_auth_result == 'Unknown'
+        end
+
+        def doc_class_name
+          true_id_product&.dig(:AUTHENTICATION_RESULT, :DocClassName)
+        end
+
+        def classification_info
+          # Acuent response has both sides info, here simulate that
+          doc_class = doc_class_name
+          {
+            Front: {
+              ClassName: doc_class,
+            },
+            Back: {
+              ClassName: doc_class,
+            },
+          }
         end
 
         def doc_auth_result

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -126,7 +126,8 @@ module DocAuth
         end
 
         def doc_type_supported?
-          !doc_class_name.present? || ID_TYPE_SLUGS.key?(doc_class_name) || doc_class_name == 'Unknown'
+          !doc_class_name.present? || ID_TYPE_SLUGS.key?(doc_class_name) ||
+            doc_class_name == 'Unknown'
         end
 
         private

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -121,12 +121,24 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         'DocIssueType' => "Driver's License - STAR",
         'OrientationChanged' => 'true',
         'PresentationChanged' => 'false',
+        classification_info: {
+          Front: {
+            ClassName: 'Drivers License',
+          },
+          Back: {
+            ClassName: 'Drivers License',
+          },
+        },
       )
     end
 
     it 'notes that address line 2 was present' do
       expect(response.pii_from_doc).to include(address2: 'APT 3E')
       expect(response.to_h).to include(address_line2_present: true)
+    end
+
+    it 'mark doc type as supported' do
+      expect(response.doc_type_supported?).to eq(true)
     end
   end
 
@@ -312,6 +324,14 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         'DocIsGeneric' => 'false',
         'OrientationChanged' => 'false',
         'PresentationChanged' => 'false',
+        classification_info: {
+          Front: {
+            ClassName: 'Drivers License',
+          },
+          Back: {
+            ClassName: 'Drivers License',
+          },
+        },
       )
     end
   end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
   end
 
   describe '#doc_type_supported?' do
-    let(:doc_class_name) {'Drivers License'}
+    let(:doc_class_name) { 'Drivers License' }
     let(:success_response) do
       response = JSON.parse(LexisNexisFixtures.true_id_response_success_2).tap do |json|
         doc_class_node = json['Products'].first['ParameterDetails'].
@@ -505,21 +505,20 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     subject(:doc_type_supported?) do
       described_class.new(success_response, config).doc_type_supported?
     end
-    it { is_expected.to eq(true)}
+    it { is_expected.to eq(true) }
 
     context 'when doc class is unknown' do
-      let(:doc_class_name) { 'Unknown'}
+      let(:doc_class_name) { 'Unknown' }
       it 'identified as supported doc type ' do
         is_expected.to eq(true)
       end
     end
 
     context 'when doc class is identified but not supported' do
-      let(:doc_class_name) { 'Passport'}
+      let(:doc_class_name) { 'Passport' }
       it 'identified as un supported doc type ' do
         is_expected.to eq(false)
       end
     end
   end
-
 end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -490,4 +490,36 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe '#doc_type_supported?' do
+    let(:doc_class_name) {'Drivers License'}
+    let(:success_response) do
+      response = JSON.parse(LexisNexisFixtures.true_id_response_success_2).tap do |json|
+        doc_class_node = json['Products'].first['ParameterDetails'].
+          select { |f| f['Name'] == 'DocClassName' }
+        doc_class_node.first['Values'].first['Value'] = doc_class_name
+      end.to_json
+      instance_double(Faraday::Response, status: 200, body: response)
+    end
+
+    subject(:doc_type_supported?) do
+      described_class.new(success_response, config).doc_type_supported?
+    end
+    it { is_expected.to eq(true)}
+
+    context 'when doc class is unknown' do
+      let(:doc_class_name) { 'Unknown'}
+      it 'identified as supported doc type ' do
+        is_expected.to eq(true)
+      end
+    end
+
+    context 'when doc class is identified but not supported' do
+      let(:doc_class_name) { 'Passport'}
+      it 'identified as un supported doc type ' do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-10337:Update error message when doc classification is not  state ID](https://cm-jira.usa.gov/browse/LG-10337)
## 🛠 Summary of changes

Check TrueId response.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
