### PR TITLE
Remove trailing references to GPO in IdV

### DIFF
--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -17,7 +17,7 @@ module Idv
       current_user.pending_profile.created_at < min_creation_date
     end
 
-    # Next two methods are analytics helpers used from GpoController and ReviewController
+    # Next two methods are analytics helpers used from RequestLetterController and ReviewController
 
     # Caveat: If the user succeeds on their final phone attempt, the :proof_address
     # RateLimiter is reset to 0. But they probably wouldn't be doing verify by mail

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'idv gpo otp verification step' do
+RSpec.feature 'idv enter letter code step' do
   include IdvStepHelper
 
   let(:otp) { 'ABC123' }

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'idv gpo step' do
+RSpec.feature 'idv request letter step' do
   include IdvStepHelper
   include OidcAuthHelper
 


### PR DESCRIPTION
We renamed the code that is used to verify by mail in #9136. This replaced "GPO" with more descriptive names. This commit removes a few lingering references to GPO.
