### PR TITLE
LG-10074: Make usps enrollment email address configurable

### DIFF
--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -63,7 +63,7 @@ module UspsInPersonProofing
             city: transliterate(pii[:city]),
             state: pii[:state],
             zip_code: pii[:zipcode],
-            email: IdentityConfig.store.usps_ipp_enrollment_email_address.presence ||
+            email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence ||
               'no-reply@login.gov',
           },
         )

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -63,7 +63,8 @@ module UspsInPersonProofing
             city: transliterate(pii[:city]),
             state: pii[:state],
             zip_code: pii[:zipcode],
-            email: 'no-reply@login.gov',
+            email: IdentityConfig.store.usps_ipp_enrollment_email_address.present? ||
+              'no-reply@login.gov',
           },
         )
 

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -63,7 +63,7 @@ module UspsInPersonProofing
             city: transliterate(pii[:city]),
             state: pii[:state],
             zip_code: pii[:zipcode],
-            email: IdentityConfig.store.usps_ipp_enrollment_email_address.present? ||
+            email: IdentityConfig.store.usps_ipp_enrollment_email_address.presence ||
               'no-reply@login.gov',
           },
         )

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -63,8 +63,7 @@ module UspsInPersonProofing
             city: transliterate(pii[:city]),
             state: pii[:state],
             zip_code: pii[:zipcode],
-            email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence ||
-              'no-reply@login.gov',
+            email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence,
           },
         )
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -339,6 +339,7 @@ usps_ipp_sponsor_id: ''
 usps_ipp_username: ''
 usps_mock_fallback: true
 usps_ipp_transliteration_enabled: false
+usps_ipp_enrollment_email_address: 'no-reply@login.gov'
 get_usps_ready_proofing_results_job_cron: '0/10 * * * *'
 get_usps_waiting_proofing_results_job_cron: '0/30 * * * *'
 get_usps_proofing_results_job_cron: '0/30 * * * *'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -339,7 +339,7 @@ usps_ipp_sponsor_id: ''
 usps_ipp_username: ''
 usps_mock_fallback: true
 usps_ipp_transliteration_enabled: false
-usps_ipp_enrollment_email_address: 'no-reply@login.gov'
+usps_ipp_enrollment_status_update_email_address: 'no-reply@login.gov'
 get_usps_ready_proofing_results_job_cron: '0/10 * * * *'
 get_usps_waiting_proofing_results_job_cron: '0/30 * * * *'
 get_usps_proofing_results_job_cron: '0/30 * * * *'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -455,6 +455,7 @@ class IdentityConfig
     config.add(:usps_ipp_sponsor_id, type: :string)
     config.add(:usps_ipp_transliteration_enabled, type: :boolean)
     config.add(:usps_ipp_username, type: :string)
+    config.add(:usps_ipp_enrollment_email_address, type: :string)
     config.add(:usps_mock_fallback, type: :boolean)
     config.add(:usps_upload_enabled, type: :boolean)
     config.add(:usps_upload_sftp_directory, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -455,7 +455,7 @@ class IdentityConfig
     config.add(:usps_ipp_sponsor_id, type: :string)
     config.add(:usps_ipp_transliteration_enabled, type: :boolean)
     config.add(:usps_ipp_username, type: :string)
-    config.add(:usps_ipp_enrollment_email_address, type: :string)
+    config.add(:usps_ipp_enrollment_status_update_email_address, type: :string)
     config.add(:usps_mock_fallback, type: :boolean)
     config.add(:usps_upload_enabled, type: :boolean)
     config.add(:usps_upload_sftp_directory, type: :string)

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
             expect(applicant.city).to eq("transliterated_#{city}")
             expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
             expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
-            expect(applicant.email).to eq('no-reply@login.gov')
+            expect(applicant.email).to eq(usps_ipp_enrollment_email_address)
             expect(applicant.unique_id).to eq(enrollment.unique_id)
 
             UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant)

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -87,8 +87,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
     end
 
     context 'an establishing enrollment record exists for the user' do
