### PR TITLE
LG-10062 Allow updater to update a single service provider 

### DIFF
--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -3,8 +3,8 @@ class ServiceProviderController < ApplicationController
 
   def update
     authorize do
-      sp_params = params.permit(service_provider: {})
-      ServiceProviderUpdater.new.run(sp_params[:service_provider]) if FeatureManagement.use_dashboard_service_providers?
+      ServiceProviderUpdater.new.run(JSON.parse(sp_params[:service_provider])) if
+        FeatureManagement.use_dashboard_service_providers?
 
       render json: { status: 'If the feature is enabled, service providers have been updated.' }
     end
@@ -29,5 +29,9 @@ class ServiceProviderController < ApplicationController
 
   def authorization_token
     request.headers['X-LOGIN-DASHBOARD-TOKEN']
+  end
+
+  def sp_params
+    params.permit(:service_provider)
   end
 end

--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -3,15 +3,8 @@ class ServiceProviderController < ApplicationController
 
   def update
     authorize do
-      ServiceProviderUpdater.new.run if FeatureManagement.use_dashboard_service_providers?
-
-      render json: { status: 'If the feature is enabled, service providers have been updated.' }
-    end
-  end
-
-  def update_one
-    authorize do
-      ServiceProviderUpdater.new.run_for_one(params[:id]) if FeatureManagement.use_dashboard_service_providers?
+      sp_params = params.permit(service_provider: {})
+      ServiceProviderUpdater.new.run(sp_params[:service_provider]) if FeatureManagement.use_dashboard_service_providers?
 
       render json: { status: 'If the feature is enabled, service providers have been updated.' }
     end

--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -3,7 +3,7 @@ class ServiceProviderController < ApplicationController
 
   def update
     authorize do
-      ServiceProviderUpdater.new.run(JSON.parse(sp_params[:service_provider])) if
+      ServiceProviderUpdater.new.run(sp_params[:service_provider]) if
         FeatureManagement.use_dashboard_service_providers?
 
       render json: { status: 'If the feature is enabled, service providers have been updated.' }
@@ -32,6 +32,6 @@ class ServiceProviderController < ApplicationController
   end
 
   def sp_params
-    params.permit(:service_provider)
+    params.permit(service_provider: {})
   end
 end

--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -9,6 +9,14 @@ class ServiceProviderController < ApplicationController
     end
   end
 
+  def update_one
+    authorize do
+      ServiceProviderUpdater.new.run_for_one(params[:id]) if FeatureManagement.use_dashboard_service_providers?
+
+      render json: { status: 'If the feature is enabled, service providers have been updated.' }
+    end
+  end
+
   private
 
   def authorize

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -17,7 +17,7 @@ class ServiceProviderUpdater
     else
       dashboard_service_providers.each do |dashboard_service_provider|
         update_local_caches(
-          ActiveSupport::HashWithIndifferentAccess.new(dashboard_service_provider)
+          ActiveSupport::HashWithIndifferentAccess.new(dashboard_service_provider),
         )
       end
     end

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -16,7 +16,9 @@ class ServiceProviderUpdater
       update_local_caches(ActiveSupport::HashWithIndifferentAccess.new(service_provider))
     else
       dashboard_service_providers.each do |dashboard_service_provider|
-        update_local_caches(ActiveSupport::HashWithIndifferentAccess.new(dashboard_service_provider))
+        update_local_caches(
+          ActiveSupport::HashWithIndifferentAccess.new(dashboard_service_provider)
+        )
       end
     end
   end

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -29,8 +29,7 @@ class ServiceProviderUpdater
 
   def update_cache(service_provider)
     issuer = service_provider['issuer']
-    # when a service provider is passed in via params, true becomes 'true'
-    if [true, 'true'].include?(service_provider['active'])
+    if service_provider['active'] == true
       create_or_update_service_provider(issuer, service_provider)
     else
       ServiceProvider.where(issuer: issuer, native: false).destroy_all

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -17,6 +17,10 @@ class ServiceProviderUpdater
     end
   end
 
+  def run_for_one(id)
+    update_local_caches(ActiveSupport::HashWithIndifferentAccess.new(dashboard_service_provider(id)))
+  end
+
   private
 
   def update_local_caches(service_provider)
