### PR TITLE
Hardcoding name of container main tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ build-idp-image:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       variables:
-        BRANCH_TAGGING_STRING: "--destination ${ECR_REGISTRY}/identity-idp/review:${$CI_DEFAULT_BRANCH}"
+        BRANCH_TAGGING_STRING: "--destination ${ECR_REGISTRY}/identity-idp/review:main"
     - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
     - if: $CI_PIPELINE_SOURCE != "merge_request_event"
       when: never


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-10505

## 🛠 Summary of changes

Bug fix - Hardcoding the "main" container tag onto the container built from the main branch. CI_DEFAULT_BRANCH appears to be a protected variable in Prod GitLab and results in an empty tag (all logic using this variable still functions as expected) for the container built from the main branch (this behavior was not see when tested in GitLab Alpha). 
