### PR TITLE
lg-10082 usps enrollment code email format

### DIFF
--- a/app/jobs/in_person/enrollments_ready_for_status_check/enrollment_pipeline.rb
+++ b/app/jobs/in_person/enrollments_ready_for_status_check/enrollment_pipeline.rb
@@ -11,7 +11,7 @@ module InPerson::EnrollmentsReadyForStatusCheck
     def analytics(user: AnonymousUser.new)
       Analytics.new(user: user, request: nil, session: {}, sp: nil)
     end
-    
+
     # Process a message from USPS indicating that an in-person
     # enrollment is ready to have its status checked.
     #

--- a/app/jobs/in_person/enrollments_ready_for_status_check/enrollment_pipeline.rb
+++ b/app/jobs/in_person/enrollments_ready_for_status_check/enrollment_pipeline.rb
@@ -8,6 +8,10 @@ module InPerson::EnrollmentsReadyForStatusCheck
       @email_body_pattern = email_body_pattern
     end
 
+    def analytics(user: AnonymousUser.new)
+      Analytics.new(user: user, request: nil, session: {}, sp: nil)
+    end
+    
     # Process a message from USPS indicating that an in-person
     # enrollment is ready to have its status checked.
     #

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1611,6 +1611,24 @@ module AnalyticsEvents
     track_event('IdV: in person proofing switch_back visited', flow_path: flow_path, **extra)
   end
 
+  # An email from USPS with an enrollment code has been received, indicating
+  # the enrollment is approved or failed. A check is required to get the status
+  # it is not included in the email.
+  # @param [boolean] multi_part If the email is marked as multi_part
+  # @param [string] part_found Records if the enrollment code was found in text_part or html_part
+  def idv_in_person_usps_proofing_enrollment_code_email_received(
+    multi_part: nil,
+    part_found: nil,
+    **extra
+  )
+    track_event(
+      'IdV: in person usps proofing enrollment code email received',
+      multi_part: multi_part,
+      part_found: part_found,
+      **extra,
+    )
+  end
+
   # GetUspsProofingResultsJob has completed. Includes counts of various outcomes encountered
   # @param [Float] duration_seconds number of minutes the job was running
   # @param [Integer] enrollments_checked number of enrollments eligible for status check

--- a/spec/jobs/in_person/enrollments_ready_for_status_check/enrollment_pipeline_spec.rb
+++ b/spec/jobs/in_person/enrollments_ready_for_status_check/enrollment_pipeline_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
   let(:error_reporter) { instance_double(InPerson::EnrollmentsReadyForStatusCheck::ErrorReporter) }
   let(:email_body_pattern) { /\A\s*(?<enrollment_code>\d{16})\s*\Z/ }
   subject(:enrollment_pipeline) { described_class.new(error_reporter:, email_body_pattern:) }
+  
+  let(:pipeline_analytics) { FakeAnalytics.new }
 
   before(:each) do
     allow(IdentityConfig.store).to receive(:in_person_enrollments_ready_job_email_body_pattern).
@@ -52,6 +54,22 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
         },
       }
     end
