### PR TITLE
Upgrade TypeScript to 5.2

### DIFF
--- a/app/javascript/packages/document-capture/components/submission-complete.tsx
+++ b/app/javascript/packages/document-capture/components/submission-complete.tsx
@@ -1,31 +1,27 @@
 import { useState, useContext, useRef } from 'react';
 import CallbackOnMount from './callback-on-mount';
 import UploadContext from '../context/upload';
+import type { UploadSuccessResponse } from '../context/upload';
 
-/** @typedef {import('../context/upload').UploadSuccessResponse} UploadSuccessResponse */
+interface Resource<T> {
+  /**
+   * Resource reader.
+   */
+  read: () => T;
+}
 
-/**
- * @typedef Resource
- *
- * @prop {()=>T} read Resource reader.
- *
- * @template T
- */
-
-/**
- * @typedef SubmissionCompleteProps
- *
- * @prop {Resource<UploadSuccessResponse>} resource Resource object.
- */
+interface SubmissionCompleteProps {
+  /**
+   * Resource object.
+   */
+  resource: Resource<UploadSuccessResponse>;
+}
 
 export class RetrySubmissionError extends Error {}
 
-/**
- * @param {SubmissionCompleteProps} props Props object.
- */
-function SubmissionComplete({ resource }) {
-  const [, setRetryError] = useState(/** @type {Error=} */ (undefined));
-  const sleepTimeout = useRef(/** @type {number=} */ (undefined));
+function SubmissionComplete({ resource }: SubmissionCompleteProps) {
+  const [, setRetryError] = useState<Error | undefined>(undefined);
+  const sleepTimeout = useRef<number>();
   const { statusPollInterval } = useContext(UploadContext);
   const response = resource.read();
 
@@ -39,8 +35,7 @@ function SubmissionComplete({ resource }) {
         }, statusPollInterval);
       }
     } else {
-      /** @type {HTMLFormElement?} */
-      const form = document.querySelector('.js-document-capture-form');
+      const form = document.querySelector<HTMLFormElement>('.js-document-capture-form');
       form?.submit();
     }
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "stylelint": "^15.10.1",
     "svgo": "^2.8.0",
     "swr": "^2.0.0",
-    "typescript": "^5.0.4",
+    "typescript": "^5.2.2",
     "webpack-dev-server": "^4.11.1"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/sinon": "^10.0.13",
     "@types/sinon-chai": "^3.2.8",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
-    "@typescript-eslint/parser": "^5.38.1",
+    "@typescript-eslint/parser": "^6.7.4",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
     "clipboard-polyfill": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,14 +1675,15 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.38.1":
-  version "5.38.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.38.1.tgz#c577f429f2c32071b92dff4af4f5fbbbd2414bd0"
-  integrity sha512-LDqxZBVFFQnQRz9rUZJhLmox+Ep5kdUmLatLQnCRR6523YV+XhRjfYzStQ4MheFA8kMAfUlclHSbu+RKdRwQKw==
+"@typescript-eslint/parser@^6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.7.4.tgz#23d1dd4fe5d295c7fa2ab651f5406cd9ad0bd435"
+  integrity sha512-I5zVZFY+cw4IMZUeNCU7Sh2PO5O57F7Lr0uyhgCJmhN/BuTlnc55KxPonR4+EM3GBdfiCyGZye6DgMjtubQkmA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.38.1"
-    "@typescript-eslint/types" "5.38.1"
-    "@typescript-eslint/typescript-estree" "5.38.1"
+    "@typescript-eslint/scope-manager" "6.7.4"
+    "@typescript-eslint/types" "6.7.4"
+    "@typescript-eslint/typescript-estree" "6.7.4"
+    "@typescript-eslint/visitor-keys" "6.7.4"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.38.1":
@@ -1692,6 +1693,14 @@
   dependencies:
     "@typescript-eslint/types" "5.38.1"
     "@typescript-eslint/visitor-keys" "5.38.1"
+
+"@typescript-eslint/scope-manager@6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.7.4.tgz#a484a17aa219e96044db40813429eb7214d7b386"
+  integrity sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==
+  dependencies:
+    "@typescript-eslint/types" "6.7.4"
+    "@typescript-eslint/visitor-keys" "6.7.4"
 
 "@typescript-eslint/type-utils@5.38.1":
   version "5.38.1"
@@ -1708,6 +1717,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.38.1.tgz#74f9d6dcb8dc7c58c51e9fbc6653ded39e2e225c"
   integrity sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==
 
+"@typescript-eslint/types@6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.7.4.tgz#5d358484d2be986980c039de68e9f1eb62ea7897"
+  integrity sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==
+
 "@typescript-eslint/typescript-estree@5.38.1":
   version "5.38.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.1.tgz#657d858d5d6087f96b638ee383ee1cff52605a1e"
@@ -1720,6 +1734,19 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz#f2baece09f7bb1df9296e32638b2e1130014ef1a"
+  integrity sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==
+  dependencies:
+    "@typescript-eslint/types" "6.7.4"
+    "@typescript-eslint/visitor-keys" "6.7.4"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
 "@typescript-eslint/utils@5.38.1":
   version "5.38.1"
@@ -1740,6 +1767,14 @@
   dependencies:
     "@typescript-eslint/types" "5.38.1"
     eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.4.tgz#80dfecf820fc67574012375859085f91a4dff043"
+  integrity sha512-pOW37DUhlTZbvph50x5zZCkFn3xzwkGtNoJHzIM3svpiSkJzwOYr/kVBaXmf+RAQiUDs1AHEZVNPg6UJCJpwRA==
+  dependencies:
+    "@typescript-eslint/types" "6.7.4"
+    eslint-visitor-keys "^3.4.1"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -6020,7 +6055,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.4, semver@^7.3.7:
+semver@^7.3.4, semver@^7.3.7, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -6652,6 +6687,11 @@ trim-newlines@^4.0.2:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.1.1.tgz#28c88deb50ed10c7ba6dc2474421904a00139125"
   integrity sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==
+
+ts-api-utils@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
+  integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
 
 tsconfig-paths@^3.14.1:
   version "3.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6729,10 +6729,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 🛠 Summary of changes

Upgrades TypeScript from 5.0.x to 5.2.x

Release notes:

- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-1.html
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html

**Why?**

- Incorporate improvements outlined in release notes above (new features, optimizations)

The `SubmissionComplete` component was ported to TypeScript due to some issues flagged which appeared to be difficult / impossible to resolve in JavaScript syntax.

```
$ tsc
app/javascript/packages/document-capture/components/submission-complete.jsx:10:15 - error TS2304: Cannot find name 'T'.

10  * @prop {()=>T} read Resource reader.
                 ~

app/javascript/packages/document-capture/components/submission-complete.jsx:18:11 - error TS2315: Type 'Resource' is not generic.

18  * @prop {Resource<UploadSuccessResponse>} resource Resource object.
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## 📜 Testing Plan

```
yarn typecheck
```