### PR TITLE
Add preview for password reset email with outstanding GPO letter

### DIFF
--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -32,6 +32,14 @@ class UserMailerPreview < ActionMailer::Preview
     )
   end
 
+  def reset_password_instructions_with_pending_gpo_letter
+    UserMailer.with(
+      user: user_with_pending_gpo_letter, email_address: email_address_record,
+    ).reset_password_instructions(
+      token: SecureRandom.hex, request_id: SecureRandom.hex,
+    )
+  end
+
   def password_changed
     UserMailer.with(user: user, email_address: email_address_record).
       password_changed(disavowal_token: SecureRandom.hex)


### PR DESCRIPTION
## 🛠 Summary of changes

- Add preview of reset password email when GPO letter has been sent
  - Created in relation to https://github.com/18F/identity-idp/pull/9167

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Navigate to http://localhost:3000/rails/mailers
- [x] Select `[reset_password_instructions_with_pending_gpo_letter](http://localhost:3000/rails/mailers/user_mailer/reset_password_instructions_with_pending_gpo_letter)`
- [x] Verify that email is rendered with GPO lette warning

## 👀 Screenshots

<details>

<summary>Email Example List</summary>

<img width="431" alt="Screenshot 2023-09-12 at 3 52 15 PM" src="https://github.com/18F/identity-idp/assets/90272033/d56603ba-4089-450b-9830-aec5f1f6e2ae">


</details>

<details>

<summary>Rendered email</summary>

<img width="1047" alt="Screenshot 2023-09-12 at 3 52 41 PM" src="https://github.com/18F/identity-idp/assets/90272033/d0693c40-0cf0-4de7-a97e-e86273900512">


</details>
