### PR TITLE
Add a message when destroying Service Providers with associated In Person Enrollments

### DIFF
--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -29,7 +29,8 @@ class DestroyableRecords
 
     stdout.puts '********'
     stdout.puts "This provider has #{in_person_enrollments.size} in person enrollments " \
-                       "that will be destroyed"
+                   "that will be destroyed - Please handle these removals manually. " \
+                   "https://cm-jira.usa.gov/browse/LG-10679?focusedId=1685546&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1685546"
     stdout.puts "\n"
 
     stdout.puts '*******'

--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -30,7 +30,7 @@ class DestroyableRecords
     stdout.puts '********'
     stdout.puts "This provider has #{in_person_enrollments.size} in person enrollments " \
                    "that will be destroyed - Please handle these removals manually. " \
-                   "https://cm-jira.usa.gov/browse/LG-10679?focusedId=1685546&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1685546"
+                   "For more details check https://cm-jira.usa.gov/browse/LG-10679"
     stdout.puts "\n"
 
     stdout.puts '*******'


### PR DESCRIPTION
## 🎫 Ticket

[LG-10679](https://cm-jira.usa.gov/browse/LG-10679)

## 🛠 Summary of changes

Adds a message telling the user to manually remove the record when there is an associated In Person Enrollment.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
