### PR TITLE
Tweak the IdentityVerificationReport

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -918,6 +918,8 @@ module AnalyticsEvents
   # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verificaiton
   # @param [Boolean] in_person_verification_pending Profile is awaiting in person verificaiton
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @see Reporting::IdentityVerificationReport#query This event is used by the identity verification report.
+  #      Changes here should be reflected there.
   # Tracks the last step of IDV, indicates the user successfully proofed
   def idv_final(
     success:,
@@ -1051,6 +1053,8 @@ module AnalyticsEvents
   # @param [Integer] attempts Number of attempts to enter a correct code
   # @param [Boolean] pending_in_person_enrollment
   # @param [Boolean] fraud_check_failed
+  # @see Reporting::IdentityVerificationReport#query This event is used by the identity verification report.
+  #      Changes here should be reflected there.
   # GPO verification submitted
   def idv_gpo_verification_submitted(
     success:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -918,8 +918,8 @@ module AnalyticsEvents
   # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verificaiton
   # @param [Boolean] in_person_verification_pending Profile is awaiting in person verificaiton
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # @see Reporting::IdentityVerificationReport#query This event is used by the identity verification report.
-  #      Changes here should be reflected there.
+  # @see Reporting::IdentityVerificationReport#query This event is used by the identity verification
+  #       report. Changes here should be reflected there.
   # Tracks the last step of IDV, indicates the user successfully proofed
   def idv_final(
     success:,
@@ -1053,8 +1053,8 @@ module AnalyticsEvents
   # @param [Integer] attempts Number of attempts to enter a correct code
   # @param [Boolean] pending_in_person_enrollment
   # @param [Boolean] fraud_check_failed
-  # @see Reporting::IdentityVerificationReport#query This event is used by the identity verification report.
-  #      Changes here should be reflected there.
+  # @see Reporting::IdentityVerificationReport#query This event is used by the identity verification
+  #       report. Changes here should be reflected there.
   # GPO verification submitted
   def idv_gpo_verification_submitted(
     success:,

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -77,6 +77,26 @@ RSpec.describe Reporting::IdentityVerificationReport do
     end
   end
 
+  describe '#query' do
+    context 'with an issuer' do
+      it 'includes an issuer filter' do
+        result = subject.query
+
+        expect(result).to include('| filter properties.service_provider = "my:example:issuer"')
+      end
+    end
+
+    context 'without an issuer' do
+      let(:issuer) { nil }
+
+      it 'does not include an issuer filter' do
+        result = subject.query
+
+        expect(result).to_not include('filter properties.service_provider')
+      end
+    end
+  end
+
   describe '#cloudwatch_client' do
     let(:opts) { {} }
     let(:subject) { described_class.new(issuer:, time_range:, **opts) }


### PR DESCRIPTION
This commit makes a few small changes to the identity verification report:

1. Allow the report to be run without an issuer
2. Change the GPO verification counter to filter users who still new fraud review or in-person proofing
3. Change the final resolution event to filter users who still new fraud review, in-person, or GPO. Previously this used "deactivation_reason" which is not deprecated
