### PR TITLE
amendment for PR 8940 to refactor backup codes analytics

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -31,7 +31,7 @@ module Users
     end
 
     def edit
-      analytics.backup_code_regenerate_visit(**properties)
+      analytics.backup_code_regenerate_visit(**analytics_properties)
     end
 
     def continue
@@ -63,10 +63,6 @@ module Users
     def confirm_backup_codes; end
 
     private
-
-    def properties
-      ParseControllerFromReferer.new(request.referer).call
-    end
 
     def track_backup_codes_created
       analytics.backup_code_created(
@@ -129,6 +125,7 @@ module Users
         multi_factor_auth_method: 'backup_codes',
         in_multi_mfa_selection_flow: in_multi_mfa_selection_flow?,
         enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
+        referer: ParseControllerFromReferer.new(request.referer).call,
       }
     end
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -226,8 +226,8 @@ module AnalyticsEvents
   end
 
   # Tracks when the user visits the Backup Code Regenerate page.
-  def backup_code_regenerate_visit(**properties)
-    track_event('Backup Code Regenerate Visited', **properties)
+  def backup_code_regenerate_visit(referer:, **extra)
+    track_event('Backup Code Regenerate Visited', referer:, **extra)
   end
 
   # Track user creating new BackupCodeSetupForm, record form submission Hash

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Users::BackupCodeSetupController do
       get :edit
       expect(@analytics).to have_logged_event(
         'Backup Code Regenerate Visited',
-        hash_including(request_came_from: anything),
+        hash_including(referer: { request_came_from: 'no referer' }),
       )
     end
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->
There were a few remaining comments on https://github.com/18F/identity-idp/pull/8940.

In particular this comment: https://github.com/18F/identity-idp/pull/8940#discussion_r1290496113 there was already an analytics_properties method. I included the call that receives the referring url into the existing method and changed how it gets referenced in analytics_events.rb.
<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
