### PR TITLE
Deploy RC 312 to Prod

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
   FF_SCRIPT_SECTIONS: 'true'
   JUNIT_OUTPUT: 'true'
   ECR_REGISTRY: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
-  IDP_CI_SHA: 'sha256:6915b54a913ebcb9066fdfaa88c3d42bda1f4505cfb59b9d5848576705954621'
+  IDP_CI_SHA: 'sha256:d085544aae118252860ebe72522457e55248dad8883b6451e6ed10340f4dffe9'
   PKI_IMAGE_TAG: 'main'
 
 default:

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -11,7 +11,10 @@ module Idv
     before_action :confirm_profile_has_been_created
 
     def show
-      analytics.idv_personal_key_visited(address_verification_method: address_verification_method)
+      analytics.idv_personal_key_visited(
+        address_verification_method: address_verification_method,
+        in_person_verification_pending: idv_session.profile&.in_person_verification_pending?,
+      )
       add_proofing_component
 
       finish_idv_session
@@ -23,6 +26,7 @@ module Idv
       analytics.idv_personal_key_submitted(
         address_verification_method: address_verification_method,
         deactivation_reason: idv_session.profile&.deactivation_reason,
+        in_person_verification_pending: idv_session.profile&.in_person_verification_pending?,
         fraud_review_pending: fraud_review_pending?,
         fraud_rejection: fraud_rejection?,
       )

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -17,23 +17,6 @@ module Idv
     rescue_from UspsInPersonProofing::Exception::RequestEnrollException,
                 with: :handle_request_enroll_exception
 
-    def confirm_current_password
-      return if valid_password?
-
-      analytics.idv_review_complete(
-        success: false,
-        gpo_verification_pending: current_user.gpo_verification_pending_profile?,
-        in_person_verification_pending: current_user.in_person_pending_profile?,
-        fraud_review_pending: fraud_review_pending?,
-        fraud_rejection: fraud_rejection?,
-        **ab_test_analytics_buckets,
-      )
-      irs_attempts_api_tracker.idv_password_entered(success: false)
-
-      flash[:error] = t('idv.errors.incorrect_password')
-      redirect_to idv_review_url
-    end
-
     def new
       Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
         call(:encrypt, :view, true)
@@ -97,6 +80,24 @@ module Idv
     end
 
     private
+
+    def confirm_current_password
+      return if valid_password?
+
+      analytics.idv_review_complete(
+        success: false,
+        gpo_verification_pending: current_user.gpo_verification_pending_profile?,
+        # note: this always returns false as of 8/23
+        in_person_verification_pending: current_user.in_person_pending_profile?,
+        fraud_review_pending: fraud_review_pending?,
+        fraud_rejection: fraud_rejection?,
+        **ab_test_analytics_buckets,
+      )
+      irs_attempts_api_tracker.idv_password_entered(success: false)
+
+      flash[:error] = t('idv.errors.incorrect_password')
+      redirect_to idv_review_url
+    end
 
     def gpo_mail_service
       @gpo_mail_service ||= Idv::GpoMail.new(current_user)

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -132,12 +132,13 @@ module OpenidConnect
           is_forced_reauthentication: false,
         )
       end
-      return unless user_signed_in? && @authorize_form.prompt == 'login'
+      return unless @authorize_form.prompt == 'login'
       return if session[:oidc_state_for_login_prompt] == @authorize_form.state
+      session[:oidc_state_for_login_prompt] = @authorize_form.state
+      return unless user_signed_in?
       return if check_sp_handoff_bounced
       unless sp_session[:request_url] == request.original_url
         sign_out
-        session[:oidc_state_for_login_prompt] = @authorize_form.state
         set_issuer_forced_reauthentication(
           issuer: @authorize_form.service_provider.issuer,
           is_forced_reauthentication: true,

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -27,7 +27,7 @@ class TwoFactorOptionsForm
   private
 
   def validate_selection_present
-    return if !has_no_mfa_or_in_required_flow? || selection.present?
+    return if selection.present? || has_minimum_required_mfa_methods?
     errors.add(:selection, missing_selection_error_message, type: :missing_selection)
   end
 
@@ -41,10 +41,6 @@ class TwoFactorOptionsForm
       selected_mfa_count: selection.count,
       enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
     }
