### PR TITLE
10301: Move the complete address search component from doc auth to address-search pkg

### DIFF
--- a/app/javascript/packages/address-search/components/address-search.tsx
+++ b/app/javascript/packages/address-search/components/address-search.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { Alert, PageHeading } from '@18f/identity-components';
-import AddressSearchInput, { InPersonLocations } from '@18f/identity-address-search';
-import type { LocationQuery, FormattedLocation } from '@18f/identity-address-search/types';
 import { useI18n } from '@18f/identity-react-i18n';
+import InPersonLocations from './in-person-locations';
+import AddressInput from './address-input';
+import type { LocationQuery, FormattedLocation } from '../types';
 
 function AddressSearch({
   registerField,
@@ -29,7 +30,7 @@ function AddressSearch({
       )}
       <PageHeading>{t('in_person_proofing.headings.po_search.location')}</PageHeading>
       <p>{t('in_person_proofing.body.location.po_search.po_search_about')}</p>
-      <AddressSearchInput
+      <AddressInput
         registerField={registerField}
         onFoundAddress={setFoundAddress}
         onFoundLocations={(locations) => {

--- a/app/javascript/packages/address-search/index.tsx
+++ b/app/javascript/packages/address-search/index.tsx
@@ -1,7 +1,8 @@
 import { snakeCase, formatLocations, transformKeys } from './utils';
 import InPersonLocations from './components/in-person-locations';
 import AddressInput from './components/address-input';
+import AddressSearch from './components/address-search';
 
-export { snakeCase, formatLocations, transformKeys, InPersonLocations };
+export { snakeCase, formatLocations, transformKeys, InPersonLocations, AddressInput };
 
-export default AddressInput;
+export default AddressSearch;

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx
@@ -1,13 +1,12 @@
 import { useState, useEffect, useCallback, useRef, useContext } from 'react';
 import { request } from '@18f/identity-request';
 import { forceRedirect } from '@18f/identity-url';
-import { transformKeys, snakeCase } from '@18f/identity-address-search';
+import AddressSearch, { transformKeys, snakeCase } from '@18f/identity-address-search';
 import type { FormattedLocation } from '@18f/identity-address-search/types';
 import BackButton from './back-button';
 import AnalyticsContext from '../context/analytics';
 import { InPersonContext } from '../context';
 import UploadContext from '../context/upload';
-import AddressSearch from './address-search';
 
 export const LOCATIONS_URL = new URL(
   '/verify/in_person/usps_locations',


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-10301)

## 🛠 Summary of changes

Moves the combined AddressSearch component, which renders the results, from doc capture package into the address-search package, and re-exports it by default.

## 📜 Testing Plan

- [x] `yarn run mocha app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx`