### PR TITLE
LG-11036 unexpected content second mfa requirement for aal2+

### DIFF
--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -58,6 +58,7 @@ module Users
         piv_cac_required: service_provider_mfa_policy.piv_cac_required?,
         show_skip_additional_mfa_link: show_skip_additional_mfa_link?,
         after_mfa_setup_path:,
+        return_to_sp_cancel_path:,
       )
     end
 

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -1,7 +1,7 @@
 class TwoFactorOptionsPresenter
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :user, :after_mfa_setup_path
+  attr_reader :user, :after_mfa_setup_path, :return_to_sp_cancel_path
 
   delegate :two_factor_enabled?, to: :mfa_policy
 
@@ -11,7 +11,8 @@ class TwoFactorOptionsPresenter
     phishing_resistant_required: false,
     piv_cac_required: false,
     show_skip_additional_mfa_link: true,
-    after_mfa_setup_path: nil
+    after_mfa_setup_path: nil,
+    return_to_sp_cancel_path: nil
   )
     @user_agent = user_agent
     @user = user
@@ -19,6 +20,7 @@ class TwoFactorOptionsPresenter
     @piv_cac_required = piv_cac_required
     @show_skip_additional_mfa_link = show_skip_additional_mfa_link
     @after_mfa_setup_path = after_mfa_setup_path
+    @return_to_sp_cancel_path = return_to_sp_cancel_path
   end
 
   def options
@@ -78,11 +80,15 @@ class TwoFactorOptionsPresenter
   end
 
   def skip_path
-    after_mfa_setup_path if two_factor_enabled? && show_skip_additional_mfa_link?
+    if show_cancel_return_to_sp?
+      return_to_sp_cancel_path
+    elsif two_factor_enabled? && show_skip_additional_mfa_link?
+      after_mfa_setup_path
+    end
   end
 
   def skip_label
-    if user_has_dismissed_second_mfa_reminder?
+    if user_has_dismissed_second_mfa_reminder? || show_cancel_return_to_sp?
       t('links.cancel')
     else
       t('mfa.skip')

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -65,8 +65,8 @@ class TwoFactorOptionsPresenter
     end
   end
 
-  def show_cancel_phishing_resistant_only
-    phishing_resistant_only?
+  def show_cancel_aal2plus
+    phishing_resistant_only? || piv_cac_required?
   end
 
   def show_skip_additional_mfa_link?

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -26,6 +26,15 @@ class TwoFactorOptionsPresenter
       backup_code_option + webauthn_option + piv_cac_option
   end
 
+  def selected_options
+    [TwoFactorAuthentication::WebauthnPlatformSelectionPresenter.new(user: user)] +
+      [TwoFactorAuthentication::SetUpAuthAppSelectionPresenter.new(user: user)] +
+      [TwoFactorAuthentication::PhoneSelectionPresenter.new(user: user)] +
+      [TwoFactorAuthentication::BackupCodeSelectionPresenter.new(user: user)] +
+      [TwoFactorAuthentication::WebauthnSelectionPresenter.new(user: user)] +
+      [TwoFactorAuthentication::PivCacSelectionPresenter.new(user: user)]
+  end
+
   def icon
     if piv_cac_required? || (phishing_resistant_only? && mfa_policy.two_factor_enabled?)
       'icon-lock-alert-important.svg'
@@ -54,6 +63,10 @@ class TwoFactorOptionsPresenter
     else
       t('mfa.info')
     end
+  end
+
+  def show_cancel_phishing_resistant_only
+    phishing_resistant_only?
   end
 
   def show_skip_additional_mfa_link?

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -26,13 +26,17 @@ class TwoFactorOptionsPresenter
       backup_code_option + webauthn_option + piv_cac_option
   end
 
