### PR TITLE
Change `<b>` tags to `<strong>` for better accessibility and code consistency

### DIFF
--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -8,14 +8,16 @@ en:
       email: Email address
       full_name: Full name
       ial1_consent_reminder_html: You must consent each year to share your information
-        with <b>%{sp}</b>. We’ll share your information with <b>%{sp}</b> to
+        with <strong>%{sp}</strong>. We’ll share your information with
+        <strong>%{sp}</strong> to connect your account.
+      ial1_intro_html: We’ll share your information with <strong>%{sp}</strong> to
         connect your account.
-      ial1_intro_html: We’ll share your information with <b>%{sp}</b> to connect your account.
-      ial2_consent_reminder_html: '<b>%{sp}</b> needs to know who you are to connect
-        to your account. You must consent each year to share your verified
-        information with <b>%{sp}</b>. We’ll share this information: '
-      ial2_intro_html: '<b>%{sp}</b> needs to know who you are to connect your
-        account. We’ll share this information with %{sp}: '
+      ial2_consent_reminder_html: '<strong>%{sp}</strong> needs to know who you are to
+        connect to your account. You must consent each year to share your
+        verified information with <strong>%{sp}</strong>. We’ll share this
+        information: '
+      ial2_intro_html: '<strong>%{sp}</strong> needs to know who you are to connect
+        your account. We’ll share this information with %{sp}: '
       ial2_reverified_consent_info: 'Because you verified your identity again, we need
         your permission to share this information with %{sp}: '
       phone: Phone number

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -8,15 +8,16 @@ es:
       email: Dirección de correo electrónico
       full_name: Nombre completo
       ial1_consent_reminder_html: Usted debe dar cada año su consentimiento para
-        compartir su información con <b>%{sp}</b>. Compartiremos su información
-        con <b>%{sp}</b> para vincular su cuenta.
-      ial1_intro_html: Le haremos llegar su información a <b>%{sp}</b> para conectar su cuenta.
-      ial2_consent_reminder_html: 'Para conectar su cuenta, <b>%{sp}</b> necesita
-        saber quién usted. Debe dar su consentimiento cada año para compartir su
-        información verificada con <b>%{sp}</b>. Compartiremos esta
-        información:'
-      ial2_intro_html: '<b>%{sp}</b> necesita saber quién es para conectar su cuenta.
-        Compartiremos esta información con el organismo asociado: '
+        compartir su información con <strong>%{sp}</strong>. Compartiremos su
+        información con <strong>%{sp}</strong> para vincular su cuenta.
+      ial1_intro_html: Le haremos llegar su información a <strong>%{sp}</strong> para
+        conectar su cuenta.
+      ial2_consent_reminder_html: 'Para conectar su cuenta, <strong>%{sp}</strong>
+        necesita saber quién usted. Debe dar su consentimiento cada año para
+        compartir su información verificada con <strong>%{sp}</strong>.
+        Compartiremos esta información:'
+      ial2_intro_html: '<strong>%{sp}</strong> necesita saber quién es para conectar
+        su cuenta. Compartiremos esta información con el organismo asociado: '
       ial2_reverified_consent_info: 'Como volvió a verificar su identidad, necesitamos
         su permiso para compartir esta información con %{sp}: '
       phone: Teléfono

--- a/config/locales/help_text/fr.yml
+++ b/config/locales/help_text/fr.yml
@@ -8,16 +8,16 @@ fr:
       email: Adresse e-mail
       full_name: Nom complet
       ial1_consent_reminder_html: Vous devez consentir chaque année au partage de vos
