### PR TITLE
Add script to get OTP delivery logs for SMS, Voice

### DIFF
--- a/bin/oncall/email-deliveries
+++ b/bin/oncall/email-deliveries
@@ -10,6 +10,7 @@ require 'terminal-table'
 $LOAD_PATH.unshift(File.expand_path(File.join(__dir__, '../../lib')))
 require 'reporting/cloudwatch_client'
 require 'reporting/cloudwatch_query_quoting'
+require 'reporting/unknown_progress_bar'
 
 class EmailDeliveries
   include Reporting::CloudwatchQueryQuoting
@@ -82,69 +83,52 @@ class EmailDeliveries
 
   # @return [Array<Result>]
   def query_data(uuids)
-    if progress_bar?
-      bar = ProgressBar.create(
-        title: 'Querying logs',
-        total: nil,
-        format: '[ %t ] %B %a',
-        output: STDERR,
+    Reporting::UnknownProgressBar.wrap(show_bar: progress_bar?, title: 'Querying logs') do
+      event_log = cloudwatch_client('prod_/srv/idp/shared/log/events.log').fetch(
+        query: <<~EOS,
+          fields
+            @timestamp
+          , properties.user_id AS user_id
+          , properties.event_properties.ses_message_id AS ses_message_id
+          | filter name = 'Email Sent'
+          | filter properties.user_id IN #{quote(uuids)}
+          | limit 10000
+        EOS
+        from: 1.week.ago,
+        to: Time.now,
       )
-      thread = Thread.new do
-        loop do
-          sleep 0.1
-          bar.increment
+
+      events_by_message_id = event_log.index_by { |event| event['ses_message_id'] }
+
+      message_id_filters = events_by_message_id.keys.map do |message_id|
+        "@message LIKE /#{message_id}/"
+      end.join(' OR ')
+
+      email_events = cloudwatch_client('/aws/lambda/SESAllEvents_Lambda').fetch(
+        query: <<~EOS,
+          fields
+            eventType AS event_type
+          | filter #{message_id_filters}
+          | parse '"messageId": "*"' as ses_message_id
+          | display @timestamp, event_type, ses_message_id
+          | limit 10000
+        EOS
+        from: 1.week.ago,
+        to: Time.now,
+      )
+
+      email_events.
+        group_by { |event| event['ses_message_id'] }.
+        map do |message_id, events|
+          Result.new(
+            user_id: events_by_message_id[message_id]['user_id'],
+            timestamp: events_by_message_id[message_id]['@timestamp'],
+            message_id: message_id,
+            events: events.sort_by { |e| e['@timestamp'] }.map { |e| e['event_type'] },
+          )
         end
-      end
     end
-
-    event_log = cloudwatch_client('prod_/srv/idp/shared/log/events.log').fetch(
-      query: <<~EOS,
-        fields
-          @timestamp
-        , properties.user_id AS user_id
-        , properties.event_properties.ses_message_id AS ses_message_id
-        | filter name = 'Email Sent'
-        | filter properties.user_id IN #{quote(uuids)}
-        | limit 10000
-      EOS
-      from: 1.week.ago,
-      to: Time.now,
-    )
-
-    events_by_message_id = event_log.index_by { |event| event['ses_message_id'] }
-
-    message_id_filters = events_by_message_id.keys.map do |message_id|
-      "@message LIKE /#{message_id}/"
-    end.join(' OR ')
-
-    email_events = cloudwatch_client('/aws/lambda/SESAllEvents_Lambda').fetch(
-      query: <<~EOS,
-        fields
-          eventType AS event_type
-        | filter #{message_id_filters}
-        | parse '"messageId": "*"' as ses_message_id
-        | display @timestamp, event_type, ses_message_id
-        | limit 10000
-      EOS
-      from: 1.week.ago,
-      to: Time.now,
-    )
-
-    email_events.
-      group_by { |event| event['ses_message_id'] }.
-      map do |message_id, events|
-        Result.new(
-          user_id: events_by_message_id[message_id]['user_id'],
-          timestamp: events_by_message_id[message_id]['@timestamp'],
-          message_id: message_id,
-          events: events.sort_by { |e| e['@timestamp'] }.map { |e| e['event_type'] },
-        )
-      end
-  ensure
-    thread&.kill
-    bar&.stop
   end
-
 
   def cloudwatch_client(log_group_name)
     Reporting::CloudwatchClient.new(

--- a/bin/oncall/otp-deliveries
+++ b/bin/oncall/otp-deliveries
@@ -1,0 +1,147 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'active_support'
+require 'active_support/core_ext/integer/time'
+require 'optparse'
+
+$LOAD_PATH.unshift(File.expand_path(File.join(__dir__, '../../lib')))
+require 'script_base'
+require 'reporting/cloudwatch_client'
+require 'reporting/cloudwatch_query_quoting'
+require 'reporting/unknown_progress_bar'
+
+class OtpDeliveries
+  include Reporting::CloudwatchQueryQuoting
+
+  # @return [OtpDeliveries]
+  def self.parse!(argv: ARGV, out: STDOUT)
+    show_help = false
+    output_format = :table
+    filter = nil
+
+    parser = OptionParser.new do |opts|
+      opts.banner = <<~EOM
+        Usage: #{$PROGRAM_NAME} uuid1 [uuid2...]
+
+        Looks up OTP delivery attempts for SMS/Voice by user UUID, within the last 72 hours
+
+        Options:
+      EOM
+
+      opts.on('--csv') do
+        output_format = :csv
+      end
+
+      opts.on('--table', 'Output format as an ASCII table (default)') do
+        output_format = :table
+      end
+
+      opts.on('--json') do
+        output_format = :json
+      end
+
+      opts.on('--filter=FILTER', 'Filters output to be only SMS or VOICE') do |filter_v|
+        filter = filter_v
+      end
+
+      opts.on('--help', 'Show this help message') do
+        show_help = true
+      end
+    end
+
+    uuids = parser.parse!(argv)
+
+    if uuids.empty? || show_help
+      out.puts parser
+      exit 1
+    end
+
+    new(uuids: uuids, filter: filter, output_format: output_format)
+  end
+
+  attr_reader :uuids, :output_format, :filter
+
+  def initialize(uuids:, output_format:, filter: nil, progress_bar: true)
+    @uuids = uuids
+    @output_format = output_format
+    @filter = filter
+    @progress_bar = progress_bar
+  end
+
+  def progress_bar?
+    @progress_bar
+  end
+
+  def run(out: STDOUT)
+    results = query_data(uuids)
+
+    table = []
+    table << %w[user_id timestamp message_id delivery_preference country_code]
+    results.each do |result|
+      table << [
+        result.user_id,
+        result.timestamp,
+        result.message_id,
+        result.delivery_preference,
+        result.country_code,
+      ]
+    end
+
+    ScriptBase.render_output(table, format: output_format, stdout: out)
+  end
+
+  Result = Struct.new(
+    :user_id,
+    :timestamp,
+    :message_id,
+    :delivery_preference,
+    :country_code,
+    keyword_init: true,
+  )
+
+  # @return [Array<Result>]
+  def query_data(uuids)
+    Reporting::UnknownProgressBar.wrap(show_bar: progress_bar?, title: 'Querying logs') do
+      cloudwatch_client.fetch(
+        query: <<~EOS,
+          fields
+            @timestamp
+          , properties.user_id
+          , properties.event_properties.telephony_response.message_id
+          , properties.event_properties.otp_delivery_preference
+          , properties.event_properties.telephony_response.delivery_status
+          , properties.event_properties.country_code
+          | filter name = 'Telephony: OTP sent'
+          #{filter ?
+            "| filter properties.event_properties.otp_delivery_preference = '#{filter.downcase}'" :
+            nil}
+          | filter properties.user_id IN #{quote(uuids)}
+          | limit 10000
+        EOS
+        from: 72.hours.ago,
+        to: Time.now,
+      ).map do |row|
+        Result.new(
+          user_id: row['properties.user_id'],
+          timestamp: row['@timestamp'],
+          message_id: row['properties.event_properties.telephony_response.message_id'],
+          delivery_preference: row['properties.event_properties.otp_delivery_preference'],
+          country_code: row['properties.event_properties.country_code'],
+        )
+      end
+    end
+  end
+
+  def cloudwatch_client
+    @cloudwatch_client ||= Reporting::CloudwatchClient.new(
+      ensure_complete_logs: false,
+      slice_interval: nil,
+      progress: false,
+    )
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  OtpDeliveries.parse!.run
+end

--- a/lib/reporting/unknown_progress_bar.rb
+++ b/lib/reporting/unknown_progress_bar.rb
@@ -1,0 +1,30 @@
+require 'ruby-progressbar'
+
+module Reporting
+  # Small wrapper around ruby-progressbar
+  class UnknownProgressBar
+    # Wraps a block and displays a progress bar while the block executes
+    # Returns the value from the block
+    def self.wrap(show_bar:, title: 'Waiting', output: STDERR)
+      if show_bar
+        bar = ProgressBar.create(
+          title: title,
+          total: nil,
+          format: '[ %t ] %B %a',
+          output: output,
+        )
+        thread = Thread.fork do
+          loop do
+            sleep 0.1
+            bar.increment
+          end
+        end
+      end
+
+      yield
+    ensure
+      thread&.kill
+      bar&.stop
+    end
+  end
+end

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -62,7 +62,7 @@ class ScriptBase
     if result.json
       stdout.puts result.json.to_json
     else
-      render_output(result.table)
+      self.class.render_output(result.table, format: config.format, stdout: stdout)
     end
   end
 
@@ -101,10 +101,10 @@ class ScriptBase
   end
 
   # @param [Array<Array<String>>] rows
-  def render_output(rows)
+  def self.render_output(rows, format:, stdout: STDOUT)
     return if rows.blank?
 
-    case config.format
+    case format
     when :table
       require 'terminal-table'
       table = Terminal::Table.new
@@ -131,7 +131,7 @@ class ScriptBase
 
       stdout.puts JSON.pretty_generate(objects)
     else
-      raise "Unknown format=#{config.format}"
+      raise "Unknown format=#{format}"
     end
   end
 end

--- a/spec/bin/oncall/otp-deliveries_spec.rb
+++ b/spec/bin/oncall/otp-deliveries_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+load Rails.root.join('bin/oncall/otp-deliveries')
+
+RSpec.describe OtpDeliveries do
+  describe '.parse!' do
+    let(:out) { StringIO.new }
+    subject(:parse!) { OtpDeliveries.parse!(argv: argv, out: out) }
+
+    context 'with --help' do
+      let(:argv) { %w[--help] }
+
+      it 'prints help and exits uncleanly' do
+        expect(OtpDeliveries).to receive(:exit).with(1)
+
+        parse!
+
+        expect(out.string).to include('Usage:')
+      end
+    end
+
+    context 'with no arguments' do
+      let(:argv) { [] }
+
+      it 'prints help and exits uncleanly' do
+        expect(OtpDeliveries).to receive(:exit).with(1)
+
+        parse!
+
+        expect(out.string).to include('Usage:')
+      end
+    end
+
+    context 'with arguments' do
+      let(:argv) { %w[abc def] }
+
+      it 'returns an instance populated with UUIDs' do
+        expect(parse!.uuids).to eq(%w[abc def])
+      end
+
+      context 'with --filter' do
+        let(:argv) { [*super(), '--filter', 'VOICE'] }
+
+        it 'sets the filter' do
+          expect(parse!.filter).to eq('VOICE')
+        end
+      end
+
+      it 'defaults to table formatting' do
+        expect(parse!.output_format).to eq(:table)
+      end
+
+      context 'with --csv' do
+        let(:argv) { [*super(), '--csv'] }
+
+        it 'outputs CSV' do
+          expect(parse!.output_format).to eq(:csv)
+        end
+      end
+
+      context 'with --json' do
+        let(:argv) { [*super(), '--json'] }
+
+        it 'outputs JSON' do
+          expect(parse!.output_format).to eq(:json)
+        end
+      end
+
+      context 'with --table' do
+        let(:argv) { [*super(), '--table'] }
+
+        it 'outputs a table' do
+          expect(parse!.output_format).to eq(:table)
+        end
+      end
+    end
+  end
+
+  describe '#run' do
+    let(:instance) do
+      OtpDeliveries.new(
+        uuids: %w[abc123 def456],
+        progress_bar: false,
+        output_format: :json,
+      )
+    end
+    let(:stdout) { StringIO.new }
+    subject(:run) { instance.run(out: stdout) }
+
+    let(:cloudwatch_client) { instance_double('Reporting::CloudwatchClient') }
+
+    before do
+      allow(instance).to receive(:cloudwatch_client).and_return(cloudwatch_client)
+
+      allow(cloudwatch_client).to receive(:fetch).and_return(
+        [
+          {
+            'properties.user_id' => 'aaa',
+            '@timestamp' => 'bbb',
+            'properties.event_properties.telephony_response.message_id' => 'ccc',
+            'properties.event_properties.otp_delivery_preference' => 'sms',
+            'properties.event_properties.country_code' => 'US',
+          }
+        ],
+      )
+    end
+
+    it 'renders a table of information for debugging otp sends' do
+      run
+
+      expect(JSON.parse(stdout.string, symbolize_names: true)).to eq(
+        [
+          {
+            user_id: 'aaa',
+            timestamp: 'bbb',
+            message_id: 'ccc',
+            delivery_preference: 'sms',
+            country_code: 'US',
+          }
+        ],
+      )
+    end
+  end
+end

--- a/spec/bin/oncall/otp-deliveries_spec.rb
+++ b/spec/bin/oncall/otp-deliveries_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe OtpDeliveries do
             'properties.event_properties.telephony_response.message_id' => 'ccc',
             'properties.event_properties.otp_delivery_preference' => 'sms',
             'properties.event_properties.country_code' => 'US',
-          }
+          },
         ],
       )
     end
