### PR TITLE
LG-8886: Catch and log network error when renewing USPS API auth token

### DIFF
--- a/app/jobs/usps_auth_token_refresh_job.rb
+++ b/app/jobs/usps_auth_token_refresh_job.rb
@@ -5,6 +5,11 @@ class UspsAuthTokenRefreshJob < ApplicationJob
     analytics.idv_usps_auth_token_refresh_job_started
 
     usps_proofer.retrieve_token!
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
+    analytics.idv_usps_auth_token_refresh_job_network_error(
+      exception_class: err.class.name,
+      exception_message: err.message,
+    )
   ensure
     analytics.idv_usps_auth_token_refresh_job_completed
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2414,6 +2414,18 @@ module AnalyticsEvents
     )
   end
 
+  # Track when USPS auth token refresh job encounters a network error
+  # [String] exception_class
+  # [String] exception_message
+  def idv_usps_auth_token_refresh_job_network_error(exception_class:, exception_message:, **extra)
+    track_event(
+      'UspsAuthTokenRefreshJob: Network error',
+      exception_class: exception_class,
+      exception_message: exception_message,
+      **extra,
+    )
+  end
+
   # Track when USPS auth token refresh job started
   def idv_usps_auth_token_refresh_job_started(**extra)
     track_event(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2415,8 +2415,8 @@ module AnalyticsEvents
   end
 
   # Track when USPS auth token refresh job encounters a network error
-  # [String] exception_class
-  # [String] exception_message
+  # @param [String] exception_class
+  # @param [String] exception_message
   def idv_usps_auth_token_refresh_job_network_error(exception_class:, exception_message:, **extra)
     track_event(
       'UspsAuthTokenRefreshJob: Network error',

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -23,6 +23,10 @@ module UspsIppHelper
     )
   end
 
+  def stub_network_error_request_token(error)
+    stub_request(:post, %r{/oauth/authenticate}).to_raise(error)
+  end
+
   def stub_request_facilities
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getIppFacilityList}).to_return(
       status: 200,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

- [LG-8886](https://cm-jira.usa.gov/browse/LG-8886)
  - This PR only includes a portion of the changes for this ticket.
  - Also see #8993 

## 🛠 Summary of changes

- Catch and log `Faraday::TimeoutError` and `Faraday::ConnectionFailed` when renewing USPS API auth token
  - This prevents these relatively common errors from bubbling up in a way that may trigger other alarms.

## 📜 Testing Plan

- Check that your local stack has the following flag enabled:
  - [x] `usps_mock_fallback`
- [x] Create a method `UspsInPersonProofing::Mock::Proofer.retrieve_token!` that throws `Faraday::TimeoutError.new("test message")`
- [x] Run USPS token renewal job
  - ```sh
     rails c
     ```
  - ```ruby
     UspsAuthTokenRefreshJob.perform_now
     ``` 
- Check that `log/events.log` includes the event `UspsAuthTokenRefreshJob: Network error` with the following fields:
  - [x] `exception_class` = `Faraday::TimeoutError`
  - [x] `exception_message` = `test message`
