### PR TITLE
Add the key_id that is used to the KMS logger

### DIFF
--- a/app/services/encryption/contextless_kms_client.rb
+++ b/app/services/encryption/contextless_kms_client.rb
@@ -17,13 +17,13 @@ module Encryption
     }.freeze
 
     def encrypt(plaintext)
-      KmsLogger.log(:encrypt)
+      KmsLogger.log(:encrypt, key_id: IdentityConfig.store.aws_kms_key_id)
       return encrypt_kms(plaintext) if FeatureManagement.use_kms?
       encrypt_local(plaintext)
     end
 
     def decrypt(ciphertext)
-      KmsLogger.log(:decrypt)
+      KmsLogger.log(:decrypt, key_id: IdentityConfig.store.aws_kms_key_id)
       return decrypt_kms(ciphertext) if use_kms?(ciphertext)
       decrypt_local(ciphertext)
     end

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -32,14 +32,14 @@ module Encryption
     end
 
     def encrypt(plaintext, encryption_context)
-      KmsLogger.log(:encrypt, encryption_context)
+      KmsLogger.log(:encrypt, context: encryption_context, key_id: kms_key_id)
       return encrypt_kms(plaintext, encryption_context) if FeatureManagement.use_kms?
       encrypt_local(plaintext, encryption_context)
     end
 
     def decrypt(ciphertext, encryption_context)
       return decrypt_contextless_kms(ciphertext) if self.class.looks_like_contextless?(ciphertext)
-      KmsLogger.log(:decrypt, encryption_context)
+      KmsLogger.log(:decrypt, context: encryption_context, key_id: kms_key_id)
       return decrypt_kms(ciphertext, encryption_context) if use_kms?(ciphertext)
       decrypt_local(ciphertext, encryption_context)
     end

--- a/app/services/encryption/kms_logger.rb
+++ b/app/services/encryption/kms_logger.rb
@@ -1,11 +1,12 @@
 module Encryption
   class KmsLogger
     LOG_FILENAME = 'kms.log'
-    def self.log(action, context = nil)
+    def self.log(action, key_id:, context: nil)
       output = {
         kms: {
           action: action,
           encryption_context: context,
+          key_id: key_id,
         },
         log_filename: LOG_FILENAME,
       }

--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -148,7 +148,10 @@ RSpec.describe Encryption::ContextlessKmsClient do
       end
 
       it 'logs the encryption' do
-        expect(Encryption::KmsLogger).to receive(:log).with(:encrypt)
+        expect(Encryption::KmsLogger).to receive(:log).with(
+          :encrypt,
+          key_id: IdentityConfig.store.aws_kms_key_id,
+        )
 
         subject.encrypt(long_kms_plaintext)
       end
@@ -180,7 +183,10 @@ RSpec.describe Encryption::ContextlessKmsClient do
       end
 
       it 'logs the decryption' do
-        expect(Encryption::KmsLogger).to receive(:log).with(:decrypt)
+        expect(Encryption::KmsLogger).to receive(:log).with(
+          :decrypt,
+          IdentityConfig.store.aws_kms_key_id,
+        )
 
         subject.decrypt('KMSx' + kms_ciphertext)
       end

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -111,7 +111,11 @@ RSpec.describe Encryption::KmsClient do
     end
 
     it 'logs the context' do
-      expect(Encryption::KmsLogger).to receive(:log).with(:encrypt, encryption_context)
+      expect(Encryption::KmsLogger).to receive(:log).with(
+        :encrypt,
+        context: encryption_context,
+        key_id: subject.kms_key_id,
+      )
 
       subject.encrypt(plaintext, encryption_context)
     end
@@ -163,7 +167,11 @@ RSpec.describe Encryption::KmsClient do
     end
 
     it 'logs the context' do
-      expect(Encryption::KmsLogger).to receive(:log).with(:decrypt, encryption_context)
+      expect(Encryption::KmsLogger).to receive(:log).with(
+        :decrypt,
+        context: encryption_context,
+        key_id: subject.kms_key_id,
+      )
       subject.decrypt(kms_ciphertext, encryption_context)
     end
   end

--- a/spec/services/encryption/kms_logger_spec.rb
+++ b/spec/services/encryption/kms_logger_spec.rb
@@ -8,13 +8,18 @@ RSpec.describe Encryption::KmsLogger do
           kms: {
             action: 'encrypt',
             encryption_context: { context: 'pii-encryption', user_uuid: '1234-abc' },
+            key_id: 'super-duper-aws-kms-key-id',
           },
           log_filename: Encryption::KmsLogger::LOG_FILENAME,
         }.to_json
 
         expect(described_class.logger).to receive(:info).with(log)
 
-        described_class.log(:encrypt, context: 'pii-encryption', user_uuid: '1234-abc')
+        described_class.log(
+          :encrypt,
+          context: { context: 'pii-encryption', user_uuid: '1234-abc' },
+          key_id: 'super-duper-aws-kms-key-id',
+        )
       end
     end
 
@@ -24,13 +29,14 @@ RSpec.describe Encryption::KmsLogger do
           kms: {
             action: 'decrypt',
             encryption_context: nil,
+            key_id: 'super-duper-aws-kms-key-id',
           },
           log_filename: Encryption::KmsLogger::LOG_FILENAME,
         }.to_json
 
         expect(described_class.logger).to receive(:info).with(log)
 
-        described_class.log(:decrypt)
+        described_class.log(:decrypt, key_id: 'super-duper-aws-kms-key-id')
       end
     end
   end


### PR DESCRIPTION
Our KMS client now supports the use of multiple keys. Specifically it can be used for encryption with a single-region or multi-region key. This commit adds logging to the KMS tooling to give us visibility into which keys are being used in which contexts.
