### PR TITLE
Couple more places to add idv_session.ssn

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -301,7 +301,7 @@ module Idv
         last_name: pii_from_doc[:last_name],
         date_of_birth: pii_from_doc[:dob],
         address: pii_from_doc[:address1],
-        ssn: pii_from_doc[:ssn],
+        ssn: idv_session.ssn || pii_from_doc[:ssn],
         failure_reason: failure_reason,
       )
     end

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -86,7 +86,7 @@ module Idv
       end
 
       def updating_ssn?
-        flow_session.dig(:pii_from_user, :ssn).present?
+        idv_session.ssn.present? || flow_session.dig(:pii_from_user, :ssn).present?
       end
 
       def confirm_in_person_address_step_complete

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -12,6 +12,7 @@ module Idv
 
       def show
         @step_indicator_steps = step_indicator_steps
+        @ssn = idv_session.ssn || flow_session[:pii_from_user][:ssn]
         @capture_secondary_id_enabled = capture_secondary_id_enabled
 
         analytics.idv_doc_auth_verify_visited(**analytics_arguments)
@@ -52,7 +53,6 @@ module Idv
       end
 
       def pii
-        @ssn = idv_session.ssn || flow_session[:pii_from_user][:ssn]
         @pii = flow_session[:pii_from_user]
       end
 

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -52,6 +52,7 @@ module Idv
       end
 
       def pii
+        @ssn = idv_session.ssn || flow_session[:pii_from_user][:ssn]
         @pii = flow_session[:pii_from_user]
       end
 

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -11,6 +11,7 @@ module Idv
 
     def show
       @step_indicator_steps = step_indicator_steps
+      @ssn = idv_session.ssn || pii_from_doc[:ssn]
 
       analytics.idv_doc_auth_verify_visited(**analytics_arguments)
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
@@ -55,7 +56,6 @@ module Idv
     end
 
     def pii
-      @ssn = idv_session.ssn || pii_from_doc[:ssn]
       @pii = pii_from_doc
     end
   end

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -54,8 +54,8 @@ module Idv
       }.merge(ab_test_analytics_buckets)
     end
 
-    # copied from verify_step
     def pii
+      @ssn = idv_session.ssn || pii_from_doc[:ssn]
       @pii = pii_from_doc
     end
   end

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -2,6 +2,7 @@
 locals:
   @step_indicator_steps - the correct Idv::Flows variable for this flow
   @pii - user's information
+  @ssn - user's ssn
   @had_barcode_read_failure - show warning if there's a barcode read error
 %>
 
@@ -132,12 +133,12 @@ locals:
       <%= t('idv.form.ssn') %>:
       <%= render(
             'shared/masked_text',
-            text: SsnFormatter.format(@pii[:ssn]),
-            masked_text: SsnFormatter.format_masked(@pii[:ssn]),
+            text: SsnFormatter.format(@ssn),
+            masked_text: SsnFormatter.format_masked(@ssn),
             accessible_masked_text: t(
               'idv.accessible_labels.masked_ssn',
-              first_number: @pii[:ssn][0],
-              last_number: @pii[:ssn][-1],
+              first_number: @ssn[0],
+              last_number: @ssn[-1],
             ),
             toggle_label: t('forms.ssn.show'),
           ) %>

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -2,6 +2,7 @@
 locals:
   @step_indicator_steps - the correct Idv::Flows variable for this flow
   @pii - user's information
+  @ssn - user's ssn
   @had_barcode_read_failure - show warning if there's a barcode read error
 %>
 
@@ -97,12 +98,12 @@ locals:
       <%= t('idv.form.ssn') %>:
       <%= render(
             'shared/masked_text',
-            text: SsnFormatter.format(@pii[:ssn]),
-            masked_text: SsnFormatter.format_masked(@pii[:ssn]),
+            text: SsnFormatter.format(@ssn),
+            masked_text: SsnFormatter.format_masked(@ssn),
             accessible_masked_text: t(
               'idv.accessible_labels.masked_ssn',
-              first_number: @pii[:ssn][0],
-              last_number: @pii[:ssn][-1],
+              first_number: @ssn[0],
+              last_number: @ssn[-1],
             ),
             toggle_label: t('forms.ssn.show'),
           ) %>


### PR DESCRIPTION
## 🎫 Ticket

LG-10886

## 🛠 Summary of changes

Missed a couple of places to add idv_session.ssn in #9129, including the verify_info show templates

## 📜 Testing Plan

- [ ] Create account, start IdV
- [ ] Edit SSN in VerifyInfo step
- [ ] Expect SSN to be saved correctly in verified profile
- [ ] Create new account, start IdV
- [ ] Upload error yaml to enter In Person flow
- [ ] Edit SSN in VerifyInfo step
- [ ] Expect SSN to be saved correctly when barcode is generated.