### PR TITLE
Load DAP analytics script asynchronously

### DIFF
--- a/app/views/shared/_dap_analytics.html.erb
+++ b/app/views/shared/_dap_analytics.html.erb
@@ -1,2 +1,2 @@
 <!-- <%= t('notices.dap_participation') %> -->
-<script src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS" id="_fed_an_ua_tag"></script>
+<script async src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS" id="_fed_an_ua_tag"></script>


### PR DESCRIPTION
## 🛠 Summary of changes

Updates DAP script load to occur asynchronously.

**Why?**

- This is how it's [documented](https://github.com/digital-analytics-program/gov-wide-code/blob/master/documentation/GSA%20DAP%204.1%20-%20Quick%20Guide.pdf) to be implemented
- Allows the script to load asynchronously to avoid page-load blocking ([documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attributes))

## 📜 Testing Plan

1. Add `participate_in_dap: true` to `config/application.yml`
2. Start server
3. Go to http://localhost:3000
4. Verify no errors in load†

† There's currently a CSP error related to [GA4 migration](https://digital.gov/guides/dap/common-questions-about-dap/#:~:text=Q%3A%20When%20will%20the%20Digital%20Analytics%20program%20migrate%20to%20Google%20Analytics%204%3F) that may need to be addressed, but is expected to be harmless currently due to the described "dual tracking" at the link above.
