### PR TITLE
Use 'profile.updated_at` not `in_person_enrollment.updated_at`

### DIFF
--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -21,7 +21,7 @@ namespace :profiles do
     )
 
     profiles.each do |profile|
-      timestamp = profile.updated_at
+      timestamp = profile.updated_at || profile.created_at
 
       warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
       if update_profiles

--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -21,7 +21,7 @@ namespace :profiles do
     )
 
     profiles.each do |profile|
-      timestamp = profile.in_person_enrollment.updated_at
+      timestamp = profile.updated_at
 
       warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
       if update_profiles


### PR DESCRIPTION
Some profiles for in-person enrollment don't have an an in_person_enrollment associated with them, so use the profile's timestamp instead.

changelog: Internal,In-person proofing,backfill `in_person_pending_at` column

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
