### PR TITLE
LG-10576 Add threatmetrix_session_id to idv_session

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -30,7 +30,8 @@ module Idv
         should_proof_state_id: should_use_aamva?(pii),
         trace_id: amzn_trace_id,
         user_id: current_user.id,
-        threatmetrix_session_id: flow_session[:threatmetrix_session_id],
+        threatmetrix_session_id:
+          idv_session.threatmetrix_session_id || flow_session[:threatmetrix_session_id],
         request_ip: request.remote_ip,
         double_address_verification: capture_secondary_id_enabled,
       )

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -23,6 +23,7 @@ module Idv
       resolution_successful
       skip_hybrid_handoff
       threatmetrix_review_status
+      threatmetrix_session_id
       user_phone_confirmation
       vendor_phone_confirmation
       verify_info_step_document_capture_session_uuid

--- a/app/services/idv/steps/threat_metrix_step_helper.rb
+++ b/app/services/idv/steps/threat_metrix_step_helper.rb
@@ -12,8 +12,12 @@ module Idv
       end
 
       def generate_threatmetrix_session_id
-        flow_session[:threatmetrix_session_id] = SecureRandom.uuid if !updating_ssn?
-        flow_session[:threatmetrix_session_id]
+        if !updating_ssn?
+          idv_session.threatmetrix_session_id = SecureRandom.uuid
+          # for 50/50 state, to be removed in next deploy
+          flow_session[:threatmetrix_session_id] = idv_session.threatmetrix_session_id
+        end
+        idv_session.threatmetrix_session_id || flow_session[:threatmetrix_session_id]
       end
 
       # @return [Array<String>]

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -84,6 +84,11 @@ RSpec.describe Idv::InPerson::SsnController do
       expect(flow_session[:threatmetrix_session_id]).to_not eq(nil)
     end
 
+    it 'adds a threatmetrix session id to idv_session' do
+      get :show
+      expect(subject.idv_session.threatmetrix_session_id).to_not eq(nil)
+    end
+
     context 'with an ssn in session' do
       let(:referer) { idv_in_person_step_url(step: :address) }
       before do
@@ -179,6 +184,14 @@ RSpec.describe Idv::InPerson::SsnController do
         session_id = flow_session[:threatmetrix_session_id]
         subject.threatmetrix_view_variables
         expect(flow_session[:threatmetrix_session_id]).to eq(session_id)
+      end
+
+      it 'does not change idv_session threatmetrix_session_id when updating ssn' do
+        flow_session[:pii_from_user][:ssn] = ssn
+        put :update, params: params
+        session_id = subject.idv_session.threatmetrix_session_id
+        subject.threatmetrix_view_variables
+        expect(subject.idv_session.threatmetrix_session_id).to eq(session_id)
       end
     end
 

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -222,12 +222,26 @@ RSpec.describe Idv::SsnController do
         expect(flow_session[:threatmetrix_session_id]).to_not eq(nil)
       end
 
-      it 'does not change threatmetrix_session_id when updating ssn' do
+      it 'does not change flow_session threatmetrix_session_id when updating ssn' do
         flow_session['pii_from_doc'][:ssn] = ssn
         put :update, params: params
         session_id = flow_session[:threatmetrix_session_id]
         subject.threatmetrix_view_variables
         expect(flow_session[:threatmetrix_session_id]).to eq(session_id)
+      end
+
+      it 'adds a threatmetrix session id to idv_session' do
+        put :update, params: params
+        subject.threatmetrix_view_variables
+        expect(subject.idv_session.threatmetrix_session_id).to_not eq(nil)
+      end
+
+      it 'does not change idv_session threatmetrix_session_id when updating ssn' do
+        flow_session['pii_from_doc'][:ssn] = ssn
+        put :update, params: params
+        session_id = subject.idv_session.threatmetrix_session_id
+        subject.threatmetrix_view_variables
+        expect(subject.idv_session.threatmetrix_session_id).to eq(session_id)
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-10576](https://cm-jira.usa.gov/browse/LG-10576)

## 🛠 Summary of changes

We are moving data from flow_session to idv_session. Now that both the unsupervised and in person Ssn steps are out of the Flow State Machine, we can move threatmetrix_session_id to idv_session. This PR adds it to idv_session, and a followup PR for the next deploy will remove it from flow_session.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Set `lexisnexis_threatmetrix_mock_enabled: true` in local application.yml and restart server
- [ ] Create account, start IdV
- [ ] In Ssn step, set "Mock device profiling behavior" dropdown to Review
- [ ] Continue with IdV
- [ ] Expect to see Please Call page at the end of the process
- [ ] Create new account, start Idv
- [ ] Upload error yml to access In Person proofing
- [ ] Choose In Person flow
- [ ] In Ssn step, set "Mock device profiling behavior" dropdown to Review
- [ ] Continue with Idv
- [ ] Do NOT expect to see Please Call page, since it is not used for In Person Proofing
