### PR TITLE
Finish removing ssn from flow session (revert the revert)

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -29,7 +29,7 @@ module Idv
       # TEMPORARY DEBUGGING
       logger.info("ResolutionJobDebug: user_uuid=#{current_user.uuid} old=#{pii[:ssn].present?} new=#{idv_session.ssn.present?} controller=#{self.class.name}")
       # rubocop:enable Layout/LineLength
-      pii[:ssn] ||= idv_session.ssn # Required for proof_resolution job
+      pii[:ssn] = idv_session.ssn # Required for proof_resolution job
       Idv::Agent.new(pii).proof_resolution(
         document_capture_session,
         should_proof_state_id: should_use_aamva?(pii),

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -74,9 +74,8 @@ module Idv
     end
 
     def ssn_rate_limiter
-      ssn = idv_session.ssn || pii[:ssn]
       @ssn_rate_limiter ||= RateLimiter.new(
-        target: Pii::Fingerprinter.fingerprint(ssn),
+        target: Pii::Fingerprinter.fingerprint(idv_session.ssn),
         rate_limit_type: :proof_ssn,
       )
     end
@@ -306,19 +305,18 @@ module Idv
         last_name: pii_from_doc[:last_name],
         date_of_birth: pii_from_doc[:dob],
         address: pii_from_doc[:address1],
-        ssn: idv_session.ssn || pii_from_doc[:ssn],
+        ssn: idv_session.ssn,
         failure_reason: failure_reason,
       )
     end
 
     def check_ssn
-      ssn = idv_session.ssn || pii[:ssn]
-      Idv::SsnForm.new(current_user).submit(ssn: ssn)
+      Idv::SsnForm.new(current_user).submit(ssn: idv_session.ssn)
     end
 
     def move_applicant_to_idv_session
       idv_session.applicant = pii
-      idv_session.applicant[:ssn] ||= idv_session.ssn
+      idv_session.applicant[:ssn] = idv_session.ssn
       idv_session.applicant['uuid'] = current_user.uuid
       delete_pii
     end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -52,7 +52,7 @@ module IdvStepConcern
   private
 
   def confirm_ssn_step_complete
-    return if pii.present? && (idv_session.ssn.present? || pii[:ssn].present?)
+    return if pii.present? && idv_session.ssn.present?
     redirect_to prev_url
   end
 

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -64,9 +64,7 @@ module RateLimitConcern
   end
 
   def pii_ssn
-    return unless defined?(flow_session) && defined?(idv_session) && user_session
-    pii_from_doc_ssn = idv_session&.ssn || flow_session[:pii_from_doc]&.[](:ssn)
-    return pii_from_doc_ssn if pii_from_doc_ssn
-    flow_session[:pii_from_user]&.[](:ssn)
+    return unless defined?(idv_session) && user_session
+    idv_session&.ssn
   end
 end

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -14,8 +14,7 @@ module Idv
       attr_accessor :error_message
 
       def show
-        incoming_ssn = idv_session.ssn || flow_session.dig(:pii_from_user, :ssn)
-        @ssn_form = Idv::SsnFormatForm.new(current_user, incoming_ssn)
+        @ssn_form = Idv::SsnFormatForm.new(current_user, idv_session.ssn)
 
         analytics.idv_doc_auth_redo_ssn_submitted(**analytics_arguments) if updating_ssn?
         analytics.idv_doc_auth_ssn_visited(**analytics_arguments)
@@ -28,8 +27,7 @@ module Idv
 
       def update
         @error_message = nil
-        incoming_ssn = idv_session.ssn || flow_session.dig(:pii_from_user, :ssn)
-        @ssn_form = Idv::SsnFormatForm.new(current_user, incoming_ssn)
+        @ssn_form = Idv::SsnFormatForm.new(current_user, idv_session.ssn)
         ssn = params.require(:doc_auth).permit(:ssn)
         form_response = @ssn_form.submit(ssn)
 
@@ -42,7 +40,6 @@ module Idv
         )
 
         if form_response.success?
-          flow_session[:pii_from_user][:ssn] = params[:doc_auth][:ssn]
           idv_session.ssn = params[:doc_auth][:ssn]
           idv_session.invalidate_steps_after_ssn!
           redirect_to idv_in_person_verify_info_url
