### PR TITLE
Jmax/lg 9565 two week gpo letter reminder email

### DIFF
--- a/app/jobs/gpo_reminder_job.rb
+++ b/app/jobs/gpo_reminder_job.rb
@@ -4,13 +4,7 @@ class GpoReminderJob < ApplicationJob
   # Send email reminders to people with USPS proofing letters whose
   # letters were sent a while ago, and haven't yet entered their code
   def perform(cutoff_time_for_sending_reminders)
-    GpoReminderSender.new(analytics).
+    GpoReminderSender.new.
       send_emails(cutoff_time_for_sending_reminders)
-  end
-
-  private
-
-  def analytics(user: AnonymousUser.new)
-    Analytics.new(user: user, request: nil, session: {}, sp: nil)
   end
 end

--- a/app/jobs/gpo_reminder_job.rb
+++ b/app/jobs/gpo_reminder_job.rb
@@ -1,0 +1,9 @@
+class GpoReminderJob < ApplicationJob
+  queue_as :low
+
+  # Send email reminders to people with USPS proofing letters whose
+  # letters were sent a while ago, and haven't yet entered their code
+  def perform(cutoff_time_for_sending_reminders)
+    GpoReminderSender.new.send_emails(cutoff_time_for_sending_reminders)
+  end
+end

--- a/app/jobs/gpo_reminder_job.rb
+++ b/app/jobs/gpo_reminder_job.rb
@@ -4,6 +4,13 @@ class GpoReminderJob < ApplicationJob
   # Send email reminders to people with USPS proofing letters whose
   # letters were sent a while ago, and haven't yet entered their code
   def perform(cutoff_time_for_sending_reminders)
-    GpoReminderSender.new.send_emails(cutoff_time_for_sending_reminders)
+    GpoReminderSender.new(analytics).
+      send_emails(cutoff_time_for_sending_reminders)
+  end
+
+  private
+
+  def analytics(user: AnonymousUser.new)
+    Analytics.new(user: user, request: nil, session: {}, sp: nil)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -393,11 +393,10 @@ class UserMailer < ActionMailer::Base
 
   def gpo_reminder
     with_user_locale(user) do
-      @date_letter_was_sent = user.
-        pending_profile.
-        gpo_verification_pending_at.
-        strftime(I18n.t('time.formats.event_date'))
-
+      @date_letter_was_sent = I18n.l(
+        user.gpo_verification_pending_profile.gpo_verification_pending_at,
+        format: :event_date,
+      )
       mail(to: email_address.email, subject: t('idv.messages.gpo_reminder.subject'))
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -397,7 +397,7 @@ class UserMailer < ActionMailer::Base
       raw_date_letter_was_sent = Time.zone.now - 2.weeks
       @date_letter_was_sent = raw_date_letter_was_sent.strftime(I18n.t('time.formats.event_date'))
 
-      mail(to: email_address.email, subject: "Finish verifying your identity")
+      mail(to: email_address.email, subject: t('idv.messages.gpo_reminder.subject'))
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -393,7 +393,7 @@ class UserMailer < ActionMailer::Base
 
   def gpo_reminder
     with_user_locale(user) do
-      @date_letter_was_sent = I18n.l(
+      @gpo_verification_pending_at = I18n.l(
         user.gpo_verification_pending_profile.gpo_verification_pending_at,
         format: :event_date,
       )

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -391,6 +391,12 @@ class UserMailer < ActionMailer::Base
     end
   end
 
+  def gpo_reminder
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: "GPO reminder")
+    end
+  end
+
   private
 
   def email_should_receive_nonessential_notifications?(email)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -393,7 +393,11 @@ class UserMailer < ActionMailer::Base
 
   def gpo_reminder
     with_user_locale(user) do
-      mail(to: email_address.email, subject: "GPO reminder")
+      # raw_date_letter_was_sent = user&.pending_profile&.gpo_verification_pending_at
+      raw_date_letter_was_sent = Time.zone.now - 2.weeks
+      @date_letter_was_sent = raw_date_letter_was_sent.strftime(I18n.t('time.formats.event_date'))
+
+      mail(to: email_address.email, subject: "Finish verifying your identity")
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -393,9 +393,10 @@ class UserMailer < ActionMailer::Base
 
   def gpo_reminder
     with_user_locale(user) do
-      # raw_date_letter_was_sent = user&.pending_profile&.gpo_verification_pending_at
-      raw_date_letter_was_sent = Time.zone.now - 2.weeks
-      @date_letter_was_sent = raw_date_letter_was_sent.strftime(I18n.t('time.formats.event_date'))
+      @date_letter_was_sent = user.
+        pending_profile.
+        gpo_verification_pending_at.
+        strftime(I18n.t('time.formats.event_date'))
 
       mail(to: email_address.email, subject: t('idv.messages.gpo_reminder.subject'))
     end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1037,7 +1037,7 @@ module AnalyticsEvents
 
   # A GPO reminder email was sent to the user
   # @param [String] to_user UUID of user who we sent a reminder to
-  def idv_gpo_reminder_email_sent(to_user: )
+  def idv_gpo_reminder_email_sent(to_user:)
     track_event('IdV: gpo reminder email sent', to_user: to_user)
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1036,8 +1036,8 @@ module AnalyticsEvents
   end
 
   # A GPO reminder email was sent to the user
-  # @param [String] to_user UUID of user who we sent a reminder to
-  def idv_gpo_reminder_email_sent(user_id:)
+  # @param [String] user_id UUID of user who we sent a reminder to
+  def idv_gpo_reminder_email_sent(user_id:, **_extra)
     track_event('IdV: gpo reminder email sent', user_id: user_id)
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1037,8 +1037,8 @@ module AnalyticsEvents
 
   # A GPO reminder email was sent to the user
   # @param [String] user_id UUID of user who we sent a reminder to
-  def idv_gpo_reminder_email_sent(user_id:, **_extra)
-    track_event('IdV: gpo reminder email sent', user_id: user_id)
+  def idv_gpo_reminder_email_sent(user_id:, **extra)
+    track_event('IdV: gpo reminder email sent', user_id: user_id, **extra)
   end
 
   # @identity.idp.previous_event_name Account verification submitted

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1035,6 +1035,12 @@ module AnalyticsEvents
     track_event('IdV: gpo confirm start over visited')
   end
 
