### PR TITLE
Add rejections to IDV report (LG-10621)

### DIFF
--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -21,6 +21,8 @@ module Reporting
       IDV_DOC_AUTH_GETTING_STARTED = 'IdV: doc auth getting_started visited'
       IDV_DOC_AUTH_WELCOME_SUBMITTED = 'IdV: doc auth welcome submitted'
       IDV_DOC_AUTH_IMAGE_UPLOAD = 'IdV: doc auth image upload vendor submitted'
+      IDV_DOC_AUTH_VERIFY_RESULTS = 'IdV: doc auth verify proofing results'
+      IDV_PHONE_FINDER_RESULTS = 'IdV: phone confirmation vendor'
       IDV_FINAL_RESOLUTION = 'IdV: final resolution'
       GPO_VERIFICATION_SUBMITTED = 'IdV: enter verify by mail code submitted'
       GPO_VERIFICATION_SUBMITTED_OLD = 'IdV: GPO verification submitted'
@@ -36,6 +38,11 @@ module Reporting
       IDV_FINAL_RESOLUTION_FRAUD_REVIEW = 'IdV: final resolution - Fraud Review Pending'
       IDV_FINAL_RESOLUTION_GPO = 'IdV: final resolution - GPO Pending'
       IDV_FINAL_RESOLUTION_IN_PERSON = 'IdV: final resolution - In Person Proofing'
+
+      IDV_REJECT_DOC_AUTH = 'IdV Reject: Doc Auth'
+      IDV_REJECT_VERIFY = 'IdV Reject: Verify'
+      IDV_REJECT_PHONE_FINDER = 'IdV Reject: Phone Finder'
+      IDV_REJECT_ANY = 'IdV Reject: Any'
     end
 
     # @param [Array<String>] issuers
@@ -144,6 +151,10 @@ module Reporting
       data[Events::IDV_DOC_AUTH_WELCOME_SUBMITTED].to_i
     end
 
+    def idv_doc_auth_rejected
+      data[Results::IDV_REJECT_ANY].to_i
+    end
+
     # Turns query results into a hash keyed by event name, values are a count of unique users
     # for that event
     # @return [Hash<Set<String>>]
@@ -156,23 +167,43 @@ module Reporting
         # IDEA: maybe there's a block form if this we can do that yields results as it loads them
         # to go slightly faster
         fetch_results.each do |row|
-          event_users[row['name']] << row['user_id']
+          event = row['name']
+          user_id = row['user_id']
+          success = row['success']
 
-          if row['name'] == Events::IDV_FINAL_RESOLUTION
+          event_users[event] << user_id
+
+          if event == Events::IDV_FINAL_RESOLUTION
             if row['identity_verified'] == '1'
-              event_users[Results::IDV_FINAL_RESOLUTION_VERIFIED] << row['user_id']
+              event_users[Results::IDV_FINAL_RESOLUTION_VERIFIED] << user_id
             end
             if row['gpo_verification_pending'] == '1'
-              event_users[Results::IDV_FINAL_RESOLUTION_GPO] << row['user_id']
+              event_users[Results::IDV_FINAL_RESOLUTION_GPO] << user_id
             end
             if row['in_person_verification_pending'] == '1'
-              event_users[Results::IDV_FINAL_RESOLUTION_IN_PERSON] << row['user_id']
+              event_users[Results::IDV_FINAL_RESOLUTION_IN_PERSON] << user_id
             end
             if row['fraud_review_pending'] == '1'
-              event_users[Results::IDV_FINAL_RESOLUTION_FRAUD_REVIEW] << row['user_id']
+              event_users[Results::IDV_FINAL_RESOLUTION_FRAUD_REVIEW] << user_id
             end
+          elsif event == Events::IDV_DOC_AUTH_IMAGE_UPLOAD && success == '0'
+            event_users[Results::IDV_REJECT_DOC_AUTH] << user_id
+          elsif event == Events::IDV_DOC_AUTH_VERIFY_RESULTS && success == '0'
+            event_users[Results::IDV_REJECT_VERIFY] << user_id
+          elsif event == Events::IDV_PHONE_FINDER_RESULTS && success == '0'
+            event_users[Results::IDV_REJECT_PHONE_FINDER] << user_id
           end
         end
+
+        # remove intermediate failures if user eventually succeeded
+        event_users[Results::IDV_REJECT_DOC_AUTH] -= event_users[Results::IDV_FINAL_RESOLUTION_VERIFIED]
+        event_users[Results::IDV_REJECT_VERIFY] -= event_users[Results::IDV_FINAL_RESOLUTION_VERIFIED]
+        event_users[Results::IDV_REJECT_PHONE_FINDER] -= event_users[Results::IDV_FINAL_RESOLUTION_VERIFIED]
+
+        event_users[Results::IDV_REJECT_ANY] =
+          event_users[Results::IDV_REJECT_DOC_AUTH] |
+          event_users[Results::IDV_REJECT_VERIFY] |
+          event_users[Results::IDV_REJECT_PHONE_FINDER]
 
         event_users.transform_values(&:count)
       end
@@ -200,6 +231,7 @@ module Reporting
         fields
             name
           , properties.user_id AS user_id
