### PR TITLE
LG-10487 Inconsistent enforcement of phishing-required second MFA setup

### DIFF
--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -82,7 +82,8 @@ class TwoFactorOptionsForm
   end
 
   def missing_selection_error_message
-    if has_no_configured_mfa? || in_phishing_resistant_or_piv_cac_required_flow? || phishing_resistant_and_mfa?
+    if has_no_configured_mfa? || in_phishing_resistant_or_piv_cac_required_flow? ||
+       phishing_resistant_and_mfa?
       t('errors.two_factor_auth_setup.must_select_option')
     elsif platform_auth_only_option?
       t('errors.two_factor_auth_setup.must_select_additional_option')

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -27,7 +27,7 @@ class TwoFactorOptionsForm
   private
 
   def validate_selection_present
-    return if !has_no_mfa_or_in_required_flow? || selection.present?
+    return if !has_no_mfa_or_in_required_flow? || selection.present? || phishing_resistant_and_mfa?
     errors.add(:selection, missing_selection_error_message, type: :missing_selection)
   end
 
@@ -75,6 +75,10 @@ class TwoFactorOptionsForm
     has_no_configured_mfa? ||
       in_phishing_resistant_or_piv_cac_required_flow? ||
       platform_auth_only_option?
+  end
+
+  def phishing_resistant_and_mfa?
+    mfa_user.enabled_mfa_methods_count >= 1 && in_phishing_resistant_or_piv_cac_required_flow?
   end
 
   def missing_selection_error_message

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -78,11 +78,11 @@ class TwoFactorOptionsForm
   end
 
   def phishing_resistant_and_mfa?
-    mfa_user.enabled_mfa_methods_count >= 1 && in_phishing_resistant_or_piv_cac_required_flow?
+    MfaPolicy.new(user).unphishable? && in_phishing_resistant_or_piv_cac_required_flow?
   end
 
   def missing_selection_error_message
-    if has_no_configured_mfa? || in_phishing_resistant_or_piv_cac_required_flow?
+    if has_no_configured_mfa? || in_phishing_resistant_or_piv_cac_required_flow? || phishing_resistant_and_mfa?
       t('errors.two_factor_auth_setup.must_select_option')
     elsif platform_auth_only_option?
       t('errors.two_factor_auth_setup.must_select_additional_option')

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe TwoFactorOptionsForm do
     end
 
     context 'when a user wants to is required to add piv_cac on sign in' do
-      let(:user) { build(:user, :with_authentication_app) }
+      let(:user) { build(:user) }
       let(:enabled_mfa_methods_count) { 1 }
       let(:mfa_selection) { ['phone'] }
       let(:phishing_resistant_required) { true }
@@ -127,6 +127,29 @@ RSpec.describe TwoFactorOptionsForm do
       end
 
       context 'when user selects an mfa' do
+        it 'is successful' do
+          submission = subject.submit(selection: mfa_selection)
+          expect(submission.success?).to eq(true)
+        end
+      end
+    end
+
+    context 'when a user signs up with phishing resistant requirement' do
+      let(:user) { build(:user) }
+      let(:enabled_mfa_methods_count) { 1 }
+      let(:phishing_resistant_required) { true }
+
+      context 'when user did not select an mfa' do
+        let(:mfa_selection) { [] }
+
+        it 'is unsuccessful' do
+          submission = subject.submit(selection: mfa_selection)
+          expect(submission.success?).to eq(false)
+        end
+      end
+
+      context 'when user selects an mfa' do
+        let(:mfa_selection) { ['piv_cac'] }
         it 'is successful' do
           submission = subject.submit(selection: mfa_selection)
           expect(submission.success?).to eq(true)

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -136,7 +136,6 @@ RSpec.describe TwoFactorOptionsForm do
 
     context 'when a user signs up with phishing resistant requirement' do
       let(:user) { build(:user) }
-      let(:enabled_mfa_methods_count) { 1 }
       let(:phishing_resistant_required) { true }
 
       context 'when user did not select an mfa' do

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe TwoFactorOptionsForm do
     end
 
     context 'when a user wants to is required to add piv_cac on sign in' do
-      let(:user) { build(:user) }
+      let(:user) { build(:user, :with_authentication_app) }
       let(:enabled_mfa_methods_count) { 1 }
       let(:mfa_selection) { ['phone'] }
       let(:phishing_resistant_required) { true }


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10487](https://cm-jira.usa.gov/browse/LG-10487)


## 🛠 Summary of changes

- Added another method specific to phishing resistant required accounts and included it into the selection validation method
- Add spec to cover changes


## 📜 Testing Plan

Locally test with Sinatra running.

- [ ] At http://localhost:9292/ set AAL setting to Phishing-resistant AAL2, click Sign-in
- [ ] Create an account and select any of the offered methods.
- [ ] When prompted to add another method click the button to add another
- [ ] At the next setup screen instead of selecting a method click Continue

You should expect to see the Continue to Example Sinatra App screen and the Agree and continue button.
You should not expect to see the Add MFA form again with the error "Select an additional authentication method."

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
