### PR TITLE
LG-10832: Pass enrollments with supported secondary ID type

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -10,6 +10,9 @@ class GetUspsProofingResultsJob < ApplicationJob
     "State driver's license",
     "State non-driver's identification card",
   ]
+  SUPPORTED_SECONDARY_ID_TYPES = [
+    'Visual Inspection of Name and Address on Primary ID Match',
+  ]
 
   queue_as :long_running
 
@@ -115,6 +118,12 @@ class GetUspsProofingResultsJob < ApplicationJob
   ensure
     # Record the attempt to update the enrollment
     enrollment.update(status_check_attempted_at: status_check_attempted_at)
+  end
+
+  def passed_with_unsupported_secondary_id_type?(enrollment, response)
+    return enrollment.capture_secondary_id_enabled &&
+           response['secondaryIdType'].present? &&
+           SUPPORTED_SECONDARY_ID_TYPES.exclude?(response['secondaryIdType'])
   end
 
   def analytics(user: AnonymousUser.new)
@@ -405,7 +414,7 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     case response['status']
     when IPP_STATUS_PASSED
-      if enrollment.capture_secondary_id_enabled && response['secondaryIdType'].present?
+      if passed_with_unsupported_secondary_id_type?(enrollment, response)
         handle_unsupported_secondary_id(enrollment, response)
       elsif SUPPORTED_ID_TYPES.include?(response['primaryIdType'])
         handle_successful_status_update(enrollment, response)

--- a/app/services/usps_in_person_proofing/mock/fixtures.rb
+++ b/app/services/usps_in_person_proofing/mock/fixtures.rb
@@ -61,6 +61,12 @@ module UspsInPersonProofing
         load_response_fixture('request_passed_proofing_secondary_id_type_results_response.json')
       end
 
+      def self.request_passed_proofing_supported_secondary_id_type_results_response
+        load_response_fixture(
+          'request_passed_proofing_supported_secondary_id_type_results_response.json',
+        )
+      end
+
       def self.request_expired_proofing_results_response
         load_response_fixture('request_expired_proofing_results_response.json')
       end

--- a/app/services/usps_in_person_proofing/mock/responses/request_passed_proofing_supported_secondary_id_type_results_response.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_passed_proofing_supported_secondary_id_type_results_response.json
@@ -7,7 +7,7 @@
   "primaryIdType": "State driver's license",
   "transactionStartDateTime": "12/17/2020 033855",
   "transactionEndDateTime": "12/17/2020 034055",
-  "secondaryIdType": "State driver's license",
+  "secondaryIdType": "Visual Inspection of Name and Address on Primary ID Match",
   "fraudSuspected": false,
   "proofingConfirmationNumber": "350040248346701",
   "ippAssuranceLevel": "1.5"

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -1196,6 +1196,21 @@ RSpec.describe GetUspsProofingResultsJob do
               ),
             )
           end
+
+          context 'when the secondary ID is supported' do
+            before do
+              stub_request_passed_proofing_supported_secondary_id_type_results
+            end
+
+            it_behaves_like(
+              'enrollment_with_a_status_update',
+              passed: true,
+              email_type: 'Success',
+              enrollment_status: InPersonEnrollment::STATUS_PASSED,
+              response_json: UspsInPersonProofing::Mock::Fixtures.
+                request_passed_proofing_supported_secondary_id_type_results_response,
+            )
+          end
         end
 
         context 'sms notifications enabled' do

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -222,6 +222,15 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_passed_proofing_supported_secondary_id_type_results
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      status: 200,
+      body: UspsInPersonProofing::Mock::
+        Fixtures.request_passed_proofing_supported_secondary_id_type_results_response,
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_passed_proofing_unsupported_status_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
       status: 200,


### PR DESCRIPTION
## 🎫 Ticket

[LG-10832](https://cm-jira.usa.gov/browse/LG-10832)

## 🛠 Summary of changes

Passes enrollments with a secondary ID, only if it has a type of "Visual Inspection of Name and Address on Primary ID Match"

## 📜 Acceptance testing plan

Once this PR is merged and in dev

- [ ] Create a new account via [the OIDC application](https://dev-identity-oidc-sinatra.app.cloud.gov/)
- [ ] Complete the in-person proofing process through to the barcode page
- [ ] Ask USPS to set a completed proof status for your enrollment code (passed, and with a secondary ID type of "Visual Inspection of Name and Address on Primary ID Match")
- [ ] Confirm that your enrollment is successfully passed