### PR TITLE
LG-10657 move pii from doc out of flow session STEP 1

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -38,7 +38,7 @@ module IdvStepConcern
   end
 
   def pii_from_doc
-    flow_session['pii_from_doc']
+    flow_session[:pii_from_doc]
   end
 
   def pii_from_user

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -29,7 +29,7 @@ module Idv
 
     def success
       profile_params.each do |key, value|
-        flow_session['pii_from_doc'][key] = value
+        flow_session[:pii_from_doc][key] = value
       end
       redirect_to idv_verify_info_url
     end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -57,8 +57,7 @@ module Idv
     def confirm_document_capture_needed
       return if idv_session.redo_document_capture
 
-      pii = flow_session['pii_from_doc'] # hash with indifferent access
-      return if pii.blank? && !idv_session.verify_info_step_complete?
+      return if pii_from_doc.blank? && !idv_session.verify_info_step_complete?
 
       redirect_to idv_ssn_url
     end

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -48,8 +48,7 @@ module Idv
     def confirm_document_capture_needed
       return if idv_session.redo_document_capture
 
-      pii = flow_session['pii_from_doc'] # hash with indifferent access
-      return if pii.blank? && !idv_session.verify_info_step_complete?
+      return if pii_from_doc.blank? && !idv_session.verify_info_step_complete?
 
       redirect_to idv_ssn_url
     end

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -60,7 +60,7 @@ module Idv
     private
 
     def ssn_from_doc
-      user_session&.dig('idv/doc_auth', 'pii_from_doc', 'ssn')
+      user_session&.dig('idv/doc_auth', :pii_from_doc, 'ssn')
     end
 
     def confirm_two_factor_authenticated_or_user_id_in_session

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -38,7 +38,7 @@ module Idv
       )
 
       if form_response.success?
-        flow_session['pii_from_doc'][:ssn] = params[:doc_auth][:ssn]
+        flow_session[:pii_from_doc][:ssn] = params[:doc_auth][:ssn]
         idv_session.invalidate_steps_after_ssn!
         redirect_to next_url
       else

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -56,7 +56,7 @@ module Idv
 
     # copied from verify_step
     def pii
-      @pii = flow_session[:pii_from_doc]
+      @pii = pii_from_doc
     end
   end
 end

--- a/app/forms/idv/ssn_format_form.rb
+++ b/app/forms/idv/ssn_format_form.rb
@@ -13,7 +13,7 @@ module Idv
 
     def initialize(user, flow_session = {})
       @user = user
-      @ssn = flow_session.dig('pii_from_doc', :ssn)
+      @ssn = flow_session.dig(:pii_from_doc, :ssn)
       @updating_ssn = ssn.present?
     end
 

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe Idv::AddressController do
   let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.stringify_keys }
 
   let(:flow_session) do
-    {
-      'pii_from_doc' => pii_from_doc,
-    }
+    { pii_from_doc: pii_from_doc }
   end
 
   before do
@@ -60,7 +58,7 @@ RSpec.describe Idv::AddressController do
     it 'updates pii_from_doc' do
       expect do
         put :update, params: params
