### PR TITLE
LG-10836 Configure IdentityVerificationReport job to run every 24 hours

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -164,6 +164,12 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.yesterday] },
       },
+      # Send Identity Verification report to S3
+      identity_verification_report: {
+        class: 'Reports::IdentityVerificationReport',
+        cron: cron_24h,
+        args: -> { [Time.zone.yesterday] },
+      },
       usps_auth_token_refresh: (if IdentityConfig.store.usps_auth_token_refresh_job_enabled
                                   {
                                     class: 'UspsAuthTokenRefreshJob',


### PR DESCRIPTION
A previous commit added a job to create an identity verification report based on cloudwatch data. The job creates the report and uploads it to S3.

Since this is the first report to leverage cloudwatch data in this way we planned on manually testing the report before setting it up to run on a recurring basis. This commit does the rest of the work to make the report run regularly after we confirm it actually works.
