### PR TITLE
Add count of users passing fraud review to Identity Verification Report

### DIFF
--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -260,7 +260,7 @@ module Reporting
           , ispresent(properties.event_properties.deactivation_reason) AS has_other_deactivation_reason
           , properties.event_properties.success = '0' AND properties.event_properties.doc_auth_result NOT IN ['Failed', 'Attention'] AS doc_auth_failed_non_fraud
         | fields
-            !fraud_review_pending and !gpo_verification_pending and !in_person_verification_pending and !has_other_deactivation_reason) AS identity_verified
+            !fraud_review_pending and !gpo_verification_pending and !in_person_verification_pending and !has_other_deactivation_reason AS identity_verified
         | limit 10000
       QUERY
     end

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -27,6 +27,7 @@ module Reporting
       GPO_VERIFICATION_SUBMITTED = 'IdV: enter verify by mail code submitted'
       GPO_VERIFICATION_SUBMITTED_OLD = 'IdV: GPO verification submitted'
       USPS_ENROLLMENT_STATUS_UPDATED = 'GetUspsProofingResultsJob: Enrollment status updated'
+      FRAUD_REVIEW_PASSED = 'Fraud: Profile review passed'
 
       def self.all_events
         constants.map { |c| const_get(c) }
@@ -42,6 +43,7 @@ module Reporting
       IDV_REJECT_DOC_AUTH = 'IdV Reject: Doc Auth'
       IDV_REJECT_VERIFY = 'IdV Reject: Verify'
       IDV_REJECT_PHONE_FINDER = 'IdV Reject: Phone Finder'
+      FRAUD_REVIEW_PASSED = 'Fraud: Profile review passed'
     end
 
     # @param [Array<String>] issuers
@@ -91,10 +93,11 @@ module Reporting
         csv << ['Workflow completed - In-Person Pending', idv_final_resolution_in_person]
         csv << ['Workflow completed - Fraud Review Pending', idv_final_resolution_fraud_review]
         csv << []
-        csv << ['Succesfully verified', successfully_verified_users]
-        csv << ['Succesfully verified - Inline', idv_final_resolution_verified]
-        csv << ['Succesfully verified - GPO Code Entry', gpo_verification_submitted]
-        csv << ['Succesfully verified - In Person', usps_enrollment_status_updated]
+        csv << ['Successfully verified', successfully_verified_users]
+        csv << ['Successfully verified - Inline', idv_final_resolution_verified]
+        csv << ['Successfully verified - GPO Code Entry', gpo_verification_submitted]
+        csv << ['Successfully verified - In Person', usps_enrollment_status_updated]
+        csv << ['Successfully verified - Passed Fraud Review', fraud_review_passed]
       end
     end
 
@@ -175,6 +178,10 @@ module Reporting
       ).count
     end
 
+    def fraud_review_passed
+      data[Results::FRAUD_REVIEW_PASSED].count
+    end
+
     # rubocop:disable Layout/LineLength
     # Turns query results into a hash keyed by event name, values are a count of unique users
     # for that event
@@ -206,6 +213,8 @@ module Reporting
             event_users[Results::IDV_REJECT_VERIFY] << user_id if success == '0'
           when Events::IDV_PHONE_FINDER_RESULTS
             event_users[Results::IDV_REJECT_PHONE_FINDER] << user_id if success == '0'
+          when Events::FRAUD_REVIEW_PASSED
+            event_users[Results::FRAUD_REVIEW_PASSED] << user_id if success == '1'
           end
         end
 

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -251,8 +251,8 @@ module Reporting
                  or (name != %{usps_enrollment_status_updated})
         | filter (name in %{gpo_verification_submitted} and properties.event_properties.success = 1 and !properties.event_properties.pending_in_person_enrollment and !properties.event_properties.fraud_check_failed)
                  or (name not in %{gpo_verification_submitted})
-        | filter (name in %{fraud_review_passed} and properties.event_properties.success = 1)
-                 or (name not in %{fraud_review_passed})
+        | filter (name = %{fraud_review_passed} and properties.event_properties.success = 1)
+                 or (name != %{fraud_review_passed})
         | fields
             coalesce(properties.event_properties.fraud_review_pending, 0) AS fraud_review_pending
           , coalesce(properties.event_properties.gpo_verification_pending, 0) AS gpo_verification_pending

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Reporting::IdentityVerificationReport do
         ['Workflow completed - In-Person Pending', '1'],
         ['Workflow completed - Fraud Review Pending', '1'],
         [],
-        ['Successfully verified', '3'],
+        ['Successfully verified', '4'],
         ['Successfully verified - Inline', '1'],
         ['Successfully verified - GPO Code Entry', '1'],
         ['Successfully verified - In Person', '1'],

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Reporting::IdentityVerificationReport do
         { 'user_id' => 'user3', 'name' => 'IdV: doc auth welcome submitted' },
         { 'user_id' => 'user3', 'name' => 'IdV: doc auth image upload vendor submitted', 'success' => '1' },
         { 'user_id' => 'user3', 'name' => 'IdV: final resolution', 'fraud_review_pending' => '1' },
+        { 'user_id' => 'user3', 'name' => 'Fraud: Profile review passed', 'success' => '1' },
 
         # Success through address confirmation user
         { 'user_id' => 'user4', 'name' => 'IdV: GPO verification submitted' },
@@ -80,10 +81,11 @@ RSpec.describe Reporting::IdentityVerificationReport do
         ['Workflow completed - In-Person Pending', '1'],
         ['Workflow completed - Fraud Review Pending', '1'],
         [],
-        ['Succesfully verified', '3'],
-        ['Succesfully verified - Inline', '1'],
-        ['Succesfully verified - GPO Code Entry', '1'],
-        ['Succesfully verified - In Person', '1'],
+        ['Successfully verified', '3'],
+        ['Successfully verified - Inline', '1'],
+        ['Successfully verified - GPO Code Entry', '1'],
+        ['Successfully verified - In Person', '1'],
+        ['Successfully verified - Passed Fraud Review', '1'],
       ]
 
       aggregate_failures do
@@ -115,6 +117,7 @@ RSpec.describe Reporting::IdentityVerificationReport do
         'IdV Reject: Doc Auth' => 3,
         'IdV Reject: Phone Finder' => 1,
         'IdV Reject: Verify' => 1,
+        'Fraud: Profile review passed' => 1,
       )
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11027](https://cm-jira.usa.gov/browse/LG-11027)

## 🛠 Summary of changes

Add a line to Identity Verification Report for users who have passed fraud review, using the new event added in #9194.

Incidentally fix spelling in the report.

## 📜 Testing Plan

- [ ] Manually test on a prod instance?
