### PR TITLE
LG-10871: Direct "Learn more" Face/Touch link to help article

### DIFF
--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -27,6 +27,7 @@ module Users
         user_opted_remember_device_cookie: user_opted_remember_device_cookie,
         remember_device_default: remember_device_default,
         platform_authenticator: @platform_authenticator,
+        url_options:,
       )
       properties = result.to_h.merge(analytics_properties)
       analytics.webauthn_setup_visit(**properties)
@@ -54,6 +55,7 @@ module Users
         user_opted_remember_device_cookie: user_opted_remember_device_cookie,
         remember_device_default: remember_device_default,
         platform_authenticator: @platform_authenticator,
+        url_options:,
       )
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)

--- a/app/presenters/webauthn_setup_presenter.rb
+++ b/app/presenters/webauthn_setup_presenter.rb
@@ -1,13 +1,17 @@
 class WebauthnSetupPresenter < SetupPresenter
+  include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::TranslationHelper
+
+  attr_reader :url_options
 
   def initialize(
     current_user:,
     user_fully_authenticated:,
     user_opted_remember_device_cookie:,
     remember_device_default:,
-    platform_authenticator:
+    platform_authenticator:,
+    url_options:
   )
     super(
       current_user: current_user,
@@ -17,6 +21,7 @@ class WebauthnSetupPresenter < SetupPresenter
     )
 
     @platform_authenticator = platform_authenticator
+    @url_options = url_options
   end
 
   def image_path
@@ -54,21 +59,19 @@ class WebauthnSetupPresenter < SetupPresenter
       t(
         'forms.webauthn_platform_setup.intro_html',
         app_name: APP_NAME,
-        link: intro_link,
+        link: link_to(
+          t('forms.webauthn_platform_setup.intro_link_text'),
+          help_center_redirect_path(
+            category: 'trouble-signing-in',
+            article: 'face-or-touch-unlock',
+            flow: :two_factor_authentication,
+            step: :webauthn_setup,
+          ),
+        ),
       )
     else
       t('forms.webauthn_setup.intro_html')
     end
-  end
-
-  def intro_link
-    link_to(
-      t('forms.webauthn_platform_setup.intro_link_text'),
-      MarketingSite.help_center_article_url(
-        category: 'get-started',
-        article: 'authentication-options',
-      ),
-    )
   end
 
   def nickname_label

--- a/spec/presenters/webauthn_setup_presenter_spec.rb
+++ b/spec/presenters/webauthn_setup_presenter_spec.rb
@@ -1,17 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe WebauthnSetupPresenter do
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::UrlHelper
+
   let(:user) { build(:user) }
   let(:user_fully_authenticated) { false }
   let(:user_opted_remember_device_cookie) { true }
   let(:remember_device_default) { true }
   let(:platform_authenticator) { false }
-  let(:intro_link) do
-    MarketingSite.help_center_article_url(
-      category: 'get-started',
-      article: 'authentication-options',
-    )
-  end
   let(:presenter) do
     described_class.new(
       current_user: user,
@@ -19,6 +16,7 @@ RSpec.describe WebauthnSetupPresenter do
       user_opted_remember_device_cookie: user_opted_remember_device_cookie,
       remember_device_default: remember_device_default,
       platform_authenticator: platform_authenticator,
+      url_options: {},
     )
   end
 
@@ -44,13 +42,6 @@ RSpec.describe WebauthnSetupPresenter do
     subject { presenter.intro_html }
 
     it { is_expected.to eq(t('forms.webauthn_setup.intro_html')) }
-  end
-
-  describe '#intro_link' do
-    subject { presenter.intro_link }
-
-    it { is_expected.to include(t('forms.webauthn_platform_setup.intro_link_text')) }
-    it { is_expected.to include(intro_link) }
   end
 
   describe '#nickname_label' do
@@ -90,6 +81,28 @@ RSpec.describe WebauthnSetupPresenter do
       subject { presenter.heading }
 
       it { is_expected.to eq(t('headings.webauthn_platform_setup.new')) }
+    end
+
+    describe '#intro_html' do
+      subject { presenter.intro_html }
+
+      it do
+        is_expected.to eq(
+          t(
+            'forms.webauthn_platform_setup.intro_html',
+            app_name: APP_NAME,
+            link: link_to(
+              t('forms.webauthn_platform_setup.intro_link_text'),
+              help_center_redirect_path(
+                category: 'trouble-signing-in',
+                article: 'face-or-touch-unlock',
+                flow: :two_factor_authentication,
+                step: :webauthn_setup,
+              ),
+            ),
+          ),
+        )
+      end
     end
 
     describe '#nickname_label' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-10871](https://cm-jira.usa.gov/browse/LG-10871)

## 🛠 Summary of changes

Updates "Learn more about face or touch unlock" link in Face/Touch setup to point to the relevant help center article.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in or create a new account
3. Add a "Face or touch unlock" authenticator
4. Click link "Learn more about face or touch unlock"

**Before:** Redirected to https://www.login.gov/help/get-started/authentication-methods/
**After:** Redirected to https://login.gov/help/trouble-signing-in/face-or-touch-unlock/

## 👀 Screenshots

![image](https://github.com/18F/identity-idp/assets/1779930/2103b544-1a83-4981-b688-052df59137a2)

