### PR TITLE
LG-10922: Display new headings for Hybrid Handoff page on AB test

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -19,6 +19,7 @@ module Idv
         true
       )
 
+      @phone_question_ab_test_bucket = phone_question_ab_test_bucket
       render :show, locals: extra_view_variables
     end
 

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -10,7 +10,11 @@
 <% end %>
 
 <%= render PageHeadingComponent.new do %>
-  <%= t('doc_auth.headings.hybrid_handoff') %>
+  <% if IdentityConfig.store.idv_phone_question_a_b_testing[:show_phone_question] == 1 %>
+    <%= t('doc_auth.headings.upload_from_phone') %>
+  <% else %>
+    <%= t('doc_auth.headings.hybrid_handoff') %>
+  <% end %>
 <% end %>
 
 <p>
@@ -31,7 +35,11 @@
       <%= t('doc_auth.info.tag') %>
     </div>
     <h2 class="margin-y-105">
-      <%= t('doc_auth.headings.upload_from_phone') %>
+      <% if IdentityConfig.store.idv_phone_question_a_b_testing[:show_phone_question] == 1 %>
+        <%= t('doc_auth.headings.switch_to_phone') %>
+      <% else %>
+        <%= t('doc_auth.headings.upload_from_phone') %>
+      <% end %>
     </h2>
     <%= t('doc_auth.info.upload_from_phone') %>
     <%= simple_form_for(

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <%= render PageHeadingComponent.new do %>
-  <% if IdentityConfig.store.idv_phone_question_a_b_testing[:show_phone_question] == 1 %>
+  <% if @phone_question_ab_test_bucket == :show_phone_question %>
     <%= t('doc_auth.headings.upload_from_phone') %>
   <% else %>
     <%= t('doc_auth.headings.hybrid_handoff') %>
@@ -35,7 +35,7 @@
       <%= t('doc_auth.info.tag') %>
     </div>
     <h2 class="margin-y-105">
-      <% if IdentityConfig.store.idv_phone_question_a_b_testing[:show_phone_question] == 1 %>
+    <% if @phone_question_ab_test_bucket == :show_phone_question %>
         <%= t('doc_auth.headings.switch_to_phone') %>
       <% else %>
         <%= t('doc_auth.headings.upload_from_phone') %>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -149,6 +149,7 @@ en:
       secure_account: Secure your account
       ssn: Enter your Social Security number
       ssn_update: Update your Social Security number
+      switch_to_phone: Switch to your phone
       text_message: We sent a message to your phone
       upload_from_computer: Continue on this computer
       upload_from_phone: Use your phone to take photos

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -179,6 +179,7 @@ es:
       secure_account: Asegure su cuenta
       ssn: Ingrese su número de Seguro Social
       ssn_update: Actualice su número de Seguro Social
+      switch_to_phone: Cambiar al teléfono
       text_message: Enviamos un mensaje a su teléfono
       upload_from_computer: Continuar en esta computadora
       upload_from_phone: Utilice su teléfono para tomar las fotos

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -185,6 +185,7 @@ fr:
       secure_account: Sécuriser votre compte
       ssn: Saisissez votre numéro de sécurité sociale
       ssn_update: Mettre à jour votre numéro de Sécurité Sociale
+      switch_to_phone: Basculez vers votre téléphone
       text_message: Nous avons envoyé un message à votre téléphone
       upload_from_computer: Continuer sur cet ordinateur
       upload_from_phone: Utilisez votre téléphone pour prendre des photos

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -171,17 +171,17 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
       end
     end
 
-    context 'with PhoneQuestion page enabled' do
+    context 'PhoneQuestion page' do
       before(:each) do
         allow_any_instance_of(Idv::HybridHandoffController).
           to receive(:phone_question_ab_test_bucket).and_return(:show_phone_question)
-
-        @user = user_with_2fa
-        sign_in_and_2fa_user(@user)
-        complete_doc_auth_steps_before_hybrid_handoff_step
       end
 
       it 'displays the expected headings' do
+        user = user_with_2fa
+        sign_in_and_2fa_user(user)
+        complete_doc_auth_steps_before_hybrid_handoff_step
+
         expect(page).to have_current_path(idv_phone_question_path)
         click_link t('doc_auth.buttons.have_phone')
         fill_in :doc_auth_phone, with: '415-555-0199'
@@ -199,6 +199,9 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
       end
 
       it 'rate limits sending the link' do
+        user = user_with_2fa
+        sign_in_and_2fa_user(user)
+        complete_doc_auth_steps_before_hybrid_handoff_step
         timeout = distance_of_time_in_words(
           RateLimiter.attempt_window_in_minutes(:idv_send_link).minutes,
         )
@@ -244,7 +247,7 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
 
         # Manual expiration is needed for now since the RateLimiter uses
         # Redis ttl instead of expiretime
-        RateLimiter.new(rate_limit_type: :idv_send_link, user: @user).reset!
+        RateLimiter.new(rate_limit_type: :idv_send_link, user: user).reset!
         travel_to(Time.zone.now + idv_send_link_attempt_window_in_minutes.minutes) do
           fill_in :doc_auth_phone, with: '415-555-0199'
           click_send_link

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -156,7 +156,8 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
           ),
         )
 
-        # expect to see the headings that reflect having :phone_question_ab_test_bucket set to :bypass_phone_question
+        # expect to see the headings that reflect having
+        # :phone_question_ab_test_bucket set to :bypass_phone_question
         expect(page).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
         expect(page).to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
         expect(page).not_to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
@@ -226,7 +227,8 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
           )
         end
 
-        # expect to see the headings that refelect having :phone_question_ab_test_bucket set to :show_phone_question
+        # expect to see the headings that refelect having
+        # :phone_question_ab_test_bucket set to :show_phone_question
         expect(page).to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
         expect(page).to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
         expect(page).not_to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -172,7 +172,7 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
     end
 
     context 'PhoneQuestion page' do
-      before(:each) do
+      before do
         allow_any_instance_of(Idv::HybridHandoffController).
           to receive(:phone_question_ab_test_bucket).and_return(:show_phone_question)
       end

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -175,7 +175,7 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
       before(:each) do
         allow_any_instance_of(Idv::HybridHandoffController).
           to receive(:phone_question_ab_test_bucket).and_return(:show_phone_question)
-        
+
         @user = user_with_2fa
         sign_in_and_2fa_user(@user)
         complete_doc_auth_steps_before_hybrid_handoff_step

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -155,6 +155,12 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
             timeout: timeout,
           ),
         )
+
+        # expect to see the headings that reflect having :phone_question_ab_test_bucket set to :bypass_phone_question
+        expect(page).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
+        expect(page).to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
+        expect(page).not_to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
+        expect(page).not_to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
       end
       expect(fake_analytics).to have_logged_event(
         'Rate Limit Reached',
@@ -175,27 +181,6 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
       before do
         allow_any_instance_of(Idv::HybridHandoffController).
           to receive(:phone_question_ab_test_bucket).and_return(:show_phone_question)
-      end
-
-      it 'displays the expected headings' do
-        user = user_with_2fa
-        sign_in_and_2fa_user(user)
-        complete_doc_auth_steps_before_hybrid_handoff_step
-
-        expect(page).to have_current_path(idv_phone_question_path)
-        click_link t('doc_auth.buttons.have_phone')
-        fill_in :doc_auth_phone, with: '415-555-0199'
-        click_send_link
-
-        expect(page).to have_current_path(idv_link_sent_path)
-
-        click_doc_auth_back_link
-
-        expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
-        expect(page).to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
-        expect(page).to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
-        expect(page).not_to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
-        expect(page).not_to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
       end
 
       it 'rate limits sending the link' do
@@ -240,6 +225,13 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
             ),
           )
         end
+
+        # expect to see the headings that refelect having :phone_question_ab_test_bucket set to :show_phone_question
+        expect(page).to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
+        expect(page).to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
+        expect(page).not_to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
+        expect(page).not_to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
+
         expect(fake_analytics).to have_logged_event(
           'Rate Limit Reached',
           limiter_type: :idv_send_link,
@@ -253,27 +245,6 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
           click_send_link
           expect(page).to have_current_path(idv_link_sent_path)
         end
-      end
-    end
-
-    context 'with PhoneQuestion page disabled' do
-      before do
-        allow_any_instance_of(Idv::HybridHandoffController).
-          to receive(:phone_question_ab_test_bucket).and_return(:bypass_phone_question)
-
-        user = user_with_2fa
-        sign_in_and_2fa_user(user)
-        complete_doc_auth_steps_before_hybrid_handoff_step
-      end
-
-      it 'displays the expected headings' do
-        expect(page).not_to have_current_path(idv_phone_question_path)
-        expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
-
-        expect(page).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
-        expect(page).to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
-        expect(page).not_to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
-        expect(page).not_to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
       end
     end
 

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -1,14 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
-  let(:show_phone_question) { 0 }
-  let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
-
   before do
-    allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
     allow(view).to receive(:current_user).and_return(@user)
-    allow(IdentityConfig.store).to receive(:idv_phone_question_a_b_testing).
-      and_return(show_phone_question:)
     @idv_form = Idv::PhoneForm.new(user: build_stubbed(:user), previous_params: nil)
   end
 
@@ -19,7 +13,9 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
   end
 
   context 'with shown phone question' do
-    let(:show_phone_question) { 1 }
+    before do
+      @phone_question_ab_test_bucket = :show_phone_question
+    end
 
     it 'displays the expected headings from the "b" case' do
       expect(rendered).to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
@@ -30,7 +26,9 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
   end
 
   context 'without shown phone question' do
-    let(:show_phone_question) { 0 }
+    before do
+      @phone_question_ab_test_bucket = :bypass_phone_question
+    end
 
     it 'displays the expected headings from the "a" case' do
       expect(rendered).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
     }
   end
 
