### PR TITLE
Do not create CI scan job when CI image is not built

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -634,10 +634,11 @@ ecr-scan-review-app:
 ecr-scan-ci:
   extends: .container_scan_template
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
-    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
-      when: never
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH || $CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"'
+      changes:
+        compare_to: 'refs/heads/main'
+        paths:
+        - dockerfiles/idp_ci.Dockerfile
   needs:
     - job: build-ci-image
   stage: scan


### PR DESCRIPTION
## 🛠 Summary of changes

This PR fixes a bug in #9231 where the `build-ci-image` is not added to the pipeline but the `ecr-scan-ci` is in the pipeline and depends on it. There is no built-in functionality to not run a job if it depends on a job that is not being run. This PR attempts to fix it by using the same rules for both jobs.

```
Unable to create pipeline
  'ecr-scan-ci' job needs 'build-ci-image' job, but 'build-ci-image' is not in any previous stage
```
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
