### PR TITLE
Inform user that a service provider request is requiring re-authentication if they are logged out due to it (LG-10661)

### DIFF
--- a/app/controllers/concerns/forced_reauthentication_concern.rb
+++ b/app/controllers/concerns/forced_reauthentication_concern.rb
@@ -7,7 +7,7 @@ module ForcedReauthenticationConcern
     session.dig(:forced_reauthentication_sps, issuer) == true
   end
 
-  def set_issuer_forced_reauthentication(issuer, is_forced_reauthentication)
+  def set_issuer_forced_reauthentication(issuer:, is_forced_reauthentication:)
     session[:forced_reauthentication_sps] ||= {}
     session[:forced_reauthentication_sps][issuer] = is_forced_reauthentication
   end

--- a/app/controllers/concerns/forced_reauthentication_concern.rb
+++ b/app/controllers/concerns/forced_reauthentication_concern.rb
@@ -8,7 +8,12 @@ module ForcedReauthenticationConcern
   end
 
   def set_issuer_forced_reauthentication(issuer:, is_forced_reauthentication:)
-    session[:forced_reauthentication_sps] ||= {}
-    session[:forced_reauthentication_sps][issuer] = is_forced_reauthentication
+    if is_forced_reauthentication
+      session[:forced_reauthentication_sps] ||= {}
+      session[:forced_reauthentication_sps][issuer] = true
+    elsif session[:forced_reauthentication_sps]
+      session[:forced_reauthentication_sps].delete(issuer)
+      session.delete(:forced_reauthentication_sps) if session[:forced_reauthentication_sps].blank?
+    end
   end
 end

--- a/app/controllers/concerns/forced_reauthentication_concern.rb
+++ b/app/controllers/concerns/forced_reauthentication_concern.rb
@@ -1,0 +1,14 @@
+# This module defines an interface for storing when an issuer has forced re-authentication
+# for an active session. A request to force re-authentication that does not result
+# in the user needing to re-authenticate due to not being authenticated should be excluded.
+
+module ForcedReauthenticationConcern
+  def issuer_forced_reauthentication?(issuer)
+    session.dig(:forced_reauthentication_sps, issuer) == true
+  end
+
+  def set_issuer_forced_reauthentication(issuer, is_forced_reauthentication)
+    session[:forced_reauthentication_sps] ||= {}
+    session[:forced_reauthentication_sps][issuer] = is_forced_reauthentication
+  end
+end

--- a/app/controllers/concerns/forced_reauthentication_concern.rb
+++ b/app/controllers/concerns/forced_reauthentication_concern.rb
@@ -3,7 +3,7 @@
 # in the user needing to re-authenticate due to not being authenticated should be excluded.
 
 module ForcedReauthenticationConcern
-  def issuer_forced_reauthentication?(issuer)
+  def issuer_forced_reauthentication?(issuer:)
     session.dig(:forced_reauthentication_sps, issuer) == true
   end
 

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -21,14 +21,20 @@ module SamlIdpAuthConcern
 
   def sign_out_if_forceauthn_is_true_and_user_is_signed_in
     if !saml_request.force_authn?
-      set_issuer_forced_reauthentication(saml_request_service_provider.issuer, false)
+      set_issuer_forced_reauthentication(
+        issuer: saml_request_service_provider.issuer,
+        is_forced_reauthentication: false,
+      )
     end
 
     return unless user_signed_in? && saml_request.force_authn?
 
     if !sp_session[:final_auth_request]
       sign_out
-      set_issuer_forced_reauthentication(saml_request_service_provider.issuer, true)
+      set_issuer_forced_reauthentication(
+        issuer: saml_request_service_provider.issuer,
+        is_forced_reauthentication: true,
+      )
     end
     sp_session[:final_auth_request] = false
   end

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -1,6 +1,7 @@
 module SamlIdpAuthConcern
   extend ActiveSupport::Concern
   extend Forwardable
+  include ForcedReauthenticationConcern
 
   included do
     # rubocop:disable Rails/LexicallyScopedActionFilter
@@ -19,9 +20,16 @@ module SamlIdpAuthConcern
   private
 
   def sign_out_if_forceauthn_is_true_and_user_is_signed_in
+    if !saml_request.force_authn?
+      set_issuer_forced_reauthentication(saml_request_service_provider.issuer, false)
+    end
+
     return unless user_signed_in? && saml_request.force_authn?
 
-    sign_out unless sp_session[:final_auth_request]
+    if !sp_session[:final_auth_request]
+      sign_out
+      set_issuer_forced_reauthentication(saml_request_service_provider.issuer, true)
+    end
     sp_session[:final_auth_request] = false
   end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -127,7 +127,10 @@ module OpenidConnect
 
     def sign_out_if_prompt_param_is_login_and_user_is_signed_in
       if @authorize_form.prompt != 'login'
-        set_issuer_forced_reauthentication(@authorize_form.service_provider.issuer, false)
+        set_issuer_forced_reauthentication(
+          issuer: @authorize_form.service_provider.issuer,
+          is_forced_reauthentication: false,
+        )
       end
       return unless user_signed_in? && @authorize_form.prompt == 'login'
       return if session[:oidc_state_for_login_prompt] == @authorize_form.state
