### PR TITLE
LG-10779 Add a specific test case for a profile that cannot pass fraud review

### DIFF
--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -84,18 +84,40 @@ RSpec.describe 'review_profile' do
     end
 
     context 'when the user has cancelled verification' do
+      before do
+        user.pending_profile.deactivate(:encryption_error)
+        create(:profile, :verify_by_mail_pending, user: user)
+      end
+
       it 'does not activate the profile' do
-        user.profiles.first.update!(gpo_verification_pending_at: user.created_at)
+        invoke_task
 
-        expect { invoke_task }.to raise_error(RuntimeError)
-
-        expect(user.reload.profiles.first.active).to eq(false)
+        expect(user.reload.active_profile).to be_nil
       end
 
       it 'logs an error to analytics' do
-        profile_fraud_review_pending_at = user.profiles.first.fraud_review_pending_at
-        user.profiles.first.update!(gpo_verification_pending_at: user.created_at)
+        invoke_task
 
+        expect(analytics).to have_logged_event(
+          'Fraud: Profile review passed',
+          success: false,
+          errors: { message: 'Error: User does not have a pending fraud review' },
+          exception: nil,
+          profile_fraud_review_pending_at: nil,
+        )
+      end
+    end
+
+    context 'when the pending profile is in an invalid state and cannot be activated' do
+      before do
+        user.pending_profile.update!(gpo_verification_pending_at: 1.day.ago)
+      end
+
+      it 'raises an error' do
+        expect { invoke_task }.to raise_error(RuntimeError)
+      end
+
+      it 'logs an exception' do
         expect { invoke_task }.to raise_error(RuntimeError)
 
         expect(analytics).to have_logged_event(
@@ -103,7 +125,7 @@ RSpec.describe 'review_profile' do
           success: false,
           errors: nil,
           exception: a_string_including('Attempting to activate profile with pending reason'),
-          profile_fraud_review_pending_at: profile_fraud_review_pending_at,
+          profile_fraud_review_pending_at: user.pending_profile.fraud_review_pending_at,
         )
       end
     end

--- a/spec/lib/tasks/review_profile_spec.rb
+++ b/spec/lib/tasks/review_profile_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe 'review_profile' do
 
     context 'when the pending profile is in an invalid state and cannot be activated' do
       before do
+        # Profiles should not be gpo_verification_pending and fraud_review_pending at the same time.
         user.pending_profile.update!(gpo_verification_pending_at: 1.day.ago)
       end
 


### PR DESCRIPTION
The review profile rake task is used to pass or reject users after fraud review. We have a test case for users who running that task against a user who is not pending fraud review because they have undergone a more recent verification. Previously that test case actually tested a case where a user had an invalid profile state that was pending GPO verification. This should not be possible and raises an exception. It also did not match the spec description.

This commit cleans up the spec to cover the case described in the spec description. In this case the user has reset their password and deactivated the fraud pending profile. Then they have created a new profile that is GPO pending.

A new spec is also introduced to cover the code paths covered by the old test: a case where the profile is in an unexpected state and an exception is raised.

[skip changelog]
