### PR TITLE
LG-10576 delete threatmetrix session id from flow session

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -30,8 +30,7 @@ module Idv
         should_proof_state_id: should_use_aamva?(pii),
         trace_id: amzn_trace_id,
         user_id: current_user.id,
-        threatmetrix_session_id:
-          idv_session.threatmetrix_session_id || flow_session[:threatmetrix_session_id],
+        threatmetrix_session_id: idv_session.threatmetrix_session_id,
         request_ip: request.remote_ip,
         double_address_verification: capture_secondary_id_enabled,
       )

--- a/app/services/idv/steps/threat_metrix_step_helper.rb
+++ b/app/services/idv/steps/threat_metrix_step_helper.rb
@@ -12,12 +12,8 @@ module Idv
       end
 
       def generate_threatmetrix_session_id
-        if !updating_ssn?
-          idv_session.threatmetrix_session_id = SecureRandom.uuid
-          # for 50/50 state, to be removed in next deploy
-          flow_session[:threatmetrix_session_id] = idv_session.threatmetrix_session_id
-        end
-        idv_session.threatmetrix_session_id || flow_session[:threatmetrix_session_id]
+        idv_session.threatmetrix_session_id = SecureRandom.uuid if !updating_ssn?
+        idv_session.threatmetrix_session_id
       end
 
       # @return [Array<String>]

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -80,8 +80,7 @@ RSpec.describe Idv::InPerson::SsnController do
     end
 
     it 'adds a threatmetrix session id to idv_session' do
-      get :show
-      expect(subject.idv_session.threatmetrix_session_id).to_not eq(nil)
+      expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }.from(nil)
     end
 
     context 'with an ssn in session' do

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -79,11 +79,6 @@ RSpec.describe Idv::InPerson::SsnController do
       )
     end
 
-    it 'adds a session id to flow session' do
-      get :show
-      expect(flow_session[:threatmetrix_session_id]).to_not eq(nil)
-    end
-
     it 'adds a threatmetrix session id to idv_session' do
       get :show
       expect(subject.idv_session.threatmetrix_session_id).to_not eq(nil)
@@ -179,14 +174,6 @@ RSpec.describe Idv::InPerson::SsnController do
       end
 
       it 'does not change threatmetrix_session_id when updating ssn' do
-        flow_session[:pii_from_user][:ssn] = ssn
-        put :update, params: params
-        session_id = flow_session[:threatmetrix_session_id]
-        subject.threatmetrix_view_variables
-        expect(flow_session[:threatmetrix_session_id]).to eq(session_id)
-      end
-
-      it 'does not change idv_session threatmetrix_session_id when updating ssn' do
         flow_session[:pii_from_user][:ssn] = ssn
         put :update, params: params
         session_id = subject.idv_session.threatmetrix_session_id

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -88,6 +88,10 @@ RSpec.describe Idv::SsnController do
       )
     end
 
+    it 'adds a threatmetrix session id to idv_session' do
+      expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }.from(nil)
+    end
+
     context 'with an ssn in session' do
       let(:referer) { idv_document_capture_url }
       before do
@@ -214,12 +218,6 @@ RSpec.describe Idv::SsnController do
 
           expect(subject.idv_session.applicant).to be_blank
         end
-      end
-
-      it 'adds a threatmetrix session id to idv_session' do
-        put :update, params: params
-        subject.threatmetrix_view_variables
-        expect(subject.idv_session.threatmetrix_session_id).to_not eq(nil)
       end
 
       it 'does not change threatmetrix_session_id when updating ssn' do

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -216,27 +216,13 @@ RSpec.describe Idv::SsnController do
         end
       end
 
-      it 'adds a threatmetrix session id to flow session' do
-        put :update, params: params
-        subject.threatmetrix_view_variables
-        expect(flow_session[:threatmetrix_session_id]).to_not eq(nil)
-      end
-
-      it 'does not change flow_session threatmetrix_session_id when updating ssn' do
-        flow_session['pii_from_doc'][:ssn] = ssn
-        put :update, params: params
-        session_id = flow_session[:threatmetrix_session_id]
-        subject.threatmetrix_view_variables
-        expect(flow_session[:threatmetrix_session_id]).to eq(session_id)
-      end
-
       it 'adds a threatmetrix session id to idv_session' do
         put :update, params: params
         subject.threatmetrix_view_variables
         expect(subject.idv_session.threatmetrix_session_id).to_not eq(nil)
       end
 
-      it 'does not change idv_session threatmetrix_session_id when updating ssn' do
+      it 'does not change threatmetrix_session_id when updating ssn' do
         flow_session['pii_from_doc'][:ssn] = ssn
         put :update, params: params
         session_id = subject.idv_session.threatmetrix_session_id


### PR DESCRIPTION
## 🎫 Ticket

[LG-10576](https://cm-jira.usa.gov/browse/LG-10576)

## 🛠 Summary of changes

As a followup to #9046, delete `flow_session[:threatmetrix_session_id]` now that it has been moved to `idv_session.threatmetrix_session_id`.

Also, test in the same way in unsupervised and in person ssn controller specs.

Note: merge after #9046 has been deployed.
