### PR TITLE
Rename ial2_consent_given (2/3)

### DIFF
--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -25,7 +25,7 @@
   <%= render ClickObserverComponent.new(event_name: 'IdV: consent checkbox toggled') do %>
     <%= render ValidatedFieldComponent.new(
           form: f,
-          name: :ial2_consent_given,
+          name: :idv_consent_given,
           as: :boolean,
           label: t('doc_auth.instructions.consent', app_name: APP_NAME),
           required: true,

--- a/app/views/idv/getting_started/show.html.erb
+++ b/app/views/idv/getting_started/show.html.erb
@@ -49,7 +49,7 @@
   <%= render ClickObserverComponent.new(event_name: 'IdV: consent checkbox toggled') do %>
     <%= render ValidatedFieldComponent.new(
           form: f,
-          name: :ial2_consent_given,
+          name: :idv_consent_given,
           as: :boolean,
           label: t('doc_auth.getting_started.instructions.consent', app_name: APP_NAME),
           required: true,

--- a/spec/views/idv/agreement/show.html.erb_spec.rb
+++ b/spec/views/idv/agreement/show.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'idv/agreement/show' do
   it 'includes code to track clicks on the consent checkbox' do
     selector = [
       'lg-click-observer[event-name="IdV: consent checkbox toggled"]',
-      '[name="doc_auth[ial2_consent_given]"]',
+      '[name="doc_auth[idv_consent_given]"]',
     ].join ' '
 
     expect(rendered).to have_css(selector)

--- a/spec/views/idv/getting_started/show.html.erb_spec.rb
+++ b/spec/views/idv/getting_started/show.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'idv/getting_started/show' do
   it 'includes code to track clicks on the consent checkbox' do
     selector = [
       'lg-click-observer[event-name="IdV: consent checkbox toggled"]',
-      '[name="doc_auth[ial2_consent_given]"]',
+      '[name="doc_auth[idv_consent_given]"]',
     ].join ' '
 
     expect(rendered).to have_css(selector)


### PR DESCRIPTION
Follow-on to #9286, removing references to ial2_consent_given from the frontend. Should not be merged until that PR has been deployed.
