### PR TITLE
LG-10347 Make the key ID the session encryptor uses configurable

### DIFF
--- a/app/services/encryption/encryptors/background_proofing_arg_encryptor.rb
+++ b/app/services/encryption/encryptors/background_proofing_arg_encryptor.rb
@@ -6,12 +6,12 @@ module Encryption
 
       def encrypt(plaintext)
         aes_ciphertext = AesEncryptor.new.encrypt(plaintext, aes_encryption_key)
-        kms_ciphertext = KmsClient.new.encrypt(aes_ciphertext, 'context' => 'session-encryption')
+        kms_ciphertext = kms_client.encrypt(aes_ciphertext, 'context' => 'session-encryption')
         encode(kms_ciphertext)
       end
 
       def decrypt(ciphertext)
-        aes_ciphertext = KmsClient.new.decrypt(
+        aes_ciphertext = kms_client.decrypt(
           decode(ciphertext), 'context' => 'session-encryption'
         )
         aes_encryptor.decrypt(aes_ciphertext, aes_encryption_key)
@@ -25,6 +25,10 @@ module Encryption
 
       def aes_encryption_key
         IdentityConfig.store.session_encryption_key[0...32]
+      end
+
+      def kms_client
+        @kms_client ||= KmsClient.new(kms_key_id: IdentityConfig.store.aws_kms_session_key_id)
       end
 
       add_method_tracer :encrypt, "Custom/#{name}/encrypt"

--- a/app/services/encryption/encryptors/session_encryptor.rb
+++ b/app/services/encryption/encryptors/session_encryptor.rb
@@ -6,12 +6,12 @@ module Encryption
 
       def encrypt(plaintext)
         aes_ciphertext = AesEncryptor.new.encrypt(plaintext, aes_encryption_key)
-        kms_ciphertext = KmsClient.new.encrypt(aes_ciphertext, 'context' => 'session-encryption')
+        kms_ciphertext = kms_client.encrypt(aes_ciphertext, 'context' => 'session-encryption')
         encode(kms_ciphertext)
       end
 
       def decrypt(ciphertext)
-        aes_ciphertext = KmsClient.new.decrypt(
+        aes_ciphertext = kms_client.decrypt(
           decode(ciphertext), 'context' => 'session-encryption'
         )
         aes_encryptor.decrypt(aes_ciphertext, aes_encryption_key)
@@ -25,6 +25,10 @@ module Encryption
 
       def aes_encryption_key
         IdentityConfig.store.session_encryption_key[0...32]
+      end
+
+      def kms_client
+        @kms_client ||= KmsClient.new(kms_key_id: IdentityConfig.store.aws_kms_session_key_id)
       end
 
       add_method_tracer :encrypt, "Custom/#{name}/encrypt"

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -52,6 +52,7 @@ aws_kms_client_contextless_pool_size: 5
 aws_kms_client_multi_pool_size: 5
 aws_kms_multi_region_key_id: alias/login-dot-gov-keymaker-multi-region
 aws_kms_multi_region_read_enabled: false
+aws_kms_session_key_id: alias/login-dot-gov-test-keymaker
 aws_logo_bucket: ''
 aws_region: 'us-west-2'
 backup_code_cost: '2000$8$1$'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -139,6 +139,7 @@ class IdentityConfig
     config.add(:aws_kms_key_id, type: :string)
     config.add(:aws_kms_multi_region_key_id, type: :string)
     config.add(:aws_kms_multi_region_read_enabled, type: :boolean)
+    config.add(:aws_kms_session_key_id, type: :string)
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)
     config.add(:backup_code_cost, type: :string)

--- a/lib/session_encryptor.rb
+++ b/lib/session_encryptor.rb
@@ -84,13 +84,15 @@ class SessionEncryptor
   end
 
   def kms_encrypt(text)
-    Base64.encode64(Encryption::KmsClient.new.encrypt(text, 'context' => 'session-encryption'))
+    Base64.encode64(kms_client.encrypt(text, 'context' => 'session-encryption'))
   end
 
   def kms_decrypt(text)
-    Encryption::KmsClient.new.decrypt(
-      Base64.decode64(text), 'context' => 'session-encryption'
-    )
+    kms_client.decrypt(Base64.decode64(text), 'context' => 'session-encryption')
+  end
+
+  def kms_client
+    Encryption::KmsClient.new(kms_key_id: IdentityConfig.store.aws_kms_session_key_id)
   end
 
   def outer_encrypt(plaintext)

--- a/spec/services/encryption/encryptors/background_proofing_arg_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/background_proofing_arg_encryptor_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Encryption::Encryptors::BackgroundProofingArgEncryptor do
         with('aes output', 'context' => 'session-encryption').
         and_return('kms output')
       allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(aes_encryptor)
-      allow(Encryption::KmsClient).to receive(:new).and_return(kms_client)
+      allow(Encryption::KmsClient).to receive(:new).with(
+        kms_key_id: IdentityConfig.store.aws_kms_session_key_id,
+      ).and_return(kms_client)
 
       expected_ciphertext = Base64.strict_encode64('kms output')
 
@@ -28,7 +30,9 @@ RSpec.describe Encryption::Encryptors::BackgroundProofingArgEncryptor do
       expect(client).to receive(:encrypt).with(
         instance_of(String), 'context' => 'session-encryption'
       ).and_return('kms_ciphertext')
-      allow(Encryption::KmsClient).to receive(:new).and_return(client)
+      allow(Encryption::KmsClient).to receive(:new).with(
+        kms_key_id: IdentityConfig.store.aws_kms_session_key_id,
+      ).and_return(client)
 
       subject.encrypt(plaintext)
     end

--- a/spec/services/encryption/encryptors/session_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/session_encryptor_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Encryption::Encryptors::SessionEncryptor do
         with('aes output', 'context' => 'session-encryption').
         and_return('kms output')
       allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(aes_encryptor)
-      allow(Encryption::KmsClient).to receive(:new).and_return(kms_client)
+      allow(Encryption::KmsClient).to receive(:new).with(
+        kms_key_id: IdentityConfig.store.aws_kms_session_key_id,
+      ).and_return(kms_client)
 
       expected_ciphertext = Base64.strict_encode64('kms output')
 
@@ -28,7 +30,9 @@ RSpec.describe Encryption::Encryptors::SessionEncryptor do
       expect(client).to receive(:encrypt).with(
         instance_of(String), 'context' => 'session-encryption'
       ).and_return('kms_ciphertext')
-      allow(Encryption::KmsClient).to receive(:new).and_return(client)
+      allow(Encryption::KmsClient).to receive(:new).with(
+        kms_key_id: IdentityConfig.store.aws_kms_session_key_id,
+      ).and_return(client)
 
       subject.encrypt(plaintext)
     end


### PR DESCRIPTION
We are currently migrating from a single-region KMS key to a multi-region capable KMS key.

This commit modifies the SessionEncryptor and BackgroundArgsEncryptor to have to use a configurable key for their KMS client. These encryptors are used in 3 contexts:

1. Encryption of sessions (SessionEncryptor)
2. Encryption of GPO confirmation entries (SessionEncryptor)
3. Encryption of arguments to background jobs (BackgroundArgsEncryptor)

The KMS client's for these encryptors will now use the configured key ID for encryptions. For decryption the client allows KMS to select the key. This means that decryption will not be affected by this change as long as KMS still has access to the keys referenced by the KeyID used for encryption.

Since all of the encryption operations done with these encryptors produce ephemeral ciphertexts there is not need to worry about holding onto old keys after this has been deployed with the multi-region key configured for a while.
