### PR TITLE
LG-10884 Add a default scope to filter cancelled and unrecoverable profiles

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -32,6 +32,8 @@ class Profile < ApplicationRecord
 
   attr_reader :personal_key
 
+  default_scope where.not(cancelled_or_encryption_error)
+
   # Class methods
   def self.active
     where(active: true)
@@ -55,6 +57,10 @@ class Profile < ApplicationRecord
 
   def self.in_person_verification_pending
     where.not(in_person_verification_pending_at: nil)
+  end
+
+  def self.cancelled_or_encryption_error
+    where(deactivation_reason: [:encryption_error, :verification_cancelled])
   end
 
   # Instance methods

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -32,6 +32,8 @@ class Profile < ApplicationRecord
 
   attr_reader :personal_key
 
+  default_scope { not_cancelled_or_encryption_error }
+
   # Class methods
   def self.active
     where(active: true)
@@ -58,10 +60,10 @@ class Profile < ApplicationRecord
   end
 
   def self.not_cancelled_or_encryption_error
-    where.not(deactivation_reason: [:encryption_error, :verification_cancelled])
+    where(deactivation_reason: nil).or(
+      where.not(deactivation_reason: [:encryption_error, :verification_cancelled]),
+    )
   end
-
-  default_scope { not_cancelled_or_encryption_error }
 
   # Instance methods
   def fraud_review_pending?

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -32,8 +32,6 @@ class Profile < ApplicationRecord
 
   attr_reader :personal_key
 
-  default_scope where.not(cancelled_or_encryption_error)
-
   # Class methods
   def self.active
     where(active: true)
@@ -59,9 +57,11 @@ class Profile < ApplicationRecord
     where.not(in_person_verification_pending_at: nil)
   end
 
-  def self.cancelled_or_encryption_error
-    where(deactivation_reason: [:encryption_error, :verification_cancelled])
+  def self.not_cancelled_or_encryption_error
+    where.not(deactivation_reason: [:encryption_error, :verification_cancelled])
   end
+
+  default_scope { not_cancelled_or_encryption_error }
 
   # Instance methods
   def fraud_review_pending?


### PR DESCRIPTION
We have a number of profiles that we keep in the database we do not want to access again. These are profiles that are cancelled or marked with an encryption error.

This commit adds a scope for these profiles and sets it as the default scope.
