### PR TITLE
LG-9559 Add document ID number to verify info screen

### DIFF
--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -55,6 +55,10 @@ locals:
           <%= I18n.l(Date.parse(@pii[:dob]), format: I18n.t('time.formats.event_date')) %>
         </dd>
       </div>
+      <div>
+        <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
+        <dd class="display-inline margin-left-0"> <%= @pii[:state_id_number] %> </dd>
+      </div>
     </dl>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-y border-primary-light">


### PR DESCRIPTION
## 🎫 Ticket

[LG-9559](https://cm-jira.usa.gov/browse/LG-9559)

## 🛠 Summary of changes

Added document ID number to the 'verify your info' screen.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create a new user and enter identity verification
- [ ] Proceed through the remote IdV flow to the 'verify  your information' screen
- [ ] Verify that the document ID number is displayed as shown in the Figma
- [ ] Verify that the Address 2 lable is present, as shown in the Figma

The updated app may be reached at [test-app](https://review-jmax-lg-95-qmbmwj.review-app.identitysandbox.gov/)

## 👀 Screenshots

<details>
<summary>Before:</summary>
  
![Screenshot 2023-08-25 at 12 03 30 PM](https://github.com/18F/identity-idp/assets/101212334/667f1ac5-ef6a-44e7-a7ce-99e4811e51fd)
</details>

<details>
<summary>After:</summary>
  
![Screenshot 2023-08-25 at 12 02 43 PM](https://github.com/18F/identity-idp/assets/101212334/01ae0fa6-161c-40f1-9851-b37ed2983c21)

</details>
