### PR TITLE
Switch AAL2 remembered device expiration configuration units from hours to minutes

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -85,7 +85,7 @@ class ServiceProviderSessionDecorator
 
   def mfa_expiration_interval
     aal_1_expiration = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
-    aal_2_expiration = IdentityConfig.store.remember_device_expiration_hours_aal_2.hours
+    aal_2_expiration = IdentityConfig.store.remember_device_expiration_minutes_aal_2.minutes
     return aal_2_expiration if sp_aal > 1
     return aal_2_expiration if sp_ial > 1
     return aal_2_expiration if requested_aal > 1

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -273,7 +273,7 @@ reg_unconfirmed_email_max_attempts: 20
 reg_unconfirmed_email_window_in_minutes: 60
 reject_id_token_hint_in_logout: false
 remember_device_expiration_hours_aal_1: 720
-remember_device_expiration_hours_aal_2: 0
+remember_device_expiration_minutes_aal_2: 0
 report_timeout: 0
 requests_per_ip_cidr_allowlist: ''
 requests_per_ip_limit: 300

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -397,7 +397,7 @@ class IdentityConfig
     config.add(:reg_unconfirmed_email_window_in_minutes, type: :integer)
     config.add(:reject_id_token_hint_in_logout, type: :boolean)
     config.add(:remember_device_expiration_hours_aal_1, type: :integer)
-    config.add(:remember_device_expiration_hours_aal_2, type: :integer)
+    config.add(:remember_device_expiration_minutes_aal_2, type: :integer)
     config.add(:report_timeout, type: :integer)
     config.add(:requests_per_ip_cidr_allowlist, type: :comma_separated_string_list)
     config.add(:requests_per_ip_limit, type: :integer)

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'remember device sp expiration' do
   AAL1_REMEMBER_DEVICE_EXPIRATION =
     IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
   AAL2_REMEMBER_DEVICE_EXPIRATION =
-    IdentityConfig.store.remember_device_expiration_hours_aal_2.hours
+    IdentityConfig.store.remember_device_expiration_minutes_aal_2.minutes
 
   let(:user) do
     user_record = sign_up_and_set_password


### PR DESCRIPTION
## 🛠 Summary of changes

In #8926, we switched the default to 0 hours, which is now consistent in all live environments. However, using hours as the unit of time is limiting. NIST 800-63B specifies one of the [AAL2 re-authentication limits](https://pages.nist.gov/800-63-3/sp800-63b.html#423-reauthentication) as 30 minutes, which we would not be able to do at the moment. We do not have any timeline for changing the value from zero, but this PR switches the unit of time to minutes to give us flexibility moving forward.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
