### PR TITLE
Add reCAPTCHA configuration overrides for Canada, Mexico

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -227,7 +227,7 @@ phone_confirmation_max_attempt_window_in_minutes: 1_440
 phone_service_check: true
 phone_recaptcha_mock_validator: true
 phone_recaptcha_score_threshold: 0.0
-phone_recaptcha_country_score_overrides: '{"AS":0.0,"GU":0.0,"MP":0.0,"PR":0.0,"US":0.0,"VI":0.0}'
+phone_recaptcha_country_score_overrides: '{"AS":0.0,"GU":0.0,"MP":0.0,"PR":0.0,"US":0.0,"VI":0.0,"CA":0.0,"MX":0.0}'
 phone_setups_per_ip_limit: 25
 phone_setups_per_ip_period: 300
 phone_setups_per_ip_track_only_mode: false

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -236,12 +236,12 @@ RSpec.describe 'Add a new phone number' do
         evaluated_as_valid: false,
         score_threshold: 0.6,
         recaptcha_version: 3,
-        phone_country_code: 'CA',
+        phone_country_code: 'AU',
       ),
     )
 
     # Passing international should display OTP confirmation
-    fill_in t('two_factor_authentication.phone_label'), with: '3065550100'
+    fill_in t('two_factor_authentication.phone_label'), with: '+61 0491 570 006'
     fill_in t('components.captcha_submit_button.mock_score_label'), with: '0.7'
     click_send_one_time_code
     expect(page).to have_content(t('two_factor_authentication.header_text'), wait: 25)

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe 'Add a new phone number' do
     within('.sidenav') { click_on t('account.navigation.add_phone_number') }
 
     # Failing international should display spam protection screen
-    fill_in t('two_factor_authentication.phone_label'), with: '3065550100'
+    fill_in t('two_factor_authentication.phone_label'), with: '+61 0491 570 006'
     fill_in t('components.captcha_submit_button.mock_score_label'), with: '0.5'
     click_send_one_time_code
     expect(page).to have_content(t('titles.spam_protection'), wait: 5)

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe NewPhoneForm do
       end
 
       it 'is invalid if existing phone is international' do
-        unformatted_phone = '+13065550100'
-        params[:phone] = '+1 3065550100'
+        unformatted_phone = '+610491570006'
+        params[:phone] = '+61 0491 570 006'
         params[:international_code] = 'CA'
         create(:phone_configuration, user: user, phone: unformatted_phone)
 
@@ -372,8 +372,8 @@ RSpec.describe NewPhoneForm do
       let(:recaptcha_mock_score) { nil }
       let(:score_threshold) { 0.6 }
       let(:recaptcha_token) { 'token' }
-      let(:phone) { '3065550100' }
-      let(:international_code) { 'CA' }
+      let(:phone) { '0491 570 006' }
+      let(:international_code) { 'AU' }
       let(:params) { super().merge(recaptcha_token:, recaptcha_mock_score:) }
 
       subject(:result) { form.submit(params) }


### PR DESCRIPTION
## 🛠 Summary of changes

Adds default reCAPTCHA score threshold configuration overrides for Canada and Mexico, so that they behave consistently across deployed environments.

## 📜 Testing Plan

Enable reCAPTCHA locally with configuration in `config/application.yml`:

```
phone_recaptcha_score_threshold: 0.5
```

1. Go to http://localhost:3000
2. Create an account
3. At MFA setup selection, choose phone
4. Enter a Canadian or Mexican phone number, e.g. `3065550100`
5. In the "reCAPTCHA score" field (internal only), enter a number lower than the threshold defined in configuration, e.g. 0.4 if using the above-defined threshold
6. Submit the page
7. Observe that you pass successfully to the "Enter your one-time code" screen