### PR TITLE
LG-10273 idv_session cleanup - remove unused properties

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -17,7 +17,6 @@ module Idv
       phone_for_mobile_flow
       pii
       previous_phone_step_params
-      profile_confirmation
       profile_id
       redo_document_capture
       resolution_successful
@@ -185,16 +184,10 @@ module Idv
 
     def mark_verify_info_step_complete!
       session[:resolution_successful] = true
-      # This is here to maintain backwards compadibility with old code.
-      # Once the code that checks `profile_confirmation` is removed from prod
-      # this setter and eventually the value in the Idv::Session struct itself
-      # can be removed.
-      session[:profile_confirmation] = true
     end
 
     def invalidate_verify_info_step!
       session[:resolution_successful] = nil
-      session[:profile_confirmation] = nil
     end
 
     def invalidate_steps_after_verify_info!

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -19,7 +19,6 @@ module Idv
       previous_phone_step_params
       profile_confirmation
       profile_id
-      profile_step_params
       redo_document_capture
       resolution_successful
       skip_hybrid_handoff


### PR DESCRIPTION
## 🎫 Ticket

[LG-10273](https://cm-jira.usa.gov/browse/LG-10273)

## 🛠 Summary of changes

While @theabrad and I were making a map of how idv_session is used, we noticed that `profile_step_params` and `profile_confirmation` are no longer used. This deletes them.
