### PR TITLE
LG-10022: Remove feature flag for second MFA reminder

### DIFF
--- a/app/controllers/concerns/second_mfa_reminder_concern.rb
+++ b/app/controllers/concerns/second_mfa_reminder_concern.rb
@@ -1,6 +1,5 @@
 module SecondMfaReminderConcern
   def user_needs_second_mfa_reminder?
-    return false unless IdentityConfig.store.second_mfa_reminder_enabled
     return false if user_has_dismissed_second_mfa_reminder?
     return false if second_mfa_enrollment_may_downgrade_for_service_provider_mfa_requirement?
     return false if user_has_multiple_mfa_methods?

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -293,7 +293,6 @@ s3_public_reports_enabled: false
 s3_reports_enabled: false
 saml_secret_rotation_enabled: false
 second_mfa_reminder_account_age_in_days: 30
-second_mfa_reminder_enabled: true
 second_mfa_reminder_sign_in_count: 10
 seed_agreements_data: true
 service_provider_request_ttl_hours: 24
@@ -475,7 +474,6 @@ production:
   s3_reports_enabled: true
   saml_endpoint_configs: '[]'
   scrypt_cost: 10000$8$1$
-  second_mfa_reminder_enabled: false
   secret_key_base:
   seed_agreements_data: false
   session_encryption_key:

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -419,7 +419,6 @@ class IdentityConfig
     config.add(:saml_secret_rotation_enabled, type: :boolean)
     config.add(:scrypt_cost, type: :string)
     config.add(:second_mfa_reminder_account_age_in_days, type: :integer)
-    config.add(:second_mfa_reminder_enabled, type: :boolean)
     config.add(:second_mfa_reminder_sign_in_count, type: :integer)
     config.add(:secret_key_base, type: :string)
     config.add(:seed_agreements_data, type: :boolean)

--- a/spec/controllers/concerns/second_mfa_reminder_concern_spec.rb
+++ b/spec/controllers/concerns/second_mfa_reminder_concern_spec.rb
@@ -28,16 +28,6 @@ RSpec.describe SecondMfaReminderConcern do
   describe '#user_needs_second_mfa_reminder?' do
     subject(:user_needs_second_mfa_reminder) { instance.user_needs_second_mfa_reminder? }
 
-    shared_examples 'second mfa reminder feature is disabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:second_mfa_reminder_account_age_in_days).
-          and_return(10)
-        allow(IdentityConfig.store).to receive(:second_mfa_reminder_enabled).and_return(false)
-      end
-
-      it { expect(user_needs_second_mfa_reminder).to eq(false) }
-    end
-
     shared_examples 'second mfa reminder with phishing-resistant required request' do
       let(:phishing_resistant_required) { true }
 
@@ -80,7 +70,6 @@ RSpec.describe SecondMfaReminderConcern do
 
         it { expect(user_needs_second_mfa_reminder).to eq(true) }
 
-        it_behaves_like 'second mfa reminder feature is disabled'
         it_behaves_like 'second mfa reminder with phishing-resistant required request'
         it_behaves_like 'second mfa reminder with piv required request'
       end
@@ -95,7 +84,6 @@ RSpec.describe SecondMfaReminderConcern do
 
         it { expect(user_needs_second_mfa_reminder).to eq(true) }
 
-        it_behaves_like 'second mfa reminder feature is disabled'
         it_behaves_like 'second mfa reminder with phishing-resistant required request'
         it_behaves_like 'second mfa reminder with piv required request'
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10022](https://cm-jira.usa.gov/browse/LG-10022)

## 🛠 Summary of changes

Removes the feature flag added in #9124 to help ensure a smooth 50/50 deployment (see https://github.com/18F/identity-idp/pull/9124#issuecomment-1721221738).

This should only be merged after #9124 is fully deployed in production.

## 📜 Testing Plan

Repeat Testing Plan from #9124.