### PR TITLE
Deploy RC 310 to Prod

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ build-idp-image:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       variables:
-        BRANCH_TAGGING_STRING: "--destination ${ECR_REGISTRY}/identity-idp/review:${$CI_DEFAULT_BRANCH}"
+        BRANCH_TAGGING_STRING: "--destination ${ECR_REGISTRY}/identity-idp/review:main"
     - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
     - if: $CI_PIPELINE_SOURCE != "merge_request_event"
       when: never

--- a/app/components/tab_navigation_component.scss
+++ b/app/components/tab_navigation_component.scss
@@ -15,27 +15,6 @@
   }
 }
 
-// Upstream: https://github.com/18F/identity-design-system/pull/359
-.usa-button-group__item {
-  &:first-child > .usa-button.usa-button--big {
-    margin-right: -1 * units($theme-button-stroke-width);
-  }
-
-  &:last-child > .usa-button.usa-button--big {
-    margin-left: -2 * units($theme-button-stroke-width);
-    width: calc(100% + #{units($theme-button-stroke-width) * 2});
-
-    @include at-media('mobile-lg') {
-      margin-left: -1 * units($theme-button-stroke-width);
-    }
-  }
-
-  &:where(:not(:first-child):not(:last-child)) > .usa-button.usa-button--big {
-    margin-right: -1 * units($theme-button-stroke-width);
-    margin-left: -1 * units($theme-button-stroke-width);
-  }
-}
-
 .tab-navigation .usa-button-group--segmented {
   .usa-button-group__item {
     flex-basis: 50%;

--- a/app/controllers/concerns/idv/step_indicator_concern.rb
+++ b/app/controllers/concerns/idv/step_indicator_concern.rb
@@ -39,7 +39,7 @@ module Idv
     private
 
     def in_person_proofing?
-      proofing_components_as_hash['document_check'] == Idp::Constants::Vendors::USPS
+      current_user&.has_in_person_enrollment?
     end
 
     def gpo_address_verification?
@@ -48,23 +48,6 @@ module Idv
       return true if current_user&.gpo_verification_pending_profile?
 
       return idv_session&.address_verification_mechanism == 'gpo' if defined?(idv_session)
-    end
-
-    def proofing_components
-      return {} if !current_user
-
-      if current_user.pending_profile
-        current_user.pending_profile.proofing_components
-      else
-        ProofingComponent.find_by(user: current_user).as_json
-      end
-    end
-
-    def proofing_components_as_hash
-      # A proofing component record exists as a zero-or-one-to-one relation with a user, and values
-      # are set during identity verification. These values are recorded to the profile at creation,
-      # including for a pending profile.
-      @proofing_components_as_hash ||= proofing_components.to_h
     end
   end
 end

--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -18,17 +18,6 @@ module Idv
     def override_csp_for_threat_metrix_no_fsm
       return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
 
-      ##
-      # In order to test the behavior without the CSP changes, we do not perform the CSP override
-      # if the user's email is on a list of CSP disabled emails.
-      #
-      current_user.email_addresses.each do |email_address|
-        no_csp_email = IdentityConfig.store.idv_tmx_test_csp_disabled_emails.include?(
-          email_address.email,
-        )
-        return nil if no_csp_email
-      end
-
       threat_metrix_csp_overrides
     end
 

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -38,7 +38,7 @@ module IdvStepConcern
   end
 
   def pii_from_doc
-    flow_session['pii_from_doc']
+    flow_session[:pii_from_doc]
   end
 
   def pii_from_user

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -71,7 +71,7 @@ module IdvStepConcern
   def confirm_verify_info_step_complete
     return if idv_session.verify_info_step_complete?
 
-    if idv_session.pending_in_person_enrollment?
+    if current_user.has_in_person_enrollment?
       redirect_to idv_in_person_verify_info_url
     else
       redirect_to idv_verify_info_url

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -29,7 +29,7 @@ module Idv
 
     def success
       profile_params.each do |key, value|
-        flow_session['pii_from_doc'][key] = value
+        flow_session[:pii_from_doc][key] = value
       end
       redirect_to idv_verify_info_url
     end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -57,8 +57,7 @@ module Idv
     def confirm_document_capture_needed
       return if idv_session.redo_document_capture
 
-      pii = flow_session['pii_from_doc'] # hash with indifferent access
-      return if pii.blank? && !idv_session.verify_info_step_complete?
+      return if pii_from_doc.blank? && !idv_session.verify_info_step_complete?
 
       redirect_to idv_ssn_url
     end

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -118,10 +118,7 @@ module Idv
     end
 
     def extra_view_variables
-      {
-        flow_session: flow_session,
-        idv_phone_form: build_form,
-      }
+      { idv_phone_form: build_form }
     end
 
     def build_form

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -48,8 +48,7 @@ module Idv
     def confirm_document_capture_needed
       return if idv_session.redo_document_capture
 
-      pii = flow_session['pii_from_doc'] # hash with indifferent access
-      return if pii.blank? && !idv_session.verify_info_step_complete?
+      return if pii_from_doc.blank? && !idv_session.verify_info_step_complete?
 
       redirect_to idv_ssn_url
     end

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -30,8 +30,7 @@ module Idv
     end
 
     def extra_view_variables
-      { phone: idv_session.phone_for_mobile_flow,
-        flow_session: flow_session }
+      { phone: idv_session.phone_for_mobile_flow }
     end
 
     private

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -60,7 +60,7 @@ module Idv
     private
 
     def ssn_from_doc
-      user_session&.dig('idv/doc_auth', 'pii_from_doc', 'ssn')
+      user_session&.dig('idv/doc_auth', :pii_from_doc, 'ssn')
     end
 
     def confirm_two_factor_authenticated_or_user_id_in_session

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -10,8 +10,6 @@ module Idv
     before_action :confirm_repeat_ssn, only: :show
     before_action :override_csp_for_threat_metrix_no_fsm
 
-    helper_method :should_render_threatmetrix_js?
-
     attr_accessor :error_message
 
     def show
@@ -47,23 +45,6 @@ module Idv
         @error_message = form_response.first_error_message
         render :show, locals: threatmetrix_view_variables
       end
-    end
-
-    ##
-    # In order to test the behavior without the threatmetrix JS, we do not load the threatmetrix
-    # JS if the user's email is on a list of JS disabled emails.
-    #
-    def should_render_threatmetrix_js?
-      return false unless FeatureManagement.proofing_device_profiling_collecting_enabled?
-
-      current_user.email_addresses.each do |email_address|
-        no_csp_email = IdentityConfig.store.idv_tmx_test_js_disabled_emails.include?(
-          email_address.email,
-        )
-        return false if no_csp_email
-      end
-
-      true
     end
 
     private

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -38,7 +38,7 @@ module Idv
       )
 
       if form_response.success?
-        flow_session['pii_from_doc'][:ssn] = params[:doc_auth][:ssn]
+        flow_session[:pii_from_doc][:ssn] = params[:doc_auth][:ssn]
         idv_session.invalidate_steps_after_ssn!
         redirect_to next_url
       else

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -56,7 +56,7 @@ module Idv
 
     # copied from verify_step
     def pii
-      @pii = flow_session[:pii_from_doc]
+      @pii = pii_from_doc
     end
   end
 end

--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -25,6 +25,7 @@ class ServiceProviderController < ApplicationController
   end
 
   def authorization_token_valid?
+    return false if authorization_token.blank?
     ActiveSupport::SecurityUtils.secure_compare(
       authorization_token,
       IdentityConfig.store.dashboard_api_token,

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -22,7 +22,7 @@ class GpoVerifyForm
     if result
       pending_profile&.remove_gpo_deactivation_reason
 
-      if profile_has_pending_in_person_enrollment?
+      if user.has_establishing_in_person_enrollment_safe?
         schedule_in_person_enrollment_and_deactivate_profile
       elsif fraud_check_failed && threatmetrix_enabled?
         pending_profile&.deactivate_for_fraud_review
@@ -43,7 +43,7 @@ class GpoVerifyForm
         letter_count: letter_count,
         attempts: attempts,
         pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
-        pending_in_person_enrollment: pending_profile&.pending_in_person_enrollment?,
+        pending_in_person_enrollment: !!pending_profile&.in_person_enrollment&.pending?,
         fraud_check_failed: fraud_check_failed,
       },
     )
@@ -59,10 +59,6 @@ class GpoVerifyForm
     return if otp.blank? || pending_profile.blank?
 
     pending_profile.gpo_confirmation_codes.first_with_otp(otp)
-  end
-
-  def profile_has_pending_in_person_enrollment?
-    pending_profile&.pending_in_person_enrollment?
   end
 
   def schedule_in_person_enrollment_and_deactivate_profile

--- a/app/forms/idv/ssn_format_form.rb
+++ b/app/forms/idv/ssn_format_form.rb
@@ -13,7 +13,7 @@ module Idv
 
     def initialize(user, flow_session = {})
       @user = user
-      @ssn = flow_session.dig('pii_from_doc', :ssn)
+      @ssn = flow_session.dig(:pii_from_doc, :ssn)
       @updating_ssn = ssn.present?
     end
 

--- a/app/javascript/packages/address-search/components/address-search.tsx
+++ b/app/javascript/packages/address-search/components/address-search.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Alert, PageHeading } from '@18f/identity-components';
-import { useI18n } from '@18f/identity-react-i18n';
+import { t } from '@18f/identity-i18n';
 import InPersonLocations from './in-person-locations';
 import AddressInput from './address-input';
 import type { LocationQuery, FormattedLocation } from '../types';
