### PR TITLE
Remove the `aws_kms_multi_region_read_enabled` flag

### DIFF
--- a/app/services/encryption/regional_ciphertext_pair.rb
+++ b/app/services/encryption/regional_ciphertext_pair.rb
@@ -6,10 +6,6 @@ Encryption::RegionalCiphertextPair = RedactedStruct.new(
   end
 
   def multi_or_single_region_ciphertext
-    if IdentityConfig.store.aws_kms_multi_region_read_enabled
-      multi_region_ciphertext.presence || single_region_ciphertext
-    else
-      single_region_ciphertext
-    end
+    multi_region_ciphertext.presence || single_region_ciphertext
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -51,7 +51,6 @@ aws_kms_key_id: alias/login-dot-gov-test-keymaker
 aws_kms_client_contextless_pool_size: 5
 aws_kms_client_multi_pool_size: 5
 aws_kms_multi_region_key_id: alias/login-dot-gov-keymaker-multi-region
-aws_kms_multi_region_read_enabled: false
 aws_kms_session_key_id: alias/login-dot-gov-test-keymaker
 aws_logo_bucket: ''
 aws_region: 'us-west-2'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -138,7 +138,6 @@ class IdentityConfig
     config.add(:aws_kms_client_multi_pool_size, type: :integer)
     config.add(:aws_kms_key_id, type: :string)
     config.add(:aws_kms_multi_region_key_id, type: :string)
-    config.add(:aws_kms_multi_region_read_enabled, type: :boolean)
     config.add(:aws_kms_session_key_id, type: :string)
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -238,6 +238,9 @@ RSpec.describe Users::SessionsController, devise: true do
         profile = create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })
         profile.update!(
           encrypted_pii: { encrypted_data: Base64.strict_encode64('nonsense') }.to_json,
+          encrypted_pii_multi_region: {
+            encrypted_data: Base64.strict_encode64('nonsense'),
+          }.to_json,
         )
 
         stub_analytics

