### PR TITLE
LG-10869 Rename the review step to the enter password step

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -1,5 +1,5 @@
 module Idv
-  class ReviewController < ApplicationController
+  class EnterPasswordController < ApplicationController
     before_action :personal_key_confirmed
 
     include IdvStepConcern
@@ -19,7 +19,7 @@ module Idv
     def new
       Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
         call(:encrypt, :view, true)
-      analytics.idv_review_info_visited(
+      analytics.idv_enter_password_visited(
         address_verification_method: address_verification_method,
         **ab_test_analytics_buckets,
       )
@@ -51,7 +51,7 @@ module Idv
 
       redirect_to next_step
 
-      analytics.idv_review_complete(
+      analytics.idv_enter_password_complete(
         success: true,
         fraud_review_pending: idv_session.profile.fraud_review_pending?,
         fraud_rejection: idv_session.profile.fraud_rejection?,
@@ -84,21 +84,21 @@ module Idv
     private
 
     def title
-      gpo_user_flow? ? t('titles.idv.review_letter') : t('titles.idv.review')
+      gpo_user_flow? ? t('titles.idv.enter_password_letter') : t('titles.idv.enter_password')
     end
 
     def heading
       if gpo_user_flow?
-        t('idv.titles.session.review_letter', app_name: APP_NAME)
+        t('idv.titles.session.enter_password_letter', app_name: APP_NAME)
       else
-        t('idv.titles.session.review', app_name: APP_NAME)
+        t('idv.titles.session.enter_password', app_name: APP_NAME)
       end
     end
 
     def confirm_current_password
       return if valid_password?
 
-      analytics.idv_review_complete(
+      analytics.idv_enter_password_complete(
         success: false,
         gpo_verification_pending: current_user.gpo_verification_pending_profile?,
         # note: this always returns false as of 8/23

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -33,7 +33,7 @@ module Idv
       if result.success?
         idv_session.user_phone_confirmation = true
         save_in_person_notification_phone
-        flash[:success] = t('idv.messages.review.phone_verified')
+        flash[:success] = t('idv.messages.enter_password.phone_verified')
         redirect_to idv_review_url
       else
         handle_otp_confirmation_failure

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -948,6 +948,55 @@ module AnalyticsEvents
     track_event('IdV: doc auth welcome visited', **extra) # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
   end
 
+  # User submitted IDV password confirm page
+  # @param [Boolean] success
+  # @param [Boolean] fraud_review_pending
+  # @param [Boolean] fraud_rejection
+  # @param [Boolean] gpo_verification_pending
+  # @param [Boolean] in_person_verification_pending
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
+  def idv_enter_password_complete(
+    success:,
+    fraud_review_pending:,
+    fraud_rejection:,
+    gpo_verification_pending:,
+    in_person_verification_pending:,
+    deactivation_reason: nil,
+    proofing_components: nil,
+    **extra
+  )
+    track_event(
+      'IdV: review complete', # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
+      success: success,
+      deactivation_reason: deactivation_reason,
+      fraud_review_pending: fraud_review_pending,
+      gpo_verification_pending: gpo_verification_pending,
+      in_person_verification_pending: in_person_verification_pending,
+      fraud_rejection: fraud_rejection,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
+  # @param [Idv::ProofingComponentsLogging] proofing_components User's
+  #        current proofing components
+  # @param [String] address_verification_method The method (phone or gpo) being
+  #        used to verify the user's identity
+  # User visited IDV password confirm page
+  def idv_enter_password_visited(
+    proofing_components: nil,
+    address_verification_method: nil,
+    **extra
+  )
+    track_event(
+      'IdV: review info visited', # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
+      address_verification_method: address_verification_method,
+      proofing_components: proofing_components,
+      **extra,
+    )
+  end
+
   # @param [Boolean] success
   # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
   # @param [Boolean] fraud_review_pending Profile is under review for fraud
@@ -2346,53 +2395,6 @@ module AnalyticsEvents
     track_event(
       'IdV: request letter visited', # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
       letter_already_sent: letter_already_sent,
-      **extra,
-    )
-  end
-
-  # User submitted IDV password confirm page
-  # @param [Boolean] success
-  # @param [Boolean] fraud_review_pending
-  # @param [Boolean] fraud_rejection
-  # @param [Boolean] gpo_verification_pending
-  # @param [Boolean] in_person_verification_pending
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
-  def idv_review_complete(
-    success:,
-    fraud_review_pending:,
-    fraud_rejection:,
-    gpo_verification_pending:,
-    in_person_verification_pending:,
-    deactivation_reason: nil,
-    proofing_components: nil,
-    **extra
-  )
-    track_event(
-      'IdV: review complete', # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
-      success: success,
-      deactivation_reason: deactivation_reason,
-      fraud_review_pending: fraud_review_pending,
-      gpo_verification_pending: gpo_verification_pending,
-      in_person_verification_pending: in_person_verification_pending,
-      fraud_rejection: fraud_rejection,
-      proofing_components: proofing_components,
-      **extra,
-    )
-  end
-
-  # @param [Idv::ProofingComponentsLogging] proofing_components User's
-  #        current proofing components
-  # @param [String] address_verification_method The method (phone or gpo) being
-  #        used to verify the user's identity
-  # User visited IDV password confirm page
-  def idv_review_info_visited(proofing_components: nil,
-                              address_verification_method: nil,
-                              **extra)
-    track_event(
-      'IdV: review info visited', # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
-      address_verification_method: address_verification_method,
-      proofing_components: proofing_components,
       **extra,
     )
   end

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -29,8 +29,8 @@ module Idv
       idv_phone_otp_delivery_selection_visit
       idv_phone_otp_delivery_selection_submitted
       idv_proofing_resolution_result_missing
-      idv_review_complete
-      idv_review_info_visited
+      idv_enter_password_complete
+      idv_enter_password_visited
       idv_please_call_visited
       idv_start_over
     ].freeze

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -17,11 +17,8 @@ module Idv
       current_user.pending_profile.created_at < min_creation_date
     end
 
-    # Next two methods are analytics helpers used from RequestLetterController and ReviewController
-
-    # Caveat: If the user succeeds on their final phone attempt, the :proof_address
-    # RateLimiter is reset to 0. But they probably wouldn't be doing verify by mail
-    # if they succeeded on the phone step.
+    # Next two methods are analytics helpers used from RequestLetterController and
+    # EnterPasswordController
     def phone_step_attempts
       RateLimiter.new(user: @current_user, rate_limit_type: :proof_address).attempts
     end

--- a/app/views/idv/enter_password/new.html.erb
+++ b/app/views/idv/enter_password/new.html.erb
@@ -12,7 +12,7 @@
 <%= render PageHeadingComponent.new.with_content(@heading) %>
 
 <p>
-  <%= t('idv.messages.review.message', app_name: APP_NAME) %>
+  <%= t('idv.messages.enter_password.message', app_name: APP_NAME) %>
 </p>
 
 <%= simple_form_for(
@@ -40,7 +40,7 @@
           id: 'by-mail-password-warning',
           class: 'margin-top-4',
         ) do
-          t('idv.messages.review.by_mail_password_reminder_html')
+          t('idv.messages.enter_password.by_mail_password_reminder_html')
         end
     %>
   <% end %>

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -1,9 +1,9 @@
-<% title t('idv.titles.review') %>
+<% title t('idv.titles.enter_password') %>
 
-<%= render PageHeadingComponent.new.with_content(t('idv.titles.session.review', app_name: APP_NAME)) %>
+<%= render PageHeadingComponent.new.with_content(t('idv.titles.session.enter_password', app_name: APP_NAME)) %>
 
 <p>
-  <%= t('idv.messages.sessions.review_message', app_name: APP_NAME) %>
+  <%= t('idv.messages.sessions.enter_password_message', app_name: APP_NAME) %>
 </p>
 
 <%= simple_form_for(

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -228,6 +228,14 @@ en:
         no longer work and you’ll have to verify your identity again.
       come_back_later_sp_html: You can return to <strong>%{sp}</strong> for now.
       confirm: We secured your verified information
+      enter_password:
+        by_mail_password_reminder_html: <strong>Remember your password.</strong> The
+          verification code in your letter won’t work if you reset your password
+          later.
+        message: '%{app_name} will encrypt your information with your password. This
+          means that your information is secure and only you will be able to
+          access or change it.'
+        phone_verified: We verified your phone number
       gpo:
         address_on_file: 'We’ll mail the letter to the address you verified earlier:'
         another_letter_on_the_way: We are sending you another letter
@@ -257,34 +265,27 @@ en:
           - Based in the United States (including U.S. territories)
           - Your primary number (the one you use the most often)
       return_to_profile: '‹ Return to your %{app_name} profile'
-      review:
-        by_mail_password_reminder_html: <strong>Remember your password.</strong> The
-          verification code in your letter won’t work if you reset your password
-          later.
-        message: '%{app_name} will encrypt your information with your password. This
-          means that your information is secure and only you will be able to
-          access or change it.'
-        phone_verified: We verified your phone number
       select_verification_with_sp: To protect you from identity fraud, we will contact
         you to confirm that this %{sp_name} account is legitimate.
       select_verification_without_sp: To protect you from identity fraud, we will
         contact you to confirm that this account is legitimate.
       sessions:
+        enter_password_message: When you re-enter your password, %{app_name} will
+          protect the information you’ve given us, so that only you can access
+          it.
         no_pii: TEST SITE - Do not use real personal information (demo purposes only) -
           TEST SITE
-        review_message: When you re-enter your password, %{app_name} will protect the
-          information you’ve given us, so that only you can access it.
       verifying: Verifying…
     titles:
       activated: Your identity has already been verified
       come_back_later: Your letter is on the way
+      enter_password: Review and submit
       mail:
         verify: Verify your address
       otp_delivery_method: How should we send a code?
-      review: Review and submit
       session:
-        review: Re-enter your %{app_name} password
-        review_letter: Re-enter your %{app_name} password to send your letter
+        enter_password: Re-enter your %{app_name} password
+        enter_password_letter: Re-enter your %{app_name} password to send your letter
       unavailable: 'We are working to resolve an error'
     troubleshooting:
       headings:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -238,6 +238,14 @@ es:
         funcionará y tendrá que verificar su identidad de nuevo.
       come_back_later_sp_html: Ahora puedes volver a <strong>%{sp}</strong>.
       confirm: Hemos asegurado su información verificada
+      enter_password:
+        by_mail_password_reminder_html: <strong>Recuerde su contraseña.</strong> El
+          código de verificación de su carta no funcionará si restablece su
+          contraseña más tarde.
+        message: '%{app_name} encriptará tu información con tu contraseña. Esto
+          significa que tu información estará segura y solo tú podrás
+          consultarla o modificarla.'
+        phone_verified: Verificamos su número de teléfono
       gpo:
         address_on_file: 'Enviaremos la carta por correo a la dirección que verificó
           anteriormente:'
@@ -270,35 +278,28 @@ es:
           - Con base en Estados Unidos (incluidos los territorios de EE.UU.)
           - Su número principal (el que utiliza con más frecuencia)
       return_to_profile: '‹ Volver a tu perfil de %{app_name}'
-      review:
-        by_mail_password_reminder_html: <strong>Recuerde su contraseña.</strong> El
-          código de verificación de su carta no funcionará si restablece su
-          contraseña más tarde.
-        message: '%{app_name} encriptará tu información con tu contraseña. Esto
-          significa que tu información estará segura y solo tú podrás
-          consultarla o modificarla.'
-        phone_verified: Verificamos su número de teléfono
       select_verification_with_sp: Para protegerlo de robo de identidad, no puede
         utilizar su cuenta en %{sp_name} hasta que la active ingresando un
         código único.
       select_verification_without_sp: Para proteger su cuenta de robo de identidad, su
         perfil no se activará hasta que ingrese un código único.
       sessions:
+        enter_password_message: Cuando vuelva a ingresar su contraseña, %{app_name}
+          cifrará sus datos para asegurarse de que nadie más pueda acceder a
+          ellos.
         no_pii: SITIO DE PRUEBA - No utilice información personal real (sólo para
           propósitos de demostración) - SITIO DE PRUEBA
-        review_message: Cuando vuelva a ingresar su contraseña, %{app_name} cifrará sus
-          datos para asegurarse de que nadie más pueda acceder a ellos.
       verifying: Verificando…
     titles:
       activated: Ya se verificó tu identidad.
       come_back_later: Su carta está en camino
+      enter_password: Revise y envíe
       mail:
         verify: Verifique su dirección
       otp_delivery_method: '¿Cómo debemos enviar un código?'
-      review: Revise y envíe
       session:
-        review: 'Vuelve a ingresar tu contraseña de %{app_name}'
-        review_letter: 'Vuelve a ingresar su contraseña de %{app_name} para enviar su carta'
+        enter_password: 'Vuelve a ingresar tu contraseña de %{app_name}'
+        enter_password_letter: 'Vuelve a ingresar su contraseña de %{app_name} para enviar su carta'
       unavailable: Estamos trabajando para resolver un error
     troubleshooting:
       headings:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -251,6 +251,14 @@ fr:
         serez obligé de vérifier à nouveau votre identité.
       come_back_later_sp_html: Vous pouvez retourner à l’agence <strong>%{sp}</strong> pour le moment.
       confirm: Nous avons sécurisé vos informations vérifiées
+      enter_password:
+        by_mail_password_reminder_html: <strong>Mémorisez votre mot de passe.</strong>
+          Le code de vérification contenu dans votre lettre ne fonctionnera pas
+          si vous réinitialisez votre mot de passe par la suite.
+        message: '%{app_name} crypte vos informations avec votre mot de passe. Cela
+          signifie que vos informations sont sécurisées et que vous seul pourrez
+          y accéder ou les modifier.'
+        phone_verified: Nous avons vérifié votre numéro de téléphone
       gpo:
         address_on_file: 'Nous enverrons la lettre à l’adresse que vous avez vérifiée
           précédemment:'
@@ -282,14 +290,6 @@ fr:
           - Basé aux Etats-Unis (y compris les territoires américains)
           - Votre numéro principal (celui que vous utilisez le plus souvent)
       return_to_profile: '‹ Revenir à votre profil %{app_name}'
-      review:
-        by_mail_password_reminder_html: <strong>Mémorisez votre mot de passe.</strong>
-          Le code de vérification contenu dans votre lettre ne fonctionnera pas
-          si vous réinitialisez votre mot de passe par la suite.
-        message: '%{app_name} crypte vos informations avec votre mot de passe. Cela
-          signifie que vos informations sont sécurisées et que vous seul pourrez
-          y accéder ou les modifier.'
-        phone_verified: Nous avons vérifié votre numéro de téléphone
       select_verification_with_sp: Afin de vous protéger des fraudes d’identité, vous
         ne pouvez pas utiliser votre compte au %{sp_name} tant que vous ne
         l’aurez pas activé en entrant votre code à usage unique.
@@ -297,22 +297,23 @@ fr:
         à l’identité, votre profil ne sera pas activé tant que vous n’aurez pas
         entré votre code à usage unique.
       sessions:
+        enter_password_message: Lorsque vous entrez à nouveau votre mot de passe,
+          %{app_name} crypte vos données pour vous assurer que personne ne peut
+          y accéder.
         no_pii: SITE DE TEST - N’utilisez pas de véritables données personnelles (il
           s’agit d’une démonstration seulement) - SITE DE TEST
-        review_message: Lorsque vous entrez à nouveau votre mot de passe, %{app_name}
-          crypte vos données pour vous assurer que personne ne peut y accéder.
       verifying: Vérification…
     titles:
       activated: Votre identité a déjà été vérifiée
       come_back_later: Votre lettre est en route
+      enter_password: Réviser et soumettre
       mail:
         verify: Vérifiez votre adresse
       otp_delivery_method: Comment envoyer un code?
-      review: Réviser et soumettre
       session:
-        review: 'Saisissez à nouveau votre mot de passe %{app_name}'
-        review_letter: 'Saisissez à nouveau votre mot de passe %{app_name} pour envoyer
-          votre lettre'
+        enter_password: 'Saisissez à nouveau votre mot de passe %{app_name}'
+        enter_password_letter: 'Saisissez à nouveau votre mot de passe %{app_name} pour
+          envoyer votre lettre'
       unavailable: Nous travaillons à la résolution d’une erreur
     troubleshooting:
       headings:

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -35,12 +35,12 @@ en:
       cancelled: Identity verification is cancelled
       come_back_soon: Come back soon
       enter_one_time_code: Enter your one-time code
+      enter_password: Re-enter your password
+      enter_password_letter: Re-enter your password to send your letter
       get_letter: Get a letter
       personal_key: Save your personal key
       phone: Verify your phone number
       reset_password: Reset Password
-      review: Re-enter your password
-      review_letter: Re-enter your password to send your letter
       verify_info: Verify your information
     mfa_setup:
       suggest_second_mfa: You’ve added your first authentication method! Add a second

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -35,12 +35,12 @@ es:
       cancelled: Se canceló la verificación de identidad
       come_back_soon: Vuelve pronto
       enter_one_time_code: Introduzca su código único
+      enter_password: Vuelve a ingresar tu contraseña
+      enter_password_letter: Vuelve a ingresar tu contraseña para enviar su carta
       get_letter: Recibe una carta
       personal_key: Guarda tu llave personal
       phone: Verifique su número de teléfono
       reset_password: Restablecer la contraseña
-      review: Vuelve a ingresar tu contraseña
-      review_letter: Vuelve a ingresar tu contraseña para enviar su carta
       verify_info: Verifica tu información
     mfa_setup:
       suggest_second_mfa: '¡Has agregado tu primer método de autenticación! Agrega un

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -35,12 +35,12 @@ fr:
       cancelled: La vérification d’identité est annulée
       come_back_soon: Revenez bientôt
       enter_one_time_code: Entrez votre code à usage unique
+      enter_password: Saisissez à nouveau votre mot de passe
+      enter_password_letter: Saisissez à nouveau votre mot de passe pour envoyer votre lettre’
       get_letter: Obtenez une lettre
       personal_key: Enregistrez votre clé personnelle
       phone: Vérifiez votre numéro de téléphone
       reset_password: Réinitialisez le mot de passe
-      review: Saisissez à nouveau votre mot de passe
-      review_letter: Saisissez à nouveau votre mot de passe pour envoyer votre lettre’
       verify_info: Vérifiez vos informations
     mfa_setup:
       suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification !

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -348,8 +348,11 @@ Rails.application.routes.draw do
       post '/phone/resend_code' => 'resend_otp#create', as: :resend_otp
       get '/phone_confirmation' => 'otp_verification#show', as: :otp_verification
       put '/phone_confirmation' => 'otp_verification#update', as: :nil
-      get '/review' => 'review#new'
-      put '/review' => 'review#create'
+      # The `/review` route is deperecated in favor of `/enter_password`
+      get '/review' => 'enter_password#new'
+      put '/review' => 'enter_password#create'
+      get '/enter_password' => 'enter_password#new'
+      put '/enter_password' => 'enter_password#create'
       get '/phone_question' => 'phone_question#show'
       get '/phone_question/phone_with_camera' => 'phone_question#phone_with_camera'
       get '/phone_question/phone_without_camera' => 'phone_question#phone_without_camera'

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::ReviewController do
+RSpec.describe Idv::EnterPasswordController do
   include UspsIppHelper
 
   let(:user) do
@@ -62,7 +62,7 @@ RSpec.describe Idv::ReviewController do
     before(:each) do
       stub_sign_in(user)
       routes.draw do
-        get 'show' => 'idv/review#show'
+        get 'show' => 'idv/enter_password#show'
       end
     end
 
@@ -96,7 +96,7 @@ RSpec.describe Idv::ReviewController do
       stub_sign_in(user)
       stub_attempts_tracker
       routes.draw do
-        post 'show' => 'idv/review#show'
+        post 'show' => 'idv/enter_password#show'
       end
       allow(subject).to receive(:confirm_idv_steps_complete).and_return(true)
       allow(subject).to receive(:idv_session).and_return(idv_session)
@@ -159,8 +159,8 @@ RSpec.describe Idv::ReviewController do
       it 'sets the correct title and header' do
         get :new
 
-        expect(assigns(:title)).to eq(t('titles.idv.review'))
-        expect(assigns(:heading)).to eq(t('idv.titles.session.review', app_name: APP_NAME))
+        expect(assigns(:title)).to eq(t('titles.idv.enter_password'))
+        expect(assigns(:heading)).to eq(t('idv.titles.session.enter_password', app_name: APP_NAME))
       end
 
       it 'uses the correct step indicator step' do
@@ -180,15 +180,17 @@ RSpec.describe Idv::ReviewController do
         it 'sets the correct title and header' do
           get :new
 
-          expect(assigns(:title)).to eq(t('titles.idv.review_letter'))
-          expect(assigns(:heading)).to eq(t('idv.titles.session.review_letter', app_name: APP_NAME))
+          expect(assigns(:title)).to eq(t('titles.idv.enter_password_letter'))
+          expect(assigns(:heading)).to eq(
+            t('idv.titles.session.enter_password_letter', app_name: APP_NAME),
+          )
         end
 
         it 'shows password reminder banner' do
           get :new
 
           expect(response.body).to include(
-            t('idv.messages.review.by_mail_password_reminder_html'),
+            t('idv.messages.enter_password.by_mail_password_reminder_html'),
           )
         end
 
@@ -205,7 +207,7 @@ RSpec.describe Idv::ReviewController do
           get :new
 
           expect(response.body).not_to include(
-            t('idv.messages.review.by_mail_password_reminder_html'),
+            t('idv.messages.enter_password.by_mail_password_reminder_html'),
           )
         end
       end

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Idv::ResendOtpController do
     context 'the user has already confirmed their phone' do
       let(:user_phone_confirmation) { true }
 
-      it 'redirects to the review step' do
+      it 'redirects to the enter password step' do
         post :create
         expect(response).to redirect_to(idv_review_path)
       end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Idv::VerifyInfoController do
     end
 
     context 'when the user has already verified their info' do
-      it 'redirects to the review controller' do
+      it 'redirects to the enter password controller' do
         subject.idv_session.resolution_successful = true
 
         get :show

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -387,7 +387,7 @@ RSpec.feature 'Analytics Regression', js: true do
       complete_ssn_step
       complete_verify_step
       complete_phone_step(user)
-      complete_review_step(user)
+      complete_enter_password_step(user)
       acknowledge_and_confirm_personal_key
     end
 
@@ -446,7 +446,7 @@ RSpec.feature 'Analytics Regression', js: true do
       complete_verify_step
       enter_gpo_flow
       gpo_step
-      complete_review_step(user)
+      complete_enter_password_step(user)
     end
 
     it 'records all of the events' do
@@ -493,7 +493,7 @@ RSpec.feature 'Analytics Regression', js: true do
       begin_in_person_proofing(user)
       complete_all_in_person_proofing_steps(user, same_address_as_id: false)
       complete_phone_step(user)
-      complete_review_step(user)
+      complete_enter_password_step(user)
       acknowledge_and_confirm_personal_key
       visit_help_center
       visit_sp_from_in_person_ready_to_verify

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe 'Identity verification', :js do
     visit_by_mail_and_return
     complete_otp_verification_page(user)
 
-    validate_review_page
-    complete_review_step(user)
-    validate_review_submit(user)
+    validate_enter_password_page
+    complete_enter_password_step(user)
+    validate_enter_password_submit(user)
 
     validate_personal_key_page
     acknowledge_and_confirm_personal_key
@@ -72,7 +72,7 @@ RSpec.describe 'Identity verification', :js do
       enter_gpo_flow
       gpo_step
 
-      complete_review_step(user)
+      complete_enter_password_step(user)
 
       validate_come_back_later_page
       complete_come_back_later
@@ -251,10 +251,10 @@ RSpec.describe 'Identity verification', :js do
     click_submit_default
   end
 
-  def validate_review_page
+  def validate_enter_password_page
     expect(page).to have_current_path(idv_review_path)
-    expect(page).to have_content(t('idv.messages.review.message', app_name: APP_NAME))
-    expect(page).to have_content(t('idv.messages.review.phone_verified'))
+    expect(page).to have_content(t('idv.messages.enter_password.message', app_name: APP_NAME))
+    expect(page).to have_content(t('idv.messages.enter_password.phone_verified'))
 
     # does not move ahead with incorrect password
     fill_in 'Password', with: 'this is not the right password'
@@ -263,7 +263,7 @@ RSpec.describe 'Identity verification', :js do
     expect(page).to have_current_path(idv_review_path)
   end
 
-  def validate_review_submit(user)
+  def validate_enter_password_submit(user)
     expect(user.events.account_verified.size).to be(1)
     expect(user.profiles.count).to eq 1
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe 'In Person Proofing', js: true do
 
       # password confirm page
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
-      expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
-      complete_review_step(user)
+      expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
+      complete_enter_password_step(user)
 
       # personal key page
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
@@ -200,8 +200,8 @@ RSpec.describe 'In Person Proofing', js: true do
 
     # password confirm page
     expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
-    expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
-    complete_review_step(user)
+    expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
+    complete_enter_password_step(user)
 
     # personal key page
     expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
@@ -248,7 +248,7 @@ RSpec.describe 'In Person Proofing', js: true do
     begin_in_person_proofing
     complete_all_in_person_proofing_steps
     complete_phone_step(user)
-    complete_review_step(user)
+    complete_enter_password_step(user)
     acknowledge_and_confirm_personal_key
 
     click_link t('links.cancel')
@@ -372,7 +372,7 @@ RSpec.describe 'In Person Proofing', js: true do
       )
       click_on t('idv.buttons.mail.send')
       expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
-      complete_review_step
+      complete_enter_password_step
 
       expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
       expect(page).to have_content(t('idv.titles.come_back_later'))
@@ -403,7 +403,7 @@ RSpec.describe 'In Person Proofing', js: true do
       complete_all_in_person_proofing_steps
       click_on t('idv.troubleshooting.options.verify_by_mail')
       click_on t('idv.buttons.mail.send')
-      complete_review_step
+      complete_enter_password_step
       click_idv_continue
       click_on t('account.index.verification.reactivate_button')
       click_on t('idv.messages.clear_and_start_over')
@@ -866,8 +866,8 @@ RSpec.describe 'In Person Proofing', js: true do
 
       # password confirm page
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
-      expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
-      complete_review_step(user)
+      expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
+      complete_enter_password_step(user)
 
       # personal key page
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))

--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'phone otp rate limiting', :js do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+      expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
       expect(current_path).to eq(idv_review_path)
     end
   end

--- a/spec/features/idv/proof_address_rate_limit_spec.rb
+++ b/spec/features/idv/proof_address_rate_limit_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'address proofing rate limit' do
       click_on t('idv.failure.phone.rate_limited.gpo.button')
       click_on t('idv.buttons.mail.send')
 
-      expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+      expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
       expect(current_path).to eq(idv_review_path)
       fill_in 'Password', with: user.password
       click_idv_continue
@@ -58,7 +58,7 @@ RSpec.feature 'address proofing rate limit' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+      expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
       expect(current_path).to eq(idv_review_path)
       fill_in 'Password', with: user.password
       click_idv_continue

--- a/spec/features/idv/steps/enter_password_step_spec.rb
+++ b/spec/features/idv/steps/enter_password_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'idv review step', :js do
+RSpec.feature 'idv enter password step', :js do
   include IdvStepHelper
 
   context 'choosing to confirm address with gpo' do
@@ -9,7 +9,7 @@ RSpec.feature 'idv review step', :js do
 
     before do
       start_idv_from_sp(sp)
-      complete_idv_steps_with_gpo_before_review_step(user)
+      complete_idv_steps_with_gpo_before_enter_password_step(user)
     end
 
     it 'sends a letter, creates an unverified profile, and sends an email' do
@@ -26,7 +26,7 @@ RSpec.feature 'idv review step', :js do
       end
     end
 
-    it 'sends you to the come_back_later page after review step' do
+    it 'sends you to the come_back_later page after enter password step' do
       fill_in 'Password', with: user_password
       click_continue
 
@@ -89,12 +89,12 @@ RSpec.feature 'idv review step', :js do
 
     before do
       start_idv_from_sp
-      complete_idv_steps_with_phone_before_review_step(user)
+      complete_idv_steps_with_phone_before_enter_password_step(user)
     end
 
     it 'allows the user to submit password and proceed to obtain a personal key' do
       visit(idv_hybrid_handoff_url(redo: true))
-      complete_review_step(user)
+      complete_enter_password_step(user)
       expect(current_path).to eq idv_personal_key_path
     end
   end

--- a/spec/features/idv/steps/forgot_password_step_spec.rb
+++ b/spec/features/idv/steps/forgot_password_step_spec.rb
@@ -3,18 +3,18 @@ require 'rails_helper'
 RSpec.feature 'forgot password step', :js do
   include IdvStepHelper
 
-  it 'goes to the forgot password page from the review page' do
+  it 'goes to the forgot password page from the enter password page' do
     start_idv_from_sp
-    complete_idv_steps_before_review_step
+    complete_idv_steps_before_enter_password_step
 
     click_link t('idv.forgot_password.link_text')
 
     expect(page.current_path).to eq(idv_forgot_password_path)
   end
 
-  it 'goes back to the review page from the forgot password page' do
+  it 'goes back to the enter password page from the forgot password page' do
     start_idv_from_sp
-    complete_idv_steps_before_review_step
+    complete_idv_steps_before_enter_password_step
 
     click_link t('idv.forgot_password.link_text')
     click_link t('idv.forgot_password.try_again')
@@ -24,7 +24,7 @@ RSpec.feature 'forgot password step', :js do
 
   it 'allows the user to reset their password' do
     start_idv_from_sp
-    complete_idv_steps_before_review_step
+    complete_idv_steps_before_enter_password_step
 
     click_link t('idv.forgot_password.link_text')
     click_button t('idv.forgot_password.reset_password')

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'phone otp verification step spec', :js do
     fill_in_code_with_last_phone_otp
     click_submit_default
 
-    expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+    expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
     expect(page).to have_current_path(idv_review_path)
   end
 
@@ -57,7 +57,7 @@ RSpec.feature 'phone otp verification step spec', :js do
     fill_in_code_with_last_phone_otp
     click_submit_default
 
-    expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+    expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
     expect(page).to have_current_path(idv_review_path)
   end
 

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'idv phone step', :js do
       click_submit_default
 
       visit idv_phone_path
-      expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+      expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
       expect(page).to have_current_path(idv_review_path)
 
       fill_in 'Password', with: user_password

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -17,15 +17,15 @@ RSpec.feature 'idv request letter step' do
       and_return(days_passed + 1)
   end
 
-  it 'redirects to and completes the review step when the user chooses to verify by letter', :js do
+  it 'visits and completes the enter password step when the user chooses verify by letter', :js do
     start_idv_from_sp
     complete_idv_steps_before_gpo_step
     click_on t('idv.buttons.mail.send')
 
-    expect(page).to have_content(t('idv.titles.session.review', app_name: APP_NAME))
+    expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
     expect(page).to have_current_path(idv_review_path)
 
-    complete_review_step
+    complete_enter_password_step
     expect(page).to have_content(t('idv.messages.gpo.letter_on_the_way'))
   end
 

--- a/spec/features/idv/threat_metrix_pending_spec.rb
+++ b/spec/features/idv/threat_metrix_pending_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Users pending ThreatMetrix review', :js do
     complete_ssn_step
     click_idv_continue
     complete_phone_step(user)
-    complete_review_step(user)
+    complete_enter_password_step(user)
     acknowledge_and_confirm_personal_key
 
     expect(page).to have_content(t('idv.failure.setup.heading'))

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -317,7 +317,7 @@ module DocAuthHelper
     complete_ssn_step
     click_idv_continue
     complete_phone_step(user)
-    complete_review_step(user)
+    complete_enter_password_step(user)
     acknowledge_and_confirm_personal_key
   end
 end

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -50,7 +50,7 @@ module IdvStepHelper
     choose_idv_otp_delivery_method_sms
   end
 
-  def complete_idv_steps_with_phone_before_review_step(user = user_with_2fa)
+  def complete_idv_steps_with_phone_before_enter_password_step(user = user_with_2fa)
     complete_idv_steps_before_phone_step(user)
     complete_phone_step(user)
   end
@@ -85,26 +85,27 @@ module IdvStepHelper
     t('in_person_proofing.body.barcode.return_to_partner_html', link_html: link_text)
   end
 
-  def complete_review_step(user = user_with_2fa)
+  def complete_enter_password_step(user = user_with_2fa)
     password = user.password || user_password
     fill_in 'Password', with: password
     click_idv_continue
   end
 
   def complete_idv_steps_with_phone_before_confirmation_step(user = user_with_2fa)
-    complete_idv_steps_with_phone_before_review_step(user)
-    complete_review_step(user)
+    complete_idv_steps_with_phone_before_enter_password_step(user)
+    complete_enter_password_step(user)
   end
 
-  alias complete_idv_steps_before_review_step complete_idv_steps_with_phone_before_review_step
+  alias complete_idv_steps_before_enter_password_step
+        complete_idv_steps_with_phone_before_enter_password_step
 
-  def complete_idv_steps_with_gpo_before_review_step(user = user_with_2fa)
+  def complete_idv_steps_with_gpo_before_enter_password_step(user = user_with_2fa)
     complete_idv_steps_before_gpo_step(user)
     gpo_step
   end
 
   def complete_idv_steps_with_gpo_before_confirmation_step(user = user_with_2fa)
-    complete_idv_steps_with_gpo_before_review_step(user)
+    complete_idv_steps_with_gpo_before_enter_password_step(user)
     password = user.password || user_password
     fill_in 'Password', with: password
     click_continue

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -221,7 +221,7 @@ module InPersonHelper
       complete_ssn_step(user)
       complete_verify_step(user)
       complete_phone_step(user)
-      complete_review_step(user)
+      complete_enter_password_step(user)
       acknowledge_and_confirm_personal_key
 
       expect(page).to have_content('MILWAUKEE')

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -47,7 +47,7 @@ module SpAuthHelper
     complete_all_in_person_proofing_steps
 
     complete_phone_step(user)
-    complete_review_step(user)
+    complete_enter_password_step(user)
     acknowledge_and_confirm_personal_key
     expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
 

--- a/spec/views/idv/enter_password/new.html.erb_spec.rb
+++ b/spec/views/idv/enter_password/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'idv/review/new.html.erb' do
+RSpec.describe 'idv/enter_password/new.html.erb' do
   include XPathHelper
 
   context 'user has completed all steps' do
@@ -16,19 +16,19 @@ RSpec.describe 'idv/review/new.html.erb' do
 
     context 'user goes through phone finder' do
       before do
-        @title = t('titles.idv.review')
-        @heading = t('idv.titles.session.review', app_name: APP_NAME)
+        @title = t('titles.idv.enter_password')
+        @heading = t('idv.titles.session.enter_password', app_name: APP_NAME)
         render
       end
 
       it 'has a localized title' do
-        expect(view).to receive(:title).with(t('titles.idv.review'))
+        expect(view).to receive(:title).with(t('titles.idv.enter_password'))
 
         render
       end
 
       it 'renders the correct content heading' do
-        expect(rendered).to have_content t('idv.titles.session.review', app_name: APP_NAME)
+        expect(rendered).to have_content t('idv.titles.session.enter_password', app_name: APP_NAME)
       end
 
       it 'shows the step indicator' do
@@ -41,19 +41,21 @@ RSpec.describe 'idv/review/new.html.erb' do
 
     context 'user goes through verify by mail flow' do
       before do
-        @title = t('titles.idv.review_letter')
-        @heading = t('idv.titles.session.review_letter', app_name: APP_NAME)
+        @title = t('titles.idv.enter_password_letter')
+        @heading = t('idv.titles.session.enter_password_letter', app_name: APP_NAME)
         render
       end
 
       it 'has a localized title' do
-        expect(view).to receive(:title).with(t('titles.idv.review_letter'))
+        expect(view).to receive(:title).with(t('titles.idv.enter_password_letter'))
 
         render
       end
 
       it 'renders the correct content heading' do
-        expect(rendered).to have_content t('idv.titles.session.review_letter', app_name: APP_NAME)
+        expect(rendered).to have_content(
+          t('idv.titles.session.enter_password_letter', app_name: APP_NAME),
+        )
       end
     end
   end


### PR DESCRIPTION
This commit renames the "Review" step to the "Enter password" step. This new name should hopefully better describe what is happening at this step.

This commit changes the name, but leaves several places out of scope:

1. URLs: To maintain compatibility in the 50/50 state this commit introduces but does not start using URLs with the new name. Follow up commits will need to be added to use and then remove the old `/review` url.
2. Analytics event names
