### PR TITLE
Add conditionalNames to webpack in address-search

### DIFF
--- a/app/javascript/packages/address-search/webpack.config.cjs
+++ b/app/javascript/packages/address-search/webpack.config.cjs
@@ -17,6 +17,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts'],
+    conditionNames: ['source'],
   },
   externals: /^(?!(@18f\/identity-|\.))/,
   module: {


### PR DESCRIPTION
## 🎫 Ticket
For tickets [LG-10330](https://cm-jira.usa.gov/browse/LG-10330) and [LG-10785](https://cm-jira.usa.gov/browse/LG-10785), new versions of `@18f/identity-address-search` were trying to be published on npm but build errors occurred. The solution is to update the webpack.config file for address-search so that dependencies can be resolved. 

## 🛠 Summary of changes
Added `conditionNames: ['source']` to the resolve object inside `app/javascript/packages/address-search/webpack.config.cjs`. 

Before this was added, `yarn run webpack` would cause errors when ran inside `app/javascript/packages/address-search`
because webpack didn’t know how to resolve a dependency when that dependency is itself.  The conditionNames tells webpack to resolve its dependencies (one of which is itself!) using the source export. (Explanation & code change taken from Matt in this [thread](https://gsa-tts.slack.com/archives/C04GA9WQ85B/p1695248742132639?thread_ts=1695233165.662219&cid=C04GA9WQ85B). I am implementing this to get unblocked.)

## 📜 Testing Plan
- [ ] Step 1 On a branch other than this one, move into `app/javascript/packages/address-search` and run `yarn run webpack`. Observer errors. You can also try to publish to npm, you likely won't be successful. 
- [ ] Step 2 On this branch, `app/javascript/packages/address-search` and run `yarn run webpack`. Observer no errors with the build