+  # A GPO reminder email was sent to the user
+  # @param [String] to_user UUID of user who we sent a reminder to
+  def idv_gpo_reminder_email_sent(to_user: )
+    track_event('IdV: gpo reminder email sent', to_user: to_user)
+  end
+
   # @identity.idp.previous_event_name Account verification submitted
   # @param [Boolean] success
   # @param [Hash] errors

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1037,8 +1037,8 @@ module AnalyticsEvents
 
   # A GPO reminder email was sent to the user
   # @param [String] to_user UUID of user who we sent a reminder to
-  def idv_gpo_reminder_email_sent(to_user:)
-    track_event('IdV: gpo reminder email sent', to_user: to_user)
+  def idv_gpo_reminder_email_sent(user_id:)
+    track_event('IdV: gpo reminder email sent', user_id: user_id)
   end
 
   # @identity.idp.previous_event_name Account verification submitted

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,10 +1,11 @@
 class GpoReminderSender
   def send_emails
-    profiles = Profile# joins(:usps_confirmation_codes)
-                 .where(gpo_verification_pending_at: ..(Time.zone.now - 14.days))
-                 # .where(reminder_sent_at: nil)
-
-    profiles.each do |profile|
+    profiles_due_for_reminder = Profile.joins(:gpo_confirmation_codes).
+      where(
+        gpo_verification_pending_at: ..(Time.zone.now - 14.days),
+        gpo_confirmation_codes: { reminder_sent_at: nil },
+      )
+    profiles_due_for_reminder.each do |profile|
       profile.user.send_email_to_all_addresses(:gpo_reminder)
     end
   end

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,5 +1,7 @@
 class GpoReminderSender
   def send_emails
-
+    Profile.where.not(gpo_verification_pending_at: nil).each do |profile|
+      profile.user.send_email_to_all_addresses(:gpo_reminder)
+    end
   end
 end

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,10 +1,11 @@
 class GpoReminderSender
-  def send_emails
+  def send_emails(for_letters_sent_before)
     profiles_due_for_reminder = Profile.joins(:gpo_confirmation_codes).
       where(
-        gpo_verification_pending_at: ..(Time.zone.now - 14.days),
+        gpo_verification_pending_at: ..for_letters_sent_before,
         gpo_confirmation_codes: { reminder_sent_at: nil },
       )
+
     profiles_due_for_reminder.each do |profile|
       profile.user.send_email_to_all_addresses(:gpo_reminder)
     end

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,0 +1,5 @@
+class GpoReminderSender
+  def send_emails
+
+  end
+end

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,6 +1,10 @@
 class GpoReminderSender
   def send_emails
-    Profile.where.not(gpo_verification_pending_at: nil).each do |profile|
+    profiles = Profile# joins(:usps_confirmation_codes)
+                 .where(gpo_verification_pending_at: ..(Time.zone.now - 14.days))
+                 # .where(reminder_sent_at: nil)
+
+    profiles.each do |profile|
       profile.user.send_email_to_all_addresses(:gpo_reminder)
     end
   end

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,8 +1,4 @@
 class GpoReminderSender
