### PR TITLE
Log user authentication status when logging SAML Auth Request

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -6,12 +6,13 @@ module SamlIdpAuthConcern
     # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :validate_saml_request, only: :auth
     before_action :validate_service_provider_and_authn_context, only: :auth
+    before_action :check_sp_active, only: :auth
+    before_action :log_external_saml_auth_request, only: [:auth]
     # this must take place _before_ the store_saml_request action or the SAML
     # request is cleared (along with the rest of the session) when the user is
     # signed out
     before_action :sign_out_if_forceauthn_is_true_and_user_is_signed_in, only: :auth
     before_action :store_saml_request, only: :auth
-    before_action :check_sp_active, only: :auth
     # rubocop:enable Rails/LexicallyScopedActionFilter
   end
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -17,7 +17,6 @@ class SamlIdpController < ApplicationController
 
   skip_before_action :verify_authenticity_token
   before_action :require_path_year
-  before_action :log_external_saml_auth_request, only: [:auth]
   before_action :handle_banned_user
   before_action :bump_auth_count, only: :auth
   before_action :redirect_to_sign_in, only: :auth, unless: :user_signed_in?
@@ -134,6 +133,7 @@ class SamlIdpController < ApplicationController
       force_authn: saml_request&.force_authn?,
       final_auth_request: sp_session[:final_auth_request],
       service_provider: saml_request&.issuer,
+      user_fully_authenticated: user_fully_authenticated?,
     )
   end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -570,6 +570,7 @@ RSpec.describe SamlIdpController do
             requested_ial: authn_context,
             service_provider: sp1_issuer,
             force_authn: false,
+            user_fully_authenticated: true,
           })
         expect(@analytics).to receive(:track_event).
           with('SAML Auth', {
@@ -712,6 +713,7 @@ RSpec.describe SamlIdpController do
             requested_ial: 'ialmax',
             service_provider: sp1_issuer,
             force_authn: false,
+            user_fully_authenticated: true,
           })
         expect(@analytics).to receive(:track_event).
           with('SAML Auth', {
@@ -936,6 +938,7 @@ RSpec.describe SamlIdpController do
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: true,
+            user_fully_authenticated: false,
           })
 
         saml_get_auth(saml_settings(overrides: { force_authn: true }))
@@ -1566,6 +1569,7 @@ RSpec.describe SamlIdpController do
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
+            user_fully_authenticated: false,
           })
 
         saml_get_auth(saml_settings)
@@ -2011,6 +2015,7 @@ RSpec.describe SamlIdpController do
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
+            user_fully_authenticated: true,
           })
         expect(@analytics).to receive(:track_event).
           with('SAML Auth', analytics_hash)
@@ -2058,6 +2063,7 @@ RSpec.describe SamlIdpController do
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
+            user_fully_authenticated: true,
           })
         expect(@analytics).to receive(:track_event).with('SAML Auth', analytics_hash)
         expect(@analytics).to receive(:track_event).
@@ -2096,6 +2102,7 @@ RSpec.describe SamlIdpController do
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
+            user_fully_authenticated: true,
           })
         expect(@analytics).to receive(:track_event).with('SAML Auth', analytics_hash)
         expect(@analytics).to receive(:track_event).

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -410,7 +410,8 @@ RSpec.feature 'saml api' do
         [{ requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
            service_provider: 'http://localhost:3000',
            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-           force_authn: false }],
+           force_authn: false,
+           user_fully_authenticated: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
 
@@ -443,7 +444,8 @@ RSpec.feature 'saml api' do
       expect(fake_analytics.events['SAML Auth Request']).to eq(
         [{ requested_ial: 'http://idmanagement.gov/ns/assurance/ial/2',
            service_provider: 'saml_sp_ial2',
-           force_authn: false }],
+           force_authn: false,
+           user_fully_authenticated: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
 
@@ -469,7 +471,8 @@ RSpec.feature 'saml api' do
         [{ requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
            service_provider: 'http://localhost:3000',
            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-           force_authn: false }],
+           force_authn: false,
+           user_fully_authenticated: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
 


### PR DESCRIPTION
## 🛠 Summary of changes

We added some additional attributes to OIDC auth requests and ensure they are logged consistently in  https://github.com/18F/identity-idp/pull/8684 and #8798. This PR takes a similar approach to SAML auth requests by moving the logging before a few of the other `before_action` calls. Moving it prior to the `sign_out_if_forceauthn_is_true_and_user_is_signed_in` call allows us to log `user_fully_authenticated` like we do for OIDC to better understand the impact of ForceAuthn usage.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
