### PR TITLE
LG-10660: Consolidate MFA setup controllers

### DIFF
--- a/app/components/page_footer_component.rb
+++ b/app/components/page_footer_component.rb
@@ -10,6 +10,6 @@ class PageFooterComponent < BaseComponent
   end
 
   def css_class
-    ['margin-top-4 padding-top-2 border-top border-primary-light', *tag_options[:class]]
+    ['page-footer margin-top-4 padding-top-2 border-top border-primary-light', *tag_options[:class]]
   end
 end

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -5,12 +5,13 @@ module Users
 
     before_action :authenticate_user
     before_action :confirm_user_authenticated_for_2fa_setup
-    before_action :confirm_user_needs_2fa_setup
+
+    delegate :enabled_mfa_methods_count, to: :mfa_context
 
     def index
       two_factor_options_form
       @presenter = two_factor_options_presenter
-      analytics.user_registration_2fa_setup_visit
+      analytics.user_registration_2fa_setup_visit(enabled_mfa_methods_count:)
     end
 
     def create
@@ -42,6 +43,10 @@ module Users
 
     private
 
+    def mfa_context
+      @mfa_context ||= MfaContext.new(current_user)
+    end
+
     def submit_form
       two_factor_options_form.submit(two_factor_options_form_params)
     end
@@ -52,18 +57,19 @@ module Users
         user: current_user,
         phishing_resistant_required: service_provider_mfa_policy.phishing_resistant_required?,
         piv_cac_required: service_provider_mfa_policy.piv_cac_required?,
+        show_skip_additional_mfa_link: show_skip_additional_mfa_link?,
+        after_mfa_setup_path:,
       )
     end
 
     def process_valid_form
       user_session[:mfa_selections] = @two_factor_options_form.selection
-      redirect_to confirmation_path(user_session[:mfa_selections].first)
-    end
 
-    def confirm_user_needs_2fa_setup
-      return unless mfa_policy.two_factor_enabled?
-      return if service_provider_mfa_policy.user_needs_sp_auth_method_setup?
-      redirect_to after_mfa_setup_path
+      if user_session[:mfa_selections].first.present?
+        redirect_to confirmation_path(user_session[:mfa_selections].first)
+      else
+        redirect_to after_mfa_setup_path
+      end
     end
 
     def two_factor_options_form_params

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -25,9 +25,7 @@ class WebauthnVisitForm
   end
 
   def current_mfa_setup_path
-    if mfa_user.two_factor_enabled? && in_mfa_selection_flow
-      second_mfa_setup_path
-    elsif mfa_user.two_factor_enabled?
+    if mfa_user.two_factor_enabled? && !in_mfa_selection_flow
       account_path
     else
       authentication_methods_setup_path

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -1,18 +1,24 @@
 class TwoFactorOptionsPresenter
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :user
+  attr_reader :user, :after_mfa_setup_path
 
-  def initialize(user_agent:,
-                 user: nil,
-                 phishing_resistant_required: false,
-                 piv_cac_required: false,
-                 show_skip_additional_mfa_link: true)
+  delegate :two_factor_enabled?, to: :mfa_policy
+
+  def initialize(
+    user_agent:,
+    user: nil,
+    phishing_resistant_required: false,
+    piv_cac_required: false,
+    show_skip_additional_mfa_link: true,
+    after_mfa_setup_path: nil
+  )
     @user_agent = user_agent
     @user = user
     @phishing_resistant_required = phishing_resistant_required
     @piv_cac_required = piv_cac_required
     @show_skip_additional_mfa_link = show_skip_additional_mfa_link
+    @after_mfa_setup_path = after_mfa_setup_path
   end
 
   def options
@@ -52,6 +58,10 @@ class TwoFactorOptionsPresenter
 
   def show_skip_additional_mfa_link?
     @show_skip_additional_mfa_link
+  end
+
+  def skip_path
+    after_mfa_setup_path if two_factor_enabled? && show_skip_additional_mfa_link?
   end
 
   private

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3865,9 +3865,12 @@ module AnalyticsEvents
   end
 
   # Tracks when user visits MFA selection page