-        informations avec <b>%{sp}</b>. Nous partagerons vos informations avec
-        <b>%{sp}</b> pour connecter votre compte.
-      ial1_intro_html: Nous partagerons vos informations avec <b>%{sp}</b> pour
-        connecter votre compte.
-      ial2_consent_reminder_html: '<b>%{sp}</b> doit savoir qui vous êtes pour se
-        connecter à votre compte. Vous devez consentir chaque année à partager
-        vos informations vérifiées avec <b>%{sp}</b>. Nous partagerons ces
-        informations :'
-      ial2_intro_html: '<b>%{sp}</b> a besoin de savoir qui vous êtes pour connecter
-        votre compte. Nous partagerons ces informations avec l’agence
+        informations avec <strong>%{sp}</strong>. Nous partagerons vos
+        informations avec <strong>%{sp}</strong> pour connecter votre compte.
+      ial1_intro_html: Nous partagerons vos informations avec <strong>%{sp}</strong>
+        pour connecter votre compte.
+      ial2_consent_reminder_html: '<strong>%{sp}</strong> doit savoir qui vous êtes
+        pour se connecter à votre compte. Vous devez consentir chaque année à
+        partager vos informations vérifiées avec <strong>%{sp}</strong>. Nous
+        partagerons ces informations :'
+      ial2_intro_html: '<strong>%{sp}</strong> a besoin de savoir qui vous êtes pour
+        connecter votre compte. Nous partagerons ces informations avec l’agence
         partenaire:'
       ial2_reverified_consent_info: 'Puisque vous avez à nouveau vérifié votre
         identité, nous avons besoin de votre autorisation pour partager ces

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -253,8 +253,9 @@ en:
           - Your primary number (the one you use the most often)
       return_to_profile: '‹ Return to your %{app_name} profile'
       review:
-        by_mail_password_reminder_html: <b>Remember your password.</b> The verification
-          code in your letter won’t work if you reset your password later.
+        by_mail_password_reminder_html: <strong>Remember your password.</strong> The
+          verification code in your letter won’t work if you reset your password
+          later.
         message: '%{app_name} will encrypt your information with your password. This
           means that your information is secure and only you will be able to
           access or change it.'

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -265,9 +265,9 @@ es:
           - Su número principal (el que utiliza con más frecuencia)
       return_to_profile: '‹ Volver a tu perfil de %{app_name}'
       review:
-        by_mail_password_reminder_html: <b>Recuerde su contraseña.</b> El código de
-          verificación de su carta no funcionará si restablece su contraseña más
-          tarde.
+        by_mail_password_reminder_html: <strong>Recuerde su contraseña.</strong> El
+          código de verificación de su carta no funcionará si restablece su
+          contraseña más tarde.
         message: '%{app_name} encriptará tu información con tu contraseña. Esto
           significa que tu información estará segura y solo tú podrás
           consultarla o modificarla.'

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -279,9 +279,9 @@ fr:
           - Votre numéro principal (celui que vous utilisez le plus souvent)
       return_to_profile: '‹ Revenir à votre profil %{app_name}'
       review:
-        by_mail_password_reminder_html: <b>Mémorisez votre mot de passe.</b> Le code de
-          vérification contenu dans votre lettre ne fonctionnera pas si vous
-          réinitialisez votre mot de passe par la suite.
+        by_mail_password_reminder_html: <strong>Mémorisez votre mot de passe.</strong>
+          Le code de vérification contenu dans votre lettre ne fonctionnera pas
+          si vous réinitialisez votre mot de passe par la suite.
         message: '%{app_name} crypte vos informations avec votre mot de passe. Cela
           signifie que vos informations sont sécurisées et que vous seul pourrez
           y accéder ou les modifier.'

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -99,8 +99,8 @@ en:
     otp_delivery_preference:
       instruction: You can change this anytime. If you use a landline number, select
         “Phone call.”
-      landline_warning_html: The phone number entered appears to be a <b>landline
-        phone</b>. Request a one-time code by %{phone_setup_path} instead.
+      landline_warning_html: The phone number entered appears to be a <strong>landline
+        phone</strong>. Request a one-time code by %{phone_setup_path} instead.
       no_supported_options: We are unable to verify phone numbers from %{location}
       phone_call: phone call
       sms: Text message (SMS)

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -104,9 +104,9 @@ es:
         seguridad para ese número de teléfono.
     otp_delivery_preference:
       instruction: Envíe mensajes de texto y llamadas a este número por defecto.
