### PR TITLE
LG-11066 Do not redirect users at the phone step unless they are phone and address rate limited

### DIFF
--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -1,10 +1,10 @@
 module RateLimitConcern
   extend ActiveSupport::Concern
 
-  ALL_IDV_RATE_LIMITTERS = [:idv_resolution, :idv_doc_auth, :proof_ssn].freeze
+  ALL_IDV_RATE_LIMITERS = [:idv_resolution, :idv_doc_auth, :proof_ssn].freeze
 
-  def confirm_not_rate_limited(rate_limiters = ALL_IDV_RATE_LIMITTERS)
-    exceeded_rate_limits = check_for_excceded_rate_limits(rate_limiters)
+  def confirm_not_rate_limited(rate_limiters = ALL_IDV_RATE_LIMITERS)
+    exceeded_rate_limits = check_for_exceeded_rate_limits(rate_limiters)
     if exceeded_rate_limits.any?
       rate_limit_redirect!(exceeded_rate_limits.first)
       return true
@@ -13,8 +13,8 @@ module RateLimitConcern
   end
 
   def confirm_not_rate_limited_after_doc_auth
-    rate_limitters = [:idv_resolution, :proof_ssn]
-    confirm_not_rate_limited(rate_limitters)
+    rate_limiters = [:idv_resolution, :proof_ssn]
+    confirm_not_rate_limited(rate_limiters)
   end
 
   def confirm_not_rate_limited_for_phone_address_verification
@@ -69,7 +69,7 @@ module RateLimitConcern
     end
   end
 
-  def check_for_excceded_rate_limits(rate_limit_types)
+  def check_for_exceeded_rate_limits(rate_limit_types)
     rate_limit_types.select do |rate_limit_type|
       idv_attempter_rate_limited?(rate_limit_type)
     end

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -7,7 +7,7 @@ module Idv
 
     attr_reader :idv_form
 
-    before_action :confirm_not_rate_limited_after_idv_resolution, except: [:new]
+    before_action :confirm_not_rate_limited_for_phone_address_verification, except: [:new]
     before_action :confirm_verify_info_step_complete
     before_action :confirm_step_needed
     before_action :set_idv_form
@@ -24,7 +24,7 @@ module Idv
 
       render 'shared/wait' and return if async_state.in_progress?
 
-      return if confirm_not_rate_limited_after_idv_resolution
+      return if confirm_not_rate_limited_for_phone_address_verification
 
       if async_state.none?
         Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -6,7 +6,7 @@ module Idv
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_phone_step_needed
-    before_action :confirm_idv_phone_step_submitted
+    before_action :confirm_idv_phone_step_submitted, except: [:failure]
     before_action :set_gpo_letter_available
     before_action :ignore_form_step_wait_requests
 
@@ -32,6 +32,8 @@ module Idv
     end
 
     def failure
+      return redirect_to(idv_phone_url) unless rate_limiter.limited?
+
       @expires_at = rate_limiter.expires_at
       track_event(type: :failure)
     end

--- a/spec/controllers/concerns/rate_limit_concern_spec.rb
+++ b/spec/controllers/concerns/rate_limit_concern_spec.rb
@@ -68,15 +68,55 @@ RSpec.describe 'RateLimitConcern' do
     end
 
     context 'with proof_address rate_limiter (PhoneStep)' do
-      before do
-        rate_limiter = RateLimiter.new(user: user, rate_limit_type: :proof_address)
-        rate_limiter.increment_to_limited!
+      context 'when the user is phone rate limited' do
+        before do
+          rate_limiter = RateLimiter.new(user: user, rate_limit_type: :proof_address)
+          rate_limiter.increment_to_limited!
+        end
+
+        it 'does not redirect' do
+          get :show
+
+          expect(response.body).to eq 'Hello'
+          expect(response.status).to eq 200
+        end
       end
 
-      it 'redirects to proof_address rate limited error page' do
-        get :show
+      context 'when the user is mail rate limited' do
+        before do
+          create(
+            :profile,
+            :verification_cancelled,
+            :letter_sends_rate_limited,
+            user: user,
+          )
+        end
 
