### PR TITLE
Fix reCAPTCHA add phone fallback links

### DIFF
--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -35,7 +35,7 @@ module Users
       if result.success?
         handle_create_success(@new_phone_form.phone)
       elsif recoverable_recaptcha_error?(result)
-        render :spam_protection, locals: { authentication_methods_setup_path: }
+        render :spam_protection
       else
         render :index
       end

--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -11,6 +11,8 @@ module Users
     before_action :allow_csp_recaptcha_src, if: :recaptcha_enabled?
     before_action :confirm_recently_authenticated_2fa
 
+    helper_method :in_multi_mfa_selection_flow?
+
     def add
       user_session[:phone_id] = nil
       @new_phone_form = NewPhoneForm.new(user: current_user, analytics: analytics)

--- a/app/views/users/phone_setup/spam_protection.html.erb
+++ b/app/views/users/phone_setup/spam_protection.html.erb
@@ -43,7 +43,7 @@
 
 <%= render TroubleshootingOptionsComponent.new do |c| %>
   <% c.with_header { t('components.troubleshooting_options.default_heading') } %>
-  <% if local_assigns[:authentication_methods_setup_path].present? %>
+  <% if in_multi_mfa_selection_flow? %>
     <% c.with_option(
          url: authentication_methods_setup_path,
        ).with_content(t('two_factor_authentication.login_options_link_text')) %>
@@ -59,7 +59,7 @@
      ).with_content(t('two_factor_authentication.learn_more')) %>
 <% end %>
 
-<% unless local_assigns[:authentication_methods_setup_path].present? %>
+<% unless in_multi_mfa_selection_flow? %>
   <%= render PageFooterComponent.new do %>
     <%= link_to t('links.cancel'), account_path %>
   <% end %>

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -220,6 +220,8 @@ RSpec.describe 'Add a new phone number' do
     fill_in t('components.captcha_submit_button.mock_score_label'), with: '0.5'
     click_send_one_time_code
     expect(page).to have_content(t('titles.spam_protection'), wait: 5)
+    expect(page).not_to have_link(t('two_factor_authentication.login_options_link_text'))
+    expect(page).to have_link(t('links.cancel'))
     click_continue
     expect(page).to have_content(t('two_factor_authentication.header_text'))
     visit account_path

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -132,6 +132,21 @@ RSpec.feature 'Sign Up' do
     expect(page).to have_content(/#{rate_limited_message}/)
   end
 
+  scenario 'signing up using phone with a reCAPTCHA challenge', :js do
+    allow(IdentityConfig.store).to receive(:phone_recaptcha_mock_validator).and_return(true)
+    allow(IdentityConfig.store).to receive(:phone_recaptcha_score_threshold).and_return(0.6)
+
+    sign_up_and_set_password
+    select_2fa_option('phone')
+
+    fill_in t('two_factor_authentication.phone_label'), with: '+61 0491 570 006'
+    fill_in t('components.captcha_submit_button.mock_score_label'), with: '0.5'
+    click_send_one_time_code
+    expect(page).to have_content(t('titles.spam_protection'), wait: 5)
+    expect(page).to have_link(t('two_factor_authentication.login_options_link_text'))
+    expect(page).not_to have_link(t('links.cancel'))
+  end
+
   context 'with js', js: true do
     before do
       page.driver.browser.execute_cdp(

--- a/spec/views/phone_setup/spam_protection.html.erb_spec.rb
+++ b/spec/views/phone_setup/spam_protection.html.erb_spec.rb
@@ -3,12 +3,13 @@ require 'rails_helper'
 RSpec.describe 'users/phone_setup/spam_protection.html.erb' do
   let(:user) { build_stubbed(:user) }
   let(:form) { NewPhoneForm.new(user:) }
-  let(:locals) { {} }
+  let(:in_multi_mfa_selection_flow) { false }
 
-  subject(:rendered) { render(template: 'users/phone_setup/spam_protection', locals:) }
+  subject(:rendered) { render(template: 'users/phone_setup/spam_protection') }
 
   before do
     @new_phone_form = form
+    allow(view).to receive(:in_multi_mfa_selection_flow?).and_return(in_multi_mfa_selection_flow)
   end
 
   it 'renders hidden form inputs' do
@@ -33,9 +34,8 @@ RSpec.describe 'users/phone_setup/spam_protection.html.erb' do
     expect(rendered).not_to have_link(t('two_factor_authentication.login_options_link_text'))
   end
 
-  context 'with two factor options path' do
-    let(:authentication_methods_setup_path) { root_path }
-    let(:locals) { { authentication_methods_setup_path: } }
+  context 'in multi mfa selectino flow' do
+    let(:in_multi_mfa_selection_flow) { true }
 
     it 'renders additional troubleshooting option to two factor options' do
       expect(rendered).to have_link(


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where the reCAPTCHA fallback screen shows incorrect links when adding a phone number to an existing account.

This was an unintended side-effect of the phone consolidation in #8966, since the links were controlled by distinct logic in the two controllers, where one would provide `locals` value to the view to render a link to "Choose another authentication method":

https://github.com/18F/identity-idp/blob/c068dfbdbaaa407f0142eaa495b48663c8a357e4/app/controllers/users/phones_controller.rb#L27

https://github.com/18F/identity-idp/blob/c068dfbdbaaa407f0142eaa495b48663c8a357e4/app/controllers/users/phone_setup_controller.rb#L38

There was not sufficient regression coverage for this behavior, hence why it was not caught previously.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create an account
3. Select phone as MFA during setup
4. At phone setup screen, use phone number `+610491570006` and assign a score `0.4`
5. Click "Send code"
6. Observe in fallback screen the "Choose another authentication method" link. Optionally click it to return to MFA selection screen.
7. Continue account creation.
8. Once account is created, click "Add phone number" from account dashboard
9. At phone setup screen, use phone number `+610491570156` and assign a score `0.4`
10. Click "Send code"
11. Observe no "Choose another authentication method" link. Instead, see link to "Cancel" to return to account dashboard.

## 👀 Screenshots

Screen|Before|After
---|---|---
New Account Fallback|![Screenshot 2023-08-29 at 8 28 49 AM](https://github.com/18F/identity-idp/assets/1779930/a62a2e2b-e404-430e-acc8-a5310bf0a047)|![Screenshot 2023-08-29 at 8 28 49 AM](https://github.com/18F/identity-idp/assets/1779930/a62a2e2b-e404-430e-acc8-a5310bf0a047)
Existing Account Fallback|![Screenshot 2023-08-29 at 8 28 49 AM](https://github.com/18F/identity-idp/assets/1779930/a62a2e2b-e404-430e-acc8-a5310bf0a047)|![Screenshot 2023-08-29 at 8 28 38 AM](https://github.com/18F/identity-idp/assets/1779930/b73706ba-471d-4272-9e7c-25c3f5dc9346)