### PR TITLE
Fix 500 with blank token when attempting to update service providers

### DIFF
--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -25,6 +25,7 @@ class ServiceProviderController < ApplicationController
   end
 
   def authorization_token_valid?
+    return false if authorization_token.blank?
     ActiveSupport::SecurityUtils.secure_compare(
       authorization_token,
       IdentityConfig.store.dashboard_api_token,

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -133,6 +133,16 @@ RSpec.describe ServiceProviderController do
       end
     end
 
+    context 'missing token in header' do
+      let(:token) { nil }
+
+      it 'returns a 401' do
+        post :update
+
+        expect(response.status).to eq 401
+      end
+    end
+
     context 'feature off' do
       let(:use_feature) { false }
       before { post :update }


### PR DESCRIPTION
## 🛠 Summary of changes

During last week's [contingency planning scenario](https://gsa-tts.slack.com/archives/C03AM5TKWHG/p1692907920840209), we noticed some unrelated 500s when comparing a nil value.

This PR skips the comparison if the value is blank. This should be fine since an attempted timing attack with a zero-length attempt should not be terribly informative.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
