### PR TITLE
Jmax/LG-9565 fix GPO reminder query

### DIFF
--- a/app/services/gpo_confirmation_exporter.rb
+++ b/app/services/gpo_confirmation_exporter.rb
@@ -5,7 +5,6 @@ class GpoConfirmationExporter
   LINE_ENDING = "\r\n".freeze
   HEADER_ROW_ID = '01'.freeze
   CONTENT_ROW_ID = '02'.freeze
-  OTP_MAX_VALID_DAYS = IdentityConfig.store.usps_confirmation_max_days
 
   def initialize(confirmations)
     @confirmations = confirmations
@@ -32,7 +31,7 @@ class GpoConfirmationExporter
 
   def make_entry_row(confirmation)
     now = current_date
-    due = confirmation.created_at + OTP_MAX_VALID_DAYS.days
+    due = confirmation.created_at + IdentityConfig.store.usps_confirmation_max_days.days
 
     entry = confirmation.entry
     service_provider = ServiceProvider.find_by(issuer: entry[:issuer])

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -7,7 +7,7 @@ class GpoReminderSender
       where(
         gpo_verification_pending_at: letter_eligible_range,
         gpo_confirmation_codes: { reminder_sent_at: nil },
-        deactivation_reason: nil,
+        deactivation_reason: [nil, :in_person_verification_pending],
       )
 
     profiles_due_for_reminder.each do |profile|

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -4,13 +4,13 @@ class GpoReminderSender
       IdentityConfig.store.usps_confirmation_max_days.days.ago..for_letters_sent_before
 
     profiles_due_for_reminder = Profile.joins(:gpo_confirmation_codes).
-                                  where(
-                                    gpo_verification_pending_at: letter_eligible_range,
-                                    gpo_confirmation_codes: { reminder_sent_at: nil },
-                                  )
+      where(
+        gpo_verification_pending_at: letter_eligible_range,
+        gpo_confirmation_codes: { reminder_sent_at: nil },
+      )
 
     profiles_due_for_reminder.each do |profile|
-      next unless user.pending_profile == profile
+      next unless profile.user.pending_profile == profile
       profile.user.send_email_to_all_addresses(:gpo_reminder)
       profile.gpo_confirmation_codes.first.update(reminder_sent_at: Time.zone.now)
       analytics.idv_gpo_reminder_email_sent(user_id: profile.user.uuid)

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -10,7 +10,6 @@ class GpoReminderSender
       )
 
     profiles_due_for_reminder.each do |profile|
-      next unless profile.user.pending_profile == profile
       profile.user.send_email_to_all_addresses(:gpo_reminder)
       profile.gpo_confirmation_codes.first.update(reminder_sent_at: Time.zone.now)
       analytics.idv_gpo_reminder_email_sent(user_id: profile.user.uuid)

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,12 +1,16 @@
 class GpoReminderSender
   def send_emails(for_letters_sent_before)
+    letter_eligible_range =
+      IdentityConfig.store.usps_confirmation_max_days.days.ago..for_letters_sent_before
+
     profiles_due_for_reminder = Profile.joins(:gpo_confirmation_codes).
-      where(
-        gpo_verification_pending_at: ..for_letters_sent_before,
-        gpo_confirmation_codes: { reminder_sent_at: nil },
-      )
+                                  where(
+                                    gpo_verification_pending_at: letter_eligible_range,
+                                    gpo_confirmation_codes: { reminder_sent_at: nil },
+                                  )
 
     profiles_due_for_reminder.each do |profile|
+      next unless user.pending_profile == profile
       profile.user.send_email_to_all_addresses(:gpo_reminder)
       profile.gpo_confirmation_codes.first.update(reminder_sent_at: Time.zone.now)
       analytics.idv_gpo_reminder_email_sent(user_id: profile.user.uuid)

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -7,6 +7,7 @@ class GpoReminderSender
       where(
         gpo_verification_pending_at: letter_eligible_range,
         gpo_confirmation_codes: { reminder_sent_at: nil },
+        deactivation_reason: nil,
       )
 
     profiles_due_for_reminder.each do |profile|

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -330,7 +330,7 @@ version_headers_enabled: false
 use_dashboard_service_providers: false
 use_kms: false
 usps_auth_token_refresh_job_enabled: false
-usps_confirmation_max_days: 10
+usps_confirmation_max_days: 30
 usps_ipp_password: ''
 usps_ipp_client_id: ''
 usps_ipp_root_url: ''

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -34,7 +34,9 @@ RSpec.feature 'verify profile with OTP' do
     end
 
     scenario 'OTP has expired' do
