### PR TITLE
LG-10586: Direct users to new SSN entry URL for in-person proofing

### DIFF
--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -48,7 +48,7 @@ module Idv
       end
 
       def prev_url
-        idv_in_person_proofing_ssn_url
+        idv_in_person_ssn_url
       end
 
       def pii

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -16,7 +16,7 @@ module Idv
 
     FLOW_STATE_MACHINE_SETTINGS = {
       step_url: :idv_in_person_step_url,
-      final_url: :idv_in_person_proofing_ssn_url,
+      final_url: :idv_in_person_ssn_url,
       flow: Idv::Flows::InPersonFlow,
       analytics_id: 'In Person Proofing',
     }.freeze

--- a/app/services/idv/steps/in_person/address_step.rb
+++ b/app/services/idv/steps/in_person/address_step.rb
@@ -30,7 +30,7 @@ module Idv
 
           redirect_to idv_in_person_verify_info_url if updating_address?
 
-          redirect_to idv_in_person_proofing_ssn_url
+          redirect_to idv_in_person_ssn_url
         end
 
         def extra_view_variables

--- a/app/services/idv/steps/in_person/state_id_step.rb
+++ b/app/services/idv/steps/in_person/state_id_step.rb
@@ -27,7 +27,7 @@ module Idv
             if pii_from_user[:same_address_as_id] == 'true'
               copy_state_id_address_to_residential_address(pii_from_user)
               mark_step_complete(:address)
-              redirect_to idv_in_person_proofing_ssn_url
+              redirect_to idv_in_person_ssn_url
             end
 
             if initial_state_of_same_address_as_id == 'true' &&

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -145,7 +145,7 @@ locals:
     <div class='grid-auto'>
       <%= link_to(
             t('idv.buttons.change_label'),
-            idv_in_person_proofing_ssn_url,
+            idv_in_person_ssn_url,
             'aria-label': t('idv.buttons.change_ssn_label'),
           ) %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -381,8 +381,8 @@ Rails.application.routes.draw do
       #
       # These have been left in temporarily to prevent any impact to users
       # during the deprecation process.
-      get '/in_person_proofing/ssn' => 'in_person/ssn#show'
-      put '/in_person_proofing/ssn' => 'in_person/ssn#update'
+      get '/in_person_proofing/ssn' => redirect('/verify/in_person/ssn', status: 307)
+      put '/in_person_proofing/ssn' => redirect('/verify/in_person/ssn', status: 307)
 
       get '/in_person' => 'in_person#index'
       get '/in_person/ready_to_verify' => 'in_person/ready_to_verify#show',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -375,6 +375,12 @@ Rails.application.routes.draw do
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
 
+      # DEPRECATION NOTICE
+      # Usage of the /in_person_proofing/ssn routes is deprecated.
+      # Use the /in_person/ssn routes instead.
+      #
+      # These have been left in temporarily to prevent any impact to users
+      # during the deprecation process.
       get '/in_person_proofing/ssn' => 'in_person/ssn#show'
       put '/in_person_proofing/ssn' => 'in_person/ssn#update'
 
@@ -384,6 +390,8 @@ Rails.application.routes.draw do
       post '/in_person/usps_locations' => 'in_person/usps_locations#index'
       put '/in_person/usps_locations' => 'in_person/usps_locations#update'
       post '/in_person/addresses' => 'in_person/address_search#index'
+      get '/in_person/ssn' => 'in_person/ssn#show'
+      put '/in_person/ssn' => 'in_person/ssn#update'
       get '/in_person/verify_info' => 'in_person/verify_info#show'
       put '/in_person/verify_info' => 'in_person/verify_info#update'
       get '/in_person/:step' => 'in_person#show', as: :in_person_step

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Idv::InPersonController do
             it 'finishes the flow' do
               put :update, params: { step: 'state_id' }
 
-              expect(response).to redirect_to idv_in_person_proofing_ssn_url
+              expect(response).to redirect_to idv_in_person_ssn_url
             end
           end
         end

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -559,7 +559,7 @@ RSpec.describe 'In Person Proofing', js: true do
         click_idv_continue
 
         # ssn page
-        expect(page).to have_current_path(idv_in_person_proofing_ssn_url)
+        expect(page).to have_current_path(idv_in_person_ssn_url)
         complete_ssn_step
 
         # verify page
@@ -652,7 +652,7 @@ RSpec.describe 'In Person Proofing', js: true do
         fill_in t('idv.form.address2_optional'), with: InPersonHelper::GOOD_ADDRESS2
         fill_in t('idv.form.city'), with: InPersonHelper::GOOD_CITY
         click_idv_continue
-        expect(page).to have_current_path(idv_in_person_proofing_ssn_url, wait: 10)
+        expect(page).to have_current_path(idv_in_person_ssn_url, wait: 10)
       end
     end
   end

--- a/spec/features/idv/steps/in_person/state_id_step_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_step_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true do
       fill_in t('in_person_proofing.form.state_id.zipcode'), with: '123456789'
       expect(page).to have_field(t('in_person_proofing.form.state_id.zipcode'), with: '12345-6789')
       click_idv_continue
-      expect(page).to have_current_path(idv_in_person_proofing_ssn_url)
+      expect(page).to have_current_path(idv_in_person_ssn_url)
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10586](https://cm-jira.usa.gov/browse/LG-10586)

## 🛠 Summary of changes

- Direct users to new SSN entry URL for in-person proofing
- Add deprecation warning to the previous routes
  - This was intentionally left in for this pull request in order to prevent issues for users who are active during the release process. The routes can be removed after this change is deployed.
  - Recommended redirects were modified to ensure that requests are processed seamlessly

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Complete in-person proofing up to SSN step with address matching ID
- [x] Verify that URL ends with `/verify/in_person/ssn`
- [x] Submit SSN form
- [x] Verify that SSN update succeeded on Verify Info page
- [x] Complete in-person proofing up to SSN step with address not matching ID
- [x] Verify that URL ends with `/verify/in_person/ssn`
- [x] Submit SSN form
- [x] Verify that SSN update succeeded on Verify Info page
- [x] Edit address from Verify Info step
- [x] Verify that URL ends with `/verify/in_person/ssn`
- [x] Complete in-person proofing up to SSN step
- [x] Manually change URL to `/verify/in_person_proofing/ssn`
- [x] Check that URL gets updated to `/verify/in_person/ssn`
- [x] Modify form to submit to `/verify/in_person_proofing/ssn` using browser inspector
- [x] Open network tab of inspector and select "Preserve log"
- [x] Submit SSN form
- [x] Check that network tab shows the a `307` status code for the `POST` to `/verify/in_person_proofing/ssn`
- [x] Check that network tab shows the a `302` status code for a subsequent `POST` to `/verify/in_person/ssn`
- [x] Check that SSN update was successful on Verify Info page