### PR TITLE
Fix Acuant Error Handler Function Naming

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.tsx
@@ -129,7 +129,7 @@ interface AcuantCameraUICallbacks {
   /**
    * Callback that occurs when there is a failure.
    */
-  onFailure: (error?: AcuantCaptureFailureError, code?: string) => void;
+  onError: (error?: AcuantCaptureFailureError, code?: string) => void;
 }
 
 type AcuantCameraUIStart = (
@@ -330,7 +330,7 @@ function AcuantCamera({
         {
           onCaptured: onCropStart,
           onCropped,
-          onFailure: onImageCaptureFailure,
+          onError: onImageCaptureFailure,
         },
         onFailureCallbackWithOptions,
         textOptions,

--- a/app/javascript/packages/document-capture/components/acuant-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.tsx
@@ -130,11 +130,6 @@ interface AcuantCameraUICallbacks {
    * Callback that occurs when there is a failure.
    */
   onError: (error?: AcuantCaptureFailureError, code?: string) => void;
-  /**
-   * Renamed in a SDK version change. Either 11.8.1 -> 11.8.2 or 11.8.2 -> 11.9.1
-   * `onError` is more current
-   */
-  onFailure: (error?: AcuantCaptureFailureError, code?: string) => void;
 }
 
 type AcuantCameraUIStart = (
@@ -336,7 +331,6 @@ function AcuantCamera({
           onCaptured: onCropStart,
           onCropped,
           onError: onImageCaptureFailure,
-          onFailure: onImageCaptureFailure,
         },
         onFailureCallbackWithOptions,
         textOptions,

--- a/app/javascript/packages/document-capture/components/acuant-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-camera.tsx
@@ -130,6 +130,11 @@ interface AcuantCameraUICallbacks {
    * Callback that occurs when there is a failure.
    */
   onError: (error?: AcuantCaptureFailureError, code?: string) => void;
+  /**
+   * Renamed in a SDK version change. Either 11.8.1 -> 11.8.2 or 11.8.2 -> 11.9.1
+   * `onError` is more current
+   */
+  onFailure: (error?: AcuantCaptureFailureError, code?: string) => void;
 }
 
 type AcuantCameraUIStart = (
@@ -331,6 +336,7 @@ function AcuantCamera({
           onCaptured: onCropStart,
           onCropped,
           onError: onImageCaptureFailure,
+          onFailure: onImageCaptureFailure,
         },
         onFailureCallbackWithOptions,
         textOptions,

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -334,8 +334,8 @@ describe('document-capture/components/acuant-capture', () => {
         </AnalyticsContext.Provider>,
       );
 
-      const start = async ({ onFailure }) => {
-        await onFailure('Camera not supported.', 'start-fail-code');
+      const start = async ({ onError }) => {
+        await onError('Camera not supported.', 'start-fail-code');
       };
 
       initialize({
@@ -412,11 +412,11 @@ describe('document-capture/components/acuant-capture', () => {
 
       initialize({
         start: sinon.stub().callsFake((callbacks) => {
-          const { onFailure } = callbacks;
+          const { onError } = callbacks;
           setTimeout(() => {
             const code = 'sequence-break-code';
             document.cookie = `AcuantCameraHasFailed=${code}`;
-            onFailure('iOS 15 sequence break', code);
+            onError('iOS 15 sequence break', code);
           }, 0);
         }),
       });
@@ -495,8 +495,8 @@ describe('document-capture/components/acuant-capture', () => {
         </AnalyticsContext.Provider>,
       );
 
-      const start = async ({ onFailure }) => {
-        await onFailure(new Error());
+      const start = async ({ onError }) => {
+        await onError(new Error());
       };
 
       initialize({
@@ -538,8 +538,8 @@ describe('document-capture/components/acuant-capture', () => {
       );
       outsideInput = getByTestId('outside-input');
 
-      const start = async ({ onFailure }) => {
-        await onFailure(new Error());
+      const start = async ({ onError }) => {
+        await onError(new Error());
       };
 
       initialize({

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -65,8 +65,8 @@ describe('document-capture/components/document-capture', () => {
     // `onError` called with an Error instance is indication of camera access declined, which is
     // expected to show both field-level and step error.
     // See: https://github.com/18F/identity-idp/blob/164231d/app/javascript/packages/document-capture/components/acuant-capture.jsx#L114
-    window.AcuantCameraUI.start.callsFake(({ _onCaptured, _onCropped, onFailure }) =>
-      onFailure(new Error()),
+    window.AcuantCameraUI.start.callsFake(({ _onCaptured, _onCropped, onError }) =>
+      onError(new Error()),
     );
 
     await userEvent.click(getByLabelText('doc_auth.headings.document_capture_front'));


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-10900

## 🛠 Summary of changes

This work changes the name of an error handling function to what the AcuantSDK expects.

## 📜 Testing Plan

Extracted from the slack thread about this bug [here](https://gsa-tts.slack.com/archives/C056RD1NEHW/p1693504572901689?thread_ts=1693489473.008259&cid=C056RD1NEHW).

- [ ] Change your settings like this and restart your dev server. You can also do `11.8.2` to test that version only.
```yml
idv_acuant_sdk_version_default: '11.9.1'
idv_acuant_sdk_version_alternate: '11.9.1'
```
- [ ] Get to the document upload page with FRONT and BACK image zones.
- [ ] Click the "FRONT" upload zone, and deny the camera permissions.
- [ ] Before this PR, you should get a white screen with an X in the corner. Clicking the "X" then trying to upload an image again doesn't give you the camera permissions popup again.
- [ ] After this PR, you should be returned to the document upload screen and see an error. Trying to upload again should give you the camera permissions popup again.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Camera permissions popup</summary>

![IMG_0417](https://github.com/18F/identity-idp/assets/6818839/abbde8e3-76be-4d66-acc4-fcd7c77927bb)

</details>

<details>
<summary>Before: White screen with X in the corner</summary>

![image (1)](https://github.com/18F/identity-idp/assets/6818839/29ab83f6-4a55-4170-a8a9-3055b0be0345)

</details>

<details>
<summary>After: Error message</summary>

![IMG_0416](https://github.com/18F/identity-idp/assets/6818839/9bf2b717-f0a2-4e49-bc08-72c806d0e9b7)

</details>