@@ -135,7 +138,10 @@ module OpenidConnect
       unless sp_session[:request_url] == request.original_url
         sign_out
         session[:oidc_state_for_login_prompt] = @authorize_form.state
-        set_issuer_forced_reauthentication(@authorize_form.service_provider.issuer, true)
+        set_issuer_forced_reauthentication(
+          issuer: @authorize_form.service_provider.issuer,
+          is_forced_reauthentication: true,
+        )
       end
     end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -6,6 +6,7 @@ module OpenidConnect
     include SecureHeadersConcern
     include AuthorizationCountConcern
     include BillableEventTrackable
+    include ForcedReauthenticationConcern
 
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :pre_validate_authorize_form, only: [:index]
@@ -125,12 +126,16 @@ module OpenidConnect
     end
 
     def sign_out_if_prompt_param_is_login_and_user_is_signed_in
+      if @authorize_form.prompt != 'login'
+        set_issuer_forced_reauthentication(@authorize_form.service_provider.issuer, false)
+      end
       return unless user_signed_in? && @authorize_form.prompt == 'login'
       return if session[:oidc_state_for_login_prompt] == @authorize_form.state
       return if check_sp_handoff_bounced
       unless sp_session[:request_url] == request.original_url
         sign_out
         session[:oidc_state_for_login_prompt] = @authorize_form.state
+        set_issuer_forced_reauthentication(@authorize_form.service_provider.issuer, true)
       end
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,6 +7,7 @@ module Users
     include RememberDeviceConcern
     include Ial2ProfileConcern
     include Api::CsrfTokenConcern
+    include ForcedReauthenticationConcern
 
     rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_signin
 
@@ -20,6 +21,7 @@ module Users
       override_csp_for_google_analytics
 
       @ial = sp_session_ial
