### PR TITLE
LG-11101: Double-track auth methods session value (Part 1 of 2)

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -67,7 +67,10 @@ module RememberDeviceConcern
 
   def handle_valid_remember_device_cookie(remember_device_cookie:)
     user_session[:auth_method] = TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
-    mark_user_session_authenticated(:device_remembered)
+    mark_user_session_authenticated(
+      auth_method: TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE,
+      authentication_type: :device_remembered,
+    )
     handle_valid_remember_device_analytics(cookie_created_at: remember_device_cookie.created_at)
     redirect_to after_sign_in_path_for(current_user)
   end

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -4,6 +4,10 @@ module TwoFactorAuthenticatableMethods
   include SecureHeadersConcern
   include MfaSetupConcern
 
+  def auth_methods_session
+    @auth_methods_session ||= AuthMethodsSession.new(user_session:)
+  end
+
   private
 
   def authenticate_user
@@ -146,13 +150,13 @@ module TwoFactorAuthenticatableMethods
 
   def handle_valid_verification_for_confirmation_context(auth_method:)
     user_session[:auth_method] = auth_method
-    mark_user_session_authenticated(:valid_2fa_confirmation)
+    mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa_confirmation)
     reset_second_factor_attempts_count
   end
 
   def handle_valid_verification_for_authentication_context(auth_method:)
     user_session[:auth_method] = auth_method
-    mark_user_session_authenticated(:valid_2fa)
+    mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa)
     create_user_event(:sign_in_after_2fa)
 
     reset_second_factor_attempts_count
@@ -162,9 +166,10 @@ module TwoFactorAuthenticatableMethods
     UpdateUser.new(user: current_user, attributes: { second_factor_attempts_count: 0 }).call
   end
 
-  def mark_user_session_authenticated(authentication_type)
+  def mark_user_session_authenticated(auth_method:, authentication_type:)
     user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
     user_session[:authn_at] = Time.zone.now
+    auth_methods_session.authenticate!(auth_method)
     mark_user_session_authenticated_analytics(authentication_type)
   end
 

--- a/app/services/auth_methods_session.rb
+++ b/app/services/auth_methods_session.rb
@@ -1,0 +1,16 @@
+class AuthMethodsSession
+  attr_reader :user_session
+
+  def initialize(user_session:)
+    @user_session = user_session
+  end
+
+  def authenticate!(auth_method)
+    user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
+    auth_events << { auth_method:, at: Time.zone.now }
+  end
+
+  def auth_events
+    user_session[:auth_events] ||= []
+  end
+end

--- a/app/services/auth_methods_session.rb
+++ b/app/services/auth_methods_session.rb
@@ -1,16 +1,20 @@
 class AuthMethodsSession
   attr_reader :user_session
 
+  MAX_AUTH_EVENTS = 10
+
   def initialize(user_session:)
     @user_session = user_session
   end
 
   def authenticate!(auth_method)
     user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
-    auth_events << { auth_method:, at: Time.zone.now }
+    user_session[:auth_events] = auth_events.
+      push({ auth_method:, at: Time.zone.now }).
+      pop(MAX_AUTH_EVENTS)
   end
 
   def auth_events
-    user_session[:auth_events] ||= []
+    user_session[:auth_events] || []
   end
 end

--- a/app/services/auth_methods_session.rb
+++ b/app/services/auth_methods_session.rb
@@ -11,7 +11,7 @@ class AuthMethodsSession
     user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
     user_session[:auth_events] = auth_events.
       push({ auth_method:, at: Time.zone.now }).
-      pop(MAX_AUTH_EVENTS)
+      last(MAX_AUTH_EVENTS)
   end
 
   def auth_events

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -42,12 +42,18 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
             with(:mfa_login_backup_code, success: true)
 
           post :create, params: payload
-        end
 
-        expect(subject.user_session[:auth_method]).to eq(
-          TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
-        )
-        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
+          expect(subject.user_session[:auth_method]).to eq(
+            TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
+          )
+          expect(subject.user_session[:auth_events]).to eq(
+            [
+              auth_method: TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
+              at: Time.zone.now,
+            ],
+          )
+          expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
+        end
       end
 
       context 'with remember_device in the params' do
@@ -141,6 +147,7 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
         expect(response).to render_template(:show)
         expect(flash[:error]).to eq t('two_factor_authentication.invalid_backup_code')
         expect(subject.user_session[:auth_method]).to eq nil
+        expect(subject.user_session[:auth_events]).to eq nil
         expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -304,8 +304,10 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
           expect(subject.user_session[:auth_method]).to eq TwoFactorAuthenticatable::AuthMethod::SMS
           expect(subject.user_session[:auth_events]).to eq(
             [
-              auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
-              at: Time.zone.now,
+              {
+                auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
+                at: Time.zone.now,
+              },
             ],
           )
           expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -174,6 +174,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
 
       it 'does not set auth_method and requires 2FA' do
         expect(controller.user_session[:auth_method]).to eq nil
+        expect(controller.user_session[:auth_events]).to eq nil
         expect(controller.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end
     end
@@ -294,13 +295,21 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_submitted).
           with(reauthentication: false, success: true)
 
-        post :create, params: {
-          code: subject.current_user.reload.direct_otp,
-          otp_delivery_preference: 'sms',
-        }
+        freeze_time do
+          post :create, params: {
+            code: subject.current_user.reload.direct_otp,
+            otp_delivery_preference: 'sms',
+          }
 
