### PR TITLE
Move user suspended check for sign-in

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,6 +1,7 @@
 class AccountsController < ApplicationController
   include RememberDeviceConcern
   before_action :confirm_two_factor_authenticated
+  before_action :confirm_user_is_not_suspended
 
   layout 'account_side_nav'
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,7 +1,6 @@
 class AccountsController < ApplicationController
   include RememberDeviceConcern
   before_action :confirm_two_factor_authenticated
-  before_action :confirm_user_is_not_suspended
 
   layout 'account_side_nav'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -218,6 +218,7 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(_user)
     accept_rules_of_use_url ||
+      user_suspended_url ||
       service_provider_mfa_setup_url ||
       add_piv_cac_setup_url ||
       fix_broken_personal_key_url ||
@@ -228,7 +229,6 @@ class ApplicationController < ActionController::Base
 
   def signed_in_url
     return user_two_factor_authentication_url unless user_fully_authenticated?
-    return user_please_call_url if current_user.suspended?
     return reactivate_account_url if user_needs_to_reactivate_account?
     return url_for_pending_profile_reason if user_has_pending_profile?
     return backup_code_reminder_url if user_needs_backup_code_reminder?
@@ -291,10 +291,6 @@ class ApplicationController < ActionController::Base
       two_factor_enabled?
   end
 
-  def confirm_user_is_not_suspended
-    redirect_to user_please_call_url if current_user.suspended?
-  end
-
   def confirm_two_factor_authenticated
     authenticate_user!(force: true)
 
@@ -348,6 +344,10 @@ class ApplicationController < ActionController::Base
 
   def prompt_to_verify_sp_required_mfa
     redirect_to sp_required_mfa_verification_url
+  end
+
+  def user_suspended_url
+    user_please_call_url if current_user.suspended?
   end
 
   def sp_required_mfa_verification_url

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -291,6 +291,10 @@ class ApplicationController < ActionController::Base
       two_factor_enabled?
   end
 
+  def confirm_user_is_not_suspended
+    redirect_to user_suspended_url if user_suspended_url
+  end
+
   def confirm_two_factor_authenticated
     authenticate_user!(force: true)
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe AccountsController do
         :before,
         :confirm_two_factor_authenticated,
       )
+      expect(subject).to have_actions(
+        :before,
+        :confirm_user_is_not_suspended,
+      )
     end
   end
 
@@ -71,6 +75,17 @@ RSpec.describe AccountsController do
 
         expect(response).to render_template(:show)
         expect(response).to render_template(partial: 'accounts/_pending_profile_gpo')
+      end
+    end
+
+    context 'when a user is suspended' do
+      it 'redirects to contact support page' do
+        user = create(:user, :fully_registered, :suspended)
+
+        sign_in user
+        get :show
+
+        expect(response).to redirect_to(user_please_call_url)
       end
     end
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe AccountsController do
         :before,
         :confirm_two_factor_authenticated,
       )
-      expect(subject).to have_actions(
-        :before,
-        :confirm_user_is_not_suspended,
-      )
     end
   end
 
@@ -75,22 +71,6 @@ RSpec.describe AccountsController do
 
         expect(response).to render_template(:show)
         expect(response).to render_template(partial: 'accounts/_pending_profile_gpo')
-      end
-    end
-
-    context 'when a user is suspended' do
-      render_views
-      it 'redirects to contact support page' do
-        user = create(
-          :user,
-          :fully_registered,
-        )
-
-        user.suspend!
-        sign_in user
-        get :show
-
-        expect(response).to redirect_to(user_please_call_url)
       end
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -190,22 +190,22 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe '#confirm_user_is_not_suspended' do
-    controller do
-      before_action :confirm_user_is_not_suspended
+  describe '#user_suspended_url' do
+    before { sign_in(user) }
 
-      def index
-        render plain: 'Hello'
+    context 'when user is suspended' do
+      let(:user) { create(:user, :suspended) }
+
+      it 'is the please call url' do
+        expect(controller.send(:user_suspended_url)).to eq(user_please_call_url)
       end
     end
 
-    context 'when user is suspended' do
-      it 'redirects to users please call page' do
-        user = create(:user, :suspended)
-        sign_in user
-        get :index
+    context 'when user is not suspended' do
+      let(:user) { create(:user) }
 
-        expect(response).to redirect_to user_please_call_url
+      it 'is nil' do
+        expect(controller.send(:user_suspended_url)).to be_nil
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -190,6 +190,26 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe '#confirm_user_is_not_suspended' do
+    controller do
+      before_action :confirm_user_is_not_suspended
+
+      def index
+        render plain: 'Hello'
+      end
+    end
+
+    context 'when user is suspended' do
+      it 'redirects to users please call page' do
+        user = create(:user, :suspended)
+        sign_in user
+        get :index
+
+        expect(response).to redirect_to user_please_call_url
+      end
+    end
+  end
+
   describe '#user_suspended_url' do
     before { sign_in(user) }
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -62,6 +62,21 @@ RSpec.feature 'Sign in' do
     expect(current_path).to eq account_path
   end
 
+  scenario 'user is suspended, gets show please call page after 2fa' do
+    user = create(:user, :fully_registered, :suspended)
+    service_provider = ServiceProvider.find_by(issuer: OidcAuthHelper::OIDC_IAL1_ISSUER)
+    IdentityLinker.new(user, service_provider).link_identity(
+      verified_attributes: %w[openid email],
+    )
+
+    visit_idp_from_sp_with_ial1(:oidc)
+    fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+
+    expect(current_path).to eq(user_please_call_path)
+  end
+
   scenario 'user opts to add piv/cac card' do
     perform_steps_to_get_to_add_piv_cac_during_sign_up
     nonce = piv_cac_nonce_from_form_action


### PR DESCRIPTION
## Background

I had a chat with @aduth about the suspension we implemented in #8755, and we think that the code would catch users signing directly in, not through an SP

## What's Changed

- Moves logic around in `application_controller.rb`, net result should be about the same
- Adds an acceptance spec for suspended users (there were none as far as I could tell)
    - check specifically for behavior for signing in from an SP