-      let(:proofer) { UspsInPersonProofing::Mock::Proofer.new }
-
       before do
         allow(Rails).to receive(:cache).and_return(
           ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
@@ -238,7 +236,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
       end
 
       context 'event logging' do
-        let(:proofer) { UspsInPersonProofing::Mock::Proofer.new }
         context 'with no service provider' do
           it 'logs event' do
             subject.schedule_in_person_enrollment(user, pii)

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -53,31 +53,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
       )
     end
 
-    it 'uses configured email address in enrollment request' do
-      allow(subject).to receive(:usps_proofer).and_return(proofer)
-      expect(proofer).to receive(:request_enroll) do |applicant|
-        expect(applicant.email).to eq(usps_ipp_enrollment_status_update_email_address)
-
-        UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant)
-      end
-
-      subject.schedule_in_person_enrollment(user, pii)
-    end
-
-    it 'uses default email address in enrollment request if no email address is configured' do
-      allow(subject).to receive(:usps_proofer).and_return(proofer)
-      allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address).
-        and_return('')
-
-      expect(proofer).to receive(:request_enroll) do |applicant|
-        expect(applicant.email).to eq('no-reply@login.gov')
-
-        UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant)
-      end
-
-      subject.schedule_in_person_enrollment(user, pii)
-    end
-
     context 'when in-person mocking is enabled' do
       let(:usps_mock_fallback) { true }
 

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -19,15 +19,17 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
   let(:service_provider) { nil }
   let(:usps_ipp_transliteration_enabled) { true }
   let(:in_person_capture_secondary_id_enabled) { false }
-  let(:usps_ipp_enrollment_email_address) { 'registration@usps.local.identitysandbox.gov' }
+  let(:usps_ipp_enrollment_status_update_email_address) do
+    'registration@usps.local.identitysandbox.gov'
+  end
   let(:proofer) { UspsInPersonProofing::Mock::Proofer.new }
 
   before(:each) do
     stub_request_token
     stub_request_enroll
     allow(IdentityConfig.store).to receive(:usps_mock_fallback).and_return(usps_mock_fallback)
-    allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_email_address).
-      and_return(usps_ipp_enrollment_email_address)
+    allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address).
+      and_return(usps_ipp_enrollment_status_update_email_address)
     allow(subject).to receive(:transliterator).and_return(transliterator)
     allow(transliterator).to receive(:transliterate).
       with(anything) do |val|
@@ -54,7 +56,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
     it 'uses configured email address in enrollment request' do
       allow(subject).to receive(:usps_proofer).and_return(proofer)
       expect(proofer).to receive(:request_enroll) do |applicant|
-        expect(applicant.email).to eq(usps_ipp_enrollment_email_address)
+        expect(applicant.email).to eq(usps_ipp_enrollment_status_update_email_address)
 
         UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant)
       end
@@ -64,7 +66,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
 
     it 'uses default email address in enrollment request if no email address is configured' do
       allow(subject).to receive(:usps_proofer).and_return(proofer)
-      allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_email_address).
+      allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address).
         and_return('')
 
       expect(proofer).to receive(:request_enroll) do |applicant|
@@ -204,7 +206,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
             expect(applicant.city).to eq("transliterated_#{city}")
             expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
             expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
-            expect(applicant.email).to eq(usps_ipp_enrollment_email_address)
+            expect(applicant.email).to eq(usps_ipp_enrollment_status_update_email_address)
             expect(applicant.unique_id).to eq(enrollment.unique_id)
 
             UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant)


### PR DESCRIPTION
## 🎫 Ticket

[LG-10074](https://cm-jira.usa.gov/browse/LG-10074)

## 🛠 Summary of changes

* Adds a new configuration value for the email address that we send to USPS when we create USPS enrollments
* Begins using the new configuration value, including falling back to 'no-reply@login.gov' if the configuration value is set to empty string

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
