### PR TITLE
LG-10753 Add GettingStarted A/B test buckets to some image upload analytics events

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -216,7 +216,9 @@ module Idv
     def doc_auth_client
       @doc_auth_client ||= DocAuthRouter.client(
         vendor_discriminator: document_capture_session_uuid,
-        warn_notifier: proc { |attrs| analytics&.doc_auth_warning(**attrs) },
+        warn_notifier: proc do |attrs|
+          analytics&.doc_auth_warning(**attrs.merge(getting_started_ab_test_analytics_bucket))
+        end,
       )
     end
 
@@ -284,7 +286,6 @@ module Idv
       {
         getting_started_ab_test_bucket:
           AbTests::IDV_GETTING_STARTED.bucket(user_uuid),
-
       }
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -139,7 +139,7 @@ module Idv
           Digest::SHA256.urlsafe_base64digest(back_image_bytes)
       end
 
-      @extra_attributes
+      @extra_attributes.merge!(getting_started_ab_test_analytics_bucket)
     end
 
     def remaining_attempts

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -248,7 +248,8 @@ module Idv
           async: false,
           flow_path: params[:flow_path],
           vendor_request_time_in_ms: vendor_request_time_in_ms,
-        ).merge(acuant_sdk_upgrade_ab_test_data),
+        ).merge(acuant_sdk_upgrade_ab_test_data).
+        merge(getting_started_ab_test_analytics_bucket),
       )
     end
 
@@ -276,6 +277,14 @@ module Idv
       {
         acuant_sdk_upgrade_ab_test_bucket:
           AbTests::ACUANT_SDK.bucket(document_capture_session.uuid),
+      }
+    end
+
+    def getting_started_ab_test_analytics_bucket
+      {
+        getting_started_ab_test_bucket:
+          AbTests::IDV_GETTING_STARTED.bucket(user_uuid),
+
       }
     end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -297,11 +297,17 @@ module AnalyticsEvents
     track_event('Doc Auth Async', error: error, uuid: uuid, result_id: result_id, **extra)
   end
 
-  # @param [String] message the warining
+  # @param [String] message the warning
+  # @param [String] getting_started_ab_test_bucket Which initial IdV screen the user saw
   # Logged when there is a non-user-facing error in the doc auth process, such as an unrecognized
   # field from a vendor
-  def doc_auth_warning(message: nil, **extra)
-    track_event('Doc Auth Warning', message: message, **extra)
+  def doc_auth_warning(message: nil, getting_started_ab_test_bucket: nil, **extra)
+    track_event(
+      'Doc Auth Warning',
+      message: message,
+      getting_started_ab_test_bucket: getting_started_ab_test_bucket,
+      **extra,
+    )
   end
 
   # When a user views the edit password page
@@ -759,6 +765,7 @@ module AnalyticsEvents
   # @param [String] flow_path
   # @param [String] front_image_fingerprint Fingerprint of front image data
   # @param [String] back_image_fingerprint Fingerprint of back image data
+  # @param [String] getting_started_ab_test_bucket Which initial IdV screen the user saw
   # The document capture image uploaded was locally validated during the IDV process
   def idv_doc_auth_submitted_image_upload_form(
     success:,
@@ -769,6 +776,7 @@ module AnalyticsEvents
     user_id: nil,
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
+    getting_started_ab_test_bucket: nil,
     **extra
   )
     track_event(
@@ -781,6 +789,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       front_image_fingerprint: front_image_fingerprint,
       back_image_fingerprint: back_image_fingerprint,
+      getting_started_ab_test_bucket: getting_started_ab_test_bucket,
       **extra,
     )
   end
@@ -800,6 +809,7 @@ module AnalyticsEvents
   # @param [Float] vendor_request_time_in_ms Time it took to upload images & get a response.
   # @param [String] front_image_fingerprint Fingerprint of front image data
   # @param [String] back_image_fingerprint Fingerprint of back image data
+  # @param [String] getting_started_ab_test_bucket Which initial IdV screen the user saw
   # The document capture image was uploaded to vendor during the IDV process
   def idv_doc_auth_submitted_image_upload_vendor(
     success:,
@@ -816,6 +826,7 @@ module AnalyticsEvents
     vendor_request_time_in_ms: nil,
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
+    getting_started_ab_test_bucket: nil,
     **extra
   )
     track_event(
@@ -835,6 +846,7 @@ module AnalyticsEvents
       vendor_request_time_in_ms: vendor_request_time_in_ms,
       front_image_fingerprint: front_image_fingerprint,
       back_image_fingerprint: back_image_fingerprint,
+      getting_started_ab_test_bucket: getting_started_ab_test_bucket,
       **extra,
     )
   end
@@ -847,6 +859,7 @@ module AnalyticsEvents
   # @param [String] flow_path
   # @param [String] front_image_fingerprint Fingerprint of front image data
   # @param [String] back_image_fingerprint Fingerprint of back image data
