### PR TITLE
LG-9164: Encapsulate Address Search

### DIFF
--- a/app/javascript/packages/document-capture/components/address-search.tsx
+++ b/app/javascript/packages/document-capture/components/address-search.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { Alert, PageHeading } from '@18f/identity-components';
+import AddressSearchInput from '@18f/identity-address-search';
+import type { LocationQuery } from '@18f/identity-address-search/types';
+import { useI18n } from '@18f/identity-react-i18n';
+import InPersonLocations, { FormattedLocation } from './in-person-locations';
+
+function AddressSearch({
+  registerField,
+  locationsURL,
+  addressSearchURL,
+  handleLocationSelect,
+  disabled,
+  onFoundLocations,
+}) {
+  const [apiError, setApiError] = useState<Error | null>(null);
+  const [foundAddress, setFoundAddress] = useState<LocationQuery | null>(null);
+  const [locationResults, setLocationResults] = useState<FormattedLocation[] | null | undefined>(
+    null,
+  );
+  const [isLoadingLocations, setLoadingLocations] = useState<boolean>(false);
+  const { t } = useI18n();
+
+  return (
+    <>
+      {apiError && (
+        <Alert type="error" className="margin-bottom-4">
+          {t('idv.failure.exceptions.post_office_search_error')}
+        </Alert>
+      )}
+      <PageHeading>{t('in_person_proofing.headings.po_search.location')}</PageHeading>
+      <p>{t('in_person_proofing.body.location.po_search.po_search_about')}</p>
+      <AddressSearchInput
+        registerField={registerField}
+        onFoundAddress={setFoundAddress}
+        onFoundLocations={(locations) => {
+          setLocationResults(locations);
+          onFoundLocations(locations);
+        }}
+        onLoadingLocations={setLoadingLocations}
+        onError={setApiError}
+        disabled={disabled}
+        locationsURL={locationsURL}
+        addressSearchURL={addressSearchURL}
+      />
+      {locationResults && foundAddress && !isLoadingLocations && (
+        <InPersonLocations
+          locations={locationResults}
+          onSelect={handleLocationSelect}
+          address={foundAddress?.address || ''}
+        />
+      )}
+    </>
+  );
+}
+
+export default AddressSearch;

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
@@ -1,15 +1,13 @@
 import { useState, useEffect, useCallback, useRef, useContext } from 'react';
-import { useI18n } from '@18f/identity-react-i18n';
-import { Alert, PageHeading } from '@18f/identity-components';
 import { request } from '@18f/identity-request';
 import { forceRedirect } from '@18f/identity-url';
-import AddressSearch, { transformKeys, snakeCase } from '@18f/identity-address-search';
-import type { LocationQuery } from '@18f/identity-address-search/types';
+import { transformKeys, snakeCase } from '@18f/identity-address-search';
 import BackButton from './back-button';
 import AnalyticsContext from '../context/analytics';
-import InPersonLocations, { FormattedLocation } from './in-person-locations';
+import { FormattedLocation } from './in-person-locations';
 import { InPersonContext } from '../context';
 import UploadContext from '../context/upload';
+import AddressSearch from './address-search';
 
 export const LOCATIONS_URL = new URL(
   '/verify/in_person/usps_locations',
@@ -19,16 +17,13 @@ export const ADDRESSES_URL = new URL('/api/addresses', window.location.href).toS
 
 function InPersonLocationPostOfficeSearchStep({ onChange, toPreviousStep, registerField }) {
   const { inPersonURL } = useContext(InPersonContext);
-  const { t } = useI18n();
   const [inProgress, setInProgress] = useState<boolean>(false);
-  const [isLoadingLocations, setLoadingLocations] = useState<boolean>(false);
   const [autoSubmit, setAutoSubmit] = useState<boolean>(false);
   const { trackEvent } = useContext(AnalyticsContext);
   const [locationResults, setLocationResults] = useState<FormattedLocation[] | null | undefined>(
     null,
   );
-  const [foundAddress, setFoundAddress] = useState<LocationQuery | null>(null);
-  const [apiError, setApiError] = useState<Error | null>(null);
+
   const [disabledAddressSearch, setDisabledAddressSearch] = useState<boolean>(false);
   const { flowPath } = useContext(UploadContext);
 
@@ -99,30 +94,14 @@ function InPersonLocationPostOfficeSearchStep({ onChange, toPreviousStep, regist
 
   return (
     <>
-      {apiError && (
-        <Alert type="error" className="margin-bottom-4">
-          {t('idv.failure.exceptions.post_office_search_error')}
-        </Alert>
-      )}
-      <PageHeading>{t('in_person_proofing.headings.po_search.location')}</PageHeading>
-      <p>{t('in_person_proofing.body.location.po_search.po_search_about')}</p>
       <AddressSearch
         registerField={registerField}
-        onFoundAddress={setFoundAddress}
         onFoundLocations={setLocationResults}
-        onLoadingLocations={setLoadingLocations}
-        onError={setApiError}
+        handleLocationSelect={handleLocationSelect}
         disabled={disabledAddressSearch}
         locationsURL={LOCATIONS_URL}
         addressSearchURL={ADDRESSES_URL}
       />
-      {locationResults && foundAddress && !isLoadingLocations && (
-        <InPersonLocations
-          locations={locationResults}
-          onSelect={handleLocationSelect}
-          address={foundAddress?.address || ''}
-        />
-      )}
       <BackButton role="link" includeBorder onClick={toPreviousStep} />
     </>
   );


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-9168)

Extracts the address search & post office location result pieces of the UI into its own component so that it can be migrated into the address-search package later.

## 🛠 Summary of changes

This should be a straightforward refactor. No features or bug fixes are included. I moved the address search UI from in-person-location-post-office-search-step.tsx into its own component _within document capture_.

This is a small step towards moving this newly encapsulated component into address-search package. I avoid doing both in order to avoid confusion.

## 📜 Testing Plan

[x] It's a refactor but spot-checking and leaning on existing tests. In a future PR, the tests for this component will be covered by @18f/address-search/index-spec.