+    let(:ses_html_payload) do
+      {
+        content: Mail.new do |m|
+          m.html_part = enrollment_code
+        end.to_s,
+        mail: {
+          messageId: Random.uuid.delete('-'),
+          timestamp: DateTime.now.to_s,
+          source: 'testsource@example.com',
+          commonHeaders: {
+            date: Mail::DateField.new(mail_date).to_s,
+            messageId: Mail::Utilities.generate_message_id,
+          },
+        },
+      }
+    end
     let(:ses_body_payload) do
       {
         content: Mail.new do |m|
@@ -87,6 +105,12 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
       {
         MessageId: sns_message_id,
         Message: ses_text_payload.to_json,
+      }
+    end
+    let(:sns_html_payload) do
+      {
+        MessageId: sns_message_id,
+        Message: ses_html_payload.to_json,
       }
     end
     let(:sns_body_payload) do
@@ -348,9 +372,12 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
     end
 
     context 'returns true for records handled as expected' do
+      before do
+        allow(enrollment_pipeline).to receive(:analytics).and_return(pipeline_analytics)
+      end
+
       it 'handles text_part' do
         allow(sqs_message).to receive(:body).and_return(sns_text_payload.to_json)
-
         enrollment = create(:in_person_enrollment, enrollment_code:, status: :pending, user:)
 
         expect(InPersonEnrollment).to receive(:update).
@@ -359,8 +386,33 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
         expect(error_reporter).not_to receive(:report_error)
 
         expect(enrollment_pipeline.process_message(sqs_message)).to be(true)
+        
+        expect(pipeline_analytics).to have_logged_event(
+          'IdV: in person usps proofing enrollment code email received',
+          multi_part: true,
+          part_found: 'text_part',
+        )
       end
-      it 'handles body' do
+
+      it 'handles html_part' do
+        allow(sqs_message).to receive(:body).and_return(sns_html_payload.to_json)
+        enrollment = create(:in_person_enrollment, enrollment_code:, status: :pending, user:)
+
+        expect(InPersonEnrollment).to receive(:update).
+          with(enrollment.id, ready_for_status_check: true).once
+
+        expect(error_reporter).not_to receive(:report_error)
+
+        expect(enrollment_pipeline.process_message(sqs_message)).to be(true)
+        
+        expect(pipeline_analytics).to have_logged_event(
+          'IdV: in person usps proofing enrollment code email received',
+          multi_part: true,
+          part_found: 'html_part',
+        )
+      end
+
+      it 'handles message body' do
         allow(sqs_message).to receive(:body).and_return(sns_body_payload.to_json)
 
         enrollment = create(:in_person_enrollment, enrollment_code:, status: :pending, user:)
@@ -371,6 +423,12 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
         expect(error_reporter).not_to receive(:report_error)
 
         expect(enrollment_pipeline.process_message(sqs_message)).to be(true)
+
+        expect(pipeline_analytics).to have_logged_event(
+          'IdV: in person usps proofing enrollment code email received',
+          multi_part: false,
+          part_found: 'message_body',
+        )
       end
       it 'marks non-ready record as ready' do
         allow(sqs_message).to receive(:body).and_return(sns_payload.to_json)

--- a/spec/jobs/in_person/enrollments_ready_for_status_check/enrollment_pipeline_spec.rb
+++ b/spec/jobs/in_person/enrollments_ready_for_status_check/enrollment_pipeline_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
   let(:error_reporter) { instance_double(InPerson::EnrollmentsReadyForStatusCheck::ErrorReporter) }
   let(:email_body_pattern) { /\A\s*(?<enrollment_code>\d{16})\s*\Z/ }
   subject(:enrollment_pipeline) { described_class.new(error_reporter:, email_body_pattern:) }
-  
+
   let(:pipeline_analytics) { FakeAnalytics.new }
 
   before(:each) do
@@ -386,7 +386,7 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
         expect(error_reporter).not_to receive(:report_error)
 
         expect(enrollment_pipeline.process_message(sqs_message)).to be(true)
-        
+
         expect(pipeline_analytics).to have_logged_event(
           'IdV: in person usps proofing enrollment code email received',
           multi_part: true,
@@ -404,7 +404,7 @@ RSpec.describe InPerson::EnrollmentsReadyForStatusCheck::EnrollmentPipeline do
         expect(error_reporter).not_to receive(:report_error)
 
         expect(enrollment_pipeline.process_message(sqs_message)).to be(true)
-        
+
         expect(pipeline_analytics).to have_logged_event(
           'IdV: in person usps proofing enrollment code email received',
           multi_part: true,


### PR DESCRIPTION
## 🎫 Ticket
[LG-10082](https://cm-jira.usa.gov/browse/LG-10082)

## 🛠 Summary of changes
Use either text_part or html_part to retrieve the enrollment code from USPS email and add an analytics event to determine in which part the code was found.