-  def selected_options
-    [TwoFactorAuthentication::WebauthnPlatformSelectionPresenter.new(user: user)] +
-      [TwoFactorAuthentication::SetUpAuthAppSelectionPresenter.new(user: user)] +
-      [TwoFactorAuthentication::PhoneSelectionPresenter.new(user: user)] +
-      [TwoFactorAuthentication::BackupCodeSelectionPresenter.new(user: user)] +
-      [TwoFactorAuthentication::WebauthnSelectionPresenter.new(user: user)] +
-      [TwoFactorAuthentication::PivCacSelectionPresenter.new(user: user)]
+  # Array of possible options selected by the user to display on the
+  # add additional MFA page
+  def all_user_selected_options
+    [
+      TwoFactorAuthentication::WebauthnPlatformSelectionPresenter.new(user: user),
+      TwoFactorAuthentication::SetUpAuthAppSelectionPresenter.new(user: user),
+      TwoFactorAuthentication::PhoneSelectionPresenter.new(user: user),
+      TwoFactorAuthentication::BackupCodeSelectionPresenter.new(user: user),
+      TwoFactorAuthentication::WebauthnSelectionPresenter.new(user: user),
+      TwoFactorAuthentication::PivCacSelectionPresenter.new(user: user),
+    ]
   end
 
   def icon
@@ -65,7 +69,7 @@ class TwoFactorOptionsPresenter
     end
   end
 
-  def show_cancel_aal2plus
+  def show_cancel_return_to_sp?
     phishing_resistant_only? || piv_cac_required?
   end
 

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -51,11 +51,11 @@
 
 <% if @presenter.skip_path || !@presenter.two_factor_enabled? %>
   <%= render PageFooterComponent.new do %>
-    <% if @presenter.skip_path && !@presenter.show_cancel_phishing_resistant_only %>
+    <% if @presenter.skip_path && !@presenter.show_cancel_aal2plus %>
       <%= link_to @presenter.skip_label, @presenter.skip_path %>
     <% elsif !@presenter.two_factor_enabled? %>
       <%= link_to t('links.cancel_account_creation'), sign_up_cancel_path %>
-    <% elsif @presenter.show_cancel_phishing_resistant_only %>
+    <% elsif @presenter.show_cancel_aal2plus %>
       <%= link_to t('links.cancel'), return_to_sp_cancel_path %>
     <% end %>
   <% end %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -51,12 +51,10 @@
 
 <% if @presenter.skip_path || !@presenter.two_factor_enabled? %>
   <%= render PageFooterComponent.new do %>
-    <% if @presenter.skip_path && !@presenter.show_cancel_return_to_sp? %>
+    <% if @presenter.skip_path %>
       <%= link_to @presenter.skip_label, @presenter.skip_path %>
     <% elsif !@presenter.two_factor_enabled? %>
       <%= link_to t('links.cancel_account_creation'), sign_up_cancel_path %>
-    <% elsif @presenter.show_cancel_return_to_sp? %>
-      <%= link_to t('links.cancel'), return_to_sp_cancel_path %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -20,7 +20,7 @@
   </h2>
 
   <ul class="usa-icon-list">
-    <% @presenter.selected_options.each do |option| %>
+    <% @presenter.all_user_selected_options.each do |option| %>
       <% if option.mfa_configuration_count > 0 %>
         <%= render partial: 'partials/multi_factor_authentication/selected_mfa_option', locals: { option: option } %>
       <% end %>
@@ -51,11 +51,11 @@
 
 <% if @presenter.skip_path || !@presenter.two_factor_enabled? %>
   <%= render PageFooterComponent.new do %>
-    <% if @presenter.skip_path && !@presenter.show_cancel_aal2plus %>
+    <% if @presenter.skip_path && !@presenter.show_cancel_return_to_sp? %>
       <%= link_to @presenter.skip_label, @presenter.skip_path %>
     <% elsif !@presenter.two_factor_enabled? %>
       <%= link_to t('links.cancel_account_creation'), sign_up_cancel_path %>
-    <% elsif @presenter.show_cancel_aal2plus %>
+    <% elsif @presenter.show_cancel_return_to_sp? %>
       <%= link_to t('links.cancel'), return_to_sp_cancel_path %>
     <% end %>
   <% end %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -20,7 +20,7 @@
   </h2>
 
   <ul class="usa-icon-list">
-    <% @presenter.options.each do |option| %>
+    <% @presenter.selected_options.each do |option| %>
       <% if option.mfa_configuration_count > 0 %>
         <%= render partial: 'partials/multi_factor_authentication/selected_mfa_option', locals: { option: option } %>
       <% end %>
