### PR TITLE
Remove unused JavaScript test stub

### DIFF
--- a/app/javascript/packages/webauthn/is-webauthn-passkey-supported.spec.ts
+++ b/app/javascript/packages/webauthn/is-webauthn-passkey-supported.spec.ts
@@ -65,13 +65,6 @@ const UNSUPPORTED_USER_AGENTS = [
 describe('isWebauthnPasskeySupported', () => {
   const defineProperty = useDefineProperty();
 
-  beforeEach(() => {
-    defineProperty(window, 'PublicKeyCredential', {
-      configurable: true,
-      value: { isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true) },
-    });
-  });
-
   UNSUPPORTED_USER_AGENTS.forEach((userAgent) => {
     context(userAgent, () => {
       beforeEach(() => {


### PR DESCRIPTION
## 🛠 Summary of changes

Removes test setup code that's inconsequential to the application code

I was searching for uses of `isUserVerifyingPlatformAuthenticatorAvailable` and came across this in the tests, despite it not being used in the implementation as of #8723.

## 📜 Testing Plan

`yarn test`