### PR TITLE
changelog: Internal, Bug Fix, Adding blank scan for automated scans w…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -517,7 +517,32 @@ ecr-scan:
         ]
       }
       else
-        "No findings"
+      {
+        "version": "15.0.4",
+        "scan": {
+          "start_time": (now | strftime("%Y-%m-%dT%H:%M:%S")),
+          "end_time": (now | strftime("%Y-%m-%dT%H:%M:%S")),
+          "scanner": {
+            "id": "clair",
+            "name": "Amazon ECR Image Scan",
+            "version": "1.0.0",
+            "vendor": {
+              "name": "Amazon Web Services"
+            }
+          },
+          "analyzer": {
+            "id": "clair",
+            "name": "Amazon ECR Image Scan",
+            "version": "1.0.0",
+            "vendor": {
+              "name": "Amazon Web Services"
+            }
+          },
+          "status": "success",
+          "type": "container_scanning"
+        },
+        "vulnerabilities": []
+      }
       end' > gl-container-scanning-report.json
   artifacts:
     paths: 


### PR DESCRIPTION


<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

## 🛠 Summary of changes
Updates the else statement of the jq scan parser to instead generate a blank scan so that an error isn't thrown in the `Vulnerability report` section of the Gitlab security dashboard.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
