### PR TITLE
LG-10022: Avoid second MFA prompt for strict MFA requirement

### DIFF
--- a/app/controllers/concerns/second_mfa_reminder_concern.rb
+++ b/app/controllers/concerns/second_mfa_reminder_concern.rb
@@ -1,11 +1,18 @@
 module SecondMfaReminderConcern
   def user_needs_second_mfa_reminder?
     return false unless IdentityConfig.store.second_mfa_reminder_enabled
-    return false if user_has_dismissed_second_mfa_reminder? || user_has_multiple_mfa_methods?
+    return false if user_has_dismissed_second_mfa_reminder?
+    return false if second_mfa_enrollment_may_downgrade_for_service_provider_mfa_requirement?
+    return false if user_has_multiple_mfa_methods?
     exceeded_sign_in_count_for_second_mfa_reminder? || exceeded_account_age_for_second_mfa_reminder?
   end
 
   private
+
+  def second_mfa_enrollment_may_downgrade_for_service_provider_mfa_requirement?
+    service_provider_mfa_policy.phishing_resistant_required? ||
+      service_provider_mfa_policy.piv_cac_required?
+  end
 
   def user_has_dismissed_second_mfa_reminder?
     current_user.second_mfa_reminder_dismissed_at.present?


### PR DESCRIPTION
## 🎫 Ticket

Follow-on revision for [LG-10022](https://cm-jira.usa.gov/browse/LG-10022) (#9124)

## 🛠 Summary of changes

Updates the second MFA reminder logic to avoid prompting the user if they are authenticating with a partner which requires stricter MFA requirements (i.e. phishing-resistant or PIV-only). This avoids an issue where the user may inadvertently "downgrade" their authentication method, since they may choose to add a second MFA which is less secure than what was required for the request. This could result in the user being prompted excessively to reauthenticate, since the less-secure method would not be valid for the authentication request, and they'd need to reauthenticate with the more secure method.

Per [related Slack discussion](https://gsa-tts.slack.com/archives/C0595QABDS7/p1695058702797529), a separate ticket will be created to explore revisions to the session `auth_method` tracking to allow multiple, simultaneous valid authentications, so that a less-secure-but-more-recent authentication will not invalidate a more-secure-but-less-recent authentication.

## 📜 Testing Plan

It's easiest to test by setting an artificially low config override for sign-ins or account page, e.g. in `config/application.yml`:

```
second_mfa_reminder_sign_in_count: 1
```

1. Go to http://localhost:3000
2. Create an account using a phishing-resistant MFA method (security key, face or touch unlock, or PIV)
3. After account creation, sign out
4. Start [the sample app](https://github.com/18F/identity-oidc-sinatra) in a separate terminal process
5. Go to http://localhost:9292/?aal=2-phishing_resistant
6. Click "Sign in"
7. Sign in
8. Observe that you are not prompted with the screen suggesting that you add a second authentication method