### PR TITLE
Mark new welcome template links with step: 'welcome_new'

### DIFF
--- a/app/views/idv/welcome/_welcome_new.html.erb
+++ b/app/views/idv/welcome/_welcome_new.html.erb
@@ -16,7 +16,7 @@
               category: 'verify-your-identity',
               article: 'how-to-verify-your-identity',
               flow: :idv,
-              step: :getting_started,
+              step: :welcome_new,
               location: 'intro_paragraph',
             ),
           ),
@@ -59,7 +59,7 @@
   </div>
 <% end %>
 
-  <%= render 'shared/cancel', link: idv_cancel_path(step: 'getting_started') %>
+  <%= render 'shared/cancel', link: idv_cancel_path(step: 'welcome_new') %>
 <% end %>
 
 <%= javascript_packs_tag_once('document-capture-welcome') %>

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -83,6 +83,16 @@ RSpec.describe 'idv/welcome/show.html.erb' do
 
       expect(rendered).to have_content(@title)
       expect(rendered).to have_content(t('doc_auth.getting_started.instructions.getting_started'))
+      expect(rendered).to have_link(
+        t('doc_auth.info.getting_started_learn_more'),
+        href: help_center_redirect_path(
+          category: 'verify-your-identity',
+          article: 'how-to-verify-your-identity',
+          flow: :idv,
+          step: :welcome_new,
+          location: 'intro_paragraph',
+        ),
+      )
       expect(rendered).not_to have_link(
         t('doc_auth.instructions.learn_more'),
         href: policy_redirect_url(flow: :idv, step: :welcome, location: :footer),


### PR DESCRIPTION
## 🎫 Ticket

[LG-10762](https://cm-jira.usa.gov/browse/LG-10762)

## 🛠 Summary of changes

Mark links in _welcome_new template with 'welcome_new' to distinguish them in analytics events from the same links on the Getting Started page in an A/B test.

## 📜 Testing Plan

- [ ] In application.yml, set  `idv_getting_started_a_b_testing: '{"welcome_default":0, "welcome_new":100, "getting_started":0 }'`
- [ ] Create account, start IdV
- [ ] Click on documentation link and then cancel link
- [ ] Check that analytics include 'step: welcome_new' in log/events.log 