@@ -61,6 +65,18 @@ class ServiceProviderUpdater
     []
   rescue StandardError
     log_error "Failed to contact #{url}"
+    []
+  end
+
+  def dashboard_service_provider(id)
+    show_url = url + "/#{id}"
+    resp = Faraday.get(show_url)
+
+    return parse_service_providers(resp.body) if resp.status == 200
+    log_error "Failed to parse response from #{show_url}: #{resp.body}"
+    []
+  rescue StandardError
+    log_error "Failed to contact #{show_url}"
     []
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
   get '/api/saml/complete' => 'saml_completion#index', as: :complete_saml
 
   post '/api/service_provider' => 'service_provider#update'
+  post '/api/service_provider/:id' => 'service_provider#update_one'
   post '/api/verify/images' => 'idv/image_uploads#create'
   post '/api/logger' => 'frontend_log#create'
   post '/api/addresses' => 'idv/in_person/address_search#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,6 @@ Rails.application.routes.draw do
   get '/api/saml/complete' => 'saml_completion#index', as: :complete_saml
 
   post '/api/service_provider' => 'service_provider#update'
-  post '/api/service_provider/:id' => 'service_provider#update_one'
   post '/api/verify/images' => 'idv/image_uploads#create'
   post '/api/logger' => 'frontend_log#create'
   post '/api/addresses' => 'idv/in_person/address_search#index'

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -6,66 +6,84 @@ RSpec.describe ServiceProviderController do
   describe '#update' do
     let(:dashboard_sp_issuer) { 'some-dashboard-service-provider' }
     let(:agency) { create(:agency) }
-    let(:dashboard_service_providers) do
-      [
-        {
-          issuer: dashboard_sp_issuer,
-          agency_id: agency.id,
-          friendly_name: 'a friendly service provider',
-          description: 'user friendly Login.gov dashboard',
-          acs_url: 'http://sp.example.org/saml/login',
-          assertion_consumer_logout_service_url: 'http://sp.example.org/saml/logout',
-          block_encryption: 'aes256-cbc',
-          certs: [saml_test_sp_cert],
-          active: true,
-        },
-      ]
+    let(:attributes) do
+      {
+        issuer: dashboard_sp_issuer,
+        agency_id: agency.id,
+        friendly_name: 'a friendly service provider',
+        description: 'user friendly Login.gov dashboard',
+        acs_url: 'http://sp.example.org/saml/login',
+        assertion_consumer_logout_service_url: 'http://sp.example.org/saml/logout',
+        block_encryption: 'aes256-cbc',
+        certs: [saml_test_sp_cert],
+        active: true,
+      }
     end
+    let(:dashboard_service_providers) { [attributes] }
 
     context 'feature on, correct token in headers' do
       before do
         correct_token = '123ABC'
         headers(correct_token)
         allow(IdentityConfig.store).to receive(:use_dashboard_service_providers).and_return(true)
-        allow_any_instance_of(ServiceProviderUpdater).to receive(:dashboard_service_providers).
-          and_return(dashboard_service_providers)
       end
 
-      after do
-        ServiceProvider.find_by(issuer: dashboard_sp_issuer)&.destroy
-      end
-
-      it 'returns 200' do
-        post :update
-
-        expect(response.status).to eq 200
-      end
-
-      it 'updates the matching ServiceProvider in the DB' do
-        post :update
-
-        sp = ServiceProvider.find_by(issuer: dashboard_sp_issuer)
-
-        expect(sp.metadata[:agency]).to eq dashboard_service_providers.first[:agency]
-        expect(sp.ssl_certs.first).to be_a OpenSSL::X509::Certificate
-        expect(sp.active?).to eq true
-      end
-
-      context 'with CSRF protection enabled' do
+      context 'with no params' do
         before do
-          correct_token = '123ABC'
-          headers(correct_token)
-          ActionController::Base.allow_forgery_protection = true
+          allow_any_instance_of(ServiceProviderUpdater).to receive(:dashboard_service_providers).
+            and_return(dashboard_service_providers)
+          post :update
         end
 
         after do
