### PR TITLE
Use where clause in Gpo Mail events query to make use of index

### DIFF
--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -42,7 +42,8 @@ module Idv
     def user_mail_events
       @user_mail_events ||= current_user.events.
         gpo_mail_sent.
-        order('updated_at DESC').
+        order('created_at DESC').
+        where('created_at >= ?', MAIL_EVENTS_WINDOW_DAYS.days.ago).
         limit(MAX_MAIL_EVENTS)
     end
 
@@ -51,7 +52,7 @@ module Idv
     end
 
     def updated_within_last_month?
-      user_mail_events.last.updated_at > MAIL_EVENTS_WINDOW_DAYS.days.ago
+      user_mail_events.last.created_at > MAIL_EVENTS_WINDOW_DAYS.days.ago
     end
   end
 end

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -9,7 +9,7 @@ module Idv
 
     def mail_spammed?
       return false if user_mail_events.empty?
-      max_events? && updated_within_last_month?
+      max_events? && created_within_limit_period?
     end
 
     def profile_too_old?
@@ -51,7 +51,7 @@ module Idv
       user_mail_events.size == MAX_MAIL_EVENTS
     end
 
-    def updated_within_last_month?
+    def created_within_limit_period?
       user_mail_events.last.created_at > MAIL_EVENTS_WINDOW_DAYS.days.ago
     end
   end

--- a/spec/services/idv/gpo_mail_spec.rb
+++ b/spec/services/idv/gpo_mail_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe Idv::GpoMail do
 
     context 'when too much mail has been sent' do
       it 'returns true if the oldest event was within the last month' do
-        event_create(event_type: :gpo_mail_sent, user: user, updated_at: 2.weeks.ago)
-        event_create(event_type: :gpo_mail_sent, user: user, updated_at: 1.week.ago)
+        event_create(event_type: :gpo_mail_sent, user: user, created_at: 2.weeks.ago)
+        event_create(event_type: :gpo_mail_sent, user: user, created_at: 1.week.ago)
 
         expect(subject.mail_spammed?).to eq true
       end
 
       it 'returns false if the oldest event was more than a month ago' do
-        event_create(event_type: :gpo_mail_sent, user: user, updated_at: 2.weeks.ago)
-        event_create(event_type: :gpo_mail_sent, user: user, updated_at: 2.months.ago)
+        event_create(event_type: :gpo_mail_sent, user: user, created_at: 2.weeks.ago)
+        event_create(event_type: :gpo_mail_sent, user: user, created_at: 2.months.ago)
 
         expect(subject.mail_spammed?).to eq false
       end
@@ -51,7 +51,7 @@ RSpec.describe Idv::GpoMail do
     user = hash[:user]
     event = hash[:event_type]
     now = Time.zone.now
-    updated_at = hash[:updated_at] || now
+    created_at = hash[:created_at] || now
     device = Device.find_by(user_id: user.id, cookie_uuid: uuid)
     if device
       device.last_used_at = now
@@ -72,7 +72,7 @@ RSpec.describe Idv::GpoMail do
       device_id: device.id,
       ip: remote_ip,
       event_type: event,
-      created_at: updated_at, updated_at: updated_at
+      created_at: created_at, updated_at: created_at
     )
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

The database query for `Idv::GpoMail#spammed?` hasn't changed much since it was added in #1440. As the `events` table has grown for the average user, the query gets a little bit slower. This PR makes a couple changes:

- Uses the `created_at` column instead of the `updated_at` column as there is an index on `created_at`
  - The events are not updated, so this should be safe to do. Disavowal tokens are the usual way this would happen, but these events cannot be disavowed.
- Adds a `WHERE` clause to the query to make use of the `created_at` index and limit the number of records scanned

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
