### PR TITLE
Remove internal uses of GET-based logout route

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -40,11 +40,15 @@ module Users
     end
 
     def destroy
-      analytics.logout_initiated(sp_initiated: false, oidc: false)
-      irs_attempts_api_tracker.logout_initiated(
-        success: true,
-      )
-      super
+      if request.method == 'GET' && IdentityConfig.store.disable_logout_get_request
+        redirect_to root_path
+      else
+        analytics.logout_initiated(sp_initiated: false, oidc: false)
+        irs_attempts_api_tracker.logout_initiated(
+          success: true,
+        )
+        super
+      end
     end
 
     private

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -16,7 +16,9 @@
       <span class="display-none tablet:display-inline padding-right-1 margin-right-1 border-right border-base-darker">
         <%= t('account.welcome') %> <strong><%= greeting %></strong>
       </span>
-      <%= link_to t('links.sign_out'), destroy_user_session_path %>
+
+      <%= button_to t('links.sign_out'), logout_path, method: :delete, class: 'usa-button usa-button--unstyled' %>
+
       <% if enable_mobile_nav %>
         <button class="usa-menu-btn margin-left-2"><%= t('account.navigation.menu') %></button>
       <% end %>

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -49,7 +49,10 @@
         t('continue', scope: modal_presenter.translation_scope),
       ) %>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) { link_to(destroy_user_session_path, **tag_options, &block) },
+        action: ->(**tag_options, &block) do
+          button_to(logout_path, **tag_options, &block)
+        end,
+        method: :delete,
         big: true,
         full_width: true,
         outline: true,

--- a/app/views/shared/_cancel.html.erb
+++ b/app/views/shared/_cancel.html.erb
@@ -2,6 +2,10 @@
   <% if user_signing_up? %>
     <%= link_to cancel_link_text, sign_up_cancel_path, method: :get, class: 'usa-button usa-button--unstyled' %>
   <% else %>
-    <%= link_to cancel_link_text, link || return_to_sp_cancel_path %>
+    <% if defined?(link_method) %>
+      <%= button_to cancel_link_text, link, method: link_method, class: 'usa-button usa-button--unstyled' %>
+    <% else %>
+      <%= link_to cancel_link_text, link %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -25,6 +25,6 @@
 
 <%= render 'shared/password_accordion' %>
 
-<%= render 'shared/cancel', link: destroy_user_session_path %>
+<%= render 'shared/cancel' %>
 
 <%= javascript_packs_tag_once 'pw-strength' %>

--- a/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
@@ -7,4 +7,4 @@
 <%= button_to t('forms.buttons.continue'), login_add_piv_cac_success_path,
               class: 'usa-button usa-button--big usa-button--wide', method: :post %>
 
-<%= render 'shared/cancel', link: destroy_user_session_path %>
+<%= render 'shared/cancel', link: logout_path, link_method: :delete %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -36,4 +36,4 @@
   <%= f.submit t('forms.buttons.continue'), class: 'margin-bottom-1' %>
 <% end %>
 
-<%= render 'shared/cancel', link: destroy_user_session_path %>
+<%= render 'shared/cancel', link: logout_path, link_method: :delete %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -78,6 +78,7 @@ deleted_user_accounts_report_configs: '[]'
 development_mailer_deliver_method: letter_opener
 disable_csp_unsafe_inline: true
 disable_email_sending: true
+disable_logout_get_request: true
 disallow_all_web_crawlers: true
 disposable_email_services: '[]'
 doc_auth_attempt_window_in_minutes: 360
@@ -438,6 +439,7 @@ production:
   database_worker_jobs_host: ''
   database_worker_jobs_password: ''
   disable_email_sending: false
+  disable_logout_get_request: false
   disallow_all_web_crawlers: false
   doc_auth_vendor: 'acuant'
   doc_auth_vendor_randomize: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -178,6 +178,7 @@ class IdentityConfig
     config.add(:development_mailer_deliver_method, type: :symbol, enum: [:file, :letter_opener])
     config.add(:disable_csp_unsafe_inline, type: :boolean)
     config.add(:disable_email_sending, type: :boolean)
+    config.add(:disable_logout_get_request, type: :boolean)
     config.add(:disallow_all_web_crawlers, type: :boolean)
     config.add(:disposable_email_services, type: :json)
     config.add(:doc_auth_attempt_window_in_minutes, type: :integer)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -5,25 +5,11 @@ RSpec.describe Users::SessionsController, devise: true do
   let(:mock_valid_site) { 'http://example.com' }
 
   describe 'GET /logout' do
