### PR TITLE
Add more useful default log group for deployed environments

### DIFF
--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-cloudwatchlogs'
+require 'identity/hostdata'
 
 module Reporting
   class CloudwatchClient
@@ -25,7 +26,7 @@ module Reporting
       slice_interval: 1.day,
       logger: nil,
       progress: true,
-      log_group_name: 'prod_/srv/idp/shared/log/events.log'
+      log_group_name: default_events_log
     )
       @ensure_complete_logs = ensure_complete_logs
       @num_threads = num_threads
@@ -178,6 +179,13 @@ module Reporting
 
     def show_progress?
       !!@progress
+    end
+
+    # The prod events log ('prod_/srv/idp/shared/log/events.log') or equivalent in lower
+    # environments
+    def default_events_log
+      env = Identity::Hostdata.in_datacenter? ? Identity::Hostdata.env : 'prod'
+      "#{env}_/srv/idp/shared/log/events.log"
     end
 
     private

--- a/spec/lib/reporting/cloudwatch_client_spec.rb
+++ b/spec/lib/reporting/cloudwatch_client_spec.rb
@@ -20,6 +20,35 @@ RSpec.describe Reporting::CloudwatchClient do
     )
   end
 
+  describe '#initialize' do
+    context 'default log_group_name' do
+      before do
+        allow(Identity::Hostdata).to receive(:env).and_return(env)
+        allow(Identity::Hostdata).to receive(:in_datacenter?).and_return(in_datacenter)
+      end
+
+      context 'locally' do
+        let(:in_datacenter) { false }
+        let(:env) { 'development' }
+
+        it 'is the default prod group' do
+          expect(client.log_group_name).to eq(client.default_events_log)
+          expect(client.log_group_name).to eq('prod_/srv/idp/shared/log/events.log')
+        end
+      end
+
+      context 'deployed environment' do
+        let(:in_datacenter) { true }
+        let(:env) { 'staging' }
+
+        it 'is the group for that environment' do
+          expect(client.log_group_name).to eq(client.default_events_log)
+          expect(client.log_group_name).to eq('staging_/srv/idp/shared/log/events.log')
+        end
+      end
+    end
+  end
+
   describe '#fetch' do
     let(:from) { 3.days.ago }
     let(:to) { 1.day.ago }


### PR DESCRIPTION
Helps avoid permissions issues [like this (slack convo)](https://gsa-tts.slack.com/archives/C16RSBG49/p1693231097015499) in the future, and preserves useful behavior in local development for test queries
