### PR TITLE
Update AAMVA billing logic (LG-11089)

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -332,8 +332,9 @@ module Idv
           add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
         elsif stage == :state_id
           next if hash[:exception].present?
+          next if hash[:vendor_name] == 'UnsupportedJurisdiction'
           add_cost(:aamva, transaction_id: hash[:transaction_id])
-          track_aamva unless hash[:vendor_name] == 'UnsupportedJurisdiction'
+          track_aamva
         elsif stage == :threatmetrix
           # transaction_id comes from request_id
           tmx_id = hash[:transaction_id]

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -333,6 +333,7 @@ module Idv
         elsif stage == :state_id
           next if hash[:exception].present?
           next if hash[:vendor_name] == 'UnsupportedJurisdiction'
+          # transaction_id comes from TransactionLocatorId
           add_cost(:aamva, transaction_id: hash[:transaction_id])
           track_aamva
         elsif stage == :threatmetrix

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Idv::VerifyInfoController do
         let(:success) { true }
         let(:vendor_name) { 'UnsupportedJurisdiction' }
 
-        it 'considers the request billable' do
+        it 'does not consider the request billable' do
           expect { put :show }.to_not change { SpCost.where(cost_type: 'aamva').count }
         end
       end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Idv::VerifyInfoController do
         let(:vendor_name) { 'UnsupportedJurisdiction' }
 
         it 'considers the request billable' do
-          expect { put :show }.to change { SpCost.where(cost_type: 'aamva').count }.by(1)
+          expect { put :show }.to_not change { SpCost.where(cost_type: 'aamva').count }
         end
       end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11089](https://cm-jira.usa.gov/browse/LG-11089)

## Description

If this seems familiar from #8599, it's because it might be.

**Problem:** AAMVA's billing doesn't match what we are logging

**Context**:
It turns out we have been recording a cost for the  `UnsupportedJurisdiction`

However, `UnsupportedJurisdiction` is from our own code: https://github.com/18F/identity-idp/blob/794448c60065af9c65ef4b4420e0188002519c3a/app/services/proofing/resolution/progressive_proofer.rb#L195-L202

Meaning we didn't make a call to AAMVA at all, so they can't bill us for it:

https://github.com/18F/identity-idp/blob/794448c60065af9c65ef4b4420e0188002519c3a/app/services/proofing/resolution/progressive_proofer.rb#L166

**Solution**:

Stop recording costs for `UnsupportedJurisdiction`

## Validation

Checking [Cloudwatch][cloudwatch-query], we can get data that closely matches the [invoice data](https://docs.google.com/spreadsheets/d/1OyYcDv8ar99ob9k9uewnX7AYtH-kYajjC5lLqY1hiz0/edit#gid=531933746), by subtracting out the `UnsupportedJuridiction` (in addition to subtracting out exceptions)

[cloudwatch-query]: https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:logs-insights$3FqueryDetail$3D~(end~'2023-08-31T23*3a59*3a59.000Z~start~'2023-08-01T00*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'fields*0a*20*20*20*20*40timestamp*0a*20*20*2c*20name*0a*20*20*2c*20ispresent*28properties.event_properties.proofing_results.context.stages.state_id.success*29*20as*20state_id_success*0a*20*20*2c*20properties.event_properties.proofing_results.context.stages.state_id.vendor_name*20*3d*20*27UnsupportedJurisdiction*27*20AS*20unsupported_jurisdiction*0a*20*20*2c*20ispresent*28properties.event_properties.proofing_results.context.stages.state_id.exception*29*20AS*20aamva_exception*0a*20*20*2c*20*40message*0a*20*20*2c*20*40logStream*0a*20*20*2c*20*40log*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20filter*20name*20*3d*20*27IdV*3a*20doc*20auth*20verify*20proofing*20results*27*0a*7c*20filter*20name*20*3d*20*0a*23*20*7c*20filter*20state_id_success*20*3d*20false*0a*23*20*7c*20limit*2010000*0a*7c*20stats*20count*28*2a*29*2c*20sum*28state_id_success*29*2c*20sum*28unsupported_jurisdiction*29*2c*20sum*28aamva_exception*29*0a~queryId~'54257698472d37ad-c1f9c35d-44690e2-9baaeebf-c4ac525b567e889a57eb4cb~source~(~'prod_*2fsrv*2fidp*2fshared*2flog*2fevents.log))