-  end
-
-  def in_phishing_resistant_or_piv_cac_required_flow?
-    phishing_resistant_required || piv_cac_required
   end
 
   def user_needs_updating?
@@ -62,8 +58,16 @@ class TwoFactorOptionsForm
     selection.include?('phone') || selection.include?('voice') || selection.include?('sms')
   end
 
-  def has_no_configured_mfa?
-    mfa_user.enabled_mfa_methods_count == 0
+  def has_minimum_required_mfa_methods?
+    if piv_cac_required
+      mfa_user.piv_cac_configurations.count > 0
+    elsif mfa_user.webauthn_platform_configurations.any?
+      !platform_auth_only_option?
+    elsif phishing_resistant_required
+      mfa_user.phishing_resistant_configurations.count > 0
+    else
+      mfa_user.enabled_mfa_methods_count > 0
+    end
   end
 
   def platform_auth_only_option?
@@ -71,17 +75,11 @@ class TwoFactorOptionsForm
       mfa_user.webauthn_platform_configurations.count == 1
   end
 
-  def has_no_mfa_or_in_required_flow?
-    has_no_configured_mfa? ||
-      in_phishing_resistant_or_piv_cac_required_flow? ||
-      platform_auth_only_option?
-  end
-
   def missing_selection_error_message
-    if has_no_configured_mfa? || in_phishing_resistant_or_piv_cac_required_flow?
-      t('errors.two_factor_auth_setup.must_select_option')
-    elsif platform_auth_only_option?
+    if platform_auth_only_option?
       t('errors.two_factor_auth_setup.must_select_additional_option')
+    else
+      t('errors.two_factor_auth_setup.must_select_option')
     end
   end
 end

--- a/app/javascript/packages/phone-input/package.json
+++ b/app/javascript/packages/phone-input/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "dependencies": {
     "intl-tel-input": "^17.0.19",
-    "libphonenumber-js": "^1.10.43"
+    "libphonenumber-js": "^1.10.44"
   }
 }

--- a/app/jobs/reports/monthly_account_reuse_report.rb
+++ b/app/jobs/reports/monthly_account_reuse_report.rb
@@ -10,13 +10,13 @@ module Reports
       @report_date = report_date
 
       _latest, path = generate_s3_paths(REPORT_NAME, 'json', now: report_date)
-      body = report_body.to_json
+      body = report_body
 
       if bucket_name.present?
         upload_file_to_s3_bucket(
           path: path,
           body: body,
-          content_type: 'application/json',
+          content_type: 'text/csv',
           bucket: bucket_name,
         )
       end
@@ -152,11 +152,11 @@ module Reports
     end
 
     def report_body
-      {
-        report_date: first_day_of_report_month,
-        month: stats_month,
-        results: [report_csv],
-      }
+      CSV.generate do |csv|
+        report_csv.each do |row|
+          csv << row
+        end
+      end
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,14 +143,12 @@ class User < ApplicationRecord
     return @pending_profile if defined?(@pending_profile)
 
     @pending_profile = begin
