### PR TITLE
Consolidate / standardize URL handling for after_sign_in_path_for

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -28,4 +28,10 @@ class AccountsController < ApplicationController
 
     redirect_to login_two_factor_options_path
   end
+
+  private
+
+  def confirm_user_is_not_suspended
+    redirect_to user_please_call_url if current_user.suspended?
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -236,7 +236,7 @@ class ApplicationController < ActionController::Base
   def user_needs_to_reactivate_account?
     return false if current_user.password_reset_profile.blank?
     return false if pending_profile_newer_than_password_reset_profile?
-    true
+    sp_session[:ial2] == true
   end
 
   def pending_profile_newer_than_password_reset_profile?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -275,10 +275,6 @@ class ApplicationController < ActionController::Base
       two_factor_enabled?
   end
 
-  def confirm_user_is_not_suspended
-    redirect_to user_suspended_url if user_suspended_url
-  end
-
   def confirm_two_factor_authenticated
     authenticate_user!(force: true)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -184,18 +184,7 @@ class ApplicationController < ActionController::Base
     @service_provider_request ||= ServiceProviderRequestProxy.from_uuid(params[:request_id])
   end
 
-  def add_piv_cac_setup_url
-    session[:needs_to_setup_piv_cac_after_sign_in] ? login_add_piv_cac_prompt_url : nil
-  end
-
-  def service_provider_mfa_setup_url
-    service_provider_mfa_policy.user_needs_sp_auth_method_setup? ?
-      authentication_methods_setup_url : nil
-  end
-
   def fix_broken_personal_key_url
-    return if !current_user.broken_personal_key?
-
     flash[:info] = t('account.personal_key.needs_new')
 
     pii_unlocked = Pii::Cacher.new(current_user, user_session).exists_in_session?
@@ -217,26 +206,21 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(_user)
-    accept_rules_of_use_url ||
-      user_suspended_url ||
-      service_provider_mfa_setup_url ||
-      add_piv_cac_setup_url ||
-      fix_broken_personal_key_url ||
-      user_session.delete(:stored_location) ||
-      sp_session_request_url_with_updated_params ||
-      signed_in_url
+    return rules_of_use_path if !current_user.accepted_rules_of_use_still_valid?
+    return user_please_call_url if current_user.suspended?
+    return authentication_methods_setup_url if user_needs_sp_auth_method_setup?
+    return login_add_piv_cac_prompt_url if session[:needs_to_setup_piv_cac_after_sign_in].present?
+    return fix_broken_personal_key_url if current_user.broken_personal_key?
+    return user_session.delete(:stored_location) if user_session.key?(:stored_location)
+    return reactivate_account_url if user_needs_to_reactivate_account?
+    return backup_code_reminder_url if user_needs_backup_code_reminder?
+    return sp_session_request_url_with_updated_params if sp_session.key?(:request_url)
+    signed_in_url
   end
 
   def signed_in_url
-    return user_two_factor_authentication_url unless user_fully_authenticated?
-    return reactivate_account_url if user_needs_to_reactivate_account?
     return url_for_pending_profile_reason if user_has_pending_profile?
-    return backup_code_reminder_url if user_needs_backup_code_reminder?
-    account_url
-  end
-
-  def accept_rules_of_use_url
-    rules_of_use_path unless current_user.accepted_rules_of_use_still_valid?
+    account_path
   end
 
   def after_mfa_setup_path
@@ -350,10 +334,6 @@ class ApplicationController < ActionController::Base
     redirect_to sp_required_mfa_verification_url
   end
 
-  def user_suspended_url
-    user_please_call_url if current_user.suspended?
-  end
-
   def sp_required_mfa_verification_url
     return login_two_factor_piv_cac_url if service_provider_mfa_policy.piv_cac_required?
 
@@ -408,6 +388,7 @@ class ApplicationController < ActionController::Base
       phishing_resistant_requested: sp_session[:phishing_resistant_requested],
     )
   end
+  delegate :user_needs_sp_auth_method_setup?, to: :service_provider_mfa_policy
 
   def sp_session
     session.fetch(:sp, {})

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -236,7 +236,7 @@ class ApplicationController < ActionController::Base
   def user_needs_to_reactivate_account?
     return false if current_user.password_reset_profile.blank?
     return false if pending_profile_newer_than_password_reset_profile?
-    sp_session[:ial2] == true
+    true
   end
 
   def pending_profile_newer_than_password_reset_profile?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -213,13 +213,13 @@ class ApplicationController < ActionController::Base
     return fix_broken_personal_key_url if current_user.broken_personal_key?
     return user_session.delete(:stored_location) if user_session.key?(:stored_location)
     return reactivate_account_url if user_needs_to_reactivate_account?