-  def initialize(analytics)
-    @analytics = analytics
-  end
-
   def send_emails(for_letters_sent_before)
     profiles_due_for_reminder = Profile.joins(:gpo_confirmation_codes).
       where(
@@ -12,7 +8,14 @@ class GpoReminderSender
 
     profiles_due_for_reminder.each do |profile|
       profile.user.send_email_to_all_addresses(:gpo_reminder)
-      @analytics.idv_gpo_reminder_email_sent(user_id: profile.user.uuid)
+      profile.gpo_confirmation_codes.first.update(reminder_sent_at: Time.zone.now)
+      analytics.idv_gpo_reminder_email_sent(user_id: profile.user.uuid)
     end
+  end
+
+  private
+
+  def analytics
+    Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
   end
 end

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -12,7 +12,7 @@ class GpoReminderSender
 
     profiles_due_for_reminder.each do |profile|
       profile.user.send_email_to_all_addresses(:gpo_reminder)
-      @analytics.idv_gpo_reminder_email_sent(to_user: profile.user.uuid)
+      @analytics.idv_gpo_reminder_email_sent(user_id: profile.user.uuid)
     end
   end
 end

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,4 +1,8 @@
 class GpoReminderSender
+  def initialize(analytics)
+    @analytics = analytics
+  end
+
   def send_emails(for_letters_sent_before)
     profiles_due_for_reminder = Profile.joins(:gpo_confirmation_codes).
       where(
@@ -8,6 +12,7 @@ class GpoReminderSender
 
     profiles_due_for_reminder.each do |profile|
       profile.user.send_email_to_all_addresses(:gpo_reminder)
+      @analytics.idv_gpo_reminder_email_sent(to_user: profile.user.uuid)
     end
   end
 end

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -1,10 +1,5 @@
 <p>
-  <%= t(
-        'idv.messages.gpo_reminder.body_html',
-        date_letter_was_sent: @date_letter_was_sent,
-        app_name: APP_NAME,
-      ) %>
-  <%= link_to(
+  <%= help_link = link_to(
         t('idv.troubleshooting.options.learn_more_verify_by_mail'),
         help_center_redirect_url(
           category: 'verify-your-identity',
@@ -13,6 +8,13 @@
           step: :gpo_send_letter,
         ),
         { style: "text-decoration: 'underline'" },
+      )
+
+      t(
+        'idv.messages.gpo_reminder.body_html',
+        date_letter_was_sent: @date_letter_was_sent,
+        app_name: APP_NAME,
+        help_link: help_link,
       ) %>
 </p>
 

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -40,7 +40,7 @@
         'idv.messages.gpo_reminder.did_not_get_a_letter_html',
         another_letter_link: link_to(
           t('idv.messages.gpo_reminder.sign_in_and_request_another_letter'),
-          idv_gpo_verify_url,
+          idv_gpo_verify_url(did_not_receive_letter: 1),
           { style: "text-decoration: 'underline'" },
         ),
       ) %>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -20,7 +20,7 @@
             <tr>
               <td style="text-align: center">
                 <%= link_to t('idv.messages.gpo_reminder.finish'),
-                            new_user_password_url,
+                            idv_gpo_verify_url,
                             target: '_blank',
                             class: 'float-center',
                             align: 'center',
@@ -40,7 +40,7 @@
         'idv.messages.gpo_reminder.did_not_get_a_letter_html',
         another_letter_link: link_to(
           t('idv.messages.gpo_reminder.sign_in_and_request_another_letter'),
-          'https://www.google.com',
+          idv_gpo_url,
           { style: "text-decoration: 'underline'" },
         ),
       ) %>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -12,7 +12,7 @@
 
       t(
         'idv.messages.gpo_reminder.body_html',
-        date_letter_was_sent: @date_letter_was_sent,
+        date_letter_was_sent: @gpo_verification_pending_at,
         app_name: APP_NAME,
         help_link: help_link,
       ) %>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -2,6 +2,7 @@
   <%= t(
         'idv.messages.gpo_reminder.body_html',
         date_letter_was_sent: @date_letter_was_sent,
+        app_name: APP_NAME,
       ) %>
   <%= link_to(
         t('idv.troubleshooting.options.learn_more_verify_by_mail'),

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -1,25 +1,34 @@
 <p>
-  This is actually the shiny new GPO reminder email.
+  You requested a letter to verify your identity
+  on <strong><%= @date_letter_was_sent %></strong>. You'll need to
+  enter the code from the letter to finish verifying your identity.
+  <a href="https://www.google.com">Learn more about verifying your address by mail.</a>
 </p>
 
-<p class="lead">
-  <%= t('user_mailer.account_rejected.intro', app_name: APP_NAME) %>
-</p>
-
-<table class="spacer">
+<table class="button expanded large radius">
   <tbody>
     <tr>
-      <td class="s10" height="10px">
-          &nbsp;
+      <td>
+        <table style="margin-bottom: 1em; margin-top: 1em">
+          <tbody>
+            <tr>
+              <td style="text-align: center">
+                  <%= link_to "Finish verifying your identity",
+                              new_user_password_url,
+                              target: '_blank',
+                              class: 'float-center',
+                              align: 'center',
+                              rel: 'noopener' %>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </td>
+      <td class="expander"></td>
     </tr>
   </tbody>
 </table>
 
-<table class="hr">
-  <tr>
-    <th>
-      &nbsp;
-    </th>
-  </tr>
-</table>
+<p>
+  If you didn't get this letter, <a href="https://www.google.com">sign in to request another letter.</a>
+</p>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -1,8 +1,17 @@
 <p>
-  You requested a letter to verify your identity
-  on <strong><%= @date_letter_was_sent %></strong>. You'll need to
-  enter the code from the letter to finish verifying your identity.
-  <a href="https://www.google.com">Learn more about verifying your address by mail.</a>
+  <%=
+    t(
+      'idv.messages.gpo_reminder.body_html',
+      date_letter_was_sent: @date_letter_was_sent,
+    )
+  %>
+  <%=
+    link_to(
+      t('idv.troubleshooting.options.learn_more_verify_by_mail'),
+      "https://www.google.com",
+      {style: "text-decoration: 'underline'"},
+     )
+  %>
 </p>
 
 <table class="button expanded large radius">
@@ -13,7 +22,7 @@
           <tbody>
             <tr>
               <td style="text-align: center">
-                  <%= link_to "Finish verifying your identity",
+                <%= link_to t('idv.messages.gpo_reminder.finish'),
                               new_user_password_url,
                               target: '_blank',
                               class: 'float-center',
@@ -30,5 +39,12 @@
 </table>
 
 <p>
-  If you didn't get this letter, <a href="https://www.google.com">sign in to request another letter.</a>
+  <%= t('idv.messages.gpo_reminder.did_not_get_a_letter') %>
+  <%=
+    link_to(
+      t('idv.messages.gpo_reminder.request_another_letter'),
+      'https://www.google.com',
+       {style: "text-decoration: 'underline'"}
+    )
+  %>
 </p>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -6,7 +6,12 @@
       ) %>
   <%= link_to(
         t('idv.troubleshooting.options.learn_more_verify_by_mail'),
-        'https://www.google.com',
+          help_center_redirect_url(
+            category: 'verify-your-identity',
+            article: 'verify-your-address-by-mail',
+            flow: :idv,
+            step: :gpo_send_letter,
+          ),
         { style: "text-decoration: 'underline'" },
       ) %>
 </p>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -6,12 +6,12 @@
       ) %>
   <%= link_to(
         t('idv.troubleshooting.options.learn_more_verify_by_mail'),
-          help_center_redirect_url(
-            category: 'verify-your-identity',
-            article: 'verify-your-address-by-mail',
-            flow: :idv,
-            step: :gpo_send_letter,
-          ),
+        help_center_redirect_url(
+          category: 'verify-your-identity',
+          article: 'verify-your-address-by-mail',
+          flow: :idv,
+          step: :gpo_send_letter,
+        ),
         { style: "text-decoration: 'underline'" },
       ) %>
 </p>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -1,17 +1,13 @@
 <p>
-  <%=
-    t(
-      'idv.messages.gpo_reminder.body_html',
-      date_letter_was_sent: @date_letter_was_sent,
-    )
-  %>
-  <%=
-    link_to(
-      t('idv.troubleshooting.options.learn_more_verify_by_mail'),
-      "https://www.google.com",
-      {style: "text-decoration: 'underline'"},
-     )
-  %>
+  <%= t(
+        'idv.messages.gpo_reminder.body_html',
+        date_letter_was_sent: @date_letter_was_sent,
+      ) %>
+  <%= link_to(
+        t('idv.troubleshooting.options.learn_more_verify_by_mail'),
+        'https://www.google.com',
+        { style: "text-decoration: 'underline'" },
+      ) %>
 </p>
 
 <table class="button expanded large radius">
@@ -23,11 +19,11 @@
             <tr>
               <td style="text-align: center">
                 <%= link_to t('idv.messages.gpo_reminder.finish'),
