### PR TITLE
LG-11083: Enable USPS Public Endpoint

### DIFF
--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -3,7 +3,6 @@ module Idv
     module Public
       class UspsLocationsController < ApplicationController
         include RenderConditionConcern
-        include UspsInPersonProofing
 
         check_or_render_not_found -> { enabled? }
 
@@ -27,7 +26,7 @@ module Idv
         protected
 
         def proofer
-          @proofer ||= EnrollmentHelper.usps_proofer
+          @proofer ||= UspsInPersonProofing::EnrollmentHelper.usps_proofer
         end
 
         def enabled?


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-11083)

## 🛠 Summary of changes

Enables USPS search endpoint. Switches to mock data when `usps_mock_fallback` flag is enabled.

## 📜 Testing Plan

To set this up locally:

In IDP, make sure you have USPS credentials set up in your application.yml. Then, set:
`usps_mock_fallback: false`

Run the IDP locally.

In identity-sites, create a file `_config.dev.yml` and add these values in it:

```
show_po_search: true
po_search_address_search_url: http://127.0.0.1:3000/api/address_search
po_search_locations_search_url: http://127.0.0.1:3000/api/usps_locations
skip_idp_translations: false
```

Run identity sites and visit [this](http://127.0.0.1:4000/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/). 