### PR TITLE
LG-10344 Opportunistically read multi-region KMS ciphertexts

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -59,6 +59,7 @@ aws_kms_key_id: alias/login-dot-gov-test-keymaker
 aws_kms_client_contextless_pool_size: 5
 aws_kms_client_multi_pool_size: 5
 aws_kms_multi_region_key_id: alias/login-dot-gov-keymaker-multi-region
+aws_kms_multi_region_read_enabled: false
 aws_logo_bucket: ''
 aws_region: 'us-west-2'
 backup_code_cost: '2000$8$1$'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -146,6 +146,7 @@ class IdentityConfig
     config.add(:aws_kms_client_multi_pool_size, type: :integer)
     config.add(:aws_kms_key_id, type: :string)
     config.add(:aws_kms_multi_region_key_id, type: :string)
+    config.add(:aws_kms_multi_region_read_enabled, type: :boolean)
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)
     config.add(:backup_code_cost, type: :string)

--- a/spec/services/encryption/encryptors/pii_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/pii_encryptor_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Encryption::Encryptors::PiiEncryptor do
       expect(scrypt_password).to receive(:digest).and_return(scrypt_digest)
       expect(SCrypt::Password).to receive(:new).and_return(scrypt_password)
 
-      kms_client = subject.send(:single_region_kms_client)
+      kms_client = subject.send(:multi_region_kms_client)
       expect(kms_client).to receive(:decrypt).
         with('kms_ciphertext', { 'context' => 'pii-encryption', 'user_uuid' => 'uuid-123-abc' }).
         and_return('aes_ciphertext')


### PR DESCRIPTION
We are in the midst of a migration to a new KMS key that support multi-region operations. This migration involves the following steps:

1. Start writing to new columns with the new key
2. Start reading from the new columns if they have a value and using the new key to decrypt them
3. Go through and convert old rows to the new key
4. Drop the old column

This commit adds code and a feature flag to allow step 2. When then flag is enabled the IDP will try to use the multi-region column's ciphertext instead of the single-region ciphertext.

Note that KMS does not require a key ID for decryption. It can determine that based on the KMS ciphertext it receives for decrypt. As a result the multi-region KMS client can be used to decrypt multi-region and single-region cihpertexts.