-      landline_warning_html: Al parecer el número ingresado pertenece a un <b>teléfono
-        fijo</b>. Mejor solicita un código de un solo uso por
-        %{phone_setup_path}.
+      landline_warning_html: Al parecer el número ingresado pertenece a un
+        <strong>teléfono fijo</strong>. Mejor solicita un código de un solo uso
+        por %{phone_setup_path}.
       no_supported_options: No podemos verificar los números de teléfono de %{location}
       phone_call: llamada telefónica
       sms: Mensaje de texto (SMS, sigla en inglés)

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -109,9 +109,9 @@ fr:
         de sécurité à ce numéro de téléphone.
     otp_delivery_preference:
       instruction: Envoyez des messages texte ainsi que des appels par défaut à ce numéro
-      landline_warning_html: Le numéro de téléphone saisi semble être un <b>téléphone
-        fixe</b>. Demandez plutôt un code à usage unique par
-        %{phone_setup_path}.
+      landline_warning_html: Le numéro de téléphone saisi semble être un
+        <strong>téléphone fixe</strong>. Demandez plutôt un code à usage unique
+        par %{phone_setup_path}.
       no_supported_options: Nous ne sommes pas en mesure de vérifier les numéros de
         téléphone de %{location}
       phone_call: appel téléphonique

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -267,8 +267,8 @@ en:
         concerned someone other than you may be trying to access your
         information.
       learn_more_link_text: Learn more about your options
-      reminder_html: As a reminder, <b>%{app_name} will never ask for your login
-        credentials by phone or email</b>. You can take additional steps to
+      reminder_html: As a reminder, <strong>%{app_name} will never ask for your login
+        credentials by phone or email</strong>. You can take additional steps to
         secure your account by enabling two-factor authentication.
       step_1: Visit the %{app_name} website and select sign in
       step_2: Select “forgot your password?” at the bottom of the page

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -283,10 +283,10 @@ es:
         preocupados alguien que no sea usted puede estar intentando acceder a su
         información.
       learn_more_link_text: Conozca más sobre sus opciones
-      reminder_html: Le recordamos que <b>%{app_name} nunca le pedirá sus credenciales
-        de inicio de sesión. por teléfono o correo electrónico</b>. Puede tomar
-        medidas adicionales para proteger su cuenta habilitando la autenticación
-        de dos factores.
+      reminder_html: Le recordamos que <strong>%{app_name} nunca le pedirá sus
+        credenciales de inicio de sesión. por teléfono o correo
+        electrónico</strong>. Puede tomar medidas adicionales para proteger su
+        cuenta habilitando la autenticación de dos factores.
       step_1: Visite el sitio web %{app_name} y seleccione iniciar sesión
       step_2: Seleccione “¿olvidó su contraseña?” al final de la página
       step_3: Siga las instrucciones para restablecer su contraseña

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -293,10 +293,10 @@ fr:
         %{app_name}. Nous sommes concernés quelqu’un d’autre que vous tente
         peut-être d’accéder à vos informations.
       learn_more_link_text: En savoir plus sur vos options
-      reminder_html: Pour rappel, <b>%{app_name} ne vous demandera jamais vos
-        identifiants de connexion par téléphone ou par e-mail</b>. Vous pouvez
-        prendre des mesures supplémentaires pour sécuriser votre compte en
-        activant l’authentification à deux facteurs.
+      reminder_html: Pour rappel, <strong>%{app_name} ne vous demandera jamais vos
+        identifiants de connexion par téléphone ou par e-mail</strong>. Vous
+        pouvez prendre des mesures supplémentaires pour sécuriser votre compte
+        en activant l’authentification à deux facteurs.
       step_1: Visitez le site Web %{app_name} et sélectionnez Connexion
       step_2: Sélectionnez “Vous avez oublié votre mot de passe?” au bas de la page
       step_3: Suivez les instructions pour réinitialiser votre mot de passe

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -266,14 +266,14 @@ test:
     ial: 2
     help_text:
       sign_in:
