### PR TITLE
Remove the `aws_kms_multi_region_write_enabled` flag

### DIFF
--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -56,15 +56,12 @@ module Encryption
           single_region_kms_encrypted_ciphertext, salt, cost
         ).to_s
 
-        multi_region_ciphertext = nil
-        if IdentityConfig.store.aws_kms_multi_region_write_enabled
-          multi_region_kms_encrypted_ciphertext = multi_region_kms_client.encrypt(
-            aes_encrypted_ciphertext, kms_encryption_context(user_uuid: user_uuid)
-          )
-          multi_region_ciphertext = Ciphertext.new(
-            multi_region_kms_encrypted_ciphertext, salt, cost
-          ).to_s
-        end
+        multi_region_kms_encrypted_ciphertext = multi_region_kms_client.encrypt(
+          aes_encrypted_ciphertext, kms_encryption_context(user_uuid: user_uuid)
+        )
+        multi_region_ciphertext = Ciphertext.new(
+          multi_region_kms_encrypted_ciphertext, salt, cost
+        ).to_s
 
         RegionalCiphertextPair.new(
           single_region_ciphertext: single_region_ciphertext,

--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -53,17 +53,14 @@ module Encryption
         password_cost: cost,
       ).to_s
 
-      multi_region_digest = nil
-      if IdentityConfig.store.aws_kms_multi_region_write_enabled
-        multi_region_encrypted_password = multi_region_kms_client.encrypt(
-          scrypted_password, kms_encryption_context(user_uuid: user_uuid)
-        )
-        multi_region_digest = PasswordDigest.new(
-          encrypted_password: multi_region_encrypted_password,
-          password_salt: salt,
-          password_cost: cost,
-        ).to_s
-      end
+      multi_region_encrypted_password = multi_region_kms_client.encrypt(
+        scrypted_password, kms_encryption_context(user_uuid: user_uuid)
+      )
+      multi_region_digest = PasswordDigest.new(
+        encrypted_password: multi_region_encrypted_password,
+        password_salt: salt,
+        password_cost: cost,
+      ).to_s
 
       RegionalCiphertextPair.new(
         single_region_ciphertext: single_region_digest,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -59,7 +59,6 @@ aws_kms_key_id: alias/login-dot-gov-test-keymaker
 aws_kms_client_contextless_pool_size: 5
 aws_kms_client_multi_pool_size: 5
 aws_kms_multi_region_key_id: alias/login-dot-gov-keymaker-multi-region
-aws_kms_multi_region_write_enabled: false
 aws_logo_bucket: ''
 aws_region: 'us-west-2'
 backup_code_cost: '2000$8$1$'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -146,7 +146,6 @@ class IdentityConfig
     config.add(:aws_kms_client_multi_pool_size, type: :integer)
     config.add(:aws_kms_key_id, type: :string)
     config.add(:aws_kms_multi_region_key_id, type: :string)
-    config.add(:aws_kms_multi_region_write_enabled, type: :boolean)
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)
     config.add(:backup_code_cost, type: :string)

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -109,50 +109,29 @@ RSpec.describe Profile do
   describe '#encrypt_pii' do
     subject(:encrypt_pii) { profile.encrypt_pii(pii, user.password) }
 
-    it 'encrypts PII' do
+    it 'encrypts pii and stores the multi region ciphertext' do
       expect(profile.encrypted_pii).to be_nil
+      expect(profile.encrypted_pii_recovery).to be_nil
+      expect(profile.encrypted_pii_multi_region).to be_nil
+      expect(profile.encrypted_pii_recovery_multi_region).to be_nil
 
-      encrypt_pii
+      profile.encrypt_pii(pii, user.password)
 
       expect(profile.encrypted_pii).to be_present
       expect(profile.encrypted_pii).to_not match 'Jane'
       expect(profile.encrypted_pii).to_not match(ssn)
-      expect(profile.encrypted_pii).to_not match(ssn.tr('-', ''))
 
       expect(profile.encrypted_pii_recovery).to be_present
-      expect(profile.encrypted_pii_multi_region).to be_nil
-      expect(profile.encrypted_pii_recovery_multi_region).to be_nil
-    end
+      expect(profile.encrypted_pii_recovery).to_not match 'Jane'
+      expect(profile.encrypted_pii_recovery).to_not match(ssn)
 
-    context 'with aws_kms_multi_region_write_enabled set to true' do
-      before do
-        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_write_enabled).and_return(true)
-      end
+      expect(profile.encrypted_pii_multi_region).to be_present
+      expect(profile.encrypted_pii_multi_region).to_not match 'Jane'
+      expect(profile.encrypted_pii_multi_region).to_not match(ssn)
 