--- a/spec/features/legacy_passwords_spec.rb
+++ b/spec/features/legacy_passwords_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'legacy passwords' do
     user = create(:user, :fully_registered)
     user.update!(
       encrypted_password_digest: Encryption::UakPasswordVerifier.digest('legacy password'),
+      encrypted_password_digest_multi_region: nil,
     )
 
     expect(
@@ -26,6 +27,7 @@ RSpec.feature 'legacy passwords' do
     user = create(:user, :fully_registered)
     user.update!(
       encrypted_password_digest: Encryption::UakPasswordVerifier.digest('legacy password'),
+      encrypted_password_digest_multi_region: nil,
     )
 
     signin(user.email, 'a different password')
@@ -40,6 +42,7 @@ RSpec.feature 'legacy passwords' do
     user = create(:user, :fully_registered)
     user.update!(
       encrypted_recovery_code_digest: Encryption::UakPasswordVerifier.digest('1111 2222 3333 4444'),
+      encrypted_recovery_code_digest_multi_region: nil,
     )
 
     expect(
@@ -59,6 +62,7 @@ RSpec.feature 'legacy passwords' do
     user = create(:user, :fully_registered)
     user.update!(
       encrypted_recovery_code_digest: Encryption::UakPasswordVerifier.digest('1111 2222 3333 4444'),
+      encrypted_recovery_code_digest_multi_region: nil,
     )
 
     sign_in_user(user)

--- a/spec/jobs/multi_region_kms_migration/profile_migration_job_spec.rb
+++ b/spec/jobs/multi_region_kms_migration/profile_migration_job_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe MultiRegionKmsMigration::ProfileMigrationJob do
-  before do
-    allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
-  end
-
   let!(:profiles) { create_list(:profile, 4, :with_pii) }
   let!(:single_region_ciphertext_profiles) do
     single_region_profiles = profiles[2..3]

--- a/spec/jobs/multi_region_kms_migration/user_migration_job_spec.rb
+++ b/spec/jobs/multi_region_kms_migration/user_migration_job_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe MultiRegionKmsMigration::UserMigrationJob do
-  before do
-    allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
-  end
-
   let!(:multi_region_password_digest_user) { create(:user, password: 'salty pickles') }
   let!(:single_region_password_digest_user) do
     user = create(:user, password: 'salty_pickles')

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Profile do
   end
 
   describe '#recover_pii' do
-    it 'decrypts the recovery PII with personal key for users with a multi region ciphertext' do
+    it 'decrypts recovery PII with personal key for users with a multi region ciphertext' do
       profile.encrypt_pii(pii, user.password)
       personal_key = profile.personal_key
 
@@ -237,7 +237,7 @@ RSpec.describe Profile do
       expect(decrypted_pii).to eq pii
     end
 
-    it 'decrypts the recovery PII with personal key for users with only a single region ciphertext' do
+    it 'decrypts recovery PII with personal key for users with only a single region ciphertext' do
       profile.encrypt_pii(pii, user.password)
       profile.update!(encrypted_pii_recovery_multi_region: nil)
       personal_key = profile.personal_key

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -195,10 +195,19 @@ RSpec.describe Profile do
   end
 
   describe '#decrypt_pii' do
-    it 'decrypts PII' do
-      expect(profile.encrypted_pii).to be_nil
-
+    it 'decrypts the PII for users with a multi region ciphertext' do
       profile.encrypt_pii(pii, user.password)
+
+      expect(profile.encrypted_pii_multi_region).to_not be_nil
+
+      decrypted_pii = profile.decrypt_pii(user.password)
+
+      expect(decrypted_pii).to eq pii
+    end
+
+    it 'decrypts the PII for users with only a single region ciphertext' do
+      profile.encrypt_pii(pii, user.password)
+      profile.update!(encrypted_pii_multi_region: nil)
 
       decrypted_pii = profile.decrypt_pii(user.password)
 
@@ -212,74 +221,32 @@ RSpec.describe Profile do
 
       expect { profile.decrypt_pii(user.password) }.to raise_error(Encryption::EncryptionError)
     end
-
-    context 'with aws_kms_multi_region_read_enabled enabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
-      end
-
-      it 'decrypts the PII for users with a multi region ciphertext' do
-        profile.encrypt_pii(pii, user.password)
-
-        expect(profile.encrypted_pii_multi_region).to_not be_nil
-
-        decrypted_pii = profile.decrypt_pii(user.password)
-
-        expect(decrypted_pii).to eq pii
-      end
-
-      it 'decrypts the PII for users with only a single region ciphertext' do
-        profile.encrypt_pii(pii, user.password)
-        profile.update!(encrypted_pii_multi_region: nil)
-
-        decrypted_pii = profile.decrypt_pii(user.password)
-
-        expect(decrypted_pii).to eq pii
-      end
-    end
   end
 
   describe '#recover_pii' do
-    it 'decrypts the encrypted_pii_recovery using a personal key' do
-      expect(profile.encrypted_pii_recovery).to be_nil
-
+    it 'decrypts the recovery PII for users with a multi region ciphertext' do
       profile.encrypt_pii(pii, user.password)
       personal_key = profile.personal_key
 
       normalized_personal_key = PersonalKeyGenerator.new(user).normalize(personal_key)
 
-      expect(profile.recover_pii(normalized_personal_key)).to eq pii
+      expect(profile.encrypted_pii_recovery_multi_region).to_not be_nil
+
+      decrypted_pii = profile.recover_pii(normalized_personal_key)
+
+      expect(decrypted_pii).to eq pii
     end
 
-    context 'with aws_kms_multi_region_read_enabled enabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
-      end
+    it 'decrypts the recovery PII for users with only a single region ciphertext' do
+      profile.encrypt_pii(pii, user.password)
+      profile.update!(encrypted_pii_recovery_multi_region: nil)
+      personal_key = profile.personal_key
 
-      it 'decrypts the PII for users with a multi region ciphertext' do
-        profile.encrypt_pii(pii, user.password)
-        personal_key = profile.personal_key
+      normalized_personal_key = PersonalKeyGenerator.new(user).normalize(personal_key)
 
-        normalized_personal_key = PersonalKeyGenerator.new(user).normalize(personal_key)
+      decrypted_pii = profile.recover_pii(normalized_personal_key)
 
-        expect(profile.encrypted_pii_recovery_multi_region).to_not be_nil
-
-        decrypted_pii = profile.recover_pii(normalized_personal_key)
-
-        expect(decrypted_pii).to eq pii
-      end
-
-      it 'decrypts the PII for users with only a single region ciphertext' do
-        profile.encrypt_pii(pii, user.password)
-        profile.update!(encrypted_pii_recovery_multi_region: nil)
-        personal_key = profile.personal_key
-
-        normalized_personal_key = PersonalKeyGenerator.new(user).normalize(personal_key)
-
-        decrypted_pii = profile.recover_pii(normalized_personal_key)
-
-        expect(decrypted_pii).to eq pii
-      end
+      expect(decrypted_pii).to eq pii
     end
   end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Profile do
   end
 
   describe '#recover_pii' do
-    it 'decrypts the recovery PII for users with a multi region ciphertext' do
+    it 'decrypts the recovery PII with personal key for users with a multi region ciphertext' do
       profile.encrypt_pii(pii, user.password)
       personal_key = profile.personal_key
 
@@ -237,7 +237,7 @@ RSpec.describe Profile do
       expect(decrypted_pii).to eq pii
     end
 
-    it 'decrypts the recovery PII for users with only a single region ciphertext' do
+    it 'decrypts the recovery PII with personal key for users with only a single region ciphertext' do
       profile.encrypt_pii(pii, user.password)
       profile.update!(encrypted_pii_recovery_multi_region: nil)
       personal_key = profile.personal_key

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -432,43 +432,30 @@ RSpec.describe User do
   end
 
   describe '#valid_password?' do
-    it 'returns true if the password matches the stored digest' do
+    it 'validates the password for a user with a multi-region digest' do
       user = build(:user, password: 'test password')
+
+      expect(user.encrypted_password_digest_multi_region).to_not be_nil
 
       expect(user.valid_password?('test password')).to eq(true)
       expect(user.valid_password?('wrong password')).to eq(false)
     end
 
-    context 'aws_kms_multi_region_read_enabled is set to true' do
-      before do
-        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
-      end
+    it 'validates the password for a user with a only a single-region digest' do
+      user = build(:user, password: 'test password')
+      user.encrypted_password_digest_multi_region = nil
 
-      it 'validates the password for a user with a multi-region digest' do
-        user = build(:user, password: 'test password')
+      expect(user.valid_password?('test password')).to eq(true)
+      expect(user.valid_password?('wrong password')).to eq(false)
+    end
 
-        expect(user.encrypted_password_digest_multi_region).to_not be_nil
+    it 'validates the password for a user with a only a single-region UAK digest' do
+      user = build(:user)
+      user.encrypted_password_digest = Encryption::UakPasswordVerifier.digest('test password')
+      user.encrypted_password_digest_multi_region = nil
 
-        expect(user.valid_password?('test password')).to eq(true)
-        expect(user.valid_password?('wrong password')).to eq(false)
-      end
-
-      it 'validates the password for a user with a only a single-region digest' do
-        user = build(:user, password: 'test password')
-        user.encrypted_password_digest_multi_region = nil
-
-        expect(user.valid_password?('test password')).to eq(true)
-        expect(user.valid_password?('wrong password')).to eq(false)
-      end
-
-      it 'validates the password for a user with a only a single-region UAK digest' do
-        user = build(:user)
-        user.encrypted_password_digest = Encryption::UakPasswordVerifier.digest('test password')
-        user.encrypted_password_digest_multi_region = nil
-
-        expect(user.valid_password?('test password')).to eq(true)
-        expect(user.valid_password?('wrong password')).to eq(false)
-      end
+      expect(user.valid_password?('test password')).to eq(true)
+      expect(user.valid_password?('wrong password')).to eq(false)
     end
   end
 
@@ -493,44 +480,31 @@ RSpec.describe User do
   end
 
   describe '#valid_personal_key?' do
-    it 'returns true if the personal key matches the stored digest' do
+    it 'validates the personal key for a user with a multi-region digest' do
       user = build(:user, personal_key: 'test personal key')
+
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not be_nil
 
       expect(user.valid_personal_key?('test personal key')).to eq(true)
       expect(user.valid_personal_key?('wrong personal key')).to eq(false)
     end
 
-    context 'aws_kms_multi_region_read_enabled is set to true' do
-      before do
-        allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
-      end
+    it 'validates the personal key for a user with a only a single-region digest' do
+      user = build(:user, personal_key: 'test personal key')
+      user.encrypted_recovery_code_digest_multi_region = nil
 
-      it 'validates the personal key for a user with a multi-region digest' do
-        user = build(:user, personal_key: 'test personal key')
+      expect(user.valid_personal_key?('test personal key')).to eq(true)
+      expect(user.valid_personal_key?('wrong personal key')).to eq(false)
+    end
 
-        expect(user.encrypted_recovery_code_digest_multi_region).to_not be_nil
+    it 'validates the personal key for a user with a only a single-region UAK digest' do
+      user = build(:user)
+      user.encrypted_recovery_code_digest =
+        Encryption::UakPasswordVerifier.digest('test personal key')
+      user.encrypted_recovery_code_digest_multi_region = nil
 
-        expect(user.valid_personal_key?('test personal key')).to eq(true)
-        expect(user.valid_personal_key?('wrong personal key')).to eq(false)
-      end
-
-      it 'validates the personal key for a user with a only a single-region digest' do
-        user = build(:user, personal_key: 'test personal key')
-        user.encrypted_recovery_code_digest_multi_region = nil
-
-        expect(user.valid_personal_key?('test personal key')).to eq(true)
-        expect(user.valid_personal_key?('wrong personal key')).to eq(false)
-      end
-
-      it 'validates the personal key for a user with a only a single-region UAK digest' do
-        user = build(:user)
-        user.encrypted_recovery_code_digest =
-          Encryption::UakPasswordVerifier.digest('test personal key')
-        user.encrypted_recovery_code_digest_multi_region = nil
-
-        expect(user.valid_personal_key?('test personal key')).to eq(true)
-        expect(user.valid_personal_key?('wrong personal key')).to eq(false)
-      end
+      expect(user.valid_personal_key?('test personal key')).to eq(true)
+      expect(user.valid_personal_key?('wrong personal key')).to eq(false)
     end
   end
 

--- a/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
+++ b/spec/services/encryption/multi_region_kms_migration/profile_migrator_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Encryption::MultiRegionKmsMigration::ProfileMigrator do
 
   subject { described_class.new(profile) }
 
-  before do
-    allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
-  end
-
   describe '#migrate!' do
     context 'for a user without multi-region ciphertexts' do
       before do

--- a/spec/services/encryption/multi_region_kms_migration/user_migrator_spec.rb
+++ b/spec/services/encryption/multi_region_kms_migration/user_migrator_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Encryption::MultiRegionKmsMigration::UserMigrator do
-  before do
-    allow(IdentityConfig.store).to receive(:aws_kms_multi_region_read_enabled).and_return(true)
-  end
-
   let(:user) { create(:user, password: 'salty pickles', personal_key: '1234-ABCD') }
 
   subject { described_class.new(user) }


### PR DESCRIPTION
The `aws_kms_multi_region_read_enabled` was in place to toggle the changes introduced in #9047. Those changes have been deployed, enabled, and have been running without issue for some time.

This commit removes the tooling to toggle the feature since we will be using it going forward.