-  context 'with shown phone question' do
+  context 'with show phone question' do
     before do
       @phone_question_ab_test_bucket = :show_phone_question
     end
@@ -25,7 +25,7 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
     end
   end
 
-  context 'without shown phone question' do
+  context 'without show phone question' do
     before do
       @phone_question_ab_test_bucket = :bypass_phone_question
     end

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
+  let(:show_phone_question) { 0 }
+  let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
+
+  before do
+    allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
+    allow(view).to receive(:current_user).and_return(@user)
+    allow(IdentityConfig.store).to receive(:idv_phone_question_a_b_testing).
+      and_return(show_phone_question:)
+    @idv_form = Idv::PhoneForm.new(user: build_stubbed(:user), previous_params: nil)
+  end
+
+  subject(:rendered) do
+    render template: 'idv/hybrid_handoff/show', locals: {
+      idv_phone_form: @idv_form,
+    }
+  end
+
+  context 'with shown phone question' do
+    let(:show_phone_question) { 1 }
+
+    it 'displays the text from the "b" case' do
+      expect(rendered).to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
+      expect(rendered).to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
+      expect(rendered).not_to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
+      expect(rendered).not_to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
+    end
+  end
+
+  context 'without shown phone question' do
+    let(:show_phone_question) { 0 }
+
+    it 'displays the text from the "a" case' do
+      expect(rendered).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
+      expect(rendered).to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
+      expect(rendered).not_to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
+      expect(rendered).not_to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
+    end
+  end
+end

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
   context 'with shown phone question' do
     let(:show_phone_question) { 1 }
 
-    it 'displays the text from the "b" case' do
+    it 'displays the expected headings from the "b" case' do
       expect(rendered).to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
       expect(rendered).to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
       expect(rendered).not_to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
@@ -32,7 +32,7 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
   context 'without shown phone question' do
     let(:show_phone_question) { 0 }
 
-    it 'displays the text from the "a" case' do
+    it 'displays the expected headings from the "a" case' do
       expect(rendered).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
       expect(rendered).to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
       expect(rendered).not_to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-10922

## 🛠 Summary of changes

This adds a change of heading text to the Hybrid Handoff page, if `idv_phone_question_a_b_testing` is set to `1`. If it's set to `0`, (the default), the old copy should remain.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] First, check that the old copy still remains:
    - [ ] Follow the flow to the `/verify/hybrid_handoff` page
    - [ ] Check that the h1 has the `hybrid_handoff` text ("How would you like to add your ID?" in English)
    - [ ] Check that the h2 has the `upload_from_phone` text ("Use your phone to take photos" in English)
- [ ] Second, check that the new copy is there:
    - [ ] Set `idv_phone_question_a_b_testing: '{"bypass_phone_question":0, "show_phone_question":100}'` in your `application.yml`
    - [ ] Follow the flow to the `/verify/hybrid_handoff` page
    - [ ] Check that the h1 has the `upload_from_phone` text ("Use your phone to take photos" in English)
    - [ ] Check that the h2 has the `upload_from_phone` text ("Switch to your phone" in English)

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before / with `idv_phone_question_a_b_testing: '{"bypass_phone_question":100, "show_phone_question":0}'`:</summary>
<img width="1092" alt="10922_A_case" src="https://github.com/18F/identity-idp/assets/35475380/52fb9aec-129c-41f9-8819-9bfae878ca78">
</details>

<details>
<summary>After / with `idv_phone_question_a_b_testing: '{"bypass_phone_question":0, "show_phone_question":100}'`</summary>
<img width="1272" alt="10922_B_case" src="https://github.com/18F/identity-idp/assets/35475380/ff8a1196-88d1-4833-9a27-42ab85d38501">
</details>