@@ -19,7 +19,6 @@ function AddressSearch({
     null,
   );
   const [isLoadingLocations, setLoadingLocations] = useState<boolean>(false);
-  const { t } = useI18n();
 
   return (
     <>

--- a/app/javascript/packages/address-search/components/in-person-locations.tsx
+++ b/app/javascript/packages/address-search/components/in-person-locations.tsx
@@ -1,4 +1,4 @@
-import { useI18n } from '@18f/identity-react-i18n';
+import { t } from '@18f/identity-i18n';
 import LocationCollection from './location-collection';
 import LocationCollectionItem from './location-collection-item';
 
@@ -21,7 +21,6 @@ interface InPersonLocationsProps {
 }
 
 function InPersonLocations({ locations, onSelect, address }: InPersonLocationsProps) {
-  const { t } = useI18n();
   const isPilot = locations?.some((l) => l.isPilot);
 
   if (locations?.length === 0) {

--- a/app/javascript/packages/address-search/components/location-collection-item.tsx
+++ b/app/javascript/packages/address-search/components/location-collection-item.tsx
@@ -1,5 +1,5 @@
 import { SpinnerButton } from '@18f/identity-spinner-button';
-import { useI18n } from '@18f/identity-react-i18n';
+import { t } from '@18f/identity-i18n';
 
 interface LocationCollectionItemProps {
   distance?: string;
@@ -24,7 +24,6 @@ function LocationCollectionItem({
   sundayHours,
   weekdayHours,
 }: LocationCollectionItemProps) {
-  const { t } = useI18n();
   const numericDistance = distance?.split(' ')[0];
 
   return (

--- a/app/javascript/packages/clipboard-button/package.json
+++ b/app/javascript/packages/clipboard-button/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@18f/identity-design-system": "^7.0.1"
+    "@18f/identity-design-system": "^7.1.0"
   }
 }

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
@@ -1,11 +1,11 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18n } from '@18f/identity-i18n';
+import { i18n } from '@18f/identity-i18n';
 import { setupServer } from 'msw/node';
 import type { SetupServer } from 'msw/node';
 import { rest } from 'msw';
 import { SWRConfig } from 'swr';
-import { I18nContext } from '@18f/identity-react-i18n';
+import { usePropertyValue } from '@18f/identity-test-helpers';
 import { ComponentType } from 'react';
 import { InPersonContext } from '../context';
 import InPersonLocationFullAddressEntryPostOfficeSearchStep from './in-person-location-full-address-entry-post-office-search-step';
@@ -243,21 +243,16 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
     await findAllByText('in_person_proofing.body.location.location_button');
   });
 
-  it('displays correct pluralization for a single location result', async () => {
-    const { findByLabelText, findByText } = render(
-      <I18nContext.Provider
-        value={
-          new I18n({
-            strings: {
-              'in_person_proofing.body.location.po_search.results_description': {
-                one: 'There is one participating Post Office within 50 miles of %{address}.',
-                other:
-                  'There are %{count} participating Post Offices within 50 miles of %{address}.',
-              },
-            },
-          })
-        }
-      >
+  context('pluralized and singularized translations are set', () => {
+    usePropertyValue(i18n, 'strings', {
+      'in_person_proofing.body.location.po_search.results_description': {
+        one: 'There is one participating Post Office within 50 miles of %{address}.',
+        other: 'There are %{count} participating Post Offices within 50 miles of %{address}.',
+      },
+    });
+
+    it('displays correct pluralization for a single location result', async () => {
+      const { findByLabelText, findByText } = render(
         <InPersonContext.Provider
           value={{
             inPersonOutageMessageEnabled: false,
@@ -267,58 +262,43 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
           }}
         >
           <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
-        </InPersonContext.Provider>
-        ,
-      </I18nContext.Provider>,
-      { wrapper },
-    );
-    await userEvent.type(
-      await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
-      '222 Merchandise Mart Plaza',
-    );
-    await userEvent.type(
-      await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
-      'Endeavor',
-    );
-    await userEvent.selectOptions(
-      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
-      'DE',
-    );
-    await userEvent.type(
-      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
-      '19701',
-    );
-    await userEvent.click(
-      await findByText('in_person_proofing.body.location.po_search.search_button'),
-    );
-    await userEvent.click(
-      await findByText('in_person_proofing.body.location.po_search.search_button'),
-    );
+        </InPersonContext.Provider>,
+        { wrapper },
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+        '222 Merchandise Mart Plaza',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+        'Endeavor',
+      );
+      await userEvent.selectOptions(
+        await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+        'DE',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+        '19701',
+      );
+      await userEvent.click(
+        await findByText('in_person_proofing.body.location.po_search.search_button'),
+      );
+      await userEvent.click(
+        await findByText('in_person_proofing.body.location.po_search.search_button'),
+      );
 
-    const addressQuery = '222 Merchandise Mart Plaza, Endeavor, DE 19701';
-    const searchResultAlert = await findByText(
-      `There is one participating Post Office within 50 miles of ${addressQuery}.`,
-    );
-    expect(searchResultAlert).to.exist();
-  });
+      const addressQuery = '222 Merchandise Mart Plaza, Endeavor, DE 19701';
+      const searchResultAlert = await findByText(
+        `There is one participating Post Office within 50 miles of ${addressQuery}.`,
+      );
+      expect(searchResultAlert).to.exist();
+    });
 
-  it('displays correct pluralization for multiple location results', async () => {
-    server.resetHandlers();
-    server.use(rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json(USPS_RESPONSE))));
-    const { findByLabelText, findByText } = render(
-      <I18nContext.Provider
-        value={
-          new I18n({
-            strings: {
-              'in_person_proofing.body.location.po_search.results_description': {
-                one: 'There is one participating Post Office within 50 miles of %{address}.',
-                other:
-                  'There are %{count} participating Post Offices within 50 miles of %{address}.',
-              },
-            },
-          })
-        }
-      >
+    it('displays correct pluralization for multiple location results', async () => {
+      server.resetHandlers();
+      server.use(rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json(USPS_RESPONSE))));
+      const { findByLabelText, findByText } = render(
         <InPersonContext.Provider
           value={{
             inPersonOutageMessageEnabled: false,
@@ -328,40 +308,39 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
           }}
         >
           <InPersonLocationFullAddressEntryPostOfficeSearchStep {...DEFAULT_PROPS} />,
-        </InPersonContext.Provider>
-        ,
-      </I18nContext.Provider>,
-      { wrapper },
-    );
+        </InPersonContext.Provider>,
+        { wrapper },
+      );
 
-    await userEvent.type(
-      await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
-      '222 Merchandise Mart Plaza',
-    );
-    await userEvent.type(
-      await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
-      'Endeavor',
-    );
-    await userEvent.selectOptions(
-      await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
-      'DE',
-    );
-    await userEvent.type(
-      await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
-      '19701',
-    );
-    await userEvent.click(
-      await findByText('in_person_proofing.body.location.po_search.search_button'),
-    );
-    await userEvent.click(
-      await findByText('in_person_proofing.body.location.po_search.search_button'),
-    );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.address_label'),
+        '222 Merchandise Mart Plaza',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.city_label'),
+        'Endeavor',
+      );
+      await userEvent.selectOptions(
+        await findByLabelText('in_person_proofing.body.location.po_search.state_label'),
+        'DE',
+      );
+      await userEvent.type(
+        await findByLabelText('in_person_proofing.body.location.po_search.zipcode_label'),
+        '19701',
+      );
+      await userEvent.click(
+        await findByText('in_person_proofing.body.location.po_search.search_button'),
+      );
+      await userEvent.click(
+        await findByText('in_person_proofing.body.location.po_search.search_button'),
+      );
 
-    const addressQuery = '222 Merchandise Mart Plaza, Endeavor, DE 19701';
-    const searchResultAlert = await findByText(
-      `There are ${USPS_RESPONSE.length} participating Post Offices within 50 miles of ${addressQuery}.`,
-    );
-    expect(searchResultAlert).to.exist();
+      const addressQuery = '222 Merchandise Mart Plaza, Endeavor, DE 19701';
+      const searchResultAlert = await findByText(
+        `There are ${USPS_RESPONSE.length} participating Post Offices within 50 miles of ${addressQuery}.`,
+      );
+      expect(searchResultAlert).to.exist();
+    });
   });
 
   it('allows user to select a location', async () => {

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useContext } from 'react';
-import { useI18n } from '@18f/identity-react-i18n';
+import { t } from '@18f/identity-i18n';
 import { Alert, PageHeading } from '@18f/identity-components';
 import { request } from '@18f/identity-request';
 import { forceRedirect } from '@18f/identity-url';
@@ -18,7 +18,6 @@ function InPersonLocationFullAddressEntryPostOfficeSearchStep({
   registerField,
 }) {
   const { inPersonURL } = useContext(InPersonContext);
-  const { t } = useI18n();
   const [inProgress, setInProgress] = useState<boolean>(false);
   const [isLoadingLocations, setLoadingLocations] = useState<boolean>(false);
   const [autoSubmit, setAutoSubmit] = useState<boolean>(false);

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
@@ -1,11 +1,11 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18n } from '@18f/identity-i18n';
+import { i18n } from '@18f/identity-i18n';
+import { usePropertyValue } from '@18f/identity-test-helpers';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import type { SetupServer } from 'msw/node';
 import { SWRConfig } from 'swr';
-import { I18nContext } from '@18f/identity-react-i18n';
 import { ComponentType } from 'react';
 import InPersonLocationPostOfficeSearchStep, {
   ADDRESSES_URL,
@@ -222,82 +222,63 @@ describe('InPersonLocationPostOfficeSearchStep', () => {
       await findAllByText('in_person_proofing.body.location.location_button');
     });
 
-    it('displays correct pluralization for a single location result', async () => {
-      const { findByLabelText, findByText } = render(
-        <I18nContext.Provider
-          value={
-            new I18n({
-              strings: {
-                'in_person_proofing.body.location.po_search.results_description': {
-                  one: 'There is one participating Post Office within 50 miles of %{address}.',
-                  other:
-                    'There are %{count} participating Post Offices within 50 miles of %{address}.',
-                },
-              },
-            })
-          }
-        >
-          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
-        </I18nContext.Provider>,
-        { wrapper },
-      );
-      await userEvent.type(
-        await findByLabelText('in_person_proofing.body.location.po_search.address_search_label'),
-        '800 main',
-      );
-      await userEvent.click(
-        await findByText('in_person_proofing.body.location.po_search.search_button'),
-      );
-      await userEvent.click(
-        await findByText('in_person_proofing.body.location.po_search.search_button'),
-      );
+    context('pluralized and singularized translations are set', () => {
+      usePropertyValue(i18n, 'strings', {
+        'in_person_proofing.body.location.po_search.results_description': {
+          one: 'There is one participating Post Office within 50 miles of %{address}.',
+          other: 'There are %{count} participating Post Offices within 50 miles of %{address}.',
+        },
+      });
 
-      const searchResultAlert = await findByText(
-        `There is one participating Post Office within 50 miles of ${MULTI_LOCATION_RESPONSE[0].address}.`,
-      );
-      expect(searchResultAlert).to.exist();
-    });
+      it('displays correct pluralization for a single location result', async () => {
+        const { findByLabelText, findByText } = render(
+          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />,
+          { wrapper },
+        );
+        await userEvent.type(
+          await findByLabelText('in_person_proofing.body.location.po_search.address_search_label'),
+          '800 main',
+        );
+        await userEvent.click(
+          await findByText('in_person_proofing.body.location.po_search.search_button'),
+        );
+        await userEvent.click(
+          await findByText('in_person_proofing.body.location.po_search.search_button'),
+        );
 
-    it('displays correct pluralization for multiple location results', async () => {
-      server.resetHandlers();
-      server.use(
-        rest.post(ADDRESSES_URL, (_req, res, ctx) =>
-          res(ctx.json(DEFAULT_RESPONSE), ctx.status(200)),
-        ),
-        rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json(MULTI_LOCATION_RESPONSE))),
-      );
-      const { findByLabelText, findByText } = render(
-        <I18nContext.Provider
-          value={
-            new I18n({
-              strings: {
-                'in_person_proofing.body.location.po_search.results_description': {
-                  one: 'There is one participating Post Office within 50 miles of %{address}.',
-                  other:
-                    'There are %{count} participating Post Offices within 50 miles of %{address}.',
-                },
-              },
-            })
-          }
-        >
-          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />
-        </I18nContext.Provider>,
-        { wrapper },
-      );
-      await userEvent.type(
-        await findByLabelText('in_person_proofing.body.location.po_search.address_search_label'),
-        '800 main',
-      );
-      await userEvent.click(
-        await findByText('in_person_proofing.body.location.po_search.search_button'),
-      );
-      await userEvent.click(
-        await findByText('in_person_proofing.body.location.po_search.search_button'),
-      );
-      const searchResultAlert = await findByText(
-        `There are ${MULTI_LOCATION_RESPONSE.length} participating Post Offices within 50 miles of ${MULTI_LOCATION_RESPONSE[0].address}.`,
-      );
-      expect(searchResultAlert).to.exist();
+        const searchResultAlert = await findByText(
+          `There is one participating Post Office within 50 miles of ${MULTI_LOCATION_RESPONSE[0].address}.`,
+        );
+        expect(searchResultAlert).to.exist();
+      });
+
+      it('displays correct pluralization for multiple location results', async () => {
+        server.resetHandlers();
+        server.use(
+          rest.post(ADDRESSES_URL, (_req, res, ctx) =>
+            res(ctx.json(DEFAULT_RESPONSE), ctx.status(200)),
+          ),
+          rest.post(LOCATIONS_URL, (_req, res, ctx) => res(ctx.json(MULTI_LOCATION_RESPONSE))),
+        );
+        const { findByLabelText, findByText } = render(
+          <InPersonLocationPostOfficeSearchStep {...DEFAULT_PROPS} />,
+          { wrapper },
+        );
+        await userEvent.type(
+          await findByLabelText('in_person_proofing.body.location.po_search.address_search_label'),
+          '800 main',
+        );
+        await userEvent.click(
+          await findByText('in_person_proofing.body.location.po_search.search_button'),
+        );
+        await userEvent.click(
+          await findByText('in_person_proofing.body.location.po_search.search_button'),
+        );
+        const searchResultAlert = await findByText(
+          `There are ${MULTI_LOCATION_RESPONSE.length} participating Post Offices within 50 miles of ${MULTI_LOCATION_RESPONSE[0].address}.`,
+        );
+        expect(searchResultAlert).to.exist();
+      });
     });
   });
 

