### PR TITLE
LG-11014: Log created at for latest WebAuthn config for failed attempt

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -143,7 +143,7 @@ module TwoFactorAuthentication
     end
 
     def webauthn_configuration_or_latest
-      form&.webauthn_configuration&.created_at || webauthn_configurations.take
+      form&.webauthn_configuration || webauthn_configurations.take
     end
 
     def webauthn_configurations

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -143,7 +143,7 @@ module TwoFactorAuthentication
     end
 
     def webauthn_configuration_or_latest
-      form.webauthn_configuration || webauthn_configurations.last
+      form.webauthn_configuration || webauthn_configurations.first
     end
 
     def webauthn_configurations

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -143,11 +143,11 @@ module TwoFactorAuthentication
     end
 
     def webauthn_configuration_or_latest
-      form&.webauthn_configuration || webauthn_configurations.last
+      form.webauthn_configuration || webauthn_configurations.last
     end
 
     def webauthn_configurations
-      MfaContext.new(current_user).webauthn_configurations.order(:created_at)
+      MfaContext.new(current_user).webauthn_configurations.order(created_at: :desc)
     end
   end
 end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -143,7 +143,7 @@ module TwoFactorAuthentication
     end
 
     def webauthn_configuration_or_latest
-      form&.webauthn_configuration || webauthn_configurations.take
+      form&.webauthn_configuration || webauthn_configurations.last
     end
 
     def webauthn_configurations

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -209,10 +209,10 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
         let(:webauthn_error) { 'NotAllowedError' }
         let(:params) do
           {
-            authenticator_data: authenticator_data,
-            client_data_json: verification_client_data_json,
-            signature: signature,
-            credential_id: credential_id,
+            authenticator_data: '',
+            client_data_json: '',
+            signature: '',
+            credential_id: '',
             platform: true,
             webauthn_error: webauthn_error,
           }
@@ -256,13 +256,19 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
 
         it 'logs an event with error details' do
           expect(@analytics).to receive(:track_mfa_submit_event).with(
-            hash_including(
-              success: false,
-              error_details: { webauthn_error: [webauthn_error] },
-              context: UserSessionContext::AUTHENTICATION_CONTEXT,
-              multi_factor_auth_method: 'webauthn_platform',
-              webauthn_configuration_id: controller.current_user.webauthn_configurations.first.id,
-            ),
+            success: false,
+            error_details: {
+              authenticator_data: [:blank],
+              client_data_json: [:blank],
+              signature: [:blank],
+              webauthn_configuration: [:blank],
+              webauthn_error: [webauthn_error],
+            },
+            context: UserSessionContext::AUTHENTICATION_CONTEXT,
+            multi_factor_auth_method: 'webauthn_platform',
+            multi_factor_auth_method_created_at:
+              controller.current_user.webauthn_configurations.first.created_at.strftime('%s%L'),
+            webauthn_configuration_id: nil,
           )
 
           patch :confirm, params: params


### PR DESCRIPTION
## 🎫 Ticket

[LG-11014](https://cm-jira.usa.gov/browse/LG-11014)

## 🛠 Summary of changes

Updates logging for MFA submission for Face/Touch Unlock to always log a creation date on failed attempts, using the latest configuration if the form submission did not include identifiers for a valid authenticator.

As noted in the ticket, there's some complexity here because a user is permitted to use any of the F/T configurations associated with their account, which can be multiple, and in the case of a failure we don't know which F/T credential they'll have wanted to use. But because the intent with logging the date was to be able to effectively compare success rates before and after the enablement of Face/Touch Unlock, we need creation dates for failed attempts.

## 📜 Testing Plan

Prerequisite: Have an account with Face or Touch Unlock.

1. Go to http://localhost:3000
2. Sign in
3. (If not prompted to MFA, click "Forget all browsers" from account page, confirm, then sign out and start over)
4. When prompted to MFA with Face or Touch Unlock, click "Use face or touch unlock"
5. Cancel the prompt or otherwise fail the authentication
6. `tail log/events.log`

**Before:** The "multi_factor_auth_method_created_at" is `nil` for the event.

**After:** A "Multi-Factor Authentication" event is logged, with a non-nil "multi_factor_auth_method_created_at" property value.