### PR TITLE
Remove unused ServiceProviderMfaPolicy from GenericDeliveryPresenter

### DIFF
--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -60,17 +60,6 @@ module TwoFactorAuthCode
 
     private
 
-    def service_provider_mfa_policy
-      @service_provider_mfa_policy ||= ServiceProviderMfaPolicy.new(
-        user: @view.current_user,
-        service_provider: @service_provider,
-        auth_method: @view.user_session[:auth_method],
-        aal_level_requested: @view.sp_session[:aal_level_requested],
-        piv_cac_requested: @view.sp_session[:piv_cac_requested],
-        phishing_resistant_requested: @view.sp_session[:phishing_resistant_requested],
-      )
-    end
-
     attr_reader :view, :user_opted_remember_device_cookie
   end
 end

--- a/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
@@ -69,10 +69,6 @@ module TwoFactorAuthCode
       :webauthn_verification
     end
 
-    def multiple_factors_enabled?
-      service_provider_mfa_policy.multiple_factors_enabled?
-    end
-
     def platform_authenticator?
       @platform_authenticator
     end

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -246,12 +246,6 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
           create(:webauthn_configuration, :platform_authenticator, user:, created_at: 1.day.ago)
         end
 
-        before do
-          allow_any_instance_of(TwoFactorAuthCode::WebauthnAuthenticationPresenter).
-            to receive(:multiple_factors_enabled?).
-            and_return(true)
-        end
-
         it 'redirects to webauthn show page' do
           patch :confirm, params: params
           expect(response).to redirect_to login_two_factor_webauthn_url(platform: true)

--- a/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
@@ -10,19 +10,6 @@ RSpec.describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
 
   let(:phishing_resistant_required) { true }
   let(:piv_cac_required) { false }
-  let(:service_provider_mfa_policy) do
-    instance_double(
-      ServiceProviderMfaPolicy,
-      phishing_resistant_required?: phishing_resistant_required,
-      piv_cac_required?: piv_cac_required,
-    )
-  end
-
-  before do
-    allow(presenter).to receive(
-      :service_provider_mfa_policy,
-    ).and_return(service_provider_mfa_policy)
-  end
 
   describe '#header' do
     let(:expected_header) { t('two_factor_authentication.piv_cac_header_text') }

--- a/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
@@ -18,17 +18,6 @@ RSpec.describe TwoFactorAuthCode::WebauthnAuthenticationPresenter do
   let(:phishing_resistant_required) { false }
   let(:platform_authenticator) { false }
   let(:multiple_factors_enabled) { false }
-  let(:service_provider_mfa_policy) do
-    instance_double(
-      ServiceProviderMfaPolicy,
-      phishing_resistant_required?: phishing_resistant_required,
-      multiple_factors_enabled?: multiple_factors_enabled,
-    )
-  end
-
-  before do
-    allow(presenter).to receive(:service_provider_mfa_policy).and_return service_provider_mfa_policy
-  end
 
   describe '#webauthn_help' do
     let(:phishing_resistant_required) { false }
@@ -67,22 +56,6 @@ RSpec.describe TwoFactorAuthCode::WebauthnAuthenticationPresenter do
         expect(presenter.authenticate_button_text).to eq(
           t('two_factor_authentication.webauthn_platform_use_key'),
         )
-      end
-    end
-  end
-
-  describe '#multiple_factors_enabled?' do
-    context 'with multiple factors enabled in user policy' do
-      let(:multiple_factors_enabled) { true }
-
-      it 'returns true' do
-        expect(presenter.multiple_factors_enabled?).to be_truthy
-      end
-    end
-
-    context 'with multiple factors not enabled for user policy' do
-      it 'returns false' do
-        expect(presenter.multiple_factors_enabled?).to be_falsey
       end
     end
   end

--- a/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe TwoFactorAuthCode::WebauthnAuthenticationPresenter do
 
   let(:phishing_resistant_required) { false }
   let(:platform_authenticator) { false }
-  let(:multiple_factors_enabled) { false }
 
   describe '#webauthn_help' do
     let(:phishing_resistant_required) { false }

--- a/spec/views/two_factor_authentication/webauthn_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/webauthn_verification/show.html.erb_spec.rb
@@ -3,17 +3,6 @@ require 'rails_helper'
 RSpec.describe 'two_factor_authentication/webauthn_verification/show.html.erb' do
   let(:user) { build_stubbed(:user) }
   let(:platform_authenticator) { false }
-  let(:phishing_resistant_required) { false }
-  let(:service_provider_mfa_policy) do
-    ServiceProviderMfaPolicy.new(
-      user:,
-      service_provider: nil,
-      auth_method: :webauthn,
-      aal_level_requested: nil,
-      piv_cac_requested: false,
-      phishing_resistant_requested: phishing_resistant_required,
-    )
-  end
 
   subject(:rendered) { render }
 
@@ -27,9 +16,6 @@ RSpec.describe 'two_factor_authentication/webauthn_verification/show.html.erb' d
       service_provider: nil,
       platform_authenticator:,
     )
-    allow(@presenter).to receive(
-      :service_provider_mfa_policy,
-    ).and_return(service_provider_mfa_policy)
   end
 
   it 'includes hidden platform form input with value false' do


### PR DESCRIPTION
## 🎫 Ticket

Relates to / simplifies [LG-11101](https://cm-jira.usa.gov/browse/LG-11101)

## 🛠 Summary of changes

Removes references to `ServiceProviderMfaPolicy` in `GenericDeliveryPresenter` which appear to be unused.

Previous usage:

- `WebauthnAuthenticationPresenter#multiple_factors_enabled?` reference added in #5976, last reference removed in #8716
- `PivCacAuthenticationPresenter` references added in #4014, last references removed in #8837

## 📜 Testing Plan

- Build should pass.
- Verify no regressions in signing in with MFA methods, particularly WebAuthn and PIV/CAC