### PR TITLE
LG-10614 Update sms copy

### DIFF
--- a/app/jobs/in_person/send_proofing_notification_job.rb
+++ b/app/jobs/in_person/send_proofing_notification_job.rb
@@ -80,6 +80,7 @@ module InPerson
           'telephony.confirmation_ipp_enrollment_result.sms',
           app_name: APP_NAME,
           proof_date: proof_date,
+          contact_number: IdentityConfig.store.idv_contact_phone_number,
         )
       end
     end

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -15,7 +15,7 @@ en:
         code expires in %{expiration} minutes.
     confirmation_ipp_enrollment_result:
       sms: |-
-        %{app_name}: You attempted to verify your identity at a Post Office on %{proof_date}. Check your email for your result.
+        %{app_name}: You visited the Post Office on %{proof_date}. Check your email for your result. Not you? Report this right away: %{contact_number}
     confirmation_otp:
       sms: |-
         %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -15,7 +15,7 @@ en:
         code expires in %{expiration} minutes.
     confirmation_ipp_enrollment_result:
       sms: |-
-        %{app_name}: You visited the Post Office on %{proof_date}. Check your email for your result. Not you? Report this right away: %{contact_number}
+        %{app_name}: You visited the Post Office on %{proof_date}. Check email for your result. Not you? Report this right away: %{contact_number}
     confirmation_otp:
       sms: |-
         %{app_name}: Your one-time code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -15,7 +15,7 @@ es:
         Este código expira en %{expiration} minutos.
     confirmation_ipp_enrollment_result:
       sms: |-
-        %{app_name}: Intentó verificar su identidad en una oficina postal en %{proof_date}. Revise su correo electrónico para ver su resultado.
+        %{app_name}: Visitó la oficina de correos el %{proof_date}. Revise su correo electrónico para ver su resultado. ¿No fue usted? Informe ahora mismo: %{contact_number}
     confirmation_otp:
       sms: |-
         %{app_name}: La contraseña es %{code}. Esta contraseña puede usarse una vez y se vence en %{expiration} minutos. No la comparta con nadie.

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -16,7 +16,7 @@ fr:
         minutes.
     confirmation_ipp_enrollment_result:
       sms: |-
-        %{app_name}: Vous avez tenté de vérifier votre identité dans un bureau de poste le %{proof_date}. Vérifiez votre e-mail pour votre résultat.
+        %{app_name}: Vous avez visité le bureau de poste le %{proof_date}. Vérifiez votre e-mail pour votre résultat. Ce n'est pas vous? Signalez-le immédiatement: %{contact_number}
     confirmation_otp:
       sms: |-
         %{app_name}: Votre code à usage unique est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez pas partager ce code avec personne.

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           passed_enrollment.update!(proofed_at: Time.zone.now)
           proofed_date = Time.zone.now.strftime('%m/%d/%Y')
           phone_number = passed_enrollment.notification_phone_configuration.formatted_phone
-          country_code = '(844) 555-5555'
+          contact_number = '(844) 555-5555'
 
           expect(Telephony).
             to(
@@ -161,7 +161,7 @@ RSpec.describe InPerson::SendProofingNotificationJob do
                 to: phone_number,
                 message: "Login.gov: Vous avez visité le bureau de poste le #{proofed_date}." \
                          " Vérifiez votre e-mail pour votre résultat. Ce n'est pas vous?" \
-                          " Signalez-le immédiatement: #{country_code}",
+                          " Signalez-le immédiatement: #{contact_number}",
                 country_code: Phonelib.parse(phone_number).country,
               ),
             )

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -152,14 +152,16 @@ RSpec.describe InPerson::SendProofingNotificationJob do
           passed_enrollment.update!(proofed_at: Time.zone.now)
           proofed_date = Time.zone.now.strftime('%m/%d/%Y')
           phone_number = passed_enrollment.notification_phone_configuration.formatted_phone
+          country_code = '(844) 555-5555'
 
           expect(Telephony).
             to(
               receive(:send_notification).
               with(
                 to: phone_number,
-                message: "Login.gov: Vous avez tenté de vérifier votre identité dans un bureau " \
-                         "de poste le #{proofed_date}. Vérifiez votre e-mail pour votre résultat.",
+                message: "Login.gov: Vous avez visité le bureau de poste le #{proofed_date}." \
+                         " Vérifiez votre e-mail pour votre résultat. Ce n'est pas vous? Signalez-le"\
+                          " immédiatement: #{country_code}",
                 country_code: Phonelib.parse(phone_number).country,
               ),
             )

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -160,8 +160,8 @@ RSpec.describe InPerson::SendProofingNotificationJob do
               with(
                 to: phone_number,
                 message: "Login.gov: Vous avez visité le bureau de poste le #{proofed_date}." \
-                         " Vérifiez votre e-mail pour votre résultat. Ce n'est pas vous? Signalez-le"\
-                          " immédiatement: #{country_code}",
+                         " Vérifiez votre e-mail pour votre résultat. Ce n'est pas vous?" \
+                          " Signalez-le immédiatement: #{country_code}",
                 country_code: Phonelib.parse(phone_number).country,
               ),
             )

--- a/spec/lib/identity_config_spec.rb
+++ b/spec/lib/identity_config_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe IdentityConfig do
     end
   end
 
+  describe 'idv_contact_phone_number' do
+    it 'has config value for contact phone number' do
+      contact_number = IdentityConfig.store.idv_contact_phone_number
+
+      expect(contact_number).to_not be_empty
+      expect(contact_number).to match(/\(\d{3}\)\ \d{3}-\d{4}/)
+    end
+  end
+
   describe 'in_person_outage_message_enabled' do
     it 'has valid config values for dates when outage enabled' do
       if IdentityConfig.store.in_person_outage_message_enabled


### PR DESCRIPTION
## 🎫 Ticket

[LG-10614](https://cm-jira.usa.gov/browse/LG-10614)


## 🛠 Summary of changes

Change sms message to match new copy that includes contact number. 

Note for designer reviewing: There are no screenshots available, in lieu of those the string files can be used to confirm the text is correct.  


## 📜 Testing Plan

To be tested after merging into dev.

- [ ] Create account on `https://idp.dev.identitysandbox.gov/`
- [ ] Create enrollment
- [ ] Use real phone number when becoming verified
- [ ] Contact USPS to pass enrollment
- [ ] Verify that you get the sms with the correct text