@@ -51,10 +51,12 @@
 
 <% if @presenter.skip_path || !@presenter.two_factor_enabled? %>
   <%= render PageFooterComponent.new do %>
-    <% if @presenter.skip_path %>
+    <% if @presenter.skip_path && !@presenter.show_cancel_phishing_resistant_only %>
       <%= link_to @presenter.skip_label, @presenter.skip_path %>
     <% elsif !@presenter.two_factor_enabled? %>
       <%= link_to t('links.cancel_account_creation'), sign_up_cancel_path %>
+    <% elsif @presenter.show_cancel_phishing_resistant_only %>
+      <%= link_to t('links.cancel'), return_to_sp_cancel_path %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe TwoFactorOptionsPresenter do
     end
   end
 
-  describe '#show_cancel_aal2plus' do
+  describe '#show_cancel_return_to_sp?' do
     context 'phishing resistant required to add additonal mfa' do
       let(:presenter) do
         described_class.new(
@@ -151,7 +151,7 @@ RSpec.describe TwoFactorOptionsPresenter do
       end
 
       it 'returns true' do
-        expect(presenter.show_cancel_aal2plus).to eq(true)
+        expect(presenter.show_cancel_return_to_sp?).to eq(true)
       end
     end
   end

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe TwoFactorOptionsPresenter do
     end
   end
 
-  describe '#show_cancel_phishing_resistant_only' do
+  describe '#show_cancel_aal2plus' do
     context 'phishing resistant required to add additonal mfa' do
       let(:presenter) do
         described_class.new(
@@ -151,7 +151,7 @@ RSpec.describe TwoFactorOptionsPresenter do
       end
 
       it 'returns true' do
-        expect(presenter.show_cancel_phishing_resistant_only).to eq(true)
+        expect(presenter.show_cancel_aal2plus).to eq(true)
       end
     end
   end

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -140,4 +140,19 @@ RSpec.describe TwoFactorOptionsPresenter do
       end
     end
   end
+
+  describe '#show_cancel_phishing_resistant_only' do
+    context 'phishing resistant required to add additonal mfa' do
+      let(:presenter) do
+        described_class.new(
+          user_agent: user_agent, user: user_with_2fa,
+          phishing_resistant_required: true
+        )
+      end
+
+      it 'returns true' do
+        expect(presenter.show_cancel_phishing_resistant_only).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe TwoFactorOptionsPresenter do
 
   describe '#skip_path' do
     subject(:skip_path) { presenter.skip_path }
-
     it { expect(skip_path).to be_nil }
 
     context 'with mfa configured' do
@@ -145,8 +144,9 @@ RSpec.describe TwoFactorOptionsPresenter do
     context 'phishing resistant required to add additonal mfa' do
       let(:presenter) do
         described_class.new(
-          user_agent: user_agent, user: user_with_2fa,
-          phishing_resistant_required: true
+          user_agent: user_agent,
+          user: user_with_2fa,
+          phishing_resistant_required: true,
         )
       end
 

--- a/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
+++ b/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
   include Devise::Test::ControllerHelpers
+  include IdvHelper
 
   let(:user) { build(:user) }
   let(:user_agent) { '' }
@@ -102,12 +103,11 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
   end
 
   context 'unphishable requires additional authentication to be added' do
-    let(:user) { build(:user, :with_phone) }
+    let(:user) { build(:user, :fully_registered, :with_phone) }
     let(:phishing_resistant_required) { true }
 
-    it 'lists current mfa methods' do
+    it 'lists current selected mfa methods' do
       render
-
       expect(rendered).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
       expect(rendered).to have_content(
         t('two_factor_authentication.two_factor_choice_options.phone'),

--- a/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
+++ b/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
   let(:show_skip_additional_mfa_link) { true }
   let(:phishing_resistant_required) { false }
   let(:after_mfa_setup_path) { account_path }
+  let(:return_to_sp_cancel_path) { '/redirect/return_to_sp/cancel' }
   subject(:rendered) { render }
 
   before do
@@ -17,6 +18,7 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
       user:,
       show_skip_additional_mfa_link:,
       after_mfa_setup_path:,
+      return_to_sp_cancel_path:,
       phishing_resistant_required:,
     )
     @two_factor_options_form = TwoFactorLoginOptionsForm.new(user)
@@ -116,7 +118,6 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
 
     it 'shows a cancel link that aborts the login' do
       render
-
       expect(rendered).not_to have_link(t('mfa.skip'))
       expect(rendered).to have_link(t('links.cancel'))
     end

--- a/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
+++ b/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
   include Devise::Test::ControllerHelpers
   include IdvHelper
+  include Rails.application.routes.url_helpers
 
   let(:user) { build(:user) }
   let(:user_agent) { '' }
   let(:show_skip_additional_mfa_link) { true }
   let(:phishing_resistant_required) { false }
   let(:after_mfa_setup_path) { account_path }
-  let(:return_to_sp_cancel_path) { '/redirect/return_to_sp/cancel' }
+  let(:return_to_sp_cancel_path) { return_to_sp_cancel_path }
   subject(:rendered) { render }
 
   before do

--- a/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
+++ b/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
@@ -3,14 +3,12 @@ require 'rails_helper'
 RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
   include Devise::Test::ControllerHelpers
   include IdvHelper
-  include Rails.application.routes.url_helpers
 
   let(:user) { build(:user) }
   let(:user_agent) { '' }
   let(:show_skip_additional_mfa_link) { true }
   let(:phishing_resistant_required) { false }
   let(:after_mfa_setup_path) { account_path }
-  let(:return_to_sp_cancel_path) { return_to_sp_cancel_path }
   subject(:rendered) { render }
 
   before do

--- a/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
+++ b/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
   end
 
   context 'unphishable requires additional authentication to be added' do
-    let(:user) { build(:user, :fully_registered, :with_phone) }
+    let(:user) { create(:user, :fully_registered, :with_phone) }
     let(:phishing_resistant_required) { true }
 
     it 'lists current selected mfa methods' do

--- a/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
+++ b/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
   let(:user) { build(:user) }
   let(:user_agent) { '' }
   let(:show_skip_additional_mfa_link) { true }
+  let(:phishing_resistant_required) { false }
   let(:after_mfa_setup_path) { account_path }
   subject(:rendered) { render }
 
@@ -15,6 +16,7 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
       user:,
       show_skip_additional_mfa_link:,
       after_mfa_setup_path:,
+      phishing_resistant_required:,
     )
     @two_factor_options_form = TwoFactorLoginOptionsForm.new(user)
   end
@@ -96,6 +98,27 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
         with: :phone,
         disabled: false,
       )
