### PR TITLE
Read records in KMS migration job while timeout is in effect

### DIFF
--- a/app/jobs/multi_region_kms_migration/profile_migration_job.rb
+++ b/app/jobs/multi_region_kms_migration/profile_migration_job.rb
@@ -49,7 +49,7 @@ module MultiRegionKmsMigration
         ).where(
           'encrypted_pii IS NOT NULL',
           'encrypted_pii_recovery IS NOT NULL',
-        ).limit(profile_count)
+        ).limit(profile_count).to_a
       end
     end
 

--- a/app/jobs/multi_region_kms_migration/user_migration_job.rb
+++ b/app/jobs/multi_region_kms_migration/user_migration_job.rb
@@ -62,7 +62,7 @@ module MultiRegionKmsMigration
           'encrypted_recovery_code_digest NOT LIKE ?', '%encryption_key%'
         )
 
-        password_scope.or(personal_key_scope).limit(user_count)
+        password_scope.or(personal_key_scope).limit(user_count).to_a
       end
     end
 


### PR DESCRIPTION
Currently the ProfileMigrationJob and UserMigrationJob make expensive queries to find users to migrate. These queries need a large amount of time to run. To enable this we run them in a transaction with a local statement timeout.

I discovered an issue with this approach. The query was not actually executed in the transaction block. The transaction returned a relation and the query was executed when we attempted to iterated over the records in the relation. This commit adds a `#to_a` call to the relation to ensure the query is run and the records are loaded into memory before the transaction block is complete.

[skip changelog]
