### PR TITLE
LG-10593 Move redo_document_capture from flow_session to idv_session

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -74,7 +74,8 @@ module Idv
         step: 'document_capture',
         analytics_id: 'Doc Auth',
         irs_reproofing: irs_reproofing?,
-        redo_document_capture: flow_session[:redo_document_capture],
+        redo_document_capture:
+          idv_session.redo_document_capture || flow_session[:redo_document_capture],
       }.compact.merge(ab_test_analytics_buckets)
     end
 

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -20,6 +20,7 @@ module Idv
 
     def update
       flow_session['redo_document_capture'] = nil # done with this redo
+      idv_session.redo_document_capture = nil # done with this redo
       result = handle_stored_result
       analytics.idv_doc_auth_document_capture_submitted(**result.to_h.merge(analytics_arguments))
 
@@ -56,6 +57,7 @@ module Idv
 
     def confirm_document_capture_needed
       return if flow_session['redo_document_capture']
+      return if idv_session.redo_document_capture
 
       pii = flow_session['pii_from_doc'] # hash with indifferent access
       return if pii.blank? && !idv_session.verify_info_step_complete?

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -217,10 +217,10 @@ module Idv
 
     def setup_for_redo
       flow_session[:redo_document_capture] = true
+      idv_session.redo_document_capture = true
 
       # If we previously skipped hybrid handoff for the user (because they're on a mobile
       # device with a camera), skip it _again_ here.
-
       if idv_session.skip_hybrid_handoff?
         idv_session.flow_path = 'standard'
       else

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -49,6 +49,7 @@ module Idv
 
     def confirm_document_capture_needed
       return if flow_session['redo_document_capture']
+      return if idv_session.redo_document_capture
 
       pii = flow_session['pii_from_doc'] # hash with indifferent access
       return if pii.blank? && !idv_session.verify_info_step_complete?

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -25,8 +25,9 @@ module Idv
 
       if success
         # Don't allow the user to go back to document capture after verifying
-        if flow_session['redo_document_capture']
+        if flow_session['redo_document_capture'] || idv_session.redo_document_capture
           flow_session.delete('redo_document_capture')
+          idv_session.redo_document_capture = nil
           idv_session.flow_path ||= 'standard'
         end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -18,6 +18,7 @@ module Idv
       profile_confirmation
       profile_id
       profile_step_params
+      redo_document_capture
       resolution_successful
       skip_hybrid_handoff
       threatmetrix_review_status

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -81,8 +81,17 @@ RSpec.describe Idv::DocumentCaptureController do
     end
 
     context 'redo_document_capture' do
-      it 'adds redo_document_capture to analytics' do
+      it 'adds redo_document_capture to analytics using flow_session' do
         flow_session[:redo_document_capture] = true
+
+        get :show
+
+        analytics_args[:redo_document_capture] = true
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      end
+
+      it 'adds redo_document_capture to analytics using idv_session' do
+        subject.idv_session.redo_document_capture = true
 
         get :show
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-10593](https://cm-jira.usa.gov/browse/LG-10593)

## 🛠 Summary of changes

We are removing attributes from flow_session now that we are not using the Flow State Machine. The `redo_document_capture` attribute is used to track when someone clicks to redo document capture in VerifyInfo after a barcode read error.

Both the idv_session and flow_session values are being written and read in this PR to cover the 50/50 state during deployment. A followup PR #8992 will remove all references to `flow_session[:redo_document_capture]` and `flow_session['redo_document_capture']`. (flow_session is a hash with indifferent access)

## 📜 Testing Plan

- [ ] Create account
- [ ] Start IdV
- [ ] Choose Upload Documents, and upload a yml file with a barcode read error 
- [ ] Choose to Continue
- [ ] On the VerifyInfo page, click on the link to redo document capture.
- [ ] Check events.log: Expect the 'IdV: doc auth document_capture visited' analytics event to have attribute redo_document_capture: true
- [ ] Continue IdV and expect to get past VerifyInfo successfully