### PR TITLE
LG-11122 add gitlab secret scanning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -489,6 +489,7 @@ include:
 secret_detection:
   variables:
       SECRET_DETECTION_LOG_OPTIONS: origin/${CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME}..HEAD
+      SECRET_DETECTION_REPORT_FILE: "gl-secret-detection-report.json"
 
 .container_scan_template:
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -484,6 +484,7 @@ stop-review-app:
 include:
   - template: Jobs/SAST.gitlab-ci.yml
   - template: Jobs/Dependency-Scanning.gitlab-ci.yml
+  - template: Security/Secret-Detection.gitlab-ci.yml
 
 .container_scan_template:
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -486,6 +486,10 @@ include:
   - template: Jobs/Dependency-Scanning.gitlab-ci.yml
   - template: Security/Secret-Detection.gitlab-ci.yml
 
+secret_detection:
+  variables:
+      SECRET_DETECTION_LOG_OPTIONS: origin/${CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME}..HEAD
+
 .container_scan_template:
   interruptible: true
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -487,9 +487,28 @@ include:
   - template: Security/Secret-Detection.gitlab-ci.yml
 
 secret_detection:
+  allow_failure: false
   variables:
       SECRET_DETECTION_LOG_OPTIONS: origin/${CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME}..HEAD
       SECRET_DETECTION_REPORT_FILE: "gl-secret-detection-report.json"
+  rules:
+    - if: $SECRET_DETECTION_DISABLED
+      when: never
+    - if: '$CI_COMMIT_BRANCH || $CI_COMMIT_TAG'
+  before_script:
+    - apk add --no-cache jq
+  script:
+    - /analyzer run
+    # check if '{ "vulnerabilities": [], ..' is empty in the report file if it exists
+    - |
+      if [ -f "$SECRET_DETECTION_REPORT_FILE" ]; then
+        if [ "$(jq ".vulnerabilities | length" $SECRET_DETECTION_REPORT_FILE)" -gt 0 ]; then
+          echo "Vulnerabilities detected. Please analyze the artifact $SECRET_DETECTION_REPORT_FILE produced by the 'secret-detection' job."
+          exit 80
+        fi
+      else
+        echo "Artifact $SECRET_DETECTION_REPORT_FILE does not exist. The 'secret-detection' job likely didn't create one. Hence, no evaluation can be performed."
+      fi
 
 .container_scan_template:
   interruptible: true


### PR DESCRIPTION
## 🎫 Ticket

[LG-11122](https://cm-jira.usa.gov/browse/LG-11122)

## 🛠 Summary of changes

We want to be clearly notified if sensitive information is accidentally pushed to a Github branch. This enables Secret Detection in Gitlab and will fail the build if the branch contains a secret. PR #9273  has these same commits with a demo "secret".
![Failing secret_detection job](https://github.com/18F/identity-idp/assets/2381438/cc661902-2a37-4c95-9279-3eea1b6ff6d4)

Note that this is not foolproof because it won't necessarily scan all commits in a newly pushed branch. And we still need to take mitigation measures if a secret is pushed up to Github, even briefly.
