### PR TITLE
LG-10656: Start moving address_edited out of flow_session

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -191,7 +191,7 @@ module Idv
         state_id_number: pii[:state_id_number],
         # todo: add other edited fields?
         extra: {
-          address_edited: !!flow_session['address_edited'],
+          address_edited: !!(idv_session.address_edited || flow_session['address_edited']),
           address_line2_present: !pii[:address2].blank?,
           pii_like_keypaths: [[:errors, :ssn], [:response_body, :first_name],
                               [:state_id, :state_id_jurisdiction]],

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -45,6 +45,7 @@ module Idv
     def capture_address_edited(result)
       address_edited = result.to_h[:address_edited]
       flow_session['address_edited'] = address_edited if address_edited
+      idv_session.address_edited = true if address_edited
     end
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -1,6 +1,7 @@
 module Idv
   class Session
     VALID_SESSION_ATTRIBUTES = %i[
+      address_edited
       address_verification_mechanism
       applicant
       document_capture_session_uuid

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -78,5 +78,16 @@ RSpec.describe Idv::AddressController do
         ),
       )
     end
+
+    it 'logs an analytics event' do
+      put :update, params: params
+      expect(@analytics).to have_logged_event(
+        'IdV: address submitted',
+        { success: true,
+          errors: {},
+          address_edited: true,
+          error_details: nil },
+      )
+    end
   end
 end

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Idv::AddressController do
 
   let(:user) { create(:user) }
 
+  let(:idv_session) { subject.idv_session }
+
   let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.stringify_keys }
 
   let(:flow_session) do
@@ -53,6 +55,12 @@ RSpec.describe Idv::AddressController do
       expect do
         put :update, params: params
       end.to change { flow_session['address_edited'] }.from(nil).to eql(true)
+    end
+
+    it 'sets address_edited in idv_session' do
+      expect do
+        put :update, params: params
+      end.to change { idv_session.address_edited }.from(nil).to eql(true)
     end
 
     it 'updates pii_from_doc' do

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe Idv::AddressController do
+  include IdvHelper
+
+  let(:user) { create(:user) }
+
+  let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.stringify_keys }
+
+  let(:flow_session) do
+    {
+      'pii_from_doc' => pii_from_doc,
+    }
+  end
+
+  before do
+    stub_sign_in(user)
+    stub_analytics
+    stub_idv_steps_before_verify_step(user)
+    subject.idv_session.flow_path = 'standard'
+    subject.user_session['idv/doc_auth'] = flow_session
+  end
+
+  describe '#new' do
+    before do
+      get :new
+    end
+
+    it 'logs an analytics event' do
+      expect(@analytics).to have_logged_event('IdV: address visited')
+    end
+  end
+
+  describe '#update' do
+    let(:params) do
+      {
+        idv_form: {
+          address1: '1234 Main St',
+          address2: 'Apt B',
+          city: 'Beverly Hills',
+          state: 'CA',
+          zipcode: '90210',
+        },
+      }
+    end
+
+    it 'redirects to verify info on success' do
+      put :update, params: params
+      expect(response).to redirect_to(idv_verify_info_url)
+    end
+
+    it 'sets address_edited in flow_session' do
+      expect do
+        put :update, params: params
+      end.to change { flow_session['address_edited'] }.from(nil).to eql(true)
+    end
+
+    it 'updates pii_from_doc' do
+      expect do
+        put :update, params: params
+      end.to change { flow_session['pii_from_doc'] }.to eql(
+        pii_from_doc.merge(
+          {
+            'address1' => '1234 Main St',
+            'address2' => 'Apt B',
+            'city' => 'Beverly Hills',
+            'state' => 'CA',
+            'zipcode' => '90210',
+          },
+        ),
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10656](https://cm-jira.usa.gov/browse/LG-10656)

## 🛠 Summary of changes

Start moving `address_edited` from `flow_session` to `idv_session`. This is the first of two PRs, enabling writing to both locations and reading from either. After this is deployed, a subsequent PR will remove reads and writes to `flow_session['address_edited']`

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
