### PR TITLE
LG-10973: Log heading and error message when warning shown

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -18,6 +18,14 @@ interface DocumentCaptureWarningProps {
 
 const DISPLAY_ATTEMPTS = 3;
 
+function findErrorMessageDisplayed(listOfErrors): string {
+  const generalOrPiiErrors = listOfErrors.filter(
+    (error) => error.field === 'general' || error.field === 'pii',
+  );
+  const messages = generalOrPiiErrors.map((error) => error.error.message);
+  return messages.join(' ');
+}
+
 function DocumentCaptureWarning({
   isFailedDocType,
   isFailedResult,
@@ -39,6 +47,8 @@ function DocumentCaptureWarning({
   const subHeading = !nonIppOrFailedResult && !isFailedDocType && (
     <h2>{t('errors.doc_auth.rate_limited_subheading')}</h2>
   );
+  const errorMessageDisplayed = findErrorMessageDisplayed(unknownFieldErrors);
+
   return (
     <>
       <Warning
@@ -46,6 +56,7 @@ function DocumentCaptureWarning({
         actionText={actionText}
         actionOnClick={actionOnClick}
         location="doc_auth_review_issues"
+        errorMessageDisplayed={errorMessageDisplayed}
         remainingAttempts={remainingAttempts}
         troubleshootingOptions={
           <DocumentCaptureTroubleshootingOptions

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -42,18 +42,18 @@ function DocumentCaptureWarning({
     <h2>{t('errors.doc_auth.rate_limited_subheading')}</h2>
   );
   const subheadingRef = useRef<HTMLDivElement>(null);
-  const errorTextRef = useRef<HTMLDivElement>(null);
+  const errorMessageDisplayedRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const subheadingText = subheadingRef.current?.textContent;
-    const errorText = errorTextRef.current?.textContent;
+    const errorMessageDisplayed = errorMessageDisplayedRef.current?.textContent;
 
     trackEvent('IdV: warning shown', {
       location: 'doc_auth_review_issues',
       remaining_attempts: remainingAttempts,
       heading,
       subheading: subheadingText,
-      errorText,
+      error_message_displayed: errorMessageDisplayed,
     });
   }, []);
 
@@ -74,7 +74,7 @@ function DocumentCaptureWarning({
         }
       >
         <div ref={subheadingRef}>{!!subheading && subheading}</div>
-        <div ref={errorTextRef}>
+        <div ref={errorMessageDisplayedRef}>
           <UnknownError
             unknownFieldErrors={unknownFieldErrors}
             remainingAttempts={remainingAttempts}

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -38,21 +38,21 @@ function DocumentCaptureWarning({
   const actionText = nonIppOrFailedResult
     ? t('idv.failure.button.warning')
     : t('idv.failure.button.try_online');
-  const subHeading = !nonIppOrFailedResult && !isFailedDocType && (
+  const subheading = !nonIppOrFailedResult && !isFailedDocType && (
     <h2>{t('errors.doc_auth.rate_limited_subheading')}</h2>
   );
-  const subHeadingRef = useRef<HTMLDivElement>(null);
+  const subheadingRef = useRef<HTMLDivElement>(null);
   const errorTextRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const subHeadingText = subHeadingRef.current?.textContent;
+    const subheadingText = subheadingRef.current?.textContent;
     const errorText = errorTextRef.current?.textContent;
 
     trackEvent('IdV: warning shown', {
       location: 'doc_auth_review_issues',
       remaining_attempts: remainingAttempts,
       heading,
-      subHeading: subHeadingText,
+      subheading: subheadingText,
       errorText,
     });
   }, []);
@@ -73,7 +73,7 @@ function DocumentCaptureWarning({
           />
         }
       >
-        <div ref={subHeadingRef}>{!!subHeading && subHeading}</div>
+        <div ref={subheadingRef}>{!!subheading && subheading}</div>
         <div ref={errorTextRef}>
           <UnknownError
             unknownFieldErrors={unknownFieldErrors}

--- a/app/javascript/packages/document-capture/components/warning.tsx
+++ b/app/javascript/packages/document-capture/components/warning.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import type { ReactNode, ReactComponentElement } from 'react';
 import { StatusPage, Button } from '@18f/identity-components';
 import type { TroubleshootingOptions } from '@18f/identity-components';
@@ -49,16 +49,6 @@ interface WarningProps {
    * Source component mounting warning.
    */
   location: string;
-
-  /**
-   * The number of attempts the user can make.
-   */
-  remainingAttempts?: number;
-
-  /**
-   * The error message displayed to the user after submitting photos that cannot be used for doc auth.
-   */
-  errorMessageDisplayed: string;
 }
 
 function Warning({
@@ -71,18 +61,8 @@ function Warning({
   children,
   troubleshootingOptions,
   location,
-  remainingAttempts,
-  errorMessageDisplayed,
 }: WarningProps) {
   const { trackEvent } = useContext(AnalyticsContext);
-  useEffect(() => {
-    trackEvent('IdV: warning shown', {
-      location,
-      remaining_attempts: remainingAttempts,
-      heading,
-      errorMessageDisplayed,
-    });
-  }, []);
 
   let actionButtons: ReactComponentElement<typeof Button>[] | undefined;
   if (actionText && actionOnClick) {

--- a/app/javascript/packages/document-capture/components/warning.tsx
+++ b/app/javascript/packages/document-capture/components/warning.tsx
@@ -54,6 +54,11 @@ interface WarningProps {
    * The number of attempts the user can make.
    */
   remainingAttempts?: number;
+
+  /**
+   * The error message displayed to the user after submitting photos that cannot be used for doc auth.
+   */
+  errorMessageDisplayed: string;
 }
 
 function Warning({
@@ -67,10 +72,16 @@ function Warning({
   troubleshootingOptions,
   location,
   remainingAttempts,
+  errorMessageDisplayed,
 }: WarningProps) {
   const { trackEvent } = useContext(AnalyticsContext);
   useEffect(() => {
-    trackEvent('IdV: warning shown', { location, remaining_attempts: remainingAttempts });
+    trackEvent('IdV: warning shown', {
+      location,
+      remaining_attempts: remainingAttempts,
+      heading,
+      errorMessageDisplayed,
+    });
   }, []);
 
   let actionButtons: ReactComponentElement<typeof Button>[] | undefined;

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -74,7 +74,7 @@ describe('DocumentCaptureWarning', () => {
     const inPersonUrl = '/verify/doc_capture';
 
     it('logs the warning displayed to the user', () => {
-      const isFailedResult = true;
+      const isFailedResult = false;
       const isFailedDocType = false;
 
       renderCcontent(isFailedDocType, isFailedResult, inPersonUrl);
@@ -82,7 +82,7 @@ describe('DocumentCaptureWarning', () => {
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
         heading: 'errors.doc_auth.rate_limited_heading',
-        subheading: '',
+        subheading: 'errors.doc_auth.rate_limited_subheading',
         error_message_displayed: 'general error',
         remaining_attempts: 2,
       });
@@ -172,7 +172,7 @@ describe('DocumentCaptureWarning', () => {
     const inPersonUrl = '';
 
     it('logs the warning displayed to the user', () => {
-      const isFailedResult = false;
+      const isFailedResult = true;
       const isFailedDocType = true;
 
       renderCcontent(isFailedDocType, isFailedResult, inPersonUrl);

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -83,7 +83,7 @@ describe('DocumentCaptureWarning', () => {
         location: 'doc_auth_review_issues',
         heading: 'errors.doc_auth.rate_limited_heading',
         subheading: '',
-        errorText: 'general error',
+        error_message_displayed: 'general error',
         remaining_attempts: 2,
       });
     });
@@ -181,7 +181,7 @@ describe('DocumentCaptureWarning', () => {
         location: 'doc_auth_review_issues',
         heading: 'errors.doc_auth.doc_type_not_supported_heading',
         subheading: '',
-        errorText: 'general error idv.warning.attempts_html',
+        error_message_displayed: 'general error idv.warning.attempts_html',
         remaining_attempts: 2,
       });
     });

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -82,7 +82,7 @@ describe('DocumentCaptureWarning', () => {
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
         heading: 'errors.doc_auth.rate_limited_heading',
-        subHeading: '',
+        subheading: '',
         errorText: 'general error',
         remaining_attempts: 2,
       });
@@ -180,7 +180,7 @@ describe('DocumentCaptureWarning', () => {
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
         heading: 'errors.doc_auth.doc_type_not_supported_heading',
-        subHeading: '',
+        subheading: '',
         errorText: 'general error idv.warning.attempts_html',
         remaining_attempts: 2,
       });

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -1,3 +1,5 @@
+import sinon from 'sinon';
+import { AnalyticsContext } from '@18f/identity-document-capture';
 import { render, screen, within } from '@testing-library/react';
 import { InPersonContext } from '@18f/identity-document-capture/context';
 import { toFormEntryError } from '@18f/identity-document-capture/services/upload';
@@ -5,6 +7,8 @@ import { expect } from 'chai';
 import DocumentCaptureWarning from '@18f/identity-document-capture/components/document-capture-warning';
 
 describe('DocumentCaptureWarning', () => {
+  const trackEvent = sinon.spy();
+
   function validateHeader(headerName, level, existing) {
     const h = screen.queryByRole('heading', {
       name: headerName,
@@ -51,20 +55,39 @@ describe('DocumentCaptureWarning', () => {
       },
     ];
     return render(
-      <InPersonContext.Provider value={{ inPersonURL: inPersonUrl }}>
-        <DocumentCaptureWarning
-          isFailedDocType={isFailedDocType}
-          isFailedResult={isFailedResult}
-          remainingAttempts={2}
-          unknownFieldErrors={unknownFieldErrors}
-          actionOnClick={() => {}}
-        />
-        ,
-      </InPersonContext.Provider>,
+      <AnalyticsContext.Provider value={{ trackEvent }}>
+        <InPersonContext.Provider value={{ inPersonURL: inPersonUrl }}>
+          <DocumentCaptureWarning
+            isFailedDocType={isFailedDocType}
+            isFailedResult={isFailedResult}
+            remainingAttempts={2}
+            unknownFieldErrors={unknownFieldErrors}
+            actionOnClick={() => {}}
+          />
+          ,
+        </InPersonContext.Provider>
+      </AnalyticsContext.Provider>,
     );
   }
+
   context('ipp ', () => {
     const inPersonUrl = '/verify/doc_capture';
+
+    it('logs the warning displayed to the user', () => {
+      const isFailedResult = true;
+      const isFailedDocType = false;
+
+      renderCcontent(isFailedDocType, isFailedResult, inPersonUrl);
+
+      expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
+        location: 'doc_auth_review_issues',
+        heading: 'errors.doc_auth.rate_limited_heading',
+        subHeading: '',
+        errorText: 'general error',
+        remaining_attempts: 2,
+      });
+    });
+
     context('not failed result', () => {
       const isFailedResult = false;
       it('renders not failed doc type', () => {
@@ -147,6 +170,22 @@ describe('DocumentCaptureWarning', () => {
 
   context('non ipp ', () => {
     const inPersonUrl = '';
+
+    it('logs the warning displayed to the user', () => {
+      const isFailedResult = false;
+      const isFailedDocType = true;
+
+      renderCcontent(isFailedDocType, isFailedResult, inPersonUrl);
+
+      expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
+        location: 'doc_auth_review_issues',
+        heading: 'errors.doc_auth.doc_type_not_supported_heading',
+        subHeading: '',
+        errorText: 'general error idv.warning.attempts_html',
+        remaining_attempts: 2,
+      });
+    });
+
     context('not failed result', () => {
       const isFailedResult = false;
       it('renders not failed doc type', () => {

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -47,7 +47,7 @@ describe('document-capture/components/review-issues-step', () => {
       location: 'doc_auth_review_issues',
       remaining_attempts: 3,
       heading: 'We couldn’t verify your ID',
-      subHeading: '',
+      subheading: '',
       errorText: 'test error',
     });
 

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -47,7 +47,8 @@ describe('document-capture/components/review-issues-step', () => {
       location: 'doc_auth_review_issues',
       remaining_attempts: 3,
       heading: 'We couldn’t verify your ID',
-      errorMessageDisplayed: 'test error',
+      subHeading: '',
+      errorText: 'test error',
     });
 
     const button = getByRole('button');

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -48,7 +48,7 @@ describe('document-capture/components/review-issues-step', () => {
       remaining_attempts: 3,
       heading: 'We couldn’t verify your ID',
       subheading: '',
-      errorText: 'test error',
+      error_message_displayed: 'test error',
     });
 
     const button = getByRole('button');

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -14,20 +14,40 @@ import { render } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/review-issues-step', () => {
-  const DEFAULT_PROPS = { remainingAttempts: 3 };
+  const DEFAULT_PROPS = {
+    remainingAttempts: 3,
+    unknownFieldErrors: [
+      {
+        field: 'general',
+        error: toFormEntryError({ field: 'general', message: 'test error' }),
+      },
+    ],
+  };
 
   it('logs warning events', async () => {
     const trackEvent = sinon.spy();
 
     const { getByRole } = render(
-      <AnalyticsContext.Provider value={{ trackEvent }}>
-        <ReviewIssuesStep {...DEFAULT_PROPS} />
-      </AnalyticsContext.Provider>,
+      <I18nContext.Provider
+        value={
+          new I18n({
+            strings: {
+              'errors.doc_auth.rate_limited_heading': 'We couldn’t verify your ID',
+            },
+          })
+        }
+      >
+        <AnalyticsContext.Provider value={{ trackEvent }}>
+          <ReviewIssuesStep {...DEFAULT_PROPS} />
+        </AnalyticsContext.Provider>
+      </I18nContext.Provider>,
     );
 
     expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
       location: 'doc_auth_review_issues',
       remaining_attempts: 3,
+      heading: 'We couldn’t verify your ID',
+      errorMessageDisplayed: 'test error',
     });
 
     const button = getByRole('button');

--- a/spec/javascript/packages/document-capture/components/warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/warning-spec.jsx
@@ -9,6 +9,7 @@ describe('document-capture/components/warning', () => {
   it('renders a warning', async () => {
     const actionOnClick = sinon.spy();
     const trackEvent = sinon.spy();
+    const errorMessage = 'We couldn’t read the address on your ID. Try taking new pictures.';
 
     const { getByRole, getByText } = render(
       <AnalyticsContext.Provider value={{ trackEvent }}>
@@ -16,6 +17,7 @@ describe('document-capture/components/warning', () => {
           heading="Oops!"
           actionText="Try again"
           actionOnClick={actionOnClick}
+          errorMessageDisplayed={errorMessage}
           troubleshootingHeading="Having trouble?"
           troubleshootingOptions={
             <TroubleshootingOptions
@@ -32,6 +34,8 @@ describe('document-capture/components/warning', () => {
 
     expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
       location: 'example',
+      heading: 'Oops!',
+      errorMessageDisplayed: 'We couldn’t read the address on your ID. Try taking new pictures.',
       remaining_attempts: undefined,
     });
 

--- a/spec/javascript/packages/document-capture/components/warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/warning-spec.jsx
@@ -9,7 +9,6 @@ describe('document-capture/components/warning', () => {
   it('renders a warning', async () => {
     const actionOnClick = sinon.spy();
     const trackEvent = sinon.spy();
-    const errorMessage = 'We couldn’t read the address on your ID. Try taking new pictures.';
 
     const { getByRole, getByText } = render(
       <AnalyticsContext.Provider value={{ trackEvent }}>
@@ -17,7 +16,6 @@ describe('document-capture/components/warning', () => {
           heading="Oops!"
           actionText="Try again"
           actionOnClick={actionOnClick}
-          errorMessageDisplayed={errorMessage}
           troubleshootingHeading="Having trouble?"
           troubleshootingOptions={
             <TroubleshootingOptions
@@ -31,13 +29,6 @@ describe('document-capture/components/warning', () => {
         </Warning>
       </AnalyticsContext.Provider>,
     );
-
-    expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
-      location: 'example',
-      heading: 'Oops!',
-      errorMessageDisplayed: 'We couldn’t read the address on your ID. Try taking new pictures.',
-      remaining_attempts: undefined,
-    });
 
     const tryAgainButton = getByRole('button', { name: 'Try again' });
     await userEvent.click(tryAgainButton);


### PR DESCRIPTION
## 🎫 Ticket

Ticket: https://cm-jira.usa.gov/browse/LG-10973

## 🛠 Summary of changes

Currently, the `Frontend: IdV: warning shown` event does not tell us what error the user saw, only that an error message was displayed. There were a couple of times where a user's uploaded photo has a few errors, and we weren't sure which message they actually saw. For example, a case where this might appear is when the user uploaded a passport image with an unreadable address, we wanted to be sure that they saw the "wrong doc type" messaging and not the "couldn't read address" messaging.

This change logs the heading and error shown so that in the future we can check what the user saw with relative ease.

## 📜 Testing Plan

- [ ] Follow the flow through to the photo upload page
- [ ] Upload photos that will cause an error (maybe one PII error and one doc type error)
- [ ] Hit submit and stay on the warning page
- [ ] Search the `log/events.log` for the `Frontend: IdV: warning shown` entry
- [ ] Look for the `heading` property and check that it matches what you see on the page
- [ ] Look for the `errorMessageDisplayed` property and check that it matches what you see on the page

## 👀 Screenshots

Not exactly a screenshot, but here is the change in logs for a DOB entry error (log shortened with `[...]`):

<details>
<summary>Before:</summary>

```
{"name":"Frontend: IdV: warning shown",
"properties":{
    "event_properties":{
        "location":"doc_auth_review_issues",
        "remaining_attempts":76,
        "flow_path":"standard",
    [...]
"log_filename":"events.log"}
```

</details>

<details>
<summary>After:</summary>

```
{"name":"Frontend: IdV: warning shown",
"properties":
    {"event_properties":{
            "location":"doc_auth_review_issues",
            "remaining_attempts":79,
            "heading":"We couldn’t verify your ID",
            "errorMessageDisplayed":"We couldn’t read the birth date on your ID. Try taking new pictures.",
            "flow_path":"standard",
    [...]
"log_filename":"events.log"}
```

</details>
