### PR TITLE
LG-11110: Allow user to reauthenticate with any MFA method in strict AAL2 setup

### DIFF
--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -1,8 +1,9 @@
 class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :user, :phishing_resistant_required, :piv_cac_required
+  attr_reader :user, :reauthentication_context, :phishing_resistant_required, :piv_cac_required
 
+  alias_method :reauthentication_context?, :reauthentication_context
   alias_method :phishing_resistant_required?, :phishing_resistant_required
   alias_method :piv_cac_required?, :piv_cac_required
 
@@ -35,6 +36,8 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
   end
 
   def restricted_options_warning_text
+    return if reauthentication_context?
+
     if piv_cac_required?
       t('two_factor_authentication.aal2_request.piv_cac_only_html', sp_name:)
     elsif phishing_resistant_required?
@@ -46,9 +49,9 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
     return @options if defined?(@options)
     mfa = MfaContext.new(user)
 
-    if @piv_cac_required
+    if piv_cac_required? && !reauthentication_context?
       configurations = mfa.piv_cac_configurations
-    elsif @phishing_resistant_required
+    elsif phishing_resistant_required? && !reauthentication_context?
       configurations = mfa.phishing_resistant_configurations
     else
       configurations = mfa.two_factor_configurations

--- a/spec/features/openid_connect/phishing_resistant_required_spec.rb
+++ b/spec/features/openid_connect/phishing_resistant_required_spec.rb
@@ -2,19 +2,59 @@ require 'rails_helper'
 
 RSpec.describe 'Phishing-resistant authentication required in an OIDC context' do
   include OidcAuthHelper
+  include WebAuthnHelper
+
+  shared_examples 'user required to set up phishing-resistant authenticator' do
+    it 'sends user to set up phishing-resistant auth' do
+      sign_in_live_with_2fa(user)
+
+      expect(page).to have_current_path(authentication_methods_setup_path)
+      expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
+      expect(page).to have_xpath("//img[@alt='important alert icon']")
+
+      # Validate that user is not allowed to continue without making a selection.
+      click_continue
+      expect(page).to have_current_path(authentication_methods_setup_path)
+      expect(page).to have_content(t('errors.two_factor_auth_setup.must_select_option'))
+
+      # Regression (LG-11110): Ensure the user can reauthenticate with any existing configuration,
+      # not limited based on phishing-resistant requirement.
+      travel (IdentityConfig.store.reauthn_window + 1).seconds do
+        check t('two_factor_authentication.two_factor_choice_options.webauthn')
+        click_continue
+
+        expect(page).to have_content(t('two_factor_authentication.login_options.sms'))
+        expect(page).to have_content(t('two_factor_authentication.login_options.voice'))
+
+        choose t('two_factor_authentication.login_options.sms')
+        click_continue
+
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        # LG-11193: Currently the user is redirected back to the MFA setup selection after
+        # reauthenticating. This should be improved to remember their original selection.
+        expect(page).to have_current_path(authentication_methods_setup_path)
+        expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
+        mock_webauthn_setup_challenge
+        check t('two_factor_authentication.two_factor_choice_options.webauthn')
+        click_continue
+
+        fill_in_nickname_and_click_continue
+        mock_press_button_on_hardware_key_on_setup
+
+        expect(page).to have_current_path(sign_up_completed_path)
+      end
+    end
+  end
 
   describe 'OpenID Connect requesting AAL3 authentication' do
     context 'user does not have phishing-resistant auth configured' do
-      it 'sends user to set up phishing-resistant auth' do
-        user = user_with_2fa
+      let(:user) { create(:user, :fully_registered, :with_phone) }
 
