### PR TITLE
Do not consider a rate limit expired if there is no value

### DIFF
--- a/app/services/rate_limiter.rb
+++ b/app/services/rate_limiter.rb
@@ -48,7 +48,7 @@ class RateLimiter
   end
 
   def expires_at
-    return Time.zone.now if attempted_at.blank?
+    return nil if attempted_at.blank?
     attempted_at + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes
   end
 
@@ -59,6 +59,7 @@ class RateLimiter
   end
 
   def expired?
+    return nil if expires_at.nil?
     expires_at <= Time.zone.now
   end
 

--- a/spec/services/rate_limiter_spec.rb
+++ b/spec/services/rate_limiter_spec.rb
@@ -131,10 +131,8 @@ RSpec.describe RateLimiter do
     let(:rate_limiter) { RateLimiter.new(target: '1', rate_limit_type: rate_limit_type) }
 
     context 'without having attempted' do
-      it 'returns current time' do
-        freeze_time do
-          expect(rate_limiter.expires_at).to eq(Time.zone.now)
-        end
+      it 'returns nil' do
+        expect(rate_limiter.expires_at).to eq(nil)
       end
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

I was reviewing some NewRelic performance data on the `users/two_factor_authentication#show` and `users/two_factor_authentication#send_code` routes ([link](https://onenr.io/0OwvgVLOlRv)) and noticed an unusual amount of calls `del` calls to Redis.

It turns out there is an extra delete going on, and it is due to the `OtpRateLimiter` proactively deleting the value when it has expired. An empty value in Redis currently considers the expiration time to be `Time.zone.now` which will often be the case when someone is logging in. The comparison done in the `expired?` method means we are treating a blank Redis value as expired, which is causing the `OtpRateLimiter` to delete what is likely an empty value.

This PR changes it so that it is only considered expired if the value actually existed and has expired. This change should eliminate the unnecessary Redis calls.

https://github.com/18F/identity-idp/blob/f534ffedcd23d89bc7ec5f37a1a9d092236847c1/app/services/otp_rate_limiter.rb#L9-L10
https://github.com/18F/identity-idp/blob/f534ffedcd23d89bc7ec5f37a1a9d092236847c1/app/services/otp_rate_limiter.rb#L25-L27
https://github.com/18F/identity-idp/blob/f534ffedcd23d89bc7ec5f37a1a9d092236847c1/app/services/rate_limiter.rb#L61-L63
https://github.com/18F/identity-idp/blob/f534ffedcd23d89bc7ec5f37a1a9d092236847c1/app/services/rate_limiter.rb#L50-L51

![image](https://github.com/18F/identity-idp/assets/1430443/e7f9e175-4651-4f72-86d1-aa7cff7c822f)
![image](https://github.com/18F/identity-idp/assets/1430443/6c304c61-c082-4792-aca5-13b2dd939cb9)


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
