### PR TITLE
LG-11042: increment idv_resolution rate limiter on success.

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -217,6 +217,8 @@ module Idv
         idv_session.mark_verify_info_step_complete!
         idv_session.invalidate_steps_after_verify_info!
 
+        resolution_rate_limiter.increment!
+
         flash[:success] = t('doc_auth.forms.doc_success')
         redirect_to next_step_url
       else

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -89,8 +89,6 @@ module Idv
         :mva_exception,
       )
 
-      resolution_rate_limiter.increment! if proofing_results_exception.blank?
-
       if ssn_rate_limiter.limited?
         idv_failure_log_rate_limited(:proof_ssn)
         redirect_to idv_session_errors_ssn_failure_url
@@ -208,7 +206,7 @@ module Idv
       )
 
       form_response = form_response.merge(check_ssn) if form_response.success?
-      summarize_result_and_rate_limit_failures(form_response)
+      summarize_result_and_rate_limit(form_response)
       delete_async
 
       if form_response.success?
@@ -216,8 +214,6 @@ module Idv
         move_applicant_to_idv_session
         idv_session.mark_verify_info_step_complete!
         idv_session.invalidate_steps_after_verify_info!
-
-        resolution_rate_limiter.increment!
 
         flash[:success] = t('doc_auth.forms.doc_success')
         redirect_to next_step_url
@@ -238,7 +234,10 @@ module Idv
       idv_session.threatmetrix_review_status = review_status
     end
 
-    def summarize_result_and_rate_limit_failures(summary_result)
+    def summarize_result_and_rate_limit(summary_result)
+      proofing_results_exception = summary_result.extra.dig(:proofing_results, :exception)
+      resolution_rate_limiter.increment! if proofing_results_exception.blank?
+
       if summary_result.success?
         add_proofing_components
       else

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
 
   let(:fake_analytics) { FakeAnalytics.new }
   let(:fake_attempts_tracker) { IrsAttemptsApiTrackingHelper::FakeAttemptsTracker.new }
+  let(:user) { user_with_2fa }
 
   # values from Idp::Constants::MOCK_IDV_APPLICANT
   let(:fake_pii_details) do
@@ -25,7 +26,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ApplicationController).to receive(:irs_attempts_api_tracker).
       and_return(fake_attempts_tracker)
-    sign_in_and_2fa_user
+    sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_ssn_step
   end
 
@@ -182,11 +183,12 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       expect(page).to have_current_path(idv_session_errors_failure_path)
 
       travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
-        sign_in_and_2fa_user
+        sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_verify_step
         click_idv_continue
 
         expect(page).to have_current_path(idv_phone_path)
+        expect(RateLimiter.new(user: user, rate_limit_type: :idv_resolution)).to be_limited
       end
     end
 
@@ -232,7 +234,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
 
       travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
-        sign_in_and_2fa_user
+        sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_verify_step
         click_idv_continue
 
@@ -281,7 +283,6 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
         allow(IdentityConfig.store).to receive(:aamva_supported_jurisdictions).and_return(
           mock_state_id_jurisdiction,
         )
-        user = create(:user, :fully_registered)
         expect_any_instance_of(Idv::Agent).
           to receive(:proof_resolution).
           with(
@@ -306,7 +307,6 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
           IdentityConfig.store.aamva_supported_jurisdictions -
             mock_state_id_jurisdiction,
         )
-        user = create(:user, :fully_registered)
         expect_any_instance_of(Idv::Agent).
           to receive(:proof_resolution).
           with(
@@ -329,7 +329,6 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       it 'does not perform the state ID check' do
         allow(IdentityConfig.store).to receive(:aamva_sp_banlist_issuers).
           and_return("[\"#{OidcAuthHelper::OIDC_IAL1_ISSUER}\"]")
-        user = create(:user, :fully_registered)
         expect_any_instance_of(Idv::Agent).
           to receive(:proof_resolution).
           with(
@@ -352,7 +351,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
 
   context 'async missing' do
     it 'allows resubmitting form' do
-      sign_in_and_2fa_user
+      sign_in_and_2fa_user(user)
       complete_doc_auth_steps_before_verify_step
 
       allow(DocumentCaptureSession).to receive(:find_by).
@@ -374,7 +373,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
         **fake_pii_details,
         ssn: DocAuthHelper::GOOD_SSN,
       )
-      sign_in_and_2fa_user
+      sign_in_and_2fa_user(user)
       complete_doc_auth_steps_before_verify_step
 
       allow(DocumentCaptureSession).to receive(:find_by).
@@ -389,7 +388,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
 
   context 'async timed out' do
     it 'allows resubmitting form' do
-      sign_in_and_2fa_user
+      sign_in_and_2fa_user(user)
       complete_doc_auth_steps_before_verify_step
 
       allow(DocumentCaptureSession).to receive(:find_by).
@@ -408,7 +407,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     before do
       allow_any_instance_of(OutageStatus).to receive(:any_phone_vendor_outage?).and_return(true)
       visit_idp_from_sp_with_ial2(:oidc)
-      sign_in_and_2fa_user
+      sign_in_and_2fa_user(user)
       complete_doc_auth_steps_before_verify_step
     end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11042](https://cm-jira.usa.gov/browse/LG-11042)

## 🛠 Summary of changes

This commit starts counting successful attempts to verify info towards the idv_resolution rate limit. This affects remote and in-person verify info.