### PR TITLE
LG-11187 Don't enforce the rate limits for previous steps during proofing

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -164,7 +164,7 @@ module Idv
         return
       end
 
-      return if confirm_not_rate_limited
+      return if confirm_not_rate_limited_after_doc_auth
 
       if current_async_state.none?
         idv_session.invalidate_verify_info_step!

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -9,7 +9,6 @@ module IdvStepConcern
   included do
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
-    before_action :confirm_not_rate_limited
     before_action :confirm_no_pending_gpo_profile
     before_action :confirm_no_pending_in_person_enrollment
     before_action :handle_fraud

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -1,15 +1,28 @@
 module RateLimitConcern
   extend ActiveSupport::Concern
 
-  def confirm_not_rate_limited
+  # idv_resolution idv_doc_auth proof_address proof_ssn
+  ALL_IDV_RATE_LIMITTERS = [:idv_resolution, :idv_doc_auth, :proof_address, :proof_ssn].freeze
+
+  def confirm_not_rate_limited(rate_limiters = ALL_IDV_RATE_LIMITTERS)
     rate_limited = false
-    %i[idv_resolution idv_doc_auth proof_address proof_ssn].each do |rate_limit_type|
+    rate_limiters.each do |rate_limit_type|
       if rate_limit_redirect!(rate_limit_type)
         rate_limited = true
         break
       end
     end
     rate_limited
+  end
+
+  def confirm_not_rate_limited_after_doc_auth
+    rate_limitters = [:idv_resolution, :proof_ssn, :proof_address]
+    confirm_not_rate_limited(rate_limitters)
+  end
+
+  def confirm_not_rate_limited_after_idv_resolution
+    rate_limitters = [:proof_address]
+    confirm_not_rate_limited(rate_limitters)
   end
 
   def rate_limit_redirect!(rate_limit_type)

--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -1,7 +1,6 @@
 module RateLimitConcern
   extend ActiveSupport::Concern
 
-  # idv_resolution idv_doc_auth proof_address proof_ssn
   ALL_IDV_RATE_LIMITTERS = [:idv_resolution, :idv_doc_auth, :proof_address, :proof_ssn].freeze
 
   def confirm_not_rate_limited(rate_limiters = ALL_IDV_RATE_LIMITTERS)

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -2,6 +2,7 @@ module Idv
   class AddressController < ApplicationController
     include IdvStepConcern
 
+    before_action :confirm_not_rate_limited_after_doc_auth
     before_action :confirm_document_capture_complete
 
     def new

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -3,6 +3,7 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
 
+    before_action :confirm_not_rate_limited
     before_action :confirm_welcome_step_complete
     before_action :confirm_agreement_needed
 

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -5,6 +5,7 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
 
+    before_action :confirm_not_rate_limited
     before_action :confirm_hybrid_handoff_complete
     before_action :confirm_document_capture_needed
     before_action :override_csp_to_allow_acuant

--- a/app/controllers/idv/getting_started_controller.rb
+++ b/app/controllers/idv/getting_started_controller.rb
@@ -2,6 +2,7 @@ module Idv
   class GettingStartedController < ApplicationController
     include IdvStepConcern
 
+    before_action :confirm_not_rate_limited
     before_action :confirm_agreement_needed
 
     def show

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -4,6 +4,7 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
 
+    before_action :confirm_not_rate_limited
     before_action :confirm_verify_info_step_needed
     before_action :confirm_agreement_step_complete
     before_action :confirm_hybrid_handoff_needed, only: :show

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -6,6 +6,7 @@ module Idv
       include Steps::ThreatMetrixStepHelper
       include ThreatMetrixConcern
 
+      before_action :confirm_not_rate_limited_after_doc_auth
       before_action :confirm_verify_info_step_needed
       before_action :confirm_in_person_address_step_complete
       before_action :confirm_repeat_ssn, only: :show

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -6,9 +6,9 @@ module Idv
       include Steps::ThreatMetrixStepHelper
       include VerifyInfoConcern
 
+      before_action :confirm_not_rate_limited_after_doc_auth, except: [:show]
       before_action :confirm_ssn_step_complete
       before_action :confirm_verify_info_step_needed
-      skip_before_action :confirm_not_rate_limited, only: :show
 
       def show
         @step_indicator_steps = step_indicator_steps

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -4,6 +4,7 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
 
+    before_action :confirm_not_rate_limited
     before_action :confirm_hybrid_handoff_complete
     before_action :confirm_document_capture_needed
 

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -7,10 +7,10 @@ module Idv
 
     attr_reader :idv_form
 
+    before_action :confirm_not_rate_limited_after_idv_resolution, except: [:new]
     before_action :confirm_verify_info_step_complete
     before_action :confirm_step_needed
     before_action :set_idv_form
-    skip_before_action :confirm_not_rate_limited, only: :new
 
     def new
       flash.keep(:success) if should_keep_flash_success?
@@ -24,7 +24,7 @@ module Idv
 
       render 'shared/wait' and return if async_state.in_progress?
 
