### PR TITLE
Fix JavaScript Webpack tree-shaking

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts'],
-    conditionNames: ['source', 'import', 'require', 'node'],
+    conditionNames: ['source', '...'],
   },
   module: {
     rules: [


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where [Webpack tree-shaking](https://webpack.js.org/guides/tree-shaking/) (dead code elimination) was not working, inflating the size of JavaScript bundles by including JavaScript for design system components not in use.

This appears to have regressed as part of the revisions to `conditionNames` in #8655, though it's not entirely clear to me the relation between `conditionNames` and tree-shaking, aside from the net result that Webpack was choosing to resolve to CommonJS over ESM. Experimenting with ordering of `conditionNames` did not yield a desired outcome, but it does work correctly using the `...` placeholder [found in Webpack's internal source](https://github.com/webpack/webpack/blob/1f13ff9fe587e094df59d660b4611b1bd19aed4c/lib/config/defaults.js#L101-L102).

**Performance Impact:**

```
NODE_ENV=production yarn build && ls public/packs/js/application-*.js | head -n 1 | xargs brotli-size
```

**Before:** 17.3kb
**After:** 1.76kb
**Diff:** -15.54kb (-89.8%)

## 📜 Testing Plan

```
NODE_ENV=production yarn build
```

Observe that the `application-[digest].js` bundle in `public/packs/js` does not contain references to `character-count`.

Verify no regressions in expected behavior of #8655.