### PR TITLE
Fix Face/Touch "Learn more" grammar for French/Spanish

### DIFF
--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -148,7 +148,7 @@ es:
       intro_html: '<p>Guarde la cara o la huella digital como credencial en su
         dispositivo. De esta forma, accederá a su cuenta con una de ellas.
         %{app_name} no almacena la cara ni la huella digital.</p><p>Es posible
-        que necesite usar el mismo dispositivo para ingresar en cada ocasión
+        que necesite usar el mismo dispositivo para ingresar en cada ocasión.
         %{link}</p>'
       intro_link_text: Obtenga más información sobre el desbloqueo con la cara o con
         la huella digital.

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -153,7 +153,7 @@ fr:
         qu’identifiant sur votre appareil, afin de pouvoir les utiliser pour
         accéder à votre compte. %{app_name} ne stocke pas votre visage ni votre
         empreinte digitale</p><p>Il se peut que vous ayez besoin d’utiliser le
-        même appareil pour vous connecter chaque fois.%{link}</p>'
+        même appareil pour vous connecter chaque fois. %{link}</p>'
       intro_link_text: En savoir plus sur le déverrouillage facial ou sur le
         déverrouillage tactile.
       nickname: Pseudo dispositivo


### PR DESCRIPTION
## 🎫 Ticket

Noticed during [LG-10871](https://cm-jira.usa.gov/browse/LG-10871) (#9155)

## 🛠 Summary of changes

Updates the Face or Touch Unlock setup screen texts to ensure consistent sentence grammar across all languages.

**Before:**

- English: Two sentences with a space between
- French: Two sentences, no space between
- Spanish: One run-on sentence

**After:** All are two sentences with a space between

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in or create an account
3. When given the opportunity to add a new MFA method, add a new Face or Touch Unlock authenticator
4. Observe the link in the second paragraph
5. Change the language
6. Notice the grammar is consistent across languages

## 👀 Screenshots

Language|Before|After
---|---|---
English|![Screenshot 2023-09-07 at 8 42 47 AM](https://github.com/18F/identity-idp/assets/1779930/82a75e2b-d1d0-4063-9b5d-a5b23a0bdd52)|![Screenshot 2023-09-07 at 8 42 47 AM](https://github.com/18F/identity-idp/assets/1779930/82a75e2b-d1d0-4063-9b5d-a5b23a0bdd52)
Spanish|![Screenshot 2023-09-07 at 8 42 35 AM](https://github.com/18F/identity-idp/assets/1779930/e7499fa8-0a53-4057-a037-2f12e8f7ae2f)|![Screenshot 2023-09-07 at 8 43 10 AM](https://github.com/18F/identity-idp/assets/1779930/9ae18664-5f33-4286-9527-527c5bca816a)
French|![Screenshot 2023-09-07 at 8 42 50 AM](https://github.com/18F/identity-idp/assets/1779930/bf4ea9f1-b8ae-4293-8a6e-7b1c91af09ff)|![Screenshot 2023-09-07 at 8 43 03 AM](https://github.com/18F/identity-idp/assets/1779930/f579f233-8e60-44fe-806a-d38f4fafb465)