### PR TITLE
LG-10780 Update the metrics in the identity verification report

### DIFF
--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -136,11 +136,11 @@ module Reporting
 
     # Turns query results into a hash keyed by event name, values are a count of unique users
     # for that event
-    # @return [Hash<String,Integer>]
+    # @return [Hash<Set<String>>]
     def data
       @data ||= begin
-        event_users = Hash.new do |h, uuid|
-          h[uuid] = Set.new
+        event_users = Hash.new do |h, event_name|
+          h[event_name] = Set.new
         end
 
         # IDEA: maybe there's a block form if this we can do that yields results as it loads them
@@ -191,8 +191,8 @@ module Reporting
                  or (name != %{usps_enrollment_status_updated})
         | filter (name = %{gpo_verification_submitted} and properties.event_properties.success = 1 and !properties.event_properties.pending_in_person_enrollment and !properties.event_properties.fraud_check_failed)
                  or (name != %{gpo_verification_submitted})
-        | fields !properties.event_properties.fraud_review_pending and !properties.event_properties.gpo_verification_pending and !properties.event_properties.in_person_verification_pending as identity_verified
         | fields properties.event_properties.fraud_review_pending as fraud_review_pending, properties.event_properties.gpo_verification_pending as gpo_verification_pending, properties.event_properties.in_person_verification_pending as in_person_verification_pending
+        | fields !fraud_review_pending and !gpo_verification_pending and !in_person_verification_pending as identity_verified
         | limit 10000
       QUERY
     end

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -24,21 +24,16 @@ module Reporting
       GPO_VERIFICATION_SUBMITTED = 'IdV: GPO verification submitted'
       USPS_ENROLLMENT_STATUS_UPDATED = 'GetUspsProofingResultsJob: Enrollment status updated'
 
+      def self.all_events
+        constants.map { |c| const_get(c) }
+      end
+    end
+
+    module Results
       IDV_FINAL_RESOLUTION_VERIFIED = 'IdV: final resolution - Verified'
       IDV_FINAL_RESOLUTION_FRAUD_REVIEW = 'IdV: final resolution - Fraud Review Pending'
       IDV_FINAL_RESOLUTION_GPO = 'IdV: final resolution - GPO Pending'
       IDV_FINAL_RESOLUTION_IN_PERSON = 'IdV: final resolution - In Person Proofing'
-
-      def self.queryable_events
-        [
-          IDV_DOC_AUTH_WELCOME,
-          IDV_DOC_AUTH_GETTING_STARTED,
-          IDV_DOC_AUTH_IMAGE_UPLOAD,
-          IDV_FINAL_RESOLUTION,
-          GPO_VERIFICATION_SUBMITTED,
-          USPS_ENROLLMENT_STATUS_UPDATED,
-        ]
-      end
     end
 
     # @param [String] isssuer
@@ -97,19 +92,19 @@ module Reporting
     end
 
     def idv_final_resolution_verified
-      data[Events::IDV_FINAL_RESOLUTION_VERIFIED].to_i
+      data[Results::IDV_FINAL_RESOLUTION_VERIFIED].to_i
     end
 
     def idv_final_resolution_gpo
-      data[Events::IDV_FINAL_RESOLUTION_GPO].to_i
+      data[Results::IDV_FINAL_RESOLUTION_GPO].to_i
     end
 
     def idv_final_resolution_in_person
-      data[Events::IDV_FINAL_RESOLUTION_IN_PERSON].to_i
+      data[Results::IDV_FINAL_RESOLUTION_IN_PERSON].to_i
     end
 
     def idv_final_resolution_fraud_review
-      data[Events::IDV_FINAL_RESOLUTION_FRAUD_REVIEW].to_i
+      data[Results::IDV_FINAL_RESOLUTION_FRAUD_REVIEW].to_i
     end
 
     def idv_final_resolution_total_pending
@@ -155,16 +150,16 @@ module Reporting
 
           if row['name'] == Events::IDV_FINAL_RESOLUTION
             if row['identity_verified'] == '1'
-              event_users[Events::IDV_FINAL_RESOLUTION_VERIFIED] << row['user_id']
+              event_users[Results::IDV_FINAL_RESOLUTION_VERIFIED] << row['user_id']
             end
             if row['gpo_verification_pending'] == '1'
-              event_users[Events::IDV_FINAL_RESOLUTION_GPO] << row['user_id']
+              event_users[Results::IDV_FINAL_RESOLUTION_GPO] << row['user_id']
             end
             if row['in_person_verification_pending'] == '1'
-              event_users[Events::IDV_FINAL_RESOLUTION_IN_PERSON] << row['user_id']
+              event_users[Results::IDV_FINAL_RESOLUTION_IN_PERSON] << row['user_id']
             end
             if row['fraud_review_pending'] == '1'
