### PR TITLE
Exclude certain paths from secrets detection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -489,6 +489,7 @@ include:
 secret_detection:
   allow_failure: false
   variables:
+    SECRET_DETECTION_EXCLUDED_PATHS: 'keys.example,config/artifacts.example,public/acuant/*/opencv.min.js,tmp/0.0.0.0-3000.key'
     SECRET_DETECTION_REPORT_FILE: 'gl-secret-detection-report.json'
   rules:
     - if: $SECRET_DETECTION_DISABLED


### PR DESCRIPTION
We have had some red builds on main due to the new secrets detection CI job. I ran it locally and it was flagging the following paths:

- `config/artifacts.example/local/oidc.key`
- `keys.example/saml_test_sp.key`
- `keys.example/saml_test_sp2.key`
- `public/acuant/11.9.1/opencv.min.js`
- `tmp/0.0.0.0-3000.key`

Note that for the OpenCV JS file, it was incorrectly identifying random blobs in a giant base64-encoded string as AWS access keys. The other files are just example keys or temporary keys used in CI itself.

This PR adds exceptions to the secret scanner to allow these paths.