### PR TITLE
Rename ial2_consent_given (3/3)

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -53,7 +53,7 @@ module Idv
     end
 
     def consent_form_params
-      params.require(:doc_auth).permit([:ial2_consent_given, :idv_consent_given])
+      params.require(:doc_auth).permit(:idv_consent_given)
     end
 
     def confirm_welcome_step_complete

--- a/app/controllers/idv/getting_started_controller.rb
+++ b/app/controllers/idv/getting_started_controller.rb
@@ -72,7 +72,7 @@ module Idv
     end
 
     def consent_form_params
-      params.require(:doc_auth).permit([:ial2_consent_given, :idv_consent_given])
+      params.require(:doc_auth).permit(:idv_consent_given)
     end
 
     def confirm_agreement_needed

--- a/app/forms/idv/consent_form.rb
+++ b/app/forms/idv/consent_form.rb
@@ -6,7 +6,7 @@ module Idv
               acceptance: { message: proc { I18n.t('errors.doc_auth.consent_form') } }
 
     def submit(params)
-      @idv_consent_given = params[:idv_consent_given] == '1' || params[:ial2_consent_given] == '1'
+      @idv_consent_given = params[:idv_consent_given] == '1'
 
       FormResponse.new(success: valid?, errors: errors)
     end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -145,20 +145,5 @@ RSpec.describe Idv::AgreementController do
         expect(response).to redirect_to(idv_hybrid_handoff_url)
       end
     end
-
-    context 'ial2_consent_given param present' do
-      let(:params) do
-        {
-          doc_auth: {
-            ial2_consent_given: 1,
-          },
-          skip_hybrid_handoff: skip_hybrid_handoff,
-        }.compact
-      end
-      it 'succeeds' do
-        put :update, params: params
-        expect(response).to redirect_to(idv_hybrid_handoff_url)
-      end
-    end
   end
 end

--- a/spec/controllers/idv/getting_started_controller_spec.rb
+++ b/spec/controllers/idv/getting_started_controller_spec.rb
@@ -155,21 +155,6 @@ RSpec.describe Idv::GettingStartedController do
       expect(response).to redirect_to(idv_hybrid_handoff_url)
     end
 
-    context 'ial2_consent_given param present' do
-      let(:params) do
-        {
-          doc_auth: {
-            ial2_consent_given: 1,
-          },
-          skip_hybrid_handoff: skip_hybrid_handoff,
-        }.compact
-      end
-      it 'succeeds' do
-        put :update, params: params
-        expect(response).to redirect_to(idv_hybrid_handoff_url)
-      end
-    end
-
     context 'skip_hybrid_handoff present in params' do
       let(:skip_hybrid_handoff) { '' }
       it 'sets flow_path to standard' do


### PR DESCRIPTION
 Follow on to #9287, removes all references to / support for ial2_consent_given. Should not be merged until that PR is deployed.