### PR TITLE
LG-10868: Update Backup code language

### DIFF
--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -20,9 +20,9 @@ en:
     attempt_remaining_warning_html:
       one: You have <strong>%{count} attempt</strong> remaining.
       other: You have <strong>%{count} attempts</strong> remaining.
-    backup_code_header_text: Enter your backup security code
-    backup_code_prompt: You can use this security code once. After you enter it,
-      you’ll need to use a new key.
+    backup_code_header_text: Enter your backup code
+    backup_code_prompt: You can use this backup code once. After you submit it,
+      you’ll need to use a new backup code next time.
     backup_codes:
       add_another_authentication_option: '‹ Add another authentication option'
       instructions: If you don’t have access to another device, keep your backup codes

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -20,9 +20,9 @@ es:
     attempt_remaining_warning_html:
       one: Le quedan <strong>%{count} intento</strong>.
       other: Le quedan <strong>%{count} intentos</strong>.
-    backup_code_header_text: Ingrese su código de seguridad de respaldo
-    backup_code_prompt: Puede utilizar este código de seguridad una vez. Después de
-      ingresarlo, deberá usar una nueva clave.
+    backup_code_header_text: Ingrese su código de respaldo
+    backup_code_prompt: Puede utilizar este código de respaldo una vez. Tendrá que
+      usar un nuevo código de respaldo la próxima vez después de que lo envíe.
     backup_codes:
       add_another_authentication_option: '‹ Añada otra opción de autenticación'
       instructions: Si no tiene acceso a otro dispositivo, guarde bien sus códigos de

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -22,9 +22,10 @@ fr:
     attempt_remaining_warning_html:
       one: Il vous reste <strong>%{count} tentative</strong>.
       other: Il vous reste <strong>%{count} tentatives</strong>.
-    backup_code_header_text: Entrez votre code de sécurité de secours
-    backup_code_prompt: Vous pouvez utiliser ce code de sécurité une fois. Après
-      l’avoir entré, vous devrez utiliser une nouvelle clé.
+    backup_code_header_text: Entrez votre code de sauvegarde
+    backup_code_prompt: Vous pouvez utiliser ce code de sauvegarde une seule fois.
+      Après l’avoir envoyé, vous devrez utiliser un nouveau code de sauvegarde
+      la fois suivante
     backup_codes:
       add_another_authentication_option: '‹ Ajouter une autre option d’authentification'
       instructions: Si vous n’avez pas accès à un autre appareil, conservez vos codes


### PR DESCRIPTION

## 🎫 Ticket
[LG-10868: Update Backup code language](https://cm-jira.usa.gov/browse/LG-10868)

## 🛠 Summary of changes
Updates the language for clearer understanding for users as to what they are entering and using language for backup code that makes sense.
Below Are what they would look like now 

<img width="770" alt="Screenshot of Backup Code sign in page in English" src="https://github.com/18F/identity-idp/assets/23225522/e94a0115-0e9e-49ed-82c5-a683faf60808">
<img width="738" alt="Screenshot of Backup Code sign in page in Spanish" src="https://github.com/18F/identity-idp/assets/23225522/689f1210-0192-4532-8d8b-642d807ec3ed">
<img width="674" alt="Screenshot of Backup Code sign in page in French" src="https://github.com/18F/identity-idp/assets/23225522/b794241a-d7f6-4496-945c-049bb36aec5d">


