### PR TITLE
Count successful phone proofing attempts towards the rate limit

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -174,11 +174,11 @@ module Idv
         ),
       )
 
-      if async_state.result[:success]
-        rate_limiter.reset!
-        redirect_to_next_step and return
+      if form_result.success?
+        redirect_to_next_step
+      else
+        handle_proofing_failure
       end
-      handle_proofing_failure
     end
 
     def is_req_from_frontend?

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Idv::PhoneController do
         end
 
         context 'the user submited their last attempt' do
-          it 'it redirects to the OTP confirmation and the rate limiter is maxed' do
+          it 'redirects to the OTP confirmation and the rate limiter is maxed' do
             RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
 
             get :new

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -162,6 +162,74 @@ RSpec.describe Idv::PhoneController do
       get :new
       expect(response).to render_template :wait
     end
+
+    context 'when the document capture session has a doc auth result' do
+      let(:phone) { '2025555555' }
+
+      before do
+        subject.idv_session.previous_phone_step_params = {
+          phone: phone, international_code: 'US', otp_delivery_preference: 'sms'
+        }
+        document_capture_session = DocumentCaptureSession.create(
+          user_id: user.id,
+          requested_at: Time.zone.now,
+        )
+        document_capture_session.create_proofing_session
+        subject.idv_session.idv_phone_step_document_capture_session_uuid =
+          document_capture_session.uuid
+        proofing_result = Proofing::Mock::AddressMockClient.new.proof(phone: phone)
+        document_capture_session.store_proofing_result(proofing_result)
+      end
+
+      context 'when the result is successful' do
+        it 'sends an OTP and redirects to OTP confirmation' do
+          get :new
+
+          expect(response).to redirect_to(idv_otp_verification_url)
+          expect(subject.idv_session.vendor_phone_confirmation).to eq(true)
+          expect(subject.idv_session.user_phone_confirmation).to eq(false)
+          expect(Telephony::Test::Message.messages.length).to eq(1)
+        end
+
+        context 'the user submited their last attempt' do
+          it 'it redirects to the OTP confirmation and the rate limiter is maxed' do
+            RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
+
+            get :new
+
+            expect(response).to redirect_to(idv_otp_verification_url)
+            expect(Telephony::Test::Message.messages.length).to eq(1)
+            expect(RateLimiter.new(user: user, rate_limit_type: :proof_address).maxed?).to eq(true)
+          end
+        end
+      end
+
+      context 'when the doc auth result is not successful' do
+        # This is a test phone number that causes the mock proofer to fail
+        let(:phone) { Proofing::Mock::AddressMockClient::UNVERIFIABLE_PHONE_NUMBER }
+
+        it 'does not send an otp and redirects to the error page' do
+          get :new
+
+          expect(response).to redirect_to(idv_phone_errors_warning_url)
+          expect(subject.idv_session.vendor_phone_confirmation).to eq(nil)
+          expect(subject.idv_session.user_phone_confirmation).to eq(nil)
+          expect(Telephony::Test::Message.messages.length).to eq(0)
+        end
+
+        context 'the user submited their last attempt' do
+          it 'it redirects to the failure page and the rate limiter is maxed' do
+            RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
+
+            get :new
+
+            expect(response).to redirect_to(idv_phone_errors_failure_url)
+            expect(Telephony::Test::Message.messages.length).to eq(0)
+            expect(RateLimiter.new(user: user, rate_limit_type: :proof_address).maxed?).to eq(true)
+          end
+        end
+      end
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
We do not currently count successful proofing attempts towards the rate limit. This was done to support a feature that prevented users from being rate limited after successfully completing a step. The logic that caused that issue was addressed in #9343.

This commit starts counting successful attempts to towards the rate limit. This protects our vendors from abuse and makes it easier for us to make this step re-entrant to support the back button.
