### PR TITLE
Use correct method to delete symlink in activate script

### DIFF
--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -61,7 +61,7 @@ module Deploy
       Dir.entries(idp_logos_dir).each do |name|
         next if name.start_with?('.')
         target = File.join(idp_logos_dir, name)
-        File.rm(target) if File.symlink?(target) && !File.file?(target)
+        FileUtils.rm(target) if File.symlink?(target) && !File.file?(target)
       end
       # Public assets: sp-logos
       # Inject the logo files into the app's asset folder. deploy/activate is

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -6,6 +6,10 @@ require 'yaml'
 
 module Deploy
   class Activate
+    FILES_TO_LINK =
+      %w[agencies iaa_gtcs iaa_orders iaa_statuses integration_statuses integrations
+         partner_account_statuses partner_accounts service_providers]
+
     attr_reader :logger, :s3_client
 
     def initialize(
@@ -32,34 +36,11 @@ module Deploy
       )
     end
 
-    private
-
-    # Clone the private-but-not-secret git repo
-    def clone_idp_config
-      private_git_repo_url = ENV.fetch(
-        'IDP_private_config_repo',
-        'git@github.com:18F/identity-idp-config.git',
-      )
-      checkout_dir = File.join(root, idp_config_checkout_name)
-
-      cmd = ['git', 'clone', '--depth', '1', '--branch', 'main', private_git_repo_url, checkout_dir]
-      logger.info('+ ' + cmd.join(' '))
-      Subprocess.check_call(cmd)
-    end
-
-    def idp_config_checkout_name
-      'identity-idp-config'
-    end
-
     # Set up symlinks into identity-idp-config needed for the idp to make use
     # of relevant config and assets.
     #
     def setup_idp_config_symlinks
-      files_to_link =
-        %w[agencies iaa_gtcs iaa_orders iaa_statuses integration_statuses integrations
-           partner_account_statuses partner_accounts service_providers]
-
-      files_to_link.each do |file|
+      FILES_TO_LINK.each do |file|
         symlink_verbose(
           File.join(root, idp_config_checkout_name, "#{file}.yml"),
           File.join(root, "config/#{file}.yml"),
@@ -73,7 +54,6 @@ module Deploy
         File.join(root, 'certs/sp'),
       )
 
-      idp_logos_dir = File.join(root, 'public/assets/sp-logos')
       FileUtils.mkdir_p(idp_logos_dir)
 
       # Invalid symlinks can cause issues in the build process, so this step iterates through the
@@ -87,15 +67,48 @@ module Deploy
       # Inject the logo files into the app's asset folder. deploy/activate is
       # run before deploy/build-post-config, so these will be picked up by the
       # rails asset pipeline.
-      logos_dir = File.join(root, idp_config_checkout_name, 'public/assets/images/sp-logos')
-      Dir.entries(logos_dir).each do |name|
+      Dir.entries(config_logos_dir).each do |name|
         next if name.start_with?('.')
-        target = File.join(logos_dir, name)
+        target = File.join(config_logos_dir, name)
         link = File.join(root, 'app/assets/images/sp-logos', name)
         symlink_verbose(target, link, force: true)
         link = File.join(root, 'public/assets/sp-logos', name)
         symlink_verbose(target, link, force: true)
       end
+    end
+
+    def root
+      @root || File.expand_path('../../../', __FILE__)
+    end
+
+    def idp_logos_dir
+      File.join(root, 'public/assets/sp-logos')
+    end
+
+    def config_logos_dir
+      File.join(checkout_dir, 'public/assets/images/sp-logos')
+    end
+
+    def checkout_dir
+      File.join(root, idp_config_checkout_name)
+    end
+
+    private
+
+    # Clone the private-but-not-secret git repo
+    def clone_idp_config
+      private_git_repo_url = ENV.fetch(
+        'IDP_private_config_repo',
+        'git@github.com:18F/identity-idp-config.git',
+      )
+
+      cmd = ['git', 'clone', '--depth', '1', '--branch', 'main', private_git_repo_url, checkout_dir]
+      logger.info('+ ' + cmd.join(' '))
+      Subprocess.check_call(cmd)
+    end
+
+    def idp_config_checkout_name
+      'identity-idp-config'
     end
 
     def symlink_verbose(dest, link, force: false)
@@ -122,10 +135,6 @@ module Deploy
       logger = Logger.new(STDOUT)
       logger.progname = 'deploy/activate'
       logger
-    end
-
-    def root
-      @root || File.expand_path('../../../', __FILE__)
     end
 
     def geolocation_db_path

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -127,4 +127,33 @@ RSpec.describe Deploy::Activate do
       expect { subject.run }.to raise_error(Net::OpenTimeout)
     end
   end
+
+  describe '#setup_idp_config_symlinks' do
+    context 'with stale identity-idp-config symlinks' do
+      it 'deletes stale symlinks' do
+        setup_identity_idp_config(subject)
+        FileUtils.ln_s(
+          'fake',
+          subject.idp_logos_dir,
+          force: true,
+        )
+
+        subject.setup_idp_config_symlinks
+
+        expect(File.exist?('fake')).to eq false
+      end
+    end
+  end
+
+  def setup_identity_idp_config(subject)
+    FileUtils.mkdir_p(subject.checkout_dir)
+    FileUtils.mkdir_p(subject.idp_logos_dir)
+    FileUtils.mkdir_p(subject.config_logos_dir)
+    # Cloned config is symlinked into the root config/ folder
+    FileUtils.mkdir_p(File.join(subject.root, 'config'))
+
+    Deploy::Activate::FILES_TO_LINK.each do |file|
+      FileUtils.touch(File.join(subject.checkout_dir, "#{file}.yml"))
+    end
+  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

In #8786, we added a section of code to delete invalid symlinks, but it used the wrong method to call for the deletion. This PR adds a spec to cover the behavior and fixes the bug by calling `FileUtils.rm` instead of `File.rm` (which does not exist) 

This PR slightly refactors some of the methods and makes some of them public so it is easier to interact with in the tests.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
