### PR TITLE
Update query-cloudwatch to be able to query multiple dates (LG-11257)

### DIFF
--- a/bin/query-cloudwatch
+++ b/bin/query-cloudwatch
@@ -3,6 +3,7 @@ Dir.chdir(__dir__) { require 'bundler/setup' }
 
 require 'active_support'
 require 'active_support/core_ext/integer/time'
+require 'active_support/time'
 require 'aws-sdk-cloudwatchlogs'
 require 'concurrent-ruby'
 require 'csv'
@@ -23,6 +24,7 @@ class QueryCloudwatch
     :app,
     :from,
     :to,
+    :time_slices,
     :query,
     :format,
     :complete,
@@ -68,8 +70,9 @@ class QueryCloudwatch
   def fetch(&block)
     cloudwatch_client.fetch(
       query: config.query,
-      from: config.from,
-      to: config.to,
+      from: config.time_slices.blank? ? config.from : nil,
+      to: config.time_slices.blank? ? config.to : nil,
+      time_slices: config.time_slices.presence,
       &block
     )
   end
@@ -92,6 +95,7 @@ class QueryCloudwatch
       slice: parse_duration('1w'),
       format: :csv,
       to: now,
+      time_slices: [],
       complete: false,
       progress: true,
       count_distinct: nil,
@@ -124,6 +128,13 @@ class QueryCloudwatch
           --group int_/srv/idp/shared/log/production.log \\
           --start "2020-01-01T00:00:00-00:00" \\
           --to "2020-12-31T23:59:59-00:00" \\
+          --query "fields @timestamp | limit 9999"
+
+        Query disjoint time slices via --date
+
+        #{$PROGRAM_NAME} \\
+          --date 2023-01-01,2023-02-01
+          --env int --app idp --log events.log
           --query "fields @timestamp | limit 9999"
 
         Timestamps
@@ -188,6 +199,15 @@ class QueryCloudwatch
         end
       end
 
+      opts.on(
+        '--date DATE,DATE',
+        '(optional) dates to query, can be disjoint, to provide time slices to query'
+      ) do |dates|
+        dates.split(',').each do |date_str|
+          config.time_slices << Date.parse(date_str).in_time_zone('UTC').all_day
+        end
+      end
+
       opts.on('--query QUERY', 'Cloudwatch Insights query') do |query|
         config.query = query
       end
@@ -237,7 +257,9 @@ class QueryCloudwatch
       errors << 'ERROR: missing log group --group or (--app and --env and --log)'
     end
 
-    errors << 'ERROR: missing time range --from or --start' if !config.from
+    if !config.from && config.time_slices.empty?
+      errors << 'ERROR: missing time range --from or --start, or --date'
+    end
 
     if !config.query
       if stdin.tty?

--- a/spec/bin/query-cloudwatch_spec.rb
+++ b/spec/bin/query-cloudwatch_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe QueryCloudwatch do
       end
     end
 
+    context 'with --date' do
+      let(:argv) { required_parameters + ['--date', '2023-01-01,2023-08-01'] }
+
+      it 'creates disjoint time slices' do
+        config = parse!
+        expect(config.time_slices).to eq(
+          [
+            Date.new(2023, 1, 1).in_time_zone('UTC').all_day,
+            Date.new(2023, 8, 1).in_time_zone('UTC').all_day,
+          ],
+        )
+      end
+    end
+
     context 'with --no-progress' do
       let(:argv) { required_parameters + %w[--no-progress] }
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11257](https://cm-jira.usa.gov/browse/LG-11257)

## 🛠 Summary of changes

Adds a new `--date` option to `query-cloudwatch` that allows using the the `time_slices` option of our `CloudwatchClient` to query separate, disjoint dates with the same query, willl help with more efficient use of time in Cloudwatch and lower billing costs.

example:
```bash
> aws-vault exec prod-power -- \
  ./bin/query-cloudwatch \
  --date 2023-09-01,2023-08-01 \ # << NEW OPTION
  --env prod --app idp --log events.log \
  --query "fields @timestamp | stats count(*) by bin(1d)" \
  --no-progress
2023-09-01 00:00:00.000,20914416
2023-08-01 00:00:00.000,25423701
```


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
