### PR TITLE
Remove usage of deprecated path helpers in user-facing views

### DIFF
--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -31,7 +31,7 @@ module Users
       if result.success?
         handle_create_success(@new_phone_form.phone)
       elsif recoverable_recaptcha_error?(result)
-        render :spam_protection, locals: { two_factor_options_path: two_factor_options_path }
+        render :spam_protection, locals: { authentication_methods_setup_path: }
       else
         render :index
       end

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -33,4 +33,4 @@
       ) %>
 <% end %>
 
-<%= link_to t('idv.messages.return_to_profile', app_name: APP_NAME), profile_path %>
+<%= link_to t('idv.messages.return_to_profile', app_name: APP_NAME), account_path %>

--- a/app/views/users/phone_setup/spam_protection.html.erb
+++ b/app/views/users/phone_setup/spam_protection.html.erb
@@ -43,9 +43,9 @@
 
 <%= render TroubleshootingOptionsComponent.new do |c| %>
   <% c.with_header { t('components.troubleshooting_options.default_heading') } %>
-  <% if local_assigns[:two_factor_options_path].present? %>
+  <% if local_assigns[:authentication_methods_setup_path].present? %>
     <% c.with_option(
-         url: two_factor_options_path,
+         url: authentication_methods_setup_path,
        ).with_content(t('two_factor_authentication.login_options_link_text')) %>
   <% end %>
   <% c.with_option(
@@ -59,7 +59,7 @@
      ).with_content(t('two_factor_authentication.learn_more')) %>
 <% end %>
 
-<% unless local_assigns[:two_factor_options_path].present? %>
+<% unless local_assigns[:authentication_methods_setup_path].present? %>
   <%= render PageFooterComponent.new do %>
     <%= link_to t('links.cancel'), account_path %>
   <% end %>

--- a/spec/views/phone_setup/spam_protection.html.erb_spec.rb
+++ b/spec/views/phone_setup/spam_protection.html.erb_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe 'users/phone_setup/spam_protection.html.erb' do
   end
 
   context 'with two factor options path' do
-    let(:two_factor_options_path) { root_path }
-    let(:locals) { { two_factor_options_path: } }
+    let(:authentication_methods_setup_path) { root_path }
+    let(:locals) { { authentication_methods_setup_path: } }
 
     it 'renders additional troubleshooting option to two factor options' do
       expect(rendered).to have_link(
         t('two_factor_authentication.login_options_link_text'),
-        href: two_factor_options_path,
+        href: authentication_methods_setup_path,
       )
     end
 
@@ -58,7 +58,7 @@ RSpec.describe 'users/phone_setup/spam_protection.html.erb' do
     it 'does not render additional troubleshooting option to two factor options' do
       expect(rendered).to_not have_link(
         t('two_factor_authentication.login_options_link_text'),
-        href: two_factor_options_path,
+        href: authentication_methods_setup_path,
       )
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Replaces usage of deprecated URLs with their updated equivalent.

These were planned to be removed in #8982, where removing the routes altogether revealed that they're still referenced in a few places.

## 📜 Testing Plan

Expect that links in affected views continue to take the user where they'd expect to arrive.