### PR TITLE
LG-11190 Don't reset the SSN rate limit on successful submission

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -239,7 +239,6 @@ module Idv
     def summarize_result_and_rate_limit_failures(summary_result)
       if summary_result.success?
         add_proofing_components
-        ssn_rate_limiter.reset!
       else
         idv_failure(summary_result)
       end

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     expect(page).to have_current_path(idv_verify_info_path)
   end
 
-  context 'resolution throttling' do
+  context 'resolution rate limiting' do
     let(:max_resolution_attempts) { 3 }
     before do
       allow(IdentityConfig.store).to receive(:idv_max_attempts).
@@ -196,7 +196,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     end
   end
 
-  context 'ssn throttling' do
+  context 'ssn rate limiting' do
     # Simulates someone trying same SSN with second account
     let(:max_resolution_attempts) { 4 }
     let(:max_ssn_attempts) { 3 }


### PR DESCRIPTION
Prior to this commit we reset the ss rate limiter on success. This was done to prevent users from being rate limited after successfully completing a step. The logic that caused that issue was addressed in #9343.

This commit starts counting successful attempts to towards the rate limit. This protects our users from fraud and makes it easier for us to make this step re-entrant to support the back button.
