### PR TITLE
Avoid duplicate analytics event for PIV/CAC login

### DIFF
--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -66,8 +66,6 @@ module Users
       user = piv_cac_login_form.user
       sign_in(:user, user)
 
-      mark_user_session_authenticated(:piv_cac)
-
       save_piv_cac_information(
         subject: piv_cac_login_form.x509_dn,
         issuer: piv_cac_login_form.x509_issuer,

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Users::PivCacLoginController do
           it 'tracks the user_marked_authed event' do
             expect(@analytics).to have_received(:track_event).with(
               'User marked authenticated',
-              { authentication_type: :piv_cac },
+              { authentication_type: :valid_2fa },
             )
           end
 


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-10022](https://cm-jira.usa.gov/browse/LG-10022) (#9124)

## 🛠 Summary of changes

Updates PIV/CAC login logic to avoid a duplicate call to `mark_user_session_authenticated`. [Among other things](https://github.com/18F/identity-idp/blob/ce54c15e713731051d86b98895018db9a7cd2247/app/controllers/concerns/two_factor_authenticatable_methods.rb#L165-L169), this method logs an analytics event for "User marked authenticated", and was used in #9124 as the point at which to increment the user's sign-in count. The duplicate logging was causing double-counting in the logic of #9124.

The call to `mark_user_session_authenticated` removed here is unnecessary because it is already called indirectly a few lines below through `handle_valid_verification_for_authentication_context`:

https://github.com/18F/identity-idp/blob/ce54c15e713731051d86b98895018db9a7cd2247/app/controllers/users/piv_cac_login_controller.rb#L77-L79

https://github.com/18F/identity-idp/blob/ce54c15e713731051d86b98895018db9a7cd2247/app/controllers/concerns/two_factor_authenticatable_methods.rb#L153-L155

It's also not necessary to have a dedicated event for PIV-specific logins, since we already log a separate analytics event "PIV/CAC Login" for this interaction:

https://github.com/18F/identity-idp/blob/ce54c15e713731051d86b98895018db9a7cd2247/app/controllers/users/piv_cac_login_controller.rb#L47

## 📜 Testing Plan

Easiest to test with PIV/CAC simulator in local development. In `config/application.yml`:

```yml
identity_pki_disabled: true
```

1. Go to http://localhost:3000
2. Click "Sign in with your government employee ID"
3. Sign in with PIV
4. In a terminal process, run `tail -n 5 log/events.log | jq .name`

**Before:** There'd be three events (2 unique) corresponding to the successful login: "PIV/CAC Login", "User marked authenticated", "User marked authenticated"
**After:** There's two events (2 unique) corresponding to the successful login: "PIV/CAC Login", "User marked authenticated"