### PR TITLE
LG-10891 Add a job for migrating user password digests to multi-region KMS

### DIFF
--- a/app/jobs/multi_region_kms_migration/user_migration_job.rb
+++ b/app/jobs/multi_region_kms_migration/user_migration_job.rb
@@ -1,0 +1,73 @@
+module MultiRegionKmsMigration
+  class UserMigrationJob < ApplicationJob
+    MAXIMUM_ERROR_TOLERANCE = 10
+
+    include ::NewRelic::Agent::MethodTracer
+
+    def perform(statement_timeout: 120, user_count: 1000)
+      return unless IdentityConfig.store.multi_region_kms_migration_jobs_enabled
+
+      error_count = 0
+      success_count = 0
+
+      users = find_users_to_migrate(statement_timeout:, user_count:)
+      users.each do |user|
+        return if error_count >= MAXIMUM_ERROR_TOLERANCE # rubocop:disable Lint/NonLocalExitFromIterator
+
+        Encryption::MultiRegionKmsMigration::UserMigrator.new(user).migrate!
+        success_count += 1
+        analytics.multi_region_kms_migration_user_migrated(
+          success: true,
+          user_id: user.id,
+          exception: nil,
+        )
+      rescue => err
+        error_count += 1
+        analytics.multi_region_kms_migration_user_migrated(
+          success: false,
+          user_id: user.id,
+          exception: err.inspect,
+        )
+      end
+      analytics.multi_region_kms_migration_user_migration_summary(
+        user_count: users.size,
+        success_count: success_count,
+        error_count: error_count,
+      )
+    end
+
+    def find_users_to_migrate(statement_timeout:, user_count:)
+      User.transaction do
+        quoted_timeout = User.connection.quote(statement_timeout * 1000)
+        User.connection.execute("SET LOCAL statement_timeout = #{quoted_timeout}")
+
+        password_scope = User.where.not(
+          encrypted_password_digest: '',
+        ).where(
+          'encrypted_password_digest IS NOT NULL',
+        ).where(
+          encrypted_password_digest_multi_region: nil,
+        ).where(
+          'encrypted_password_digest NOT LIKE ?', '%encryption_key%'
+        )
+        personal_key_scope = User.where.not(
+          encrypted_recovery_code_digest: '',
+        ).where(
+          'encrypted_recovery_code_digest IS NOT NULL',
+        ).where(
+          encrypted_recovery_code_digest_multi_region: nil,
+        ).where(
+          'encrypted_recovery_code_digest NOT LIKE ?', '%encryption_key%'
+        )
+
+        password_scope.or(personal_key_scope).limit(user_count)
+      end
+    end
+
+    def analytics
+      @analytics ||= Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
+    end
+
+    add_method_tracer :find_users_to_migrate, "Custom/#{name}/find_users_to_migrate"
+  end
+end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2863,6 +2863,44 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success
+  # @param [String] exception
+  # @param [Integer] user_id
+  # A user was migrated from a single-region key to a multi-region key
+  def multi_region_kms_migration_user_migrated(
+    success:,
+    exception:,
+    user_id:,
+    **extra
+  )
+    track_event(
+      'Multi-region KMS migration: User migrated',
+      success: success,
+      exception: exception,
+      user_id: user_id,
+      **extra,
+    )
+  end
+
+  # @param [Integer] user_count
+  # @param [Integer] success_count
+  # @param [Integer] error_count
+  # The user migration job finished running
+  def multi_region_kms_migration_user_migration_summary(
+    user_count:,
+    success_count:,
+    error_count:,
+    **extra
+  )
+    track_event(
+      'Multi-region KMS migration: User migration summary',
+      user_count: user_count,
+      success_count: success_count,
+      error_count: error_count,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
   # @param [String] client_id
   # @param [Boolean] client_id_parameter_present
   # @param [Boolean] id_token_hint_parameter_present

--- a/app/services/encryption/multi_region_kms_migration/user_migrator.rb
+++ b/app/services/encryption/multi_region_kms_migration/user_migrator.rb
@@ -1,0 +1,91 @@
+module Encryption
+  module MultiRegionKmsMigration
+    class UserMigrator
+      include ::NewRelic::Agent::MethodTracer
+
+      attr_reader :user
+
+      def initialize(user)
+        @user = user
+      end
+
+      def migrate!
+        user.with_lock do
+          if needs_password_migration?
+            multi_region_digest = migrate_ciphertext(user.encrypted_password_digest)
+            user.update!(
+              encrypted_password_digest: user.encrypted_password_digest,
+              encrypted_password_digest_multi_region: multi_region_digest,
+            )
+          end
+
+          if needs_recovery_code_migration?
+            multi_region_digest = migrate_ciphertext(user.encrypted_recovery_code_digest)
+            user.update!(
+              encrypted_recovery_code_digest: user.encrypted_recovery_code_digest,
+              encrypted_recovery_code_digest_multi_region: multi_region_digest,
+            )
+          end
+        end
+      end
+
+      private
+
+      def migrate_ciphertext(ciphertext_string)
+        ciphertext = Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
+          ciphertext_string,
+        )
+        kms_decrypted_password_digest = multi_region_kms_client.decrypt(
+          ciphertext.encrypted_password, kms_encryption_context
+        )
+        multi_region_kms_encrypted_password = multi_region_kms_client.encrypt(
+          kms_decrypted_password_digest, kms_encryption_context
+        )
+        Encryption::PasswordVerifier::PasswordDigest.new(
+          encrypted_password: multi_region_kms_encrypted_password,
+          password_salt: ciphertext.password_salt,
+          password_cost: ciphertext.password_cost,
+        ).to_s
+      end
+
+      def needs_password_migration?
+        return false if user.encrypted_password_digest_multi_region.present?
+        return false if user.encrypted_password_digest.blank?
+
+        ciphertext = Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
+          user.encrypted_password_digest,
+        )
+
+        return false if ciphertext.uak_password_digest?
+        true
+      end
+
+      def needs_recovery_code_migration?
+        return false if user.encrypted_recovery_code_digest_multi_region.present?
+        return false if user.encrypted_recovery_code_digest.blank?
+
+        ciphertext = Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
+          user.encrypted_recovery_code_digest,
+        )
+
+        return false if ciphertext.uak_password_digest?
+        true
+      end
+
+      def kms_encryption_context
+        {
+          'context' => 'password-digest',
+          'user_uuid' => user.uuid,
+        }
+      end
+
+      def multi_region_kms_client
+        @multi_region_kms_client ||= KmsClient.new(
+          kms_key_id: IdentityConfig.store.aws_kms_multi_region_key_id,
+        )
+      end
+
+      add_method_tracer :migrate!, "Custom/#{name}/migrate!"
+    end
+  end
+end

