### PR TITLE
Optimize ProofingRateReport

### DIFF
--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -46,7 +46,8 @@ module Reporting
       verbose: false,
       progress: false,
       slice: 3.hours,
-      threads: 5
+      threads: 5,
+      data: nil
     )
       @issuers = issuers
       @time_range = time_range
@@ -54,6 +55,7 @@ module Reporting
       @progress = progress
       @slice = slice
       @threads = threads
+      @data = data
     end
 
     def verbose?
@@ -90,39 +92,54 @@ module Reporting
       end
     end
 
+    # @param [Reporting::IdentityVerificationReport] other
+    # @return [Reporting::IdentityVerificationReport]
+    def merge(other)
+      self.class.new(
+        issuers: (Array(issuers) + Array(other.issuers)).uniq,
+        time_range: Range.new(
+          [time_range.begin, other.time_range.begin].min,
+          [time_range.end, other.time_range.end].max,
+        ),
+        data: data.merge(other.data) do |_event, old_user_ids, new_user_ids|
+          old_user_ids + new_user_ids
+        end,
+      )
+    end
+
     def idv_final_resolution
-      data[Events::IDV_FINAL_RESOLUTION].to_i
+      data[Events::IDV_FINAL_RESOLUTION].count
     end
 
     def idv_final_resolution_verified
-      data[Results::IDV_FINAL_RESOLUTION_VERIFIED].to_i
+      data[Results::IDV_FINAL_RESOLUTION_VERIFIED].count
     end
 
     def idv_final_resolution_gpo
-      data[Results::IDV_FINAL_RESOLUTION_GPO].to_i
+      data[Results::IDV_FINAL_RESOLUTION_GPO].count
     end
 
     def idv_final_resolution_in_person
-      data[Results::IDV_FINAL_RESOLUTION_IN_PERSON].to_i
+      data[Results::IDV_FINAL_RESOLUTION_IN_PERSON].count
     end
 
     def idv_final_resolution_fraud_review
-      data[Results::IDV_FINAL_RESOLUTION_FRAUD_REVIEW].to_i
+      data[Results::IDV_FINAL_RESOLUTION_FRAUD_REVIEW].count
     end
 
     def idv_final_resolution_total_pending
-      idv_final_resolution - idv_final_resolution_verified
+      @idv_final_resolution_total_pending ||=
+        (data[Events::IDV_FINAL_RESOLUTION] - data[Results::IDV_FINAL_RESOLUTION_VERIFIED]).count
     end
 
     def gpo_verification_submitted
-      [
-        data[Events::GPO_VERIFICATION_SUBMITTED].to_i,
-        data[Events::GPO_VERIFICATION_SUBMITTED_OLD].to_i,
-      ].sum
+      @gpo_verification_submitted ||= (
+        data[Events::GPO_VERIFICATION_SUBMITTED] +
+          data[Events::GPO_VERIFICATION_SUBMITTED_OLD]).count
     end
 
     def usps_enrollment_status_updated
-      data[Events::USPS_ENROLLMENT_STATUS_UPDATED].to_i
+      data[Events::USPS_ENROLLMENT_STATUS_UPDATED].count
     end
 
     def successfully_verified_users
@@ -130,21 +147,19 @@ module Reporting
     end
 
     def idv_started
-      [
-        data[Events::IDV_DOC_AUTH_WELCOME].to_i,
-        data[Events::IDV_DOC_AUTH_GETTING_STARTED].to_i,
-      ].sum
+      @idv_started ||=
+        (data[Events::IDV_DOC_AUTH_WELCOME] + data[Events::IDV_DOC_AUTH_GETTING_STARTED]).count
     end
 
     def idv_doc_auth_image_vendor_submitted
-      data[Events::IDV_DOC_AUTH_IMAGE_UPLOAD].to_i
+      data[Events::IDV_DOC_AUTH_IMAGE_UPLOAD].count
     end
 
     def idv_doc_auth_welcome_submitted
-      data[Events::IDV_DOC_AUTH_WELCOME_SUBMITTED].to_i
+      data[Events::IDV_DOC_AUTH_WELCOME_SUBMITTED].count
     end
 
-    # Turns query results into a hash keyed by event name, values are a count of unique users
+    # Turns query results into a hash keyed by event name, values are the unique user IDs
     # for that event
     # @return [Hash<Set<String>>]
     def data
@@ -174,7 +189,7 @@ module Reporting
           end
         end
 
-        event_users.transform_values(&:count)
+        event_users
       end
     end
 

--- a/spec/lib/reporting/proofing_rate_report_spec.rb
+++ b/spec/lib/reporting/proofing_rate_report_spec.rb
@@ -93,18 +93,24 @@ RSpec.describe Reporting::ProofingRateReport do
       )
 
       expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-        issuers: nil,
         time_range: (end_date - 30.days)..end_date,
+        issuers: nil,
+        verbose: false,
+        progress: false,
       ).once
 
       expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-        issuers: nil,
         time_range: (end_date - 60.days)..(end_date - 30.days),
+        issuers: nil,
+        verbose: false,
+        progress: false,
       ).once
 
       expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-        issuers: nil,
         time_range: (end_date - 90.days)..(end_date - 60.days),
+        issuers: nil,
+        verbose: false,
+        progress: false,
       ).once
     end
   end


### PR DESCRIPTION
One more change to #9186

**Problem**:
Currently, to get 30, 60, 90 day lookbacks, we end-up re-querying the most recent 30 days 30x. This adds up and times out locally

**Solution**:
Cache the results and merge them. Normally this might be a premature optimization, but since we're already hitting AWS session timeouts, this is no longer premature.


- Switches underlying `IdentityVerificationReport` to save unique UUIDs instead of just counts (this is similar to what we already to in `AuthenticationReport`
- Adds `#merge` method to reports to combine the underlying data