-      GpoConfirmationCode.first.update(code_sent_at: 11.days.ago)
+      GpoConfirmationCode.first.update(
+        code_sent_at: (IdentityConfig.store.usps_confirmation_max_days + 1).days.ago,
+      )
 
       sign_in_live_with_2fa(user)
       fill_in t('idv.gpo.form.otp_label'), with: otp

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -86,7 +86,13 @@ RSpec.describe GpoVerifyForm do
     end
 
     context 'when OTP is expired' do
-      let(:code_sent_at) { 11.days.ago }
+      let(:expiration_days) { 10 }
+      let(:code_sent_at) { (expiration_days + 1).days.ago }
+
+      before do
+        allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).
+          and_return(expiration_days)
+      end
 
       it 'is invalid' do
         result = subject.submit

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe GpoReminderJob do
     let(:gpo_expired_user) { create(:user, :with_pending_gpo_profile) }
     let(:due_for_reminder_user) { create(:user, :with_pending_gpo_profile) }
     let(:not_yet_due_for_reminder_user) { create(:user, :with_pending_gpo_profile) }
+    let(:user_with_invalid_profile) { create(:user, :with_pending_gpo_profile) }
 
     let(:job_analytics) { FakeAnalytics.new }
 
@@ -31,6 +32,11 @@ RSpec.describe GpoReminderJob do
       not_yet_due_for_reminder_user.gpo_verification_pending_profile.update(
         gpo_verification_pending_at: (days_before_sending_reminder - 1).days.ago,
       )
+
+      user_with_invalid_profile.gpo_verification_pending_profile.update(
+        gpo_verification_pending_at: days_before_sending_reminder.days.ago,
+      )
+      user_with_invalid_profile.gpo_verification_pending_profile.deactivate(:password_reset)
     end
 
     it 'sends only one reminder email, to the correct user' do

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -1,27 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe GpoReminderJob do
-  let(:wait_before_sending_reminder) { 14.days }
+  let(:days_before_sending_reminder) { 12 }
+  let(:max_days_ago_to_send_letter) { 27 }
 
   describe '#perform' do
-    subject(:perform) { job.perform(wait_before_sending_reminder.ago) }
+    subject(:perform) { job.perform(days_before_sending_reminder.days.ago) }
 
     let(:job) { GpoReminderJob.new }
-    let(:user) { create(:user, :with_pending_gpo_profile) }
-    let(:pending_profile) { user.pending_profile }
+
+    let(:gpo_expired_user) { create(:user, :with_pending_gpo_profile) }
+    let(:due_for_reminder_user) { create(:user, :with_pending_gpo_profile) }
+    let(:not_yet_due_for_reminder_user) { create(:user, :with_pending_gpo_profile) }
+
     let(:job_analytics) { FakeAnalytics.new }
 
     before do
-      pending_profile.update(
-        gpo_verification_pending_at: wait_before_sending_reminder.ago,
-      )
+      allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).
+        and_return(max_days_ago_to_send_letter)
       allow(Analytics).to receive(:new).and_return(job_analytics)
+
+      gpo_expired_user.gpo_verification_pending_profile.update(
+        gpo_verification_pending_at: (max_days_ago_to_send_letter + 1).days.ago,
+      )
+
+      due_for_reminder_user.gpo_verification_pending_profile.update(
+        gpo_verification_pending_at: days_before_sending_reminder.days.ago,
+      )
+
+      not_yet_due_for_reminder_user.gpo_verification_pending_profile.update(
+        gpo_verification_pending_at: (days_before_sending_reminder - 1).days.ago,
+      )
     end
 
-    it 'sends reminder emails' do
+    it 'sends only one reminder email, to the correct user' do
       expect { perform }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(ActionMailer::Base.deliveries.last.to.first).to eq(due_for_reminder_user.email)
       expect(job_analytics).to have_logged_event(
         'IdV: gpo reminder email sent',
+        user_id: due_for_reminder_user.uuid,
       )
     end
   end

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe GpoReminderSender do
       end
     end
 
-    xcontext 'when a user has two gpo reminders' do
+    context 'when a user has two gpo reminders' do
       before do
         set_gpo_verification_pending_at(time_due_for_reminder)
 
@@ -179,9 +179,10 @@ RSpec.describe GpoReminderSender do
           to change { ActionMailer::Base.deliveries.size }.by(1)
       end
 