--- a/spec/jobs/multi_region_kms_migration/user_migration_job_spec.rb
+++ b/spec/jobs/multi_region_kms_migration/user_migration_job_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe MultiRegionKmsMigration::UserMigrationJob do
     user
   end
 
-
   describe '#perform' do
     it 'does not modify records that do have multi-region ciphertexts' do
       original_encrypted_password_digest_multi_region =

--- a/spec/services/encryption/multi_region_kms_migration/user_migrator_spec.rb
+++ b/spec/services/encryption/multi_region_kms_migration/user_migrator_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+RSpec.describe Encryption::MultiRegionKmsMigration::UserMigrator do
+  before do
+    allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
+  end
+
+  let(:user) { create(:user, password: 'salty pickles', personal_key: '1234-ABCD') }
+
+  subject { described_class.new(user) }
+
+  describe '#migrate!' do
+    context 'for a user with a single-region password digest' do
+      let(:user) do
+        record = super()
+        record.update!(encrypted_password_digest_multi_region: nil)
+        record
+      end
+
+      it 'migrates the ciphertext' do
+        subject.migrate!
+
+        expect_ciphertext_to_be_migrated(
+          single_region_ciphertext: user.reload.encrypted_password_digest,
+          multi_region_ciphertext: user.encrypted_password_digest_multi_region,
+          password: user.password,
+          user_uuid: user.uuid,
+        )
+      end
+    end
+
+    context 'for a user with a blank password digest' do
+      let(:user) do
+        record = super()
+        record.update!(
+          encrypted_password_digest: '',
+          encrypted_password_digest_multi_region: '',
+        )
+        record
+      end
+
+      it 'does not try to migrate the password digest' do
+        subject.migrate!
+
+        expect(user.reload.encrypted_password_digest_multi_region).to eq('')
+      end
+    end
+
+    context 'for a user with a nil password digest' do
+      let(:user) do
+        record = super()
+        record.update!(
+          encrypted_password_digest: nil,
+          encrypted_password_digest_multi_region: nil,
+        )
+        record
+      end
+
+      it 'does not try to migrate the password digest' do
+        subject.migrate!
+
+        expect(user.reload.encrypted_password_digest_multi_region).to be_nil
+      end
+    end
+
+    context 'for a user with a password that has already been migrated' do
+      it 'does not modify the multi-region digest' do
+        original_multi_region_password_digest = user.encrypted_password_digest_multi_region
+
+        subject.migrate!
+
+        expect(user.reload.encrypted_password_digest_multi_region).to eq(
+          original_multi_region_password_digest,
+        )
+      end
+    end
+
+    context 'for a user with a single-region recovery code digest' do
+      let(:user) do
+        record = super()
+        record.update!(encrypted_recovery_code_digest_multi_region: nil)
+        record
+      end
+
+      it 'migrates the ciphertext' do
+        subject.migrate!
+
+        expect_ciphertext_to_be_migrated(
+          single_region_ciphertext: user.reload.encrypted_recovery_code_digest,
+          multi_region_ciphertext: user.encrypted_recovery_code_digest_multi_region,
+          password: user.personal_key,
+          user_uuid: user.uuid,
+        )
+      end
+    end
+
+    context 'for a user with a blank recovery code digest' do
+      let(:user) do
+        record = super()
+        record.update!(
+          encrypted_recovery_code_digest: '',
+          encrypted_recovery_code_digest_multi_region: '',
+        )
+        record
+      end
+
+      it 'does not try to migrate the password digest' do
+        subject.migrate!
+
+        expect(user.reload.encrypted_recovery_code_digest_multi_region).to eq('')
+      end
+    end
+
+    context 'for a user with a nil recovery code digest' do
+      let(:user) do
+        record = super()
+        record.update!(
+          encrypted_recovery_code_digest: nil,
+          encrypted_recovery_code_digest_multi_region: nil,
+        )
+        record
+      end
+
+      it 'does not try to migrate the password digest' do
+        subject.migrate!
+
+        expect(user.reload.encrypted_recovery_code_digest_multi_region).to be_nil
+      end
+    end
+
+    context 'for a user with a recovery code that has already been migrated' do
+      it 'does not modify the multi-region digest' do
+        original_multi_region_recovery_code_digest =
+          user.encrypted_recovery_code_digest_multi_region
+
+        subject.migrate!
+
+        expect(user.reload.encrypted_recovery_code_digest_multi_region).to eq(
+          original_multi_region_recovery_code_digest,
+        )
+      end
+    end
+  end
+
+  def expect_ciphertext_to_be_migrated(
+    single_region_ciphertext:,
+    multi_region_ciphertext:,
+    password:,
+    user_uuid:
+  )
+    password_verifier = Encryption::PasswordVerifier.new
+    single_region_digest_pair = Encryption::RegionalCiphertextPair.new(
+      single_region_ciphertext: single_region_ciphertext, multi_region_ciphertext: nil,
+    )
+    multi_region_digest_pair = Encryption::RegionalCiphertextPair.new(
+      single_region_ciphertext: nil, multi_region_ciphertext: multi_region_ciphertext,
+    )
+
+    aggregate_failures do
+      expect(
+        password_verifier.verify(digest_pair: single_region_digest_pair, user_uuid:, password:),
+      ).to eq(true)
+      expect(
+        password_verifier.verify(digest_pair: multi_region_digest_pair, user_uuid:, password:),
+      ).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
We are in the midst of a migration from a single-region KMS key to a multi-region capable KMS key. That migration involves the following steps:

1. Add new columns for multi-region ciphertexts
2. Start writing to the new columns with multi-region ciphertexts
3. Start opportunistically reading from the multi-region columns
4. Backfill the multi-region columns for old users
5. Stop using the old single-region columns

This commit is part of step number 4.

This commit adds a `UserMigrator` class which takes a user and migrates the single-region encrypted `encrypted_password_digest` and `encrypted_recovery_code_digest` to `encrypted_password_digest_multi_region` and `encrypted_recovery_code_digest_multi_region` respectively. This commit also includes a job to find users that require migration and invoke the `UserMigrator` against them.

The background job is not currently on the background job schedule. This will allow us to do some testing with it in lower environments before we start using it in production.