-    it 'tracks a logout event' do
-      stub_analytics
-      stub_attempts_tracker
-      expect(@analytics).to receive(:track_event).with(
-        'Logout Initiated',
-        hash_including(
-          sp_initiated: false,
-          oidc: false,
-        ),
-      )
-
+    it 'does not log user out and redirects to root' do
       sign_in_as_user
-
-      expect(@irs_attempts_api_tracker).to receive(:logout_initiated).with(
-        success: true,
-      )
-
       get :destroy
-      expect(controller.current_user).to be nil
+      expect(controller.current_user).to_not be nil
+      expect(response).to redirect_to root_url
     end
   end
 

--- a/spec/features/idv/clearing_and_restarting_spec.rb
+++ b/spec/features/idv/clearing_and_restarting_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'clearing IdV and restarting' do
     context 'after signing out' do
       before do
         visit account_path
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         start_idv_from_sp
         sign_in_live_with_2fa(user)
       end

--- a/spec/features/idv/steps/gpo_step_spec.rb
+++ b/spec/features/idv/steps/gpo_step_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature 'idv gpo step' do
       click_continue
       visit root_path
       click_on t('idv.gpo.return_to_profile')
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
     end
 
     def complete_idv_and_return_to_gpo_step

--- a/spec/features/multiple_emails/sign_in_spec.rb
+++ b/spec/features/multiple_emails/sign_in_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'sign in with any email address' do
 
     expect(page).to have_current_path(account_path)
 
-    first(:link, t('links.sign_out')).click
+    first(:button, t('links.sign_out')).click
 
     signin(email2, user.password)
     fill_in_code_with_last_phone_otp

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -797,7 +797,9 @@ RSpec.describe 'OpenID Connect' do
       uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
-      visit destroy_user_session_url
+
+      visit account_path
+      click_button t('links.sign_out')
 
       visit_idp_from_ial1_oidc_sp(prompt: 'select_account')
       fill_in_credentials_and_submit(user.email, user.password)

--- a/spec/features/remember_device/phone_spec.rb
+++ b/spec/features/remember_device/phone_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Remembering a phone' do
       check t('forms.messages.remember_device')
       fill_in_code_with_last_phone_otp
       click_submit_default
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
       user
     end
 
@@ -36,7 +36,7 @@ RSpec.feature 'Remembering a phone' do
       click_submit_default
       skip_second_mfa_prompt
 
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
       user
     end
 

--- a/spec/features/remember_device/revocation_spec.rb
+++ b/spec/features/remember_device/revocation_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'taking an action that revokes remember device' do
       find_sidenav_forget_browsers_link.click
       click_on(t('forms.buttons.confirm'))
 
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
 
       expect_mfa_to_be_required_for_user(user)
     end
@@ -34,7 +34,7 @@ RSpec.feature 'taking an action that revokes remember device' do
         find_sidenav_forget_browsers_link.click
         click_on(t('forms.buttons.confirm'))
 
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
 
         expect_mfa_to_be_required_for_user(user)
       end
@@ -51,7 +51,7 @@ RSpec.feature 'taking an action that revokes remember device' do
     check t('forms.messages.remember_device')
     fill_in_code_with_last_phone_otp
     click_submit_default
-    first(:link, t('links.sign_out')).click
+    first(:button, t('links.sign_out')).click
   end
 
   def expect_mfa_to_be_required_for_user(user)

--- a/spec/features/remember_device/session_expiration_spec.rb
+++ b/spec/features/remember_device/session_expiration_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'signing in with remember device and idling on the sign in page' 
     check t('forms.messages.remember_device')
     fill_in_code_with_last_phone_otp
     click_submit_default
