### PR TITLE
Fix require for oncall scripts

### DIFF
--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -1,5 +1,4 @@
 require 'aws-sdk-cloudwatchlogs'
-require 'identity/hostdata'
 
 module Reporting
   class CloudwatchClient


### PR DESCRIPTION
Somehow I broke scripts that use the cloudwatch client by adding this require in #9098

**before:**
```bash
identity-idp:main> aws-vault exec prod-power -- ./bin/oncall/email-deliveries c7abcdef
<internal:/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:148:in `require': cannot load such file -- identity/hostdata (LoadError)
```


**after:**
```bash
> aws-vault exec prod-power -- ./bin/oncall/email-deliveries abcdef
[ Querying logs ] --=---=---=---=---=---=---=---=-----=---=---
```
