### PR TITLE
Update changelog script to reflect non-security Dependabot usage

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -18,7 +18,7 @@ REVERT_COMMIT_MESSAGE = /This reverts commit ([a-z\d]+)./
 SECURITY_CHANGELOG = {
   category: 'Internal',
   subcategory: 'Dependencies',
-  change: 'Update dependencies to resolve security advisories',
+  change: 'Update dependencies to latest versions',
 }.freeze
 REVERT_CHANGELOG = {
   category: 'Bug Fixes',

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -130,3 +130,18 @@ commit_changelog_with_commas_in_change:
   pr_number: '7000'
   commit_messages:
     - 'changelog:Internal,Changelog,Allow listing one, two, and more items with commas'
+dependabot_dependency_update:
+  commit_log: |
+    title: Bump libphonenumber-js from 1.10.46 to 1.10.47 (#9332)
+    body:...
+
+    Signed-off-by: dependabot[bot] <support@github.com>
+    DELIMITER
+  title: Bump libphonenumber-js from 1.10.46 to 1.10.47 (#9332)
+  category: Internal
+  subcategory: Dependencies
+  change: Update dependencies to latest versions
+  pr_number: '9332'
+  commit_messages:
+    - '...'
+    - 'Signed-off-by: dependabot[bot] <support@github.com>'

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'scripts/changelog_check' do
     it 'builds a git log into structured changelog objects' do
       git_log = git_fixtures.values.pluck('commit_log').join("\n")
       changelog_entries = generate_changelog(git_log)
-      expect(changelog_entries.length).to eq 8
+      expect(changelog_entries.length).to eq 9
       fixture_and_changelog = git_fixtures.values.filter do |x|
         x['category'].present?
       end.zip(changelog_entries)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the messaging generated by the changelog script to accommodate actual usage including updates for non-security related dependency updates.

We use Dependabot for automated updates to several dependencies, not just for security updates ([see config](https://github.com/18F/identity-idp/blob/main/.github/dependabot.yml)).

Previously, these would generate messaging in changelogs of "Update dependencies to resolve security advisories" (see #9344 as example).

The changes here generalize the messaging to "Update dependencies to latest versions", which should accommodate both security and non-security dependency updates.

## 📜 Testing Plan

```
rspec spec/scripts/changelog_check_spec.rb
```