-        expect(response).to redirect_to idv_phone_errors_failure_url
+        it 'does not redirect' do
+          get :show
+
+          expect(response.body).to eq 'Hello'
+          expect(response.status).to eq 200
+        end
+      end
+
+      context 'when the user is phone and mail rate limited' do
+        before do
+          create(
+            :profile,
+            :verification_cancelled,
+            :letter_sends_rate_limited,
+            user: user,
+          )
+          rate_limiter = RateLimiter.new(user: user, rate_limit_type: :proof_address)
+          rate_limiter.increment_to_limited!
+        end
+
+        it 'redirects to proof_address rate limited error page' do
+          get :show
+
+          expect(response).to redirect_to idv_phone_errors_failure_url
+        end
       end
     end
 
@@ -133,9 +173,9 @@ RSpec.describe 'RateLimitConcern' do
     end
   end
 
-  describe '#confirm_not_rate_limited_after_idv_resolution' do
+  describe '#confirm_not_rate_limited_for_phone_address_verification' do
     controller(idv_step_controller_class) do
-      before_action :confirm_not_rate_limited_after_idv_resolution
+      before_action :confirm_not_rate_limited_for_phone_address_verification
     end
 
     before(:each) do
@@ -147,7 +187,7 @@ RSpec.describe 'RateLimitConcern' do
       end
     end
 
-    it 'redirects if the user is rate limited for a step after idv resolution' do
+    it 'redirects if the user is rate limited for phone address verification' do
       RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
 
       get :show
@@ -158,6 +198,15 @@ RSpec.describe 'RateLimitConcern' do
     it 'does not redirect if the user is rate limited for idv resolution' do
       RateLimiter.new(user: user, rate_limit_type: :idv_doc_auth).increment_to_limited!
       RateLimiter.new(user: user, rate_limit_type: :idv_resolution).increment_to_limited!
+
+      get :show
+
+      expect(response.body).to eq 'Hello'
+      expect(response.status).to eq 200
+    end
+
+    it 'does not redirect if the user is rate limited for mail' do
+      create(:profile, :verification_cancelled, :letter_sends_rate_limited, user: user)
 
       get :show
 

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe IdvController do
         stub_sign_in(profile.user)
       end
 
