### PR TITLE
LG-11101: Support multiple valid MFA to satisfy authentication request (Part 2 of 2)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   include VerifySpAttributesConcern
   include EffectiveUser
   include SecondMfaReminderConcern
+  include TwoFactorAuthenticatableMethods
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -380,7 +381,7 @@ class ApplicationController < ActionController::Base
     @service_provider_mfa_policy ||= ServiceProviderMfaPolicy.new(
       user: current_user,
       service_provider: sp_from_sp_session,
-      auth_method: user_session[:auth_method],
+      auth_methods_session:,
       aal_level_requested: sp_session[:aal_level_requested],
       piv_cac_requested: sp_session[:piv_cac_requested],
       phishing_resistant_requested: sp_session[:phishing_resistant_requested],

--- a/app/controllers/concerns/reauthentication_required_concern.rb
+++ b/app/controllers/concerns/reauthentication_required_concern.rb
@@ -1,28 +1,19 @@
 module ReauthenticationRequiredConcern
   include MfaSetupConcern
+  include TwoFactorAuthenticatableMethods
 
   def confirm_recently_authenticated_2fa
-    return unless user_fully_authenticated?
-    non_remembered_device_authentication = user_session[:auth_method].present? &&
-                                           user_session[:auth_method] != 'remember_device'
-    return if recently_authenticated? && non_remembered_device_authentication
+    return if !user_fully_authenticated? || auth_methods_session.recently_authenticated_2fa?
 
     analytics.user_2fa_reauthentication_required(
-      auth_method: user_session[:auth_method],
-      authenticated_at: user_session[:authn_at],
+      auth_method: auth_methods_session.last_auth_event&.[](:auth_method),
+      authenticated_at: auth_methods_session.last_auth_event&.[](:at),
     )
 
     prompt_for_second_factor
   end
 
   private
-
-  def recently_authenticated?
-    return false if user_session.blank?
-    authn_at = user_session[:authn_at]
-    return false if authn_at.blank?
-    authn_at > Time.zone.now - IdentityConfig.store.reauthn_window
-  end
 
   def prompt_for_second_factor
     store_location(request.url)

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -53,9 +53,7 @@ module RememberDeviceConcern
   private
 
   def expired_for_interval?(user, interval)
-    unless user_session[:auth_method] == TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
-      return false
-    end
+    return false unless has_remember_device_auth_event?
     remember_cookie = remember_device_cookie
     return true if remember_cookie.nil?
 
@@ -65,8 +63,13 @@ module RememberDeviceConcern
     )
   end
 
+  def has_remember_device_auth_event?
+    auth_methods_session.auth_events.any? do |auth_event|
+      auth_event[:auth_method] == TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
+    end
+  end
+
   def handle_valid_remember_device_cookie(remember_device_cookie:)
-    user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
     mark_user_session_authenticated(
       auth_method: TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE,
       authentication_type: :device_remembered,

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -149,13 +149,11 @@ module TwoFactorAuthenticatableMethods
   end
 
   def handle_valid_verification_for_confirmation_context(auth_method:)
-    user_session[:auth_method] = auth_method
     mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa_confirmation)
     reset_second_factor_attempts_count
   end
 
   def handle_valid_verification_for_authentication_context(auth_method:)
-    user_session[:auth_method] = auth_method
     mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa)
     create_user_event(:sign_in_after_2fa)
 
@@ -167,8 +165,6 @@ module TwoFactorAuthenticatableMethods
   end
 
   def mark_user_session_authenticated(auth_method:, authentication_type:)
-    user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
-    user_session[:authn_at] = Time.zone.now
     auth_methods_session.authenticate!(auth_method)
     mark_user_session_authenticated_analytics(authentication_type)
   end

--- a/app/services/auth_methods_session.rb
+++ b/app/services/auth_methods_session.rb
@@ -17,4 +17,15 @@ class AuthMethodsSession
   def auth_events
     user_session[:auth_events] || []
   end
+
+  def last_auth_event
+    auth_events.last
+  end
+
+  def recently_authenticated_2fa?
+    auth_events.any? do |auth_event|
+      auth_event[:auth_method] != TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE &&
+        auth_event[:at] > Time.zone.now - IdentityConfig.store.reauthn_window
+    end
+  end
 end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -832,7 +832,9 @@ RSpec.describe SamlIdpController do
 
         it 'returns AAL3 authn_context when AAL3 is requested' do
           allow(controller).to receive(:user_session).and_return(
-            { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC },
+            auth_events: [
+              { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC, at: Time.zone.now },
+            ],
           )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
