### PR TITLE
Exclude 'IRS Attempt API: Event metadata' events from log results

### DIFF
--- a/lib/data_requests/local/fetch_cloudwatch_logs.rb
+++ b/lib/data_requests/local/fetch_cloudwatch_logs.rb
@@ -78,7 +78,7 @@ module DataRequests
       def query_string
         <<~QUERY
           fields @timestamp, @message
-          | filter @message like /#{uuid}/
+          | filter properties.user_id = '#{uuid}' and name != 'IRS Attempt API: Event metadata'
         QUERY
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

In discussing results of this report, it can be confusing to include these events since it mentions the IRS and understandably can suggest there is a link with the IRS in the logs (which is rarely the case).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
