### PR TITLE
Add events-summary data-pull dask (LG-11256)

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -266,10 +266,10 @@ class DataPull
     def run(args:, config:)
       uuids = args
 
-      users = User.includes(:events).where(uuid: uuids).order(:uuid)
+      users = User.includes(events: :device).where(uuid: uuids).order(:uuid)
 
       table = []
-      table << %w[uuid event_type event_timestamp event_ip]
+      table << %w[uuid event_type event_timestamp event_ip device_cookie]
 
       users.each do |user|
         user.events.sort_by(&:created_at).each do |event|
@@ -278,13 +278,14 @@ class DataPull
             event.event_type,
             event.created_at,
             event.ip,
+            event.device&.cookie_uuid,
           ]
         end
       end
 
       if config.include_missing?
         (uuids - users.map(&:uuid)).each do |missing_uuid|
-          table << [missing_uuid, '[UUID NOT FOUND]', nil, nil]
+          table << [missing_uuid, '[UUID NOT FOUND]', nil, nil, nil]
         end
       end
 

--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -30,10 +30,6 @@ class DataPull
 
       Example usage:
 
-        * #{basename} uuid-lookup email1@example.com email2@example.com
-
-        * #{basename} uuid-convert partner-uuid1 partner-uuid2
-
         * #{basename} email-lookup uuid1 uuid2
 
         * #{basename} events-summary uuid1 uuid2
@@ -42,8 +38,11 @@ class DataPull
 
         * #{basename} profile-summary uuid1 uuid2
 
+        * #{basename} uuid-convert partner-uuid1 partner-uuid2
+
         * #{basename} uuid-export uuid1 uuid2 --requesting-issuer ABC:DEF:GHI
 
+        * #{basename} uuid-lookup email1@example.com email2@example.com
       Options:
     EOS
   end
@@ -54,13 +53,13 @@ class DataPull
   # @return [Class,nil]
   def subtask(name)
     {
-      'uuid-lookup' => UuidLookup,
-      'uuid-convert' => UuidConvert,
       'email-lookup' => EmailLookup,
       'events-summary' => EventsSummary,
       'ig-request' => InspectorGeneralRequest,
       'profile-summary' => ProfileSummary,
+      'uuid-convert' => UuidConvert,
       'uuid-export' => UuidExport,
+      'uuid-lookup' => UuidLookup,
     }[name]
   end
 

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -346,13 +346,23 @@ RSpec.describe DataPull do
     subject(:subtask) { DataPull::EventsSummary.new }
 
     let(:user) { create(:user) }
-    let!(:event) do
+
+    before do
       create(
         :event,
         user: user,
         event_type: :account_created,
         ip: '1.2.3.4',
-        device: create(:device, user: user, cookie_uuid: 'cookie1234'),
+        created_at: Date.new(2023, 1, 1).in_time_zone('UTC'),
+      )
+
+      create_list(
+        :event,
+        5,
+        user: user,
+        event_type: :account_created,
+        ip: '1.2.3.4',
+        created_at: Date.new(2023, 1, 2).in_time_zone('UTC'),
       )
     end
 
@@ -364,9 +374,10 @@ RSpec.describe DataPull do
       it 'loads events for the users' do
         expect(result.table).to match_array(
           [
-            %w[uuid event_type event_timestamp event_ip device_cookie],
-            [user.uuid, event.event_type, event.created_at, event.ip, event.device.cookie_uuid],
-            ['uuid-does-not-exist', '[UUID NOT FOUND]', nil, nil, nil],
+            %w[uuid date events_count],
+            [user.uuid, '2023-01-02', 5],
+            [user.uuid, '2023-01-01', 1],
+            ['uuid-does-not-exist', '[UUID NOT FOUND]', nil],
           ],
         )
 

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -346,7 +346,15 @@ RSpec.describe DataPull do
     subject(:subtask) { DataPull::EventsSummary.new }
 
     let(:user) { create(:user) }
-    let!(:event) { create(:event, user: user, event_type: :account_created, ip: '1.2.3.4') }
+    let!(:event) do
+      create(
+        :event,
+        user: user,
+        event_type: :account_created,
+        ip: '1.2.3.4',
+        device: create(:device, user: user, cookie_uuid: 'cookie1234'),
+      )
+    end
 
     let(:args) { [user.uuid, 'uuid-does-not-exist'] }
     let(:config) { ScriptBase::Config.new(include_missing: true) }
@@ -356,9 +364,9 @@ RSpec.describe DataPull do
       it 'loads events for the users' do
         expect(result.table).to match_array(
           [
-            %w[uuid event_type event_timestamp event_ip],
-            [user.uuid, event.event_type, event.created_at, event.ip],
-            ['uuid-does-not-exist', '[UUID NOT FOUND]', nil, nil],
+            %w[uuid event_type event_timestamp event_ip device_cookie],
+            [user.uuid, event.event_type, event.created_at, event.ip, event.device.cookie_uuid],
+            ['uuid-does-not-exist', '[UUID NOT FOUND]', nil, nil, nil],
           ],
         )
 


### PR DESCRIPTION
## Ticket

[LG-11256](https://cm-jira.usa.gov/browse/LG-11256)

## Description

Adds a new data-pull task that can export a summary of the events table, intended for fraud team investigations

## Demo

```bash
> bundle exec bin/data-pull events-summary 593f754d-418d-491b-bbbd-b1c1f2143b72
*Task*: `events-summary`
*UUIDs*: `593f754d-418d-491b-bbbd-b1c1f2143b72`
+--------------------------------------+------------+--------------+
| uuid                                 | date       | events_count |
+--------------------------------------+------------+--------------+
| 593f754d-418d-491b-bbbd-b1c1f2143b72 | 2023-10-13 | 2            |
+--------------------------------------+------------+--------------+
```