### PR TITLE
Rename ial2_consent_given (1/3)

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -53,7 +53,7 @@ module Idv
     end
 
     def consent_form_params
-      params.require(:doc_auth).permit(:ial2_consent_given)
+      params.require(:doc_auth).permit([:ial2_consent_given, :idv_consent_given])
     end
 
     def confirm_welcome_step_complete

--- a/app/controllers/idv/getting_started_controller.rb
+++ b/app/controllers/idv/getting_started_controller.rb
@@ -72,7 +72,7 @@ module Idv
     end
 
     def consent_form_params
-      params.require(:doc_auth).permit(:ial2_consent_given)
+      params.require(:doc_auth).permit([:ial2_consent_given, :idv_consent_given])
     end
 
     def confirm_agreement_needed

--- a/app/forms/idv/consent_form.rb
+++ b/app/forms/idv/consent_form.rb
@@ -2,17 +2,17 @@ module Idv
   class ConsentForm
     include ActiveModel::Model
 
-    validates :ial2_consent_given?,
+    validates :idv_consent_given?,
               acceptance: { message: proc { I18n.t('errors.doc_auth.consent_form') } }
 
     def submit(params)
-      @ial2_consent_given = params[:ial2_consent_given] == '1'
+      @idv_consent_given = params[:idv_consent_given] == '1' || params[:ial2_consent_given] == '1'
 
       FormResponse.new(success: valid?, errors: errors)
     end
 
-    def ial2_consent_given?
-      @ial2_consent_given
+    def idv_consent_given?
+      @idv_consent_given
     end
   end
 end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Idv::AgreementController do
     let(:params) do
       {
         doc_auth: {
-          ial2_consent_given: 1,
+          idv_consent_given: 1,
         },
         skip_hybrid_handoff: skip_hybrid_handoff,
       }.compact
@@ -142,6 +142,21 @@ RSpec.describe Idv::AgreementController do
       end
 
       it 'redirects to hybrid handoff' do
+        put :update, params: params
+        expect(response).to redirect_to(idv_hybrid_handoff_url)
+      end
+    end
+
+    context 'ial2_consent_given param present' do
+      let(:params) do
+        {
+          doc_auth: {
+            ial2_consent_given: 1,
+          },
+          skip_hybrid_handoff: skip_hybrid_handoff,
+        }.compact
+      end
+      it 'succeeds' do
         put :update, params: params
         expect(response).to redirect_to(idv_hybrid_handoff_url)
       end

--- a/spec/controllers/idv/getting_started_controller_spec.rb
+++ b/spec/controllers/idv/getting_started_controller_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Idv::GettingStartedController do
     let(:params) do
       {
         doc_auth: {
-          ial2_consent_given: 1,
+          idv_consent_given: 1,
         },
         skip_hybrid_handoff: skip_hybrid_handoff,
       }.compact
@@ -154,6 +154,21 @@ RSpec.describe Idv::GettingStartedController do
     it 'redirects to hybrid handoff' do
       put :update, params: params
       expect(response).to redirect_to(idv_hybrid_handoff_url)
+    end
+
+    context 'ial2_consent_given param present' do
+      let(:params) do
+        {
+          doc_auth: {
+            ial2_consent_given: 1,
+          },
+          skip_hybrid_handoff: skip_hybrid_handoff,
+        }.compact
+      end
+      it 'succeeds' do
+        put :update, params: params
+        expect(response).to redirect_to(idv_hybrid_handoff_url)
+      end
     end
 
     context 'skip_hybrid_handoff present in params' do


### PR DESCRIPTION
While working on [LG-11041](https://cm-jira.usa.gov/browse/LG-11041) I noticed that, while we store the fact that the user checked the consent checkbox in IdvSession as `idv_consent_given`, we are still using `ial2_consent_given` for the form fields. I'd like to get the naming consistent to help avoid confusion in the future.

This PR renames some _internal_ variables and allows using either `params[:idv_consent_given]` or `params[ial2_consent_given]`. There will be two subsequent PRs required after this one is deployed:

1. Actually change the `ial2_consent_given` form field to `idv_consent_given`
2. Remove references to `ial2_consent_given` entirely
