### PR TITLE
LG-10983: use mock client to generate http status error response

### DIFF
--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -40,6 +40,8 @@ module DocAuth
     # Doc type
     DOC_TYPE_CHECK = 'doc_type_check'
     CARD_TYPE = 'card_type'
+    # network
+    NETWORK = 'network'
     # Other
     FALLBACK_FIELD_LEVEL = 'fallback_field_level'
 

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -1,6 +1,7 @@
 module DocAuth
   module Mock
     class DocAuthMockClient
+      include DocAuth::Mock::YmlLoaderConcern
       attr_reader :config
 
       def initialize(**config_keywords)
@@ -34,15 +35,17 @@ module DocAuth
       # rubocop:disable Lint/UnusedMethodArgument
       def post_front_image(image:, instance_id:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
-
         self.class.last_uploaded_front_image = image
+        error_response = http_error_response(image, 'front')
+        return error_response if error_response
         DocAuth::Response.new(success: true)
       end
 
       def post_back_image(image:, instance_id:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
-
         self.class.last_uploaded_back_image = image
+        error_response = http_error_response(image, 'back')
+        return error_response if error_response
         DocAuth::Response.new(success: true)
       end
 
@@ -71,7 +74,8 @@ module DocAuth
 
       def get_results(instance_id:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
-
+        error_response = http_error_response(self.class.last_uploaded_back_image, 'result')
+        return error_response if error_response
         overriden_config = config.dup.tap do |c|
           c.dpi_threshold = 290
           c.sharpness_threshold = 40
@@ -95,6 +99,38 @@ module DocAuth
         return if self.class.response_mocks.nil?
 
         self.class.response_mocks[method_name.to_sym]
+      end
+
+      def http_error_response(image, side)
+        data = parse_yaml(image.to_s)
+        status = data.dig('http_status', side)
+        return nil unless [500, 440, 438, 439].include?(status)
+        error = case status
+                when 438
+                  Errors::IMAGE_LOAD_FAILURE
+                when 439
+                  Errors::PIXEL_DEPTH_FAILURE
+                when 440
+                  Errors::IMAGE_SIZE_FAILURE
+                when 500
+                  Errors::NETWORK
+                end
+        return nil unless error
+        errors = { general: [error] }
+        message = [
+          self.class.name,
+          'Unexpected HTTP response',
+          status,
+        ].join(' ')
+        exception = DocAuth::RequestError.new(message, status)
+        return DocAuth::Response.new(
+          success: false,
+          errors: errors,
+          exception: exception,
+          extra: { vendor: 'Mock' },
+        )
+      rescue Psych::SyntaxError
+        nil
       end
     end
   end

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -2,6 +2,7 @@ module DocAuth
   module Mock
     class ResultResponse < DocAuth::Response
       include DocAuth::Acuant::ClassificationConcern
+      include DocAuth::Mock::YmlLoaderConcern
 
       attr_reader :uploaded_file, :config
 
@@ -80,7 +81,7 @@ module DocAuth
       def parsed_data_from_uploaded_file
         return @parsed_data_from_uploaded_file if defined?(@parsed_data_from_uploaded_file)
 
-        @parsed_data_from_uploaded_file = parse_uri || parse_yaml
+        @parsed_data_from_uploaded_file = parse_uri || parse_yaml(uploaded_file)
       end
 
       def doc_auth_result
@@ -114,7 +115,7 @@ module DocAuth
         # no-op, allows falling through to YAML parsing
       end
 
-      def parse_yaml
+      def parse_yaml2
         data = YAML.safe_load(uploaded_file, permitted_classes: [Date])
         if data.is_a?(Hash)
           if (m = data.dig('document', 'dob').to_s.

--- a/app/services/doc_auth/mock/yml_loader_concern.rb
+++ b/app/services/doc_auth/mock/yml_loader_concern.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DocAuth
+  module Mock
+    module YmlLoaderConcern
+      extend ActiveSupport::Concern
+      # @param [String] uploaded_file: string content
+      def parse_yaml(uploaded_file)
+        data = YAML.safe_load(uploaded_file, permitted_classes: [Date])
+        if data.is_a?(Hash)
+          if (m = data.dig('document', 'dob').to_s.
+            match(%r{(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{4})}))
+            data['document']['dob'] =
+              Date.new(m[:year].to_i, m[:month].to_i, m[:day].to_i)
+          end
+
+          if data.dig('document', 'zipcode')
+            data['document']['zipcode'] = data.dig('document', 'zipcode').to_s
+          end
+
+          JSON.parse(data.to_json) # converts Dates back to strings
+        else
+          { general: ["YAML data should have been a hash, got #{data.class}"] }
+        end
+      rescue Psych::SyntaxError
+        if uploaded_file.ascii_only? # don't want this error for images
+          { general: ['invalid YAML file'] }
+        else
+          {}
+        end
+      end
+    end
+  end
+end

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -174,4 +174,50 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
 
     expect(post_images_response).to be_a(DocAuth::Response)
   end
+
+  describe 'generate response for failure indicating http status' do
+    it 'generate network error response for status 500 when post image' do
+      image = <<-YAML
+      http_status:
+        front: 500
+        back: 500
+      YAML
+      response = client.post_front_image(
+        image: image,
+        instance_id: nil,
+      )
+      expect(response).to be_a(DocAuth::Response)
+      expect(response.success?).to eq(false)
+      expect(response.errors).to eq(general: ['network'])
+    end
+
+    it 'generate network error response for status 500 when get result' do
+      image = <<~YAML
+        http_status:
+          result: 500
+      YAML
+      client.post_back_image(
+        image: image,
+        instance_id: nil,
+      )
+      response = client.get_results(instance_id: nil)
+      expect(response).to be_a(DocAuth::Response)
+      expect(response.success?).to eq(false)
+      expect(response.errors).to eq(general: ['network'])
+    end
+
+    it 'generate correct error for status 440' do
+      image = <<~YAML
+        http_status:
+          front: 440
+      YAML
+      response = client.post_front_image(
+        image: image,
+        instance_id: nil,
+      )
+      expect(response).to be_a(DocAuth::Response)
+      expect(response.success?).to eq(false)
+      expect(response.errors).to eq(general: [DocAuth::Errors::IMAGE_SIZE_FAILURE])
+    end
+  end
 end


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

LG-10983


## 🛠 Summary of changes

The original mock client always generate error from the last http call( of the 3 http call conversation with Acuant AssureID), it's expecting a http response of 2xx in most cases.

This change allows to return non 2xx response at any step of the 3 http calls. Namely 440, 438, 439 for some image metric issue during post front/back image phase, in addition to 5xx for these phases.

Also can trigger 5xx at the last step(get result) as needed, though 4xx codes seems not used according to API documentation.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1: Enter doc auth flow
- [ ] Step 2: Stop at the image upload step
- [ ] Step 3: Test with example yaml file like following

Front side 440 error
```yaml
http_status:
  front: 440
```
Back side 438 error
```yaml
http_status:
  back: 438
```
Get result 500 error
```yaml
http_status:
  result: 500
```


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
