### PR TITLE
Add an abort when there are IPEs that will need to be removed when removing SPs

### DIFF
--- a/lib/cleanup/destroy_unused_providers.rb
+++ b/lib/cleanup/destroy_unused_providers.rb
@@ -28,6 +28,8 @@ class DestroyUnusedProviders
 
       records.print_data
 
+      break if records.service_provider.in_person_enrollments.size > 0
+
       stdout.puts "Type 'yes' and hit enter to continue and " \
                     "destroy this service provider and associated records:\n"
 

--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -28,9 +28,14 @@ class DestroyableRecords
     stdout.puts "\n"
 
     stdout.puts '********'
+    if in_person_enrollments.size == 0
     stdout.puts "This provider has #{in_person_enrollments.size} in person enrollments " \
+                   "that will be destroyed"
+    else
+    stdout.puts "\e[31mThis provider has #{in_person_enrollments.size} in person enrollments " \
                    "that will be destroyed - Please handle these removals manually. " \
-                   "For more details check https://cm-jira.usa.gov/browse/LG-10679"
+                   "For more details check https://cm-jira.usa.gov/browse/LG-10679\e[0m"
+    end
     stdout.puts "\n"
 
     stdout.puts '*******'


### PR DESCRIPTION
## 🎫 Ticket

[LG-10679](https://cm-jira.usa.gov/browse/LG-10679)

## 🛠 Summary of changes

Stops execution of the script when there are In Person Enrollments associated with the Service Provider that is about to be destroyed so it can be handled manually. Also changes the message to be red so the user has an understanding as to why the script aborted.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