-                              new_user_password_url,
-                              target: '_blank',
-                              class: 'float-center',
-                              align: 'center',
-                              rel: 'noopener' %>
+                            new_user_password_url,
+                            target: '_blank',
+                            class: 'float-center',
+                            align: 'center',
+                            rel: 'noopener' %>
               </td>
             </tr>
           </tbody>
@@ -39,12 +35,12 @@
 </table>
 
 <p>
-  <%= t('idv.messages.gpo_reminder.did_not_get_a_letter') %>
-  <%=
-    link_to(
-      t('idv.messages.gpo_reminder.request_another_letter'),
-      'https://www.google.com',
-       {style: "text-decoration: 'underline'"}
-    )
-  %>
+  <%= t(
+        'idv.messages.gpo_reminder.did_not_get_a_letter_html',
+        another_letter_link: link_to(
+          t('idv.messages.gpo_reminder.sign_in_and_request_another_letter'),
+          'https://www.google.com',
+          { style: "text-decoration: 'underline'" },
+        ),
+      ) %>
 </p>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -40,7 +40,7 @@
         'idv.messages.gpo_reminder.did_not_get_a_letter_html',
         another_letter_link: link_to(
           t('idv.messages.gpo_reminder.sign_in_and_request_another_letter'),
-          idv_gpo_url,
+          idv_gpo_verify_url,
           { style: "text-decoration: 'underline'" },
         ),
       ) %>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -1,0 +1,25 @@
+<p>
+  This is actually the shiny new GPO reminder email.
+</p>
+
+<p class="lead">
+  <%= t('user_mailer.account_rejected.intro', app_name: APP_NAME) %>
+</p>
+
+<table class="spacer">
+  <tbody>
+    <tr>
+      <td class="s10" height="10px">
+          &nbsp;
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="hr">
+  <tr>
+    <th>
+      &nbsp;
+    </th>
+  </tr>
+</table>

--- a/app/views/user_mailer/gpo_reminder.html.erb
+++ b/app/views/user_mailer/gpo_reminder.html.erb
@@ -43,7 +43,7 @@
 <p>
   <%= t(
         'idv.messages.gpo_reminder.did_not_get_a_letter_html',
-        another_letter_link: link_to(
+        another_letter_link_html: link_to(
           t('idv.messages.gpo_reminder.sign_in_and_request_another_letter'),
           idv_gpo_verify_url(did_not_receive_letter: 1),
           { style: "text-decoration: 'underline'" },

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -186,7 +186,7 @@ else
       send_gpo_code_reminders: {
         class: 'GpoReminderJob',
         cron: cron_24h,
-        args: -> { [Time.zone.now - 14.days] },
+        args: -> { [14.days.ago] },
       },
     }.compact
   end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -182,6 +182,12 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.today] },
       },
+      # Send reminder letters for old, outstanding GPO verification codes
+      send_gpo_code_reminders: {
+        class: 'GpoReminderJob',
+        cron: cron_24h,
+        args: -> { [Time.zone.now - 14.days] },
+      },
     }.compact
   end
   # rubocop:enable Metrics/BlockLength

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -237,8 +237,8 @@ en:
         body_html: You requested a letter to verify your identity on
           <strong>%{date_letter_was_sent}</strong>. You’ll need to enter the
           code from the letter to finish verifying your identity. Sign back in
-          to %{app_name} to finish verifying your identity.
-        did_not_get_a_letter_html: If you didn’t get this letter, %{another_letter_link_html}
+          to %{app_name} to finish verifying your identity. %{help_link}.
+        did_not_get_a_letter_html: If you didn’t get this letter, %{another_letter_link_html}.
         finish: Finish verifying your identity
         sign_in_and_request_another_letter: sign in to request another letter
         subject: Finish verifying your identity

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -233,6 +233,16 @@ en:
         resend_timeframe: Letters typically take 3 to 7 business days to arrive.
         timeframe_html: Letters are sent the next business day via USPS First Class Mail
           and <strong>typically take 3 to 7 business days to arrive</strong>.
+      gpo_reminder:
+        body_html: You requested a letter to verify your identity on
+          <strong>%{date_letter_was_sent}</strong>. You'll need to
+          enter the code from the letter to finish verifying your
+          identity. Sign back in to Login.gov to finish verifying your
+          identity.
+        did_not_get_a_letter: "If you didn't get this letter, "
+        finish: Finish verifying your identity
+        request_another_letter: sign in to request another letter
+        subject: Finish verifying your identity
       otp_delivery_method_description: If you entered a landline above, please select “Phone call” below.
       personal_key: This is your new personal key. Write it down and keep it in a safe
         place. You will need it if you ever lose your password.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -238,7 +238,8 @@ en:
           <strong>%{date_letter_was_sent}</strong>. You’ll need to enter the
           code from the letter to finish verifying your identity. Sign back in
           to %{app_name} to finish verifying your identity.
-        did_not_get_a_letter_html: If you didn’t get this letter, <span class=shut-up-lint></span>%{another_letter_link}
+        did_not_get_a_letter_html: If you didn’t get this letter, <span
+          class=shut-up-lint></span>%{another_letter_link}
         finish: Finish verifying your identity
         sign_in_and_request_another_letter: sign in to request another letter
         subject: Finish verifying your identity

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -237,8 +237,8 @@ en:
         body_html: You requested a letter to verify your identity on
           <strong>%{date_letter_was_sent}</strong>. You’ll need to enter the
           code from the letter to finish verifying your identity. Sign back in
-          to Login.gov to finish verifying your identity.
-        did_not_get_a_letter_html: If you didn’t get this letter, %{another_letter_link}
+          to %{app_name} to finish verifying your identity.
+        did_not_get_a_letter_html: If you didn’t get this letter, <span class=shut-up-lint></span>%{another_letter_link}
         finish: Finish verifying your identity
         sign_in_and_request_another_letter: sign in to request another letter
         subject: Finish verifying your identity

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -235,13 +235,12 @@ en:
           and <strong>typically take 3 to 7 business days to arrive</strong>.
       gpo_reminder:
         body_html: You requested a letter to verify your identity on