@@ -70,7 +67,7 @@ module Idv
       end
 
       def confirm_repeat_ssn
-        return if !idv_session.ssn && !pii_from_user[:ssn]
+        return if !idv_session.ssn
         return if request.referer == idv_in_person_verify_info_url
         redirect_to idv_in_person_verify_info_url
       end
@@ -86,7 +83,7 @@ module Idv
       end
 
       def updating_ssn?
-        idv_session.ssn.present? || flow_session.dig(:pii_from_user, :ssn).present?
+        idv_session.ssn.present?
       end
 
       def confirm_in_person_address_step_complete

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -12,7 +12,7 @@ module Idv
 
       def show
         @step_indicator_steps = step_indicator_steps
-        @ssn = idv_session.ssn || flow_session[:pii_from_user][:ssn]
+        @ssn = idv_session.ssn
         @capture_secondary_id_enabled = capture_secondary_id_enabled
 
         analytics.idv_doc_auth_verify_visited(**analytics_arguments)

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -39,9 +39,9 @@ module Idv
     def ssn_failure
       rate_limiter = nil
 
-      if ssn_from_doc
+      if idv_session&.ssn
         rate_limiter = RateLimiter.new(
-          target: Pii::Fingerprinter.fingerprint(ssn_from_doc),
+          target: Pii::Fingerprinter.fingerprint(idv_session.ssn),
           rate_limit_type: :proof_ssn,
         )
         @expires_at = rate_limiter.expires_at
@@ -58,10 +58,6 @@ module Idv
     end
 
     private
-
-    def ssn_from_doc
-      idv_session&.ssn || user_session&.dig('idv/doc_auth', :pii_from_doc, :ssn)
-    end
 
     def confirm_two_factor_authenticated_or_user_id_in_session
       return if session[:doc_capture_user_id].present?

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -13,8 +13,7 @@ module Idv
     attr_accessor :error_message
 
     def show
-      incoming_ssn = idv_session.ssn || flow_session.dig(:pii_from_doc, :ssn)
-      @ssn_form = Idv::SsnFormatForm.new(current_user, incoming_ssn)
+      @ssn_form = Idv::SsnFormatForm.new(current_user, idv_session.ssn)
 
       analytics.idv_doc_auth_redo_ssn_submitted(**analytics_arguments) if @ssn_form.updating_ssn?
       analytics.idv_doc_auth_ssn_visited(**analytics_arguments)
@@ -28,8 +27,7 @@ module Idv
     def update
       @error_message = nil
 
-      incoming_ssn = idv_session.ssn || flow_session.dig(:pii_from_doc, :ssn)
-      @ssn_form = Idv::SsnFormatForm.new(current_user, incoming_ssn)
+      @ssn_form = Idv::SsnFormatForm.new(current_user, idv_session.ssn)
       form_response = @ssn_form.submit(params.require(:doc_auth).permit(:ssn))
 
       analytics.idv_doc_auth_ssn_submitted(
@@ -40,7 +38,6 @@ module Idv
       )
 
       if form_response.success?
-        flow_session[:pii_from_doc][:ssn] = params[:doc_auth][:ssn]
         idv_session.ssn = params[:doc_auth][:ssn]
         idv_session.invalidate_steps_after_ssn!
         redirect_to next_url
@@ -53,7 +50,7 @@ module Idv
     private
 
     def confirm_repeat_ssn
-      return if !idv_session.ssn && !pii_from_doc[:ssn]
+      return if !idv_session.ssn
       return if request.referer == idv_verify_info_url
 
       redirect_to idv_verify_info_url

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -11,7 +11,7 @@ module Idv
 
     def show
       @step_indicator_steps = step_indicator_steps
-      @ssn = idv_session.ssn || pii_from_doc[:ssn]
+      @ssn = idv_session.ssn
 
       analytics.idv_doc_auth_verify_visited(**analytics_arguments)
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -89,16 +89,6 @@ RSpec.describe 'RateLimitConcern' do
         ).increment_to_limited!
       end
 
