### PR TITLE
LG-10828 rate limit doc auth when credentials validation fails

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -32,7 +32,6 @@ module Idv
 
         if client_response.success?
           doc_pii_response = validate_pii_from_doc(client_response)
-          rate_limiter.reset!
         end
       end
 
@@ -114,7 +113,10 @@ module Idv
 
       analytics.idv_doc_auth_submitted_pii_validation(**response.to_h)
 
-      store_pii(client_response) if client_response.success? && response.success?
+      if client_response.success? && response.success?
+        store_pii(client_response)
+        rate_limiter.reset!
+      end
 
       response
     end

--- a/rubocop.xml
+++ b/rubocop.xml
@@ -1,4 +1,0 @@
-<?xml version='1.0'?>
-<testsuites>
-  <testsuite name='rubocop' tests='2002' failures='0'/>
-</testsuites>

--- a/rubocop.xml
+++ b/rubocop.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0'?>
+<testsuites>
+  <testsuite name='rubocop' tests='2002' failures='0'/>
+</testsuites>

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -28,45 +28,30 @@ RSpec.feature 'doc auth test credentials', :js do
     expect(page).to have_content('Jane')
   end
 
-  it 'triggers an error if the test credentials have a friendly error', allow_browser_log: true do
-    complete_doc_auth_steps_before_document_capture_step
+  context 'displays credential errors' do
+    it 'triggers an error if the test credentials have a friendly error', allow_browser_log: true do
+      triggers_error_test_credentials_missing('spec/fixtures/ial2_test_credential_forces_error.yml', I18n.t('doc_auth.errors.alerts.barcode_content_check').tr(' ', ' '))
+    end
 
-    attach_file(
-      'Front of your ID',
-      File.expand_path('spec/fixtures/ial2_test_credential_forces_error.yml'),
-    )
-    attach_file(
-      'Back of your ID',
-      File.expand_path('spec/fixtures/ial2_test_credential_forces_error.yml'),
-    )
-    click_on I18n.t('forms.buttons.submit.default')
+    it 'triggers an error if the test credentials missing required address', allow_browser_log: true do
+      triggers_error_test_credentials_missing('spec/fixtures/ial2_test_credential_no_address.yml', I18n.t('doc_auth.errors.alerts.address_check').tr(' ', ' '))
+    end
 
-    expect(page).to have_content(
-      I18n.t(
-        'doc_auth.errors.alerts.barcode_content_check',
-      ).tr(' ', ' '),
-    )
-    expect(page).to have_current_path(idv_document_capture_url)
-  end
+    def triggers_error_test_credentials_missing(credential_file, alert_message)
+      complete_doc_auth_steps_before_document_capture_step
 
-  it 'triggers an error if the test credentials missing required address', allow_browser_log: true do
-    complete_doc_auth_steps_before_document_capture_step
+      attach_file(
+        'Front of your ID',
+        File.expand_path(credential_file),
+      )
+      attach_file(
+        'Back of your ID',
+        File.expand_path(credential_file),
+      )
+      click_on I18n.t('forms.buttons.submit.default')
 
-    attach_file(
-      'Front of your ID',
-      File.expand_path('spec/fixtures/ial2_test_credential_no_address.yml'),
-    )
-    attach_file(
-      'Back of your ID',
-      File.expand_path('spec/fixtures/ial2_test_credential_no_address.yml'),
-    )
-    click_on I18n.t('forms.buttons.submit.default')
-
-    expect(page).to have_content(
-      I18n.t(
-        'doc_auth.errors.alerts.address_check',
-      ).tr(' ', ' '),
-    )
-    expect(page).to have_current_path(idv_document_capture_url)
+      expect(page).to have_content(alert_message)
+      expect(page).to have_current_path(idv_document_capture_url)
+    end
   end
 end

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -30,29 +30,49 @@ RSpec.feature 'doc auth test credentials', :js do
 
   context 'displays credential errors' do
     it 'triggers an error if the test credentials have a friendly error', allow_browser_log: true do
-      triggers_error_test_credentials_missing('spec/fixtures/ial2_test_credential_forces_error.yml', I18n.t('doc_auth.errors.alerts.barcode_content_check').tr(' ', ' '))
+      triggers_error_test_credentials_missing(
+        'spec/fixtures/ial2_test_credential_forces_error.yml', I18n.t('doc_auth.errors.alerts.barcode_content_check').tr(
+          ' ', ' '
+        )
+      )
     end
 
-    it 'triggers an error if the test credentials missing required address', allow_browser_log: true do
-      triggers_error_test_credentials_missing('spec/fixtures/ial2_test_credential_no_address.yml', I18n.t('doc_auth.errors.alerts.address_check').tr(' ', ' '))
+    it 'triggers an error if the test credentials missing required address',
+       allow_browser_log: true do
+      triggers_error_test_credentials_missing(
+        'spec/fixtures/ial2_test_credential_no_address.yml',
+        I18n.t('doc_auth.errors.alerts.address_check').tr(
+          ' ', ' '
+        ),
+      )
     end
 
     def triggers_error_test_credentials_missing(credential_file, alert_message)
