### PR TITLE
LG-10271: SPIKE to look at improving back button.

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -4,7 +4,6 @@ module Idv
     include StepIndicatorConcern
 
     before_action :confirm_welcome_step_complete
-    before_action :confirm_agreement_needed
 
     def show
       analytics.idv_doc_auth_agreement_visited(**analytics_arguments)
@@ -60,12 +59,6 @@ module Idv
       return if idv_session.welcome_visited
 
       redirect_to idv_welcome_url
-    end
-
-    def confirm_agreement_needed
-      return unless idv_session.idv_consent_given
-
-      redirect_to idv_hybrid_handoff_url
     end
   end
 end

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -4,7 +4,6 @@ module Idv
     include StepIndicatorConcern
     include GettingStartedAbTestConcern
 
-    before_action :confirm_welcome_needed
     before_action :maybe_redirect_for_getting_started_ab_test
 
     def show
@@ -54,12 +53,6 @@ module Idv
       return unless IdentityConfig.store.in_person_proofing_enabled
       UspsInPersonProofing::EnrollmentHelper.
         cancel_stale_establishing_enrollments_for_user(current_user)
-    end
-
-    def confirm_welcome_needed
-      return unless idv_session.welcome_visited
-
-      redirect_to idv_agreement_url
     end
   end
 end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -73,16 +73,6 @@ RSpec.describe Idv::AgreementController do
         expect(response).to redirect_to(idv_welcome_url)
       end
     end
-
-    context 'agreement already visited' do
-      it 'redirects to hybrid_handoff' do
-        allow(subject.idv_session).to receive(:idv_consent_given).and_return(true)
-
-        get :show
-
-        expect(response).to redirect_to(idv_hybrid_handoff_url)
-      end
-    end
   end
 
   describe '#update' do

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -69,16 +69,6 @@ RSpec.describe Idv::WelcomeController do
       )
     end
 
-    context 'welcome already visited' do
-      it 'redirects to agreement' do
-        subject.idv_session.welcome_visited = true
-
-        get :show
-
-        expect(response).to redirect_to(idv_agreement_url)
-      end
-    end
-
     it 'redirects to please call page if fraud review is pending' do
       profile = create(:profile, :fraud_review_pending)
 


### PR DESCRIPTION
We remove before actions that recognize a user has already completed the step for the welcome, agreement and ssn controllers. These controllers do not make API calls to vendors and we feel there is no harm in letting users go back to them.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
