### PR TITLE
LG-10858 Improve tappable area of LDP footer for mobile users

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -16,7 +16,7 @@ body {
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  font-size: 0.9rem;
+  font-size: 0.75rem;
 
   @include at-media('tablet') {
     @include u-bg('primary-darker');

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -21,7 +21,6 @@ body {
   @include at-media('tablet') {
     @include u-bg('primary-darker');
     flex-direction: row;
-    font-size: 0.75rem;
   }
 
   a {

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -26,9 +26,11 @@ body {
   @include at-media-max('tablet') {
     .footer__links {
       flex-wrap: wrap;
+      @include u-padding-x(1);
+      @include u-padding-y(0);
     }
     a {
-      padding: 0.5rem 0;
+      @include u-padding-y(1);
     }
     font-size: 0.9rem;
   }

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -16,26 +16,16 @@ body {
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  font-size: 0.75rem;
+  font-size: 0.9rem;
 
   @include at-media('tablet') {
     @include u-bg('primary-darker');
     flex-direction: row;
-  }
-
-  @include at-media-max('tablet') {
-    .footer__links {
-      flex-wrap: wrap;
-      @include u-padding-x(1);
-      @include u-padding-y(0);
-    }
-    a {
-      @include u-padding-y(1);
-    }
-    font-size: 0.9rem;
+    font-size: 0.75rem;
   }
 
   a {
+    @include u-padding-y(1);
     text-decoration: none;
 
     @include at-media('tablet') {
@@ -71,6 +61,12 @@ body {
 }
 
 .footer__links {
-  @include u-padding-y(1);
+  @include u-padding-x(1);
   display: flex;
+  flex-wrap: wrap;
+
+  @include at-media('tablet') {
+    @include u-padding-y(1);
+    @include u-padding-x(0);
+  }
 }

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -29,6 +29,7 @@ body {
     text-decoration: none;
 
     @include at-media('tablet') {
+      @include u-padding-y(0);
       &,
       &:visited {
         color: color($theme-link-reverse-color);

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -23,6 +23,16 @@ body {
     flex-direction: row;
   }
 
+  @include at-media-max('tablet') {
+    .footer__links {
+      flex-wrap: wrap;
+    }
+    a {
+      padding: 0.5rem 0;
+    }
+    font-size: 0.9rem;
+  }
+
   a {
     text-decoration: none;
 

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -6,7 +6,7 @@
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>
   <div class="footer__links">
     <%= new_tab_link_to('https://www.gsa.gov', class: 'tablet:display-none display-flex margin-right-2') do %>
-      <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: t('shared.footer_lite.gsa') %>
+      <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'), size: 25, alt: t('shared.footer_lite.gsa') %>
     <% end %>
     <%= new_tab_link_to(t('links.help'), MarketingSite.help_url, class: 'margin-right-2') %>
     <%= new_tab_link_to(t('links.contact'), MarketingSite.contact_url, class: 'margin-right-2') %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -6,7 +6,7 @@
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>
   <div class="footer__links">
     <%= new_tab_link_to('https://www.gsa.gov', class: 'tablet:display-none display-flex margin-right-2') do %>
-      <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'), size: 25, alt: t('shared.footer_lite.gsa') %>
+      <%= image_tag asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: t('shared.footer_lite.gsa') %>
     <% end %>
     <%= new_tab_link_to(t('links.help'), MarketingSite.help_url, class: 'margin-right-2') %>
     <%= new_tab_link_to(t('links.contact'), MarketingSite.contact_url, class: 'margin-right-2') %>


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket.
[LG-10858](https://cm-jira.usa.gov/browse/LG-10858)


## 🛠 Summary of changes

For mobile users the footer text is now upsized and has added padding to increase target area. The GSA logo in that same footer area is also slightly increased in size.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->


## 👀 Screenshots
_simulated iPhone SE in MacOS Chrome browser_
Before
![Screenshot 2023-09-07 at 8 54 15 AM (2)](https://github.com/18F/identity-idp/assets/135744319/2a50a288-45ce-4b89-86a4-665119fd98c5)

After
![Screenshot 2023-09-07 at 9 59 07 AM (2)](https://github.com/18F/identity-idp/assets/135744319/f6788cba-c7e8-4e22-8efc-241d9bb82d9a)


