### PR TITLE
Retire `log_password_verification_failure`

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -14,7 +14,6 @@ module UserAccessKeyOverrides
       user_uuid: uuid,
     )
     @password = password if result
-    log_password_verification_failure unless result
     result
   end
 
@@ -81,16 +80,5 @@ module UserAccessKeyOverrides
     Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
       encrypted_password_digest,
     ).password_salt
-  end
-
-  private
-
-  def log_password_verification_failure
-    metadata = {
-      event: 'Failure to validate password',
-      uuid: uuid,
-      timestamp: Time.zone.now,
-    }
-    Rails.logger.info(metadata.to_json)
   end
 end


### PR DESCRIPTION
This method was added to log exceptions that were raised when trying to validate passwords. This was because an invalid password attempt would raise an encryption error; there was concern that this would cause other exceptions to be missed. This was only relevant when we were encrypting passwords with UAKs.

Now that we are not longer using UAKs this method just writes invalid password attempts to production.log. This duplicates what is written to events.log for events where passwords are entered.

I could not find anywhere that we are looking at this log line. This commit removes it.
