### PR TITLE
LG-10718: rename Proofing Resolution Result Missing event

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2291,7 +2291,7 @@ module AnalyticsEvents
   # The system encountered an error and the proofing results are missing
   def idv_proofing_resolution_result_missing(proofing_components: nil, **extra)
     track_event(
-      'Proofing Resolution Result Missing',
+      'IdV: proofing resolution result missing',
       proofing_components: proofing_components,
       **extra,
     )

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -359,7 +359,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
         and_return(nil)
 
       click_idv_continue
-      expect(fake_analytics).to have_logged_event('Proofing Resolution Result Missing')
+      expect(fake_analytics).to have_logged_event('IdV: proofing resolution result missing')
       expect(page).to have_content(t('idv.failure.timeout'))
       expect(page).to have_current_path(idv_verify_info_path)
       allow(DocumentCaptureSession).to receive(:find_by).and_call_original


### PR DESCRIPTION
Event renamed to `IdV: proofing resolution result missing` to conform to the other idv events.

Note: the old event name does not appear in any terraformed dashboards/metrics.

## 🎫 Ticket

[LG-10718
](https://cm-jira.usa.gov/browse/LG-10718)