-          <strong>%{date_letter_was_sent}</strong>. You'll need to
-          enter the code from the letter to finish verifying your
-          identity. Sign back in to Login.gov to finish verifying your
-          identity.
-        did_not_get_a_letter: "If you didn't get this letter, "
+          <strong>%{date_letter_was_sent}</strong>. You’ll need to enter the
+          code from the letter to finish verifying your identity. Sign back in
+          to Login.gov to finish verifying your identity.
+        did_not_get_a_letter_html: If you didn’t get this letter, %{another_letter_link}
         finish: Finish verifying your identity
-        request_another_letter: sign in to request another letter
+        sign_in_and_request_another_letter: sign in to request another letter
         subject: Finish verifying your identity
       otp_delivery_method_description: If you entered a landline above, please select “Phone call” below.
       personal_key: This is your new personal key. Write it down and keep it in a safe

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -238,8 +238,7 @@ en:
           <strong>%{date_letter_was_sent}</strong>. You’ll need to enter the
           code from the letter to finish verifying your identity. Sign back in
           to %{app_name} to finish verifying your identity.
-        did_not_get_a_letter_html: If you didn’t get this letter, <span
-          class=shut-up-lint></span>%{another_letter_link}
+        did_not_get_a_letter_html: If you didn’t get this letter, %{another_letter_link_html}
         finish: Finish verifying your identity
         sign_in_and_request_another_letter: sign in to request another letter
         subject: Finish verifying your identity

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -242,6 +242,15 @@ es:
         timeframe_html: Las cartas se envían al día siguiente por First Class Mail de
           USPS y <strong>suelen tardar entre 3 y 7 días hábiles en
           llegar</strong>.
+      gpo_reminder:
+        body_html: El <strong>%{date_letter_was_sent}</strong> solicitaste una carta
+          para verificar tu identidad. Deberás ingresar el código que contiene
+          esa carta para completar la verificación por correo. Vuelve a iniciar
+          sesión en Login.gov para terminar de verificar tu identidad.
+        did_not_get_a_letter_html: Si no recibiste dicha carta, %{another_letter_link}
+        finish: Termina de verificar tu identidad
+        sign_in_and_request_another_letter: inicia sesión para solicitar otra
+        subject: Termina de verificar tu identidad
       otp_delivery_method_description: Si ha introducido un teléfono fijo más arriba,
         seleccione “Llamada telefónica” más abajo.
       personal_key: Esta es su nueva clave personal. Escríbala y guárdela en un lugar

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -247,7 +247,8 @@ es:
           para verificar tu identidad. Deberás ingresar el código que contiene
           esa carta para completar la verificación por correo. Vuelve a iniciar
           sesión en %{app_name} para terminar de verificar tu identidad.
-        did_not_get_a_letter_html: Si no recibiste dicha carta, <span class=shut-up-lint></span>%{another_letter_link}
+        did_not_get_a_letter_html: Si no recibiste dicha carta, <span
+          class=shut-up-lint></span>%{another_letter_link}
         finish: Termina de verificar tu identidad
         sign_in_and_request_another_letter: inicia sesión para solicitar otra
         subject: Termina de verificar tu identidad

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -247,8 +247,7 @@ es:
           para verificar tu identidad. Deberás ingresar el código que contiene
           esa carta para completar la verificación por correo. Vuelve a iniciar
           sesión en %{app_name} para terminar de verificar tu identidad.
-        did_not_get_a_letter_html: Si no recibiste dicha carta, <span
-          class=shut-up-lint></span>%{another_letter_link}
+        did_not_get_a_letter_html: Si no recibiste dicha carta, %{another_letter_link_html}
         finish: Termina de verificar tu identidad
         sign_in_and_request_another_letter: inicia sesión para solicitar otra
         subject: Termina de verificar tu identidad

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -246,8 +246,8 @@ es:
         body_html: El <strong>%{date_letter_was_sent}</strong> solicitaste una carta
           para verificar tu identidad. Deberás ingresar el código que contiene
           esa carta para completar la verificación por correo. Vuelve a iniciar
-          sesión en %{app_name} para terminar de verificar tu identidad.
-        did_not_get_a_letter_html: Si no recibiste dicha carta, %{another_letter_link_html}
+          sesión en %{app_name} para terminar de verificar tu identidad. %{help_link}.
+        did_not_get_a_letter_html: Si no recibiste dicha carta, %{another_letter_link_html}.
         finish: Termina de verificar tu identidad
         sign_in_and_request_another_letter: inicia sesión para solicitar otra
         subject: Termina de verificar tu identidad

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -246,8 +246,8 @@ es:
         body_html: El <strong>%{date_letter_was_sent}</strong> solicitaste una carta
           para verificar tu identidad. Deberás ingresar el código que contiene
           esa carta para completar la verificación por correo. Vuelve a iniciar
-          sesión en Login.gov para terminar de verificar tu identidad.
-        did_not_get_a_letter_html: Si no recibiste dicha carta, %{another_letter_link}
+          sesión en %{app_name} para terminar de verificar tu identidad.
+        did_not_get_a_letter_html: Si no recibiste dicha carta, <span class=shut-up-lint></span>%{another_letter_link}
         finish: Termina de verificar tu identidad
         sign_in_and_request_another_letter: inicia sesión para solicitar otra
         subject: Termina de verificar tu identidad

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -246,7 +246,8 @@ es:
         body_html: El <strong>%{date_letter_was_sent}</strong> solicitaste una carta
           para verificar tu identidad. Deberás ingresar el código que contiene
           esa carta para completar la verificación por correo. Vuelve a iniciar
-          sesión en %{app_name} para terminar de verificar tu identidad. %{help_link}.
+          sesión en %{app_name} para terminar de verificar tu identidad.
+          %{help_link}.
         did_not_get_a_letter_html: Si no recibiste dicha carta, %{another_letter_link_html}.
         finish: Termina de verificar tu identidad
         sign_in_and_request_another_letter: inicia sesión para solicitar otra

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -262,9 +262,9 @@ fr:
         body_html: Vous avez demandé une lettre pour vérifier votre identité le
           <strong>%{date_letter_was_sent}</strong>. Vous devrez saisir le code
           figurant dans la lettre pour terminer la vérification par courrier.
-          Reconnectez-vous à Login.gov pour terminer la vérification de votre
+          Reconnectez-vous à %{app_name} pour terminer la vérification de votre
           identité.