-      it 'encrypts pii and stores the multi region ciphertext' do
-        expect(profile.encrypted_pii).to be_nil
-        expect(profile.encrypted_pii_recovery).to be_nil
-        expect(profile.encrypted_pii_multi_region).to be_nil
-        expect(profile.encrypted_pii_recovery_multi_region).to be_nil
-
-        profile.encrypt_pii(pii, user.password)
-
-        expect(profile.encrypted_pii).to be_present
-        expect(profile.encrypted_pii).to_not match 'Jane'
-        expect(profile.encrypted_pii).to_not match(ssn)
-
-        expect(profile.encrypted_pii_recovery).to be_present
-        expect(profile.encrypted_pii_recovery).to_not match 'Jane'
-        expect(profile.encrypted_pii_recovery).to_not match(ssn)
-
-        expect(profile.encrypted_pii_multi_region).to be_present
-        expect(profile.encrypted_pii_multi_region).to_not match 'Jane'
-        expect(profile.encrypted_pii_multi_region).to_not match(ssn)
-
-        expect(profile.encrypted_pii_recovery_multi_region).to be_present
-        expect(profile.encrypted_pii_recovery_multi_region).to_not match 'Jane'
-        expect(profile.encrypted_pii_recovery_multi_region).to_not match(ssn)
-      end
+      expect(profile.encrypted_pii_recovery_multi_region).to be_present
+      expect(profile.encrypted_pii_recovery_multi_region).to_not match 'Jane'
+      expect(profile.encrypted_pii_recovery_multi_region).to_not match(ssn)
     end
 
     it 'generates new personal key' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe User do
   end
 
   describe '#password=' do
-    it 'digests and saves the digested password' do
+    it 'digests and saves a single region and multi region password digests' do
       user = build(:user, password: nil)
 
       user.password = 'test password'
@@ -383,31 +383,14 @@ RSpec.describe User do
       expect(user.encrypted_password_digest).to_not be_blank
       expect(user.encrypted_password_digest).to_not match(/test password/)
 
-      expect(user.encrypted_password_digest_multi_region).to be_nil
-    end
+      expect(user.encrypted_password_digest_multi_region).to_not be_blank
+      expect(user.encrypted_password_digest_multi_region).to_not match(/test password/)
 
-    context 'with aws_kms_multi_region_write_enabled set to true' do
-      before do
-        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_write_enabled).and_return(true)
-      end
-
-      it 'digests and saves a single region and multi region password digests' do
-        user = build(:user, password: nil)
-
-        user.password = 'test password'
-
-        expect(user.encrypted_password_digest).to_not be_blank
-        expect(user.encrypted_password_digest).to_not match(/test password/)
-
-        expect(user.encrypted_password_digest_multi_region).to_not be_blank
-        expect(user.encrypted_password_digest_multi_region).to_not match(/test password/)
-
-        expect(
-          user.encrypted_password_digest,
-        ).to_not eq(
-          user.encrypted_password_digest_multi_region,
-        )
-      end
+      expect(
+        user.encrypted_password_digest,
+      ).to_not eq(
+        user.encrypted_password_digest_multi_region,
+      )
     end
   end
 
@@ -421,7 +404,7 @@ RSpec.describe User do
   end
 
   describe '#personal_key=' do
-    it 'digests and saves the digested personal key' do
+    it 'digests and saves a single region and multi region personal key digests' do
       user = build(:user, personal_key: nil)
 
       user.personal_key = 'test personal key'
@@ -429,31 +412,14 @@ RSpec.describe User do
       expect(user.encrypted_recovery_code_digest).to_not be_blank
       expect(user.encrypted_recovery_code_digest).to_not match(/test personal key/)
 
-      expect(user.encrypted_recovery_code_digest_multi_region).to be_nil
-    end
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not be_blank
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not match(/test personal key/)
 
-    context 'with aws_kms_multi_region_write_enabled set to true' do
-      before do
-        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_write_enabled).and_return(true)
-      end
-
-      it 'digests and saves a single region and multi region personal key digests' do
-        user = build(:user, personal_key: nil)
-
-        user.personal_key = 'test personal key'
-
-        expect(user.encrypted_recovery_code_digest).to_not be_blank
-        expect(user.encrypted_recovery_code_digest).to_not match(/test personal key/)
-
-        expect(user.encrypted_recovery_code_digest_multi_region).to_not be_blank
-        expect(user.encrypted_recovery_code_digest_multi_region).to_not match(/test personal key/)
-
-        expect(
-          user.encrypted_recovery_code_digest,
-        ).to_not eq(
-          user.encrypted_recovery_code_digest_multi_region,
-        )
-      end
+      expect(
+        user.encrypted_recovery_code_digest,
+      ).to_not eq(
+        user.encrypted_recovery_code_digest_multi_region,
+      )
     end
   end
 

--- a/spec/services/encryption/encryptors/pii_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/pii_encryptor_spec.rb
@@ -43,80 +43,41 @@ RSpec.describe Encryption::Encryptors::PiiEncryptor do
         with(plaintext, decoded_scrypt_digest).
         and_return('aes_ciphertext')
 
