### PR TITLE
LG-11221 Personal key doesn't change on page refresh

### DIFF
--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -30,6 +30,7 @@ module Idv
         fraud_review_pending: fraud_review_pending?,
         fraud_rejection: fraud_rejection?,
       )
+      idv_session.personal_key = nil
       redirect_to next_step
     end
 
@@ -64,7 +65,7 @@ module Idv
       @personal_key_generated_at = current_user.personal_key_generated_at
 
       user_session[:personal_key] = @code
-      idv_session.personal_key = nil
+      idv_session.personal_key = @code
 
       irs_attempts_api_tracker.idv_personal_key_generated
     end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -64,7 +64,6 @@ module Idv
       @code = personal_key
       @personal_key_generated_at = current_user.personal_key_generated_at
 
-      user_session[:personal_key] = @code
       idv_session.personal_key = @code
 
       irs_attempts_api_tracker.idv_personal_key_generated

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe AccountsController do
   describe 'before_actions' do
-    it 'includes before_actions from AccountStateChecker' do
+    it 'includes before_actions' do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Idv::PersonalKeyController do
   end
 
   describe 'before_actions' do
-    it 'includes before_actions from AccountStateChecker' do
+    it 'includes before_actions' do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
@@ -133,6 +133,16 @@ RSpec.describe Idv::PersonalKeyController do
       subject.idv_session.create_profile_from_applicant_with_password(password)
       code = subject.idv_session.personal_key
 
+      get :show
+
+      expect(assigns(:code)).to eq(code)
+    end
+
+    it 'shows the same personal key when page is refreshed' do
+      subject.idv_session.create_profile_from_applicant_with_password(password)
+      code = subject.idv_session.personal_key
+
+      get :show
       get :show
 
       expect(assigns(:code)).to eq(code)

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Idv::ReviewController do
   end
 
   describe 'before_actions' do
-    it 'includes before_actions from AccountStateChecker' do
+    it 'includes before_actions' do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,


### PR DESCRIPTION
## 🎫 Ticket

[LG-11221](https://cm-jira.usa.gov/browse/LG-11221)

## 🛠 Summary of changes

Previously, when the user refreshed the Personal Key page, a new key was generated each time. This could prevent the user from recovering their account if they saved the previous key and didn't notice it had changed. Now, the personal key remains the same when the page is refreshed.

## 📜 Testing Plan

- [ ] Go through IdV up to personal key page
- [ ] Refresh page
- [ ] Expect key to be unchanged.