+  # @param [String] getting_started_ab_test_bucket Which initial IdV screen the user saw
   # The PII that came back from the document capture vendor was validated
   def idv_doc_auth_submitted_pii_validation(
     success:,
@@ -857,6 +870,7 @@ module AnalyticsEvents
     user_id: nil,
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
+    getting_started_ab_test_bucket: nil,
     **extra
   )
     track_event(
@@ -869,6 +883,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       front_image_fingerprint: front_image_fingerprint,
       back_image_fingerprint: back_image_fingerprint,
+      getting_started_ab_test_bucket: getting_started_ab_test_bucket,
       **extra,
     )
   end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe Idv::ImageUploadsController do
           flow_path: 'standard',
           front_image_fingerprint: nil,
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
         )
 
         expect(@irs_attempts_api_tracker).to receive(:track_event).with(
@@ -263,6 +264,7 @@ RSpec.describe Idv::ImageUploadsController do
           flow_path: 'standard',
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
         )
 
         expect(@irs_attempts_api_tracker).to receive(:track_event).with(
@@ -323,6 +325,7 @@ RSpec.describe Idv::ImageUploadsController do
           flow_path: 'standard',
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -348,6 +351,7 @@ RSpec.describe Idv::ImageUploadsController do
           vendor_request_time_in_ms: a_kind_of(Float),
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
           doc_type_supported: boolean,
         )
 
@@ -363,6 +367,7 @@ RSpec.describe Idv::ImageUploadsController do
           flow_path: 'standard',
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
         )
 
         expect(@irs_attempts_api_tracker).to receive(:track_event).with(
@@ -480,6 +485,7 @@ RSpec.describe Idv::ImageUploadsController do
               flow_path: 'standard',
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -505,6 +511,7 @@ RSpec.describe Idv::ImageUploadsController do
               vendor_request_time_in_ms: a_kind_of(Float),
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
               doc_type_supported: boolean,
             )
 
@@ -525,6 +532,7 @@ RSpec.describe Idv::ImageUploadsController do
               flow_path: 'standard',
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
             )
 
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
@@ -567,6 +575,7 @@ RSpec.describe Idv::ImageUploadsController do
               flow_path: 'standard',
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -592,6 +601,7 @@ RSpec.describe Idv::ImageUploadsController do
               vendor_request_time_in_ms: a_kind_of(Float),
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
               doc_type_supported: boolean,
             )
 
@@ -612,6 +622,7 @@ RSpec.describe Idv::ImageUploadsController do
               flow_path: 'standard',
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
             )
 
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
@@ -654,6 +665,7 @@ RSpec.describe Idv::ImageUploadsController do
               flow_path: 'standard',
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -679,6 +691,7 @@ RSpec.describe Idv::ImageUploadsController do
               vendor_request_time_in_ms: a_kind_of(Float),
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
               doc_type_supported: boolean,
             )
 
@@ -699,6 +712,7 @@ RSpec.describe Idv::ImageUploadsController do
               flow_path: 'standard',
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
+              getting_started_ab_test_bucket: :welcome_default,
             )
 
             expect(@irs_attempts_api_tracker).to receive(:track_event).with(
@@ -764,6 +778,7 @@ RSpec.describe Idv::ImageUploadsController do
           flow_path: 'standard',
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -791,6 +806,7 @@ RSpec.describe Idv::ImageUploadsController do
           vendor_request_time_in_ms: a_kind_of(Float),
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
           doc_type_supported: boolean,
         )
 
@@ -832,6 +848,7 @@ RSpec.describe Idv::ImageUploadsController do
           flow_path: 'standard',
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -861,6 +878,7 @@ RSpec.describe Idv::ImageUploadsController do
           vendor_request_time_in_ms: a_kind_of(Float),
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
           doc_type_supported: boolean,
         )
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -69,10 +69,10 @@ RSpec.feature 'Analytics Regression', js: true do
         'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO'
       },
       'IdV: doc auth image upload form submitted' => {
-        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String)
+        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default
       },
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String)
+        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false
@@ -174,10 +174,10 @@ RSpec.feature 'Analytics Regression', js: true do
         'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO'
       },
       'IdV: doc auth image upload form submitted' => {
-        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String)
+        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default
       },
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String)
+        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false
@@ -258,7 +258,7 @@ RSpec.feature 'Analytics Regression', js: true do
         'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO'
       },
       'IdV: doc auth image upload form submitted' => {
-        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String)
+        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default
       },
       'IdV: doc auth image upload vendor submitted' => hash_including(success: true, flow_path: 'standard', attention_with_barcode: true, doc_auth_result: 'Attention'),
       'IdV: verify in person troubleshooting option clicked' => {

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
           doc_type_supported: boolean,
+          getting_started_ab_test_bucket: :welcome_default,
         )
       end
 

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           flow_path: anything,
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
         )
 
         expect(fake_analytics).to have_logged_event(
@@ -204,6 +205,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           flow_path: anything,
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
+          getting_started_ab_test_bucket: :welcome_default,
         )
       end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-10753](https://cm-jira.usa.gov/browse/LG-10753)

## 🛠 Summary of changes

To continue investigating GettingStarted A/B test differences in Doc Auth success rates, add the A/B test bucket to analytics events in ApiImageUploadForm
- IdV: doc auth image upload form submitted
- IdV: doc auth image upload vendor submitted
- IdV: doc auth image upload vendor pii validation
- Doc Auth Warning

Note: Looked at adding the bucket to the Frontend events, but got bogged down with getting access to the uuid that's used as the GettingStarted bucket discriminator, and backed out.

## 📜 Testing Plan

- [ ] Create account, start IdV
- [ ] After DocumentCapture step, confirm getting_started_ab_test_bucket: :welcome_default is present in image upload events in log/events.log
- [ ] Try hybrid flow, confirm it works.
