### PR TITLE
Gitignore .bak files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@
 .capistrano
 
 # avoid checking in stray files
-.bak
+*.bak
 
 # root files
 capybara-*.html

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@
 .vagrant
 .capistrano
 
+# avoid checking in stray files
+.bak
+
 # root files
 capybara-*.html
 dump.rdb


### PR DESCRIPTION
Avoid accidentally checking in stray .bak files.

This is a followup to an incident where a backup config file had sensitive information and was accidentally pushed to github.
