### PR TITLE
LG-10823 Report Faraday timeout errors to NewRelic

### DIFF
--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -98,13 +98,8 @@ module Proofing
       end
 
       def send_to_new_relic(result)
-        case result.exception
-        when Proofing::TimeoutError
+        if result.mva_timeout?
           return # noop
-        when Proofing::Aamva::VerificationError
-          if result.mva_timeout?
-            return # noop
-          end
         end
         NewRelic::Agent.notice_error(result.exception)
       end

--- a/spec/services/proofing/aamva/proofer_spec.rb
+++ b/spec/services/proofing/aamva/proofer_spec.rb
@@ -151,13 +151,16 @@ RSpec.describe Proofing::Aamva::Proofer do
       context 'the exception is a timeout error' do
         let(:exception) { Proofing::TimeoutError.new }
 
-        it 'does not log to NewRelic' do
-          expect(NewRelic::Agent).not_to receive(:notice_error)
+        it 'logs to NewRelic' do
+          expect(NewRelic::Agent).to receive(:notice_error)
 
           result = subject.proof(state_id_data)
 
           expect(result.success?).to eq(false)
           expect(result.exception).to eq(exception)
+          expect(result.mva_unavailable?).to eq(false)
+          expect(result.mva_system_error?).to eq(false)
+          expect(result.mva_timeout?).to eq(false)
           expect(result.mva_exception?).to eq(false)
         end
       end


### PR DESCRIPTION
Currently we do not report MVA timeouts or DLDV connection issues to NewRelic. We do this because this service often has issues and creates a lot of noise.

The issues we observe are generally the result of individual MVA timeouts and not issues connecting to the DLDV service. Moreover, during DLDV outages not having DLDV issues reported limits our visibility.

This commit removes the constraint that prevents DLDV connection issues from being reported so we have visibility. Since the DLDV service itself is generally reliable this should not result in too much noise.
