### PR TITLE
LG-10343 Add a class for migrating encrypted PII to the multi-region KMS key

### DIFF
--- a/app/services/encryption/multi_region_kms_migration/profile_migrator.rb
+++ b/app/services/encryption/multi_region_kms_migration/profile_migrator.rb
@@ -1,0 +1,65 @@
+module Encryption
+  module MultiRegionKmsMigration
+    class ProfileMigrator
+      include ::NewRelic::Agent::MethodTracer
+
+      attr_reader :profile
+
+      def initialize(profile)
+        @profile = profile
+      end
+
+      def migrate!
+        if profile.encrypted_pii.blank? || profile.encrypted_pii_recovery.blank?
+          raise "Profile##{profile.id} is missing encrypted_pii or or encrypted_pii_recovery"
+        end
+
+        return if profile.encrypted_pii_multi_region.present? ||
+                  profile.encrypted_pii_recovery_multi_region.present?
+
+        encrypted_pii_multi_region = migrate_ciphertext(profile.encrypted_pii)
+        encrypted_pii_recovery_multi_region = migrate_ciphertext(profile.encrypted_pii_recovery)
+        profile.update!(
+          encrypted_pii: profile.encrypted_pii,
+          encrypted_pii_multi_region: encrypted_pii_multi_region,
+          encrypted_pii_recovery: profile.encrypted_pii_recovery,
+          encrypted_pii_recovery_multi_region: encrypted_pii_recovery_multi_region,
+        )
+      end
+
+      private
+
+      def migrate_ciphertext(ciphertext_string)
+        ciphertext = Encryption::Encryptors::PiiEncryptor::Ciphertext.parse_from_string(
+          ciphertext_string,
+        )
+        aes_encrypted_data = multi_region_kms_client.decrypt(
+          ciphertext.encrypted_data, kms_encryption_context
+        )
+        multi_region_kms_encrypted_data = multi_region_kms_client.encrypt(
+          aes_encrypted_data, kms_encryption_context
+        )
+        Encryption::Encryptors::PiiEncryptor::Ciphertext.new(
+          multi_region_kms_encrypted_data,
+          ciphertext.salt,
+          ciphertext.cost,
+        )
+      end
+
+      def kms_encryption_context
+        {
+          'context' => 'pii-encryption',
+          'user_uuid' => profile.user.uuid,
+        }
+      end
+
+      def multi_region_kms_client
+        @multi_region_kms_client ||= KmsClient.new(
+          kms_key_id: IdentityConfig.store.aws_kms_multi_region_key_id,
+        )
+      end
+
+      add_method_tracer :migrate!, "Custom/#{name}/migrate!"
+    end
+  end
+end

--- a/app/services/encryption/multi_region_kms_migration/profile_migrator.rb
+++ b/app/services/encryption/multi_region_kms_migration/profile_migrator.rb
@@ -11,7 +11,7 @@ module Encryption
 
       def migrate!
         if profile.encrypted_pii.blank? || profile.encrypted_pii_recovery.blank?
-          raise "Profile##{profile.id} is missing encrypted_pii or or encrypted_pii_recovery"
+          raise "Profile##{profile.id} is missing encrypted_pii or encrypted_pii_recovery"
         end
 
         return if profile.encrypted_pii_multi_region.present? ||

--- a/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
+++ b/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Encryption::MultiRegionKmsMigration::ProfileMigrator do
+  let(:profile) { create(:profile, :with_pii) }
+  let!(:user_password) { profile.user.password }
+  let!(:personal_key) { PersonalKeyGenerator.new(profile.user).normalize(profile.personal_key) }
+
+  subject { described_class.new(profile) }
+
+  before do
+    allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
+  end
+
+  describe '#migrate!' do
+    context 'for a user without multi-region ciphertexts' do
+      before do
+        profile.update!(
+          encrypted_pii_multi_region: nil,
+          encrypted_pii_recovery_multi_region: nil,
+        )
+      end
+
+      it 'migrates the single-region ciphertext and saves it to the profile' do
+        subject.migrate!
+
+        pii_encryptor = Encryption::Encryptors::PiiEncryptor.new(user_password)
+
+        single_region_pii = pii_encryptor.decrypt(
+          Encryption::RegionalCiphertextPair.new(
+            single_region_ciphertext: profile.encrypted_pii,
+            multi_region_ciphertext: nil,
+          ),
+          user_uuid: profile.user.uuid,
+        )
+        multi_region_pii = pii_encryptor.decrypt(
+          Encryption::RegionalCiphertextPair.new(
+            single_region_ciphertext: nil,
+            multi_region_ciphertext: profile.encrypted_pii_multi_region,
+          ),
+          user_uuid: profile.user.uuid,
+        )
+        expect(profile.encrypted_pii).to_not eq(profile.encrypted_pii_multi_region)
+        expect(single_region_pii).to eq(multi_region_pii)
+
+        pii_recovery_encryptor = Encryption::Encryptors::PiiEncryptor.new(personal_key)
+
+        single_region_pii_recovery = pii_recovery_encryptor.decrypt(
+          Encryption::RegionalCiphertextPair.new(
+            single_region_ciphertext: profile.encrypted_pii_recovery,
+            multi_region_ciphertext: nil,
+          ),
+          user_uuid: profile.user.uuid,
+        )
+        multi_region_pii_recovery = pii_recovery_encryptor.decrypt(
+          Encryption::RegionalCiphertextPair.new(
+            single_region_ciphertext: nil,
+            multi_region_ciphertext: profile.encrypted_pii_recovery_multi_region,
+          ),
+          user_uuid: profile.user.uuid,
+        )
+        expect(
+          profile.encrypted_pii_recovery,
+        ).to_not eq(
+          profile.encrypted_pii_recovery_multi_region,
+        )
+        expect(single_region_pii_recovery).to eq(multi_region_pii_recovery)
+      end
+    end
+
+    context 'for a user with multi-region ciphertexts' do
+      it 'does not modify the profile record' do
+        expect { subject.migrate! }.to_not change { profile.attributes }
+      end
+    end
+
+    context 'for a user without multi-region or single-region ciphertexts' do
+      before do
+        profile.update!(
+          encrypted_pii: nil,
+          encrypted_pii_multi_region: nil,
+          encrypted_pii_recovery: nil,
+          encrypted_pii_recovery_multi_region: nil,
+        )
+      end
+
+      it 'does not modify the profile record' do
+        expect { subject.migrate! }.to raise_error(
+          RuntimeError,
+          "Profile##{profile.id} is missing encrypted_pii or or encrypted_pii_recovery"
+        )
+      end
+    end
+  end
+end

--- a/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
+++ b/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Encryption::MultiRegionKmsMigration::ProfileMigrator do
       it 'does not modify the profile record' do
         expect { subject.migrate! }.to raise_error(
           RuntimeError,
-          "Profile##{profile.id} is missing encrypted_pii or or encrypted_pii_recovery"
+          "Profile##{profile.id} is missing encrypted_pii or encrypted_pii_recovery",
         )
       end
     end


### PR DESCRIPTION
We are working on migrating between KMS keys. The new key will support multi-region encryption. As part of this migration we encrypting records with both keys.

Previous commits added code for encrypting with both keys and writing ciphertexts for both on `INSERT` and `UPDATE`. This commit adds tooling for going back and updating records that are not being changed by normal user behavior.
