### PR TITLE
LG-10779 Log analytics events from the fraud review/reject script

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -532,11 +532,13 @@ module AnalyticsEvents
   # @param [Boolean] success
   # @param [Hash] errors
   # @param [String] exception
+  # @param [String] profile_fraud_review_pending_at
   # The user was passed by manual fraud review
   def fraud_review_passed(
     success:,
     errors:,
     exception:,
+    profile_fraud_review_pending_at:,
     **extra
   )
     track_event(
@@ -544,6 +546,7 @@ module AnalyticsEvents
       success: success,
       errors: errors,
       exception: exception,
+      profile_fraud_review_pending_at: profile_fraud_review_pending_at,
       **extra,
     )
   end
@@ -551,11 +554,13 @@ module AnalyticsEvents
   # @param [Boolean] success
   # @param [Hash] errors
   # @param [String] exception
+  # @param [String] profile_fraud_review_pending_at
   # The user was rejected by manual fraud review
   def fraud_review_rejected(
     success:,
     errors:,
     exception:,
+    profile_fraud_review_pending_at:,
     **extra
   )
     track_event(
@@ -563,6 +568,7 @@ module AnalyticsEvents
       success: success,
       errors: errors,
       exception: exception,
+      profile_fraud_review_pending_at: profile_fraud_review_pending_at,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -530,6 +530,44 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] exception
+  # The user was passed by manual fraud review
+  def fraud_review_passed(
+    success:,
+    errors:,
+    exception:,
+    **extra
+  )
+    track_event(
+      'Fraud: Profile review passed',
+      success: success,
+      errors: errors,
+      exception: exception,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] errors
+  # @param [String] exception
+  # The user was rejected by manual fraud review
+  def fraud_review_rejected(
+    success:,
+    errors:,
+    exception:,
+    **extra
+  )
+    track_event(
+      'Fraud: Profile review rejected',
+      success: success,
+      errors: errors,
+      exception: exception,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
   # @param [Boolean] address_edited
   # @param [Hash] pii_like_keypaths
   # @param [Hash] errors

--- a/lib/tasks/review_profile.rake
+++ b/lib/tasks/review_profile.rake
@@ -5,7 +5,7 @@ namespace :users do
   namespace :review do
     desc 'Pass a user that has a pending review'
     task pass: :environment do |_task, args|
-      user = AnonymousUser.new
+      user = nil
       success = false
       exception = nil
 
@@ -65,14 +65,14 @@ namespace :users do
       end
 
       Analytics.new(
-        user: AnonymousUser.new, request: nil, session: {}, sp: nil,
+        user: user || AnonymousUser.new, request: nil, session: {}, sp: nil,
       ).fraud_review_passed(success:, errors: analytics_error_hash, exception: exception&.inspect)
     end
 
     desc 'Reject a user that has a pending review'
     task reject: :environment do |_task, args|
       error = nil
-      user = AnonymousUser.new
+      user = nil
       success = false
 
       STDOUT.sync = true
@@ -119,7 +119,7 @@ namespace :users do
       end
 
       Analytics.new(
-        user: AnonymousUser.new, request: nil, session: {}, sp: nil,
+        user: user || AnonymousUser.new, request: nil, session: {}, sp: nil,
       ).fraud_review_rejected(success:, errors: analytics_error_hash, exception: exception&.inspect)
     end
   end

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe 'review_profile' do
     end
 
     it 'logs that the user was passed to analytics' do
+      profile_fraud_review_pending_at = user.profiles.first.fraud_review_pending_at
+
       invoke_task
 
       expect(analytics).to have_logged_event(
@@ -54,6 +56,7 @@ RSpec.describe 'review_profile' do
         success: true,
         errors: nil,
         exception: nil,
+        profile_fraud_review_pending_at: profile_fraud_review_pending_at,
       )
     end
 
@@ -75,6 +78,7 @@ RSpec.describe 'review_profile' do
           success: false,
           errors: { message: 'Error: Could not find user with that UUID' },
           exception: nil,
+          profile_fraud_review_pending_at: nil,
         )
       end
     end
@@ -89,6 +93,7 @@ RSpec.describe 'review_profile' do
       end
 
       it 'logs an error to analytics' do
+        profile_fraud_review_pending_at = user.profiles.first.fraud_review_pending_at
         user.profiles.first.update!(gpo_verification_pending_at: user.created_at)
 
         expect { invoke_task }.to raise_error(RuntimeError)
@@ -98,6 +103,7 @@ RSpec.describe 'review_profile' do
           success: false,
           errors: nil,
           exception: a_string_including('Attempting to activate profile with pending reason'),
+          profile_fraud_review_pending_at: profile_fraud_review_pending_at,
         )
       end
     end
@@ -117,6 +123,8 @@ RSpec.describe 'review_profile' do
     end
 
     it 'logs that the user was rejected to analytics' do
