### PR TITLE
Use Redis expiretime to avoid repeated TTL calls when building IdToken

### DIFF
--- a/app/controllers/openid_connect/token_controller.rb
+++ b/app/controllers/openid_connect/token_controller.rb
@@ -8,9 +8,14 @@ module OpenidConnect
       @token_form = OpenidConnectTokenForm.new(token_params)
 
       result = @token_form.submit
-      analytics.openid_connect_token(**result.to_h)
+      response = @token_form.response
 
-      render json: @token_form.response,
+      analytics_attributes = result.to_h
+      analytics_attributes[:expires_in] = response[:expires_in]
+
+      analytics.openid_connect_token(**analytics_attributes)
+
+      render json: response,
              status: (result.success? ? :ok : :bad_request)
     end
 

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -201,6 +201,7 @@ class OpenidConnectTokenForm
       code_digest: code ? Digest::SHA256.hexdigest(code) : nil,
       code_verifier_present: code_verifier.present?,
       service_provider_pkce: service_provider&.pkce,
+      ial: identity&.ial,
     }
   end
 

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -47,11 +47,12 @@ class OpenidConnectTokenForm
   def response
     if valid?
       id_token_builder = IdTokenBuilder.new(identity: identity, code: code)
+      @ttl = id_token_builder.ttl
 
       {
         access_token: identity.access_token,
         token_type: 'Bearer',
-        expires_in: id_token_builder.ttl,
+        expires_in: @ttl,
         id_token: id_token_builder.id_token,
       }
     else

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3137,12 +3137,16 @@ module AnalyticsEvents
   # @param [String] client_id
   # @param [String] user_id
   # @param [String] code_digest hash of "code" param
-  def openid_connect_token(client_id:, user_id:, code_digest:, **extra)
+  # @param [Integer, nil] expires_in time to expiration of token
+  # @param [Integer, nil] ial ial level of identity
+  def openid_connect_token(client_id:, user_id:, code_digest:, expires_in:, ial:, **extra)
     track_event(
       'OpenID Connect: token',
       client_id: client_id,
       user_id: user_id,
       code_digest: code_digest,
+      expires_in: expires_in,
+      ial: ial,
       **extra,
     )
   end

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -48,7 +48,7 @@ class IdTokenBuilder
 
   def timestamp_claims
     {
-      exp: @custom_expiration || expires,
+      exp: @custom_expiration || session_accessor.expires_at.to_i,
       iat: now.to_i,
       nbf: now.to_i,
     }

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe OpenidConnect::TokenController do
             code_digest: kind_of(String),
             code_verifier_present: false,
             service_provider_pkce: nil,
+            expires_in: 0,
           })
         action
       end
@@ -90,6 +91,7 @@ RSpec.describe OpenidConnect::TokenController do
             code_verifier_present: false,
             service_provider_pkce: nil,
             error_details: hash_including(:grant_type),
+            expires_in: nil,
           })
 
         action

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe OpenidConnect::TokenController do
             code_verifier_present: false,
             service_provider_pkce: nil,
             expires_in: 0,
+            ial: 1,
           })
         action
       end
@@ -92,6 +93,7 @@ RSpec.describe OpenidConnect::TokenController do
             service_provider_pkce: nil,
             error_details: hash_including(:grant_type),
             expires_in: nil,
+            ial: 1,
           })
 
         action

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -381,6 +381,7 @@ RSpec.describe OpenidConnectTokenForm do
           code_digest: Digest::SHA256.hexdigest(code),
           code_verifier_present: false,
           service_provider_pkce: nil,
+          ial: 1,
         )
       end
     end

--- a/spec/services/access_token_verifier_spec.rb
+++ b/spec/services/access_token_verifier_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe AccessTokenVerifier do
       let(:access_token) { identity.access_token }
       before do
         identity.save!
-        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 1)
+        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 5)
       end
 
       it 'is successful' do
@@ -65,7 +65,7 @@ RSpec.describe AccessTokenVerifier do
     context 'with a valid access_token' do
       before do
         identity.save!
-        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 1)
+        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 5)
       end
       let(:access_token) { identity.access_token }
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe IdTokenBuilder do
       before { OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii(nil, expiration) }
 
       it 'sets the expiration to the ttl of the session key in redis' do
-        expect(decoded_payload[:exp]).to eq(now.to_i + expiration)
+        expect(decoded_payload[:exp]).to be_within(3.seconds).of(now.to_i + expiration)
       end
     end
 

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -15,13 +15,7 @@ RSpec.describe OutOfBandSessionAccessor do
     it 'returns the remaining time-to-live of the session data in redis' do
       store.put_pii({ first_name: 'Fakey' }, 5.minutes.to_i)
 
-      expect(store.ttl).to eq(5.minutes.to_i)
-    end
-
-    it 'returns the remaining time-to-live of the session data in redis' do
-      store.put_pii({ first_name: 'Fakey' }, 5.minutes.to_i)
-
-      expect(store.ttl).to eq(5.minutes.to_i)
+      expect(store.ttl).to be_within(1).of(5.minutes.to_i)
     end
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

We currently make two TTL redis calls when responding to OpenID Token requests ([link](https://onenr.io/0oR8bVyneQG))
<img width="1347" alt="image" src="https://github.com/18F/identity-idp/assets/1430443/958f215e-b1fe-4e40-8256-49443deac075">

Since we've upgraded to Redis 7, we can use `expiretime` rather than `ttl` and only make the call once to re-calculate the TTL each time. This change is somewhat similar to https://github.com/18F/identity-idp/pull/7776

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
