### PR TITLE
Do not end session when switching languages during forced re-authentication OIDC request (LG-10936)

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -132,12 +132,13 @@ module OpenidConnect
           is_forced_reauthentication: false,
         )
       end
-      return unless user_signed_in? && @authorize_form.prompt == 'login'
+      return unless @authorize_form.prompt == 'login'
       return if session[:oidc_state_for_login_prompt] == @authorize_form.state
+      session[:oidc_state_for_login_prompt] = @authorize_form.state
+      return unless user_signed_in?
       return if check_sp_handoff_bounced
       unless sp_session[:request_url] == request.original_url
         sign_out
-        session[:oidc_state_for_login_prompt] = @authorize_form.state
         set_issuer_forced_reauthentication(
           issuer: @authorize_form.service_provider.issuer,
           is_forced_reauthentication: true,

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
         action
         sign_in_as_user(user)
         get :index, params: params.merge(locale: 'es')
-        expect(controller.current_user).to_not be_nil
+        expect(controller.current_user).to eq(user)
       end
     end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
   let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
   let(:service_provider) { build(:service_provider, issuer: client_id) }
+  let(:prompt) { 'select_account' }
   let(:params) do
     {
       acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
       client_id: client_id,
       nonce: SecureRandom.hex,
-      prompt: 'select_account',
+      prompt: prompt,
       redirect_uri: 'gov.gsa.openidconnect.test://result',
       response_type: 'code',
       scope: 'openid profile',
@@ -26,6 +27,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
   describe '#index' do
     subject(:action) { get :index, params: params }
+
+    context 'with prompt=login' do
+      let(:prompt) { 'login' }
+
+      it 'does not log user out when switching languages after authentication' do
+        user = create(:user, :with_phone)
+        action
+        sign_in_as_user(user)
+        get :index, params: params.merge(locale: 'es')
+        expect(controller.current_user).to_not be_nil
+      end
+    end
 
     context 'user is signed in' do
       let(:user) { create(:user, :fully_registered) }


### PR DESCRIPTION
## 🎫 Ticket

[LG-10936](https://cm-jira.usa.gov/browse/LG-10936)

## 🛠 Summary of changes

This was a bug introduced from the changes in #8684. If an OIDC authorization request is received that uses `prompt=login`, and the user switches languages, they will be logged out and have to authenticate again, which is not intended. The core of the issue is due to the OIDC state session check not being set each time. This was working most of the time because the comparison of the URL [here](https://github.com/18F/identity-idp/blob/507fa1d/app/controllers/openid_connect/authorization_controller.rb#L138) only triggers a log out when the URL has changed from the original request. Because the locale is part of the URL, it falls through that check and logs the user out again.

To address this, this PR ensures the `oidc_state_for_login_prompt` value is set regardless. The intention behind this is that the state will only be nil once on the initial request. Any OIDC request following that will not log the user out because the state will match.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