-  def user_registration_2fa_setup_visit
+  # @param [Integer] Number of MFAs associated with user at time of visit
+  def user_registration_2fa_setup_visit(enabled_mfa_methods_count:, **extra)
     track_event(
       'User Registration: 2FA Setup visited',
+      enabled_mfa_methods_count:,
+      **extra,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3865,7 +3865,7 @@ module AnalyticsEvents
   end
 
   # Tracks when user visits MFA selection page
-  # @param [Integer] Number of MFAs associated with user at time of visit
+  # @param [Integer] enabled_mfa_methods_count Number of MFAs associated with user at time of visit
   def user_registration_2fa_setup_visit(enabled_mfa_methods_count:, **extra)
     track_event(
       'User Registration: 2FA Setup visited',

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -10,7 +10,7 @@
 
 <div class="col-12">
   <%= link_to(
-        second_mfa_setup_path,
+        authentication_methods_setup_path,
         class: 'usa-button usa-button--wide usa-button--big margin-bottom-3',
       ) { @content.button } %>
 </div>

--- a/app/views/shared/_cancel_or_back_to_options.html.erb
+++ b/app/views/shared/_cancel_or_back_to_options.html.erb
@@ -1,7 +1,5 @@
 <%= render PageFooterComponent.new do %>
-  <% if MfaPolicy.new(current_user).two_factor_enabled? && in_multi_mfa_selection_flow? %>
-    <%= link_to t('two_factor_authentication.choose_another_option'), second_mfa_setup_path %>
-  <% elsif MfaPolicy.new(current_user).two_factor_enabled? %>
+  <% if MfaPolicy.new(current_user).two_factor_enabled? && !in_multi_mfa_selection_flow? %>
     <%= link_to t('links.cancel'), account_path %>
   <% else %>
     <%= link_to t('two_factor_authentication.choose_another_option'), authentication_methods_setup_path %>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -18,7 +18,7 @@
   <%= render(AlertComponent.new(type: :warning, class: 'margin-bottom-4')) do %>
     <%= link_to(
           t('mfa.second_method_warning.link'),
-          second_mfa_setup_path,
+          authentication_methods_setup_path,
         ) %>
     <%= t('mfa.second_method_warning.text') %>
   <% end %>

--- a/app/views/users/backup_code_setup/confirm_backup_codes.html.erb
+++ b/app/views/users/backup_code_setup/confirm_backup_codes.html.erb
@@ -27,11 +27,11 @@
           big: true,
           full_width: true,
           outline: true,
-        ).with_content(t('two_factor_authentication.backup_codes.new_backup_codes_html')) %> 
+        ).with_content(t('two_factor_authentication.backup_codes.new_backup_codes_html')) %>
   </div>
 </div>
 
 <%= render PageFooterComponent.new do %>
-  <%= link_to t('two_factor_authentication.backup_codes.add_another_authentication_option'), second_mfa_setup_path %>
-<% end %> 
+  <%= link_to t('two_factor_authentication.backup_codes.add_another_authentication_option'), authentication_methods_setup_path %>
+<% end %>
 

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -14,6 +14,20 @@
 
 <p class="maxw-mobile-lg margin-bottom-0"><%= @presenter.intro %></p>
 
+<% if @presenter.two_factor_enabled? %>
+  <h2 class="margin-top-2 margin-bottom-1">
+    <%= t('headings.account.two_factor') %>
+  </h2>
+
+  <ul class="usa-icon-list">
+    <% @presenter.options.each do |option| %>
+      <% if option.mfa_configuration_count > 0 %>
+        <%= render partial: 'partials/multi_factor_authentication/selected_mfa_option', locals: { option: option } %>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>
+
 <%= simple_form_for @two_factor_options_form,
                     html: { autocomplete: 'off' },
                     method: :patch,
@@ -35,4 +49,12 @@
   <%= f.submit t('forms.buttons.continue'), class: 'margin-bottom-1' %>
 <% end %>
 
