### PR TITLE
Test that `deactivation_reason` doesn't change

### DIFF
--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -665,7 +665,6 @@ RSpec.describe Profile do
       expect(profile.verified_at).to eq verified_at
     end
 
-    # ??? This method still nils out deactivation_reason even though it raises
     it 'does not activate a profile if it has a pending reason' do
       profile = create(
         :profile,
@@ -676,7 +675,7 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_nil
       expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to eq('password_reset') # to change
+      expect(profile.deactivation_reason).to eq('password_reset')
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.in_person_verification_pending_at).to be_nil
@@ -690,7 +689,7 @@ RSpec.describe Profile do
 
       expect(profile.activated_at).to be_nil
       expect(profile.active).to eq(false)
-      expect(profile.deactivation_reason).to be_nil # changed
+      expect(profile.deactivation_reason).to eq('password_reset')
       expect(profile.fraud_review_pending?).to eq(true)
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.in_person_verification_pending_at).to be_nil


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-11072](https://cm-jira.usa.gov/browse/LG-11072)
Password reset profile's deactivation_reason should persist when activate raises an error

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
