### PR TITLE
Remove unused WebAuthn public key value

### DIFF
--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -103,7 +103,6 @@ describe('enrollWebauthnDevice', () => {
 
       expect(result).to.deep.equal({
         webauthnId: btoa('123'),
-        webauthnPublicKey: '123',
         attestationObject: btoa('attest'),
         clientDataJSON: btoa('json'),
         authenticatorDataFlagsValue: 65,

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -28,8 +28,6 @@ interface EnrollOptions {
 interface EnrollResult {
   webauthnId: string;
 
-  webauthnPublicKey: string;
-
   attestationObject: string;
 
   clientDataJSON: string;
@@ -99,7 +97,6 @@ async function enrollWebauthnDevice({
 
   return {
     webauthnId: arrayBufferToBase64(credential.rawId),
-    webauthnPublicKey: credential.id,
     attestationObject: arrayBufferToBase64(response.attestationObject),
     clientDataJSON: arrayBufferToBase64(response.clientDataJSON),
     authenticatorDataFlagsValue,

--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -59,8 +59,6 @@ function webauthn() {
     })
       .then((result) => {
         (document.getElementById('webauthn_id') as HTMLInputElement).value = result.webauthnId;
-        (document.getElementById('webauthn_public_key') as HTMLInputElement).value =
-          result.webauthnPublicKey;
         (document.getElementById('attestation_object') as HTMLInputElement).value =
           result.attestationObject;
         (document.getElementById('client_data_json') as HTMLInputElement).value =

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -26,7 +26,6 @@
   <%= hidden_field_tag :user_challenge, user_session[:webauthn_challenge].to_json, id: 'user_challenge' %>
   <%= hidden_field_tag :exclude_credentials, @exclude_credentials&.join(','), id: 'exclude_credentials' %>
   <%= hidden_field_tag :webauthn_id, '', id: 'webauthn_id' %>
-  <%= hidden_field_tag :webauthn_public_key, '', id: 'webauthn_public_key' %>
   <%= hidden_field_tag :attestation_object, '', id: 'attestation_object' %>
   <%= hidden_field_tag :client_data_json, '', id: 'client_data_json' %>
   <%= hidden_field_tag :authenticator_data_value, '', id: 'authenticator_data_value' %>

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -34,7 +34,6 @@ module WebAuthnHelper
 
     # simulate javascript that is triggered when the hardware key button is pressed
     set_hidden_field('webauthn_id', webauthn_id)
-    set_hidden_field('webauthn_public_key', webauthn_public_key)
     set_hidden_field('attestation_object', attestation_object)
     set_hidden_field('client_data_json', setup_client_data_json)
 
@@ -139,10 +138,6 @@ module WebAuthnHelper
 
   def webauthn_id
     'ufhgW+5bCVo1N4lGCfTHjBfj1Z0ED8uTj4qys4WJzkgZunHEbx3ixuc1kLG6QTGes6lg+hbXRHztVh4eiDXoLg=='
-  end
-
-  def webauthn_public_key
-    'ufhgW-5bCVo1N4lGCfTHjBfj1Z0ED8uTj4qys4WJzkgZunHEbx3ixuc1kLG6QTGes6lg-hbXRHztVh4eiDXoLg'
   end
 
   def credential_public_key


### PR DESCRIPTION
## 🛠 Summary of changes

Removes references to WebAuthn credential `id` as a public key. It is not a public key, but it also appears (thankfully) to be unused. The public key is actually contained within the attestation object, which is what's used in the creation of the credential:

https://github.com/18F/identity-idp/blob/3233189e62a4a6de314b0b0c1c78b60c06e9bc18/app/forms/webauthn_setup_form.rb#L115

https://github.com/18F/identity-idp/blob/3233189e62a4a6de314b0b0c1c78b60c06e9bc18/app/forms/webauthn_setup_form.rb#L114

https://github.com/18F/identity-idp/blob/3233189e62a4a6de314b0b0c1c78b60c06e9bc18/app/forms/webauthn_setup_form.rb#L75-L78

## 📜 Testing Plan

Confirm there are no regressions in the creation of a Security Key or Face or Touch Unlock MFA method.