@@ -115,7 +115,7 @@ RSpec.describe OtpDeliveries do
             message_id: 'ccc',
             delivery_preference: 'sms',
             country_code: 'US',
-          }
+          },
         ],
       )
     end

--- a/spec/lib/reporting/unknown_progress_bar_spec.rb
+++ b/spec/lib/reporting/unknown_progress_bar_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'reporting/unknown_progress_bar'
+
+RSpec.describe Reporting::UnknownProgressBar do
+  describe '.wrap' do
+    let(:output) { StringIO.new }
+    let(:show_bar) { true }
+    let(:title) { 'my title' }
+
+    subject(:wrap) do
+      proc do |&block|
+        Reporting::UnknownProgressBar.wrap(show_bar:, title:, output:, &block)
+      end
+    end
+
+    context 'when show_bar is false' do
+      let(:show_bar) { false }
+
+      it 'returns the value inside the block and does not render a bar' do
+        result = wrap.call { 10 }
+
+        expect(result).to eq(10)
+        expect(output.string).to eq('')
+      end
+    end
+
+    context 'when show_bar is true' do
+      let(:show_bar) { true }
+
+      it 'returns the value inside the block and render a bar with the title' do
+        result = wrap.call { 15 }
+
+        expect(result).to eq(15)
+        expect(output.string).to include(title)
+      end
+
+      it 'kills the background thread that it creates' do
+        thread = instance_double('Thread')
+
+        expect(Thread).to receive(:fork).and_return(thread)
+        expect(thread).to receive(:kill)
+
+        wrap.call { 11 }
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Script to help triage OTP deliveries by pulling message IDs

changelog: Internal, Scripts, Add script to triage OTP delivery

Usage:
```bash
aws-vault exec prod-power -- ./bin/oncall/otp-deliveries uuid1 --csv
[ Querying logs ] --=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---= Time: 00:00:11
user_id,timestamp,message_id,delivery_preference,country_code
uuid1,2023-01-01T00:00:00Z,messageid1,sms,US
```