### PR TITLE
Do not always prompt for password when logging in with PIV/CAC during identity verification request

### DIFF
--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -79,7 +79,8 @@ module Users
     end
 
     def next_step
-      if ial_context.ial2_requested?
+      if ial_context.ial2_requested? && current_user.identity_verified? &&
+         !Pii::Cacher.new(current_user, user_session).exists_in_session?
         capture_password_url
       elsif !current_user.accepted_rules_of_use_still_valid?
         rules_of_use_path

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -168,6 +168,14 @@ RSpec.describe Users::PivCacLoginController do
                 expect(response).to redirect_to(account_url)
               end
 
+              context 'ial2 service_level' do
+                let(:sp_session) { { ial: Idp::Constants::IAL2, issuer: service_provider.issuer } }
+
+                it 'redirects to account' do
+                  expect(response).to redirect_to(account_url)
+                end
+              end
+
               context 'ial_max service level' do
                 let(:sp_session) do
                   { ial: Idp::Constants::IAL_MAX, issuer: service_provider.issuer }


### PR DESCRIPTION
## 🛠 Summary of changes

Makes a fix similar to #8622, #6121, #6309 where we should only request the password if it is strictly needed. If a user is not logging in during an IAL2 request with an active profile, we should not prompt for a password.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
