### PR TITLE
Lg 10556 move error message out of flow session 2 of 2

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -118,10 +118,7 @@ module Idv
     end
 
     def extra_view_variables
-      {
-        flow_session: flow_session,
-        idv_phone_form: build_form,
-      }
+      { idv_phone_form: build_form }
     end
 
     def build_form

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -30,8 +30,7 @@ module Idv
     end
 
     def extra_view_variables
-      { phone: idv_session.phone_for_mobile_flow,
-        flow_session: flow_session }
+      { phone: idv_session.phone_for_mobile_flow }
     end
 
     private

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -9,16 +9,6 @@
       ) %>
 <% end %>
 
-<%= render AlertComponent.new(
-      type: :error,
-      class: [
-        'js-consent-form-alert',
-        'margin-bottom-4',
-        'display-none',
-      ].select(&:present?),
-      message: t('errors.doc_auth.consent_form'),
-    ) %>
-
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.lets_go')) %>
 <p><%= t('doc_auth.info.lets_go') %></p>
 <h2><%= t('doc_auth.headings.verify_identity') %></h2>

--- a/app/views/idv/doc_auth/_error_messages.html.erb
+++ b/app/views/idv/doc_auth/_error_messages.html.erb
@@ -1,8 +1,0 @@
-<% unless flow_session[:error_message].nil? %>
-  <%= render AlertComponent.new(
-        type: :error,
-        class: 'margin-bottom-4',
-      ) do %>
-    <%= flow_session[:error_message] %>
-  <% end %>
-<% end %>

--- a/app/views/idv/getting_started/show.html.erb
+++ b/app/views/idv/getting_started/show.html.erb
@@ -5,16 +5,6 @@
       intro: t('idv.getting_started.no_js_intro', sp_name: @sp_name),
     ) do %>
 
-<%= render AlertComponent.new(
-      type: :error,
-      class: [
-        'js-consent-form-alert',
-        'margin-bottom-4',
-        'display-none',
-      ].select(&:present?),
-      message: t('errors.doc_auth.consent_form'),
-    ) %>
-
 <%= render PageHeadingComponent.new.with_content(@title) %>
   <p>
     <%= t(

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -9,8 +9,6 @@
       ) %>
 <% end %>
 
-<%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
-
 <%= render PageHeadingComponent.new do %>
   <%= t('doc_auth.headings.hybrid_handoff') %>
 <% end %>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -9,14 +9,6 @@
 
 <% title t('titles.doc_auth.link_sent') %>
 
-<% if flow_session[:error_message] %>
-  <%= render AlertComponent.new(
-        type: :error,
-        class: 'margin-bottom-4',
-        message: flow_session[:error_message],
-      ) %>
-<% end %>
-
 <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-4') do %>
   <strong class="display-block"><%= t('doc_auth.info.keep_window_open') %></strong>
   <% if FeatureManagement.doc_capture_polling_enabled? %>

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -3,10 +3,7 @@ require 'rails_helper'
 RSpec.describe Idv::LinkSentController do
   include IdvHelper
 
-  let(:flow_session) do
-    { document_capture_session_uuid: 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
-      threatmetrix_session_id: 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0' }
-  end
+  let(:flow_session) { {} }
 
   let(:user) { create(:user) }
 

--- a/spec/features/idv/doc_auth/agreement_spec.rb
+++ b/spec/features/idv/doc_auth/agreement_spec.rb
@@ -2,27 +2,6 @@ require 'rails_helper'
 
 RSpec.feature 'agreement step error checking' do
   include DocAuthHelper
-  context 'when JS is disabled' do
-    before do
-      sign_in_and_2fa_user
-      complete_doc_auth_steps_before_agreement_step
-    end
-
-    it 'shows the notice if the user clicks continue without giving consent' do
-      click_continue
-
-      expect(page).to have_current_path(idv_agreement_url)
-      expect(page).to have_content(t('errors.doc_auth.consent_form'))
-    end
-
-    it 'allows the user to continue after checking the checkbox' do
-      check t('doc_auth.instructions.consent', app_name: APP_NAME)
-      click_continue
-
-      expect(page).to have_current_path(idv_hybrid_handoff_path)
-    end
-  end
-
   context 'skipping hybrid_handoff step', :js, driver: :headless_chrome_mobile do
     let(:fake_analytics) { FakeAnalytics.new }
 

--- a/spec/features/idv/doc_auth/getting_started_spec.rb
+++ b/spec/features/idv/doc_auth/getting_started_spec.rb
@@ -45,22 +45,6 @@ RSpec.feature 'getting started step' do
     )
   end
 
-  context 'when JS is disabled' do
-    it 'shows the notice if the user clicks continue without giving consent' do
-      click_continue
-
-      expect(page).to have_current_path(idv_getting_started_url)
-      expect(page).to have_content(t('errors.doc_auth.consent_form'))
-    end
-
-    it 'allows the user to continue after checking the checkbox' do
-      check t('doc_auth.instructions.consent', app_name: APP_NAME)
-      click_continue
-
-      expect(page).to have_current_path(idv_hybrid_handoff_path)
-    end
-  end
-
   context 'skipping hybrid_handoff step', :js, driver: :headless_chrome_mobile do
     before do
       complete_getting_started_step

--- a/spec/views/idv/agreement/show.html.erb_spec.rb
+++ b/spec/views/idv/agreement/show.html.erb_spec.rb
@@ -1,10 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'idv/agreement/show' do
-  let(:flow_session) { {} }
-
   before do
-    allow(view).to receive(:flow_session).and_return(flow_session)
     allow(view).to receive(:user_signing_up?).and_return(false)
     allow(view).to receive(:url_for).and_wrap_original do |method, *args, &block|
       method.call(*args, &block)

--- a/spec/views/idv/getting_started/show.html.erb_spec.rb
+++ b/spec/views/idv/getting_started/show.html.erb_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'idv/getting_started/show' do
-  let(:flow_session) { {} }
   let(:user_fully_authenticated) { true }
   let(:sp_name) { nil }
   let(:user) { create(:user) }
@@ -12,7 +11,6 @@ RSpec.describe 'idv/getting_started/show' do
     @title = t('doc_auth.headings.getting_started', sp_name: @sp_name)
     allow(@decorated_session).to receive(:sp_name).and_return(sp_name)
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
-    allow(view).to receive(:flow_session).and_return(flow_session)
     allow(view).to receive(:user_fully_authenticated?).and_return(user_fully_authenticated)
     allow(view).to receive(:user_signing_up?).and_return(false)
     allow(view).to receive(:url_for).and_wrap_original do |method, *args, &block|


### PR DESCRIPTION
## 🎫 Ticket

[LG-10556](https://cm-jira.usa.gov/browse/LG-9727) 

## 🛠 Summary of changes

- [x] continuation of https://github.com/18F/identity-idp/pull/9095, merge after deployed
This PR is the follow-up PR to remove code that displays `flow_session` error messages to the user.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Create account, start IDV
- [x] On agreement step, try to continue without checking the box
- [x] Expected result: see error under checkbox
- [x] check box, continue to hybrid handoff
- [x] On hybrid handoff, send link enough times to get rate limited, i.e. 6
- [x] Expected result: see error on page in flash messages
- [x] Create account, start IDV
- [x] Choose hybrid flow
- [x] Open `/test/telephony` in a new incognito window
- [x] Visit hybrid link
- [x] Cancel document upload
- [x] Expected result: see error on link sent page in flash messages

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
