### PR TITLE
LG-10530: Add redirects for select old GPO routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -404,12 +404,9 @@ Rails.application.routes.draw do
 
       get '/by_mail/letter_enqueued' => 'by_mail/letter_enqueued#show', as: :letter_enqueued
 
-      # BEGIN temporary routes & redirects supporting GPO route renaming
-      get '/come_back_later' => redirect('/verify/by_mail/letter_enqueued')
-
-      get '/by_mail' => redirect('/verify/by_mail/enter_code')
-      post '/by_mail' => 'by_mail/enter_code#create'
-      # END temporary routes
+      # Redirects for old verify by mail routes
+      get '/come_back_later' => redirect('/verify/by_mail/letter_enqueued', status: 301)
+      get '/by_mail' => redirect('/verify/by_mail/enter_code', status: 301)
     end
 
     root to: 'users/sessions#new'


### PR DESCRIPTION
## 🎫 Ticket

[LG-10530](https://cm-jira.usa.gov/browse/LG-10530)

## 🛠 Summary of changes

* Remove a temporary route added in support of changing verify by mail related routes (see #9136, #9184)
* Keep redirects related to the "Come back later" page and "Enter code" page (but make them 301's for good measure)

The idea here is we want to keep supporting any users who've bookmarked verify by mail pages in anticipation of receiving their letter.

I've added LG-11023 to track the eventual cleanup of these redirects.
