### PR TITLE
Fix pinpoint script parsing

### DIFF
--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -84,7 +84,7 @@ class PinpointSupportedCountries
 
         CountrySupport.new(
           iso_code: iso_code,
-          name: trim_spaces(sms_config['Country or region']),
+          name: trim_spaces_digits(sms_config['Country or region']),
           supports_sms: supports_sms,
         )
       end
@@ -157,6 +157,10 @@ class PinpointSupportedCountries
 
   def trim_spaces(str)
     str.gsub(/\s{2,}/, ' ').gsub(/\s+$/, '')
+  end
+
+  def trim_spaces_digits(str)
+    trim_spaces(str).gsub(/\d+$/, '')
   end
 
   def digits_only?(str)

--- a/spec/lib/pinpoint_supported_countries_spec.rb
+++ b/spec/lib/pinpoint_supported_countries_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PinpointSupportedCountries do
           </td>
         </tr>
         <tr>
-          <td>Argentina</td>
+          <td>Argentina<sup><a href="#sms-support-note-1">2</a></sup></td>
           <td>AR</td>
           <td></td>
           <td>Yes</td>


### PR DESCRIPTION
This footnote for New Zealand appeared and broke our script, so this PR strips trailing footnote digits from country names, fixes build

| screenshot |
| ---- |
| <img width="549" alt="Screenshot 2023-09-25 at 8 33 58 AM" src="https://github.com/18F/identity-idp/assets/458784/5c4b1f9c-2489-4338-8e48-cad79f9a73f2"> |