+          , coalesce(properties.event_properties.success, 0) AS success
         #{issuers.present? ? '| filter properties.service_provider IN %{issuers}' : ''}
         | filter name in %{event_names}
         | filter (name = %{usps_enrollment_status_updated} and properties.event_properties.passed = 1)

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -14,38 +14,43 @@ RSpec.describe Reporting::IdentityVerificationReport do
     cloudwatch_client = double(
       'Reporting::CloudwatchClient',
       fetch: [
-        # Online verification user
+        # Online verification user (failed each vendor once, then suceeded once)
         { 'user_id' => 'user1', 'name' => 'IdV: doc auth welcome visited' },
         { 'user_id' => 'user1', 'name' => 'IdV: doc auth welcome submitted' },
-        { 'user_id' => 'user1', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user1', 'name' => 'IdV: doc auth image upload vendor submitted', 'success' => '0' },
+        { 'user_id' => 'user1', 'name' => 'IdV: doc auth image upload vendor submitted', 'success' => '1' },
+        { 'user_id' => 'user1', 'name' => 'IdV: doc auth verify proofing results', 'success' => '0' },
+        { 'user_id' => 'user1', 'name' => 'IdV: doc auth verify proofing results', 'success' => '1' },
+        { 'user_id' => 'user1', 'name' => 'IdV: phone confirmation vendor', 'success' => '0' },
+        { 'user_id' => 'user1', 'name' => 'IdV: phone confirmation vendor', 'success' => '1' },
         { 'user_id' => 'user1', 'name' => 'IdV: final resolution', 'identity_verified' => '1' },
 
         # Letter requested user (incomplete)
         { 'user_id' => 'user2', 'name' => 'IdV: doc auth welcome visited' },
         { 'user_id' => 'user2', 'name' => 'IdV: doc auth welcome submitted' },
-        { 'user_id' => 'user2', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user2', 'name' => 'IdV: doc auth image upload vendor submitted', 'success' => '1' },
         { 'user_id' => 'user2', 'name' => 'IdV: final resolution', 'gpo_verification_pending' => '1' },
 
         # Fraud review user (incomplete)
         { 'user_id' => 'user3', 'name' => 'IdV: doc auth welcome visited' },
         { 'user_id' => 'user3', 'name' => 'IdV: doc auth welcome submitted' },
-        { 'user_id' => 'user3', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user3', 'name' => 'IdV: doc auth image upload vendor submitted', 'success' => '1' },
         { 'user_id' => 'user3', 'name' => 'IdV: final resolution', 'fraud_review_pending' => '1' },
 
         # Success through address confirmation user
         { 'user_id' => 'user4', 'name' => 'IdV: GPO verification submitted' },
 
-        # Success through in-person verification
+        # Success through in-person verification, failed doc auth
         { 'user_id' => 'user5', 'name' => 'IdV: doc auth welcome visited' },
         { 'user_id' => 'user5', 'name' => 'IdV: doc auth welcome submitted' },
-        { 'user_id' => 'user5', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user5', 'name' => 'IdV: doc auth image upload vendor submitted', 'success' => '0' },
         { 'user_id' => 'user5', 'name' => 'IdV: final resolution', 'in_person_verification_pending' => '1' },
         { 'user_id' => 'user5', 'name' => 'GetUspsProofingResultsJob: Enrollment status updated' },
 
         # Incomplete user
         { 'user_id' => 'user6', 'name' => 'IdV: doc auth welcome visited' },
         { 'user_id' => 'user6', 'name' => 'IdV: doc auth welcome submitted' },
-        { 'user_id' => 'user6', 'name' => 'IdV: doc auth image upload vendor submitted' },
+        { 'user_id' => 'user6', 'name' => 'IdV: doc auth image upload vendor submitted', 'success' => '0' },
       ],
     )
 
@@ -92,16 +97,25 @@ RSpec.describe Reporting::IdentityVerificationReport do
   describe '#data' do
     it 'counts unique users per event as a hash' do
       expect(report.data).to eq(
+        # events
+        'GetUspsProofingResultsJob: Enrollment status updated' => 1,
         'IdV: doc auth image upload vendor submitted' => 5,
+        'IdV: doc auth verify proofing results' => 1,
         'IdV: doc auth welcome submitted' => 5,
         'IdV: doc auth welcome visited' => 5,
         'IdV: final resolution' => 4,
+        'IdV: GPO verification submitted' => 1,
+        'IdV: phone confirmation vendor' => 1,
+
+        # results
+        'IdV: final resolution - Fraud Review Pending' => 1,
         'IdV: final resolution - GPO Pending' => 1,
         'IdV: final resolution - In Person Proofing' => 1,
-        'IdV: final resolution - Fraud Review Pending' => 1,
         'IdV: final resolution - Verified' => 1,
-        'IdV: GPO verification submitted' => 1,
-        'GetUspsProofingResultsJob: Enrollment status updated' => 1,
+        'IdV Reject: Any' => 2,
+        'IdV Reject: Doc Auth' => 2,
+        'IdV Reject: Phone Finder' => 0,
+        'IdV Reject: Verify' => 0,
       )
     end
   end


### PR DESCRIPTION
Adds IDV rejects (doc auth fails, resolution fails, phonefinder fails) to the IDV report, so we can calculate the "industry rate" [(per Google Doc)](https://docs.google.com/document/d/1O6sw0_83EeOGX0QtUiYoHfm-m0VQCJqYQXgsgXuOU1M/edit#bookmark=id.budguol4yf)

This will be a V2 addition to https://github.com/18F/identity-idp/pull/9186