### PR TITLE
LG-10445: bump up the GPO verification code max attempts to 5

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -320,7 +320,7 @@ vendor_status_sms: 'operational'
 vendor_status_voice: 'operational'
 verification_errors_report_configs: '[]'
 verify_gpo_key_attempt_window_in_minutes: 10
-verify_gpo_key_max_attempts: 3
+verify_gpo_key_max_attempts: 5
 verify_personal_key_attempt_window_in_minutes: 15
 verify_personal_key_max_attempts: 5
 version_headers_enabled: false

--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -411,7 +411,12 @@ RSpec.describe Idv::ByMail::EnterCodeController do
 
     context 'final attempt before rate limited' do
       let(:invalid_otp) { 'a-wrong-otp' }
-      let(:max_attempts) { IdentityConfig.store.verify_gpo_key_max_attempts }
+      let(:max_attempts) { 2 }
+
+      before do
+        allow(IdentityConfig.store).to receive(:verify_gpo_key_max_attempts).
+          and_return(max_attempts)
+      end
 
       context 'user is rate limited' do
         it 'renders the index page to show errors' do


### PR DESCRIPTION
Most of our rate limiting allows a user 5 attempts so this brings the entering of the GPO verification code in line with the others.

We spoke to security and confirmed that there is no issue with this change.

changelog: User-facing Improvements, Identity Verification By Mail, Increased user's max attempts to enter their verification code before being rate limited.

## 🎫 Ticket

[LG-10445](https://cm-jira.usa.gov/browse/LG-10445)