-      it 'logs two events' do
-        expect { subject.send_emails(time_due_for_reminder) }.
-          to change { fake_analytics.events.count }.by(2)
+      it 'logs an event' do
+        subject.send_emails(time_due_for_reminder)
+
+        expect(fake_analytics).to have_logged_event('IdV: gpo reminder email sent')
       end
     end
   end

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -54,10 +54,12 @@ RSpec.describe GpoReminderSender do
           to change { ActionMailer::Base.deliveries.size }.by(1)
       end
 
-      it 'logs an event' do
-        subject.send_emails(time_due_for_reminder)
+      it 'logs the email events' do
+        expect { subject.send_emails(time_due_for_reminder) }.
+          to change { fake_analytics.events.count }.by(2)
 
         expect(fake_analytics).to have_logged_event('IdV: gpo reminder email sent')
+        expect(fake_analytics).to have_logged_event('Email Sent')
       end
 
       it 'updates the GPO verification code `reminder_sent_at`' do
@@ -179,10 +181,12 @@ RSpec.describe GpoReminderSender do
           to change { ActionMailer::Base.deliveries.size }.by(1)
       end
 
-      it 'logs an event' do
-        subject.send_emails(time_due_for_reminder)
+      it 'logs the email events' do
+        expect { subject.send_emails(time_due_for_reminder) }.
+          to change { fake_analytics.events.count }.by(2)
 
         expect(fake_analytics).to have_logged_event('IdV: gpo reminder email sent')
+        expect(fake_analytics).to have_logged_event('Email Sent')
       end
     end
   end

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -134,6 +134,12 @@ RSpec.describe GpoReminderSender do
 
         include_examples 'sends no emails'
       end
+
+      context 'but the user has changed their password' do
+        before { user.gpo_verification_pending_profile.deactivate(:password_reset) }
+
+        include_examples 'sends no emails'
+      end
     end
 
     context 'when a user is due for a reminder from too long ago' do

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe GpoReminderSender do
       include_examples 'sends no emails'
     end
 
-    context 'when a user has requested two GPO letters' do
+    context 'when a user has requested two letters' do
       before do
         set_gpo_verification_pending_at(time_due_for_reminder - 2.days)
 
@@ -82,8 +82,6 @@ RSpec.describe GpoReminderSender do
         )
         gpo_code = create(:gpo_confirmation_code)
         profile.gpo_confirmation_codes << gpo_code
-        device = create(:device, user: user)
-        create(:event, user: user, device: device, event_type: :gpo_mail_sent)
       end
 
       include_examples 'sends emails', 2, 2

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe GpoReminderSender do
       end
     end
 
-    context 'when a user is due for a reminder from a long time ago' do
+    context 'when a user is due for a reminder from too long ago' do
       let(:max_age_to_send_letter_in_days) { 30 }
 
       before do

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples 'sends emails' do |expected_number_of_emails:,
     subject.send_emails(time_due_for_reminder)
 
     expect(fake_analytics.events['IdV: gpo reminder email sent'].size).to(
-      eq(expected_number_of_number_of_idv_events),
+      eq(expected_number_of_analytics_events),
     )
     expect(fake_analytics.events['Email Sent'].size).to(
       eq(expected_number_of_emails),

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -29,7 +29,9 @@ RSpec.shared_examples 'gpo otp verification' do
   it 'renders an error for an expired GPO OTP' do
     sign_in_live_with_2fa(user)
 
-    gpo_confirmation_code.update(code_sent_at: 11.days.ago)
+    gpo_confirmation_code.update(
+      code_sent_at: (IdentityConfig.store.usps_confirmation_max_days + 1).days.ago,
+    )
     fill_in t('idv.gpo.form.otp_label'), with: otp
     click_button t('idv.gpo.form.submit')
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9565](https://cm-jira.usa.gov/browse/LG-9565)

## 🛠 Summary of changes

The original query to retrieve users who need a reminder letter did not respect the 30-day cutoff (we shouldn't remind users if their request for a letter is older than 30 days).

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Log in to the app and create two users in the IdV remote GPO address confirmation flow.
- [ ] Using the rails console, back date one user's gpo request date (in the user's pending profile) to 30 days, and the other user's to 29 days ago
- [ ] Use the Rails console to run the gpo reminder job (`GpoReminderJob.new.perform(14.days.ago)`)
- [ ] Verify that the user with the 29 day old GPO code receives a reminder, and that the user with a 30 day old GPO code does not.