+      profile_fraud_review_pending_at = user.profiles.first.fraud_review_pending_at
+
       invoke_task
 
       expect(analytics).to have_logged_event(
@@ -124,6 +132,7 @@ RSpec.describe 'review_profile' do
         success: true,
         errors: nil,
         exception: nil,
+        profile_fraud_review_pending_at: profile_fraud_review_pending_at,
       )
     end
 
@@ -145,6 +154,7 @@ RSpec.describe 'review_profile' do
           success: false,
           errors: { message: 'Error: Could not find user with that UUID' },
           exception: nil,
+          profile_fraud_review_pending_at: nil,
         )
       end
     end
@@ -172,6 +182,7 @@ RSpec.describe 'review_profile' do
           success: false,
           errors: { message: 'Error: User does not have a pending fraud review' },
           exception: nil,
+          profile_fraud_review_pending_at: nil,
         )
       end
     end

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'review_profile' do
   let(:user) { create(:user, :fraud_review_pending) }
   let(:uuid) { user.uuid }
   let(:task_name) { nil }
+  let(:analytics) { FakeAnalytics.new }
 
   subject(:invoke_task) do
     Rake::Task[task_name].reenable
@@ -22,6 +23,8 @@ RSpec.describe 'review_profile' do
       uuid,
     )
     stub_const('STDOUT', stdout)
+
+    allow(Analytics).to receive(:new).and_return(analytics)
   end
 
   describe 'users:review:pass' do
@@ -43,6 +46,17 @@ RSpec.describe 'review_profile' do
       end
     end
 
+    it 'logs that the user was passed to analytics' do
+      invoke_task
+
+      expect(analytics).to have_logged_event(
+        'Fraud: Profile review passed',
+        success: true,
+        errors: nil,
+        exception: nil,
+      )
+    end
+
     context 'when the user does not exist' do
       let(:user) { nil }
       let(:uuid) { 'not-a-real-uuid' }
@@ -51,6 +65,17 @@ RSpec.describe 'review_profile' do
         invoke_task
 
         expect(stdout.string).to include('Error: Could not find user with that UUID')
+      end
+
+      it 'logs the error to analytics' do
+        invoke_task
+
+        expect(analytics).to have_logged_event(
+          'Fraud: Profile review passed',
+          success: false,
+          errors: { message: 'Error: Could not find user with that UUID' },
+          exception: nil,
+        )
       end
     end
 
@@ -61,6 +86,19 @@ RSpec.describe 'review_profile' do
         expect { invoke_task }.to raise_error(RuntimeError)
 
         expect(user.reload.profiles.first.active).to eq(false)
+      end
+
+      it 'logs an error to analytics' do
+        user.profiles.first.update!(gpo_verification_pending_at: user.created_at)
+
+        expect { invoke_task }.to raise_error(RuntimeError)
+
+        expect(analytics).to have_logged_event(
+          'Fraud: Profile review passed',
+          success: false,
+          errors: nil,
+          exception: a_string_including('Attempting to activate profile with pending reason'),
+        )
       end
     end
   end
@@ -78,6 +116,17 @@ RSpec.describe 'review_profile' do
       expect { invoke_task }.to change(ActionMailer::Base.deliveries, :count).by(1)
     end
 
+    it 'logs that the user was rejected to analytics' do
+      invoke_task
+
+      expect(analytics).to have_logged_event(
+        'Fraud: Profile review rejected',
+        success: true,
+        errors: nil,
+        exception: nil,
+      )
+    end
+
     context 'when the user does not exist' do
       let(:user) { nil }
       let(:uuid) { 'not-a-real-uuid' }
@@ -86,6 +135,17 @@ RSpec.describe 'review_profile' do
         invoke_task
 
         expect(stdout.string).to include('Error: Could not find user with that UUID')
+      end
+
+      it 'logs the error to analytics' do
+        invoke_task
+
+        expect(analytics).to have_logged_event(
+          'Fraud: Profile review rejected',
+          success: false,
+          errors: { message: 'Error: Could not find user with that UUID' },
+          exception: nil,
+        )
       end
     end
 
@@ -102,6 +162,17 @@ RSpec.describe 'review_profile' do
         invoke_task
 
         expect(stdout.string).to include('Error: User does not have a pending fraud review')
+      end
+
+      it 'logs the error to analytics' do
+        invoke_task
+
+        expect(analytics).to have_logged_event(
+          'Fraud: Profile review rejected',
+          success: false,
+          errors: { message: 'Error: User does not have a pending fraud review' },
+          exception: nil,
+        )
       end
     end
   end


### PR DESCRIPTION
We have a script that marks users pending fraud review as passed or rejected. Previously when users are passed or rejected in this way there was not event in events.log to log it.

This commit adds logging so we can track these events in cloudwatch.
