### PR TITLE
Disable the GPO reminder job

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -182,12 +182,6 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.today] },
       },
-      # Send reminder letters for old, outstanding GPO verification codes
-      send_gpo_code_reminders: {
-        class: 'GpoReminderJob',
-        cron: cron_24h,
-        args: -> { [14.days.ago] },
-      },
     }.compact
   end
   # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
The GPO reminder job currently has a query that sends an email to users who are GPO pending. Unfortunately it is configured to send an email to every user who has ever been GPO pending. As a result every pending user from all of history will receive an email once it is merged.

This commit temporarily disables the job while we figure that problem out.