-      context 'ssn is in flow session' do
-        it 'redirects to proof_ssn rate limited error page' do
-          flow_session = { pii_from_doc: { ssn: ssn } }
-          allow(subject).to receive(:flow_session).and_return(flow_session)
-          get :show
-
-          expect(response).to redirect_to idv_session_errors_ssn_failure_url
-        end
-      end
-
       context 'ssn is in idv_session' do
         it 'redirects to proof_ssn rate limited error page' do
           subject.idv_session.ssn = ssn

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -81,31 +81,6 @@ RSpec.describe Idv::InPerson::SsnController do
       expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }.from(nil)
     end
 
-    context 'with an ssn in flow_session' do
-      let(:referer) { idv_in_person_step_url(step: :address) }
-      before do
-        flow_session[:pii_from_user][:ssn] = ssn
-        request.env['HTTP_REFERER'] = referer
-      end
-
-      context 'referer is not verify_info' do
-        it 'redirects to verify_info' do
-          get :show
-
-          expect(response).to redirect_to(idv_in_person_verify_info_url)
-        end
-      end
-
-      context 'referer is verify_info' do
-        let(:referer) { idv_in_person_verify_info_url }
-        it 'does not redirect' do
-          get :show
-
-          expect(response).to render_template :show
-        end
-      end
-    end
-
     context 'with an ssn in idv_session' do
       let(:referer) { idv_in_person_step_url(step: :address) }
       before do
@@ -163,12 +138,6 @@ RSpec.describe Idv::InPerson::SsnController do
         put :update, params: params
       end
 
-      it 'merges ssn into pii session value' do
-        put :update, params: params
-
-        expect(flow_session[:pii_from_user][:ssn]).to eq(ssn)
-      end
-
       it 'adds ssn to idv_session' do
         put :update, params: params
 
@@ -190,7 +159,7 @@ RSpec.describe Idv::InPerson::SsnController do
       end
 
       it 'does not change threatmetrix_session_id when updating ssn' do
-        flow_session[:pii_from_user][:ssn] = ssn
+        subject.idv_session.ssn = ssn
         put :update, params: params
         session_id = subject.idv_session.threatmetrix_session_id
         subject.threatmetrix_view_variables

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
   before do
     allow(subject).to receive(:flow_session).and_return(flow_session)
     stub_sign_in(user)
+    subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID[:ssn]
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe Idv::SessionErrorsController do
           rate_limit_type: :proof_ssn,
           target: Pii::Fingerprinter.fingerprint(ssn),
         ).increment_to_limited!
-        controller.user_session['idv/doc_auth'] = { pii_from_doc: { ssn: ssn } }
+        allow(idv_session).to receive(:ssn).and_return(ssn)
       end
 
       it 'assigns expiration time' do
@@ -303,30 +303,6 @@ RSpec.describe Idv::SessionErrorsController do
           ),
         )
         get action
-      end
-
-      context 'with ssn in idv_session' do
-        before do
-          controller.user_session['idv/doc_auth'] = {}
-          allow(idv_session).to receive(:ssn).and_return(ssn)
-        end
-
-        it 'assigns expiration time' do
-          get action
-
-          expect(assigns(:expires_at)).not_to eq(Time.zone.now)
-        end
-
-        it 'logs an event with attempts remaining' do
-          expect(@analytics).to receive(:track_event).with(
-            'IdV: session error visited',
-            hash_including(
-              type: 'ssn_failure',
-              attempts_remaining: 0,
-            ),
-          )
-          get action
-        end
       end
     end
   end

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -90,31 +90,6 @@ RSpec.describe Idv::SsnController do
       expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }.from(nil)
     end
 
-    context 'with an ssn in flow_session' do
-      let(:referer) { idv_document_capture_url }
-      before do
-        flow_session[:pii_from_doc][:ssn] = ssn
-        request.env['HTTP_REFERER'] = referer
-      end
-
-      context 'referer is not verify_info' do
-        it 'redirects to verify_info' do
-          get :show
-
-          expect(response).to redirect_to(idv_verify_info_url)
-        end
-      end
-
-      context 'referer is verify_info' do
-        let(:referer) { idv_verify_info_url }
-        it 'does not redirect' do
-          get :show
-
-          expect(response).to render_template :show
-        end
-      end
-    end
-
     context 'with an ssn in idv_session' do
       let(:referer) { idv_document_capture_url }
       before do