-        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, %{another_letter_link}
+        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, <span class=shut-up-lint></span>%{another_letter_link}
         finish: Terminer la vérification de votre identité
         sign_in_and_request_another_letter: connectez-vous pour en demander une autre.
         subject: Terminer la vérification de votre identité

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -258,6 +258,16 @@ fr:
         timeframe_html: Les lettres sont envoyées les jours ouvrables par courriel de
           première classe de USPS et <strong>prennent généralement entre trois à
           sept jours ouvrables pour être reçues</strong>.
+      gpo_reminder:
+        body_html: Vous avez demandé une lettre pour vérifier votre identité le
+          <strong>%{date_letter_was_sent}</strong>. Vous devrez saisir le code
+          figurant dans la lettre pour terminer la vérification par courrier.
+          Reconnectez-vous à Login.gov pour terminer la vérification de votre
+          identité.
+        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, %{another_letter_link}
+        finish: Terminer la vérification de votre identité
+        sign_in_and_request_another_letter: connectez-vous pour en demander une autre.
+        subject: Terminer la vérification de votre identité
       otp_delivery_method_description: Si vous avez saisi une ligne fixe ci-dessus,
         veuillez sélectionner « Appel téléphonique » ci-dessous.
       personal_key: Il s’agit de votre nouvelle clé personnelle. Notez-la et

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -264,7 +264,8 @@ fr:
           figurant dans la lettre pour terminer la vérification par courrier.
           Reconnectez-vous à %{app_name} pour terminer la vérification de votre
           identité.
-        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, <span class=shut-up-lint></span>%{another_letter_link}
+        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, <span
+          class=shut-up-lint></span>%{another_letter_link}
         finish: Terminer la vérification de votre identité
         sign_in_and_request_another_letter: connectez-vous pour en demander une autre.
         subject: Terminer la vérification de votre identité

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -264,8 +264,7 @@ fr:
           figurant dans la lettre pour terminer la vérification par courrier.
           Reconnectez-vous à %{app_name} pour terminer la vérification de votre
           identité.
-        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, <span
-          class=shut-up-lint></span>%{another_letter_link}
+        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, %{another_letter_link_html}
         finish: Terminer la vérification de votre identité
         sign_in_and_request_another_letter: connectez-vous pour en demander une autre.
         subject: Terminer la vérification de votre identité

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -263,8 +263,8 @@ fr:
           <strong>%{date_letter_was_sent}</strong>. Vous devrez saisir le code
           figurant dans la lettre pour terminer la vérification par courrier.
           Reconnectez-vous à %{app_name} pour terminer la vérification de votre
-          identité.
-        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, %{another_letter_link_html}
+          identité. %{help_link}.
+        did_not_get_a_letter_html: Si vous n’avez pas reçu cette lettre, %{another_letter_link_html}.
         finish: Terminer la vérification de votre identité
         sign_in_and_request_another_letter: connectez-vous pour en demander une autre.
         subject: Terminer la vérification de votre identité

--- a/db/primary_migrate/20230809194211_add_reminder_sent_at_to_usps_confirmation_codes.rb
+++ b/db/primary_migrate/20230809194211_add_reminder_sent_at_to_usps_confirmation_codes.rb
@@ -1,0 +1,8 @@
+class AddReminderSentAtToUspsConfirmationCodes < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :usps_confirmation_codes, :reminder_sent_at, :datetime, precision: nil
+    add_index :usps_confirmation_codes, :reminder_sent_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -619,8 +619,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_130423) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "bounced_at", precision: nil
+    t.datetime "reminder_sent_at", precision: nil
     t.index ["otp_fingerprint"], name: "index_usps_confirmation_codes_on_otp_fingerprint"
     t.index ["profile_id"], name: "index_usps_confirmation_codes_on_profile_id"
+    t.index ["reminder_sent_at"], name: "index_usps_confirmation_codes_on_reminder_sent_at"
   end
 
   create_table "usps_confirmations", id: :serial, force: :cascade do |t|

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GpoReminderJob do
       pending_profile.update(
         gpo_verification_pending_at: wait_before_sending_reminder.ago,
       )
-      allow(job).to receive(:analytics).and_return(job_analytics)
+      allow(Analytics).to receive(:new).and_return(job_analytics)
     end
 
     it 'sends reminder emails' do

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GpoReminderJob do
 
     before do
       pending_profile.update(
-        gpo_verification_pending_at: Time.zone.now - WAIT_BEFORE_SENDING_REMINDER,
+        gpo_verification_pending_at: wait_before_sending_reminder.ago,
       )
       allow(job).to receive(:analytics).and_return(job_analytics)
     end

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe GpoReminderJob do
+  describe '#perform' do
+    subject(:perform) { GpoReminderJob.new.perform(Time.zone.now - 14.days) }
+
+    before do
+      create(:user, :with_pending_gpo_profile).
+        pending_profile.
+        update(
+          gpo_verification_pending_at: Time.zone.now - 14.days,
+        )
+    end
+
+    it 'sends reminder emails' do
+      expect { perform }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+end

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe GpoReminderJob do
-  WAIT_BEFORE_SENDING_REMINDER = 14.days
+  let(:wait_before_sending_reminder) { 14.days }
 
   describe '#perform' do
-    subject(:perform) { job.perform(Time.zone.now - WAIT_BEFORE_SENDING_REMINDER) }
+    subject(:perform) { job.perform(wait_before_sending_reminder.ago) }
 
     let(:job) { GpoReminderJob.new }
     let(:user) { create(:user, :with_pending_gpo_profile) }

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -1,19 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe GpoReminderJob do
+  WAIT_BEFORE_SENDING_REMINDER = 14.days
+
   describe '#perform' do
-    subject(:perform) { GpoReminderJob.new.perform(Time.zone.now - 14.days) }
+    subject(:perform) { job.perform(Time.zone.now - WAIT_BEFORE_SENDING_REMINDER) }
+
+    let(:job) { GpoReminderJob.new }
+    let(:user) { create(:user, :with_pending_gpo_profile) }
+    let(:pending_profile) { user.pending_profile }
+    let(:job_analytics) { FakeAnalytics.new }
 
     before do
