### PR TITLE
Fix identity verification session error tests to use the correct rate limiter

### DIFF
--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Idv::SessionErrorsController do
       let(:user) { create(:user) }
 
       before do
-        RateLimiter.new(rate_limit_type: :proof_address, user: user).increment!
+        RateLimiter.new(rate_limit_type: :idv_resolution, user: user).increment!
       end
 
       it 'assigns remaining count' do
@@ -180,7 +180,7 @@ RSpec.describe Idv::SessionErrorsController do
           'IdV: session error visited',
           hash_including(
             type: action.to_s,
-            attempts_remaining: 5,
+            attempts_remaining: IdentityConfig.store.idv_max_attempts - 1,
           ),
         )
         response
@@ -236,7 +236,7 @@ RSpec.describe Idv::SessionErrorsController do
       let(:user) { create(:user) }
 
       before do
-        RateLimiter.new(rate_limit_type: :proof_address, user: user).increment_to_limited!
+        RateLimiter.new(rate_limit_type: :idv_resolution, user: user).increment_to_limited!
       end
 
       it 'assigns expiration time' do
@@ -258,7 +258,7 @@ RSpec.describe Idv::SessionErrorsController do
           'IdV: session error visited',
           hash_including(
             type: action.to_s,
-            attempts_remaining: 5,
+            attempts_remaining: 0,
           ),
         )
         get action


### PR DESCRIPTION
Discovered in #9221 that some of the tests added in https://github.com/18F/identity-idp/pull/5546 were using the incorrect rate limit type. This PR fixes them.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
