### PR TITLE
Enable ActionControllerFlashBeforeRender Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -789,7 +789,7 @@ Performance/UriDefaultParser:
   Enabled: true
 
 Rails/ActionControllerFlashBeforeRender:
-  Enabled: false
+  Enabled: true
 
 Rails/ActionControllerTestCase:
   Enabled: true

--- a/app/controllers/account_reset/cancel_controller.rb
+++ b/app/controllers/account_reset/cancel_controller.rb
@@ -19,9 +19,11 @@ module AccountReset
       analytics.account_reset_cancel(**result.to_h)
       irs_attempts_api_tracker.account_reset_cancel_request
 
-      handle_success if result.success?
-
-      redirect_to root_url
+      if result.success?
+        handle_success
+      else
+        redirect_to root_url
+      end
     end
 
     private
@@ -42,6 +44,7 @@ module AccountReset
         'two_factor_authentication.account_reset.successful_cancel',
         app_name: APP_NAME,
       )
+      redirect_to root_url
     end
 
     def token

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -19,7 +19,6 @@ module IdvSession
   end
 
   def confirm_phone_or_address_confirmed
-    return if flash[:allow_confirmations_continue]
     return if idv_session.address_confirmed? || idv_session.phone_confirmed?
 
     redirect_to idv_review_url

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -63,8 +63,6 @@ module Idv
       idv_session.personal_key = nil
 
       irs_attempts_api_tracker.idv_personal_key_generated
-
-      flash[:allow_confirmations_continue] = true
     end
 
     def personal_key

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -40,8 +40,11 @@ module Users
     end
 
     def disable
-      process_successful_disable if MfaPolicy.new(current_user).multiple_factors_enabled?
-      redirect_to account_two_factor_authentication_path
+      if MfaPolicy.new(current_user).multiple_factors_enabled?
+        process_successful_disable
+      else
+        redirect_to account_two_factor_authentication_path
+      end
     end
 
     private
@@ -103,6 +106,7 @@ module Users
       revoke_remember_device(current_user)
       revoke_otp_secret_key
       flash[:success] = t('notices.totp_disabled')
+      redirect_to account_two_factor_authentication_path
     end
 
     def revoke_otp_secret_key

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -149,12 +149,6 @@ RSpec.describe Idv::PersonalKeyController do
       )
     end
 
-    it 'sets flash[:allow_confirmations_continue] to true' do
-      get :show
-
-      expect(flash[:allow_confirmations_continue]).to eq true
-    end
-
     it 'logs when user generates personal key' do
       expect(@irs_attempts_api_tracker).to receive(:idv_personal_key_generated)
       get :show


### PR DESCRIPTION
## 🛠 Summary of changes

Enables `Rails/ActionControllerFlashBeforeRender` and resolves existing issues.

**Why?**

- This would catch real-world bugs like the one addressed in #8984

Previously:

- https://github.com/18F/identity-idp/pull/8984#pullrequestreview-1573838223
- #8961

## 📜 Testing Plan

```
rubocop
```