### PR TITLE
Add lint check for reasonable asset bundle sizes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,6 +243,7 @@ js_build:
     - *bundle_install
     - *yarn_production_install
     - bundle exec rake assets:precompile
+    - make lint_asset_bundle_size
 
 js_tests:
   stage: test

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 	lint_tracker_events \
 	lint_yaml \
 	lint_yarn_workspaces \
+	lint_asset_bundle_size \
 	lintfix \
 	normalize_yaml \
 	optimize_assets \
@@ -112,6 +113,10 @@ lint_yaml: normalize_yaml ## Lints YAML files
 
 lint_yarn_workspaces: ## Lints Yarn workspace packages
 	scripts/validate-workspaces.js
+
+lint_asset_bundle_size: ## Lints JavaScript and CSS compiled bundle size
+	find app/assets/builds/application.css -size -350000c | grep .
+	find public/packs/js/application-*.digested.js -size -8000c | grep .
 
 lint_migrations:
 	scripts/migration_check

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts'],
-    conditionNames: ['source', 'import', 'require', 'node'],
+    conditionNames: ['source', '...'],
   },
   module: {
     rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts'],
-    conditionNames: ['source', '...'],
+    conditionNames: ['source', 'import', 'require', 'node'],
   },
   module: {
     rules: [


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a check in continuous integration that production-compiled JavaScript and CSS sizes are within a reasonable size constraint.

This is a follow-up to #9217, specifically implementing the suggestion made by @allthesignals at https://github.com/18F/identity-idp/pull/9217#issuecomment-1721692585 .

Currently, limits are set to:

- `application.css` must be less than 350kb (currently 299kb)
- `application.js` must be less than 8kb (currently 4kb) 

## 📜 Testing Plan

Observe CI build results for commit history. I'll push a temporary commit shortly to test a revert of #9217, which should fail the check.