### PR TITLE
Add feature flag for resetting account passwords when receiving authorization fraud event

### DIFF
--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -43,7 +43,8 @@ class SecurityEventForm
         occurred_at: occurred_at,
       )
 
-      if event_type == SecurityEvent::AUTHORIZATION_FRAUD_DETECTED
+      if event_type == SecurityEvent::AUTHORIZATION_FRAUD_DETECTED &&
+         IdentityConfig.store.reset_password_on_auth_fraud_event
         ResetUserPassword.new(user: user).call
       end
     end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -279,6 +279,7 @@ requests_per_ip_period: 300
 requests_per_ip_track_only_mode: false
 reset_password_email_max_attempts: 20
 reset_password_email_window_in_minutes: 60
+reset_password_on_auth_fraud_event: true
 risc_notifications_local_enabled: false
 risc_notifications_active_job_enabled: false
 risc_notifications_rate_limit_interval: 60

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -403,6 +403,7 @@ class IdentityConfig
     config.add(:requests_per_ip_track_only_mode, type: :boolean)
     config.add(:reset_password_email_max_attempts, type: :integer)
     config.add(:reset_password_email_window_in_minutes, type: :integer)
+    config.add(:reset_password_on_auth_fraud_event, type: :boolean)
     config.add(:risc_notifications_active_job_enabled, type: :boolean)
     config.add(:risc_notifications_local_enabled, type: :boolean)
     config.add(:risc_notifications_rate_limit_interval, type: :integer)

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -70,8 +70,30 @@ RSpec.describe SecurityEventForm do
     context 'for authorization fraud events' do
       let(:event_type) { SecurityEvent::AUTHORIZATION_FRAUD_DETECTED }
 
-      it 'resets the user password for authorization fraud detected events' do
-        expect { submit }.to(change { user.reload.encrypted_password_digest })
+      context 'reset_password_on_auth_fraud_event is enabled' do
+        before do
+          allow(IdentityConfig.store).to(
+            receive(:reset_password_on_auth_fraud_event).
+            and_return(true),
+          )
+        end
+
+        it 'resets the user password for authorization fraud detected events' do
+          expect { submit }.to(change { user.reload.encrypted_password_digest })
+        end
+      end
+
+      context 'reset_password_on_auth_fraud_event is disabled' do
+        before do
+          allow(IdentityConfig.store).to(
+            receive(:reset_password_on_auth_fraud_event).
+            and_return(false),
+          )
+        end
+
+        it 'does not reset the user password for authorization fraud detected events' do
+          expect { submit }.to_not(change { user.reload.encrypted_password_digest })
+        end
       end
 
       it 'creates a password_invalidated event' do


### PR DESCRIPTION
## 🛠 Summary of changes

Allows us to enable and disable the password reset functionality when we receive authorization fraud security events. Based on discussion [here](https://gsa-tts.slack.com/archives/C03A12WPCLW/p1693516061825139).


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