-      return if confirm_not_rate_limited
+      return if confirm_not_rate_limited_after_idv_resolution
 
       if async_state.none?
         Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).

--- a/app/controllers/idv/phone_question_controller.rb
+++ b/app/controllers/idv/phone_question_controller.rb
@@ -4,6 +4,7 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
 
+    before_action :confirm_not_rate_limited
     before_action :confirm_verify_info_step_needed
     before_action :confirm_agreement_step_complete
     before_action :confirm_hybrid_handoff_needed, only: :show

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -10,7 +10,6 @@ module Idv
     before_action :confirm_verify_info_step_complete
     before_action :confirm_address_step_complete
     before_action :confirm_current_password, only: [:create]
-    skip_before_action :confirm_not_rate_limited
 
     helper_method :step_indicator_step
 

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -5,6 +5,7 @@ module Idv
     include Steps::ThreatMetrixStepHelper
     include ThreatMetrixConcern
 
+    before_action :confirm_not_rate_limited_after_doc_auth
     before_action :confirm_verify_info_step_needed
     before_action :confirm_document_capture_complete
     before_action :confirm_repeat_ssn, only: :show

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -5,9 +5,9 @@ module Idv
     include VerifyInfoConcern
     include Steps::ThreatMetrixStepHelper
 
+    before_action :confirm_not_rate_limited_after_doc_auth, except: [:show]
     before_action :confirm_ssn_step_complete
     before_action :confirm_verify_info_step_needed
-    skip_before_action :confirm_not_rate_limited, only: :show
 
     def show
       @step_indicator_steps = step_indicator_steps

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -4,6 +4,7 @@ module Idv
     include StepIndicatorConcern
     include GettingStartedAbTestConcern
 
+    before_action :confirm_not_rate_limited
     before_action :confirm_welcome_needed
     before_action :maybe_redirect_for_getting_started_ab_test
 

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -17,13 +17,6 @@ RSpec.describe 'IdvStepConcern' do
   end
 
   describe 'before_actions' do
-    it 'includes confirm_not_rate_limited before_action' do
-      expect(Idv::StepController).to have_actions(
-        :before,
-        :confirm_not_rate_limited,
-      )
-    end
-
     it 'includes handle_fraud' do
       expect(Idv::StepController).to have_actions(
         :before,

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'RateLimitConcern' do
       end
     end
 
-    it 'redirects if the user is rate limitted for a step after doc auth' do
+    it 'redirects if the user is rate limited for a step after doc auth' do
       RateLimiter.new(user: user, rate_limit_type: :idv_resolution).increment_to_limited!
 
       get :show
@@ -121,7 +121,7 @@ RSpec.describe 'RateLimitConcern' do
       expect(response).to redirect_to(idv_session_errors_failure_url)
     end
 
-    it 'does not redirect if the user is rate limitted for doc auth' do
+    it 'does not redirect if the user is rate limited for doc auth' do
       RateLimiter.new(user: user, rate_limit_type: :idv_doc_auth).increment_to_limited!
 
       get :show
@@ -145,7 +145,7 @@ RSpec.describe 'RateLimitConcern' do
       end
     end
 
-    it 'redirects if the user is rate limitted for a step after idv resolution' do
+    it 'redirects if the user is rate limited for a step after idv resolution' do
       RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
 
       get :show
@@ -153,7 +153,7 @@ RSpec.describe 'RateLimitConcern' do
       expect(response).to redirect_to(idv_phone_errors_failure_url)
     end
 
-    it 'does not redirect if the user is rate limitted for idv resolution' do
+    it 'does not redirect if the user is rate limited for idv resolution' do
       RateLimiter.new(user: user, rate_limit_type: :idv_doc_auth).increment_to_limited!
       RateLimiter.new(user: user, rate_limit_type: :idv_resolution).increment_to_limited!
 

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -98,4 +98,16 @@ RSpec.describe 'RateLimitConcern' do
       end
     end
   end
+
+  describe '#confirm_not_rate_limited_after_doc_auth' do
+    it 'redirects if the user is rate limitted for a step after doc auth'
+
+    it 'does not if the user is rate limitted for a step before doc auth'
+  end
+
+  describe '#confirm_not_rate_limited_after_idv_resolution' do
+    it 'redirects if the user is rate limitted for a step before idv resolution'
+
+    it 'does not if the user is rate limitted for a step after idv resolution'
+  end
 end


### PR DESCRIPTION
Currently we have a before action that enforces all of the rate limits that a user might encounter during proofing. This is done so that if a user will encounter a rate limit during a proofing attempt they are sent to an error instead of being put through the process which they will not be able to complete when they reach a rate limited step.

Prior to this commit we would check on all steps for whether a rate limiter has exceeded the maximum. This check was applied to all steps in a before action in `IdvStepConcern`. A consequence of this is we cannot count successful attempts towards the rate limit. In the case where we did that a user would complete a step successfully, then be redirected on the next step since the rate limiter for the previous trip exceeded the number of allowable attempts.

This commit changes the logic to add methods for checking rate limits only on future steps after points in the flow where the rate limits are invoked. This will make it possible to count successful attempts towards the limit.
