### PR TITLE
Identity Verification report  job to immediately exit when s3 reports are disabled

### DIFF
--- a/app/jobs/reports/identity_verification_report.rb
+++ b/app/jobs/reports/identity_verification_report.rb
@@ -7,6 +7,7 @@ module Reports
     attr_accessor :report_date
 
     def perform(report_date)
+      return unless IdentityConfig.store.s3_reports_enabled
       self.report_date = report_date
 
       csv = report_maker.to_csv

--- a/spec/jobs/reports/identity_verification_report_spec.rb
+++ b/spec/jobs/reports/identity_verification_report_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Reports::IdentityVerificationReport do
+  before do
+    allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
+  end
+
   describe '#perform' do
     it 'gets a CSV from the report maker and saves it to S3' do
       report_maker = double(Reporting::IdentityVerificationReport, to_csv: 'I am a CSV, see')


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

## 🛠 Summary of changes
IdentityVerification job exits immediately when S3 reports are disabled.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