-      end.to change { flow_session['pii_from_doc'] }.to eql(
+      end.to change { flow_session[:pii_from_doc] }.to eql(
         pii_from_doc.merge(
           {
             'address1' => '1234 Main St',

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Idv::DocumentCaptureController do
 
     context 'with pii in session' do
       it 'redirects to ssn step' do
-        flow_session['pii_from_doc'] = Idp::Constants::MOCK_IDV_APPLICANT
+        flow_session[:pii_from_doc] = Idp::Constants::MOCK_IDV_APPLICANT
         get :show
 
         expect(response).to redirect_to(idv_ssn_url)

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Idv::LinkSentController do
 
     context 'with pii in session' do
       it 'redirects to ssn step' do
-        flow_session['pii_from_doc'] = Idp::Constants::MOCK_IDV_APPLICANT
+        flow_session[:pii_from_doc] = Idp::Constants::MOCK_IDV_APPLICANT
         get :show
 
         expect(response).to redirect_to(idv_ssn_url)

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Idv::SessionErrorsController do
           rate_limit_type: :proof_ssn,
           target: Pii::Fingerprinter.fingerprint(ssn),
         ).increment_to_limited!
-        controller.user_session['idv/doc_auth'] = { 'pii_from_doc' => { 'ssn' => ssn } }
+        controller.user_session['idv/doc_auth'] = { pii_from_doc: { 'ssn' => ssn } }
       end
 
       it 'assigns expiration time' do

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Idv::SsnController do
   include IdvHelper
 
   let(:flow_session) do
-    { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
-      'pii_from_doc' => Idp::Constants::MOCK_IDV_APPLICANT.dup,
-      :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0' }
+    { pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT.dup }
   end
 
   let(:ssn) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn] }
@@ -95,7 +93,7 @@ RSpec.describe Idv::SsnController do
     context 'with an ssn in session' do
       let(:referer) { idv_document_capture_url }
       before do
-        flow_session['pii_from_doc'][:ssn] = ssn
+        flow_session[:pii_from_doc][:ssn] = ssn
         request.env['HTTP_REFERER'] = referer
       end
 
@@ -158,12 +156,12 @@ RSpec.describe Idv::SsnController do
       it 'merges ssn into pii session value' do
         put :update, params: params
 
-        expect(flow_session['pii_from_doc'][:ssn]).to eq(ssn)
+        expect(flow_session[:pii_from_doc][:ssn]).to eq(ssn)
       end
 
       context 'with a Puerto Rico address' do
         it 'redirects to address controller after user enters their SSN' do
-          flow_session['pii_from_doc'][:state] = 'PR'
+          flow_session[:pii_from_doc][:state] = 'PR'
 
           put :update, params: params
 
@@ -171,8 +169,8 @@ RSpec.describe Idv::SsnController do
         end
 
         it 'redirects to the verify info controller if a user is updating their SSN' do
-          flow_session['pii_from_doc'][:ssn] = ssn
-          flow_session['pii_from_doc'][:state] = 'PR'
+          flow_session[:pii_from_doc][:ssn] = ssn
+          flow_session[:pii_from_doc][:state] = 'PR'
 
           put :update, params: params
 
@@ -198,7 +196,7 @@ RSpec.describe Idv::SsnController do
       end
 
       it 'does not change threatmetrix_session_id when updating ssn' do
-        flow_session['pii_from_doc'][:ssn] = ssn
+        flow_session[:pii_from_doc][:ssn] = ssn
         put :update, params: params
         session_id = subject.idv_session.threatmetrix_session_id
         subject.threatmetrix_view_variables
@@ -239,7 +237,7 @@ RSpec.describe Idv::SsnController do
     context 'when pii_from_doc is not present' do
       before do
         subject.idv_session.flow_path = 'standard'
-        flow_session.delete('pii_from_doc')
+        flow_session.delete(:pii_from_doc)
       end
 
       it 'redirects to DocumentCaptureController on standard flow' do

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe Idv::VerifyInfoController do
   include IdvHelper
 
   let(:flow_session) do
-    { 'error_message' => nil,
-      'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
-      :pii_from_doc => Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup,
-      'threatmetrix_session_id' => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0' }
+    { pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup }
   end
 
   let(:user) { create(:user) }

--- a/spec/forms/idv/ssn_format_form_spec.rb
+++ b/spec/forms/idv/ssn_format_form_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Idv::SsnFormatForm do
     end
 
     context 'when there is an SSN in the pii_from_doc hash' do
-      let(:flow_session) { { 'pii_from_doc' => { ssn: '900-12-3456' } } }
+      let(:flow_session) { { pii_from_doc: { ssn: '900-12-3456' } } }
 
       it { expect(subject.updating_ssn?).to eq(true) }
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10657](https://cm-jira.usa.gov/browse/LG-10657)

## 🛠 Summary of changes

Start the process of moving :pii_from_doc into idv_session. Incidentally clean up some controller spec flow_session values that are no longer used. 

Plan:
1) Align on :pii_from_doc as flow_session key, replacing 'pii_from_doc' where needed (this PR)
2) Make as many reads as possible go through pii_from_doc method in IdvStepConcern (this PR)
3) Move ssn out of pii_from_doc into idv_session, possibly into applicant, or its own key (two separate PRs, [LG-10886](https://cm-jira.usa.gov/browse/LG-10886))
4) Copy pii_from_doc into idv_session (are there session size issues with this?) (future PR)
5) Remove flow_session[:pii_from_doc] (future PR)

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create account, go through IdV
- [ ] On VerifyInfo step, edit address and SSN.
- [ ] Expect profile to be created correctly.
