### PR TITLE
LG-10658: Cleanup merge of A/B testing fields into proofing results analytics

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -196,7 +196,7 @@ module Idv
           pii_like_keypaths: [[:errors, :ssn], [:response_body, :first_name],
                               [:same_address_as_id],
                               [:state_id, :state_id_jurisdiction]],
-        }.merge(ab_test_analytics_buckets),
+        },
       )
       log_idv_verification_submitted_event(
         success: form_response.success?,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10658](https://cm-jira.usa.gov/browse/LG-10658) (cleanup only)

## 🛠 Summary of changes

- AC are implemented in https://github.com/18F/identity-idp/pull/9064
- This cleans up a redundant merge of A/B testing analytics fields into the proofing results log entry.
  - The only impacts here are compute time and code complexity, not functionality.

## 📜 Testing Plan

Automated analytics tests.
