### PR TITLE
LG-11115: Email Addresses deletion bug fixes in user reinstate

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -220,6 +220,6 @@ class RegisterUserEmailForm
     return @blocked_email_address if defined?(@blocked_email_address)
 
     @blocked_email_address = SuspendedEmail.find_with_email_digest(digested_base_email)&.
-    email_address
+      email_address
   end
 end

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -219,6 +219,7 @@ class RegisterUserEmailForm
   def blocked_email_address
     return @blocked_email_address if defined?(@blocked_email_address)
 
-    @blocked_email_address = SuspendedEmail.find_with_email_digest(digested_base_email)
+    @blocked_email_address = SuspendedEmail.find_with_email_digest(digested_base_email)&.
+    email_address
   end
 end

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -202,6 +202,7 @@ class RegisterUserEmailForm
     existing_user.email_addresses.none?(&:confirmed?)
   end
 
+  # @return [EmailAddress,nil]
   def email_address_record
     return @email_address_record if defined?(@email_address_record)
 
@@ -216,6 +217,7 @@ class RegisterUserEmailForm
     request_id if request_id.present? && ServiceProviderRequestProxy.find_by(uuid: request_id)
   end
 
+  # @return [EmailAddress,nil]
   def blocked_email_address
     return @blocked_email_address if defined?(@blocked_email_address)
 

--- a/app/models/suspended_email.rb
+++ b/app/models/suspended_email.rb
@@ -16,11 +16,11 @@ class SuspendedEmail < ApplicationRecord
     end
 
     def find_with_email(email)
-      find_by(digested_base_email: generate_email_digest(email))&.email_address
+      find_by(digested_base_email: generate_email_digest(email))
     end
 
     def find_with_email_digest(digest)
-      find_by(digested_base_email: digest)&.email_address
+      find_by(digested_base_email: digest)
     end
   end
 end

--- a/app/models/suspended_email.rb
+++ b/app/models/suspended_email.rb
@@ -15,10 +15,12 @@ class SuspendedEmail < ApplicationRecord
       )
     end
 
+    # @return [SuspendedEmail,nil]
     def find_with_email(email)
       find_by(digested_base_email: generate_email_digest(email))
     end
 
+    # @return [SuspendedEmail,nil]
     def find_with_email_digest(digest)
       find_by(digested_base_email: digest)
     end

--- a/spec/models/suspended_email_spec.rb
+++ b/spec/models/suspended_email_spec.rb
@@ -23,22 +23,21 @@ RSpec.describe SuspendedEmail, type: :model do
       it 'returns nil' do
         email = 'not_blocked@example.com'
 
-        expect(SuspendedEmail.find_with_email(email)&.email_address).to be_nil
+        expect(SuspendedEmail.find_with_email(email)).to be_nil
       end
     end
 
     context 'when the email is blocked' do
-      it 'returns the original email address' do
+      it 'returns the SuspendedEmail' do
         blocked_email = FactoryBot.create(:email_address, email: 'blocked@example.com')
         digested_base_email = SuspendedEmail.generate_email_digest('blocked@example.com')
