### PR TITLE
changelog: Internal, In-Person Proofing, Make PO button rendering optional

### DIFF
--- a/app/javascript/packages/document-capture/components/location-collection-item.spec.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.spec.tsx
@@ -147,4 +147,44 @@ describe('LocationCollectionItem', () => {
       expect(sunHours).not.to.exist();
     });
   });
+
+  context('when handleSelect callback is not provided', () => {
+    it('renders the component without the button', () => {
+      const onClick = sinon.stub();
+      const { container } = render(
+        <LocationCollectionItem
+          name=""
+          streetAddress=""
+          formattedCityStateZip=""
+          handleSelect={onClick}
+          weekdayHours=""
+          saturdayHours=""
+          selectId={0}
+          sundayHours=""
+        />,
+      );
+
+      expect(container.textContent).to.contain('in_person_proofing.body.location.location_button');
+    });
+  });
+
+  context('when handleSelect callback is provided', () => {
+    it('renders the component with the button', () => {
+      const { container } = render(
+        <LocationCollectionItem
+          name=""
+          streetAddress=""
+          formattedCityStateZip=""
+          weekdayHours=""
+          saturdayHours=""
+          selectId={0}
+          sundayHours=""
+        />,
+      );
+
+      expect(container.textContent).to.not.contain(
+        'in_person_proofing.body.location.location_button',
+      );
+    });
+  });
 });

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -4,7 +4,7 @@ import { useI18n } from '@18f/identity-react-i18n';
 interface LocationCollectionItemProps {
   distance?: string;
   formattedCityStateZip: string;
-  handleSelect: (event: React.MouseEvent, selection: number) => void;
+  handleSelect?: (event: React.MouseEvent, selection: number) => void;
   name?: string;
   saturdayHours: string;
   selectId: number;
@@ -69,15 +69,17 @@ function LocationCollectionItem({
             </SpinnerButton>
           </div>
           <div className="grid-col-auto">
-            <SpinnerButton
-              className="display-none tablet:display-inline-block"
-              onClick={(event) => {
-                handleSelect(event, selectId);
-              }}
-              type="submit"
-            >
-              {t('in_person_proofing.body.location.location_button')}
-            </SpinnerButton>
+            {handleSelect && (
+              <SpinnerButton
+                className="display-none tablet:display-inline-block"
+                onClick={(event) => {
+                  handleSelect(event, selectId);
+                }}
+                type="submit"
+              >
+                {t('in_person_proofing.body.location.location_button')}
+              </SpinnerButton>
+            )}
           </div>
         </div>
       </div>

--- a/app/javascript/packages/document-capture/components/location-collection-item.tsx
+++ b/app/javascript/packages/document-capture/components/location-collection-item.tsx
@@ -60,13 +60,15 @@ function LocationCollectionItem({
                 {`${t('in_person_proofing.body.location.retail_hours_sun')} ${sundayHours}`}
               </div>
             )}
-            <SpinnerButton
-              className="tablet:display-none margin-top-2 width-full"
-              onClick={(event) => handleSelect(event, selectId)}
-              type="submit"
-            >
-              {t('in_person_proofing.body.location.location_button')}
-            </SpinnerButton>
+            {handleSelect && (
+              <SpinnerButton
+                className="tablet:display-none margin-top-2 width-full"
+                onClick={(event) => handleSelect(event, selectId)}
+                type="submit"
+              >
+                {t('in_person_proofing.body.location.location_button')}
+              </SpinnerButton>
+            )}
           </div>
           <div className="grid-col-auto">
             {handleSelect && (


### PR DESCRIPTION
changelog: Internal, In-Person Proofing, Make PO button rendering optional
test

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/18F/identity-idp/pull/9069).
* __->__ #9069
* #9069