-      expect(subject.send(:single_region_kms_client)).to receive(:encrypt).
+      single_region_kms_client = subject.send(:single_region_kms_client)
+      multi_region_kms_client = subject.send(:multi_region_kms_client)
+
+      expect(single_region_kms_client.kms_key_id).to eq(
+        IdentityConfig.store.aws_kms_key_id,
+      )
+      expect(multi_region_kms_client.kms_key_id).to eq(
+        IdentityConfig.store.aws_kms_multi_region_key_id,
+      )
+
+      expect(single_region_kms_client).to receive(:encrypt).
         with('aes_ciphertext', { 'context' => 'pii-encryption', 'user_uuid' => 'uuid-123-abc' }).
-        and_return('kms_ciphertext')
+        and_return('single_region_kms_ciphertext')
+      expect(multi_region_kms_client).to receive(:encrypt).
+        with('aes_ciphertext', { 'context' => 'pii-encryption', 'user_uuid' => 'uuid-123-abc' }).
+        and_return('multi_region_kms_ciphertext')
 
-      expected_ciphertext = Base64.strict_encode64('kms_ciphertext')
+      ciphertext_single_region, ciphertext_multi_region = subject.encrypt(
+        plaintext, user_uuid: 'uuid-123-abc'
+      )
 
-      ciphertext, ciphertext_multi_region = subject.encrypt(plaintext, user_uuid: 'uuid-123-abc')
-
-      expect(ciphertext).to eq(
+      expect(ciphertext_single_region).to eq(
         {
-          encrypted_data: expected_ciphertext,
+          encrypted_data: Base64.strict_encode64('single_region_kms_ciphertext'),
           salt: salt,
           cost: '800$8$1$',
         }.to_json,
       )
-      expect(ciphertext_multi_region).to eq(nil)
-    end
-
-    context 'with aws_kms_multi_region_write_enabled set to true' do
-      it 'returns a single region and multi-region KMS ciphertext' do
-        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_write_enabled).and_return(true)
-
-        salt = '0' * 64
-        allow(SecureRandom).to receive(:hex).and_call_original
-        allow(SecureRandom).to receive(:hex).once.with(32).and_return(salt)
-
-        scrypt_digest = '31' * 32 # hex_encode('1111..')
-        decoded_scrypt_digest = '1' * 32
-
-        scrypt_password = instance_double(SCrypt::Password)
-        expect(scrypt_password).to receive(:digest).and_return(scrypt_digest)
-        expect(SCrypt::Password).to receive(:new).and_return(scrypt_password)
-
-        cipher = subject.send(:aes_cipher)
-        expect(cipher).to receive(:encrypt).
-          with(plaintext, decoded_scrypt_digest).
-          and_return('aes_ciphertext')
-
-        single_region_kms_client = subject.send(:single_region_kms_client)
-        multi_region_kms_client = subject.send(:multi_region_kms_client)
-
-        expect(single_region_kms_client.kms_key_id).to eq(
-          IdentityConfig.store.aws_kms_key_id,
-        )
-        expect(multi_region_kms_client.kms_key_id).to eq(
-          IdentityConfig.store.aws_kms_multi_region_key_id,
-        )
-
-        expect(single_region_kms_client).to receive(:encrypt).
-          with('aes_ciphertext', { 'context' => 'pii-encryption', 'user_uuid' => 'uuid-123-abc' }).
-          and_return('single_region_kms_ciphertext')
-        expect(multi_region_kms_client).to receive(:encrypt).
-          with('aes_ciphertext', { 'context' => 'pii-encryption', 'user_uuid' => 'uuid-123-abc' }).
-          and_return('multi_region_kms_ciphertext')
-
-        ciphertext_single_region, ciphertext_multi_region = subject.encrypt(
-          plaintext, user_uuid: 'uuid-123-abc'
-        )
-
-        expect(ciphertext_single_region).to eq(
-          {
-            encrypted_data: Base64.strict_encode64('single_region_kms_ciphertext'),
-            salt: salt,
-            cost: '800$8$1$',
-          }.to_json,
-        )
-        expect(ciphertext_multi_region).to eq(
-          {
-            encrypted_data: Base64.strict_encode64('multi_region_kms_ciphertext'),
-            salt: salt,
-            cost: '800$8$1$',
-          }.to_json,
-        )
-      end
+      expect(ciphertext_multi_region).to eq(
+        {
+          encrypted_data: Base64.strict_encode64('multi_region_kms_ciphertext'),
+          salt: salt,
+          cost: '800$8$1$',
+        }.to_json,
+      )
     end
   end
 


### PR DESCRIPTION
We have safely demonstrated that we can write multi-region ciphertexts to the new columns so we can remove this feature flag.
