### PR TITLE
LG-11189 Count successful doc auth proofing towards the rate limit

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -5,7 +5,7 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
 
-    before_action :confirm_not_rate_limited
+    before_action :confirm_not_rate_limited, except: [:update]
     before_action :confirm_hybrid_handoff_complete
     before_action :confirm_document_capture_needed
     before_action :override_csp_to_allow_acuant

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -116,7 +116,6 @@ module Idv
 
       if client_response.success? && response.success?
         store_pii(client_response)
-        rate_limiter.reset!
       end
 
       response

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -105,6 +105,10 @@ RSpec.feature 'document capture step', :js do
         it 'proceeds to the next page with valid info' do
           attach_and_submit_images
           expect(page).to have_current_path(idv_ssn_url)
+
+          visit idv_document_capture_path
+
+          expect(page).to have_current_path(idv_session_errors_rate_limited_path)
         end
       end
     end


### PR DESCRIPTION
Prior to this commit we reset the doc auth rate limiter on success. This was done to prevent users from being rate limited after successfully completing a step. The logic that caused that issue was addressed in #9343.

This commit starts counting successful attempts to towards the rate limit. This protects our vendors from abuse and makes it easier for us to make this step re-entrant to support the back button.
