### PR TITLE
Update the name of the password digest method tracer

### DIFF
--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -127,7 +127,7 @@ module Encryption
       UakPasswordVerifier.verify(password: password, digest: digest)
     end
 
-    add_method_tracer :digest, "Custom/#{name}/digest"
+    add_method_tracer :create_digest_pair, "Custom/#{name}/create_digest_pair"
     add_method_tracer :verify, "Custom/#{name}/verify"
   end
 end


### PR DESCRIPTION
We changed the name of this method but missed this tracer. As a result our NewRelic stats got a little wonky. This commit fixes that.