-      complete_document_capture_step_with_yml(credential_file, expected_path: idv_document_capture_url)
+      complete_document_capture_step_with_yml(
+        credential_file,
+        expected_path: idv_document_capture_url,
+      )
 
       expect(page).to have_content(alert_message)
       expect(page).to have_current_path(idv_document_capture_url)
     end
   end
 
-  it 'rate limits the user if invalid credentials submitted for max allowed attempts', allow_browser_log: true do
+  it 'rate limits the user if invalid credentials submitted for max allowed attempts',
+     allow_browser_log: true do
     max_attempts = IdentityConfig.store.doc_auth_max_attempts
     (max_attempts - 1).times do
-      complete_document_capture_step_with_yml('spec/fixtures/ial2_test_credential_no_address.yml', expected_path: idv_document_capture_url)
+      complete_document_capture_step_with_yml(
+        'spec/fixtures/ial2_test_credential_no_address.yml',
+        expected_path: idv_document_capture_url,
+      )
       click_on t('idv.failure.button.warning')
     end
 
-    complete_document_capture_step_with_yml('spec/fixtures/ial2_test_credential_no_address.yml', expected_path: idv_document_capture_url)
+    complete_document_capture_step_with_yml(
+      'spec/fixtures/ial2_test_credential_no_address.yml',
+      expected_path: idv_document_capture_url,
+    )
 
     expect(page).to have_current_path(idv_session_errors_rate_limited_path)
   end

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature 'doc auth test credentials', :js do
   end
 
   it 'allows proofing with test credentials' do
-    
     complete_document_capture_step_with_yml('spec/fixtures/ial2_test_credential.yml')
 
     expect(page).to have_current_path(idv_ssn_path)
@@ -39,7 +38,7 @@ RSpec.feature 'doc auth test credentials', :js do
     end
 
     def triggers_error_test_credentials_missing(credential_file, alert_message)
-      attach_and_submit_test_credential_file(credential_file)
+      complete_document_capture_step_with_yml(credential_file, expected_path: idv_document_capture_url)
 
       expect(page).to have_content(alert_message)
       expect(page).to have_current_path(idv_document_capture_url)
@@ -49,24 +48,12 @@ RSpec.feature 'doc auth test credentials', :js do
   it 'rate limits the user if invalid credentials submitted for max allowed attempts', allow_browser_log: true do
     max_attempts = IdentityConfig.store.doc_auth_max_attempts
     (max_attempts - 1).times do
-      attach_and_submit_test_credential_file('spec/fixtures/ial2_test_credential_no_address.yml')
+      complete_document_capture_step_with_yml('spec/fixtures/ial2_test_credential_no_address.yml', expected_path: idv_document_capture_url)
       click_on t('idv.failure.button.warning')
     end
 
-    attach_and_submit_test_credential_file('spec/fixtures/ial2_test_credential_no_address.yml')
+    complete_document_capture_step_with_yml('spec/fixtures/ial2_test_credential_no_address.yml', expected_path: idv_document_capture_url)
+
     expect(page).to have_current_path(idv_session_errors_rate_limited_path)
-  end
-
-  def attach_and_submit_test_credential_file(credential_file)
-    attach_file(
-      'Front of your ID',
-      File.expand_path(credential_file),
-    )
-    attach_file(
-      'Back of your ID',
-      File.expand_path(credential_file),
-    )
-
-    click_on I18n.t('forms.buttons.submit.default')
   end
 end

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'doc auth test credentials', :js do
 
   before do
     sign_in_and_2fa_user
+    complete_doc_auth_steps_before_document_capture_step
   end
 
   around do |example|
@@ -17,7 +18,7 @@ RSpec.feature 'doc auth test credentials', :js do
   end
 
   it 'allows proofing with test credentials' do
-    complete_doc_auth_steps_before_document_capture_step
+    
     complete_document_capture_step_with_yml('spec/fixtures/ial2_test_credential.yml')
 
     expect(page).to have_current_path(idv_ssn_path)
@@ -38,20 +39,34 @@ RSpec.feature 'doc auth test credentials', :js do
     end
 
     def triggers_error_test_credentials_missing(credential_file, alert_message)
-      complete_doc_auth_steps_before_document_capture_step
-
-      attach_file(
-        'Front of your ID',
-        File.expand_path(credential_file),
-      )
-      attach_file(
-        'Back of your ID',
-        File.expand_path(credential_file),
-      )
-      click_on I18n.t('forms.buttons.submit.default')
+      attach_and_submit_test_credential_file(credential_file)
 
       expect(page).to have_content(alert_message)
       expect(page).to have_current_path(idv_document_capture_url)
     end
