### PR TITLE
LG-10062 register gzip Mime::Type

### DIFF
--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -36,12 +36,15 @@ class ServiceProviderController < ApplicationController
   end
 
   def sp_params
-    return {} unless request.headers['Content-Type'] == 'gzip/json'
-
-    body = request.body.read
-
-    return {} unless body.present?
-
-    JSON.parse(Zlib.gunzip(body))
+    if request.headers['Content-Type'] == 'gzip/json'
+      body = request.body.read
+      if body.present?
+        JSON.parse(Zlib.gunzip(body))
+      else
+        {}
+      end
+    else
+      params.permit(service_provider: {})
+    end
   end
 end

--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -4,15 +4,8 @@ class ServiceProviderController < ApplicationController
   def update
     authorize do
       if !FeatureManagement.use_dashboard_service_providers?
-        render json: { status: 'If the feature is enabled, service providers have been updated.' }
+        render json: { status: 'Service providers updater has not been enabled.' }
         return
-      end
-
-      if request.headers['content-type'] == 'gzip/json'
-        body = request.body.read
-        sp_params = JSON.parse(Zlib.gunzip(body))
-      else
-        sp_params = {}
       end
 
       ServiceProviderUpdater.new.run(sp_params['service_provider'])
@@ -40,5 +33,15 @@ class ServiceProviderController < ApplicationController
 
   def authorization_token
     request.headers['X-LOGIN-DASHBOARD-TOKEN']
+  end
+
+  def sp_params
+    return {} unless request.headers['Content-Type'] == 'gzip/json'
+
+    body = request.body.read
+
+    return {} unless body.present?
+
+    JSON.parse(Zlib.gunzip(body))
   end
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,7 +1,1 @@
 Mime::Type.register 'application/secevent+jwt', :secevent_jwt
-Mime::Type.register "gzip/json", :gzip
-
-ActionDispatch::Request.parameter_parsers[:gzip] = -> (raw_body) {
-  body = ActiveSupport::Gzip.decompress(raw_body)
-  JSON.parse(body).with_indifferent_access
-}

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,1 +1,7 @@
 Mime::Type.register 'application/secevent+jwt', :secevent_jwt
+Mime::Type.register "gzip/json", :gzip
+
+ActionDispatch::Request.parameter_parsers[:gzip] = -> (raw_body) {
+  body = ActiveSupport::Gzip.decompress(raw_body)
+  JSON.parse(body).with_indifferent_access
+}

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ServiceProviderController do
         end
 
         before do
-          request.content_type = 'application/json'
+          request.content_type = 'gzip/json'
           post :update, params:
         end
 


### PR DESCRIPTION
## 🎫 Ticket
https://cm-jira.usa.gov/browse/LG-10062

## 🛠 Summary of changes
This ticket surfaced an issue where, when JSON requests to sync the service providers are over 20k, they are automatically rejected by nginx. We raised the nginx threshold, but also would like to compress requests to make sure the requests stay below the threshold.

It should be merged before https://github.com/18F/identity-dashboard/pull/667

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Pull down this branch locally 
- [ ] Pull down https://github.com/18F/identity-dashboard/pull/667 for the dashboard
- [ ] `make run` both repos
- [ ] Navigate to http://localhost:3001/ and create/save a new app configuration
- [ ] Update it with a new cert
- [ ] Navigate to http://localhost:3001/service_providers/all (you may have to make yourself an admin via the rails console)
- [ ] Click the "Publish Service Providers" button

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