-      pending = profiles.where(deactivation_reason: :in_person_verification_pending).or(
-        profiles.where.not(gpo_verification_pending_at: nil),
+      pending = profiles.in_person_verification_pending.or(
+        profiles.gpo_verification_pending,
       ).or(
-        profiles.where.not(in_person_verification_pending_at: nil),
+        profiles.fraud_review_pending,
       ).or(
-        profiles.where.not(fraud_review_pending_at: nil),
-      ).or(
-        profiles.where.not(fraud_rejection_at: nil),
+        profiles.fraud_rejection,
       ).order(created_at: :desc).first
 
       if pending.blank?

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2032,16 +2032,19 @@ module AnalyticsEvents
   # @param [String, nil] deactivation_reason Reason profile was deactivated.
   # @param [Boolean] fraud_review_pending Profile is under review for fraud
   # @param [Boolean] fraud_rejection Profile is rejected due to fraud
+  # @param [Boolean] in_person_verification_pending Profile is pending in-person verification
   # User submitted IDV personal key page
   def idv_personal_key_submitted(
     fraud_review_pending:,
     fraud_rejection:,
+    in_person_verification_pending:,
     proofing_components: nil,
     deactivation_reason: nil,
     **extra
   )
     track_event(
       'IdV: personal key submitted',
+      in_person_verification_pending: in_person_verification_pending,
       deactivation_reason: deactivation_reason,
       fraud_review_pending: fraud_review_pending,
       fraud_rejection: fraud_rejection,

--- a/bin/oncall/download-piv-certs
+++ b/bin/oncall/download-piv-certs
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+Dir.chdir(__dir__) { require 'bundler/setup' }
+
 require 'active_support'
 require 'active_support/core_ext/enumerable' # index_by
 require 'active_support/core_ext/integer/time'

--- a/bin/oncall/email-deliveries
+++ b/bin/oncall/email-deliveries
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+Dir.chdir(__dir__) { require 'bundler/setup' }
+
 require 'active_support'
 require 'active_support/core_ext/enumerable' # index_by
 require 'active_support/core_ext/integer/time'

--- a/bin/oncall/otp-deliveries
+++ b/bin/oncall/otp-deliveries
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+Dir.chdir(__dir__) { require 'bundler/setup' }
+
 require 'active_support'
 require 'active_support/core_ext/integer/time'
 require 'optparse'

--- a/bin/query-cloudwatch
+++ b/bin/query-cloudwatch
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-Dir.chdir(File.dirname(__FILE__)) { require 'bundler/setup' }
+Dir.chdir(__dir__) { require 'bundler/setup' }
 
 require 'active_support'
 require 'active_support/core_ext/integer/time'

--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -1,5 +1,6 @@
 require 'aws-sdk-cloudwatchlogs'
 require 'ruby-progressbar'
+require 'identity/hostdata'
 
 module Reporting
   class CloudwatchClient

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Idv::PersonalKeyController do
 
         context 'profile is pending due to in person proofing' do
           before do
-            profile.update!(deactivation_reason: :in_person_verification_pending)
+            profile.deactivate_for_in_person_verification
             subject.idv_session.profile_id = nil
           end
 
@@ -115,7 +115,7 @@ RSpec.describe Idv::PersonalKeyController do
             get :index
 
             expect(profile.user.pending_profile?).to eq true
-            expect(profile.deactivation_reason).to eq('in_person_verification_pending')
+            expect(profile.in_person_verification_pending?).to eq(true)
             expect(response).to_not be_redirect
           end
         end
@@ -208,6 +208,7 @@ RSpec.describe Idv::PersonalKeyController do
           address_verification_method: nil,
           fraud_review_pending: false,
           fraud_rejection: false,
+          in_person_verification_pending: false,
           deactivation_reason: nil,
           proofing_components: nil,
         )
@@ -252,6 +253,7 @@ RSpec.describe Idv::PersonalKeyController do
           fraud_review_pending: false,
           fraud_rejection: false,
           deactivation_reason: nil,
+          in_person_verification_pending: false,
           proofing_components: nil,
         )
       end
@@ -278,6 +280,7 @@ RSpec.describe Idv::PersonalKeyController do
             address_verification_method: nil,
             fraud_review_pending: false,
             fraud_rejection: false,
+            in_person_verification_pending: false,
             deactivation_reason: nil,
             proofing_components: nil,
           )
@@ -304,6 +307,7 @@ RSpec.describe Idv::PersonalKeyController do
             fraud_review_pending: true,
             fraud_rejection: false,
             address_verification_method: nil,
