### PR TITLE
Require recent authentication before deleting account

### DIFF
--- a/app/controllers/users/delete_controller.rb
+++ b/app/controllers/users/delete_controller.rb
@@ -1,7 +1,10 @@
 module Users
   class DeleteController < ApplicationController
+    include ReauthenticationRequiredConcern
+
     before_action :confirm_two_factor_authenticated
     before_action :confirm_current_password, only: [:delete]
+    before_action :confirm_recently_authenticated_2fa
 
     def show
       analytics.account_delete_visited

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Users::DeleteController do
+  describe 'before_actions' do
+    it 'includes authentication before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+        :confirm_recently_authenticated_2fa,
+      )
+    end
+  end
+
   describe '#show' do
     it 'shows and logs a visit' do
       stub_analytics


### PR DESCRIPTION
## 🛠 Summary of changes

A follow-up to to complete the missing account management actions described in [this SBAR](https://docs.google.com/document/d/1lhjFcHlh2FmUrPFJ8h6QJmXHN_hDyW113U-ZidhSYNw/edit#heading=h.n0oa4p1mcfvz). Most of these were done in #8037, but account deletion was missed.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
