### PR TITLE
LG-10795 Update "address" to address line 1

### DIFF
--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -168,9 +168,9 @@ fr:
         - Vous devrez ressaisir vos informations personnelles, comme votre nom,
           pièce d’identité officielle, etc.
     form:
-      address1: Adresse Ligne 1
-      address2: Adresse Ligne 2
-      address2_optional: Adresse Ligne 2 (optional)
+      address1: Adresse ligne 1
+      address2: Adresse ligne 2
+      address2_optional: Adresse ligne 2 (optional)
       city: Ville
       dob: Date de naissance
       first_name: Prénom


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-10795](https://cm-jira.usa.gov/browse/LG-10795)


## 🛠 Summary of changes

The ticket was originally update "Address" to "Address line 1" for the "Update your address" screen. Since that was already present the only thing that needed to be changed was the capitalization of "Linge" form the French translation.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV
- [ ] Verify that it says Address line 1 on the verify info screen. Verify that the french translation says "Adresse ligne 1"
- [ ] Click update on the address line
- [ ] Verify that it says "Address line 1" and "Adresse ligne 1" in the french translation.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
![Screenshot 2023-08-25 at 12 46 28 PM](https://github.com/18F/identity-idp/assets/1034049/32824bf5-95a5-4305-ae4a-d7fccfccd86b)

</details>

<details>
<summary>After:</summary>
![Screenshot 2023-08-25 at 12 36 03 PM](https://github.com/18F/identity-idp/assets/1034049/e3bb6a49-d0cb-4e9c-88d3-3df9c34a4f17)

</details>
-->