-              event_users[Events::IDV_FINAL_RESOLUTION_FRAUD_REVIEW] << row['user_id']
+              event_users[Results::IDV_FINAL_RESOLUTION_FRAUD_REVIEW] << row['user_id']
             end
           end
         end
@@ -180,7 +175,7 @@ module Reporting
     def query
       params = {
         issuer: issuer && quote(issuer),
-        event_names: quote(Events.queryable_events),
+        event_names: quote(Events.all_events),
         usps_enrollment_status_updated: quote(Events::USPS_ENROLLMENT_STATUS_UPDATED),
         gpo_verification_submitted: quote(Events::GPO_VERIFICATION_SUBMITTED),
         idv_final_resolution: quote(Events::IDV_FINAL_RESOLUTION),

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -17,15 +17,27 @@ module Reporting
     attr_reader :issuer, :time_range
 
     module Events
+      IDV_DOC_AUTH_WELCOME = 'IdV: doc auth welcome visited'
+      IDV_DOC_AUTH_GETTING_STARTED = 'IdV: doc auth getting_started visited'
       IDV_DOC_AUTH_IMAGE_UPLOAD = 'IdV: doc auth image upload vendor submitted'
-      IDV_GPO_ADDRESS_LETTER_REQUESTED = 'IdV: USPS address letter requested'
-      USPS_IPP_ENROLLMENT_CREATED = 'USPS IPPaaS enrollment created'
       IDV_FINAL_RESOLUTION = 'IdV: final resolution'
       GPO_VERIFICATION_SUBMITTED = 'IdV: GPO verification submitted'
       USPS_ENROLLMENT_STATUS_UPDATED = 'GetUspsProofingResultsJob: Enrollment status updated'
 
-      def self.all_events
-        constants.map { |c| const_get(c) }
+      IDV_FINAL_RESOLUTION_VERIFIED = 'IdV: final resolution - Verified'
+      IDV_FINAL_RESOLUTION_FRAUD_REVIEW = 'IdV: final resolution - Fraud Review Pending'
+      IDV_FINAL_RESOLUTION_GPO = 'IdV: final resolution - GPO Pending'
+      IDV_FINAL_RESOLUTION_IN_PERSON = 'IdV: final resolution - In Person Proofing'
+
+      def self.queryable_events
+        [
+          IDV_DOC_AUTH_WELCOME,
+          IDV_DOC_AUTH_GETTING_STARTED,
+          IDV_DOC_AUTH_IMAGE_UPLOAD,
+          IDV_FINAL_RESOLUTION,
+          GPO_VERIFICATION_SUBMITTED,
+          USPS_ENROLLMENT_STATUS_UPDATED,
+        ]
       end
     end
 
@@ -62,41 +74,46 @@ module Reporting
         csv << ['Issuer', issuer] if issuer.present?
         csv << []
         csv << ['Metric', '# of Users']
-        csv << ['Started IdV Verification', idv_doc_auth_image_vendor_submitted]
-        csv << ['Incomplete Users', incomplete_users]
-        csv << ['Address Confirmation Letters Requested', idv_gpo_address_letter_requested]
-        csv << ['Started In-Person Verification', usps_ipp_enrollment_created]
-        csv << ['Alternative Process Users', alternative_process_users]
-        csv << ['Success through Online Verification', idv_final_resolution]
-        csv << ['Success through Address Confirmation Letters', gpo_verification_submitted]
-        csv << ['Success through In-Person Verification', usps_enrollment_status_updated]
-        csv << ['Successfully Verified Users', successfully_verified_users]
+        csv << []
+        csv << ['Started IdV Verification', idv_started]
+        csv << ['Images uploaded', idv_doc_auth_image_vendor_submitted]
+        csv << []
+        csv << ['Workflow completed', idv_final_resolution]
+        csv << ['Workflow completed - Verified', idv_final_resolution_verified]
+        csv << ['Workflow completed - Total Pending', idv_final_resolution_total_pending]
+        csv << ['Workflow completed - GPO Pending', idv_final_resolution_gpo]
+        csv << ['Workflow completed - In-Person Pending', idv_final_resolution_in_person]
+        csv << ['Workflow completed - Fraud Review Pending', idv_final_resolution_fraud_review]
+        csv << []
+        csv << ['Succesfully verified', successfully_verified_users]
+        csv << ['Succesfully verified - Inline', idv_final_resolution_verified]
+        csv << ['Succesfully verified - GPO Code Entry', gpo_verification_submitted]
+        csv << ['Succesfully verified - In Person', usps_enrollment_status_updated]
       end
-    end
-
-    def incomplete_users
-      idv_doc_auth_image_vendor_submitted - successfully_verified_users - alternative_process_users
-    end
-
-    def idv_gpo_address_letter_requested
-      data[Events::IDV_GPO_ADDRESS_LETTER_REQUESTED].to_i
-    end
-
-    def usps_ipp_enrollment_created
-      data[Events::USPS_IPP_ENROLLMENT_CREATED].to_i
-    end
-
-    def alternative_process_users
-      [
-        idv_gpo_address_letter_requested,
-        usps_ipp_enrollment_created,
-        -gpo_verification_submitted,
-        -usps_enrollment_status_updated,
-      ].sum
     end
 
     def idv_final_resolution
       data[Events::IDV_FINAL_RESOLUTION].to_i
+    end
+
+    def idv_final_resolution_verified
+      data[Events::IDV_FINAL_RESOLUTION_VERIFIED].to_i
+    end
+
+    def idv_final_resolution_gpo
+      data[Events::IDV_FINAL_RESOLUTION_GPO].to_i
+    end
+
+    def idv_final_resolution_in_person
+      data[Events::IDV_FINAL_RESOLUTION_IN_PERSON].to_i
+    end
+
+    def idv_final_resolution_fraud_review
+      data[Events::IDV_FINAL_RESOLUTION_FRAUD_REVIEW].to_i
+    end
+
+    def idv_final_resolution_total_pending
+      idv_final_resolution - idv_final_resolution_verified
     end
 
     def gpo_verification_submitted
@@ -108,7 +125,14 @@ module Reporting
     end
 
     def successfully_verified_users
-      idv_final_resolution + gpo_verification_submitted + usps_enrollment_status_updated
+      idv_final_resolution_verified + gpo_verification_submitted + usps_enrollment_status_updated
+    end
+
+    def idv_started
+      [
+        data[Events::IDV_DOC_AUTH_WELCOME].to_i,
+        data[Events::IDV_DOC_AUTH_GETTING_STARTED].to_i,
+      ].sum
     end
 
     def idv_doc_auth_image_vendor_submitted
@@ -128,6 +152,21 @@ module Reporting
         # to go slightly faster
         fetch_results.each do |row|
           event_users[row['name']] << row['user_id']
+
+          if row['name'] == Events::IDV_FINAL_RESOLUTION
+            if row['identity_verified'] == '1'
+              event_users[Events::IDV_FINAL_RESOLUTION_VERIFIED] << row['user_id']
+            end
+            if row['gpo_verification_pending'] == '1'
+              event_users[Events::IDV_FINAL_RESOLUTION_GPO] << row['user_id']
+            end
+            if row['in_person_verification_pending'] == '1'
+              event_users[Events::IDV_FINAL_RESOLUTION_IN_PERSON] << row['user_id']
+            end
+            if row['fraud_review_pending'] == '1'
+              event_users[Events::IDV_FINAL_RESOLUTION_FRAUD_REVIEW] << row['user_id']
+            end
+          end
         end
 
         event_users.transform_values(&:count)
@@ -141,7 +180,7 @@ module Reporting
     def query
       params = {
         issuer: issuer && quote(issuer),
-        event_names: quote(Events.all_events),
+        event_names: quote(Events.queryable_events),
         usps_enrollment_status_updated: quote(Events::USPS_ENROLLMENT_STATUS_UPDATED),
         gpo_verification_submitted: quote(Events::GPO_VERIFICATION_SUBMITTED),
         idv_final_resolution: quote(Events::IDV_FINAL_RESOLUTION),
@@ -157,8 +196,8 @@ module Reporting
                  or (name != %{usps_enrollment_status_updated})
         | filter (name = %{gpo_verification_submitted} and properties.event_properties.success = 1 and !properties.event_properties.pending_in_person_enrollment and !properties.event_properties.fraud_check_failed)
                  or (name != %{gpo_verification_submitted})
-        | filter (name = %{idv_final_resolution} and !properties.event_properties.fraud_review_pending and !properties.event_properties.gpo_verification_pending and !properties.event_properties.in_person_verification_pending)
-                 or (name != %{idv_final_resolution})
+        | fields !properties.event_properties.fraud_review_pending and !properties.event_properties.gpo_verification_pending and !properties.event_properties.in_person_verification_pending as identity_verified
+        | fields properties.event_properties.fraud_review_pending as fraud_review_pending, properties.event_properties.gpo_verification_pending as gpo_verification_pending, properties.event_properties.in_person_verification_pending as in_person_verification_pending
         | limit 10000
       QUERY
     end


### PR DESCRIPTION
This commit updates the identity verification report to include 3 groups of metrics:

1. Metrics on starting the flow
2. Metrics on completion of the in-line flow
3. Metrics on verified users

These metrics are broken down further to cover specific scenarios we are concerned about.
