### PR TITLE
LG-10851: Log 'TAP' or 'AUTO' when an image upload fails

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -523,6 +523,7 @@ function AcuantCapture(
     setIsCapturingEnvironment(false);
     trackEvent('IdV: Image capture failed', {
       field: name,
+      acuantCaptureMode,
       error: getNormalizedAcuantCaptureFailureMessage(error, code),
     });
   }

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -284,6 +284,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(trackEvent).to.have.been.calledWith('IdV: Image capture failed', {
         field: 'test',
+        acuantCaptureMode: 'AUTO',
         error: 'Camera not supported',
       });
       expect(document.activeElement).to.equal(button);
@@ -315,6 +316,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(trackEvent).to.have.been.calledWith('IdV: Image capture failed', {
         field: 'test',
+        acuantCaptureMode: 'AUTO',
         error: 'Cropping failure',
       });
       expect(document.activeElement).to.equal(button);
@@ -348,6 +350,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(trackEvent).to.have.been.calledWith('IdV: Image capture failed', {
         field: 'test',
+        acuantCaptureMode: 'AUTO',
         error: 'Camera not supported',
       });
       expect(document.activeElement).to.equal(button);
@@ -383,6 +386,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(trackEvent).to.have.been.calledWith('IdV: Image capture failed', {
         field: 'test',
+        acuantCaptureMode: 'AUTO',
         error: 'iOS 15 GPU Highwater failure (SEQUENCE_BREAK_CODE)',
       });
       await waitFor(() => document.activeElement === button);
@@ -425,6 +429,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(trackEvent).to.have.been.calledWith('IdV: Image capture failed', {
         field: 'test',
+        acuantCaptureMode: 'AUTO',
         error: 'iOS 15 GPU Highwater failure (SEQUENCE_BREAK_CODE)',
       });
       await waitFor(() => document.activeElement === button);
@@ -467,6 +472,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(trackEvent).to.have.been.calledWith('IdV: Image capture failed', {
         field: 'test',
+        acuantCaptureMode: 'AUTO',
         error: 'User or system denied camera access',
       });
       expect(document.activeElement).to.equal(button);
@@ -507,6 +513,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(container.querySelector('.full-screen')).to.be.null();
       expect(trackEvent).to.have.been.calledWith('IdV: Image capture failed', {
         field: 'test',
+        acuantCaptureMode: 'AUTO',
         error: 'User or system denied camera access',
       });
       expect(document.activeElement).to.equal(button);


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-10851

## 🛠 Summary of changes

This PR adds the `acuantCaptureMode` property to the `'IdV: Image capture failed'` event so we can more easily answer the question: "Are all cropping errors coming from users of the Acuant SDK's 'Tap to capture' mode?

## 📜 Testing Plan

- [ ] Log in and go to the page where you upload the front/back of an ID.
- [ ] Upload one of the yaml files that causes a failure to the "FRONT".
- [ ] Upload any image to the "BACK"
- [ ] Click submit, you should get a failure page (without the upload areas).
- [ ] Go look in the logs, you should see a log containing both:
    - [ ] `'IdV: Image capture failed'`
    - [ ] `acuantCaptureMode: 'AUTO'`
- [ ] Optional: Force the Acuant SDK [into 'Tap to capture' mode](https://docs.google.com/document/d/1hdVyI74M7736TwL8ubpPLoq-Tw10m-FLs-Co9H80pnU/edit#heading=h.lo3db1wzl1mn) and verify that you get `acuantCaptureMode: 'TAP'` in a log when you do the above steps.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