-          ActionController::Base.allow_forgery_protection = false
+          ServiceProvider.find_by(issuer: dashboard_sp_issuer)&.destroy
         end
 
-        it 'ignores invalid CSRF tokens' do
-          post :update
+        it 'returns 200' do
+          expect(response.status).to eq 200
+        end
 
-          expect(response.status).to eq(200)
+        it 'updates the matching ServiceProvider in the DB' do
+          sp = ServiceProvider.find_by(issuer: dashboard_sp_issuer)
+
+          expect(sp.metadata[:agency]).to eq dashboard_service_providers.first[:agency]
+          expect(sp.ssl_certs.first).to be_a OpenSSL::X509::Certificate
+          expect(sp.active?).to eq true
+        end
+
+        context 'with CSRF protection enabled' do
+          before do
+            ActionController::Base.allow_forgery_protection = true
+          end
+
+          after do
+            ActionController::Base.allow_forgery_protection = false
+          end
+
+          it 'ignores invalid CSRF tokens' do
+            expect(response.status).to eq(200)
+          end
+        end
+      end
+
+      context 'with a service provider passed via params' do
+        let(:params) {{ service_provider: attributes }}
+        let(:friendly_name) { "A new friendly name" }
+        before do
+          params[:service_provider][:friendly_name] = friendly_name
+          post :update, params:
+        end
+
+        it 'returns 200' do
+          expect(response.status).to eq 200
+        end
+
+        it 'updates the matching ServiceProvider in the DB' do
+          sp = ServiceProvider.find_by(issuer: dashboard_sp_issuer)
+
+          expect(sp.agency).to eq agency
+          expect(sp.friendly_name).to eq friendly_name
+          expect(sp.active?).to eq true
         end
       end
     end

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe ServiceProviderController do
       end
 
       context 'with a service provider passed via params' do
-        let(:params) {{ service_provider: attributes }}
-        let(:friendly_name) { "A new friendly name" }
+        let(:params) { { service_provider: attributes } }
+        let(:friendly_name) { 'A new friendly name' }
         before do
           params[:service_provider][:friendly_name] = friendly_name
           post :update, params:

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -67,10 +67,15 @@ RSpec.describe ServiceProviderController do
       end
 
       context 'with a service provider passed via params' do
-        let(:params) { { service_provider: attributes } }
         let(:friendly_name) { 'A new friendly name' }
+        let(:params) do
+          {
+            service_provider: attributes.merge(friendly_name:),
+          }
+        end
+
         before do
-          params[:service_provider][:friendly_name] = friendly_name
+          request.content_type = 'application/json'
           post :update, params:
         end
 


### PR DESCRIPTION
## 🎫 Ticket
https://cm-jira.usa.gov/browse/LG-10062

## 🛠 Summary of changes
When a partner on the dashboard side updates their sandbox configurations, those are synced with the [int environment](https://idp.int.identitysandbox.gov/). The updater historically has pinged the dashboard to get a full list of service provider and then synced through the entire list. This no longer scales for the number of sandbox configurations we have and has led to many timeouts.

This change updates the updater to accept a service_provider param, and uses that param to update a single service_provider. It does not remove/alter the existing code, which may be in use in other parts of the application.

It has this [associated PR](https://github.com/18F/identity-dashboard/pull/663) on the Dashboard application.

Open questions:
* Do we still want/need the conditionals around the `native` attribute? It appears that that is a deprecated attribute, but I didn't want to remove it without more context.
	* answer: the dashboard does not send over the deprecated `native` attribute. will follow up in a separate PR to remove it
* Do we want to remove the original code, which updates all the service providers? It has two references in the Dashboard application, one which has been updated in the associated PR, and the other is in the API and may not be in use.
    * answer: this code is still in use! there is a button on the service_providers `all` view. we should move this code out of the API section as part of our tech debt work as the update requires a session.
* I broke the existing pattern of having the IDP ping the dashboard for the attributes because it seemed unnecessarily convoluted, but I can't find the reason that that pattern was created in the first place. If there is a known reason that having the dashboard submit a POST to the IDP that then does a GET request to the dashboard, I can update the code to make that work.