### PR TITLE
Update specs to initialize session as HashWithIndifferentAccess

### DIFF
--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Idv::PersonalKeyController do
 
         expect(@analytics).to have_logged_event(
           'IdV: personal key submitted',
-          address_verification_method: nil,
+          address_verification_method: 'phone',
           fraud_review_pending: false,
           fraud_rejection: false,
           in_person_verification_pending: false,
@@ -249,7 +249,7 @@ RSpec.describe Idv::PersonalKeyController do
 
         expect(@analytics).to have_logged_event(
           'IdV: personal key submitted',
-          address_verification_method: nil,
+          address_verification_method: 'phone',
           fraud_review_pending: false,
           fraud_rejection: false,
           deactivation_reason: nil,
@@ -277,7 +277,7 @@ RSpec.describe Idv::PersonalKeyController do
 
           expect(@analytics).to have_logged_event(
             'IdV: personal key submitted',
-            address_verification_method: nil,
+            address_verification_method: 'phone',
             fraud_review_pending: false,
             fraud_rejection: false,
             in_person_verification_pending: false,
@@ -306,7 +306,7 @@ RSpec.describe Idv::PersonalKeyController do
             'IdV: personal key submitted',
             fraud_review_pending: true,
             fraud_rejection: false,
-            address_verification_method: nil,
+            address_verification_method: 'phone',
             in_person_verification_pending: false,
             deactivation_reason: nil,
             proofing_components: nil,

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -620,9 +620,6 @@ RSpec.describe Idv::ReviewController do
                   let(:applicant) do
                     Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
                   end
-                  let(:stub_idv_session) do
-                    stub_user_with_applicant_data(user, applicant)
-                  end
 
                   before do
                     allow(IdentityConfig.store).to receive(:proofing_device_profiling).

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -16,7 +16,8 @@ module ControllerHelper
   def stub_sign_in(user = build(:user, password: VALID_PASSWORD))
     allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(request.env['warden']).to receive(:session).and_return(user: {})
-    allow(controller).to receive(:user_session).and_return(authn_at: Time.zone.now)
+    allow(controller).to receive(:user_session).
+      and_return({ authn_at: Time.zone.now }.with_indifferent_access)
     controller.user_session[:auth_method] ||= TwoFactorAuthenticatable::AuthMethod::SMS
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:confirm_two_factor_authenticated).and_return(true)
@@ -54,7 +55,7 @@ module ControllerHelper
   end
 
   def stub_verify_steps_one_and_two(user)
-    user_session = {}
+    user_session = ActiveSupport::HashWithIndifferentAccess.new
     stub_sign_in(user)
     idv_session = Idv::Session.new(
       user_session: user_session, current_user: user,
@@ -67,20 +68,6 @@ module ControllerHelper
       dob: 50.years.ago.to_date.to_s,
       ssn: '666-12-1234',
     }.with_indifferent_access
-    idv_session.resolution_successful = true
-    allow(subject).to receive(:confirm_idv_applicant_created).and_return(true)
-    allow(subject).to receive(:idv_session).and_return(idv_session)
-    allow(subject).to receive(:user_session).and_return(user_session)
-  end
-
-  def stub_user_with_applicant_data(user, applicant)
-    user_session = {}
-    stub_sign_in(user)
-    idv_session = Idv::Session.new(
-      user_session: user_session, current_user: user,
-      service_provider: nil
-    )
-    idv_session.applicant = applicant.with_indifferent_access
     idv_session.resolution_successful = true
     allow(subject).to receive(:confirm_idv_applicant_created).and_return(true)
     allow(subject).to receive(:idv_session).and_return(idv_session)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates spec controller helper methods to stub `user_session` as an instance of `HashWithIndifferentAccess`.

**Why?**

- It matches the real-world behavior that the session is a hash with indifferent access [[1]](https://github.com/roidrage/redis-session-store#other-notes) [[2]](https://github.com/18F/identity-idp/blob/214b400fd705b50fc64894fb3191afb0cbbda7a3/lib/session_encryptor.rb#L55)
- It resolves inaccuracies in existing specs (`Idv::PersonalKeyController`)

Split from #9335, after discovering unrelated spec failures after introducing the HashWithIndifferentAccess there.

## 📜 Testing Plan

```
rspec
```