-        FactoryBot.create(
+        suspended_email = FactoryBot.create(
           :suspended_email,
           digested_base_email: digested_base_email,
           email_address: blocked_email,
         )
 
-        email_address = SuspendedEmail.find_with_email('blocked@example.com')&.email_address
-        expect(email_address).to eq(blocked_email)
+        expect(SuspendedEmail.find_with_email('blocked@example.com')).to eq(suspended_email)
       end
     end
   end
@@ -49,22 +48,21 @@ RSpec.describe SuspendedEmail, type: :model do
         email = 'not_blocked@example.com'
         digested_base_email = Digest::SHA256.hexdigest(email)
 
-        expect(SuspendedEmail.find_with_email_digest(digested_base_email)&.email_address).to be_nil
+        expect(SuspendedEmail.find_with_email_digest(digested_base_email)).to be_nil
       end
     end
 
     context 'when the email is blocked' do
-      it 'returns the original email address' do
+      it 'returns the SuspendedEmail' do
         blocked_email = FactoryBot.create(:email_address, email: 'blocked@example.com')
-        digested_base_email = Digest::SHA256.hexdigest('blocked@example.com')
-        FactoryBot.create(
+        digested_base_email = SuspendedEmail.generate_email_digest('blocked@example.com')
+        suspended_email = FactoryBot.create(
           :suspended_email,
           digested_base_email: digested_base_email,
           email_address: blocked_email,
         )
 
-        email_address = SuspendedEmail.find_with_email_digest(digested_base_email)&.email_address
-        expect(email_address).to eq(blocked_email)
+        expect(SuspendedEmail.find_with_email('blocked@example.com')).to eq(suspended_email)
       end
     end
   end

--- a/spec/models/suspended_email_spec.rb
+++ b/spec/models/suspended_email_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SuspendedEmail, type: :model do
       it 'returns nil' do
         email = 'not_blocked@example.com'
 
-        expect(SuspendedEmail.find_with_email(email)).to be_nil
+        expect(SuspendedEmail.find_with_email(email)&.email_address).to be_nil
       end
     end
 
@@ -37,7 +37,8 @@ RSpec.describe SuspendedEmail, type: :model do
           email_address: blocked_email,
         )
 
-        expect(SuspendedEmail.find_with_email('blocked@example.com')).to eq(blocked_email)
+        email_address = SuspendedEmail.find_with_email('blocked@example.com')&.email_address
+        expect(email_address).to eq(blocked_email)
       end
     end
   end
@@ -48,7 +49,7 @@ RSpec.describe SuspendedEmail, type: :model do
         email = 'not_blocked@example.com'
         digested_base_email = Digest::SHA256.hexdigest(email)
 
-        expect(SuspendedEmail.find_with_email_digest(digested_base_email)).to be_nil
+        expect(SuspendedEmail.find_with_email_digest(digested_base_email)&.email_address).to be_nil
       end
     end
 
@@ -62,7 +63,8 @@ RSpec.describe SuspendedEmail, type: :model do
           email_address: blocked_email,
         )
 
-        expect(SuspendedEmail.find_with_email_digest(digested_base_email)).to eq(blocked_email)
+        email_address = SuspendedEmail.find_with_email_digest(digested_base_email)&.email_address
+        expect(email_address).to eq(blocked_email)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -969,7 +969,7 @@ RSpec.describe User do
         email_address = email_addresses.last
         expect(email_addresses.count).to eq 1
         expect { user.reinstate! }.
-          to(change { SuspendedEmail.find_with_email(email_address.email)&.email_address }.to(nil))
+          to(change { SuspendedEmail.find_with_email(email_address.email) }.to(nil))
         expect(user.email_addresses.reload.last).to be_present
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -969,10 +969,8 @@ RSpec.describe User do
         email_address = email_addresses.last
         expect(email_addresses.count).to eq 1
         expect { user.reinstate! }.
-          to(change { SuspendedEmail.find_with_email(email_address.email)&.email_address }.
-            from(email_address).to(nil))
-        expect(email_addresses.reload.last).to_not be_nil
-        expect(email_addresses.reload.count).to eq 1
+          to(change { SuspendedEmail.find_with_email(email_address.email)&.email_address }.to(nil))
+        expect(user.email_addresses.reload.last).to be_present
       end
 
       it 'updates the reinstated_at attribute with the current time' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -965,10 +965,14 @@ RSpec.describe User do
       end
 
       it 'destroys SuspendedEmail records for each email address' do
-        email_address = user.email_addresses.last
+        email_addresses = user.email_addresses
+        email_address = email_addresses.last
+        expect(email_addresses.count).to eq 1
         expect { user.reinstate! }.
-          to(change { SuspendedEmail.find_with_email(email_address.email) }.
+          to(change { SuspendedEmail.find_with_email(email_address.email)&.email_address }.
             from(email_address).to(nil))
+        expect(email_addresses.reload.last).to_not be_nil
+        expect(email_addresses.reload.count).to eq 1
       end
 
       it 'updates the reinstated_at attribute with the current time' do


### PR DESCRIPTION
why: deleting the SuspendedEmail row cascades and deletes its associated email addresses