-<%= render 'shared/cancel', link: logout_path, link_method: :delete %>
+<% if @presenter.skip_path || !@presenter.two_factor_enabled? %>
+  <%= render PageFooterComponent.new do %>
+    <% if @presenter.skip_path %>
+      <%= link_to t('mfa.skip'), @presenter.skip_path %>
+    <% elsif !@presenter.two_factor_enabled? %>
+      <%= link_to t('links.cancel_account_creation'), sign_up_cancel_path %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/spec/components/page_footer_component_spec.rb
+++ b/spec/components/page_footer_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PageFooterComponent, type: :component do
     rendered = render_inline PageFooterComponent.new.with_content(content)
 
     expect(rendered).to have_content(content)
+    expect(rendered).to have_css('.page-footer')
   end
 
   context 'tag options' do
@@ -20,7 +21,7 @@ RSpec.describe PageFooterComponent, type: :component do
     it 'appends custom class' do
       rendered = render_inline PageFooterComponent.new(class: 'custom-class')
 
-      expect(rendered).to have_css('.custom-class')
+      expect(rendered).to have_css('.page-footer.custom-class')
     end
   end
 end

--- a/spec/features/multi_factor_authentication/mfa_cta_spec.rb
+++ b/spec/features/multi_factor_authentication/mfa_cta_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'mfa cta banner' do
       expect(page).to have_current_path(confirm_backup_codes_path)
       acknowledge_backup_code_confirmation
       click_link(t('mfa.second_method_warning.link'))
-      expect(page).to have_current_path(second_mfa_setup_path)
+      expect(page).to have_current_path(authentication_methods_setup_path)
     end
   end
 end

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Remembering a webauthn device' do
 
         click_link t('mfa.add')
 
-        expect(page).to have_current_path(second_mfa_setup_path)
+        expect(page).to have_current_path(authentication_methods_setup_path)
 
         click_2fa_option('phone')
 

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
 
       click_link t('two_factor_authentication.choose_another_option')
 
-      expect(page).to have_current_path(second_mfa_setup_path)
+      expect(page).to have_current_path(authentication_methods_setup_path)
 
       select_2fa_option('auth_app')
       fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
@@ -168,7 +168,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
           expect(page).to have_current_path(auth_method_confirmation_path)
 
           click_link t('mfa.add')
-          expect(page).to have_current_path(second_mfa_setup_path)
+          expect(page).to have_current_path(authentication_methods_setup_path)
 
           click_link t('mfa.skip')
           expect(page).to have_current_path(account_path)
@@ -189,7 +189,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
           expect(page).to have_current_path(auth_method_confirmation_path)
 
           click_link t('mfa.add')
-          expect(page).to have_current_path(second_mfa_setup_path)
+          expect(page).to have_current_path(authentication_methods_setup_path)
 
           click_continue
           expect(page).to have_current_path(account_path)
@@ -218,10 +218,10 @@ RSpec.feature 'Multi Two Factor Authentication' do
           expect(page).to_not have_button(t('mfa.skip'))
 
           click_link t('mfa.add')
-          expect(page).to have_current_path(second_mfa_setup_path)
+          expect(page).to have_current_path(authentication_methods_setup_path)
 
           click_continue
-          expect(page).to have_current_path(second_mfa_setup_path)
+          expect(page).to have_current_path(authentication_methods_setup_path)
           expect(page).to have_content(
             t('errors.two_factor_auth_setup.must_select_additional_option'),
           )

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe WebauthnVisitForm do
     context 'with two_factor_enabled and in_mfa_selection_flow' do
       let(:user) { create(:user, :with_phone) }
 
-      it { is_expected.to eq(second_mfa_setup_path) }
+      it { is_expected.to eq(authentication_methods_setup_path) }
     end
 
     context 'with two_factor_enabled' do

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -4,18 +4,27 @@ RSpec.describe TwoFactorOptionsPresenter do
   include Rails.application.routes.url_helpers
   include RequestHelper
 
+  let(:user) { build(:user) }
   let(:user_agent) do
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 \
 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36'
   end
