### PR TITLE
LG-10972 Adding backup codes invalidates remembered browser

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -92,9 +92,7 @@ module Users
     end
 
     def generate_codes
-      if current_user.backup_code_configurations.length.nonzero?
-        revoke_remember_device(current_user)
-      end
+      revoke_remember_device(current_user) if current_user.backup_code_configurations.any?
       @codes = generator.generate
       user_session[:backup_codes] = @codes
     end

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -92,6 +92,9 @@ module Users
     end
 
     def generate_codes
+      if current_user.backup_code_configurations.length.nonzero?
+        revoke_remember_device(current_user)
+      end
       @codes = generator.generate
       user_session[:backup_codes] = @codes
     end

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -92,7 +92,6 @@ module Users
     end
 
     def generate_codes
-      revoke_remember_device(current_user)
       @codes = generator.generate
       user_session[:backup_codes] = @codes
     end

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -48,17 +48,6 @@ RSpec.describe Users::BackupCodeSetupController do
     expect(user.backup_code_configurations.length).to eq BackupCodeGenerator::NUMBER_OF_CODES
   end
 
-  it 'creating backup codes revokes remember device cookies' do
-    user = create(:user, :fully_registered)
-    stub_sign_in(user)
-    expect(user.remember_device_revoked_at).to eq nil
-
-    freeze_time do
-      post :create
-      expect(user.reload.remember_device_revoked_at).to eq Time.zone.now
-    end
-  end
-
   it 'deletes backup codes' do
     user = build(:user, :fully_registered, :with_authentication_app, :with_backup_code)
     stub_sign_in(user)

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe Users::BackupCodeSetupController do
     expect(user.backup_code_configurations.length).to eq BackupCodeGenerator::NUMBER_OF_CODES
   end
 
+  it 'creating backup codes at setup remember device cookies' do
+    user = create(:user, :fully_registered)
+    stub_sign_in(user)
+    expect(user.remember_device_revoked_at).to eq nil
+
+    freeze_time do
+      post :create
+      expect(user.reload.remember_device_revoked_at).to eq nil
+    end
+  end
+
   it 'deletes backup codes' do
     user = build(:user, :fully_registered, :with_authentication_app, :with_backup_code)
     stub_sign_in(user)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-10972](https://cm-jira.usa.gov/browse/LG-10972)


## 🛠 Summary of changes

Deleted method that clears the remember browser cookie and removed block in spec that looks for that.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go to localhost:3000 and set up a new account
- [ ] Set up Text or voice MFA method
- [ ] At One time code screen make sure "Remember this browser" is checked
- [ ] Submit then Add another method -> Backup codes
- [ ] Sign out after adding Backup codes
- [ ] Sign in: you should expect to login without authenticating as your browser is remembered


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