-      create(:user, :with_pending_gpo_profile).
-        pending_profile.
-        update(
-          gpo_verification_pending_at: Time.zone.now - 14.days,
-        )
+      pending_profile.update(
+        gpo_verification_pending_at: Time.zone.now - WAIT_BEFORE_SENDING_REMINDER,
+      )
+      allow(job).to receive(:analytics).and_return(job_analytics)
     end
 
     it 'sends reminder emails' do
       expect { perform }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(job_analytics).to have_logged_event(
+        'IdV: gpo reminder email sent',
+      )
     end
   end
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -179,6 +179,13 @@ class UserMailerPreview < ActionMailer::Preview
     ).suspended_reset_password
   end
 
+  def gpo_reminder
+    UserMailer.with(
+      user: user,
+      email_address: email_address_record,
+    ).gpo_reminder
+  end
+
   private
 
   def user

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -181,7 +181,7 @@ class UserMailerPreview < ActionMailer::Preview
 
   def gpo_reminder
     UserMailer.with(
-      user: user,
+      user: user_with_pending_gpo_letter,
       email_address: email_address_record,
     ).gpo_reminder
   end
@@ -190,6 +190,19 @@ class UserMailerPreview < ActionMailer::Preview
 
   def user
     unsaveable(User.new(email_addresses: [email_address_record]))
+  end
+
+  def user_with_pending_gpo_letter
+    raw_user = user
+    gpo_pending_profile = unsaveable(
+      Profile.new(
+        user: raw_user,
+        active: false,
+        gpo_verification_pending_at: Time.zone.now,
+      ),
+    )
+    raw_user.send(:instance_variable_set, :@pending_profile, gpo_pending_profile)
+    raw_user
   end
 
   def email_address

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -908,5 +908,19 @@ RSpec.describe UserMailer, type: :mailer do
 
       expect(mail.html_part.body).to have_content(expected_body)
     end
+
+    it 'renders the finish link' do
+      expect(mail.html_part.body).to have_link(
+        t('idv.messages.gpo_reminder.finish'),
+        href: idv_gpo_verify_url,
+      )
+    end
+
+    it 'renders the did not get it link' do
+      expect(mail.html_part.body).to have_link(
+        t('idv.messages.gpo_reminder.sign_in_and_request_another_letter'),
+        href: idv_gpo_verify_url(did_not_receive_letter: 1),
+      )
+    end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -922,5 +922,17 @@ RSpec.describe UserMailer, type: :mailer do
         href: idv_gpo_verify_url(did_not_receive_letter: 1),
       )
     end
+
+    it 'renders the help link' do
+      expect(mail.html_part.body).to have_link(
+        t('idv.troubleshooting.options.learn_more_verify_by_mail'),
+        href: help_center_redirect_url(
+          category: 'verify-your-identity',
+          article: 'verify-your-address-by-mail',
+          flow: :idv,
+          step: :gpo_send_letter,
+        ),
+      )
+    end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -898,11 +898,23 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it 'renders the body' do
+      expected_help_link = ActionController::Base.helpers.link_to(
+        t('idv.troubleshooting.options.learn_more_verify_by_mail'),
+        help_center_redirect_url(
+          category: 'verify-your-identity',
+          article: 'verify-your-address-by-mail',
+          flow: :idv,
+          step: :gpo_send_letter,
+        ),
+        { style: "text-decoration: 'underline'" },
+      )
+
       expected_body = strip_tags(
         t(
           'idv.messages.gpo_reminder.body_html',
           date_letter_was_sent: date_letter_was_sent.strftime(t('time.formats.event_date')),
           app_name: APP_NAME,
+          help_link: expected_help_link,
         ),
       )
 

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GpoReminderSender do
 
     def set_reminder_sent_at(to_time)
       gpo_confirmation_code = user.gpo_verification_pending_profile.gpo_confirmation_codes.first
-      gpo_confirmation_code.reminder_sent_at = Time.zone.now - 1.day
+      gpo_confirmation_code.reminder_sent_at = to_time
       gpo_confirmation_code.save
     end
 
@@ -18,7 +18,7 @@ RSpec.describe GpoReminderSender do
       before { set_gpo_verification_pending_at(Time.zone.now - 13.days) }
 
       it 'sends no emails' do
-        expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(0)
+        expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(0)
       end
     end
 
@@ -26,14 +26,14 @@ RSpec.describe GpoReminderSender do
       before { set_gpo_verification_pending_at(Time.zone.now - 14.days) }
 
       it 'sends that user an email' do
-        expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(1)
+        expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(1)
       end
 
       context 'but a reminder has already been sent' do
         before { set_reminder_sent_at(Time.zone.now - 1.day) }
 
         it 'does not send that user an email' do
-          expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(0)
+          expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(0)
         end
       end
     end

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe GpoReminderSender do
+  describe '#send_emails' do
+    let(:user) { create(:user, :with_pending_gpo_profile) }
+
+    context 'when no users need a reminder' do
+      before do
+        user.gpo_verification_pending_profile.gpo_verification_pending_at = Time.zone.now - 13.days
+        user.save
+      end
+
+      it 'sends no emails' do
+        expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(0)
+      end
+    end
+
+    context 'when a user is due for a reminder' do
+      before do
+        user.gpo_verification_pending_profile.gpo_verification_pending_at = Time.zone.now - 14.days
+        user.save
+      end
+
+      it 'sends that user an email' do
+        expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(1)
+      end
+
+      context 'but a reminder has already been sent' do
+        before do
+          user.gpo_verification_pending_profile.gpo_reminder_sent_at = Time.zone.now - 1.day
+        end
+
+        it 'does not send that user an email' do
+          expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GpoReminderSender do
   describe '#send_emails' do
-    subject(:sender) { GpoReminderSender.new(fake_analytics) }
+    subject(:sender) { GpoReminderSender.new }
 
     let(:user) { create(:user, :with_pending_gpo_profile) }
     let(:gpo_confirmation_code) do
@@ -29,6 +29,8 @@ RSpec.describe GpoReminderSender do
         reminder_sent_at: to_time,
       )
     end