-        expect(subject.user_session[:auth_method]).to eq TwoFactorAuthenticatable::AuthMethod::SMS
-        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
+          expect(subject.user_session[:auth_method]).to eq TwoFactorAuthenticatable::AuthMethod::SMS
+          expect(subject.user_session[:auth_events]).to eq(
+            [
+              auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
+              at: Time.zone.now,
+            ],
+          )
+          expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
+        end
       end
 
       context "with a leading '#' sign" do

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -20,11 +20,21 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
         expect(Db::AuthAppConfiguration).to receive(:authenticate).and_return(cfg)
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
 
-        post :create, params: { code: generate_totp_code(@secret) }
+        freeze_time do
+          post :create, params: { code: generate_totp_code(@secret) }
 
-        expect(response).to redirect_to account_path
-        expect(subject.user_session[:auth_method]).to eq TwoFactorAuthenticatable::AuthMethod::TOTP
-        expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
+          expect(response).to redirect_to account_path
+          expect(subject.user_session[:auth_method]).to eq(
+            TwoFactorAuthenticatable::AuthMethod::TOTP,
+          )
+          expect(subject.user_session[:auth_events]).to eq(
+            [
+              auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,
+              at: Time.zone.now,
+            ],
+          )
+          expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
+        end
       end
 
       it 'resets the second_factor_attempts_count' do
@@ -103,6 +113,7 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
 
       it 'does not set auth_method and still requires 2FA' do
         expect(subject.user_session[:auth_method]).to eq nil
+        expect(subject.user_session[:auth_events]).to eq nil
         expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end
     end

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe Users::PivCacLoginController do
 
             expect(controller.user_session[:authn_at]).to_not be nil
             expect(controller.user_session[:authn_at].class).to eq ActiveSupport::TimeWithZone
+            expect(controller.auth_methods_session.auth_events).to match(
+              [
+                {
+                  auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
+                  at: kind_of(ActiveSupport::TimeWithZone),
+                },
+              ],
+            )
           end
 
           it 'tracks the user_marked_authed event' do

--- a/spec/services/auth_methods_session_spec.rb
+++ b/spec/services/auth_methods_session_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe AuthMethodsSession do
+  let(:user_session) { {} }
+  let(:auth_methods_session) { described_class.new(user_session:) }
+
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  describe '#authenticate!' do
+    let(:auth_method) { 'example' }
+    subject(:result) { auth_methods_session.authenticate!(auth_method) }
+
+    context 'no auth events' do
+      it 'modifies auth events to include the new event' do
+        expect { result }.to change { auth_methods_session.auth_events }.
+          from([]).
+          to([{ auth_method:, at: Time.zone.now }])
+      end
+
+      it 'returns the new array of auth events' do
+        expect(result).to eq([{ auth_method:, at: Time.zone.now }])
+      end
+    end
+
+    context 'with existing auth event' do
+      let(:first_auth_event) { { auth_method: 'first', at: Time.zone.now } }
+      let(:user_session) { { auth_events: [first_auth_event] } }
+
+      it 'appends the new event to the existing set' do
+        expect { result }.to change { auth_methods_session.auth_events }.
+          from([first_auth_event]).
+          to([first_auth_event, { auth_method:, at: Time.zone.now }])
+      end
+
+      it 'returns the new array of auth events' do
+        expect(result).to eq([first_auth_event, { auth_method:, at: Time.zone.now }])
+      end
+    end
+  end
+
+  describe '#auth_events' do
+    subject(:auth_events) { auth_methods_session.auth_events }
+
+    context 'no auth events' do
+      it 'returns an empty array' do
+        expect(auth_events).to eq([])
+      end
+    end
+
+    context 'with multiple auth events' do
+      let(:session_auth_events) do
+        [
+          { auth_method: 'first', at: Time.zone.now },
+          { auth_method: 'second', at: Time.zone.now },
+        ]
+      end
+      let(:user_session) { { auth_events: session_auth_events } }
+
+      it 'returns an array of auth events' do
+        expect(auth_events).to eq(session_auth_events)
+      end
+    end
+  end
+end

--- a/spec/services/auth_methods_session_spec.rb
+++ b/spec/services/auth_methods_session_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe AuthMethodsSession do
         expect(result).to eq([first_auth_event, { auth_method:, at: Time.zone.now }])
       end
     end
+
+    context 'with maximum tracked events' do
+      before do
+        stub_const('AuthMethodsSession::MAX_AUTH_EVENTS', 2)
+      end
+
+      let(:first_auth_event) { { auth_method: 'first', at: 2.days.ago } }
+      let(:second_auth_event) { { auth_method: 'second', at: 1.day.ago } }
+      let(:user_session) { { auth_events: [first_auth_event, second_auth_event] } }
+
+      it 'ejects the oldest' do
+        expect { result }.to change { auth_methods_session.auth_events }.
+          from([first_auth_event, second_auth_event]).
+          to([second_auth_event, { auth_method:, at: Time.zone.now }])
+      end
+    end
   end
 
   describe '#auth_events' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11101](https://cm-jira.usa.gov/browse/LG-11101)

## 🛠 Summary of changes

Starts double-tracking authentication events to a new session value, in preparation for #9335 (Part 2) to switch over to that session value for considering whether one of the events would satisfy an authentication request.

## 📜 Testing Plan

Since this is only setting but not reading from a new session value, there should not be an expected change in user behavior.

Verify there are no regressions in allowing the user to be considered authenticated, e.g. by remember device cookie, or AAL2 strict requests. See testing plan in #9335 for example.