### PR TITLE
Add missing require back to cloudwatch_client.rb

### DIFF
--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-cloudwatchlogs'
+require 'ruby-progressbar'
 
 module Reporting
   class CloudwatchClient


### PR DESCRIPTION
This require being gone was causing errors when running query-cloudwatch locally.

[skip changelog]

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