+      @issuer_forced_reauthentication = issuer_forced_reauthentication?(decorated_session.sp_issuer)
       analytics.sign_in_page_visit(
         flash: flash[:alert],
         stored_location: session['user_return_to'],

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,9 @@ module Users
       override_csp_for_google_analytics
 
       @ial = sp_session_ial
-      @issuer_forced_reauthentication = issuer_forced_reauthentication?(decorated_session.sp_issuer)
+      @issuer_forced_reauthentication = issuer_forced_reauthentication?(
+        issuer: decorated_session.sp_issuer,
+      )
       analytics.sign_in_page_visit(
         flash: flash[:alert],
         stored_location: session['user_return_to'],

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,6 +17,12 @@
 
 <%= render 'shared/sp_alert', section: 'sign_in' %>
 
+<% if @issuer_forced_reauthentication %>
+  <p>
+    <%= t('account.login.forced_reauthentication_notice_html', sp_name: decorated_session.sp_name) %>
+  </p>
+<% end %>
+
 <%= simple_form_for(
       resource,
       as: resource_name,

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -71,6 +71,8 @@ en:
       delete_account: Delete
       regenerate_personal_key: Reset
     login:
+      forced_reauthentication_notice_html: <strong>%{sp_name}</strong> needs you to
+        enter your email and password again.
       piv_cac: Sign in with your government employee ID
       tab_navigation: Account creation tabs
     navigation:

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -72,6 +72,8 @@ es:
       delete_account: Eliminar
       regenerate_personal_key: Restablecer
     login:
+      forced_reauthentication_notice_html: <strong>%{sp_name}</strong> requiere que
+        vuelvas a ingresar tu correo electrónico y contraseña.
       piv_cac: Inicie sesión con su identificación de empleado del gobierno
       tab_navigation: Pestañas de creación de cuenta
     navigation:

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -77,6 +77,9 @@ fr:
       delete_account: Effacer
       regenerate_personal_key: Réinitialiser
     login:
+      forced_reauthentication_notice_html: <strong>%{sp_name}</strong> nécessite que
+        vous saisissiez à nouveau votre adresse électronique et votre mot de
+        passe.
       piv_cac: Connectez-vous avec votre ID d’employé du gouvernement
       tab_navigation: Onglets de création de compte
     navigation:

--- a/spec/controllers/concerns/forced_reauthentication_concern_spec.rb
+++ b/spec/controllers/concerns/forced_reauthentication_concern_spec.rb
@@ -1,15 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe ForcedReauthenticationConcern do
-  class TestClass
-    include ForcedReauthenticationConcern
+  let(:test_class) do
+    Class.new do
+      include ForcedReauthenticationConcern
 
-    attr_reader :session
+      attr_reader :session
 
-    def initialize(session = {})
-      @session = session
+      def initialize(session = {})
+        @session = session
+      end
     end
   end
+  let(:instance) { test_class.new }
 
   describe '#issuer_forced_reauthentication?' do
     it 'returns true if issuer has forced reauthentication' do

--- a/spec/controllers/concerns/forced_reauthentication_concern_spec.rb
+++ b/spec/controllers/concerns/forced_reauthentication_concern_spec.rb
@@ -16,27 +16,35 @@ RSpec.describe ForcedReauthenticationConcern do
 
   describe '#issuer_forced_reauthentication?' do
     it 'returns true if issuer has forced reauthentication' do
-      instance = TestClass.new
-      instance.set_issuer_forced_reauthentication('test_issuer', true)
-      expect(instance.issuer_forced_reauthentication?('test_issuer')).to eq true
+      instance.set_issuer_forced_reauthentication(
+        issuer: 'test_issuer',
+        is_forced_reauthentication: true,
+      )
+      expect(instance.issuer_forced_reauthentication?(issuer: 'test_issuer')).to eq true
     end
 
     it 'returns false if issuer has not forced reauthentication' do
-      instance = TestClass.new
-      expect(instance.issuer_forced_reauthentication?('test_issuer')).to eq false
+      expect(instance.issuer_forced_reauthentication?(issuer: 'test_issuer')).to eq false
     end
 
     it 'returns false if forced reauthentication is set to false for an issuer' do
-      instance = TestClass.new
-      instance.set_issuer_forced_reauthentication('test_issuer', false)
-      expect(instance.issuer_forced_reauthentication?('test_issuer')).to eq false
+      instance.set_issuer_forced_reauthentication(
+        issuer: 'test_issuer',
+        is_forced_reauthentication: false,
+      )
+      expect(instance.issuer_forced_reauthentication?(issuer: 'test_issuer')).to eq false
     end
 
     it 'returns false if issuer sets forced reauthentication to true and then false' do
-      instance = TestClass.new
-      instance.set_issuer_forced_reauthentication('test_issuer', true)
-      instance.set_issuer_forced_reauthentication('test_issuer', false)
-      expect(instance.issuer_forced_reauthentication?('test_issuer')).to eq false
+      instance.set_issuer_forced_reauthentication(
+        issuer: 'test_issuer',
+        is_forced_reauthentication: true,
+      )
+      instance.set_issuer_forced_reauthentication(
+        issuer: 'test_issuer',
+        is_forced_reauthentication: false,
+      )
+      expect(instance.issuer_forced_reauthentication?(issuer: 'test_issuer')).to eq false
     end
   end
 end

--- a/spec/controllers/concerns/forced_reauthentication_concern_spec.rb
+++ b/spec/controllers/concerns/forced_reauthentication_concern_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe ForcedReauthenticationConcern do
+  class TestClass
+    include ForcedReauthenticationConcern
+
+    attr_reader :session
+
+    def initialize(session = {})
+      @session = session
+    end
+  end
+
+  describe '#issuer_forced_reauthentication?' do
+    it 'returns true if issuer has forced reauthentication' do
+      instance = TestClass.new
+      instance.set_issuer_forced_reauthentication('test_issuer', true)
+      expect(instance.issuer_forced_reauthentication?('test_issuer')).to eq true
+    end
+
+    it 'returns false if issuer has not forced reauthentication' do
+      instance = TestClass.new
+      expect(instance.issuer_forced_reauthentication?('test_issuer')).to eq false
+    end
+
+    it 'returns false if forced reauthentication is set to false for an issuer' do
+      instance = TestClass.new
+      instance.set_issuer_forced_reauthentication('test_issuer', false)
+      expect(instance.issuer_forced_reauthentication?('test_issuer')).to eq false
+    end
+
+    it 'returns false if issuer sets forced reauthentication to true and then false' do
+      instance = TestClass.new
+      instance.set_issuer_forced_reauthentication('test_issuer', true)
+      instance.set_issuer_forced_reauthentication('test_issuer', false)
+      expect(instance.issuer_forced_reauthentication?('test_issuer')).to eq false
+    end
+  end
+end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -3,6 +3,7 @@ require 'saml_idp_constants'
 ## GET /api/saml/auth helper methods
 module SamlAuthHelper
   PATH_YEAR = '2023'
+  SP_ISSUER = 'http://localhost:3000'
 
   def saml_settings(overrides: {})
     settings = OneLogin::RubySaml::Settings.new
@@ -16,7 +17,7 @@ module SamlAuthHelper
     settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
 
     # SP + IdP Settings
-    settings.issuer = 'http://localhost:3000'
+    settings.issuer = SP_ISSUER
     settings.security[:authn_requests_signed] = true
     settings.security[:logout_requests_signed] = true
     settings.security[:embed_sign] = true


### PR DESCRIPTION
## 🎫 Ticket

[LG-10661](https://cm-jira.usa.gov/browse/LG-10661)

## 🛠 Summary of changes

Currently, if you are fully authenticated and initiate an authorization request with a service provider that requests forced re-authentication (via login=prompt in OIDC or ForceAuhthn in SAML), the session is terminated without any notification. We are working on other changes to improve this experience, but this is a shorter-term change to try to communicate this behavior better to the end user. The message should not be displayed if the session is not terminated.

Awaiting translations at the moment.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

![image](https://github.com/18F/identity-idp/assets/1430443/fc3e1ebe-fb14-44d3-9858-dd32b102a39d)

</details>

<details>
<summary>After:</summary>

![image](https://github.com/18F/identity-idp/assets/1430443/d0de54ed-e35f-4a54-8d46-aa7131defca6)

</details>