### PR TITLE
Override Propshaft digesting for shorter file names

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,5 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
+require 'extensions/propshaft/asset'
+
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
@@ -10,5 +12,3 @@ Rails.application.config.assets.paths.push(
   'node_modules/@18f/identity-design-system/dist/assets/img',
   'node_modules/@18f/identity-design-system/dist/assets/fonts',
 )
-
-require Rails.root.join('lib', 'extensions', 'propshaft', 'asset')

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,5 @@ Rails.application.config.assets.paths.push(
   'node_modules/@18f/identity-design-system/dist/assets/img',
   'node_modules/@18f/identity-design-system/dist/assets/fonts',
 )
+
+require Rails.root.join('lib', 'extensions', 'propshaft', 'asset')

--- a/lib/extensions/propshaft/asset.rb
+++ b/lib/extensions/propshaft/asset.rb
@@ -1,0 +1,7 @@
+module Extensions
+  Propshaft::Asset.class_eval do
+    def digest
+      @digest ||= Digest::SHA1.hexdigest("#{content}#{version}")[0...7]
+    end
+  end
+end

--- a/lib/extensions/propshaft/asset.rb
+++ b/lib/extensions/propshaft/asset.rb
@@ -5,7 +5,7 @@
 module Extensions
   Propshaft::Asset.class_eval do
     def digest
-      @digest ||= Digest::SHA1.hexdigest("#{content}#{version}")[0...7]
+      @digest ||= Digest::SHA1.hexdigest("#{content}#{version}")[0...8]
     end
   end
 end

--- a/lib/extensions/propshaft/asset.rb
+++ b/lib/extensions/propshaft/asset.rb
@@ -1,7 +1,9 @@
 module Extensions
   Propshaft::Asset.class_eval do
+    alias_method :original_digest, :digest
+
     def digest
-      @digest ||= Digest::SHA1.hexdigest("#{content}#{version}")[0...7]
+      @digest ||= original_digest[0...7]
     end
   end
 end

--- a/lib/extensions/propshaft/asset.rb
+++ b/lib/extensions/propshaft/asset.rb
@@ -1,3 +1,7 @@
+# Monkey-patch Propshaft::Asset to produce a shorter digest as an optimization to built output size.
+#
+# See: https://github.com/rails/propshaft/blob/main/lib/propshaft/asset.rb
+
 module Extensions
   Propshaft::Asset.class_eval do
     alias_method :original_digest, :digest

--- a/lib/extensions/propshaft/asset.rb
+++ b/lib/extensions/propshaft/asset.rb
@@ -4,10 +4,8 @@
 
 module Extensions
   Propshaft::Asset.class_eval do
-    alias_method :original_digest, :digest
-
     def digest
-      @digest ||= original_digest[0...7]
+      @digest ||= Digest::SHA1.hexdigest("#{content}#{version}")[0...7]
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

This explores overriding Propshaft's default digesting logic in order to produce shorter file names. Since these files names are referenced in stylesheets (e.g. `url(/public/assets/...)`) and are not likely to be well-optimized by [DEFLATE](https://en.wikipedia.org/wiki/Deflate)/[LZ77](https://en.wikipedia.org/wiki/LZ77_and_LZ78)/[Huffman](https://en.wikipedia.org/wiki/Huffman_coding)-based compression, it's theorized that they may be contributing to larger overall file size.

The downside of this is it increases the likelihood of a hash collision, though it's quite unlikely, both that a hash collision would occur in the first place, and that two versions of a collided file hash would be cached in a user's browser such that conflicts could occur.

To my knowledge, Propshaft does not expose a way to customize this behavior, so the implementation here monkeypatches the original class method. The logic is largely the same, except the digest is shortened from its original result to take only the first 7 characters.

https://github.com/rails/propshaft/blob/18979c176132f432f70f8d7f7ff97ece035cba5d/lib/propshaft/asset.rb#L23-L25

### Performance Impact:

This affects the file names for all compiled assets, notably impacting:

- References to `url(...)` file paths within CSS files
- Total size of HTML markup from path references to images and stylesheets
- Response [preload headers](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload)

**Results on `application.css`:**

Before: 27.6kb brotli'd, minified
After: 26.7kb brotli'd, minified
Diff: -0.9kb (-3.26%)

**Markup size:**

```
curl --compressed -so /dev/null http://localhost:3000 -w '%{size_download}'
```

Before: 4598 bytes
After: 4155 bytes
Diff: -433 bytes (-9.6%)

**"Link" Header size:**

```
curl --silent -I http://localhost:3000 | sed -n -e 's/^Link: //p' | wc -c
```

Before: 1632 bytes
After: 1467 bytes
Diff: -165 bytes (-10.1%)


## 📜 Testing Plan

```
NODE_ENV=production RAILS_ENV=production rails assets:precompile
```

Observe:

1. Files in `public/assets` have a fingerprint in file path that is only 7 characters in length (compare to longer on `main`)
2. Within CSS files (e.g. `public/assets/application-*.css`), references to other files are accurate and use the shorter fingerprint