+  end
+
+  it 'rate limits the user if invalid credentials submitted for max allowed attempts', allow_browser_log: true do
+    max_attempts = IdentityConfig.store.doc_auth_max_attempts
+    (max_attempts - 1).times do
+      attach_and_submit_test_credential_file('spec/fixtures/ial2_test_credential_no_address.yml')
+      click_on t('idv.failure.button.warning')
+    end
+
+    attach_and_submit_test_credential_file('spec/fixtures/ial2_test_credential_no_address.yml')
+    expect(page).to have_current_path(idv_session_errors_rate_limited_path)
+  end
+
+  def attach_and_submit_test_credential_file(credential_file)
+    attach_file(
+      'Front of your ID',
+      File.expand_path(credential_file),
+    )
+    attach_file(
+      'Back of your ID',
+      File.expand_path(credential_file),
+    )
+
+    click_on I18n.t('forms.buttons.submit.default')
   end
 end

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -31,7 +31,8 @@ RSpec.feature 'doc auth test credentials', :js do
   context 'displays credential errors' do
     it 'triggers an error if the test credentials have a friendly error', allow_browser_log: true do
       triggers_error_test_credentials_missing(
-        'spec/fixtures/ial2_test_credential_forces_error.yml', I18n.t('doc_auth.errors.alerts.barcode_content_check').tr(
+        'spec/fixtures/ial2_test_credential_forces_error.yml',
+        I18n.t('doc_auth.errors.alerts.barcode_content_check').tr(
           ' ', ' '
         )
       )

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -33,8 +33,8 @@ RSpec.feature 'doc auth test credentials', :js do
       triggers_error_test_credentials_missing(
         'spec/fixtures/ial2_test_credential_forces_error.yml',
         I18n.t('doc_auth.errors.alerts.barcode_content_check').tr(
-          ' ', ' ',
-        )
+          ' ', ' '
+        ),
       )
     end
 

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -48,4 +48,25 @@ RSpec.feature 'doc auth test credentials', :js do
     )
     expect(page).to have_current_path(idv_document_capture_url)
   end
+
+  it 'triggers an error if the test credentials missing required address', allow_browser_log: true do
+    complete_doc_auth_steps_before_document_capture_step
+
+    attach_file(
+      'Front of your ID',
+      File.expand_path('spec/fixtures/ial2_test_credential_no_address.yml'),
+    )
+    attach_file(
+      'Back of your ID',
+      File.expand_path('spec/fixtures/ial2_test_credential_no_address.yml'),
+    )
+    click_on I18n.t('forms.buttons.submit.default')
+
+    expect(page).to have_content(
+      I18n.t(
+        'doc_auth.errors.alerts.address_check',
+      ).tr(' ', ' '),
+    )
+    expect(page).to have_current_path(idv_document_capture_url)
+  end
 end

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'doc auth test credentials', :js do
       triggers_error_test_credentials_missing(
         'spec/fixtures/ial2_test_credential_forces_error.yml',
         I18n.t('doc_auth.errors.alerts.barcode_content_check').tr(
-          ' ', ' '
+          ' ', ' ',
         )
       )
     end

--- a/spec/fixtures/ial2_test_credential_no_address.yml
+++ b/spec/fixtures/ial2_test_credential_no_address.yml
@@ -1,0 +1,10 @@
+document:
+  first_name: Jane
+  last_name: Doe
+  middle_name: Q
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  dob: 10/06/1938
+  phone: +1 314-555-1212
+  state_id_jurisdiction: 'ND'

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -96,11 +96,11 @@ module DocAuthHelper
   end
 
   # yml_file example: 'spec/fixtures/puerto_rico_resident.yml'
-  def complete_document_capture_step_with_yml(proofing_yml)
+  def complete_document_capture_step_with_yml(proofing_yml, expected_path: idv_ssn_url)
     attach_file I18n.t('doc_auth.headings.document_capture_front'), File.expand_path(proofing_yml)
     attach_file I18n.t('doc_auth.headings.document_capture_back'), File.expand_path(proofing_yml)
     click_on I18n.t('forms.buttons.submit.default')
-    expect(page).to have_current_path(idv_ssn_url, wait: 10)
+    expect(page).to have_current_path(expected_path, wait: 10)
   end
 
   def complete_doc_auth_steps_before_phone_otp_step(expect_accessible: false)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-10828](https://cm-jira.usa.gov/browse/LG-10828)

## 🛠 Summary of changes
Reset doc_auth rate limiter after successful 3rd party doc auth verification and successful PIIDocForm validation.  

###Why
Current implementation resets only after successfull 3rd party verification but should also include successful PIIDocForm validation.

## 📜 Testing Plan
- [ ] Start IdV until doc auth
- [ ] Submit [missing-address.yml](https://github.com/18F/identity-idp/pull/9002#issue-1850259456) repeatedly (~5 times) until rate limited

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
