### PR TITLE
LG-10463 FSM/Residential Address - Create feature flag

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -137,6 +137,7 @@ in_person_enrollments_ready_job_queue_url: ''
 in_person_enrollments_ready_job_max_number_of_messages: 10
 in_person_enrollments_ready_job_visibility_timeout_seconds: 30
 in_person_enrollments_ready_job_wait_time_seconds: 20
+in_person_residential_address_controller_enabled: false
 in_person_results_delay_in_hours: 1
 in_person_completion_survey_url: 'https://login.gov'
 in_person_full_address_entry_enabled: true

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -254,6 +254,7 @@ class IdentityConfig
     config.add(:in_person_outage_message_enabled, type: :boolean)
     config.add(:in_person_proofing_enabled, type: :boolean)
     config.add(:in_person_public_address_search_enabled, type: :boolean)
+    congig.add(:in_person_residential_address_controller_enabled, type: :boolean)
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:in_person_send_proofing_notifications_enabled, type: :boolean)
     config.add(:in_person_stop_expiring_enrollments, type: :boolean)


### PR DESCRIPTION
## 🎫 Ticket
[LG-10463](https://cm-jira.usa.gov/browse/LG-10463) FSM/Residential Address - Create feature flag

## 🛠 Summary of changes
* Added `in_person_residential_address_controller_enabled` to identify_config.rb and application.yml.default to be used in upcoming work for Residential Address step FSM (flow state machine) removal epic.

## 📜 Testing Plan
* Application will start with no errors.
