### PR TITLE
Remove NewRelic domains from CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,7 +2,7 @@ require 'feature_management'
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.config.content_security_policy do |policy|
-  connect_src = ["'self'", '*.nr-data.net']
+  connect_src = ["'self'"]
 
   font_src = [:self, :data, IdentityConfig.store.asset_host.presence].compact
 
@@ -15,14 +15,8 @@ Rails.application.config.content_security_policy do |policy|
       "https://s3.#{IdentityConfig.store.aws_region}.amazonaws.com",
   ].select(&:present?)
 
-  script_src = [
-    :self,
-    'js-agent.newrelic.com',
-    '*.nr-data.net',
-    IdentityConfig.store.asset_host.presence,
-  ].compact
-
-  script_src = [:self, :unsafe_eval] if !Rails.env.production?
+  script_src = [:self, IdentityConfig.store.asset_host.presence].compact
+  script_src << :unsafe_eval if !Rails.env.production?
 
   style_src = [:self, IdentityConfig.store.asset_host.presence].compact
 

--- a/spec/requests/csp_spec.rb
+++ b/spec/requests/csp_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe 'content security policy' do
       expect(content_security_policy['default-src']).to eq("'self'")
       expect(content_security_policy['base-uri']).to eq("'self'")
       expect(content_security_policy['child-src']).to eq("'self'")
-      expect(content_security_policy['connect-src']).to eq(
-        "'self' *.nr-data.net",
-      )
+      expect(content_security_policy['connect-src']).to eq("'self'")
       expect(content_security_policy['font-src']).to eq("'self' data:")
       expect(content_security_policy['form-action']).to eq(
         "'self' http://localhost:7654 https://example.com http://www.example.com",
@@ -39,9 +37,7 @@ RSpec.describe 'content security policy' do
       expect(content_security_policy['default-src']).to eq("'self'")
       expect(content_security_policy['base-uri']).to eq("'self'")
       expect(content_security_policy['child-src']).to eq("'self'")
-      expect(content_security_policy['connect-src']).to eq(
-        "'self' *.nr-data.net",
-      )
+      expect(content_security_policy['connect-src']).to eq("'self'")
       expect(content_security_policy['font-src']).to eq("'self' data:")
       expect(content_security_policy['form-action']).to eq("'self'")
       expect(content_security_policy['img-src']).to eq(


### PR DESCRIPTION
## 🛠 Summary of changes

Removes NewRelic domains from the Content Security Policy.

**Why?**

- We're no longer calling to NewRelic on the frontend as of #8950
- Hardens the security policy

## 📜 Testing Plan

- Check that response headers don't include NewRelic in any environment
- `rspec spec/requests/csp_spec.rb`