-    first(:link, t('links.sign_out')).click
+    first(:button, t('links.sign_out')).click
 
     IdentityLinker.new(
       user, build(:service_provider, issuer: OidcAuthHelper::OIDC_IAL1_ISSUER)

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'remember device sp expiration' do
     click_submit_default
     skip_second_mfa_prompt
 
-    first(:link, t('links.sign_out')).click
+    first(:button, t('links.sign_out')).click
     user_record
   end
 

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Remembering a TOTP device' do
       fill_in :code, with: generate_totp_code(user.auth_app_configurations.first.otp_secret_key)
       check t('forms.messages.remember_device')
       click_submit_default
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
       user
     end
 
@@ -32,7 +32,7 @@ RSpec.describe 'Remembering a TOTP device' do
       click_submit_default
       skip_second_mfa_prompt
 
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
       user
     end
 
@@ -52,7 +52,7 @@ RSpec.describe 'Remembering a TOTP device' do
       check t('forms.messages.remember_device')
       click_submit_default
       expect(page).to have_current_path(account_two_factor_authentication_path)
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
       user
     end
 

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Unchecking remember device' do
         click_button 'Submit'
         skip_second_mfa_prompt
 
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         sign_in_user(user)
       end
 
@@ -44,7 +44,7 @@ RSpec.describe 'Unchecking remember device' do
         click_continue
         skip_second_mfa_prompt
 
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         sign_in_user(user)
       end
 
@@ -72,7 +72,7 @@ RSpec.describe 'Unchecking remember device' do
         click_submit_default
         skip_second_mfa_prompt
 
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         sign_in_user(user)
       end
 
@@ -92,7 +92,7 @@ RSpec.describe 'Unchecking remember device' do
         fill_in :code, with: generate_totp_code(user.auth_app_configurations.first.otp_secret_key)
         uncheck t('forms.messages.remember_device')
         click_submit_default
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         sign_in_user(user)
       end
 
@@ -119,7 +119,7 @@ RSpec.describe 'Unchecking remember device' do
         sign_in_user(user)
         uncheck(:remember_device)
         mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
 
         sign_in_user(user)
       end
@@ -138,7 +138,7 @@ RSpec.describe 'Unchecking remember device' do
         uncheck t('forms.messages.remember_device')
         fill_in_code_with_last_phone_otp
         click_submit_default
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
 
         sign_in_user(user)
       end

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Remembering a webauthn device' do
         sign_in_user(user)
         check t('forms.messages.remember_device')
         mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         user
       end
 
@@ -46,7 +46,7 @@ RSpec.describe 'Remembering a webauthn device' do
         mock_press_button_on_hardware_key_on_setup
         skip_second_mfa_prompt
 
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         user
       end
 
@@ -64,7 +64,7 @@ RSpec.describe 'Remembering a webauthn device' do
         check t('forms.messages.remember_device')
         mock_press_button_on_hardware_key_on_setup
         expect(page).to have_current_path(account_two_factor_authentication_path)
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         user
       end
 
@@ -89,7 +89,7 @@ RSpec.describe 'Remembering a webauthn device' do
         sign_in_user(user)
         check t('forms.messages.remember_device')
         mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         user
       end
 
@@ -140,7 +140,7 @@ RSpec.describe 'Remembering a webauthn device' do
         fill_in_code_with_last_phone_otp
         click_submit_default
 
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         user
       end
 
@@ -157,7 +157,7 @@ RSpec.describe 'Remembering a webauthn device' do
         check t('forms.messages.remember_device')
         mock_press_button_on_hardware_key_on_setup
         expect(page).to have_current_path(account_two_factor_authentication_path)
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         user
       end
 

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'IAL2 Single Sign On' do
   end
 
   def sign_out_user
-    first(:link, t('links.sign_out')).click
+    first(:button, t('links.sign_out')).click
   end
 
   context 'First time registration' do

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'SAML logout' do
 
         # Sign out of the IDP
         visit account_path
-        first(:link, t('links.sign_out')).click
+        first(:button, t('links.sign_out')).click
         expect(current_path).to eq root_path
 
         # SAML logout request

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -88,6 +88,6 @@ RSpec.feature 'sign up with backup code' do
   end
 
   def sign_out_user
-    first(:link, t('links.sign_out')).click
+    first(:button, t('links.sign_out')).click
   end
 end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -336,7 +336,7 @@ RSpec.feature 'Sign in' do
     end
 
     scenario 'user can continue browsing with refreshed CSRF token' do
-      token = find('[name=authenticity_token]', visible: false).value
+      token = first('[name=authenticity_token]', visible: false).value
       click_button t('notices.timeout_warning.signed_in.continue')
       expect(page).not_to have_css('.usa-js-modal--active')
       expect(page).to have_css(
@@ -347,7 +347,7 @@ RSpec.feature 'Sign in' do
     end
 
     scenario 'user has option to sign out' do
-      click_link(t('notices.timeout_warning.signed_in.sign_out'))
+      click_button(t('notices.timeout_warning.signed_in.sign_out'))
 
       expect(page).to have_content t('devise.sessions.signed_out')
       expect(current_path).to eq new_user_session_path
@@ -394,7 +394,7 @@ RSpec.feature 'Sign in' do
 
     it 'fails to sign in the user, with CSRF error' do
       user = sign_in_and_2fa_user
-      click_link(t('links.sign_out'), match: :first)
+      click_button(t('links.sign_out'), match: :first)
 
       travel(Devise.timeout_in + 1.minute) do
         expect(page).to_not have_content(t('forms.buttons.continue'))

--- a/spec/features/users/sign_out_spec.rb
+++ b/spec/features/users/sign_out_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Sign out' do
   scenario 'user signs out successfully' do
     sign_in_and_2fa_user
-    click_link(t('links.sign_out'), match: :first)
+    click_button(t('links.sign_out'), match: :first)
 
     expect(page).to have_content t('devise.sessions.signed_out')
   end

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -72,8 +72,8 @@ RSpec.feature 'Email confirmation during sign up' do
     it 'redirects to sign in page with message that user is already confirmed' do
       allow(IdentityConfig.store).to receive(:participate_in_dap).and_return(true)
       sign_up_and_set_password
+      logout(:user)
 
-      visit destroy_user_session_url
       visit sign_up_create_email_confirmation_url(confirmation_token: @raw_confirmation_token)
 
       expect(page.html).to include(t('notices.dap_participation'))

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -72,7 +72,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       fill_in 'Password', with: user.password
       click_continue
       acknowledge_and_confirm_personal_key
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
     end
 
     it 'does not require verification and hands off successfully' do
@@ -107,7 +107,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       acknowledge_and_confirm_personal_key
       click_agree_and_continue
       visit account_path
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
     end
 
     it 'does not require idv or requested attribute verification and hands off successfully' do

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples 'sp requesting attributes' do |sp|
       acknowledge_and_confirm_personal_key
       click_agree_and_continue
       visit account_path
-      first(:link, t('links.sign_out')).click
+      first(:button, t('links.sign_out')).click
     end
 
     it 'does not require the user to verify attributes' do

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples 'remember device' do
     click_submit_default
 
     # Sign out second user
-    first(:link, t('links.sign_out')).click
+    first(:button, t('links.sign_out')).click
 
     # Sign in as first user again and expect otp confirmation
     sign_in_user(first_user)

--- a/spec/views/accounts/_nav_auth.html.erb_spec.rb
+++ b/spec/views/accounts/_nav_auth.html.erb_spec.rb
@@ -19,11 +19,14 @@ RSpec.describe 'accounts/_nav_auth.html.erb' do
     end
 
     it 'does not contain link to cancel the auth process' do
-      expect(rendered).not_to have_link(t('links.cancel'), href: destroy_user_session_path)
+      expect(rendered).not_to have_link(t('links.cancel'))
     end
 
     it 'contains sign out link' do
-      expect(rendered).to have_link(t('links.sign_out'), href: destroy_user_session_path)
+      expect(rendered).to have_button(t('links.sign_out'))
+      expect(rendered).to have_selector('form') do |f|
+        expect(f['action']).to eq logout_path
+      end
     end
   end
 

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'layouts/application.html.erb' do
 
       expect(rendered).to have_css('.page-header--basic')
       expect(rendered).to_not have_content(t('account.welcome'))
-      expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
+      expect(rendered).to_not have_button(t('links.sign_out'))
+      expect(rendered).to_not have_selector('form')
     end
   end
 

--- a/spec/views/shared/_nav_lite.html.erb_spec.rb
+++ b/spec/views/shared/_nav_lite.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'shared/_nav_lite.html.erb' do
     it 'does not contain sign out link' do
       render
 
-      expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
+      expect(rendered).to_not have_button(t('links.sign_out'))
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Back in https://github.com/18F/identity-idp/pull/6436 and based on discussion in this [thread](https://gsa-tts.slack.com/archives/C0NGESUN5/p1654010545842009), we added a DELETE logout route with the intention of switching usage to it, but never changed over.

This PR switches all of our internal usage to the DELETE form, and adds a config for disabling the usage of the GET route.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