-        en: <b>First time here from %{sp_name}?</b><p>Your old %{sp_name} username
+        en: <strong>First time here from %{sp_name}?</strong><p>Your old %{sp_name} username
           and password won’t work. Please <a href=%{sp_create_link}>create a Login.gov account</a> using the same email address you use for %{sp_name}. <p><a href="https://login.gov/help/">Learn
           more</a>
-        es: <b>¿Ha venido de %{sp_name}?</b><p>Si tiene un perfil de %{sp_name}
+        es: <strong>¿Ha venido de %{sp_name}?</strong><p>Si tiene un perfil de %{sp_name}
           existente, favor de usar la dirección de correo electrónico primaria o secundaria
           que usó para %{sp_name} para <a href=%{sp_create_link}>crear un nueva cuenta
           de Login.gov</a> <p><a href="https://login.gov/help/">Obtenga más información.</a>
-        fr: <b>Êtes-vous venu(e) de %{sp_name}?</b><p> Si vous avez déjà un profil
+        fr: <strong>Êtes-vous venu(e) de %{sp_name}?</strong><p> Si vous avez déjà un profil
           %{sp_name}, veuillez utiliser l'adresse e-mail principale ou secondaire
           que vous avez utilisée pour %{sp_name} pour <a href=%{sp_create_link}> créer
           votre nouveau compte Login.gov</a> <p><a href="https://login.gov/help/">En

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ServiceProviderSession do
     context 'sp has custom alert' do
       it 'uses the custom template' do
         expect(subject.sp_alert('sign_in')).
-          to eq "<b>custom sign in help text for #{sp.friendly_name}</b>"
+          to eq "<strong>custom sign in help text for #{sp.friendly_name}</strong>"
       end
     end
 

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -8,9 +8,9 @@ FactoryBot.define do
     return_to_sp_url { '/' }
     agency { association :agency }
     help_text do
-      { sign_in: { en: '<b>custom sign in help text for %{sp_name}</b>' },
-        sign_up: { en: '<b>custom sign up help text for %{sp_name}</b>' },
-        forgot_password: { en: '<b>custom forgot password help text for %{sp_name}</b>' } }
+      { sign_in: { en: '<strong>custom sign in help text for %{sp_name}</strong>' },
+        sign_up: { en: '<strong>custom sign up help text for %{sp_name}</strong>' },
+        forgot_password: { en: '<strong>custom forgot password help text for %{sp_name}</strong>' } }
     end
 
     trait :without_help_text do

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -10,7 +10,9 @@ FactoryBot.define do
     help_text do
       { sign_in: { en: '<strong>custom sign in help text for %{sp_name}</strong>' },
         sign_up: { en: '<strong>custom sign up help text for %{sp_name}</strong>' },
-        forgot_password: { en: '<strong>custom forgot password help text for %{sp_name}</strong>' } }
+        forgot_password: {
+          en: '<strong>custom forgot password help text for %{sp_name}</strong>',
+        } }
     end
 
     trait :without_help_text do

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe ServiceProviderUpdater do
       active: true,
       approved: true,
       help_text: {
-        sign_in: { en: '<b>A new different sign-in help text</b>' },
-        sign_up: { en: '<b>A new different help text</b>' },
-        forgot_password: { en: '<b>A new different forgot password help text</b>' },
+        sign_in: { en: '<strong>A new different sign-in help text</strong>' },
+        sign_up: { en: '<strong>A new different help text</strong>' },
+        forgot_password: { en: '<strong>A new different forgot password help text</strong>' },
       },
     }
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11043](https://cm-jira.usa.gov/browse/LG-11043)

## 🛠 Summary of changes

Replace `<b>` tags with `<strong>`. It could be argued that making the service provider name bold is a case of the guideline below, in which case those should be reverted to `<b>`.

```
Note: Docs on when "b" is preferable over "strong" (See "[Usage notes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b#usage_notes)".) 
Use the <b> for cases like keywords in a summary, product names in a review, or other spans of text whose typical 
presentation would be boldfaced (but not including any special importance)." 

It is unlikely we have any such cases of this but we should be aware of it when making this change.
```