+  let(:after_mfa_setup_path) { account_path }
+  let(:show_skip_additional_mfa_link) { true }
 
   let(:presenter) do
-    described_class.new(user_agent: user_agent)
+    described_class.new(user:, user_agent:, after_mfa_setup_path:, show_skip_additional_mfa_link:)
   end
 
   before do
     allow(IdentityConfig.store).to receive(:platform_auth_set_up_enabled).
       and_return(false)
+  end
+
+  describe '#two_factor_enabled?' do
+    it 'delegates to mfa_policy' do
+      expect(presenter).to delegate_method(:two_factor_enabled?).to(:mfa_policy)
+    end
   end
 
   describe '#options' do
@@ -74,6 +83,24 @@ RSpec.describe TwoFactorOptionsPresenter do
           TwoFactorAuthentication::WebauthnSelectionPresenter,
           TwoFactorAuthentication::PivCacSelectionPresenter,
         ]
+      end
+    end
+  end
+
+  describe '#skip_path' do
+    subject(:skip_path) { presenter.skip_path }
+
+    it { expect(skip_path).to be_nil }
+
+    context 'with mfa configured' do
+      let(:user) { build(:user, :with_phone) }
+
+      it { expect(skip_path).to eq(after_mfa_setup_path) }
+
+      context 'with skip link hidden' do
+        let(:show_skip_additional_mfa_link) { false }
+
+        it { expect(skip_path).to be_nil }
       end
     end
   end

--- a/spec/views/shared/_cancel_or_back_to_options.html.erb_spec.rb
+++ b/spec/views/shared/_cancel_or_back_to_options.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_cancel_or_back_to_options.html.erb' do
+  let(:user) { build(:user) }
+  let(:in_multi_mfa_selection_flow) { false }
+
+  subject(:rendered) { render }
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:in_multi_mfa_selection_flow?).and_return(in_multi_mfa_selection_flow)
+  end
+
+  it 'renders link to choose another authentication method' do
+    expect(rendered).to have_link(
+      t('two_factor_authentication.choose_another_option'),
+      href: authentication_methods_setup_path,
+    )
+  end
+
+  context 'with mfa configured' do
+    let(:user) { build(:user, :with_phone) }
+
+    it 'renders link to cancel and return to account' do
+      expect(rendered).to have_link(t('links.cancel'), href: account_path)
+    end
+
+    context 'when in multi mfa selection flow' do
+      let(:in_multi_mfa_selection_flow) { true }
+
+      it 'renders link to choose another authentication method' do
+        expect(rendered).to have_link(
+          t('two_factor_authentication.choose_another_option'),
+          href: authentication_methods_setup_path,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10660](https://cm-jira.usa.gov/browse/LG-10660)

## 🛠 Summary of changes

Updates links and updates capability of `TwoFactorAuthenticationSetupController` to handle both initial and additional MFA setups, with planned follow-on pull request to remove `MfaSelectionController`.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create an account, up to "Authentication method setup"
3. Observe no visual differences from `main`
4. Set up an MFA method
5. When prompted, choose to "Add another method"
6. On the additional MFA setup screen, observe no visual differences from `main`

Also try a few variations:
- Choosing "Face or touch unlock" as your first MFA should hide the option to skip when setting up second method (#8739)
- MFAs added and single-only restrictions should apply (#8863)

## 👀 Screenshots

There should be no visual differences, aside from the URL in the additional MFA setup:

Before: `/second_mfa_setup`
After: `/authentication_methods_setup`

Screen|Before|After
---|---|---
Initial|![before-initial](https://github.com/18F/identity-idp/assets/1779930/f99b2038-6919-47d3-8c6c-35eb78f5b33f)|![after-initial](https://github.com/18F/identity-idp/assets/1779930/6a9c3dfe-0605-478d-87a1-c5adbe64d72c)
Second|![before-second](https://github.com/18F/identity-idp/assets/1779930/e5af1e03-5413-40af-909f-d9567d0cc296)|![after-second](https://github.com/18F/identity-idp/assets/1779930/b3e3ac91-4e50-4d6c-8afb-8d0d90064253)