### PR TITLE
Un-scale percents in Monthly Account Reuse Report

### DIFF
--- a/app/jobs/reports/monthly_account_reuse_report.rb
+++ b/app/jobs/reports/monthly_account_reuse_report.rb
@@ -44,23 +44,23 @@ module Reports
               SELECT
                   COUNT(DISTINCT agencies.id) AS num_agencies
                   , identities.user_id
-              FROM 
+              FROM
                   identities
-              JOIN 
+              JOIN
                   service_providers sp ON identities.service_provider = sp.issuer
-              JOIN 
+              JOIN
                   agencies ON sp.agency_id = agencies.id
               WHERE
                   identities.last_ial2_authenticated_at IS NOT NULL
               AND
                   identities.verified_at < %{query_date}
-              GROUP BY 
+              GROUP BY
                   identities.user_id
           ) agencies_per_user
-          GROUP BY 
+          GROUP BY
               agencies_per_user.num_agencies
           HAVING agencies_per_user.num_agencies > 1
-          ORDER BY 
+          ORDER BY
               num_agencies ASC
       SQL
 

--- a/app/jobs/reports/monthly_account_reuse_report.rb
+++ b/app/jobs/reports/monthly_account_reuse_report.rb
@@ -109,8 +109,7 @@ module Reports
 
         if total_proofed > 0
           reuse_stats.each_with_index do |result_entry, index|
-            reuse_stats[index]['percentage'] =
-              result_entry['num_users'] / total_proofed.to_f * 100
+            reuse_stats[index]['percentage'] = result_entry['num_users'] / total_proofed.to_f
 
             reuse_total_percentage += reuse_stats[index]['percentage']
           end

--- a/spec/jobs/reports/monthly_account_reuse_report_spec.rb
+++ b/spec/jobs/reports/monthly_account_reuse_report_spec.rb
@@ -130,9 +130,9 @@ RSpec.describe Reports::MonthlyAccountReuseReport do
                 [
                   { title: 'IDV app reuse rate Feb-2021', float_as_percent: true, precision: 4 },
                   ['Num. SPs', 'Num. users', 'Percentage'],
-                  [2, 3, 30.0],
-                  [3, 2, 20.0],
-                  ['Total (all >1)', 5, 50.0],
+                  [2, 3, 0.3],
+                  [3, 2, 0.2],
+                  ['Total (all >1)', 5, 0.5],
                 ],
                 [
                   { title: 'Total proofed identities' },


### PR DESCRIPTION
**Why**: The tables report mailer expects percent data to be between 0.0 and 1.0,
this also matches how Excel and Sheets treat percents when formatting them

