### PR TITLE
Remove password toggle click frontend event

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -27,7 +27,6 @@ class FrontendLogController < ApplicationController
     'IdV: user clicked what to bring link on ready to verify page' => :idv_in_person_ready_to_verify_what_to_bring_link_clicked,
     'IdV: verify in person troubleshooting option clicked' => :idv_verify_in_person_troubleshooting_option_clicked,
     'Multi-Factor Authentication: download backup code' => :multi_factor_auth_backup_code_download,
-    'Show Password button clicked' => :show_password_button_clicked,
     'Sign In: IdV requirements accordion clicked' => :sign_in_idv_requirements_accordion_clicked,
     'User prompted before navigation' => :user_prompted_before_navigation,
     'User prompted before navigation and still on page' => :user_prompted_before_navigation_and_still_on_page,

--- a/app/javascript/packages/password-confirmation/password-confirmation-element.spec.ts
+++ b/app/javascript/packages/password-confirmation/password-confirmation-element.spec.ts
@@ -1,7 +1,5 @@
 import userEvent from '@testing-library/user-event';
 import { getByLabelText, waitFor } from '@testing-library/dom';
-import { useSandbox } from '@18f/identity-test-helpers';
-import * as analytics from '@18f/identity-analytics';
 import './password-confirmation-element';
 import type PasswordConfirmationElement from './password-confirmation-element';
 
@@ -10,7 +8,6 @@ describe('PasswordConfirmationElement', () => {
   let input1: HTMLInputElement;
   let input2: HTMLInputElement;
   let idCounter = 0;
-  const sandbox = useSandbox();
 
   function createElement() {
     element = document.createElement('lg-password-confirmation') as PasswordConfirmationElement;
@@ -51,17 +48,6 @@ describe('PasswordConfirmationElement', () => {
     await userEvent.click(toggle);
 
     expect(input1.type).to.equal('text');
-  });
-
-  it('logs an event when clicking the Show Password button', async () => {
-    sandbox.stub(analytics, 'trackEvent');
-    const toggle = getByLabelText(element, 'Show password') as HTMLInputElement;
-
-    await userEvent.click(toggle);
-
-    expect(analytics.trackEvent).to.have.been.calledWith('Show Password button clicked', {
-      path: window.location.pathname,
-    });
   });
 
   describe('Password validation', () => {

--- a/app/javascript/packages/password-confirmation/password-confirmation-element.ts
+++ b/app/javascript/packages/password-confirmation/password-confirmation-element.ts
@@ -1,10 +1,8 @@
-import { trackEvent } from '@18f/identity-analytics';
 import { t } from '@18f/identity-i18n';
 
 class PasswordConfirmationElement extends HTMLElement {
   connectedCallback() {
     this.toggle.addEventListener('change', () => this.setInputType());
-    this.toggle.addEventListener('click', () => this.trackToggleEvent());
     this.input.addEventListener('input', () => this.validatePassword());
     this.inputConfirmation.addEventListener('input', () => this.validatePassword());
     this.setInputType();
@@ -35,10 +33,6 @@ class PasswordConfirmationElement extends HTMLElement {
     const checked = this.toggle.checked ? 'text' : 'password';
     this.input.type = checked;
     this.inputConfirmation.type = checked;
-  }
-
-  trackToggleEvent() {
-    trackEvent('Show Password button clicked', { path: window.location.pathname });
   }
 
   validatePassword() {

--- a/app/javascript/packages/password-toggle/password-toggle-element.spec.ts
+++ b/app/javascript/packages/password-toggle/password-toggle-element.spec.ts
@@ -1,13 +1,10 @@
 import userEvent from '@testing-library/user-event';
 import { getByLabelText } from '@testing-library/dom';
-import { useSandbox } from '@18f/identity-test-helpers';
-import * as analytics from '@18f/identity-analytics';
 import './password-toggle-element';
 import type PasswordToggleElement from './password-toggle-element';
 
 describe('PasswordToggleElement', () => {
   let idCounter = 0;
-  const sandbox = useSandbox();
 
   function createElement() {
     const element = document.createElement('lg-password-toggle') as PasswordToggleElement;
@@ -47,17 +44,5 @@ describe('PasswordToggleElement', () => {
     await userEvent.click(toggle);
 
     expect(input.type).to.equal('text');
-  });
-
-  it('logs an event when clicking the Show Password button', async () => {
-    sandbox.stub(analytics, 'trackEvent');
-    const element = createElement();
-    const toggle = getByLabelText(element, 'Show password') as HTMLInputElement;
-
-    await userEvent.click(toggle);
-
-    expect(analytics.trackEvent).to.have.been.calledWith('Show Password button clicked', {
-      path: window.location.pathname,
-    });
   });
 });

--- a/app/javascript/packages/password-toggle/password-toggle-element.ts
+++ b/app/javascript/packages/password-toggle/password-toggle-element.ts
@@ -1,9 +1,6 @@
-import { trackEvent } from '@18f/identity-analytics';
-
 class PasswordToggleElement extends HTMLElement {
   connectedCallback() {
     this.toggle.addEventListener('change', () => this.setInputType());
-    this.toggle.addEventListener('click', () => this.trackToggleEvent());
     this.setInputType();
   }
 
@@ -23,10 +20,6 @@ class PasswordToggleElement extends HTMLElement {
 
   setInputType() {
     this.input.type = this.toggle.checked ? 'text' : 'password';
-  }
-
-  trackToggleEvent() {
-    trackEvent('Show Password button clicked', { path: window.location.pathname });
   }
 }
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3732,12 +3732,6 @@ module AnalyticsEvents
     track_event('User Maximum Session Length Exceeded')
   end
 
-  # Tracks if a user clicks the "Show Password button"
-  # @param [String] path URL path where the click occurred
-  def show_password_button_clicked(path:, **extra)
-    track_event('Show Password Button Clicked', path: path, **extra)
-  end
-
   # Tracks if a user clicks the "You will also need" accordion on the homepage
   def sign_in_idv_requirements_accordion_clicked
     track_event('Sign In: IdV requirements accordion clicked')


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the "Show Password button clicked" frontend event logged when toggling password visibility.

**Why?** It's not being actively monitored, and we should avoid unnecessarily inflating the size of JavaScript bundles.

## 📜 Testing Plan

Verify no regressions in toggling password visibility.