### PR TITLE
Refactor WebAuthn public key algorithms

### DIFF
--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -37,6 +37,33 @@ interface EnrollResult {
   transports?: string[];
 }
 
+/**
+ * @see https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+ */
+const enum COSEAlgorithm {
+  ES256 = -7,
+  ES384 = -35,
+  ES512 = -36,
+  PS256 = -37,
+  PS384 = -38,
+  PS512 = -39,
+  RS256 = -257,
+}
+
+/**
+ * @see https://github.com/18F/identity-idp/blob/main/config/initializers/webauthn.rb
+ * @see https://github.com/cedarcode/webauthn-ruby/blob/6db9596/lib/webauthn/relying_party.rb#L16
+ */
+const SUPPORTED_ALGORITHMS: COSEAlgorithm[] = [
+  COSEAlgorithm.ES256,
+  COSEAlgorithm.ES384,
+  COSEAlgorithm.ES512,
+  COSEAlgorithm.PS256,
+  COSEAlgorithm.PS384,
+  COSEAlgorithm.PS512,
+  COSEAlgorithm.RS256,
+];
+
 async function enrollWebauthnDevice({
   user,
   challenge,
@@ -48,36 +75,7 @@ async function enrollWebauthnDevice({
       challenge,
       rp: { name: window.location.hostname },
       user,
-      pubKeyCredParams: [
-        {
-          type: 'public-key',
-          alg: -7, // ECDSA w/ SHA-256
-        },
-        {
-          type: 'public-key',
-          alg: -35, // ECDSA w/ SHA-384
-        },
-        {
-          type: 'public-key',
-          alg: -36, // ECDSA w/ SHA-512
-        },
-        {
-          type: 'public-key',
-          alg: -37, // RSASSA-PSS w/ SHA-256
-        },
-        {
-          type: 'public-key',
-          alg: -38, // RSASSA-PSS w/ SHA-384
-        },
-        {
-          type: 'public-key',
-          alg: -39, // RSASSA-PSS w/ SHA-512
-        },
-        {
-          type: 'public-key',
-          alg: -257, // RSASSA-PKCS1-v1_5 w/ SHA-256
-        },
-      ],
+      pubKeyCredParams: SUPPORTED_ALGORITHMS.map((alg) => ({ alg, type: 'public-key' })),
       timeout: 800000,
       attestation: 'none',
       authenticatorSelection: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,7 @@ module.exports = (api) => {
   return {
     presets: [
       ['@babel/preset-env', { targets }],
-      '@babel/typescript',
+      ['@babel/typescript', { optimizeConstEnums: true }],
       [
         '@babel/preset-react',
         {

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,3 +1,3 @@
 WebAuthn.configure do |config|
-  config.algorithms.concat(%w[ES384 ES512 PS256 PS384 PS512])
+  config.algorithms.concat(%w[ES384 ES512 PS384 PS512])
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Some small revisions and clean-up around WebAuthn supported algorithms.

**Why?**

- Reduce repeated code with `pubKeyCredParams` object structure
- Improve readability of possible and supported algorithms
- Add sources for referencing, to improve understanding and help ensure accuracy in the future
- Optimize output size by leveraging [TypeScript `const` enum inlining](https://www.typescriptlang.org/docs/handbook/enums.html#const-enums) (minified brotli size reduction of `webauthn-setup.js` by about 2%, from 1.17kb to 1.15kb)
   - As a follow-up task, we should consider porting most of our `enum` to `const enum` to take advantage of the same optimization
- Eliminate duplicate algorithm in server-side WebAuthn gem configuration (PS256 was previously both a [default](https://github.com/cedarcode/webauthn-ruby/blob/6db959662bf00a22c252ed16c73afedae8f6408f/lib/webauthn/relying_party.rb#L16) and [concatenated](https://github.com/18F/identity-idp/blob/b2d5058d8014002a2f9ea31c99af1cc59fd2714f/config/initializers/webauthn.rb#L2))

## 📜 Testing Plan

Verify no regressions in setting up a WebAuthn authentication method.