### PR TITLE
LG-10628: Enable Dependabot updates for phone dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: 'daily'
+      interval: daily
     allow:
       - dependency-name: '@18f/identity-design-system'
+      - dependency-name: libphonenumber-js
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: phonelib


### PR DESCRIPTION
## 🎫 Ticket

[LG-10628](https://cm-jira.usa.gov/browse/LG-10628)

## 🛠 Summary of changes

Adds auto-updater configurations to the existing Dependabot configuration to automatically create pull requests for updates to dependencies which are used for phone metadata and validation:

- `libphonenumber-js` (npm)
- `phonelib` (ruby)

**Why?**

- Outdated phone metadata can prevent users from using certain phone numbers, as was the case with #8932

**Reference:**

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

## 📜 Testing Plan

This is difficult to test, since it would only be expected to take effect once the configuration changes are merged and a dependency update is available.