### PR TITLE
Pin PostCSS to resolve advisory, remove explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "mocha": "^10.0.0",
     "mq-polyfill": "^1.1.8",
     "msw": "^1.3.2",
-    "postcss": "^8.4.22",
     "prettier": "^3.0.3",
     "quibble": "^0.6.17",
     "react-test-renderer": "^17.0.2",
@@ -92,6 +91,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "resolutions": {
-    "minimist": "1.2.6"
+    "minimist": "1.2.6",
+    "postcss": "8.4.31"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5480,10 +5480,10 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.22, postcss@^8.4.24:
-  version "8.4.25"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.25.tgz#4a133f5e379eda7f61e906c3b1aaa9b81292726f"
-  integrity sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==
+postcss@8.4.31, postcss@^8.4.24:
+  version "8.4.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
+  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"


### PR DESCRIPTION
## 🛠 Summary of changes

Updates PostCSS to resolve [a (moderate) security advisory](https://github.com/18F/identity-idp/security/dependabot/63).

Couple notes:

- As of #6591, we no longer use PostCSS directly, so it's removed as an explicit dependency
- We still have a dependency through [stylelint](https://github.com/stylelint/stylelint), and while they have [merged an update](https://github.com/stylelint/stylelint/pull/7218), there's not yet a published version containing this change, so this assigns `resolutions` instead. Per SemVer version ranges, this should be expected to be safe, and is a [designed use-case for `resolutions`](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/#:~:text=A%20sub%2Ddependency%20of%20your%20project%20got%20an%20important%20security%20update%20and%20you%20don%E2%80%99t%20want%20to%20wait%20for%20your%20direct%2Ddependency%20to%20issue%20a%20minimum%20version%20update.).

We should follow-up to remove `resolutions` entry once `stylelint` publishes an updated version.
 
## 📜 Testing Plan

1. `yarn install`
2. `yarn lint:css`