+    end
+  end
+
+  context 'unphishable requires additional authentication to be added' do
+    let(:user) { build(:user, :with_phone) }
+    let(:phishing_resistant_required) { true }
+
+    it 'lists current mfa methods' do
+      render
+
+      expect(rendered).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
+      expect(rendered).to have_content(
+        t('two_factor_authentication.two_factor_choice_options.phone'),
+      )
+    end
+
+    it 'shows a cancel link that aborts the login' do
+      render
+
+      expect(rendered).not_to have_link(t('mfa.skip'))
+      expect(rendered).to have_link(t('links.cancel'))
     end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-11036](https://cm-jira.usa.gov/browse/LG-11036)


## 🛠 Summary of changes

The presenter was repurposing code that populated the available mfa in the form to show the list of selected mfa. That caused a bug in AAL2+ Add Second MFA view if the user had a phone option selected or any other phishing vulnerable options it couldn't show there. 
I added a method that collects the selected mfa independent of the options that add checkboxes to the form.


## 📜 Testing Plan


- [ ] Prerequisite: Have an account with a phishable MFA method (e.g. phone) in local idp (https://localhost:3000/)
- [ ] Go to local sinatra app https://localhost:9292?aal=2-phishing_resistant
- [ ] Click "Sign in"
- [ ] Continue sign-in process until "Additional authentication required" screen

You should expect to see "Your authentication methods" lists authentication methods, and there's no option to skip this step since it's required to sign in to the partner.  Cancel (link) replaces skip for now and signs out.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
