### PR TITLE
Do not query for PivCacConfiguration when x509_dn_uuid is blank

### DIFF
--- a/app/forms/user_piv_cac_verification_form.rb
+++ b/app/forms/user_piv_cac_verification_form.rb
@@ -21,6 +21,7 @@ class UserPivCacVerificationForm
   end
 
   def piv_cac_configuration
+    return nil if x509_dn_uuid.blank?
     @piv_cac_configuration ||= ::PivCacConfiguration.find_by(x509_dn_uuid: x509_dn_uuid)
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Currently, when displaying the PivCacVerificationForm prior to receiving a form submission, there is a database query that will always be blank. We can safely skip this query.

The query looks like:
```
  PivCacConfiguration Load (0.3ms)  SELECT "piv_cac_configurations"."id", "piv_cac_configurations"."user_id", "piv_cac_configurations"."x509_dn_uuid", "piv_cac_configurations"."name", "piv_cac_configurations"."created_at", "piv_cac_configurations"."updated_at", "piv_cac_configurations"."x509_issuer" FROM "piv_cac_configurations" WHERE "piv_cac_configurations"."x509_dn_uuid" IS NULL LIMIT $1  [["LIMIT", 1]]
  ↳ app/forms/user_piv_cac_verification_form.rb:24:in `piv_cac_configuration'
``` 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