+
+    before { allow(Analytics).to receive(:new).and_return(fake_analytics) }
 
     context 'when no users need a reminder' do
       before { set_gpo_verification_pending_at(time_not_yet_due) }

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe GpoReminderSender do
   describe '#send_emails' do
+    WAIT_BEFORE_SENDING_REMINDER = 14.days
+    TIME_DUE_FOR_REMINDER = Time.zone.now - WAIT_BEFORE_SENDING_REMINDER
+    TIME_NOT_YET_DUE = TIME_DUE_FOR_REMINDER + 1.day
+    TIME_YESTERDAY = Time.zone.now - 1.day
+
     let(:user) { create(:user, :with_pending_gpo_profile) }
 
     def set_gpo_verification_pending_at(to_time)
@@ -15,33 +20,37 @@ RSpec.describe GpoReminderSender do
     end
 
     context 'when no users need a reminder' do
-      before { set_gpo_verification_pending_at(Time.zone.now - 13.days) }
+      before { set_gpo_verification_pending_at(TIME_NOT_YET_DUE) }
 
       it 'sends no emails' do
-        expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(0)
+        expect { subject.send_emails(TIME_DUE_FOR_REMINDER) }.
+          to change { ActionMailer::Base.deliveries.size }.by(0)
       end
     end
 
     context 'when a user is due for a reminder' do
-      before { set_gpo_verification_pending_at(Time.zone.now - 14.days) }
+      before { set_gpo_verification_pending_at(TIME_DUE_FOR_REMINDER) }
 
       it 'sends that user an email' do
-        expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        expect { subject.send_emails(TIME_DUE_FOR_REMINDER) }.
+          to change { ActionMailer::Base.deliveries.size }.by(1)
       end
 
       context 'and the user has multiple emails' do
         let(:user) { create(:user, :with_pending_gpo_profile, :with_multiple_emails) }
 
         it 'sends an email to all of them' do
-          expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(2)
+          expect { subject.send_emails(TIME_DUE_FOR_REMINDER) }.
+            to change { ActionMailer::Base.deliveries.size }.by(2)
         end
       end
 
       context 'but a reminder has already been sent' do
-        before { set_reminder_sent_at(Time.zone.now - 1.day) }
+        before { set_reminder_sent_at(TIME_YESTERDAY) }
 
         it 'does not send that user an email' do
-          expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(0)
+          expect { subject.send_emails(TIME_DUE_FOR_REMINDER) }.
+            to change { ActionMailer::Base.deliveries.size }.by(0)
         end
       end
     end

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -4,11 +4,18 @@ RSpec.describe GpoReminderSender do
   describe '#send_emails' do
     let(:user) { create(:user, :with_pending_gpo_profile) }
 
+    def set_gpo_verification_pending_at(to_time)
+      user.gpo_verification_pending_profile.update(gpo_verification_pending_at: to_time)
+    end
+
+    def set_reminder_sent_at(to_time)
+      gpo_confirmation_code = user.gpo_verification_pending_profile.gpo_confirmation_codes.first
+      gpo_confirmation_code.reminder_sent_at = Time.zone.now - 1.day
+      gpo_confirmation_code.save
+    end
+
     context 'when no users need a reminder' do
-      before do
-        user.gpo_verification_pending_profile.gpo_verification_pending_at = Time.zone.now - 13.days
-        user.save
-      end
+      before { set_gpo_verification_pending_at(Time.zone.now - 13.days) }
 
       it 'sends no emails' do
         expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(0)
@@ -16,19 +23,14 @@ RSpec.describe GpoReminderSender do
     end
 
     context 'when a user is due for a reminder' do
-      before do
-        user.gpo_verification_pending_profile.gpo_verification_pending_at = Time.zone.now - 14.days
-        user.save
-      end
+      before { set_gpo_verification_pending_at(Time.zone.now - 14.days) }
 
       it 'sends that user an email' do
         expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(1)
       end
 
       context 'but a reminder has already been sent' do
-        before do
-          user.gpo_verification_pending_profile.gpo_reminder_sent_at = Time.zone.now - 1.day
-        end
+        before { set_reminder_sent_at(Time.zone.now - 1.day) }
 
         it 'does not send that user an email' do
           expect{subject.send_emails}.to change{ActionMailer::Base.deliveries.size}.by(0)

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe GpoReminderSender do
         expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(1)
       end
 
+      context 'and the user has multiple emails' do
+        let(:user) { create(:user, :with_pending_gpo_profile, :with_multiple_emails) }
+
+        it 'sends an email to all of them' do
+          expect { subject.send_emails }.to change { ActionMailer::Base.deliveries.size }.by(2)
+        end
+      end
+
       context 'but a reminder has already been sent' do
         before { set_reminder_sent_at(Time.zone.now - 1.day) }
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9565](https://cm-jira.usa.gov/browse/LG-9565)

## 🛠 Summary of changes

Added a new reminder email for users who requested a GPO letter two weeks ago.
Added task to send such letters daily.
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Visually validate the email's layout and copy using Rails' email preview mechanism
- [ ] (In a sandbox or local dev environment) Manually create two users in GPO verification. Use the Rails console to back-date the `gpo_verification_pending_at` column for one user's pending profile. Run the GpoReminderJob from the rails console (`GpoReminderJob.new(14.days.ago)`, and verify that the expected email was sent to the user that you backdated, and that no email is sent to the other user.
- [ ] Run the GpoReminderJob again, and verify that no emails are sent.
## 👀 Screenshots

<details>
<summary>English:</summary>

![Screenshot 2023-08-15 at 6 28 13 PM](https://github.com/18F/identity-idp/assets/101212334/6b4e44f4-d9b0-4d32-9820-d754b621c4ea)

</details>

<details>
<summary>Spanish:</summary>

![Screenshot 2023-08-15 at 6 28 43 PM](https://github.com/18F/identity-idp/assets/101212334/3193459d-7ff6-42a2-a69d-329051687784)

</details>

<details>

<summary>French:</summary>

![Screenshot 2023-08-15 at 6 29 09 PM](https://github.com/18F/identity-idp/assets/101212334/96ed2de7-c846-419e-92c4-be97849f4a23)

</details>