+            in_person_verification_pending: false,
             deactivation_reason: nil,
             proofing_components: nil,
           )

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe Idv::ReviewController do
             expect(enrollment.user_id).to eq(user.id)
             expect(enrollment.enrollment_code).to be_a(String)
             expect(enrollment.profile).to eq(user.profiles.last)
-            expect(enrollment.profile.deactivation_reason).to eq('in_person_verification_pending')
+            expect(enrollment.profile.in_person_verification_pending?).to eq(true)
           end
 
           it 'sends ready to verify email' do
@@ -505,7 +505,7 @@ RSpec.describe Idv::ReviewController do
               expect(enrollment.user_id).to eq(user.id)
               expect(enrollment.enrollment_code).to be_a(String)
               expect(enrollment.profile).to eq(user.profiles.last)
-              expect(enrollment.profile.deactivation_reason).to eq('in_person_verification_pending')
+              expect(enrollment.profile.in_person_verification_pending?).to eq(true)
             end
           end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
   let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
   let(:service_provider) { build(:service_provider, issuer: client_id) }
+  let(:prompt) { 'select_account' }
   let(:params) do
     {
       acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
       client_id: client_id,
       nonce: SecureRandom.hex,
-      prompt: 'select_account',
+      prompt: prompt,
       redirect_uri: 'gov.gsa.openidconnect.test://result',
       response_type: 'code',
       scope: 'openid profile',
@@ -26,6 +27,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
   describe '#index' do
     subject(:action) { get :index, params: params }
+
+    context 'with prompt=login' do
+      let(:prompt) { 'login' }
+
+      it 'does not log user out when switching languages after authentication' do
+        user = create(:user, :with_phone)
+        action
+        sign_in_as_user(user)
+        get :index, params: params.merge(locale: 'es')
+        expect(controller.current_user).to eq(user)
+      end
+    end
 
     context 'user is signed in' do
       let(:user) { create(:user, :fully_registered) }

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -34,7 +34,6 @@ FactoryBot.define do
     end
 
     trait :in_person_verification_pending do
-      deactivation_reason { :in_person_verification_pending }
       in_person_verification_pending_at { 15.days.ago }
     end
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -129,15 +129,15 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
-        address_verification_method: 'phone',
-        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        address_verification_method: 'phone', in_person_verification_pending: false,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {
         checked: true,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: personal key submitted' => {
-        address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, deactivation_reason: nil,
+        address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, in_person_verification_pending: false, deactivation_reason: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
     }
@@ -328,14 +328,15 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: review complete' => {
-        success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, deactivation_reason: 'in_person_verification_pending',
+        success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, deactivation_reason: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: final resolution' => {
-        success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, deactivation_reason: 'in_person_verification_pending',
+        success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, deactivation_reason: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
+        in_person_verification_pending: true,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }, address_verification_method: 'phone'
       },
       'IdV: personal key acknowledgment toggled' => {
@@ -343,7 +344,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: personal key submitted' => {
-        address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, deactivation_reason: 'in_person_verification_pending',
+        address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, in_person_verification_pending: true, deactivation_reason: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: in person ready to verify visited' => {

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -147,8 +147,7 @@ RSpec.describe GpoVerifyForm do
           pending_profile.reload
 
           expect(pending_profile).not_to be_active
-          expect(pending_profile.deactivation_reason).to eq('in_person_verification_pending')
-          expect(pending_profile.in_person_verification_pending_at).to be_present
+          expect(pending_profile.in_person_verification_pending?).to eq(true)
           expect(pending_profile.gpo_verification_pending?).to eq(false)
         end
 

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -133,5 +133,27 @@ RSpec.describe TwoFactorOptionsForm do
         end
       end
     end
+
+    context 'when a user signs up with phishing resistant requirement' do
+      let(:user) { build(:user) }
+      let(:phishing_resistant_required) { true }
+
+      context 'when user did not select an mfa' do
+        let(:mfa_selection) { [] }
+
+        it 'is unsuccessful' do
+          submission = subject.submit(selection: mfa_selection)
+          expect(submission.success?).to eq(false)
+        end
+      end
+
+      context 'when user selects an mfa' do
+        let(:mfa_selection) { ['piv_cac'] }
+        it 'is successful' do
+          submission = subject.submit(selection: mfa_selection)
+          expect(submission.success?).to eq(true)
+        end
+      end
+    end
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Profile do
   end
 
   describe '#in_person_verification_pending?' do
-    it 'returns true if the deactivation_reason is in_person_verification_pending' do
+    it 'returns true if the in_person_verification_pending_at is present' do
       profile = create(
         :profile,
         :in_person_verification_pending,
@@ -78,7 +78,9 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_nil
       expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to eq('in_person_verification_pending')
+      expect(profile.deactivation_reason).to be_nil
+      expect(profile.in_person_verification_pending_at).to be_present
+      expect(profile.in_person_verification_pending?).to eq(true)
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
@@ -806,7 +808,7 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_nil # to change
       expect(profile.active).to eq(false) # to change
-      expect(profile.deactivation_reason).to eq 'in_person_verification_pending' # to change
+      expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(true) # to change
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.in_person_verification_pending_at).to be_present
@@ -817,7 +819,7 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_present # changed
       expect(profile.active).to eq(true) # changed
-      expect(profile.deactivation_reason).to be_nil # changed
+      expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false) # changed
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.in_person_verification_pending_at).to be_nil
@@ -842,7 +844,7 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_nil
       expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to eq('in_person_verification_pending')