@@ -849,7 +851,9 @@ RSpec.describe SamlIdpController do
 
         it 'returns AAL3-HSPD12 authn_context when AAL3-HSPD12 is requested' do
           allow(controller).to receive(:user_session).and_return(
-            { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC },
+            auth_events: [
+              { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC, at: Time.zone.now },
+            ],
           )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
@@ -866,7 +870,9 @@ RSpec.describe SamlIdpController do
 
         it 'returns AAL2-HSPD12 authn_context when AAL2-HSPD12 is requested' do
           allow(controller).to receive(:user_session).and_return(
-            { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC },
+            auth_events: [
+              { auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC, at: Time.zone.now },
+            ],
           )
           user = create(:user, :with_piv_or_cac)
           auth_settings = saml_settings(
@@ -883,7 +889,9 @@ RSpec.describe SamlIdpController do
 
         it 'returns AAL2-phishing-resistant authn_context when AAL2-phishing-resistant requested' do
           allow(controller).to receive(:user_session).and_return(
-            { auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN },
+            auth_events: [
+              { auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN, at: Time.zone.now },
+            ],
           )
           user = create(:user, :with_webauthn)
           auth_settings = saml_settings(

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -43,9 +43,6 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
 
           post :create, params: payload
 
-          expect(subject.user_session[:auth_method]).to eq(
-            TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
-          )
           expect(subject.user_session[:auth_events]).to eq(
             [
               auth_method: TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
@@ -146,7 +143,6 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
 
         expect(response).to render_template(:show)
         expect(flash[:error]).to eq t('two_factor_authentication.invalid_backup_code')
-        expect(subject.user_session[:auth_method]).to eq nil
         expect(subject.user_session[:auth_events]).to eq nil
         expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -173,7 +173,6 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
       end
 
       it 'does not set auth_method and requires 2FA' do
-        expect(controller.user_session[:auth_method]).to eq nil
         expect(controller.user_session[:auth_events]).to eq nil
         expect(controller.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end
@@ -301,7 +300,6 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
             otp_delivery_preference: 'sms',
           }
 
-          expect(subject.user_session[:auth_method]).to eq TwoFactorAuthenticatable::AuthMethod::SMS
           expect(subject.user_session[:auth_events]).to eq(
             [
               {

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -71,9 +71,6 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
         freeze_time do
           post :create, params: payload
 
-          expect(subject.user_session[:auth_method]).to eq(
-            TwoFactorAuthenticatable::AuthMethod::PERSONAL_KEY,
-          )
           expect(subject.user_session[:auth_events]).to eq(
             [
               auth_method: TwoFactorAuthenticatable::AuthMethod::PERSONAL_KEY,
@@ -138,7 +135,6 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
 
         post :create, params: payload
 
-        expect(subject.user_session[:auth_method]).to eq nil
         expect(subject.user_session[:auth_events]).to eq nil
         expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -69,9 +69,6 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
         freeze_time do
           get :show, params: { token: 'good-token' }
 
-          expect(subject.user_session[:auth_method]).to eq(
-            TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
-          )
           expect(subject.user_session[:auth_events]).to eq(
             [
               auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
@@ -163,7 +160,6 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
       end
 
       it 'does not set auth_method and requires 2FA' do
-        expect(subject.user_session[:auth_method]).to eq nil
         expect(subject.user_session[:auth_events]).to eq nil
         expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -24,9 +24,6 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
           post :create, params: { code: generate_totp_code(@secret) }
 
           expect(response).to redirect_to account_path
-          expect(subject.user_session[:auth_method]).to eq(
-            TwoFactorAuthenticatable::AuthMethod::TOTP,
-          )
           expect(subject.user_session[:auth_events]).to eq(
             [
               auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,
@@ -112,7 +109,6 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
       end
 
       it 'does not set auth_method and still requires 2FA' do
-        expect(subject.user_session[:auth_method]).to eq nil
         expect(subject.user_session[:auth_events]).to eq nil
         expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -161,9 +161,6 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
           freeze_time do
             patch :confirm, params: params
 
-            expect(subject.user_session[:auth_method]).to eq(
-              TwoFactorAuthenticatable::AuthMethod::WEBAUTHN,
-            )
             expect(subject.user_session[:auth_events]).to eq(
               [
                 auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN,
@@ -200,9 +197,6 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
 
             freeze_time do
               patch :confirm, params: params
-              expect(subject.user_session[:auth_method]).to eq(
-                TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM,
-              )
               expect(subject.user_session[:auth_events]).to eq(
                 [
                   auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM,
@@ -267,7 +261,6 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
         it 'redirects to webauthn show page' do
           patch :confirm, params: params
           expect(response).to redirect_to login_two_factor_webauthn_url(platform: true)
-          expect(subject.user_session[:auth_method]).to eq nil
           expect(subject.user_session[:auth_events]).to eq nil
           expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
         end

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -75,8 +75,6 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
         allow(PivCacService).to receive(:decode_token).with(bad_token) { bad_token_response }
         allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
         subject.user_session[:piv_cac_nickname] = nickname
-        subject.user_session[:authn_at] = Time.zone.now
-        subject.user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::SMS
       end
 
       let(:nonce) { 'nonce' }

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -125,8 +125,6 @@ RSpec.describe Users::PivCacLoginController do
             expect(controller.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).
               to eq false
 
-            expect(controller.user_session[:authn_at]).to_not be nil
-            expect(controller.user_session[:authn_at].class).to eq ActiveSupport::TimeWithZone
             expect(controller.auth_methods_session.auth_events).to match(
               [
                 {

--- a/spec/features/openid_connect/phishing_resistant_required_spec.rb
+++ b/spec/features/openid_connect/phishing_resistant_required_spec.rb
@@ -100,6 +100,23 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end
+
+      context 'adding an ineligible method after authenticating with phishing-resistant' do
+        before do
+          signin_with_piv
+          within('.sidenav') { click_on t('account.navigation.add_phone_number') }
+          fill_in t('two_factor_authentication.phone_label'), with: '5135550100'
+          click_send_one_time_code
+          fill_in_code_with_last_phone_otp
+          click_submit_default
+        end
+
+        it 'does not prompt the user to authenticate again' do
+          visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
+
+          expect(page).to have_current_path(sign_up_completed_path)
+        end
+      end
     end
   end
 
@@ -155,6 +172,23 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end
+
+      context 'adding an ineligible method after authenticating with phishing-resistant' do
+        before do
+          signin_with_piv
+          within('.sidenav') { click_on t('account.navigation.add_phone_number') }
+          fill_in t('two_factor_authentication.phone_label'), with: '5135550100'
+          click_send_one_time_code
+          fill_in_code_with_last_phone_otp
+          click_submit_default
+        end
+
+        it 'does not prompt the user to authenticate again' do
+          visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
+
+          expect(page).to have_current_path(sign_up_completed_path)
+        end
+      end
     end
   end
 
@@ -209,6 +243,23 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
         visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
+      end
+
+      context 'adding an ineligible method after authenticating with phishing-resistant' do
+        before do
+          signin_with_piv
+          within('.sidenav') { click_on t('account.navigation.add_phone_number') }
+          fill_in t('two_factor_authentication.phone_label'), with: '5135550100'
+          click_send_one_time_code
+          fill_in_code_with_last_phone_otp
+          click_submit_default
+        end
+
+        it 'does not prompt the user to authenticate again' do
+          visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
+
+          expect(page).to have_current_path(sign_up_completed_path)
+        end
       end
     end
   end

--- a/spec/features/saml/phishing_resistant_required_spec.rb
+++ b/spec/features/saml/phishing_resistant_required_spec.rb
@@ -114,6 +114,27 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
           expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
         end
       end
+
+      context 'adding an ineligible method after authenticating with phishing-resistant' do
+        before do
+          signin_with_piv
+          within('.sidenav') { click_on t('account.navigation.add_phone_number') }
+          fill_in t('two_factor_authentication.phone_label'), with: '5135550100'
+          click_send_one_time_code
+          fill_in_code_with_last_phone_otp
+          click_submit_default
+        end
+
+        it 'does not prompt the user to authenticate again' do
+          visit_saml_authn_request_url(
+            overrides: {
+              authn_context: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            },
+          )
+
+          expect(page).to have_current_path(sign_up_completed_path)
+        end
+      end
     end
   end
 
@@ -179,6 +200,27 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
           )
           visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+        end
+      end
+
+      context 'adding an ineligible method after authenticating with phishing-resistant' do
+        before do
+          signin_with_piv
+          within('.sidenav') { click_on t('account.navigation.add_phone_number') }
+          fill_in t('two_factor_authentication.phone_label'), with: '5135550100'
+          click_send_one_time_code
+          fill_in_code_with_last_phone_otp
+          click_submit_default
+        end
+
+        it 'does not prompt the user to authenticate again' do
+          visit_saml_authn_request_url(
+            overrides: {
+              authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+            },
+          )
+
+          expect(page).to have_current_path(sign_up_completed_path)
         end
       end
     end
@@ -258,6 +300,28 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
         )
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
+      end
+
+      context 'adding an ineligible method after authenticating with phishing-resistant' do
+        before do
+          signin_with_piv
+          within('.sidenav') { click_on t('account.navigation.add_phone_number') }
+          fill_in t('two_factor_authentication.phone_label'), with: '5135550100'
+          click_send_one_time_code
+          fill_in_code_with_last_phone_otp
+          click_submit_default
+        end
+
+        it 'does not prompt the user to authenticate again' do
+          visit_saml_authn_request_url(
+            overrides: {
+              issuer: aal3_issuer,
+              authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            },
+          )
+
+          expect(page).to have_current_path(sign_up_completed_path)
+        end
       end
     end
   end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -16,9 +16,8 @@ module ControllerHelper
   def stub_sign_in(user = build(:user, password: VALID_PASSWORD))
     allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(request.env['warden']).to receive(:session).and_return(user: {})
-    allow(controller).to receive(:user_session).
-      and_return({ authn_at: Time.zone.now }.with_indifferent_access)
-    controller.user_session[:auth_method] ||= TwoFactorAuthenticatable::AuthMethod::SMS
+    allow(controller).to receive(:user_session).and_return({}.with_indifferent_access)
+    controller.auth_methods_session.authenticate!(TwoFactorAuthenticatable::AuthMethod::SMS)
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:confirm_two_factor_authenticated).and_return(true)
     allow(controller).to receive(:user_fully_authenticated?).and_return(true)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -203,8 +203,10 @@ module Features
 
       Warden.on_next_request do |proxy|
         session = proxy.env['rack.session']
-        session['warden.user.user.session'] = { authn_at: Time.zone.now }
-        session['warden.user.user.session']['auth_method'] = auth_method if auth_method
+        session['warden.user.user.session'] = {}.with_indifferent_access
+        if auth_method
+          session['warden.user.user.session']['auth_events'] = [{ auth_method:, at: Time.zone.now }]
+        end
       end
       visit account_path
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11101](https://cm-jira.usa.gov/browse/LG-11101)

## 🛠 Summary of changes

Updates MFA handling to track multiple MFAs in the current session, to improve reuse and avoid situations where adding an MFA may unintentionally "downgrade" the user's session (such as what prompted the changes in #9263).

Effectively, this changes the session to be able to track all authentications in the session and choose if any would be valid for the scenarios where it is checked.

This depends on (and merges to) changes proposed in #9388 to start tracking the session value, and should not be merged until #9388 is live in production.

## 📜 Testing Plan

Verify new supported behavior to allow strict MFA reuse after adding or authenticating with a "lesser" MFA:

1. (Prerequisite) Create an account with an unphishable method (e.g. PIV, security key, face or touch unlock)
2. Start in a private browsing window to ensure no use of remember device cookie
3. Go to http://localhost:3000
4. Sign in
5. MFA with your unphishable method
6. When signed in, add a phishable MFA method (e.g. phone, authentication app, backup codes)
7. With [sample app](https://github.com/18F/identity-oidc-sinatra) running in a separate terminal process, go to http://localhost:9292/?aal=2-phishing_resistant in your private browsing session
8. Click "Sign in"
9. Observe that you are not prompted for MFA, and can return to the SP

Verify no regressions in expected behaviors for MFA authentication:

- Remember device cookie usage
- Strict MFA authentication for phishing-resistant / PIV-only when not having previously authenticated with those methods in the same session