### PR TITLE
Add logging to debug ssn 50/50 state issue.

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -25,6 +25,10 @@ module Idv
       idv_session.vendor_phone_confirmation = false
       idv_session.user_phone_confirmation = false
 
+      # rubocop:disable Layout/LineLength
+      # TEMPORARY DEBUGGING
+      logger.info("ResolutionJobDebug: user_uuid=#{current_user.uuid} old=#{pii[:ssn].present?} new=#{idv_session.ssn.present?} controller=#{self.class.name}")
+      # rubocop:enable Layout/LineLength
       Idv::Agent.new(pii).proof_resolution(
         document_capture_session,
         should_proof_state_id: should_use_aamva?(pii),

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -29,6 +29,7 @@ module Idv
       # TEMPORARY DEBUGGING
       logger.info("ResolutionJobDebug: user_uuid=#{current_user.uuid} old=#{pii[:ssn].present?} new=#{idv_session.ssn.present?} controller=#{self.class.name}")
       # rubocop:enable Layout/LineLength
+      pii[:ssn] ||= idv_session.ssn # Required for proof_resolution job
       Idv::Agent.new(pii).proof_resolution(
         document_capture_session,
         should_proof_state_id: should_use_aamva?(pii),


### PR DESCRIPTION
## 🛠 Summary of changes

Add temporary logging to figure out why ssn was not available for resolution proofing job when deploying #9182 to remove the ssn from the flow_session.

Log includes controller name to check whether the user is in remote or in person proofing flow.

Also, add the line that was missing from old instances that caused the problem during the 50/50 state. This needs to be deployed before unreverting the [delete PR](https://github.com/18F/identity-idp/pull/9182/) that caused the issue.

## 📜 Testing Plan

- [ ] Create account, start IdV
- [ ] After submitting the VerifyInfo step, expect to see the following in development.log (if testing locally)
`ResolutionJobDebug: user_uuid=f46901d3-4c7f-4f5c-84bf-b0f76d84b211 old=true new=true controller=Idv::VerifyInfoController`
