### PR TITLE
LG-10836 Add a report job for the identity verification report

### DIFF
--- a/app/jobs/reports/identity_verification_report.rb
+++ b/app/jobs/reports/identity_verification_report.rb
@@ -1,0 +1,25 @@
+require 'reporting/identity_verification_report'
+
+module Reports
+  class IdentityVerificationReport < BaseReport
+    REPORT_NAME = 'identity-verification-report'
+
+    attr_accessor :report_date
+
+    def perform(report_date)
+      self.report_date = report_date
+
+      csv = report_maker.to_csv
+
+      save_report(REPORT_NAME, csv, extension: 'csv')
+    end
+
+    def report_maker
+      Reporting::IdentityVerificationReport.new(
+        issuer: nil,
+        time_range: report_date.all_day,
+        slice: 4.hours,
+      )
+    end
+  end
+end

--- a/spec/jobs/reports/identity_verification_report_spec.rb
+++ b/spec/jobs/reports/identity_verification_report_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Reports::IdentityVerificationReport do
+  describe '#perform' do
+    it 'gets a CSV from the report maker and saves it to S3' do
+      report_maker = double(Reporting::IdentityVerificationReport, to_csv: 'I am a CSV, see')
+      allow(subject).to receive(:report_maker).and_return(report_maker)
+      expect(subject).to receive(:save_report).with(
+        'identity-verification-report',
+        'I am a CSV, see',
+        extension: 'csv',
+      )
+
+      subject.perform(Date.new(2023, 12, 25))
+    end
+  end
+
+  describe '#report_maker' do
+    it 'is a identity verification report maker with the right time range' do
+      report_date = Date.new(2023, 12, 25)
+
+      subject.report_date = report_date
+
+      expect(subject.report_maker.time_range).to eq(report_date.all_day)
+    end
+  end
+end


### PR DESCRIPTION
This commit takes the existing cloudwatch based identity verification report and adds a job that runs the report for a single day and uploads result to S3.

This commit does not include a configuration in `job_configurations.rb` so that we can verify this works before we enable it.
