### PR TITLE
Don’t crash when integration.partner_acocunt is nil

### DIFF
--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -15,7 +15,9 @@ class DestroyableRecords
 
   def print_data
     stdout.puts "You are about to delete a service provider with issuer #{service_provider.issuer}"
-    stdout.puts "The partner is #{integration.partner_account.name}"
+    if integration.partner_account.present?
+      stdout.puts "The partner is #{integration.partner_account.name}"
+    end
     stdout.puts "\n\n"
 
     stdout.puts 'Attributes:'

--- a/spec/lib/cleanup/destroy_unused_providers_spec.rb
+++ b/spec/lib/cleanup/destroy_unused_providers_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe DestroyUnusedProviders do
   let(:stdin) { StringIO.new }
   let(:service_provider) { create(:service_provider) }
   let(:issuer) { service_provider.issuer }
+  let(:partner_account) { create(:partner_account) }
+  let(:integration) do
+    create(
+      :integration,
+      issuer: issuer,
+      name: 'Integration',
+      partner_account: partner_account,
+    )
+  end
 
   subject(:destroy_unused_providers) { described_class.new([issuer], stdout:, stdin:) }
 
@@ -69,6 +78,27 @@ RSpec.describe DestroyUnusedProviders do
 
         it 'calls destroy on the records' do
           expect(records).to receive(:destroy_records)
+          subject.run
+        end
+      end
+    end
+
+    describe 'when integration does not exist' do
+      let(:records) { subject.destroy_list.first }
+      let(:stdin) { StringIO.new('anything_but_yes') }
+      let(:prompt) do
+        "Type 'yes' and hit enter to continue and " \
+          "destroy this service provider and associated records:\n"
+      end
+
+      before do
+        allow(records).to receive(:print_data)
+      end
+
+      describe 'when partner account does not exist' do
+        it 'prints the record data' do
+          partner_account.destroy!
+          expect(records).to receive(:print_data)
           subject.run
         end
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10920](https://cm-jira.usa.gov/browse/LG-10920)

## 🛠 Summary of changes

Fix a bug where you could not use `destroy_unused_records.rb` if the Integration associated with the Service Provider being removed didn't have a Partner Account would fail.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