-        visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
-        sign_in_live_with_2fa(user)
+      before { visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account') }
 
-        expect(current_url).to eq(authentication_methods_setup_url)
-        expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
-        expect(page).to have_xpath("//img[@alt='important alert icon']")
-      end
+      it_behaves_like 'user required to set up phishing-resistant authenticator'
     end
 
     context 'user has phishing-resistant auth configured' do
@@ -65,16 +105,11 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
 
   describe 'OpenID Connect requesting phishing-resistant authentication' do
     context 'user does not have phishing-resistant auth configured' do
-      it 'sends user to set up phishing-resistant auth' do
-        user = user_with_2fa
+      let(:user) { create(:user, :fully_registered, :with_phone) }
 
-        visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
-        sign_in_live_with_2fa(user)
+      before { visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account') }
 
-        expect(current_url).to eq(authentication_methods_setup_url)
-        expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
-        expect(page).to have_xpath("//img[@alt='important alert icon']")
-      end
+      it_behaves_like 'user required to set up phishing-resistant authenticator'
     end
 
     context 'user has phishing-resistant auth configured' do
@@ -125,31 +160,11 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
 
   describe 'ServiceProvider configured to default to AAL3 authentication' do
     context 'user does not have phishing-resistant auth configured' do
-      it 'sends user to set up phishing-resistant auth' do
-        user = user_with_2fa
+      let(:user) { create(:user, :fully_registered, :with_phone) }
 
-        visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
-        sign_in_live_with_2fa(user)
+      before { visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account') }
 
-        expect(current_url).to eq(authentication_methods_setup_url)
-        expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
-        expect(page).to have_xpath("//img[@alt='important alert icon']")
-      end
-
-      it 'throws an error if user doesnt select phishing-resistant auth' do
-        user = user_with_2fa
-
-        visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
-        sign_in_live_with_2fa(user)
-
-        expect(current_url).to eq(authentication_methods_setup_url)
-        expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
-        expect(page).to have_xpath("//img[@alt='important alert icon']")
-
-        click_continue
-
-        expect(page).to have_content(t('errors.two_factor_auth_setup.must_select_option'))
-      end
+      it_behaves_like 'user required to set up phishing-resistant authenticator'
     end
 
     context 'user has phishing-resistant auth configured' do

--- a/spec/features/openid_connect/phishing_resistant_required_spec.rb
+++ b/spec/features/openid_connect/phishing_resistant_required_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
   include OidcAuthHelper
   include WebAuthnHelper
 
-  shared_examples 'user required to set up phishing-resistant authenticator' do
+  shared_examples 'setting up phishing-resistant authenticator in an OIDC context' do
     it 'sends user to set up phishing-resistant auth' do
       sign_in_live_with_2fa(user)
 
@@ -54,7 +54,7 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
 
       before { visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account') }
 
-      it_behaves_like 'user required to set up phishing-resistant authenticator'
+      it_behaves_like 'setting up phishing-resistant authenticator in an OIDC context'
     end
 
     context 'user has phishing-resistant auth configured' do
@@ -109,7 +109,7 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
 
       before { visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account') }
 
-      it_behaves_like 'user required to set up phishing-resistant authenticator'
+      it_behaves_like 'setting up phishing-resistant authenticator in an OIDC context'
     end
 
     context 'user has phishing-resistant auth configured' do
@@ -164,7 +164,7 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
 
       before { visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account') }
 
-      it_behaves_like 'user required to set up phishing-resistant authenticator'
+      it_behaves_like 'setting up phishing-resistant authenticator in an OIDC context'
     end
 
     context 'user has phishing-resistant auth configured' do

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
       context 'with sp' do
         let(:service_provider) { build(:service_provider) }
 
-        it 'returns piv cac required warning text for service provider' do
+        it 'returns phishing resistant required warning text for service provider' do
           expect(restricted_options_warning_text).to eq(
             t(
               'two_factor_authentication.aal2_request.phishing_resistant_html',
@@ -199,7 +199,7 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
       context 'with sp' do
         let(:service_provider) { build(:service_provider) }
 
-        it 'returns phishing resistant required warning text for service provider' do
+        it 'returns piv cac required warning text for service provider' do
           expect(restricted_options_warning_text).to eq(
             t(
               'two_factor_authentication.aal2_request.piv_cac_only_html',

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -80,14 +80,16 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
     let(:options_classes) { options.map(&:class) }
 
     it 'returns classes for mfas associated with account' do
-      expect(options_classes).to contain_exactly(
-        TwoFactorAuthentication::SmsSelectionPresenter,
-        TwoFactorAuthentication::VoiceSelectionPresenter,
-        TwoFactorAuthentication::WebauthnSelectionPresenter,
-        TwoFactorAuthentication::BackupCodeSelectionPresenter,
-        TwoFactorAuthentication::PivCacSelectionPresenter,
-        TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
-        TwoFactorAuthentication::PersonalKeySelectionPresenter,
+      expect(options_classes).to eq(
+        [
+          TwoFactorAuthentication::SmsSelectionPresenter,
+          TwoFactorAuthentication::VoiceSelectionPresenter,
+          TwoFactorAuthentication::WebauthnSelectionPresenter,
+          TwoFactorAuthentication::BackupCodeSelectionPresenter,
+          TwoFactorAuthentication::PivCacSelectionPresenter,
+          TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
+          TwoFactorAuthentication::PersonalKeySelectionPresenter,
+        ],
       )
     end
 
@@ -103,23 +105,23 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
       let(:piv_cac_required) { true }
 
       it 'filters to piv method' do
-        expect(options_classes).to contain_exactly(
-          TwoFactorAuthentication::PivCacSelectionPresenter,
-        )
+        expect(options_classes).to eq([TwoFactorAuthentication::PivCacSelectionPresenter])
       end
 
       context 'in reauthentication context' do
         let(:reauthentication_context) { true }
 
         it 'returns all mfas associated with account' do
-          expect(options_classes).to contain_exactly(
-            TwoFactorAuthentication::SmsSelectionPresenter,
-            TwoFactorAuthentication::VoiceSelectionPresenter,
-            TwoFactorAuthentication::WebauthnSelectionPresenter,
-            TwoFactorAuthentication::BackupCodeSelectionPresenter,
-            TwoFactorAuthentication::PivCacSelectionPresenter,
-            TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
-            TwoFactorAuthentication::PersonalKeySelectionPresenter,
+          expect(options_classes).to eq(
+            [
+              TwoFactorAuthentication::SmsSelectionPresenter,
+              TwoFactorAuthentication::VoiceSelectionPresenter,
+              TwoFactorAuthentication::WebauthnSelectionPresenter,
+              TwoFactorAuthentication::BackupCodeSelectionPresenter,
+              TwoFactorAuthentication::PivCacSelectionPresenter,
+              TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
+              TwoFactorAuthentication::PersonalKeySelectionPresenter,
+            ],
           )
         end
       end
@@ -129,9 +131,11 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
       let(:phishing_resistant_required) { true }
 
       it 'filters to phishing resistant methods' do
-        expect(options_classes).to contain_exactly(
-          TwoFactorAuthentication::WebauthnSelectionPresenter,
-          TwoFactorAuthentication::PivCacSelectionPresenter,
+        expect(options_classes).to eq(
+          [
+            TwoFactorAuthentication::WebauthnSelectionPresenter,
+            TwoFactorAuthentication::PivCacSelectionPresenter,
+          ],
         )
       end
 
@@ -139,14 +143,16 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
         let(:reauthentication_context) { true }
 
         it 'returns all mfas associated with account' do
-          expect(options_classes).to contain_exactly(
-            TwoFactorAuthentication::SmsSelectionPresenter,
-            TwoFactorAuthentication::VoiceSelectionPresenter,
-            TwoFactorAuthentication::WebauthnSelectionPresenter,
-            TwoFactorAuthentication::BackupCodeSelectionPresenter,
-            TwoFactorAuthentication::PivCacSelectionPresenter,
-            TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
-            TwoFactorAuthentication::PersonalKeySelectionPresenter,
+          expect(options_classes).to eq(
+            [
+              TwoFactorAuthentication::SmsSelectionPresenter,
+              TwoFactorAuthentication::VoiceSelectionPresenter,
+              TwoFactorAuthentication::WebauthnSelectionPresenter,
+              TwoFactorAuthentication::BackupCodeSelectionPresenter,
+              TwoFactorAuthentication::PivCacSelectionPresenter,
+              TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
+              TwoFactorAuthentication::PersonalKeySelectionPresenter,
+            ],
           )
         end
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11110](https://cm-jira.usa.gov/browse/LG-11110)

## 🛠 Summary of changes

Fixes an issue where a user's MFA methods are filtered to PIV or phishing-resistant methods when prompted to reauthenticate after making a selection to set up a new, eligible strict AAL2 method, thereby preventing them from continuing if they don't already have one of these methods.

## 📜 Testing Plan

It can help to set `reauthn_window` to a low value in local development to force frequent reauthentication, e.g. 20 seconds in `config/application.yml`:

```
reauthn_window: 20
```

1. Go to http://localhost:3000 in local development
2. Create an account with phishable MFA method(s) (i.e. anything other than face/touch, PIV, or security key)
3. Start [OIDC Sample App](https://github.com/18F/identity-oidc-sinatra) in a separate terminal process
4. Go to http://localhost:9292/?aal=2-phishing_resistant
5. Click "Sign in"
6. You should see an "additional authentication required" screen
7. Choose an authentication to add and click "Continue"
8. Continue to set up your new, stricter authentication method

Before: You would not have been successful, since you'd be prompted to reauthenticate, but you would see no options to use to reauthenticate.
After: You'll eventually be successful after reauthenticating with one of your existing methods.

## 👀 Screenshots

Before|After
---|---
![Screenshot 2023-10-03 at 12 56 40 PM](https://github.com/18F/identity-idp/assets/1779930/7c9da612-3919-4727-9640-7afe454a522c)|![Screenshot 2023-10-03 at 12 56 26 PM](https://github.com/18F/identity-idp/assets/1779930/4391318d-f846-438f-a5f7-a5d36dea50da)

