### PR TITLE
Fix alert paragraph rendering semantics, redundant styling

### DIFF
--- a/app/views/accounts/_password_reset.html.erb
+++ b/app/views/accounts/_password_reset.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= t('account.index.reactivation.instructions') %>
   </p>
-  <p class="margin-bottom-0">
+  <p>
     <%= link_to t('account.index.reactivation.link'), reactivate_account_path %>
   </p>
 <% end %>

--- a/app/views/accounts/_pending_profile_gpo.html.erb
+++ b/app/views/accounts/_pending_profile_gpo.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= t('account.index.verification.instructions') %>
   </p>
-  <p class="margin-bottom-0">
+  <p>
     <%= link_to t('account.index.verification.reactivate_button'), idv_verify_by_mail_enter_code_path %>
   </p>
 <% end %>

--- a/app/views/accounts/_service_provider_continue.html.erb
+++ b/app/views/accounts/_service_provider_continue.html.erb
@@ -1,3 +1,3 @@
-<%= render AlertComponent.new(type: :info, text_tag: 'div') do %>
+<%= render AlertComponent.new(type: :info) do %>
   <%= link_to(t('account.index.continue_to_service_provider', service_provider: presenter.sp_name), presenter.sp_session_request_url) %>
 <% end %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -30,7 +30,7 @@
 
 <%= render AlertComponent.new(class: 'margin-y-4', text_tag: :div) do %>
   <p class="margin-bottom-1 margin-top-0 h3"><strong><%= t('in_person_proofing.body.barcode.deadline', deadline: @presenter.formatted_due_date) %></strong></p>
-  <p class="margin-bottom-0"><%= t('in_person_proofing.body.barcode.deadline_restart') %></p>
+  <p><%= t('in_person_proofing.body.barcode.deadline_restart') %></p>
 <% end %>
 
 <section class="border-1px border-primary-light radius-lg padding-4">

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -20,11 +20,7 @@ locals:
 </div>
 
 <% if @had_barcode_read_failure %>
-  <%= render AlertComponent.new(
-        type: :warning,
-        class: 'margin-bottom-4',
-        text_tag: 'div',
-      ) do %>
+  <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-4') do %>
     <%= t(
           'doc_auth.headings.capture_scan_warning_html',
           link_html: link_to(


### PR DESCRIPTION
## 🛠 Summary of changes

Updates a few alerts:

- Removes `text_tag` attribute where the alert is displaying simple text and should use the default behavior of rendering the simple text within a `<p>` tag
- Removes explicit margin resets on the last paragraphs within alerts, since this was [added as a global style](https://github.com/18F/identity-idp/blob/f2efbd7b0572767cf7fefb3ce6e27db50d7341cd/app/assets/stylesheets/components/_alert.scss#L19-L21)

This was initially prompted by some recent observation of unnecessary use of `text_tag`. Originally I was trying some more ambitious ideas (replacing `text_tag` with `with_paragraph` [slot](https://viewcomponent.org/guide/slots.html), or adding `AlertComponent#text_tag` as a private method which inspects its own content to decide the appropriate wrapper tag), but those proved to be more challenging. I had discovered these improvements along the way, so figured to at least resolve them.

## 📜 Testing Plan

Verify no visual regression in affected usage.