### PR TITLE
LG-10849 Use hybrid flow phone number in phone form

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -145,6 +145,7 @@ module Idv
         allowed_countries:
           PhoneNumberCapabilities::ADDRESS_IDENTITY_PROOFING_SUPPORTED_COUNTRY_CODES,
         failed_phone_numbers: idv_session.failed_phone_step_numbers,
+        hybrid_handoff_phone_number: idv_session.phone_for_mobile_flow,
       )
     end
 
@@ -171,6 +172,7 @@ module Idv
             [:context, :stages, :address],
           ],
           new_phone_added: new_phone_added?,
+          hybrid_handoff_phone_used: hybrid_handoff_phone_used?,
         ),
       )
 
@@ -198,8 +200,18 @@ module Idv
       configured_phones = context.phone_configurations.map(&:phone).map do |number|
         PhoneFormatter.format(number)
       end
-      applicant_phone = PhoneFormatter.format(idv_session.applicant['phone'])
-      !configured_phones.include?(applicant_phone)
+      !configured_phones.include?(formatted_previous_phone_step_params_phone)
+    end
+
+    def hybrid_handoff_phone_used?
+      formatted_previous_phone_step_params_phone ==
+        PhoneFormatter.format(idv_session.phone_for_mobile_flow)
+    end
+
+    def formatted_previous_phone_step_params_phone
+      PhoneFormatter.format(
+        idv_session.previous_phone_step_params&.fetch('phone'),
+      )
     end
 
     def gpo_letter_available

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -5,7 +5,7 @@ module Idv
     ALL_DELIVERY_METHODS = [:sms, :voice].freeze
 
     attr_reader :user, :phone, :allowed_countries, :delivery_methods, :international_code,
-                :otp_delivery_preference, :failed_phone_numbers
+                :otp_delivery_preference, :failed_phone_numbers, :hybrid_handoff_phone_number
 
     validate :validate_valid_phone_for_allowed_countries
     validate :validate_phone_delivery_methods
@@ -20,13 +20,15 @@ module Idv
       previous_params:,
       allowed_countries: nil,
       delivery_methods: ALL_DELIVERY_METHODS,
-      failed_phone_numbers: []
+      failed_phone_numbers: [],
+      hybrid_handoff_phone_number: nil
     )
       previous_params ||= {}
       @user = user
       @allowed_countries = allowed_countries
       @delivery_methods = delivery_methods
       @failed_phone_numbers = failed_phone_numbers
+      @hybrid_handoff_phone_number = hybrid_handoff_phone_number
 
       @international_code, @phone = determine_initial_values(
         **previous_params.
@@ -52,7 +54,7 @@ module Idv
     # @return [Array<string,string>] The international_code and phone values to use.
     def determine_initial_values(international_code: nil, phone: nil)
       if phone.nil? && international_code.nil?
-        default_phone = user.default_phone_configuration&.phone
+        default_phone = user.default_phone_configuration&.phone || hybrid_handoff_phone_number
         if valid_phone?(default_phone, phone_confirmed: true)
           phone = default_phone
           international_code = country_code_for(default_phone)

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -478,6 +478,7 @@ RSpec.describe Idv::PhoneController do
         result = {
           success: true,
           new_phone_added: true,
+          hybrid_handoff_phone_used: false,
           errors: {},
           phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
           country_code: proofing_phone.country,
@@ -504,6 +505,27 @@ RSpec.describe Idv::PhoneController do
         expect(response).to redirect_to idv_phone_path
         get :new
       end
+    end
+
+    it 'tracks that the hybrid handoff phone was used' do
+      user = build(:user)
+      stub_verify_steps_one_and_two(user)
+
+      stub_analytics
+      allow(@analytics).to receive(:track_event)
+
+      expect(@analytics).to receive(:track_event).ordered.with(
+        'IdV: phone confirmation form', hash_including(:success)
+      )
+      expect(@analytics).to receive(:track_event).ordered.with(
+        'IdV: phone confirmation vendor', hash_including(hybrid_handoff_phone_used: true)
+      )
+
+      subject.idv_session.phone_for_mobile_flow = good_phone
+
+      put :create, params: { idv_phone_form: { phone: good_phone } }
+      expect(response).to redirect_to idv_phone_path
+      get :new
     end
 
     context 'when verification fails' do
@@ -548,6 +570,7 @@ RSpec.describe Idv::PhoneController do
         result = {
           success: false,
           new_phone_added: true,
+          hybrid_handoff_phone_used: false,
           phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
           country_code: proofing_phone.country,
           area_code: proofing_phone.area_code,

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: phone confirmation vendor' => {
-        success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
+        success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, hybrid_handoff_phone_used: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp sent' => {
@@ -312,7 +312,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' }
       },
       'IdV: phone confirmation vendor' => {
-        success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
+        success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, hybrid_handoff_phone_used: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
         proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' }
       },
       'IdV: phone confirmation otp sent' => {

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -130,6 +130,29 @@ RSpec.describe Idv::PhoneForm do
       end
     end
 
+    context 'with a number submitted on the hybrid handoff step' do
+      context 'with a phone number on the user record' do
+        let(:user_phone) { '2025555000' }
+        let(:hybrid_handoff_phone_number) { '2025551234' }
+        let(:user) { build_stubbed(:user, :fully_registered, with: { phone: user_phone }) }
+        let(:optional_params) { { hybrid_handoff_phone_number: hybrid_handoff_phone_number } }
+
+        it 'uses the user phone as the initial value' do
+          expect(subject.phone).to eq(PhoneFormatter.format(user_phone))
+        end
+      end
+
+      context 'without a phone number on the user record' do
+        let(:hybrid_handoff_phone_number) { '2025551234' }
+        let(:user) { build_stubbed(:user) }
+        let(:optional_params) { { hybrid_handoff_phone_number: hybrid_handoff_phone_number } }
+
+        it 'uses the hybrid handoff phone as the initial value' do
+          expect(subject.phone).to eq(PhoneFormatter.format(hybrid_handoff_phone_number))
+        end
+      end
+    end
+
     context 'with previously submitted value' do
       let(:user) { build_stubbed(:user, :fully_registered, with: { phone: '7035551234' }) }
       let(:previous_params) { { phone: '2255555000' } }


### PR DESCRIPTION
This commit uses the phone number a user used to complete the hybrid flow if we have the user has no MFA phone number. Hopefully pre-filling the number in this way will help improve success on the phone step.
