### PR TITLE
LG-10343 Enable the profile backfill job

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -189,10 +189,16 @@ else
         cron: cron_24h,
         args: -> { [14.days.ago] },
       },
+      # Weekly report describing account reuse
       monthly_account_reuse_report: {
         class: 'Reports::MonthlyAccountReuseReport',
         cron: cron_1st_of_mo,
         args: -> { [Time.zone.today] },
+      },
+      # Job to backfill encrypted_pii_recovery_multi_region on profiles
+      multi_region_kms_migration_profile_migraiton: {
+        class: 'MultiRegionKmsMigration::ProfileMigrationJob',
+        cron: cron_12m,
       },
     }.compact
   end


### PR DESCRIPTION
We have added code to start writing to profiles with a multi-region KMS key. This is in addition to the single-region key was were using previously. Records that were created before we introduced the multi-region key do not have a value encrypted with the multi-region KMS key.

https://github.com/18F/identity-idp/commit/5506d9e4dfe67283d8bd36f25df333ddd3aa9f31 added a background job for backfilling the empty multi-region ciphertexts. This commit enables it after testing and timing it in lower environments and in production.