+      expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.in_person_verification_pending_at).to be_present
@@ -855,14 +857,14 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_nil
       expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to eq('in_person_verification_pending')
+      expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.in_person_verification_pending_at).to be_present
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
 
-      expect(profile.deactivation_reason).to eq('in_person_verification_pending')
+      expect(profile.deactivation_reason).to be_nil
       expect(profile).to_not be_active
     end
   end
@@ -1000,7 +1002,7 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_nil
       expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to be_nil # to change
+      expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.in_person_verification_pending_at).to be_nil
@@ -1011,7 +1013,7 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_nil
       expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to eq('in_person_verification_pending') # changed
+      expect(profile.deactivation_reason).to be_nil
       expect(profile.fraud_review_pending?).to eq(false)
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.in_person_verification_pending_at).to be_present # changed
@@ -1200,8 +1202,8 @@ RSpec.describe Profile do
     end
   end
 
-  describe 'scopes' do
-    describe '#active' do
+  describe 'query class methods' do
+    describe '.active' do
       it 'returns only active Profiles' do
         user.profiles.create(active: false)
         user.profiles.create(active: true)
@@ -1209,11 +1211,43 @@ RSpec.describe Profile do
       end
     end
 
-    describe '#verified' do
+    describe '.verified' do
       it 'returns only verified Profiles' do
         user.profiles.create(verified_at: Time.zone.now)
         user.profiles.create(verified_at: nil)
         expect(user.profiles.verified.count).to eq 1
