### PR TITLE
Lg 10488 add missing analytics addendum

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -31,7 +31,7 @@ module Users
     end
 
     def edit
-      analytics.backup_code_regenerate_visit
+      analytics.backup_code_regenerate_visit(**properties)
     end
 
     def continue
@@ -63,6 +63,10 @@ module Users
     def confirm_backup_codes; end
 
     private
+
+    def properties
+      ParseControllerFromReferer.new(request.referer).call
+    end
 
     def track_backup_codes_created
       analytics.backup_code_created(

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -31,7 +31,7 @@ module Users
     end
 
     def edit
-      analytics.backup_code_regenerate_visit(**properties)
+      analytics.backup_code_regenerate_visit(**analytics_properties)
     end
 
     def continue
@@ -63,10 +63,6 @@ module Users
     def confirm_backup_codes; end
 
     private
-
-    def properties
-      ParseControllerFromReferer.new(request.referer).call
-    end
 
     def track_backup_codes_created
       analytics.backup_code_created(
@@ -129,6 +125,7 @@ module Users
         multi_factor_auth_method: 'backup_codes',
         in_multi_mfa_selection_flow: in_multi_mfa_selection_flow?,
         enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
+        referer: ParseControllerFromReferer.new(request.referer).call,
       }
     end
   end

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -30,7 +30,9 @@ module Users
       track_backup_codes_created
     end
 
-    def edit; end
+    def edit
+      analytics.backup_code_regenerate_visit
+    end
 
     def continue
       flash[:success] = t('notices.backup_codes_configured')

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -9,6 +9,7 @@ module Users
     before_action :confirm_recently_authenticated_2fa
 
     def show
+      analytics.add_email_visit
       @add_user_email_form = AddUserEmailForm.new
     end
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -7,6 +7,7 @@ module Users
     before_action :confirm_recently_authenticated_2fa
 
     def edit
+      analytics.edit_password_visit
       @update_user_password_form = UpdateUserPasswordForm.new(current_user)
       @forbidden_passwords = current_user.email_addresses.flat_map do |email_address|
         ForbiddenPasswords.new(email_address.email).call

--- a/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
@@ -8,17 +8,6 @@ module TwoFactorAuthentication
       user&.piv_cac_configurations&.any?
     end
 
-    def mfa_configuration_description
-      return '' if !disabled?
-      t(
-        'two_factor_authentication.two_factor_choice_options.no_count_configuration_added',
-      )
-    end
-
-    def mfa_added_label
-      ''
-    end
-
     def mfa_configuration_count
       user.piv_cac_configurations.count
     end

--- a/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
@@ -8,8 +8,19 @@ module TwoFactorAuthentication
       user&.piv_cac_configurations&.any?
     end
 
+    def mfa_configuration_description
+      return '' if !disabled?
+      t(
+        'two_factor_authentication.two_factor_choice_options.no_count_configuration_added',
+      )
+    end
+
+    def mfa_added_label
+      ''
+    end
+
     def mfa_configuration_count
-      user&.piv_cac_configurations&.count?
+      user.piv_cac_configurations.count
     end
   end
 end

--- a/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/piv_cac_selection_presenter.rb
@@ -9,7 +9,7 @@ module TwoFactorAuthentication
     end
 
     def mfa_configuration_count
-      user.piv_cac_configurations.count
+      user&.piv_cac_configurations&.count?
     end
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -303,7 +303,6 @@ module AnalyticsEvents
     track_event('Doc Auth Warning', message: message, **extra)
   end
 
-
   # When a user views the add email address page
   def edit_password_visit
     track_event('Edit Password Page Visited')

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -303,7 +303,7 @@ module AnalyticsEvents
     track_event('Doc Auth Warning', message: message, **extra)
   end
 
-  # When a user views the add email address page
+  # When a user views the edit password page
   def edit_password_visit
     track_event('Edit Password Page Visited')
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -226,8 +226,8 @@ module AnalyticsEvents
   end
 
   # Tracks when the user visits the Backup Code Regenerate page.
-  def backup_code_regenerate_visit
-    track_event('Backup Code Regenerate Visited')
+  def backup_code_regenerate_visit(**properties)
+    track_event('Backup Code Regenerate Visited', **properties)
   end
 
   # Track user creating new BackupCodeSetupForm, record form submission Hash

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -176,6 +176,11 @@ module AnalyticsEvents
     )
   end
 
+  # When a user views the add email address page
+  def add_email_visit
+    track_event('Add Email Address Page Visited')
+  end
+
   # Tracks When users visit the add phone page
   def add_phone_setup_visit
     track_event(
@@ -218,6 +223,11 @@ module AnalyticsEvents
       enabled_mfa_methods_count: enabled_mfa_methods_count,
       **extra,
     )
+  end
+
+  # Tracks when the user visits the Backup Code Regenerate page.
+  def backup_code_regenerate_visit
+    track_event('Backup Code Regenerate Visited')
   end
 
   # Track user creating new BackupCodeSetupForm, record form submission Hash
@@ -291,6 +301,12 @@ module AnalyticsEvents
   # field from a vendor
   def doc_auth_warning(message: nil, **extra)
     track_event('Doc Auth Warning', message: message, **extra)