@@ -178,12 +153,6 @@ RSpec.describe Idv::SsnController do
         }.merge(ab_test_args)
       end
 
-      it 'merges ssn into pii session value' do
-        put :update, params: params
-
-        expect(flow_session[:pii_from_doc][:ssn]).to eq(ssn)
-      end
-
       it 'updates idv_session.ssn' do
         expect { put :update, params: params }.to change { subject.idv_session.ssn }.
           from(nil).to(ssn)
@@ -199,7 +168,7 @@ RSpec.describe Idv::SsnController do
         end
 
         it 'redirects to the verify info controller if a user is updating their SSN' do
-          flow_session[:pii_from_doc][:ssn] = ssn
+          subject.idv_session.ssn = ssn
           flow_session[:pii_from_doc][:state] = 'PR'
 
           put :update, params: params
@@ -226,7 +195,7 @@ RSpec.describe Idv::SsnController do
       end
 
       it 'does not change threatmetrix_session_id when updating ssn' do
-        flow_session[:pii_from_doc][:ssn] = ssn
+        subject.idv_session.ssn = ssn
         put :update, params: params
         session_id = subject.idv_session.threatmetrix_session_id
         subject.threatmetrix_view_variables

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Idv::VerifyInfoController do
   include IdvHelper
 
   let(:flow_session) do
-    { pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup }
+    { pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT.dup }
   end
 
   let(:user) { create(:user) }
@@ -26,6 +26,7 @@ RSpec.describe Idv::VerifyInfoController do
     stub_attempts_tracker
     stub_idv_steps_before_verify_step(user)
     subject.idv_session.flow_path = 'standard'
+    subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
     subject.user_session['idv/doc_auth'] = flow_session
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
@@ -64,7 +65,7 @@ RSpec.describe Idv::VerifyInfoController do
       }.merge(ab_test_args)
     end
 
-    it 'renders the show template (with ssn in flow_session)' do
+    it 'renders the show template' do
       get :show
 
       expect(response).to render_template :show
@@ -114,21 +115,11 @@ RSpec.describe Idv::VerifyInfoController do
     end
 
     it 'redirects to ssn controller when ssn info is missing' do
-      flow_session[:pii_from_doc][:ssn] = nil
       subject.idv_session.ssn = nil
 
       get :show
 
       expect(response).to redirect_to(idv_ssn_url)
-    end
-
-    it 'renders show when ssn is in idv_session' do
-      subject.idv_session.ssn = flow_session[:pii_from_doc][:ssn]
-      flow_session[:pii_from_doc][:ssn] = nil
-
-      get :show
-
-      expect(response).to render_template :show
     end
 
     context 'when the user is ssn rate limited' do
@@ -141,16 +132,7 @@ RSpec.describe Idv::VerifyInfoController do
         ).increment_to_limited!
       end
 
-      it 'redirects to ssn failure url with ssn in flow session' do
-        get :show
-
-        expect(response).to redirect_to idv_session_errors_ssn_failure_url
-      end
-
-      it 'redirects to ssn failure url with ssn in idv_session' do
-        subject.idv_session.ssn = flow_session[:pii_from_doc][:ssn]
-        flow_session[:pii_from_doc][:ssn] = nil
-
+      it 'redirects to ssn failure url' do
         get :show
 
         expect(response).to redirect_to idv_session_errors_ssn_failure_url


### PR DESCRIPTION
## 🎫 Ticket

[LG-10886](https://cm-jira.usa.gov/browse/LG-10886)

## 🛠 Summary of changes

Fixed 50/50 state issue by adding :ssn to pii going to proof resolution job in deploy 314.2 #9226.

This reverts commit 4f0ad0433e3af392ded077c95749ba7ae58006d3, which reverted the commit to delete ssn from pii_from_doc.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create account, start IdV
- [ ] Confirm that ssn is correct and can get past VerifyInfo step
- [ ] Cancel, start again and use in person flow
- [ ] Confirm that ssn is correct and can get past VerifyInfo step


