### PR TITLE
Cleanup ThreatMetrix CSP before_action name now that in_person SSN step is out of the FSM

### DIFF
--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -5,16 +5,6 @@ module Idv
     THREAT_METRIX_DOMAIN = 'h.online-metrix.net'
     THREAT_METRIX_WILDCARD_DOMAIN = '*.online-metrix.net'
 
-    def override_csp_for_threat_metrix
-      return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
-
-      return if params[:step] != 'ssn'
-
-      threat_metrix_csp_overrides
-    end
-
-    # Remove this duplication once in_person_controller is no longer in use
-    # for their SSN step
     def override_csp_for_threat_metrix_no_fsm
       return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
 

--- a/app/controllers/concerns/idv/threat_metrix_concern.rb
+++ b/app/controllers/concerns/idv/threat_metrix_concern.rb
@@ -5,7 +5,7 @@ module Idv
     THREAT_METRIX_DOMAIN = 'h.online-metrix.net'
     THREAT_METRIX_WILDCARD_DOMAIN = '*.online-metrix.net'
 
-    def override_csp_for_threat_metrix_no_fsm
+    def override_csp_for_threat_metrix
       return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
 
       threat_metrix_csp_overrides

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -9,7 +9,7 @@ module Idv
       before_action :confirm_verify_info_step_needed
       before_action :confirm_in_person_address_step_complete
       before_action :confirm_repeat_ssn, only: :show
-      before_action :override_csp_for_threat_metrix_no_fsm
+      before_action :override_csp_for_threat_metrix
 
       attr_accessor :error_message
 

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -12,7 +12,6 @@ module Idv
     include Idv::ThreatMetrixConcern
 
     before_action :redirect_if_flow_completed
-    before_action :override_csp_for_threat_metrix
 
     FLOW_STATE_MACHINE_SETTINGS = {
       step_url: :idv_in_person_step_url,

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -8,7 +8,7 @@ module Idv
     before_action :confirm_verify_info_step_needed
     before_action :confirm_document_capture_complete
     before_action :confirm_repeat_ssn, only: :show
-    before_action :override_csp_for_threat_metrix_no_fsm
+    before_action :override_csp_for_threat_metrix
 
     attr_accessor :error_message
 

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -21,42 +21,32 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
 
     context 'ff is set' do
       it 'modifies CSP headers' do
-        assert_csp_is_modified
+        get :index
+
+        csp = response.request.content_security_policy
+
+        aggregate_failures do
+          expect(csp.directives['script-src']).to include('h.online-metrix.net')
+          expect(csp.directives['script-src']).to include("'unsafe-eval'")
+
+          expect(csp.directives['style-src']).to include("'unsafe-inline'")
+
+          expect(csp.directives['child-src']).to include('h.online-metrix.net')
+
+          expect(csp.directives['connect-src']).to include('h.online-metrix.net')
+
+          expect(csp.directives['img-src']).to include('*.online-metrix.net')
+        end
       end
     end
 
     context 'ff is not set' do
       let(:ff_enabled) { false }
       it 'does not modify CSP headers' do
-        assert_csp_is_not_modified
+        get :index
+        secure_header_config = response.request.headers.env['secure_headers_request_config']
+        expect(secure_header_config).to be_nil
       end
     end
-  end
-
-  private
-
-  def assert_csp_is_modified
-    get :index
-
-    csp = response.request.content_security_policy
-
-    aggregate_failures do
-      expect(csp.directives['script-src']).to include('h.online-metrix.net')
-      expect(csp.directives['script-src']).to include("'unsafe-eval'")
-
-      expect(csp.directives['style-src']).to include("'unsafe-inline'")
-
-      expect(csp.directives['child-src']).to include('h.online-metrix.net')
-
-      expect(csp.directives['connect-src']).to include('h.online-metrix.net')
-
-      expect(csp.directives['img-src']).to include('*.online-metrix.net')
-    end
-  end
-
-  def assert_csp_is_not_modified
-    get :index
-    secure_header_config = response.request.headers.env['secure_headers_request_config']
-    expect(secure_header_config).to be_nil
   end
 end

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
   controller ApplicationController do
     include Idv::ThreatMetrixConcern
 
-    before_action :override_csp_for_threat_metrix
+    before_action :override_csp_for_threat_metrix_no_fsm
 
     def index; end
   end
 
-  describe '#override_csp_for_threat_metrix' do
+  describe '#override_csp_for_threat_metrix_no_fsm' do
     let(:ff_enabled) { true }
 
     before do
@@ -20,30 +20,23 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
     end
 
     context 'ff is set' do
-      it 'modifies CSP headers for SSN step' do
-        assert_csp_is_modified 'ssn'
-      end
-
-      it 'does not modify CSP headers for any other step' do
-        assert_csp_is_not_modified 'some_other_step'
+      it 'modifies CSP headers' do
+        assert_csp_is_modified
       end
     end
 
     context 'ff is not set' do
       let(:ff_enabled) { false }
-      it 'does not modify CSP headers for SSN step' do
-        assert_csp_is_not_modified 'ssn'
-      end
-      it 'does not modify CSP headers for any other step' do
-        assert_csp_is_not_modified 'some_other_step'
+      it 'does not modify CSP headers' do
+        assert_csp_is_not_modified
       end
     end
   end
 
   private
 
-  def assert_csp_is_modified(step)
-    get :index, params: { step: step }
+  def assert_csp_is_modified
+    get :index
 
     csp = response.request.content_security_policy
 
@@ -61,8 +54,8 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
     end
   end
 
-  def assert_csp_is_not_modified(step)
-    get :index, params: { step: step }
+  def assert_csp_is_not_modified
+    get :index
     secure_header_config = response.request.headers.env['secure_headers_request_config']
     expect(secure_header_config).to be_nil
   end

--- a/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/idv/threat_metrix_concern_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Idv::ThreatMetrixConcern, type: :controller do
   controller ApplicationController do
     include Idv::ThreatMetrixConcern
 
-    before_action :override_csp_for_threat_metrix_no_fsm
+    before_action :override_csp_for_threat_metrix
 
     def index; end
   end
 
-  describe '#override_csp_for_threat_metrix_no_fsm' do
+  describe '#override_csp_for_threat_metrix' do
     let(:ff_enabled) { true }
 
     before do

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Idv::InPersonController do
         :confirm_two_factor_authenticated,
         :initialize_flow_state_machine,
         :ensure_correct_step,
-        :override_csp_for_threat_metrix,
       )
     end
   end

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Idv::SsnController do
     it 'overrides CSPs for ThreatMetrix' do
       expect(subject).to have_actions(
         :before,
-        :override_csp_for_threat_metrix_no_fsm,
+        :override_csp_for_threat_metrix,
       )
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Remove the Flow State Machine version of the ThreatMetrix CSP before_action because both the remote and in_person SSN steps are now out of the FSM.

## 📜 Testing Plan

- [ ] After merging, deploy to staging
- [ ] Create account, start from Sinatra app, go through remote IdV
- [ ] On SSN step, confirm there are no permissions errors in Javascript console
- [ ] Cancel and restart IdV
- [ ] In DocumentCapture, upload special license image to trigger in person proofing
- [ ] On in person SSN step, confirm there are no permissions errors in Javascript console