-      it 'redirects to failure page' do
+      it 'redirects to rate limited page' do
         get :index
 
         expect(response).to redirect_to idv_session_errors_rate_limited_url

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -70,6 +70,12 @@ FactoryBot.define do
       pii { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
     end
 
+    trait :letter_sends_rate_limited do
+      gpo_confirmation_codes do
+        build_list(:gpo_confirmation_code, IdentityConfig.store.max_mail_events)
+      end
+    end
+
     after(:build) do |profile, evaluator|
       if evaluator.pii
         pii_attrs = Pii::Attributes.new_from_hash(evaluator.pii)

--- a/spec/features/idv/phone_errors_spec.rb
+++ b/spec/features/idv/phone_errors_spec.rb
@@ -13,8 +13,8 @@ RSpec.feature 'phone errors', :js do
       verify_phone_submitted(idv_phone_errors_warning_url, idv_phone_errors_warning_path)
     end
 
-    it 'only renders failure after phone has been submitted' do
-      verify_phone_submitted(idv_phone_errors_failure_url, idv_phone_errors_failure_path)
+    it 'only renders timeout after phone has been submitted' do
+      verify_phone_submitted(idv_phone_errors_timeout_url, idv_phone_errors_timeout_path)
     end
 
     it 'only renders jobfail after phone has been submitted' do

--- a/spec/features/idv/proof_address_rate_limit_spec.rb
+++ b/spec/features/idv/proof_address_rate_limit_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.feature 'address proofing rate limit' do
+  include IdvStepHelper
+  include IdvHelper
+
+  context 'a user is phone rate limited' do
+    scenario 'the user does not encounter an error until phone entry and can verify by mail', :js do
+      user = user_with_2fa
+      RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
+
+      start_idv_from_sp
+      complete_idv_steps_before_phone_step(user)
+
+      expect(current_path).to eq(idv_phone_errors_failure_path)
+
+      click_on t('idv.failure.phone.rate_limited.gpo.button')
+      click_on t('idv.buttons.mail.send')
+
+      expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+      expect(current_path).to eq(idv_review_path)
+      fill_in 'Password', with: user.password
+      click_idv_continue
+      expect(page).to have_current_path(idv_letter_enqueued_path)
+    end
+  end
+
+  context 'a user is mail limited' do
+    scenario 'the user can verify by phone but does not have the mail option', :js do
+      profile = create(
+        :profile,
+        :verify_by_mail_pending,
+        :with_pii,
+        :verification_cancelled,
+        :letter_sends_rate_limited,
+      )
+      user = profile.user
+
+      start_idv_from_sp
+      complete_idv_steps_before_phone_step(user)
+
+      # There should be no option to verify by mail on the phone input screen
+      expect(page).to_not have_content(t('idv.troubleshooting.options.verify_by_mail'))
+
+      fill_out_phone_form_fail
+      click_idv_send_security_code
+
+      # There should be no option to verify by mail on the warning page
+      expect(current_path).to eq(idv_phone_errors_warning_path)
+      expect(page).to_not have_content(t('idv.failure.phone.warning.gpo.button'))
+
+      # Visiting the letter request URL should redirect to phone
+      visit idv_request_letter_path
+      expect(current_path).to eq(idv_phone_path)
+
+      fill_out_phone_form_ok
+      click_idv_send_security_code
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+      expect(current_path).to eq(idv_review_path)
+      fill_in 'Password', with: user.password
+      click_idv_continue
+      expect(current_path).to eq(idv_personal_key_path)
+      expect(user.reload.active_profile.present?).to eq(true)
+    end
+  end
+
+  context 'a user is phone rate limited and mail rate limited', :js do
+    scenario 'the user is not able to start proofing' do
+      user = create(
+        :profile,
+        :verify_by_mail_pending,
+        :with_pii,
+        :verification_cancelled,
+        :letter_sends_rate_limited,
+      ).user
+      RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
+
+      start_idv_from_sp
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq(idv_phone_errors_failure_path)
+      expect(page).to_not have_content(t('idv.failure.phone.warning.gpo.button'))
+
+      # Visiting the letter request URL should redirect to phone failure
+      visit idv_request_letter_path
+      expect(current_path).to eq(idv_phone_errors_failure_path)
+    end
+  end
+end

--- a/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/gpo_otp_verification_step_spec.rb
@@ -189,6 +189,20 @@ RSpec.feature 'idv gpo otp verification step' do
     expect(current_path).to eq idv_welcome_path
   end
 
+  context 'user cancels idv from enter code page after getting rate limited', :js do
+    it 'redirects to welcome page' do
+      RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
+
+      sign_in_live_with_2fa(user)
+
+      click_on t('idv.messages.clear_and_start_over')
+      expect(current_path).to eq idv_confirm_start_over_path
+      click_idv_continue
+
+      expect(current_path).to eq idv_welcome_path
+    end
+  end
+
   def verify_no_spam_warning_banner
     expect(page).not_to have_content(
       t(


### PR DESCRIPTION
Users are being rate limited and encountering the phone error screen even if they can still verify by mail. This commit changes the rate limit logic to allow users to proceed to the phone step if they can still verify their phone or complete verification by mail.

A side-effect of this change is a bug is fixed where the following situation would exist:

1. A user proofed by mail after exhausting phone attempts
2. The user goes to GPO entry and chooses to cancel and start over
3. The user is redirected to the welcome step to start over
4. The welcome step before action observes the user is phone rate limited and sends the user to the phone errors controller
5. The phone errors controller has a before action to confirm the user has completed the phone errors step; the user has not since in this session so they are redirected to the welcome step
6. Steps 4 and 5 complete until there are too many redirects