+      end
+    end
+
+    describe '.fraud_rejection' do
+      it 'returns only fraud_rejection Profiles' do
+        user.profiles.create(fraud_rejection_at: Time.zone.now)
+        user.profiles.create(fraud_rejection_at: nil)
+        expect(user.profiles.fraud_rejection.count).to eq 1
+      end
+    end
+
+    describe '.fraud_review_pending' do
+      it 'returns only fraud_review_pending Profiles' do
+        user.profiles.create(fraud_review_pending_at: Time.zone.now)
+        user.profiles.create(fraud_review_pending_at: nil)
+        expect(user.profiles.fraud_review_pending.count).to eq 1
+      end
+    end
+
+    describe '.gpo_verification_pending' do
+      it 'returns only gpo_verification_pending Profiles' do
+        user.profiles.create(gpo_verification_pending_at: Time.zone.now)
+        user.profiles.create(gpo_verification_pending_at: nil)
+        expect(user.profiles.gpo_verification_pending.count).to eq 1
+      end
+    end
+
+    describe '.in_person_verification_pending' do
+      it 'returns only in_person_verification_pending Profiles' do
+        user.profiles.create(in_person_verification_pending_at: Time.zone.now)
+        user.profiles.create(in_person_verification_pending_at: nil)
+        expect(user.profiles.in_person_verification_pending.count).to eq 1
       end
     end
   end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe Idv::ProfileMaker do
 
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
-        expect(profile.deactivation_reason).to eq('in_person_verification_pending')
-        expect(profile.in_person_verification_pending_at).to_not be_nil
+        expect(profile.deactivation_reason).to be_nil
+        expect(profile.in_person_verification_pending?).to eq(true)
         expect(profile.fraud_review_pending?).to eq(false)
         expect(profile.gpo_verification_pending_at.present?).to eq(false)
         expect(profile.initiating_service_provider).to eq(nil)

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -163,8 +163,7 @@ RSpec.describe Idv::Session do
           expect(subject).not_to have_received(:move_pii_to_user_session)
           expect(profile.activated_at).to eq nil
           expect(profile.active).to eq false
-          expect(profile.deactivation_reason).to_not eq :in_person_verification_pending
-          expect(profile.deactivation_reason).to eq 'in_person_verification_pending'
+          expect(profile.in_person_verification_pending?).to eq(true)
           expect(profile.fraud_review_pending?).to eq(false)
           expect(profile.gpo_verification_pending_at.present?).to eq false
           expect(profile.initiating_service_provider).to eq nil
@@ -182,8 +181,7 @@ RSpec.describe Idv::Session do
           expect(profile).to eq(user.profiles.last)
           expect(profile.activated_at).to eq nil
           expect(profile.active).to eq false
-          expect(profile.deactivation_reason).to_not eq :in_person_verification_pending
-          expect(profile.deactivation_reason).to eq 'in_person_verification_pending'
+          expect(profile.in_person_verification_pending?).to eq(true)
           expect(profile.fraud_review_pending?).to eq(false)
           expect(profile.gpo_verification_pending_at.present?).to eq false
           expect(profile.initiating_service_provider).to eq nil

--- a/yarn.lock
+++ b/yarn.lock
@@ -4457,10 +4457,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libphonenumber-js@^1.10.43:
-  version "1.10.43"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.43.tgz#ef8b697c70a160142a653fc92931852c403a656f"
-  integrity sha512-M/iPACJGsTvEy8QmUY4K0SoIFB71X2j7y2JvUMYzUXUxCNmiU+NTfHdz7gt+dC48BVfBzZi2oO6s9TDGllCfxA==
+libphonenumber-js@^1.10.44:
+  version "1.10.44"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.44.tgz#6709722461173e744190494aaaec9c1c690d8ca8"
+  integrity sha512-svlRdNBI5WgBjRC20GrCfbFiclbF0Cx+sCcQob/C1r57nsoq0xg8r65QbTyVyweQIlB33P+Uahyho6EMYgcOyQ==
 
 lightningcss-darwin-arm64@1.16.1:
   version "1.16.1"


### PR DESCRIPTION
## User-Facing Improvements
- MFA Setup: Bug-fix for inconsistent enforcement of phishing-resistant account. ([#9119](https://github.com/18F/identity-idp/pull/9119))

## Bug Fixes
- OpenID Connect: Do not end session when switching languages during forced re-authentication request ([#9157](https://github.com/18F/identity-idp/pull/9157))

## Internal
- Dependencies: Update dependencies to resolve security advisories ([#9138](https://github.com/18F/identity-idp/pull/9138))
- IdV IPP: Write to in_person_verification_pending_at ([#8971](https://github.com/18F/identity-idp/pull/8971))
- formatting: Un-embed the CSV from within JSON ([#9137](https://github.com/18F/identity-idp/pull/9137))