-    return backup_code_reminder_url if user_needs_backup_code_reminder?
     return sp_session_request_url_with_updated_params if sp_session.key?(:request_url)
     signed_in_url
   end
 
   def signed_in_url
     return url_for_pending_profile_reason if user_has_pending_profile?
+    return backup_code_reminder_url if user_needs_backup_code_reminder?
     account_path
   end
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe AccountsController do
   end
 
   describe '#show' do
+    context 'signed out' do
+      it 'redirects to sign in' do
+        get :show
+
+        expect(response).to redirect_to(new_user_session_url)
+      end
+    end
+
     context 'when user has an active identity' do
       it 'renders the profile and does not redirect out of the app' do
         stub_analytics

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -190,46 +190,6 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe '#confirm_user_is_not_suspended' do
-    controller do
-      before_action :confirm_user_is_not_suspended
-
-      def index
-        render plain: 'Hello'
-      end
-    end
-
-    context 'when user is suspended' do
-      it 'redirects to users please call page' do
-        user = create(:user, :suspended)
-        sign_in user
-        get :index
-
-        expect(response).to redirect_to user_please_call_url
-      end
-    end
-  end
-
-  describe '#user_suspended_url' do
-    before { sign_in(user) }
-
-    context 'when user is suspended' do
-      let(:user) { create(:user, :suspended) }
-
-      it 'is the please call url' do
-        expect(controller.send(:user_suspended_url)).to eq(user_please_call_url)
-      end
-    end
-
-    context 'when user is not suspended' do
-      let(:user) { create(:user) }
-
-      it 'is nil' do
-        expect(controller.send(:user_suspended_url)).to be_nil
-      end
-    end
-  end
-
   describe '#confirm_two_factor_authenticated' do
     controller do
       before_action :confirm_two_factor_authenticated

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -92,10 +92,29 @@ RSpec.feature 'Password recovery via personal key' do
     end
   end
 
+  describe 'signing in as IAL1 with proofed account after resetting password' do
+    it 'redirects to SP without prompting to reactivate account' do
+      user = create(:user, :proofed)
+      visit_idp_from_sp_with_ial1(:oidc)
+      trigger_reset_password_and_click_email_link(user.email)
+      fill_in t('forms.passwords.edit.labels.password'), with: new_password
+      fill_in t('components.password_confirmation.confirm_label'),
+              with: new_password
+      click_button t('forms.passwords.edit.buttons.submit')
+      fill_in_credentials_and_submit(user.email, new_password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      click_agree_and_continue
+
+      expect(current_url).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+
   it_behaves_like 'signing in as IAL1 with personal key after resetting password', :saml
   it_behaves_like 'signing in as IAL1 with personal key after resetting password', :oidc
-  it_behaves_like 'signing in as IAL2 with personal key after resetting password', :saml
-  it_behaves_like 'signing in as IAL2 with personal key after resetting password', :oidc
+  it_behaves_like 'signing in as IAL2 after resetting password', :saml
+  it_behaves_like 'signing in as IAL2 after resetting password', :oidc
 
   def reactivate_profile(password, personal_key)
     click_on t('links.account.reactivate.with_key')


### PR DESCRIPTION
## 🛠 Summary of changes

Updates handling of signed-in URL handling:

- Removes proxy methods in favor of inline condition early returns
   - The hope here is (a) make the logic clearer by avoiding the indirection and (b) avoid naming gymnastics (and resulting confusion) in generating a URL under only certain conditions (e.g. `accept_rules_of_use_url` returns `rules_of_use_path` only if the user must accept rules of user, otherwise returns `nil`).
- Similar to #9147, moves more interception screens into the expected SP-initiated sign-in flow
   - Backup code reminder
   - Account reactivation
- Removes a seemingly-redundant check for `user_fully_authenticated?` in `signed_in_url`

Ideally we would be able to eliminate one or the other of `after_sign_in_path_for` and `signed_in_url`, but we currently rely on `signed_in_url` for handling various pending profile states. However, this is something which we ought to reevaluate, since it blocks users from managing their account settings in some cases (see [LG-10119](https://cm-jira.usa.gov/browse/LG-10119)).

## 📜 Testing Plan

Verify that there are no regressions in the following prompts:

- Rules of use
- PIV/CAC setup from sign-in attempt
- Service-provider required MFA
- Broken personal key
- Suspended account dead-end
- Identity-verified profile reactivation after password reset
- GPO pending IdV
- IPP pending IdV
- Backup code reminder