+  end
+
+
+  # When a user views the add email address page
+  def edit_password_visit
+    track_event('Edit Password Page Visited')
   end
 
   # @param [Boolean] success

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -226,8 +226,9 @@ module AnalyticsEvents
   end
 
   # Tracks when the user visits the Backup Code Regenerate page.
-  def backup_code_regenerate_visit(**properties)
-    track_event('Backup Code Regenerate Visited', **properties)
+  # @param [String] request_came_from the controller/action the request came from
+  def backup_code_regenerate_visit(referer:, **extra)
+    track_event('Backup Code Regenerate Visited', referer:, **extra)
   end
 
   # Track user creating new BackupCodeSetupForm, record form submission Hash

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -141,14 +141,16 @@ RSpec.describe Users::BackupCodeSetupController do
     end
   end
 
-  it 'visits the Backup codes regenerate page' do
-    user = create(:user, :fully_registered)
-    stub_sign_in(user)
-    analytics = stub_analytics
-    stub_attempts_tracker
-
-    get :edit
-
-    expect(@analytics).to receive(:track_event).with(hash_including('Backup Code Regenerate Visited'))
+  context 'user visits the Backup codes regenerate page' do
+    let(:user) { create(:user) }
+    before do
+      stub_sign_in(user)
+      stub_analytics
+    end
+    it 'renders the index view' do
+      get :edit
+      expect(@analytics).to have_logged_event('Backup Code Regenerate Visited', hash_including(request_came_from: anything))
+    end
   end
+  
 end

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -149,8 +149,10 @@ RSpec.describe Users::BackupCodeSetupController do
     end
     it 'renders the index view' do
       get :edit
-      expect(@analytics).to have_logged_event('Backup Code Regenerate Visited', hash_including(request_came_from: anything))
+      expect(@analytics).to have_logged_event(
+        'Backup Code Regenerate Visited',
+        hash_including(request_came_from: anything),
+      )
     end
   end
-  
 end

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Users::BackupCodeSetupController do
       get :edit
       expect(@analytics).to have_logged_event(
         'Backup Code Regenerate Visited',
-        hash_including(request_came_from: anything),
+        hash_including(referer: { request_came_from: 'no referer' }),
       )
     end
   end

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -140,4 +140,15 @@ RSpec.describe Users::BackupCodeSetupController do
       expect(response).to redirect_to(backup_code_setup_url)
     end
   end
+
+  it 'visits the Backup codes regenerate page' do
+    user = create(:user, :fully_registered)
+    stub_sign_in(user)
+    analytics = stub_analytics
+    stub_attempts_tracker
+
+    get :edit
+
+    expect(@analytics).to receive(:track_event).with(hash_including('Backup Code Regenerate Visited'))
+  end
 end

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -10,23 +10,17 @@ RSpec.describe Users::EmailsController do
     end
   end
 
-  context 'user adds an email address' do
+  context 'user visits add an email address page' do
     let(:user) { create(:user) }
-      before do
-        stub_sign_in(user)
-        stub_analytics
-        
-        while EmailPolicy.new(user).can_add_email?
-          email = Faker::Internet.safe_email
-          user.email_addresses.create(email: email, confirmed_at: Time.zone.now)
-        end
-      end
-      it 'visits the add email page' do
-        get :show 
-        expect(@analytics).to receive(:track_event).with(hash_including('Add Email Address Page Visited'))
-      end
+    before do
+      stub_sign_in(user)
+      stub_analytics
+    end
+    it 'renders the index view' do
+      get :show
+      expect(@analytics).to have_logged_event('Add Email Address Page Visited')
+    end
   end
-
 
   describe '#limit' do
     context 'user exceeds email limit' do

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -10,6 +10,24 @@ RSpec.describe Users::EmailsController do
     end
   end
 
+  context 'user adds an email address' do
+    let(:user) { create(:user) }
+      before do
+        stub_sign_in(user)
+        stub_analytics
+        
+        while EmailPolicy.new(user).can_add_email?
+          email = Faker::Internet.safe_email
+          user.email_addresses.create(email: email, confirmed_at: Time.zone.now)
+        end
+      end
+      it 'visits the add email page' do
+        get :show 
+        expect(@analytics).to receive(:track_event).with(hash_including('Add Email Address Page Visited'))
+      end
+  end
+
+
   describe '#limit' do
     context 'user exceeds email limit' do
       let(:user) { create(:user) }

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Users::PasswordsController do
+
+  context 'user visits add an email address page' do
+    let(:user) { create(:user) }
+    before do
+      stub_sign_in(user)
+      stub_analytics
+    end
+    it 'renders the index view' do
+      get :edit
+      expect(@analytics).to have_logged_event('Edit Password Page Visited')
+    end
+  end
+
   describe '#update' do
     context 'form returns success' do
       it 'redirects to profile and sends a password change email' do

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Users::PasswordsController do
-
   context 'user visits add an email address page' do
     let(:user) { create(:user) }
     before do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->
There were a few remaining comments on [PR 8940](https://github.com/18F/identity-idp/pull/8940).

In particular this comment: https://github.com/18F/identity-idp/pull/8940#discussion_r1290496113 there was already an analytics_properties method. I included the call that receives the referring url into the existing method and changed how it gets referenced in analytics_events.rb.

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
