### PR TITLE
Fix bug in reporting "months" helper

### DIFF
--- a/app/jobs/reports/month_helper.rb
+++ b/app/jobs/reports/month_helper.rb
@@ -17,6 +17,8 @@ module Reports
     def months(date_range)
       return [date_range] if start_end_same_month?(date_range)
 
+      results = []
+
       results << (date_range.begin..date_range.begin.end_of_month)
 
       current = date_range.begin.end_of_month + 1.day

--- a/app/jobs/reports/month_helper.rb
+++ b/app/jobs/reports/month_helper.rb
@@ -15,7 +15,7 @@ module Reports
     # @param [Range<Date>] date_range
     # @return [Array<Range<Date>>]
     def months(date_range)
-      results = []
+      return [date_range] if start_end_same_month?(date_range)
 
       results << (date_range.begin..date_range.begin.end_of_month)
 
@@ -32,6 +32,14 @@ module Reports
       results << (date_range.end.beginning_of_month..date_range.end) if current < date_range.end
 
       results
+    end
+
+    # @api private
+    def start_end_same_month?(date_range)
+      start_date = date_range.begin
+      end_date = date_range.end
+
+      start_date.year == end_date.year && start_date.month == end_date.month
     end
   end
 end

--- a/spec/jobs/reports/month_helper_spec.rb
+++ b/spec/jobs/reports/month_helper_spec.rb
@@ -21,5 +21,14 @@ RSpec.describe Reports::MonthHelper do
         ],
       )
     end
+
+    it 'correctly returns a partial month when the first month is a partial month' do
+      expect(months(Date.new(2022, 1, 1)..Date.new(2022, 1, 28))).to eq(
+        [
+          Date.new(2022, 1, 1)..Date.new(2022, 1, 28),
+        ],
+      )
+    end
+
   end
 end

--- a/spec/jobs/reports/month_helper_spec.rb
+++ b/spec/jobs/reports/month_helper_spec.rb
@@ -29,6 +29,5 @@ RSpec.describe Reports::MonthHelper do
         ],
       )
     end
-
   end
 end


### PR DESCRIPTION
- If the first month was a partial month, the code would inadvertently return the whole month instead of just that partial month

- This came up for a one-off reporting request, most production agreements last longer than just a month