--- a/app/javascript/packages/webauthn/is-webauthn-passkey-supported.spec.ts
+++ b/app/javascript/packages/webauthn/is-webauthn-passkey-supported.spec.ts
@@ -65,13 +65,6 @@ const UNSUPPORTED_USER_AGENTS = [
 describe('isWebauthnPasskeySupported', () => {
   const defineProperty = useDefineProperty();
 
-  beforeEach(() => {
-    defineProperty(window, 'PublicKeyCredential', {
-      configurable: true,
-      value: { isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true) },
-    });
-  });
-
   UNSUPPORTED_USER_AGENTS.forEach((userAgent) => {
     context(userAgent, () => {
       beforeEach(() => {

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -10,6 +10,9 @@ class GetUspsProofingResultsJob < ApplicationJob
     "State driver's license",
     "State non-driver's identification card",
   ]
+  SUPPORTED_SECONDARY_ID_TYPES = [
+    'Visual Inspection of Name and Address on Primary ID Match',
+  ]
 
   queue_as :long_running
 
@@ -115,6 +118,12 @@ class GetUspsProofingResultsJob < ApplicationJob
   ensure
     # Record the attempt to update the enrollment
     enrollment.update(status_check_attempted_at: status_check_attempted_at)
+  end
+
+  def passed_with_unsupported_secondary_id_type?(enrollment, response)
+    return enrollment.capture_secondary_id_enabled &&
+           response['secondaryIdType'].present? &&
+           SUPPORTED_SECONDARY_ID_TYPES.exclude?(response['secondaryIdType'])
   end
 
   def analytics(user: AnonymousUser.new)
@@ -405,7 +414,7 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     case response['status']
     when IPP_STATUS_PASSED
-      if enrollment.capture_secondary_id_enabled && response['secondaryIdType'].present?
+      if passed_with_unsupported_secondary_id_type?(enrollment, response)
         handle_unsupported_secondary_id(enrollment, response)
       elsif SUPPORTED_ID_TYPES.include?(response['primaryIdType'])
         handle_successful_status_update(enrollment, response)

--- a/app/jobs/multi_region_kms_migration/profile_migration_job.rb
+++ b/app/jobs/multi_region_kms_migration/profile_migration_job.rb
@@ -1,0 +1,60 @@
+module MultiRegionKmsMigration
+  class ProfileMigrationJob < ApplicationJob
+    MAXIMUM_ERROR_TOLERANCE = 10
+
+    include ::NewRelic::Agent::MethodTracer
+
+    def perform(statement_timeout: 120, profile_count: 1000)
+      return unless IdentityConfig.store.multi_region_kms_migration_jobs_enabled
+
+      error_count = 0
+      success_count = 0
+
+      profiles = find_profiles_to_migrate(statement_timeout:, profile_count:)
+      profiles.each do |profile|
+        return if error_count >= MAXIMUM_ERROR_TOLERANCE # rubocop:disable Lint/NonLocalExitFromIterator
+
+        Encryption::MultiRegionKmsMigration::ProfileMigrator.new(profile).migrate!
+        success_count += 1
+        analytics.multi_region_kms_migration_profile_migrated(
+          success: true,
+          profile_id: profile.id,
+          exception: nil,
+        )
+      rescue => err
+        error_count += 1
+        analytics.multi_region_kms_migration_profile_migrated(
+          success: false,
+          profile_id: profile.id,
+          exception: err.inspect,
+        )
+      end
+      analytics.multi_region_kms_migration_profile_migration_summary(
+        profile_count: profiles.size,
+        success_count: success_count,
+        error_count: error_count,
+      )
+    end
+
+    def find_profiles_to_migrate(statement_timeout:, profile_count:)
+      Profile.transaction do
+        quoted_timeout = Profile.connection.quote(statement_timeout * 1000)
+        Profile.connection.execute("SET LOCAL statement_timeout = #{quoted_timeout}")
+
+        Profile.where(
+          encrypted_pii_multi_region: nil,
+          encrypted_pii_recovery_multi_region: nil,
+        ).where(
+          'encrypted_pii IS NOT NULL',
+          'encrypted_pii_recovery IS NOT NULL',
+        ).limit(profile_count)
+      end
+    end
+
+    def analytics
+      @analytics ||= Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
+    end
+
+    add_method_tracer :find_profiles_to_migrate, "Custom/#{name}/find_profiles_to_migrate"
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -254,10 +254,6 @@ class Profile < ApplicationRecord
     values.join(':')
   end
 
-  def pending_in_person_enrollment?
-    proofing_components&.[]('document_check') == Idp::Constants::Vendors::USPS
-  end
-
   def includes_phone_check?
     return false if proofing_components.blank?
     proofing_components['address_check'] == 'lexis_nexis_address'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -198,6 +198,15 @@ class User < ApplicationRecord
     pending_profile if pending_profile&.in_person_verification_pending?
   end
 
+  def has_in_person_enrollment?
+    pending_in_person_enrollment.present? || establishing_in_person_enrollment.present?
+  end
+
+  # Trust `pending_profile` rather than enrollment associations
+  def has_establishing_in_person_enrollment_safe?
+    !!pending_profile&.in_person_enrollment&.establishing?
+  end
+
   def personal_key_generated_at
     encrypted_recovery_code_digest_generated_at ||
       active_profile&.verified_at ||

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2863,6 +2863,44 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success
+  # @param [String] exception
+  # @param [Integer] profile_id
+  # A profile was migrated from a single-region key to a multi-region key
+  def multi_region_kms_migration_profile_migrated(
+    success:,
+    exception:,
+    profile_id:,
+    **extra
+  )
+    track_event(
+      'Multi-region KMS migration: Profile migrated',
+      success: success,
+      exception: exception,
+      profile_id: profile_id,
+      **extra,
+    )
+  end
+
+  # @param [Integer] profile_count
+  # @param [Integer] success_count
+  # @param [Integer] error_count
+  # The profile migration job finished running
+  def multi_region_kms_migration_profile_migration_summary(
+    profile_count:,
+    success_count:,
+    error_count:,
+    **extra
+  )
+    track_event(
+      'Multi-region KMS migration: Profile migration summary',
+      profile_count: profile_count,
+      success_count: success_count,
+      error_count: error_count,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
   # @param [String] client_id
   # @param [Boolean] client_id_parameter_present
   # @param [Boolean] id_token_hint_parameter_present

--- a/app/services/encryption/multi_region_kms_migration/profile_migrator.rb
+++ b/app/services/encryption/multi_region_kms_migration/profile_migrator.rb
@@ -10,21 +10,23 @@ module Encryption
       end
 
       def migrate!
-        if profile.encrypted_pii.blank? || profile.encrypted_pii_recovery.blank?
-          raise "Profile##{profile.id} is missing encrypted_pii or encrypted_pii_recovery"
-        end
+        profile.with_lock do
+          if profile.encrypted_pii.blank? || profile.encrypted_pii_recovery.blank?
+            raise "Profile##{profile.id} is missing encrypted_pii or encrypted_pii_recovery"
+          end
 
-        return if profile.encrypted_pii_multi_region.present? ||
+          next if profile.encrypted_pii_multi_region.present? ||
                   profile.encrypted_pii_recovery_multi_region.present?
 
-        encrypted_pii_multi_region = migrate_ciphertext(profile.encrypted_pii)
-        encrypted_pii_recovery_multi_region = migrate_ciphertext(profile.encrypted_pii_recovery)
-        profile.update!(
-          encrypted_pii: profile.encrypted_pii,
-          encrypted_pii_multi_region: encrypted_pii_multi_region,
-          encrypted_pii_recovery: profile.encrypted_pii_recovery,
-          encrypted_pii_recovery_multi_region: encrypted_pii_recovery_multi_region,
-        )
+          encrypted_pii_multi_region = migrate_ciphertext(profile.encrypted_pii)
+          encrypted_pii_recovery_multi_region = migrate_ciphertext(profile.encrypted_pii_recovery)
+          profile.update!(
+            encrypted_pii: profile.encrypted_pii,
+            encrypted_pii_multi_region: encrypted_pii_multi_region,
+            encrypted_pii_recovery: profile.encrypted_pii_recovery,
+            encrypted_pii_recovery_multi_region: encrypted_pii_recovery_multi_region,
+          )
+        end
       end
 
       private

--- a/app/services/encryption/multi_region_kms_migration/profile_migrator.rb
+++ b/app/services/encryption/multi_region_kms_migration/profile_migrator.rb
@@ -1,0 +1,65 @@
+module Encryption
+  module MultiRegionKmsMigration
+    class ProfileMigrator
+      include ::NewRelic::Agent::MethodTracer
+
+      attr_reader :profile
+
+      def initialize(profile)
+        @profile = profile
+      end
+
+      def migrate!
+        if profile.encrypted_pii.blank? || profile.encrypted_pii_recovery.blank?
+          raise "Profile##{profile.id} is missing encrypted_pii or encrypted_pii_recovery"
+        end
+
+        return if profile.encrypted_pii_multi_region.present? ||
+                  profile.encrypted_pii_recovery_multi_region.present?
+
+        encrypted_pii_multi_region = migrate_ciphertext(profile.encrypted_pii)
+        encrypted_pii_recovery_multi_region = migrate_ciphertext(profile.encrypted_pii_recovery)
+        profile.update!(
+          encrypted_pii: profile.encrypted_pii,
+          encrypted_pii_multi_region: encrypted_pii_multi_region,
+          encrypted_pii_recovery: profile.encrypted_pii_recovery,
+          encrypted_pii_recovery_multi_region: encrypted_pii_recovery_multi_region,
+        )
+      end
+
+      private
+
+      def migrate_ciphertext(ciphertext_string)
+        ciphertext = Encryption::Encryptors::PiiEncryptor::Ciphertext.parse_from_string(
+          ciphertext_string,
+        )
+        aes_encrypted_data = multi_region_kms_client.decrypt(
+          ciphertext.encrypted_data, kms_encryption_context
+        )
+        multi_region_kms_encrypted_data = multi_region_kms_client.encrypt(
+          aes_encrypted_data, kms_encryption_context
+        )
+        Encryption::Encryptors::PiiEncryptor::Ciphertext.new(
+          multi_region_kms_encrypted_data,
+          ciphertext.salt,
+          ciphertext.cost,
+        )
+      end
+
+      def kms_encryption_context
+        {
+          'context' => 'pii-encryption',
+          'user_uuid' => profile.user.uuid,
+        }
+      end
+
+      def multi_region_kms_client
+        @multi_region_kms_client ||= KmsClient.new(
+          kms_key_id: IdentityConfig.store.aws_kms_multi_region_key_id,
+        )
+      end
+
+      add_method_tracer :migrate!, "Custom/#{name}/migrate!"
+    end
+  end
+end

--- a/app/services/gpo_confirmation_exporter.rb
+++ b/app/services/gpo_confirmation_exporter.rb
@@ -5,7 +5,6 @@ class GpoConfirmationExporter
   LINE_ENDING = "\r\n".freeze
   HEADER_ROW_ID = '01'.freeze
   CONTENT_ROW_ID = '02'.freeze
-  OTP_MAX_VALID_DAYS = IdentityConfig.store.usps_confirmation_max_days
 
   def initialize(confirmations)
     @confirmations = confirmations
@@ -32,7 +31,7 @@ class GpoConfirmationExporter
 
   def make_entry_row(confirmation)
     now = current_date
-    due = confirmation.created_at + OTP_MAX_VALID_DAYS.days
+    due = confirmation.created_at + IdentityConfig.store.usps_confirmation_max_days.days
 
     entry = confirmation.entry
     service_provider = ServiceProvider.find_by(issuer: entry[:issuer])

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -1,9 +1,13 @@
 class GpoReminderSender
   def send_emails(for_letters_sent_before)
+    letter_eligible_range =
+      IdentityConfig.store.usps_confirmation_max_days.days.ago..for_letters_sent_before
+
     profiles_due_for_reminder = Profile.joins(:gpo_confirmation_codes).
       where(
-        gpo_verification_pending_at: ..for_letters_sent_before,
+        gpo_verification_pending_at: letter_eligible_range,
         gpo_confirmation_codes: { reminder_sent_at: nil },
+        deactivation_reason: [nil, :in_person_verification_pending],
       )
 
     profiles_due_for_reminder.each do |profile|

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -60,7 +60,7 @@ module Idv
       profile = profile_maker.save_profile(
         fraud_pending_reason: threatmetrix_fraud_pending_reason,
         gpo_verification_needed: gpo_verification_needed?,
-        in_person_verification_needed: pending_in_person_enrollment?,
+        in_person_verification_needed: current_user.has_in_person_enrollment?,
       )
 
       profile.activate unless profile.reason_not_to_activate
@@ -76,7 +76,7 @@ module Idv
         move_pii_to_user_session
       elsif address_verification_mechanism == 'gpo'
         create_gpo_entry
-      elsif pending_in_person_enrollment?
+      elsif current_user.has_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
           current_user,
           pii,
@@ -106,7 +106,8 @@ module Idv
     end
 
     def associate_in_person_enrollment_with_profile
-      return unless pending_in_person_enrollment? && current_user.establishing_in_person_enrollment
+      return unless current_user.has_in_person_enrollment?
+
       current_user.establishing_in_person_enrollment.update(profile: profile)
     end
 
@@ -140,10 +141,6 @@ module Idv
       parsed_phone = Phonelib.parse(phone)
       phone_e164 = parsed_phone.e164
       failed_phone_step_numbers << phone_e164 if !failed_phone_step_numbers.include?(phone_e164)
-    end
-
-    def pending_in_person_enrollment?
-      current_user.proofing_component&.document_check == Idp::Constants::Vendors::USPS
     end
 
     def verify_info_step_complete?

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -63,7 +63,7 @@ module UspsInPersonProofing
             city: transliterate(pii[:city]),
             state: pii[:state],
             zip_code: pii[:zipcode],
-            email: 'no-reply@login.gov',
+            email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence,
           },
         )
 

--- a/app/services/usps_in_person_proofing/mock/fixtures.rb
+++ b/app/services/usps_in_person_proofing/mock/fixtures.rb
@@ -61,6 +61,12 @@ module UspsInPersonProofing
         load_response_fixture('request_passed_proofing_secondary_id_type_results_response.json')
       end
 
+      def self.request_passed_proofing_supported_secondary_id_type_results_response
+        load_response_fixture(
+          'request_passed_proofing_supported_secondary_id_type_results_response.json',
+        )
+      end
+
       def self.request_expired_proofing_results_response
         load_response_fixture('request_expired_proofing_results_response.json')
       end

--- a/app/services/usps_in_person_proofing/mock/responses/request_passed_proofing_supported_secondary_id_type_results_response.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_passed_proofing_supported_secondary_id_type_results_response.json
@@ -7,7 +7,7 @@
   "primaryIdType": "State driver's license",
   "transactionStartDateTime": "12/17/2020 033855",
   "transactionEndDateTime": "12/17/2020 034055",
-  "secondaryIdType": "State driver's license",
+  "secondaryIdType": "Visual Inspection of Name and Address on Primary ID Match",
   "fraudSuspected": false,
   "proofingConfirmationNumber": "350040248346701",
   "ippAssuranceLevel": "1.5"

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -9,16 +9,6 @@
       ) %>
 <% end %>
 
-<%= render AlertComponent.new(
-      type: :error,
-      class: [
-        'js-consent-form-alert',
-        'margin-bottom-4',
-        'display-none',
-      ].select(&:present?),
-      message: t('errors.doc_auth.consent_form'),
-    ) %>
-
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.lets_go')) %>
 <p><%= t('doc_auth.info.lets_go') %></p>
 <h2><%= t('doc_auth.headings.verify_identity') %></h2>

--- a/app/views/idv/doc_auth/_error_messages.html.erb
+++ b/app/views/idv/doc_auth/_error_messages.html.erb
@@ -1,8 +1,0 @@
-<% unless flow_session[:error_message].nil? %>
-  <%= render AlertComponent.new(
-        type: :error,
-        class: 'margin-bottom-4',
-      ) do %>
-    <%= flow_session[:error_message] %>
-  <% end %>
-<% end %>

--- a/app/views/idv/getting_started/show.html.erb
+++ b/app/views/idv/getting_started/show.html.erb
@@ -5,16 +5,6 @@
       intro: t('idv.getting_started.no_js_intro', sp_name: @sp_name),
     ) do %>
 
-<%= render AlertComponent.new(
-      type: :error,
-      class: [
-        'js-consent-form-alert',
-        'margin-bottom-4',
-        'display-none',
-      ].select(&:present?),
-      message: t('errors.doc_auth.consent_form'),
-    ) %>
-
 <%= render PageHeadingComponent.new.with_content(@title) %>
   <p>
     <%= t(

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -9,8 +9,6 @@
       ) %>
 <% end %>
 
-<%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
-
 <%= render PageHeadingComponent.new do %>
   <%= t('doc_auth.headings.hybrid_handoff') %>
 <% end %>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -9,14 +9,6 @@
 
 <% title t('titles.doc_auth.link_sent') %>
 
-<% if flow_session[:error_message] %>
-  <%= render AlertComponent.new(
-        type: :error,
-        class: 'margin-bottom-4',
-        message: flow_session[:error_message],
-      ) %>
-<% end %>
-
 <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-4') do %>
   <strong class="display-block"><%= t('doc_auth.info.keep_window_open') %></strong>
   <% if FeatureManagement.doc_capture_polling_enabled? %>

--- a/app/views/idv/ssn/show.html.erb
+++ b/app/views/idv/ssn/show.html.erb
@@ -30,7 +30,7 @@ locals:
   <% end %>
 </p>
 
-<% if should_render_threatmetrix_js? %>
+<% if FeatureManagement.proofing_device_profiling_collecting_enabled? %>
   <% if threatmetrix_session_id.present? %>
     <% threatmetrix_javascript_urls.each do |threatmetrix_javascript_url| %>
       <%= javascript_include_tag threatmetrix_javascript_url, nonce: true %>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -55,6 +55,10 @@ locals:
           <%= I18n.l(Date.parse(@pii[:dob]), format: I18n.t('time.formats.event_date')) %>
         </dd>
       </div>
+      <div>
+        <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
+        <dd class="display-inline margin-left-0"> <%= @pii[:state_id_number] %> </dd>
+      </div>
     </dl>
   </div>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-y border-primary-light">

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -207,6 +207,7 @@ max_mail_events_window_in_days: 30
 max_phone_numbers_per_account: 5
 max_piv_cac_per_account: 2
 min_password_score: 3
+multi_region_kms_migration_jobs_enabled: true
 mx_timeout: 3
 otp_delivery_blocklist_maxretry: 10
 otp_valid_for: 10

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -337,6 +337,7 @@ usps_ipp_sponsor_id: ''
 usps_ipp_username: ''
 usps_mock_fallback: true
 usps_ipp_transliteration_enabled: false
+usps_ipp_enrollment_status_update_email_address: 'no-reply@login.gov'
 get_usps_ready_proofing_results_job_cron: '0/10 * * * *'
 get_usps_waiting_proofing_results_job_cron: '0/30 * * * *'
 get_usps_proofing_results_job_cron: '0/30 * * * *'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -328,7 +328,7 @@ version_headers_enabled: false
 use_dashboard_service_providers: false
 use_kms: false
 usps_auth_token_refresh_job_enabled: false
-usps_confirmation_max_days: 10
+usps_confirmation_max_days: 30
 usps_ipp_password: ''
 usps_ipp_client_id: ''
 usps_ipp_root_url: ''

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -128,8 +128,6 @@ idv_acuant_sdk_upgrade_a_b_testing_percent: 50
 idv_getting_started_a_b_testing: '{"welcome_default":100, "welcome_new":0, "getting_started":0}'
 idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
-idv_tmx_test_csp_disabled_emails: '[]'
-idv_tmx_test_js_disabled_emails: '[]'
 idv_sp_required: false
 in_person_capture_secondary_id_enabled: false
 in_person_public_address_search_enabled: false

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -164,6 +164,12 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.yesterday] },
       },
+      # Send Identity Verification report to S3
+      identity_verification_report: {
+        class: 'Reports::IdentityVerificationReport',
+        cron: cron_24h,
+        args: -> { [Time.zone.yesterday] },
+      },
       usps_auth_token_refresh: (if IdentityConfig.store.usps_auth_token_refresh_job_enabled
                                   {
                                     class: 'UspsAuthTokenRefreshJob',

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -6,6 +6,10 @@ require 'yaml'
 
 module Deploy
   class Activate
+    FILES_TO_LINK =
+      %w[agencies iaa_gtcs iaa_orders iaa_statuses integration_statuses integrations
+         partner_account_statuses partner_accounts service_providers]
+
     attr_reader :logger, :s3_client
 
     def initialize(
@@ -32,34 +36,11 @@ module Deploy
       )
     end
 
-    private
-
-    # Clone the private-but-not-secret git repo
-    def clone_idp_config
-      private_git_repo_url = ENV.fetch(
-        'IDP_private_config_repo',
-        'git@github.com:18F/identity-idp-config.git',
-      )
-      checkout_dir = File.join(root, idp_config_checkout_name)
-
-      cmd = ['git', 'clone', '--depth', '1', '--branch', 'main', private_git_repo_url, checkout_dir]
-      logger.info('+ ' + cmd.join(' '))
-      Subprocess.check_call(cmd)
-    end
-
-    def idp_config_checkout_name
-      'identity-idp-config'
-    end
-
     # Set up symlinks into identity-idp-config needed for the idp to make use
     # of relevant config and assets.
     #
     def setup_idp_config_symlinks
-      files_to_link =
-        %w[agencies iaa_gtcs iaa_orders iaa_statuses integration_statuses integrations
-           partner_account_statuses partner_accounts service_providers]
-
-      files_to_link.each do |file|
+      FILES_TO_LINK.each do |file|
         symlink_verbose(
           File.join(root, idp_config_checkout_name, "#{file}.yml"),
           File.join(root, "config/#{file}.yml"),
@@ -73,7 +54,6 @@ module Deploy
         File.join(root, 'certs/sp'),
       )
 
-      idp_logos_dir = File.join(root, 'public/assets/sp-logos')
       FileUtils.mkdir_p(idp_logos_dir)
 
       # Invalid symlinks can cause issues in the build process, so this step iterates through the
@@ -81,21 +61,54 @@ module Deploy
       Dir.entries(idp_logos_dir).each do |name|
         next if name.start_with?('.')
         target = File.join(idp_logos_dir, name)
-        File.rm(target) if File.symlink?(target) && !File.file?(target)
+        FileUtils.rm(target) if File.symlink?(target) && !File.file?(target)
       end
       # Public assets: sp-logos
       # Inject the logo files into the app's asset folder. deploy/activate is
       # run before deploy/build-post-config, so these will be picked up by the
       # rails asset pipeline.
-      logos_dir = File.join(root, idp_config_checkout_name, 'public/assets/images/sp-logos')
-      Dir.entries(logos_dir).each do |name|
+      Dir.entries(config_logos_dir).each do |name|
         next if name.start_with?('.')
-        target = File.join(logos_dir, name)
+        target = File.join(config_logos_dir, name)
         link = File.join(root, 'app/assets/images/sp-logos', name)
         symlink_verbose(target, link, force: true)
         link = File.join(root, 'public/assets/sp-logos', name)
         symlink_verbose(target, link, force: true)
       end
+    end
+
+    def root
+      @root || File.expand_path('../../../', __FILE__)
+    end
+
+    def idp_logos_dir
+      File.join(root, 'public/assets/sp-logos')
+    end
+
+    def config_logos_dir
+      File.join(checkout_dir, 'public/assets/images/sp-logos')
+    end
+
+    def checkout_dir
+      File.join(root, idp_config_checkout_name)
+    end
+
+    private
+
+    # Clone the private-but-not-secret git repo
+    def clone_idp_config
+      private_git_repo_url = ENV.fetch(
+        'IDP_private_config_repo',
+        'git@github.com:18F/identity-idp-config.git',
+      )
+
+      cmd = ['git', 'clone', '--depth', '1', '--branch', 'main', private_git_repo_url, checkout_dir]
+      logger.info('+ ' + cmd.join(' '))
+      Subprocess.check_call(cmd)
+    end
+
+    def idp_config_checkout_name
+      'identity-idp-config'
     end
 
     def symlink_verbose(dest, link, force: false)
@@ -122,10 +135,6 @@ module Deploy
       logger = Logger.new(STDOUT)
       logger.progname = 'deploy/activate'
       logger
-    end
-
-    def root
-      @root || File.expand_path('../../../', __FILE__)
     end
 
     def geolocation_db_path

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -241,8 +241,6 @@ class IdentityConfig
     config.add(:idv_send_link_attempt_window_in_minutes, type: :integer)
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_sp_required, type: :boolean)
-    config.add(:idv_tmx_test_csp_disabled_emails, type: :json)
-    config.add(:idv_tmx_test_js_disabled_emails, type: :json)
     config.add(:in_person_capture_secondary_id_enabled, type: :boolean)
     config.add(:in_person_completion_survey_url, type: :string)
     config.add(:in_person_doc_auth_button_enabled, type: :boolean)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -453,6 +453,7 @@ class IdentityConfig
     config.add(:usps_ipp_sponsor_id, type: :string)
     config.add(:usps_ipp_transliteration_enabled, type: :boolean)
     config.add(:usps_ipp_username, type: :string)
+    config.add(:usps_ipp_enrollment_status_update_email_address, type: :string)
     config.add(:usps_mock_fallback, type: :boolean)
     config.add(:usps_upload_enabled, type: :boolean)
     config.add(:usps_upload_sftp_directory, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -315,6 +315,7 @@ class IdentityConfig
     config.add(:max_phone_numbers_per_account, type: :integer)
     config.add(:max_piv_cac_per_account, type: :integer)
     config.add(:min_password_score, type: :integer)
+    config.add(:multi_region_kms_migration_jobs_enabled, type: :boolean)
     config.add(:mx_timeout, type: :integer)
     config.add(:newrelic_browser_app_id, type: :string)
     config.add(:newrelic_browser_key, type: :string)

--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-cloudwatchlogs'
+require 'ruby-progressbar'
 
 module Reporting
   class CloudwatchClient

--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -21,7 +21,7 @@ namespace :profiles do
     )
 
     profiles.each do |profile|
-      timestamp = profile.in_person_enrollment.updated_at
+      timestamp = profile.updated_at || profile.created_at
 
       warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
       if update_profiles

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:css": "build-sass app/assets/stylesheets/*.css.scss app/components/*.scss --load-path=app/assets/stylesheets --out-dir=app/assets/builds"
   },
   "dependencies": {
-    "@18f/identity-design-system": "^7.0.1",
+    "@18f/identity-design-system": "^7.1.0",
     "@babel/core": "^7.20.7",
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-react": "^7.14.5",

--- a/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
+++ b/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
         end
 
         it 'returns in person gpo steps' do
+          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
+          create(:in_person_enrollment, :establishing, user: user)
           expect(steps).to eq in_person_step_indicator_steps_gpo
         end
       end
@@ -104,6 +106,7 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
       context 'via current idv session' do
         before do
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
+          create(:in_person_enrollment, :establishing, user: user)
         end
 
         it 'returns in person steps' do

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -171,13 +171,17 @@ RSpec.describe 'IdvStepConcern' do
     end
 
     context 'the user has not completed the verify info step with an in-person enrollment' do
+      let(:selected_location_details) do
+        JSON.parse(UspsInPersonProofing::Mock::Fixtures.enrollment_selected_location_details)
+      end
+
       it 'redirects to the in-person verify info step' do
         idv_session.resolution_successful = nil
 
-        ProofingComponent.find_or_create_by(
+        InPersonEnrollment.find_or_create_by(
           user: user,
         ).update!(
-          document_check: Idp::Constants::Vendors::USPS,
+          selected_location_details: selected_location_details,
         )
 
         get :show

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe Idv::AddressController do
   let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.stringify_keys }
 
   let(:flow_session) do
-    {
-      'pii_from_doc' => pii_from_doc,
-    }
+    { pii_from_doc: pii_from_doc }
   end
 
   before do
@@ -60,7 +58,7 @@ RSpec.describe Idv::AddressController do
     it 'updates pii_from_doc' do
       expect do
         put :update, params: params
-      end.to change { flow_session['pii_from_doc'] }.to eql(
+      end.to change { flow_session[:pii_from_doc] }.to eql(
         pii_from_doc.merge(
           {
             'address1' => '1234 Main St',

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Idv::DocumentCaptureController do
 
     context 'with pii in session' do
       it 'redirects to ssn step' do
-        flow_session['pii_from_doc'] = Idp::Constants::MOCK_IDV_APPLICANT
+        flow_session[:pii_from_doc] = Idp::Constants::MOCK_IDV_APPLICANT
         get :show
 
         expect(response).to redirect_to(idv_ssn_url)

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Idv::LinkSentController do
 
     context 'with pii in session' do
       it 'redirects to ssn step' do
-        flow_session['pii_from_doc'] = Idp::Constants::MOCK_IDV_APPLICANT
+        flow_session[:pii_from_doc] = Idp::Constants::MOCK_IDV_APPLICANT
         get :show
 
         expect(response).to redirect_to(idv_ssn_url)

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -3,10 +3,7 @@ require 'rails_helper'
 RSpec.describe Idv::LinkSentController do
   include IdvHelper
 
-  let(:flow_session) do
-    { document_capture_session_uuid: 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
-      threatmetrix_session_id: 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0' }
-  end
+  let(:flow_session) { {} }
 
   let(:user) { create(:user) }
 

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Idv::SessionErrorsController do
           rate_limit_type: :proof_ssn,
           target: Pii::Fingerprinter.fingerprint(ssn),
         ).increment_to_limited!
-        controller.user_session['idv/doc_auth'] = { 'pii_from_doc' => { 'ssn' => ssn } }
+        controller.user_session['idv/doc_auth'] = { pii_from_doc: { 'ssn' => ssn } }
       end
 
       it 'assigns expiration time' do

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Idv::SsnController do
   include IdvHelper
 
   let(:flow_session) do
-    { 'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
-      'pii_from_doc' => Idp::Constants::MOCK_IDV_APPLICANT.dup,
-      :threatmetrix_session_id => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0' }
+    { pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT.dup }
   end
 
   let(:ssn) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn] }
@@ -95,7 +93,7 @@ RSpec.describe Idv::SsnController do
     context 'with an ssn in session' do
       let(:referer) { idv_document_capture_url }
       before do
-        flow_session['pii_from_doc'][:ssn] = ssn
+        flow_session[:pii_from_doc][:ssn] = ssn
         request.env['HTTP_REFERER'] = referer
       end
 
@@ -158,12 +156,12 @@ RSpec.describe Idv::SsnController do
       it 'merges ssn into pii session value' do
         put :update, params: params
 
-        expect(flow_session['pii_from_doc'][:ssn]).to eq(ssn)
+        expect(flow_session[:pii_from_doc][:ssn]).to eq(ssn)
       end
 
       context 'with a Puerto Rico address' do
         it 'redirects to address controller after user enters their SSN' do
-          flow_session['pii_from_doc'][:state] = 'PR'
+          flow_session[:pii_from_doc][:state] = 'PR'
 
           put :update, params: params
 
@@ -171,8 +169,8 @@ RSpec.describe Idv::SsnController do
         end
 
         it 'redirects to the verify info controller if a user is updating their SSN' do
-          flow_session['pii_from_doc'][:ssn] = ssn
-          flow_session['pii_from_doc'][:state] = 'PR'
+          flow_session[:pii_from_doc][:ssn] = ssn
+          flow_session[:pii_from_doc][:state] = 'PR'
 
           put :update, params: params
 
@@ -198,7 +196,7 @@ RSpec.describe Idv::SsnController do
       end
 
       it 'does not change threatmetrix_session_id when updating ssn' do
-        flow_session['pii_from_doc'][:ssn] = ssn
+        flow_session[:pii_from_doc][:ssn] = ssn
         put :update, params: params
         session_id = subject.idv_session.threatmetrix_session_id
         subject.threatmetrix_view_variables
@@ -239,7 +237,7 @@ RSpec.describe Idv::SsnController do
     context 'when pii_from_doc is not present' do
       before do
         subject.idv_session.flow_path = 'standard'
-        flow_session.delete('pii_from_doc')
+        flow_session.delete(:pii_from_doc)
       end
 
       it 'redirects to DocumentCaptureController on standard flow' do

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -137,29 +137,6 @@ RSpec.describe Idv::SsnController do
         expect(csp.directives['img-src']).to include('*.online-metrix.net')
       end
     end
-
-    it 'does not override the Content Security for CSP disabled test users' do
-      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
-        and_return(:enabled)
-      allow(IdentityConfig.store).to receive(:idv_tmx_test_csp_disabled_emails).
-        and_return([user.email_addresses.first.email])
-
-      get :show
-
-      csp = response.request.content_security_policy
-
-      aggregate_failures do
-        expect(csp.directives['script-src']).to_not include('h.online-metrix.net')
-
-        expect(csp.directives['style-src']).to_not include("'unsafe-inline'")
-
-        expect(csp.directives['child-src']).to_not include('h.online-metrix.net')
-
-        expect(csp.directives['connect-src']).to_not include('h.online-metrix.net')
-
-        expect(csp.directives['img-src']).to_not include('*.online-metrix.net')
-      end
-    end
   end
 
   describe '#update' do
@@ -284,31 +261,6 @@ RSpec.describe Idv::SsnController do
         expect(response.status).to eq 302
         expect(response).to redirect_to idv_hybrid_handoff_url
       end
-    end
-  end
-
-  describe '#should_render_threatmetrix_js?' do
-    it 'returns true if the JS should be disabled for the user' do
-      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
-        and_return(:enabled)
-      allow(IdentityConfig.store).to receive(:idv_tmx_test_js_disabled_emails).
-        and_return([user.email_addresses.first.email])
-
-      expect(controller.should_render_threatmetrix_js?).to eq(false)
-    end
-
-    it 'returns true if the JS should not be disabled for the user' do
-      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
-        and_return(:enabled)
-
-      expect(controller.should_render_threatmetrix_js?).to eq(true)
-    end
-
-    it 'returns false if TMx profiling is disabled' do
-      allow(IdentityConfig.store).to receive(:proofing_device_profiling).
-        and_return(:disabled)
-
-      expect(controller.should_render_threatmetrix_js?).to eq(false)
     end
   end
 end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe Idv::VerifyInfoController do
   include IdvHelper
 
   let(:flow_session) do
-    { 'error_message' => nil,
-      'document_capture_session_uuid' => 'fd14e181-6fb1-4cdc-92e0-ef66dad0df4e',
-      :pii_from_doc => Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup,
-      'threatmetrix_session_id' => 'c90ae7a5-6629-4e77-b97c-f1987c2df7d0' }
+    { pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup }
   end
 
   let(:user) { create(:user) }

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -133,6 +133,16 @@ RSpec.describe ServiceProviderController do
       end
     end
 
+    context 'missing token in header' do
+      let(:token) { nil }
+
+      it 'returns a 401' do
+        post :update
+
+        expect(response.status).to eq 401
+      end
+    end
+
     context 'feature off' do
       let(:use_feature) { false }
       before { post :update }

--- a/spec/features/idv/doc_auth/agreement_spec.rb
+++ b/spec/features/idv/doc_auth/agreement_spec.rb
@@ -2,27 +2,6 @@ require 'rails_helper'
 
 RSpec.feature 'agreement step error checking' do
   include DocAuthHelper
-  context 'when JS is disabled' do
-    before do
-      sign_in_and_2fa_user
-      complete_doc_auth_steps_before_agreement_step
-    end
-
-    it 'shows the notice if the user clicks continue without giving consent' do
-      click_continue
-
-      expect(page).to have_current_path(idv_agreement_url)
-      expect(page).to have_content(t('errors.doc_auth.consent_form'))
-    end
-
-    it 'allows the user to continue after checking the checkbox' do
-      check t('doc_auth.instructions.consent', app_name: APP_NAME)
-      click_continue
-
-      expect(page).to have_current_path(idv_hybrid_handoff_path)
-    end
-  end
-
   context 'skipping hybrid_handoff step', :js, driver: :headless_chrome_mobile do
     let(:fake_analytics) { FakeAnalytics.new }
 

--- a/spec/features/idv/doc_auth/getting_started_spec.rb
+++ b/spec/features/idv/doc_auth/getting_started_spec.rb
@@ -45,22 +45,6 @@ RSpec.feature 'getting started step' do
     )
   end
 
-  context 'when JS is disabled' do
-    it 'shows the notice if the user clicks continue without giving consent' do
-      click_continue
-
-      expect(page).to have_current_path(idv_getting_started_url)
-      expect(page).to have_content(t('errors.doc_auth.consent_form'))
-    end
-
-    it 'allows the user to continue after checking the checkbox' do
-      check t('doc_auth.instructions.consent', app_name: APP_NAME)
-      click_continue
-
-      expect(page).to have_current_path(idv_hybrid_handoff_path)
-    end
-  end
-
   context 'skipping hybrid_handoff step', :js, driver: :headless_chrome_mobile do
     before do
       complete_getting_started_step

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -34,7 +34,9 @@ RSpec.feature 'verify profile with OTP' do
     end
 
     scenario 'OTP has expired' do
-      GpoConfirmationCode.first.update(code_sent_at: 11.days.ago)
+      GpoConfirmationCode.first.update(
+        code_sent_at: (IdentityConfig.store.usps_confirmation_max_days + 1).days.ago,
+      )
 
       sign_in_live_with_2fa(user)
       fill_in t('idv.gpo.form.otp_label'), with: otp

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -86,7 +86,13 @@ RSpec.describe GpoVerifyForm do
     end
 
     context 'when OTP is expired' do
-      let(:code_sent_at) { 11.days.ago }
+      let(:expiration_days) { 10 }
+      let(:code_sent_at) { (expiration_days + 1).days.ago }
+
+      before do
+        allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).
+          and_return(expiration_days)
+      end
 
       it 'is invalid' do
         result = subject.submit

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -124,13 +124,20 @@ RSpec.describe GpoVerifyForm do
         expect(result.to_h[:enqueued_at]).to eq(confirmation_code.code_sent_at)
       end
 
-      context 'pending in person enrollment' do
-        let!(:enrollment) do
-          create(:in_person_enrollment, :establishing, profile: pending_profile, user: user)
+      context 'establishing in person enrollment' do
+        let!(:establishing_enrollment) do
+          create(
+            :in_person_enrollment,
+            :establishing,
+            profile: pending_profile,
+            user: user,
+          )
         end
+
         let(:proofing_components) do
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
         end
+
         before do
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end
@@ -148,11 +155,40 @@ RSpec.describe GpoVerifyForm do
         it 'updates establishing in-person enrollment to pending' do
           subject.submit
 
-          enrollment.reload
+          establishing_enrollment.reload
 
-          expect(enrollment.status).to eq(InPersonEnrollment::STATUS_PENDING)
-          expect(enrollment.user_id).to eq(user.id)
-          expect(enrollment.enrollment_code).to be_a(String)
+          expect(establishing_enrollment.status).to eq(InPersonEnrollment::STATUS_PENDING)
+          expect(establishing_enrollment.user_id).to eq(user.id)
+          expect(establishing_enrollment.enrollment_code).to be_a(String)
+        end
+      end
+
+      context 'pending in person enrollment' do
+        let!(:pending_enrollment) do
+          create(
+            :in_person_enrollment,
+            :pending,
+            profile: pending_profile,
+            user: user,
+          )
+        end
+
+        let(:proofing_components) do
+          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
+        end
+
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+        end
+
+        it 'changes profile from pending to active' do
+          subject.submit
+          pending_profile.reload
+
+          expect(pending_profile).to be_active
+          expect(pending_profile.deactivation_reason).to be_nil
+          expect(pending_profile.in_person_verification_pending_at).to be_nil
+          expect(pending_profile.gpo_verification_pending?).to eq(false)
         end
       end
 

--- a/spec/forms/idv/ssn_format_form_spec.rb
+++ b/spec/forms/idv/ssn_format_form_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Idv::SsnFormatForm do
     end
 
     context 'when there is an SSN in the pii_from_doc hash' do
-      let(:flow_session) { { 'pii_from_doc' => { ssn: '900-12-3456' } } }
+      let(:flow_session) { { pii_from_doc: { ssn: '900-12-3456' } } }
 
       it { expect(subject.updating_ssn?).to eq(true) }
     end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -1196,6 +1196,21 @@ RSpec.describe GetUspsProofingResultsJob do
               ),
             )
           end
+
+          context 'when the secondary ID is supported' do
+            before do
+              stub_request_passed_proofing_supported_secondary_id_type_results
+            end
+
+            it_behaves_like(
+              'enrollment_with_a_status_update',
+              passed: true,
+              email_type: 'Success',
+              enrollment_status: InPersonEnrollment::STATUS_PASSED,
+              response_json: UspsInPersonProofing::Mock::Fixtures.
+                request_passed_proofing_supported_secondary_id_type_results_response,
+            )
+          end
         end
 
         context 'sms notifications enabled' do

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -1,27 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe GpoReminderJob do
-  let(:wait_before_sending_reminder) { 14.days }
+  let(:days_before_sending_reminder) { 12 }
+  let(:max_days_ago_to_send_letter) { 27 }
 
   describe '#perform' do
-    subject(:perform) { job.perform(wait_before_sending_reminder.ago) }
+    subject(:perform) { job.perform(days_before_sending_reminder.days.ago) }
 
     let(:job) { GpoReminderJob.new }
-    let(:user) { create(:user, :with_pending_gpo_profile) }
-    let(:pending_profile) { user.pending_profile }
+
+    let(:gpo_expired_user) { create(:user, :with_pending_gpo_profile) }
+    let(:due_for_reminder_user) { create(:user, :with_pending_gpo_profile) }
+    let(:not_yet_due_for_reminder_user) { create(:user, :with_pending_gpo_profile) }
+    let(:user_with_invalid_profile) { create(:user, :with_pending_gpo_profile) }
+
     let(:job_analytics) { FakeAnalytics.new }
 
     before do
-      pending_profile.update(
-        gpo_verification_pending_at: wait_before_sending_reminder.ago,
-      )
+      allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).
+        and_return(max_days_ago_to_send_letter)
       allow(Analytics).to receive(:new).and_return(job_analytics)
+
+      gpo_expired_user.gpo_verification_pending_profile.update(
+        gpo_verification_pending_at: (max_days_ago_to_send_letter + 1).days.ago,
+      )
+
+      due_for_reminder_user.gpo_verification_pending_profile.update(
+        gpo_verification_pending_at: days_before_sending_reminder.days.ago,
+      )
+
+      not_yet_due_for_reminder_user.gpo_verification_pending_profile.update(
+        gpo_verification_pending_at: (days_before_sending_reminder - 1).days.ago,
+      )
+
+      user_with_invalid_profile.gpo_verification_pending_profile.update(
+        gpo_verification_pending_at: days_before_sending_reminder.days.ago,
+      )
+      user_with_invalid_profile.gpo_verification_pending_profile.deactivate(:password_reset)
     end
 
-    it 'sends reminder emails' do
+    it 'sends only one reminder email, to the correct user' do
       expect { perform }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(ActionMailer::Base.deliveries.last.to.first).to eq(due_for_reminder_user.email)
       expect(job_analytics).to have_logged_event(
         'IdV: gpo reminder email sent',
+        user_id: due_for_reminder_user.uuid,
       )
     end
   end

--- a/spec/jobs/multi_region_kms_migration/profile_migration_job_spec.rb
+++ b/spec/jobs/multi_region_kms_migration/profile_migration_job_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe MultiRegionKmsMigration::ProfileMigrationJob do
+  let!(:profiles) { create_list(:profile, 4, :with_pii) }
+  let!(:single_region_ciphertext_profiles) do
+    single_region_profiles = profiles[2..3]
+    single_region_profiles.each do |profile|
+      profile.update!(
+        encrypted_pii_multi_region: nil,
+        encrypted_pii_recovery_multi_region: nil,
+      )
+    end
+    single_region_profiles
+  end
+  let!(:multi_region_ciphertext_profiles) { profiles[0..1] }
+
+  describe '#perform' do
+    it 'does not modify records that do have multi-region ciphertexts' do
+      profile = multi_region_ciphertext_profiles.first
+
+      original_encrypted_pii_multi_region = profile.encrypted_pii_multi_region
+      original_encrypted_pii_recovery_multi_region = profile.encrypted_pii_recovery_multi_region
+
+      described_class.perform_now
+
+      expect(profile.reload.encrypted_pii_multi_region).to eq(
+        original_encrypted_pii_multi_region,
+      )
+      expect(profile.encrypted_pii_recovery_multi_region).to eq(
+        original_encrypted_pii_recovery_multi_region,
+      )
+    end
+
+    it 'migrates records that do not have multi-region ciphertexts' do
+      described_class.perform_now
+
+      aggregate_failures do
+        single_region_ciphertext_profiles.each do |profile|
+          expect(profile.reload.encrypted_pii_multi_region).to_not be_blank
+          expect(profile.encrypted_pii_recovery_multi_region).to_not be_blank
+        end
+      end
+    end
+
+    context 'when errors occur' do
+      let(:profile_migrator) { double(Encryption::MultiRegionKmsMigration::ProfileMigrator) }
+
+      before do
+        allow(profile_migrator).to receive(:migrate!).and_raise(RuntimeError, 'test error')
+        allow(
+          Encryption::MultiRegionKmsMigration::ProfileMigrator,
+        ).to receive(:new).and_return(profile_migrator)
+      end
+
+      it 'logs the error' do
+        analytics = subject.analytics
+
+        expect(analytics).to receive(:track_event).twice.with(
+          'Multi-region KMS migration: Profile migrated',
+          success: false,
+          profile_id: instance_of(Integer),
+          exception: instance_of(String),
+        )
+        expect(analytics).to receive(:track_event).with(
+          'Multi-region KMS migration: Profile migration summary',
+          profile_count: 2,
+          success_count: 0,
+          error_count: 2,
+        )
+
+        subject.perform_now
+      end
+
+      it 'aborts after it encounters too many errors' do
+        # rubocop:disable Rails/SkipsModelValidations
+        create_list(:profile, 11, :with_pii)
+        Profile.update_all(
+          encrypted_pii_multi_region: nil,
+          encrypted_pii_recovery_multi_region: nil,
+        )
+        # rubocop:enable Rails/SkipsModelValidations
+
+        subject.perform_now
+
+        expect(profile_migrator).to have_received(:migrate!).exactly(10).times
+      end
+    end
+  end
+
+  describe '#find_profiles_to_migrate' do
+    it 'returns the profiles that need to be migrated' do
+      results = subject.find_profiles_to_migrate(statement_timeout: 120, profile_count: 2)
+
+      expect(results).to match_array(single_region_ciphertext_profiles)
+    end
+
+    context 'when a profile does not include PII' do
+      let(:profiles) { create_list(:profile, 4) }
+
+      it 'does not return the profile' do
+        results = subject.find_profiles_to_migrate(statement_timeout: 120, profile_count: 2)
+
+        expect(results).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -127,4 +127,33 @@ RSpec.describe Deploy::Activate do
       expect { subject.run }.to raise_error(Net::OpenTimeout)
     end
   end
+
+  describe '#setup_idp_config_symlinks' do
+    context 'with stale identity-idp-config symlinks' do
+      it 'deletes stale symlinks' do
+        setup_identity_idp_config(subject)
+        FileUtils.ln_s(
+          'fake',
+          subject.idp_logos_dir,
+          force: true,
+        )
+
+        subject.setup_idp_config_symlinks
+
+        expect(File.exist?('fake')).to eq false
+      end
+    end
+  end
+
+  def setup_identity_idp_config(subject)
+    FileUtils.mkdir_p(subject.checkout_dir)
+    FileUtils.mkdir_p(subject.idp_logos_dir)
+    FileUtils.mkdir_p(subject.config_logos_dir)
+    # Cloned config is symlinked into the root config/ folder
+    FileUtils.mkdir_p(File.join(subject.root, 'config'))
+
+    Deploy::Activate::FILES_TO_LINK.each do |file|
+      FileUtils.touch(File.join(subject.checkout_dir, "#{file}.yml"))
+    end
+  end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -46,26 +46,6 @@ RSpec.describe Profile do
     end
   end
 
-  describe '#pending_in_person_enrollment?' do
-    it 'returns true if the document_check component is usps' do
-      profile = create(:profile, proofing_components: { document_check: 'usps' })
-
-      expect(profile.pending_in_person_enrollment?).to eq(true)
-    end
-
-    it 'returns false if the document_check component is something else' do
-      profile = create(:profile, proofing_components: { document_check: 'something_else' })
-
-      expect(profile.pending_in_person_enrollment?).to eq(false)
-    end
-
-    it 'returns false if proofing_components is blank' do
-      profile = create(:profile, proofing_components: '')
-
-      expect(profile.pending_in_person_enrollment?).to eq(false)
-    end
-  end
-
   describe '#includes_phone_check?' do
     it 'returns true if the address_check component is lexis_nexis_address' do
       profile = create(:profile, proofing_components: { address_check: 'lexis_nexis_address' })

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -314,6 +314,43 @@ RSpec.describe User do
         expect(user.establishing_in_person_enrollment).to eq establishing_enrollment
       end
     end
+
+    describe '#has_in_person_enrollment?' do
+      it 'returns the establishing IPP enrollment that has an address' do
+        ProofingComponent.find_or_create_by(user: user).
+          update!(document_check: Idp::Constants::Vendors::USPS)
+
+        expect(user.has_in_person_enrollment?).to eq(true)
+      end
+    end
+
+    # We don't know yet if #establishing_in_person_enrollment is, in fact, `establishing`
+    # so we trust the pending profile in the meantime
+    describe '#has_establishing_in_person_enrollment_safe?' do
+      let(:new_user) { create(:user, :fully_registered) }
+      let(:proofing_components) { nil }
+      let(:new_pending_profile) do
+        create(
+          :profile,
+          :verify_by_mail_pending,
+          user: new_user,
+          proofing_components: proofing_components,
+        )
+      end
+      let!(:establishing_enrollment) do
+        create(
+          :in_person_enrollment,
+          :establishing,
+          profile: new_pending_profile,
+          user: new_user,
+        )
+      end
+
+      it 'returns the establishing IPP enrollment through the pending profile' do
+        # trust pending_profile
+        expect(new_user.has_establishing_in_person_enrollment_safe?).to eq(true)
+      end
+    end
   end
 
   describe 'deleting identities' do

--- a/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
+++ b/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Encryption::MultiRegionKmsMigration::ProfileMigrator do
+  let(:profile) { create(:profile, :with_pii) }
+  let!(:user_password) { profile.user.password }
+  let!(:personal_key) { PersonalKeyGenerator.new(profile.user).normalize(profile.personal_key) }
+
+  subject { described_class.new(profile) }
+
+  before do
+    allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
+  end
+
+  describe '#migrate!' do
+    context 'for a user without multi-region ciphertexts' do
+      before do
+        profile.update!(
+          encrypted_pii_multi_region: nil,
+          encrypted_pii_recovery_multi_region: nil,
+        )
+      end
+
+      it 'migrates the single-region ciphertext and saves it to the profile' do
+        subject.migrate!
+
+        pii_encryptor = Encryption::Encryptors::PiiEncryptor.new(user_password)
+
+        single_region_pii = pii_encryptor.decrypt(
+          Encryption::RegionalCiphertextPair.new(
+            single_region_ciphertext: profile.encrypted_pii,
+            multi_region_ciphertext: nil,
+          ),
+          user_uuid: profile.user.uuid,
+        )
+        multi_region_pii = pii_encryptor.decrypt(
+          Encryption::RegionalCiphertextPair.new(
+            single_region_ciphertext: nil,
+            multi_region_ciphertext: profile.encrypted_pii_multi_region,
+          ),
+          user_uuid: profile.user.uuid,
+        )
+        expect(profile.encrypted_pii).to_not eq(profile.encrypted_pii_multi_region)
+        expect(single_region_pii).to eq(multi_region_pii)
+
+        pii_recovery_encryptor = Encryption::Encryptors::PiiEncryptor.new(personal_key)
+
+        single_region_pii_recovery = pii_recovery_encryptor.decrypt(
+          Encryption::RegionalCiphertextPair.new(
+            single_region_ciphertext: profile.encrypted_pii_recovery,
+            multi_region_ciphertext: nil,
+          ),
+          user_uuid: profile.user.uuid,
+        )
+        multi_region_pii_recovery = pii_recovery_encryptor.decrypt(
+          Encryption::RegionalCiphertextPair.new(
+            single_region_ciphertext: nil,
+            multi_region_ciphertext: profile.encrypted_pii_recovery_multi_region,
+          ),
+          user_uuid: profile.user.uuid,
+        )
+        expect(
+          profile.encrypted_pii_recovery,
+        ).to_not eq(
+          profile.encrypted_pii_recovery_multi_region,
+        )
+        expect(single_region_pii_recovery).to eq(multi_region_pii_recovery)
+      end
+    end
+
+    context 'for a user with multi-region ciphertexts' do
+      it 'does not modify the profile record' do
+        expect { subject.migrate! }.to_not change { profile.attributes }
+      end
+    end
+
+    context 'for a user without multi-region or single-region ciphertexts' do
+      before do
+        profile.update!(
+          encrypted_pii: nil,
+          encrypted_pii_multi_region: nil,
+          encrypted_pii_recovery: nil,
+          encrypted_pii_recovery_multi_region: nil,
+        )
+      end
+
+      it 'does not modify the profile record' do
+        expect { subject.migrate! }.to raise_error(
+          RuntimeError,
+          "Profile##{profile.id} is missing encrypted_pii or encrypted_pii_recovery",
+        )
+      end
+    end
+  end
+end

--- a/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
+++ b/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
@@ -69,7 +69,16 @@ RSpec.describe Encryption::MultiRegionKmsMigration::ProfileMigrator do
 
     context 'for a user with multi-region ciphertexts' do
       it 'does not modify the profile record' do
-        expect { subject.migrate! }.to_not change { profile.attributes }
+        expect do
+          subject.migrate!
+        end.to_not change {
+          profile.attributes.slice(
+            :encrypted_pii,
+            :encrypted_pii_multi_region,
+            :encrypted_pii_recovery,
+            :encrypted_pii_recovery_multi_region,
+          )
+        }
       end
     end
 

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -1,5 +1,37 @@
 require 'rails_helper'
 
+RSpec.shared_examples 'sends no emails' do
+  it 'sends no emails' do
+    expect { subject.send_emails(time_due_for_reminder) }.
+      not_to change { ActionMailer::Base.deliveries.size }
+  end
+
+  it 'logs no events' do
+    expect { subject.send_emails(time_due_for_reminder) }.
+      not_to change { fake_analytics.events.count }
+  end
+end
+
+RSpec.shared_examples 'sends emails' do |expected_number_of_emails:,
+                                         expected_number_of_analytics_events:
+                                           expected_number_of_emails|
+  it "sends that user #{expected_number_of_emails} email(s)" do
+    expect { subject.send_emails(time_due_for_reminder) }.
+      to change { ActionMailer::Base.deliveries.size }.by(expected_number_of_emails)
+  end
+
+  it 'logs the email events' do
+    subject.send_emails(time_due_for_reminder)
+
+    expect(fake_analytics.events['IdV: gpo reminder email sent']&.size).to(
+      eq(expected_number_of_analytics_events),
+    )
+    expect(fake_analytics.events['Email Sent']&.size).to(
+      eq(expected_number_of_emails),
+    )
+  end
+end
+
 RSpec.describe GpoReminderSender do
   describe '#send_emails' do
     subject(:sender) { GpoReminderSender.new }
@@ -18,7 +50,7 @@ RSpec.describe GpoReminderSender do
     let(:time_not_yet_due) { time_due_for_reminder + 1.day }
     let(:time_yesterday) { Time.zone.now - 1.day }
 
-    def set_gpo_verification_pending_at(to_time)
+    def set_gpo_verification_pending_at(user, to_time)
       user.
         gpo_verification_pending_profile.
         update(gpo_verification_pending_at: to_time)
@@ -33,76 +65,62 @@ RSpec.describe GpoReminderSender do
     before { allow(Analytics).to receive(:new).and_return(fake_analytics) }
 
     context 'when no users need a reminder' do
-      before { set_gpo_verification_pending_at(time_not_yet_due) }
+      before { set_gpo_verification_pending_at(user, time_not_yet_due) }
 
-      it 'sends no emails' do
-        expect { subject.send_emails(time_due_for_reminder) }.
-          to change { ActionMailer::Base.deliveries.size }.by(0)
-      end
-
-      it 'logs no events' do
-        expect { subject.send_emails(time_due_for_reminder) }.
-          not_to change { fake_analytics.events.count }
-      end
+      include_examples 'sends no emails'
     end
 
-    context 'when a user is due for a reminder' do
-      before { set_gpo_verification_pending_at(time_due_for_reminder) }
-
-      it 'sends that user an email' do
-        expect { subject.send_emails(time_due_for_reminder) }.
-          to change { ActionMailer::Base.deliveries.size }.by(1)
+    context 'when a user has requested two letters' do
+      before do
+        set_gpo_verification_pending_at(user, time_due_for_reminder - 2.days)
+        new_confirmation_code = create(:gpo_confirmation_code)
+        user.gpo_verification_pending_profile.gpo_confirmation_codes << new_confirmation_code
       end
 
-      it 'logs an event' do
-        subject.send_emails(time_due_for_reminder)
-
-        expect(fake_analytics).to have_logged_event('IdV: gpo reminder email sent')
-      end
+      include_examples 'sends emails', expected_number_of_emails: 2
 
       it 'updates the GPO verification code `reminder_sent_at`' do
         subject.send_emails(time_due_for_reminder)
 
-        expect(gpo_confirmation_code.reminder_sent_at).to be_within(1).of(Time.zone.now)
+        expect(gpo_confirmation_code.reminder_sent_at).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+
+    context 'when a user is due for a reminder' do
+      before { set_gpo_verification_pending_at(user, time_due_for_reminder) }
+
+      include_examples 'sends emails', expected_number_of_emails: 1
+
+      it 'updates the GPO verification code `reminder_sent_at`' do
+        subject.send_emails(time_due_for_reminder)
+
+        expect(gpo_confirmation_code.reminder_sent_at).to be_within(1.second).of(Time.zone.now)
       end
 
       context 'and the user has multiple emails' do
         let(:user) { create(:user, :with_pending_gpo_profile, :with_multiple_emails) }
 
-        it 'sends an email to all of them' do
-          expect { subject.send_emails(time_due_for_reminder) }.
-            to change { ActionMailer::Base.deliveries.size }.by(2)
+        include_examples 'sends emails',
+                         expected_number_of_emails: 2,
+                         expected_number_of_analytics_events: 1
+
+        it 'updates the GPO verification code `reminder_sent_at`' do
+          subject.send_emails(time_due_for_reminder)
+
+          expect(gpo_confirmation_code.reminder_sent_at).to be_within(1.second).of(Time.zone.now)
         end
       end
 
       context 'but the user has cancelled gpo verification' do
-        before do
-          Idv::CancelVerificationAttempt.new(user: user).call
-        end
+        before { Idv::CancelVerificationAttempt.new(user: user).call }
 
-        it 'does not send that user an email' do
-          expect { subject.send_emails(time_due_for_reminder) }.
-            to change { ActionMailer::Base.deliveries.size }.by(0)
-        end
-
-        it 'logs no events' do
-          expect { subject.send_emails(time_due_for_reminder) }.
-            not_to change { fake_analytics.events.count }
-        end
+        include_examples 'sends no emails'
       end
 
       context 'but a reminder has already been sent' do
         before { set_reminder_sent_at(time_yesterday) }
 
-        it 'does not send that user an email' do
-          expect { subject.send_emails(time_due_for_reminder) }.
-            to change { ActionMailer::Base.deliveries.size }.by(0)
-        end
-
-        it 'logs no events' do
-          expect { subject.send_emails(time_due_for_reminder) }.
-            not_to change { fake_analytics.events.count }
-        end
+        include_examples 'sends no emails'
       end
 
       context 'but the user has completed gpo verification' do
@@ -126,16 +144,39 @@ RSpec.describe GpoReminderSender do
           ).submit
         end
 
-        it 'does not send that user an email' do
-          expect { subject.send_emails(time_due_for_reminder) }.
-            to change { ActionMailer::Base.deliveries.size }.by(0)
-        end
-
-        it 'logs no events' do
-          expect { subject.send_emails(time_due_for_reminder) }.
-            not_to change { fake_analytics.events.count }
-        end
+        include_examples 'sends no emails'
       end
+
+      context 'but the user has changed their password' do
+        before { user.gpo_verification_pending_profile.deactivate(:password_reset) }
+
+        include_examples 'sends no emails'
+      end
+    end
+
+    context 'when a user is due for a reminder from too long ago' do
+      let(:max_age_to_send_letter_in_days) { 42 }
+
+      before do
+        set_gpo_verification_pending_at(user, (max_age_to_send_letter_in_days + 1).days.ago)
+        allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).
+          and_return(max_age_to_send_letter_in_days)
+      end
+
+      include_examples 'sends no emails'
+    end
+
+    context 'a user in the in-person flow who also requested a GPO letter' do
+      let(:user) { create(:user, :with_pending_in_person_enrollment) }
+
+      before do
+        gpo_code = create(:gpo_confirmation_code)
+        user.pending_profile.gpo_confirmation_codes << gpo_code
+        user.pending_profile.gpo_verification_pending_at = time_due_for_reminder
+        user.pending_profile.save
+      end
+
+      include_examples 'sends emails', expected_number_of_emails: 1
     end
   end
 end

--- a/spec/support/idv_examples/gpo_otp_verification.rb
+++ b/spec/support/idv_examples/gpo_otp_verification.rb
@@ -29,7 +29,9 @@ RSpec.shared_examples 'gpo otp verification' do
   it 'renders an error for an expired GPO OTP' do
     sign_in_live_with_2fa(user)
 
-    gpo_confirmation_code.update(code_sent_at: 11.days.ago)
+    gpo_confirmation_code.update(
+      code_sent_at: (IdentityConfig.store.usps_confirmation_max_days + 1).days.ago,
+    )
     fill_in t('idv.gpo.form.otp_label'), with: otp
     click_button t('idv.gpo.form.submit')
 

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -222,6 +222,15 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_passed_proofing_supported_secondary_id_type_results
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      status: 200,
+      body: UspsInPersonProofing::Mock::
+        Fixtures.request_passed_proofing_supported_secondary_id_type_results_response,
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_passed_proofing_unsupported_status_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
       status: 200,

--- a/spec/views/idv/agreement/show.html.erb_spec.rb
+++ b/spec/views/idv/agreement/show.html.erb_spec.rb
@@ -1,10 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'idv/agreement/show' do
-  let(:flow_session) { {} }
-
   before do
-    allow(view).to receive(:flow_session).and_return(flow_session)
     allow(view).to receive(:user_signing_up?).and_return(false)
     allow(view).to receive(:url_for).and_wrap_original do |method, *args, &block|
       method.call(*args, &block)

--- a/spec/views/idv/getting_started/show.html.erb_spec.rb
+++ b/spec/views/idv/getting_started/show.html.erb_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'idv/getting_started/show' do
-  let(:flow_session) { {} }
   let(:user_fully_authenticated) { true }
   let(:sp_name) { nil }
   let(:user) { create(:user) }
@@ -12,7 +11,6 @@ RSpec.describe 'idv/getting_started/show' do
     @title = t('doc_auth.headings.getting_started', sp_name: @sp_name)
     allow(@decorated_session).to receive(:sp_name).and_return(sp_name)
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
-    allow(view).to receive(:flow_session).and_return(flow_session)
     allow(view).to receive(:user_fully_authenticated?).and_return(user_fully_authenticated)
     allow(view).to receive(:user_signing_up?).and_return(false)
     allow(view).to receive(:url_for).and_wrap_original do |method, *args, &block|

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@18f/identity-design-system@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@18f/identity-design-system/-/identity-design-system-7.0.1.tgz#5303dbf27aff48b5ed14cffd6e21cc39d44595e5"
-  integrity sha512-5KblBGmHLrsLGsF0cCThnkBWG0ZK+sP9NQln4FyEYXs0dzzGr0duhtqnMfGUZr6dj6ziZZjFCTmP8WNlkkpclA==
+"@18f/identity-design-system@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@18f/identity-design-system/-/identity-design-system-7.1.0.tgz#ddde006a4ee1371fed75dda6cd97ef0cc929331c"
+  integrity sha512-/DChj/p9hju15HMQCtukId2POIhHo25SjZzKh11bklkTICLOBEpPc1GRIkWUIDv5WU/N5DtX1saFafqs+HKnEA==
   dependencies:
     "@uswds/uswds" "^3.4.1"
 


### PR DESCRIPTION
## User-Facing Improvements
- IdV: Added state ID number to 'verify your info' screen ([#9090](https://github.com/18F/identity-idp/pull/9090))
- In-person Proofing: Pass enrollments with supported secondary ID types ([#9123](https://github.com/18F/identity-idp/pull/9123))

## Bug Fixes
- Dashboard Integration: Fix 500 with blank token when attempting to update service providers ([#9102](https://github.com/18F/identity-idp/pull/9102))
- Gitlab CI: Hardcode container tag instead of using protected variable ([#9113](https://github.com/18F/identity-idp/pull/9113))
- Verify by Mail: Fixed database query for reminder letters ([#9080](https://github.com/18F/identity-idp/pull/9080))
- Service Provider Setup: Call correct method to delete symlink (https://github.com/18F/identity-idp/pull/9126)

## Internal
- Code Quality: Remove unused code ([#9121](https://github.com/18F/identity-idp/pull/9121))
- Dependencies: Update dependencies to resolve security advisories ([#9107](https://github.com/18F/identity-idp/pull/9107))
- IPP enrollment updates by email: Add configurable email address for status updates ([#9115](https://github.com/18F/identity-idp/pull/9115))
- IdV IPP: Consolidate in_person_enrollment? methods ([#9052](https://github.com/18F/identity-idp/pull/9052))
- In-Person Proofing: Change Address Search i18n lib ([#9109](https://github.com/18F/identity-idp/pull/9109))
- In-person proofing: Backfill `in_person_pending_at` column ([#9097](https://github.com/18F/identity-idp/pull/9097))
- Multi-Region KMS: A multi-region KMS pii migrator was added for future use to encrypt and save encrypted pii and encrypted recovery pii columns with the new multi-region KMS key after decrypting the KMS layer with the single region KMS key. ([#9114](https://github.com/18F/identity-idp/pull/9114))
- Multi-Region KMS: A MultiRegionKmsMigration::ProfileMigrationJob job was added to query for profiles that are not encrypted with a multi-region KMS key and invoke the MultiRegionKmsMigration::ProfileMigrator added previously to migrate the profiles from being encrypted with a single-region KMS key only to being encrypted with both a single-region KMS key and a multi-region KMS key in order to support the larger migration from a single-region KMS key to a multi-region KMS key. ([#9116](https://github.com/18F/identity-idp/pull/9116))