### PR TITLE
LG-11139: question upon exit

### DIFF
--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -33,6 +33,16 @@ module Idv
       end
     end
 
+    def exit
+      analytics.idv_cancellation_confirmed(step: params[:step])
+      cancel_session
+      if hybrid_session?
+        render :destroy
+      else
+        redirect_to cancelled_redirect_path
+      end
+    end
+
     private
 
     def barcode_step?

--- a/app/javascript/packages/components/checkbox.spec.tsx
+++ b/app/javascript/packages/components/checkbox.spec.tsx
@@ -32,8 +32,8 @@ describe('Checkbox', () => {
     });
   });
 
-  context('withs hint', () => {
-    it('render hint', () => {
+  context('with hint', () => {
+    it('renders hint', () => {
       const { getByText } = render(
         <Checkbox
           isTitle

--- a/app/javascript/packages/components/checkbox.spec.tsx
+++ b/app/javascript/packages/components/checkbox.spec.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import Checkbox from './checkbox';
+
+describe('Checkbox', () => {
+  it('renders given checkbox', () => {
+    const { getByRole, getByText } = render(
+      <Checkbox id="checkbox1" label="A checkbox" labelDescription="A checkbox for testing" />,
+    );
+
+    const checkbox = getByRole('checkbox');
+    expect(checkbox.classList.contains('usa-checkbox__input')).to.be.true();
+    expect(checkbox.classList.contains('usa-button__input-title')).to.be.false();
+    expect(checkbox.id).to.eq('checkbox1');
+
+    const label = getByText('A checkbox');
+    expect(label).to.be.ok();
+    expect(label.classList.contains('usa-checkbox__label')).to.be.true();
+    expect(label.getAttribute('for')).eq('checkbox1');
+
+    const labelDescription = getByText('A checkbox for testing');
+    expect(labelDescription).to.be.ok();
+    expect(labelDescription.classList.contains('usa-checkbox__label-description')).to.be.true();
+  });
+
+  context('with isTitle', () => {
+    it('renders with correct style', () => {
+      const { getByRole } = render(
+        <Checkbox isTitle label="A checkbox" labelDescription="A checkbox for testing" />,
+      );
+      const checkbox = getByRole('checkbox');
+      expect(checkbox.classList.contains('usa-button__input-title')).to.be.true();
+    });
+  });
+
+  context('withs hint', () => {
+    it('render hint', () => {
+      const { getByText } = render(
+        <Checkbox
+          isTitle
+          label="A checkbox"
+          labelDescription="A checkbox for testing"
+          hint="Please check this box"
+        />,
+      );
+      const hint = getByText('Please check this box');
+      expect(hint).to.be.ok();
+    });
+  });
+});

--- a/app/javascript/packages/components/checkbox.tsx
+++ b/app/javascript/packages/components/checkbox.tsx
@@ -28,6 +28,7 @@ function Checkbox({
   const classes = ['usa-checkbox__input', isTitle && 'usa-button__input-title', className]
     .filter(Boolean)
     .join(' ');
+
   return (
     <div className="usa-checkbox">
       <input id={inputId} className={classes} type="checkbox" {...inputProps} />

--- a/app/javascript/packages/components/checkbox.tsx
+++ b/app/javascript/packages/components/checkbox.tsx
@@ -35,7 +35,7 @@ function Checkbox({
       <label className="usa-checkbox__label" htmlFor={inputId}>
         {label}
         {labelDescription && (
-          <span className="usa-checkbox__label-description">labelDescription</span>
+          <span className="usa-checkbox__label-description">{labelDescription}</span>
         )}
       </label>
       {hint && (

--- a/app/javascript/packages/components/checkbox.tsx
+++ b/app/javascript/packages/components/checkbox.tsx
@@ -2,10 +2,29 @@ import type { InputHTMLAttributes } from 'react';
 import { useInstanceId } from '@18f/identity-react-hooks';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * Whether checkbox is considered title, a box around it, with optional description for the label
+   */
   isTitle?: boolean;
+  /**
+   * Whether is focused, a focus box around the checkbox
+   */
+  isFocus?: boolean;
+  /**
+   * Optional id for the element
+   */
   id?: string;
+  /**
+   * Optional additional class names.
+   */
   className?: string;
+  /**
+   * Label text for the checkbox
+   */
   label: string;
+  /**
+   * Optional description for the label, used with isTitle
+   */
   labelDescription?: string;
   /**
    * Muted explainer text sitting below the label.
@@ -16,6 +35,7 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
 function Checkbox({
   id,
   isTitle,
+  isFocus,
   className,
   label,
   labelDescription,
@@ -23,9 +43,14 @@ function Checkbox({
   ...inputProps
 }: CheckboxProps) {
   const instanceId = useInstanceId();
-  const inputId = id ?? `checkbox-input-${instanceId}`;
-  const hintId = id ?? `select-input-hint-${instanceId}`;
-  const classes = ['usa-checkbox__input', isTitle && 'usa-button__input-title', className]
+  const inputId = id ?? `check-input-${instanceId}`;
+  const hintId = id ?? `check-input-hint-${instanceId}`;
+  const classes = [
+    'usa-checkbox__input',
+    isTitle && 'usa-button__input-title',
+    isFocus && 'usa-focus',
+    className,
+  ]
     .filter(Boolean)
     .join(' ');
 

--- a/app/javascript/packages/components/checkbox.tsx
+++ b/app/javascript/packages/components/checkbox.tsx
@@ -1,0 +1,48 @@
+import type { InputHTMLAttributes } from 'react';
+import { useInstanceId } from '@18f/identity-react-hooks';
+
+export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  isTitle?: boolean;
+  id?: string;
+  className?: string;
+  label: string;
+  labelDescription?: string;
+  /**
+   * Muted explainer text sitting below the label.
+   */
+  hint?: string;
+}
+
+function Checkbox({
+  id,
+  isTitle,
+  className,
+  label,
+  labelDescription,
+  hint,
+  ...inputProps
+}: CheckboxProps) {
+  const instanceId = useInstanceId();
+  const inputId = id ?? `checkbox-input-${instanceId}`;
+  const hintId = id ?? `select-input-hint-${instanceId}`;
+  const classes = ['usa-checkbox__input', isTitle && 'usa-button__input-title', className]
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <div className="usa-checkbox">
+      <input id={inputId} className={classes} type="checkbox" {...inputProps} />
+      <label className="usa-checkbox__label" htmlFor={inputId}>
+        {label}
+        {labelDescription && (
+          <span className="usa-checkbox__label-description">labelDescription</span>
+        )}
+      </label>
+      {hint && (
+        <div id={hintId} className="usa-hint">
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+}
+export default Checkbox;

--- a/app/javascript/packages/components/field-set-spec.tsx
+++ b/app/javascript/packages/components/field-set-spec.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import FieldSet from './field-set';
+
+describe('FieldSet', () => {
+  it('renders given fieldset', () => {
+    const { getByRole, getByText } = render(
+      <FieldSet>
+        <p>Inner text</p>
+      </FieldSet>,
+    );
+    const fieldSet = getByRole('group');
+    expect(fieldSet).to.be.ok();
+    expect(fieldSet.classList.contains('usa-fieldset')).to.be.true();
+
+    const child = getByText('Inner text');
+    expect(child).to.be.ok();
+  });
+  context('with legend', () => {
+    it('renders legend', () => {
+      const { getByText } = render(
+        <FieldSet legend="Legend text">
+          <p>Inner text</p>
+        </FieldSet>,
+      );
+      const legend = getByText('Legend text');
+      expect(legend).to.be.ok();
+      expect(legend.classList.contains('usa-legend')).to.be.true();
+    });
+  });
+});

--- a/app/javascript/packages/components/field-set.tsx
+++ b/app/javascript/packages/components/field-set.tsx
@@ -1,4 +1,4 @@
-import { FieldsetHTMLAttributes, HTMLAttributes, ReactNode } from 'react';
+import { FieldsetHTMLAttributes, ReactNode } from 'react';
 
 export interface FieldSetProps extends FieldsetHTMLAttributes<HTMLFieldSetElement> {
   /**

--- a/app/javascript/packages/components/field-set.tsx
+++ b/app/javascript/packages/components/field-set.tsx
@@ -12,7 +12,7 @@ export interface FieldSetProps extends FieldsetHTMLAttributes<HTMLFieldSetElemen
 function FieldSet({ legend, children }: FieldSetProps) {
   return (
     <fieldset className="usa-fieldset">
-      {legend && <legend className="usa-fieldset">{legend}</legend>}
+      {legend && <legend className="usa-legend">{legend}</legend>}
       {children}
     </fieldset>
   );

--- a/app/javascript/packages/components/field-set.tsx
+++ b/app/javascript/packages/components/field-set.tsx
@@ -1,0 +1,21 @@
+import { FieldsetHTMLAttributes, HTMLAttributes, ReactNode } from 'react';
+
+export interface FieldSetProps extends FieldsetHTMLAttributes<HTMLFieldSetElement> {
+  /**
+   * Footer contents.
+   */
+  children: ReactNode;
+
+  legend?: string;
+}
+
+function FieldSet({ legend, children }: FieldSetProps) {
+  return (
+    <fieldset className="usa-fieldset">
+      {legend && <legend className="usa-fieldset">{legend}</legend>}
+      {children}
+    </fieldset>
+  );
+}
+
+export default FieldSet;

--- a/app/javascript/packages/components/index.ts
+++ b/app/javascript/packages/components/index.ts
@@ -21,8 +21,11 @@ export { default as StatusPage } from './status-page';
 export { default as Tag } from './tag';
 export { default as TextInput } from './text-input';
 export { default as TroubleshootingOptions } from './troubleshooting-options';
+export { default as Checkbox } from './checkbox';
+export { default as FieldSet } from './field-set';
 
 export type { ButtonProps } from './button';
 export type { FullScreenRefHandle } from './full-screen';
 export type { LinkProps } from './link';
 export type { TextInputProps } from './text-input';
+export type { CheckboxProps } from './checkbox';

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -1,0 +1,56 @@
+import { Tag, Checkbox, FieldSet, Button } from '@18f/identity-components';
+import { useI18n } from '@18f/identity-react-i18n';
+
+function DocumentCaptureAbandon() {
+  const { t } = useI18n();
+
+  const header = <h3>Don&amp;apos;t have a driver;apos;s licnese or State ID?</h3>;
+  const content = (
+    <p>
+      If you dont have a driver;apos;s licens or state ID card, you cannot continu with Loging.gov.
+      Please exit Login.gov and contact[Partner Agency] to find out what you can do.
+    </p>
+  );
+
+  const optionalTag = <Tag isBig={false}>Optional</Tag>;
+
+  const optionalText = (
+    <p>
+      Help us add more identity documents to Login.gov. Which types of identity documents do you
+      have instead?
+    </p>
+  );
+  const idTypes = [
+    'us_passport',
+    'resident_card',
+    'military_id',
+    'tribal_id',
+    'voter_registration_card',
+    'other',
+  ];
+
+  const idTypeLabels = [
+    t('doc_auth.exit_survey_id_types.us_passport'),
+    t('doc_auth.exit_survey_id_types.resident_card'),
+    t('doc_auth.exit_survey_id_types.military_id'),
+    t('doc_auth.exit_survey_id_types.tribal_id'),
+    t('doc_auth.exit_survey_id_types.voter_registration_card'),
+    t('doc_auth.exit_survey_id_types.other'),
+  ];
+
+  const checkboxes = idTypes.map((idType, idx) => (
+    <Checkbox key={idType} name={idType} value={idType} label={idTypeLabels[idx]} />
+  ));
+  return (
+    <>
+      {header}
+      {content}
+      {optionalTag}
+      {optionalText}
+      <FieldSet legend="Optional. Select any of the documents you have.">{checkboxes}</FieldSet>
+      <Button isOutline>Submit and exit Login.gov</Button>
+    </>
+  );
+}
+
+export default DocumentCaptureAbandon;

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -22,7 +22,7 @@ function formatContentHtml({ msg, url }) {
 function DocumentCaptureAbandon() {
   const { t } = useI18n();
   const { trackEvent } = useContext(AnalyticsContext);
-  const { currentStep, exitURL } = useContext(FlowContext);
+  const { currentStep, exitURL, cancelURL } = useContext(FlowContext);
   const { name: spName } = useContext(ServiceProviderContext);
   const appName = getConfigValue('appName');
   const header = <h3>{t('doc_auth.exit_survey.header')}</h3>;
@@ -30,11 +30,19 @@ function DocumentCaptureAbandon() {
   const content = (
     <p>
       {formatContentHtml({
-        msg: t('doc_auth.exit_survey.content_html', {
-          sp_name: spName ?? 'NA',
-          app_name: appName,
+        msg:
+          spName && spName.trim()
+            ? t('doc_auth.exit_survey.content_html', {
+                sp_name: spName,
+                app_name: appName,
+              })
+            : t('doc_auth.exit_survey.content_nosp_html', {
+                app_name: appName,
+              }),
+        url: addSearchParams(spName && spName.trim() ? exitURL : cancelURL, {
+          step: currentStep,
+          location: 'optional_question',
         }),
-        url: addSearchParams(exitURL, { step: currentStep, location: 'optional_question' }),
       })}
     </p>
   );
@@ -77,18 +85,22 @@ function DocumentCaptureAbandon() {
     );
   };
 
-  const checkboxes = idTypeOptions.map((idType, idx) => (
-    <Checkbox
-      key={idType.name}
-      name={idType.name}
-      value={idType.name}
-      label={idTypeLabels[idx]}
-      onChange={() => updateCheckStatus(idx)}
-    />
-  ));
+  const checkboxes = (
+    <>
+      {idTypeOptions.map((idType, idx) => (
+        <Checkbox
+          key={idType.name}
+          name={idType.name}
+          value={idType.name}
+          label={idTypeLabels[idx]}
+          onChange={() => updateCheckStatus(idx)}
+        />
+      ))}
+    </>
+  );
 
   const handleExit = () => {
-    trackEvent('IdV: exit optional id types', { ids: idTypeOptions });
+    trackEvent('IdV: exit optional questions', { ids: idTypeOptions });
     forceRedirect(addSearchParams(exitURL, { step: currentStep }));
   };
 

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -51,12 +51,12 @@ function DocumentCaptureAbandon({ navigate }: DocumentCaptureAbandonProps) {
   );
   const optionalTag = (
     <Tag isBig={false} id="optional_question_tag">
-      {t('doc_auth.exit_survey.optional.tag')}
+      {t('doc_auth.exit_survey.optional.tag', { app_name: appName })}
     </Tag>
   );
   const optionalText = (
     <p className="margin-top-3">
-      <strong>{t('doc_auth.exit_survey.optional.content_html')}</strong>
+      <strong>{t('doc_auth.exit_survey.optional.content_html', { app_name: appName })}</strong>
     </p>
   );
 

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -56,7 +56,7 @@ function DocumentCaptureAbandon({ navigate }: DocumentCaptureAbandonProps) {
   );
   const optionalText = (
     <p className="margin-top-3">
-      <strong>{t('doc_auth.exit_survey.optional.content_html', { app_name: appName })}</strong>
+      <strong>{t('doc_auth.exit_survey.optional.content', { app_name: appName })}</strong>
     </p>
   );
 

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -1,8 +1,11 @@
 import { Tag, Checkbox, FieldSet, Button } from '@18f/identity-components';
 import { useI18n } from '@18f/identity-react-i18n';
+import { useContext, useState } from 'react';
+import AnalyticsContext from '../context/analytics';
 
 function DocumentCaptureAbandon() {
   const { t } = useI18n();
+  const { trackEvent } = useContext(AnalyticsContext);
 
   const header = <h3>Don&amp;apos;t have a driver;apos;s licnese or State ID?</h3>;
   const content = (
@@ -20,14 +23,6 @@ function DocumentCaptureAbandon() {
       have instead?
     </p>
   );
-  const idTypes = [
-    'us_passport',
-    'resident_card',
-    'military_id',
-    'tribal_id',
-    'voter_registration_card',
-    'other',
-  ];
 
   const idTypeLabels = [
     t('doc_auth.exit_survey_id_types.us_passport'),
@@ -38,9 +33,40 @@ function DocumentCaptureAbandon() {
     t('doc_auth.exit_survey_id_types.other'),
   ];
 
-  const checkboxes = idTypes.map((idType, idx) => (
-    <Checkbox key={idType} name={idType} value={idType} label={idTypeLabels[idx]} />
+  const allIdTypeOptions = [
+    { name: 'us_passport', checked: false },
+    { name: 'resident_card', checked: false },
+    { name: 'military_id', checked: false },
+    { name: 'tribal_id', checked: false },
+    { name: 'voter_registration_card', checked: false },
+    { name: 'other', checked: false },
+  ];
+
+  const [idTypeOptions, setIdTypeOptions] = useState(allIdTypeOptions);
+
+  const updateCheckStatus = (index: number) => {
+    setIdTypeOptions(
+      idTypeOptions.map((id_option, currentIndex) =>
+        currentIndex === index ? { ...id_option, checked: !id_option.checked } : { ...id_option },
+      ),
+    );
+  };
+
+  const checkboxes = idTypeOptions.map((idType, idx) => (
+    <Checkbox
+      key={idType.name}
+      name={idType.name}
+      value={idType.name}
+      label={idTypeLabels[idx]}
+      onChange={() => updateCheckStatus(idx)}
+    />
   ));
+
+  const handleExit = () => {
+    trackEvent('IdV: exit optional id types', { ids: idTypeOptions });
+    window.location.href = '/verify/exit?step=document-capture&location=optional_question';
+  };
+
   return (
     <>
       {header}
@@ -48,7 +74,9 @@ function DocumentCaptureAbandon() {
       {optionalTag}
       {optionalText}
       <FieldSet legend="Optional. Select any of the documents you have.">{checkboxes}</FieldSet>
-      <Button isOutline>Submit and exit Login.gov</Button>
+      <Button isOutline onClick={handleExit}>
+        Submit and exit Login.gov
+      </Button>
     </>
   );
 }

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -55,7 +55,7 @@ function DocumentCaptureAbandon({ navigate }: DocumentCaptureAbandonProps) {
     </Tag>
   );
   const optionalText = (
-    <p className="margin-top-3">
+    <p className="margin-top-2">
       <strong>{t('doc_auth.exit_survey.optional.content', { app_name: appName })}</strong>
     </p>
   );
@@ -104,9 +104,11 @@ function DocumentCaptureAbandon({ navigate }: DocumentCaptureAbandonProps) {
 
   const handleExit = () => {
     trackEvent('IdV: exit optional questions', { ids: idTypeOptions });
-    const url = spName?.trim() ? exitURL : cancelURL;
     forceRedirect(
-      addSearchParams(url, { step: currentStep, location: 'optional_question' }),
+      addSearchParams(spName ? exitURL : cancelURL, {
+        step: currentStep,
+        location: 'optional_question',
+      }),
       navigate,
     );
   };

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -29,7 +29,7 @@ function DocumentCaptureAbandon({ navigate }: DocumentCaptureAbandonProps) {
   const { currentStep, exitURL, cancelURL } = useContext(FlowContext);
   const { name: spName } = useContext(ServiceProviderContext);
   const appName = getConfigValue('appName');
-  const header = <h3>{t('doc_auth.exit_survey.header')}</h3>;
+  const header = <h2 className="h3">{t('doc_auth.exit_survey.header')}</h2>;
 
   const content = (
     <p>

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -50,7 +50,7 @@ function DocumentCaptureAbandon({ navigate }: DocumentCaptureAbandonProps) {
     </p>
   );
   const optionalTag = (
-    <Tag isBig={false} id="optional_question_tag">
+    <Tag isBig={false} isInformative>
       {t('doc_auth.exit_survey.optional.tag', { app_name: appName })}
     </Tag>
   );

--- a/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-abandon.tsx
@@ -115,14 +115,16 @@ function DocumentCaptureAbandon({ navigate }: DocumentCaptureAbandonProps) {
     <>
       {header}
       {content}
-      {optionalTag}
-      {optionalText}
-      <FieldSet legend={t('doc_auth.exit_survey.optional.legend')}>{checkboxes}</FieldSet>
-      <Button isOutline className="margin-top-3" onClick={handleExit}>
-        {t('doc_auth.exit_survey.optional.button', { app_name: appName })}
-      </Button>
-      <div className="usa-prose margin-top-3">
-        {t('idv.legal_statement.information_collection')}
+      <div className="document-capture-optional-questions">
+        {optionalTag}
+        {optionalText}
+        <FieldSet legend={t('doc_auth.exit_survey.optional.legend')}>{checkboxes}</FieldSet>
+        <Button isOutline className="margin-top-3" onClick={handleExit}>
+          {t('doc_auth.exit_survey.optional.button', { app_name: appName })}
+        </Button>
+        <div className="usa-prose margin-top-3">
+          {t('idv.legal_statement.information_collection')}
+        </div>
       </div>
     </>
   );

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -10,6 +10,7 @@ import { useI18n } from '@18f/identity-react-i18n';
 import UnknownError from './unknown-error';
 import TipList from './tip-list';
 import DocumentSideAcuantCapture from './document-side-acuant-capture';
+import DocumentCaptureAbandon from './document-capture-abandon';
 
 interface DocumentCaptureReviewIssuesProps {
   isFailedDocType: boolean;
@@ -78,6 +79,7 @@ function DocumentCaptureReviewIssues({
         />
       ))}
       <FormStepsButton.Submit />
+      <DocumentCaptureAbandon />
       <Cancel />
     </>
   );

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -8,6 +8,7 @@ import DocumentSideAcuantCapture from './document-side-acuant-capture';
 import DeviceContext from '../context/device';
 import UploadContext from '../context/upload';
 import TipList from './tip-list';
+import DocumentCaptureAbandon from './document-capture-abandon';
 
 /**
  * @typedef {'front'|'back'} DocumentSide
@@ -70,6 +71,8 @@ function DocumentsStep({
         />
       ))}
       {isLastStep ? <FormStepsButton.Submit /> : <FormStepsButton.Continue />}
+
+      <DocumentCaptureAbandon />
       <Cancel />
     </>
   );

--- a/app/javascript/packages/document-capture/components/optional-questions.scss
+++ b/app/javascript/packages/document-capture/components/optional-questions.scss
@@ -1,0 +1,24 @@
+@use 'uswds-core' as *;
+
+.document-capture-optional-questions {
+  margin-top: 2em;
+  .usa-tag {
+    background-color: #306F84FF;
+    color: white;
+  }
+  .usa-fieldset {
+    .usa-legend {
+      text-transform: none;
+      margin-top: 1rem;
+      font-size: 1rem;
+      line-height: 1.4;
+      display: block;
+      border-bottom: none;
+    }
+    .usa-checkbox {
+      .usa-checkbox__label {
+        display: block; //collapsing margin
+      }
+    }
+  }
+}

--- a/app/javascript/packages/document-capture/components/optional-questions.scss
+++ b/app/javascript/packages/document-capture/components/optional-questions.scss
@@ -1,15 +1,18 @@
 @use 'uswds-core' as *;
 
 .document-capture-optional-questions {
-  margin-top: 2em;
+  margin-top: 1.5em;
   .usa-fieldset {
+    margin-top: 0;
     .usa-legend {
       text-transform: none;
-      margin-top: 1rem;
+      margin-top: 0;
       font-size: 1rem;
       line-height: 1.4;
       display: block;
       border-bottom: none;
+      padding-bottom: 0;
+      padding-top: 0;
     }
     .usa-checkbox {
       .usa-checkbox__label {

--- a/app/javascript/packages/document-capture/components/optional-questions.scss
+++ b/app/javascript/packages/document-capture/components/optional-questions.scss
@@ -3,7 +3,7 @@
 .document-capture-optional-questions {
   margin-top: 2em;
   .usa-tag {
-    background-color: #306F84FF;
+    background-color: #306f84ff;
     color: white;
   }
   .usa-fieldset {

--- a/app/javascript/packages/document-capture/components/optional-questions.scss
+++ b/app/javascript/packages/document-capture/components/optional-questions.scss
@@ -2,10 +2,6 @@
 
 .document-capture-optional-questions {
   margin-top: 2em;
-  .usa-tag {
-    background-color: #306f84ff;
-    color: white;
-  }
   .usa-fieldset {
     .usa-legend {
       text-transform: none;

--- a/app/javascript/packages/document-capture/styles.scss
+++ b/app/javascript/packages/document-capture/styles.scss
@@ -2,3 +2,4 @@
 @import './components/acuant-capture-canvas';
 @import './components/location-collection-item';
 @import './components/select-error';
+@import './components/optional-questions';

--- a/app/javascript/packages/verify-flow/cancel.spec.tsx
+++ b/app/javascript/packages/verify-flow/cancel.spec.tsx
@@ -15,6 +15,7 @@ describe('Cancel', () => {
         <FlowContext.Provider
           value={{
             cancelURL: 'http://example.test/cancel',
+            exitURL: 'http://example.test/exit',
             currentStep: 'one',
           }}
         >

--- a/app/javascript/packages/verify-flow/context/flow-context.tsx
+++ b/app/javascript/packages/verify-flow/context/flow-context.tsx
@@ -7,6 +7,11 @@ export interface FlowContextValue {
   cancelURL: string;
 
   /**
+   * URL to exit session without confirmation
+   */
+  exitURL: string;
+
+  /**
    * Current step name.
    */
   currentStep: string;
@@ -14,6 +19,7 @@ export interface FlowContextValue {
 
 const FlowContext = createContext<FlowContextValue>({
   cancelURL: '',
+  exitURL: '',
   currentStep: '',
 });
 

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -30,6 +30,7 @@ interface AppRootData {
   acuantVersion: string;
   flowPath: FlowPath;
   cancelUrl: string;
+  exitUrl: string;
   idvInPersonUrl?: string;
   securityAndPrivacyHowItWorksUrl: string;
 }
@@ -76,6 +77,7 @@ const {
   acuantVersion,
   flowPath,
   cancelUrl: cancelURL,
+  exitUrl: exitURL,
   idvInPersonUrl: inPersonURL,
   securityAndPrivacyHowItWorksUrl: securityAndPrivacyHowItWorksURL,
   inPersonFullAddressEntryEnabled,
@@ -134,6 +136,7 @@ const App = composeComponents(
     {
       value: {
         cancelURL,
+        exitURL,
         currentStep: 'document_capture',
       },
     },

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -26,6 +26,7 @@
       sp_name: sp_name,
       flow_path: flow_path,
       cancel_url: idv_cancel_path(step: :document_capture),
+      exit_url: idv_exit_path,
       failure_to_proof_url: failure_to_proof_url,
       idv_in_person_url: (IdentityConfig.store.in_person_doc_auth_button_enabled && Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)) ? idv_in_person_url : nil,
       security_and_privacy_how_it_works_url: MarketingSite.security_and_privacy_how_it_works_url,

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -116,7 +116,7 @@ en:
       header: Don’t have a driver’s license or state ID?
       optional:
         button: Submit and exit %{app_name}
-        content_html: Help us add more identity documents to Login.gov. Which types of
+        content_html: Help us add more identity documents to %{app_name}. Which types of
           identity documents do you have instead?
         id_types:
           military_id: Military ID card (this includes a Department of Defense

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -105,6 +105,15 @@ en:
         top_msg_plural: We couldn’t read your ID. Your photos may be too blurry or dark.
           Try taking new pictures in a bright area.
       upload_error: Sorry, something went wrong on our end.
+    exit_survey_id_types:
+      military_id: Military ID card(this includes a Department of Defense
+        Identification Card, a Veteran Health Identification Card, or a Veteran
+        ID Card)
+      other: Something not listed
+      resident_card: U.S. Green Card(also referred to as a Permanent Resident Card)
+      tribal_id: Tribal ID card
+      us_passport: U.S. Passport
+      voter_registration_card: Voter registration card
     forms:
       captured_image: Captured Image
       change_file: Change file

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -107,8 +107,12 @@ en:
       upload_error: Sorry, something went wrong on our end.
     exit_survey:
       content_html: <strong>If you do not have a driver’s license or state ID card,
-        you cannot continue with Login.gov.</strong> Please <a>exit %{app_name}
-        and contact %{sp_name}</a> to find out what you can do.
+        you cannot continue with %{app_name}.</strong> Please <a>exit
+        %{app_name} and contact %{sp_name}</a> to find out what you can do.
+      content_nosp_html: <strong>If you do not have a driver’s license or state ID
+        card, you cannot continue with %{app_name}.</strong> <a>Cancel verifying
+        your identity with %{app_name}</a> and you can restart the process when
+        you’re ready.
       header: Don’t have a driver’s license or state ID?
       optional:
         button: Submit and exit %{app_name}

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -116,7 +116,7 @@ en:
       header: Don’t have a driver’s license or state ID?
       optional:
         button: Submit and exit %{app_name}
-        content_html: Help us add more identity documents to %{app_name}. Which types of
+        content: Help us add more identity documents to %{app_name}. Which types of
           identity documents do you have instead?
         id_types:
           military_id: Military ID card (this includes a Department of Defense

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -105,15 +105,26 @@ en:
         top_msg_plural: We couldn’t read your ID. Your photos may be too blurry or dark.
           Try taking new pictures in a bright area.
       upload_error: Sorry, something went wrong on our end.
-    exit_survey_id_types:
-      military_id: Military ID card(this includes a Department of Defense
-        Identification Card, a Veteran Health Identification Card, or a Veteran
-        ID Card)
-      other: Something not listed
-      resident_card: U.S. Green Card(also referred to as a Permanent Resident Card)
-      tribal_id: Tribal ID card
-      us_passport: U.S. Passport
-      voter_registration_card: Voter registration card
+    exit_survey:
+      content_html: <strong>If you do not have a driver’s license or state ID card,
+        you cannot continue with Login.gov.</strong> Please <a>exit %{app_name}
+        and contact %{sp_name}</a> to find out what you can do.
+      header: Don’t have a driver’s license or state ID?
+      optional:
+        button: Submit and exit %{app_name}
+        content_html: Help us add more identity documents to Login.gov. Which types of
+          identity documents do you have instead?
+        id_types:
+          military_id: Military ID card (this includes a Department of Defense
+            Identification Card, a Veteran Health Identification Card, or a
+            Veteran ID Card
+          other: Something not listed
+          resident_card: U.S. Green Card (also referred to as a Permanent Resident Card)
+          tribal_id: Tribal ID card
+          us_passport: U.S. Passport
+          voter_registration_card: Voter registration card
+        legend: Optional. Select any of the documents you have.
+        tag: Optional
     forms:
       captured_image: Captured Image
       change_file: Change file

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -121,7 +121,7 @@ en:
         id_types:
           military_id: Military ID card (this includes a Department of Defense
             Identification Card, a Veteran Health Identification Card, or a
-            Veteran ID Card
+            Veteran ID Card)
           other: Something not listed
           resident_card: U.S. Green Card (also referred to as a Permanent Resident Card)
           tribal_id: Tribal ID card

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -145,8 +145,8 @@ es:
       header: No cuenta con una licencia de conducir o identificación estatal?
       optional:
         button: Enviar y salir de %{app_name}
-        content_html: Ayúdenos a agregar más identificaciones oficiales a %{app_name}.
-          ¿Qué identificaciones tiene como alternativa?
+        content: Ayúdenos a agregar más identificaciones oficiales a %{app_name}. ¿Qué
+          identificaciones tiene como alternativa?
         id_types:
           military_id: Credencial militar (puede ser una credencial del Departamento de
             Defensa, una credencial de Salud de los Veteranos o una credencial

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -296,20 +296,6 @@ es:
         - '<strong>Verificar por correo</strong>: Le enviaremos una carta a su
           domicilio. Esto tarda entre <strong>5 y 10 días</strong>.'
       welcome: 'Necesitará su:'
-    legal_statement:
-      information_collection: >-
-        Esta recopilación de información cumple con los requisitos del título 44
-        del U.S.C., § 3507, modificado por la sección 2 de la Ley de Reducción
-        de Trámites de 1995. No es necesario que responda a estas preguntas, a
-        menos que le mostremos un número de control válido de la Oficina de
-        Administración y Presupuesto (OMB). El número de control de la OMB para
-        esta recopilación es 3090-0325. Nous estimons qu’il faut une minute pour
-        lire les instructions, rassembler les preuves et répondre aux questions.
-        N’envoyez que des commentaires relatifs à notre estimation du temps, y
-        compris des suggestions pour réduire cette charge, ou tout autre aspect
-        de cette collecte d’informations à : General Services Administration,
-        Regulatory Secretariat Division (MVCB), ATTN : Lois Mandell/IC
-        3090-0325, 1800 F Street, NW, Washington, DC 20405.
     phone_question:
       do_not_have: No tengo teléfono
     tips:

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -133,6 +133,28 @@ es:
           estén demasiado borrosas u oscuras. Intente tomar nuevas fotos en un
           área iluminada.
       upload_error: Lo siento, algo salió mal por nuestra parte.
+    exit_survey:
+      content_html: <strong>Si no tiene una licencia de conducir o identificación
+        estatal, no puede continuar en Login.gov.</strong> Por favor <a>salga de
+        Login.gov y contacte a [Partner Agency]</a> para averiguar qué puede
+        hacer.
+      header: No cuenta con una licencia de conducir o identificación estatal?
+      optional:
+        button: Enviar y salir de Login.gov
+        content_html: Ayúdenos a agregar más identificaciones oficiales a Login.gov.
+          ¿Qué identificaciones tiene como alternativa?
+        id_types:
+          military_id: Credencial militar (puede ser una credencial del Departamento de
+            Defensa, una credencial de Salud de los Veteranos o una credencial
+            de veterano)
+          other: Una que no aparece en la lista
+          resident_card: Tarjeta verde de Estados Unidos (también conocida como tarjeta de
+            residente permanente)
+          tribal_id: Credencial tribal
+          us_passport: Pasaporte estadounidense
+          voter_registration_card: Credencial para votar
+        legend: Opcional. Seleccione todas las identificaciones que tenga.
+        tag: Opcional
     forms:
       captured_image: Imagen capturada
       change_file: Cambiar archivo
@@ -270,6 +292,20 @@ es:
         - '<strong>Verificar por correo</strong>: Le enviaremos una carta a su
           domicilio. Esto tarda entre <strong>5 y 10 días</strong>.'
       welcome: 'Necesitará su:'
+    legal_statement:
+      information_collection: >-
+        Esta recopilación de información cumple con los requisitos del título 44
+        del U.S.C., § 3507, modificado por la sección 2 de la Ley de Reducción
+        de Trámites de 1995. No es necesario que responda a estas preguntas, a
+        menos que le mostremos un número de control válido de la Oficina de
+        Administración y Presupuesto (OMB). El número de control de la OMB para
+        esta recopilación es 3090-0325. Nous estimons qu’il faut une minute pour
+        lire les instructions, rassembler les preuves et répondre aux questions.
+        N’envoyez que des commentaires relatifs à notre estimation du temps, y
+        compris des suggestions pour réduire cette charge, ou tout autre aspect
+        de cette collecte d’informations à : General Services Administration,
+        Regulatory Secretariat Division (MVCB), ATTN : Lois Mandell/IC
+        3090-0325, 1800 F Street, NW, Washington, DC 20405.
     phone_question:
       do_not_have: No tengo teléfono
     tips:

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -135,9 +135,13 @@ es:
       upload_error: Lo siento, algo salió mal por nuestra parte.
     exit_survey:
       content_html: <strong>Si no tiene una licencia de conducir o identificación
-        estatal, no puede continuar en Login.gov.</strong> Por favor <a>salga de
-        Login.gov y contacte a [Partner Agency]</a> para averiguar qué puede
+        estatal, no puede continuar en %{app_name}.</strong> Por favor <a>salga
+        de %{app_name} y contacte a %{sp_name}</a> para averiguar qué puede
         hacer.
+      content_nosp_html: <strong>Si no tiene una licencia de conducir o identificación
+        estatal, no puede continuar en %{app_name}.</strong> <a>Cancele la
+        verificación de identidad con %{app_name}</a> y podrá reiniciar el
+        proceso cuando esté listo.
       header: No cuenta con una licencia de conducir o identificación estatal?
       optional:
         button: Enviar y salir de Login.gov

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -152,8 +152,8 @@ es:
             Defensa, una credencial de Salud de los Veteranos o una credencial
             de veterano)
           other: Una que no aparece en la lista
-          resident_card: Tarjeta verde de Estados Unidos (también conocida como tarjeta de
-            residente permanente)
+          resident_card: Tarjeta Verde de Estados Unidos (también conocida como Tarjeta de
+            Residente Permanente)
           tribal_id: Credencial tribal
           us_passport: Pasaporte estadounidense
           voter_registration_card: Credencial para votar

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -144,8 +144,8 @@ es:
         proceso cuando esté listo.
       header: No cuenta con una licencia de conducir o identificación estatal?
       optional:
-        button: Enviar y salir de Login.gov
-        content_html: Ayúdenos a agregar más identificaciones oficiales a Login.gov.
+        button: Enviar y salir de %{app_name}
+        content_html: Ayúdenos a agregar más identificaciones oficiales a %{app_name}.
           ¿Qué identificaciones tiene como alternativa?
         id_types:
           military_id: Credencial militar (puede ser una credencial del Departamento de

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -139,6 +139,28 @@ fr:
           peut-être trop floues ou trop sombres. Essayez de prendre de nouvelles
           photos dans un endroit lumineux.
       upload_error: Désolé, quelque chose a mal tourné de notre côté.
+    exit_survey:
+      content_html: <strong>Si vous n’avez pas de permis de conduire ou de carte
+        d’identité de l’État, vous ne pouvez pas continuer à utiliser
+        Login.gov.</strong> Veuillez <a>quitter Login.gov et contacter [Partner
+        Agency]</a> pour savoir ce que vous pouvez faire.
+      header: N’avez-vous pas de permis de conduire ou de carte d’identité de l’État?
+      optional:
+        button: Soumettre et quitter Login.gov
+        content_html: Aidez-nous à ajouter plus de documents d’identité à Login.gov.
+          Quels types de documents d’identité avez-vous à la place?
+        id_types:
+          military_id: Carte d’identité militaire (y compris la carte d’identité du
+            ministère de la défense, la carte d’identité médicale des anciens
+            combattants ou la carte d’identité des anciens combattants)
+          other: Quelque chose qui ne figure pas dans la liste
+          resident_card: Carte verte américaine (également appelée carte de résident
+            permanent)
+          tribal_id: Carte d’identité tribale
+          us_passport: Passeport américain
+          voter_registration_card: Carte d’électeur
+        legend: Facultatif. Sélectionnez l’un des documents que vous possédez.
+        tag: Facultatif
     forms:
       captured_image: Image capturée
       change_file: Changer de fichier
@@ -279,6 +301,7 @@ fr:
           lettre à votre adresse personnelle. Cela prend <strong>5 à 10
           jours</strong>.'
       welcome: 'Vous aurez besoin de votre:'
+
     phone_question:
       do_not_have: Je n’ai pas de téléphone
     tips:

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -151,8 +151,8 @@ fr:
         serez prêt.
       header: N’avez-vous pas de permis de conduire ou de carte d’identité de l’État?
       optional:
-        button: Soumettre et quitter Login.gov
-        content_html: Aidez-nous à ajouter plus de documents d’identité à Login.gov.
+        button: Soumettre et quitter %{app_name}
+        content_html: Aidez-nous à ajouter plus de documents d’identité à %{app_name}.
           Quels types de documents d’identité avez-vous à la place?
         id_types:
           military_id: Carte d’identité militaire (y compris la carte d’identité du

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -152,8 +152,8 @@ fr:
       header: N’avez-vous pas de permis de conduire ou de carte d’identité de l’État?
       optional:
         button: Soumettre et quitter %{app_name}
-        content_html: Aidez-nous à ajouter plus de documents d’identité à %{app_name}.
-          Quels types de documents d’identité avez-vous à la place?
+        content: Aidez-nous à ajouter plus de documents d’identité à %{app_name}. Quels
+          types de documents d’identité avez-vous à la place?
         id_types:
           military_id: Carte d’identité militaire (y compris la carte d’identité du
             ministère de la défense, la carte d’identité médicale des anciens

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -142,8 +142,13 @@ fr:
     exit_survey:
       content_html: <strong>Si vous n’avez pas de permis de conduire ou de carte
         d’identité de l’État, vous ne pouvez pas continuer à utiliser
-        Login.gov.</strong> Veuillez <a>quitter Login.gov et contacter [Partner
-        Agency]</a> pour savoir ce que vous pouvez faire.
+        %{app_name}.</strong> Veuillez <a>quitter %{app_name} et contacter
+        %{sp_name}</a> pour savoir ce que vous pouvez faire.
+      content_nosp_html: <strong>Si vous n’avez pas de permis de conduire ou de carte
+        d’identité de l’État, vous ne pouvez pas continuer à utiliser
+        %{app_name}.</strong> <a>Annulez la vérification de votre identité avec
+        %{app_name}</a> et vous pourrez redémarrer le processus lorsque vous
+        serez prêt.
       header: N’avez-vous pas de permis de conduire ou de carte d’identité de l’État?
       optional:
         button: Soumettre et quitter Login.gov

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -159,8 +159,8 @@ fr:
             ministère de la défense, la carte d’identité médicale des anciens
             combattants ou la carte d’identité des anciens combattants)
           other: Quelque chose qui ne figure pas dans la liste
-          resident_card: Carte verte américaine (également appelée carte de résident
-            permanent)
+          resident_card: Carte Verte américaine (également appelée Carte de Résident
+            Permanent)
           tribal_id: Carte d’identité tribale
           us_passport: Passeport américain
           voter_registration_card: Carte d’électeur

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -209,6 +209,19 @@ en:
       wrong_address: Not the right address?
     images:
       come_back_later: Letter with a check mark
+    legal_statement:
+      information_collection: >-
+        This information collection meets the requirements of 44 U.S.C. § 3507,
+        as amended by section 2 of the Paperwork Reduction Act of 1995. You do
+        not need to answer these questions unless we display a valid Office of
+        Management and Budget (OMB) control number. The OMB control number for
+        this collection is 3090-0325. We estimate that it will take 1 minute to
+        read the instructions, gather the facts, and answer the questions. Send
+        only comments relating to our time estimate, including suggestions for
+        reducing this burden, or any other aspects of this collection of
+        information to: General Services Administration, Regulatory Secretariat
+        Division (MVCB), ATTN: Lois Mandell/IC 3090-0325, 1800 F Street, NW,
+        Washington, DC 20405.
     messages:
       activated_html: Your identity has been verified. If you need to change your
         verified information, please %{link_html}.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -218,6 +218,21 @@ es:
       wrong_address: ¿La dirección no es correcta?
     images:
       come_back_later: Carta con una marca de verificación
+    legal_statement:
+      information_collection: >-
+        Cette collecte d’informations répond aux exigences de l’article 3507 du
+        44 U.S.C., tel que modifié par l’article 2 de la loi de 1995 sur la
+        réduction des tâches administratives. Vous n’avez pas besoin de répondre
+        à ces questions, sauf si nous affichons un numéro de contrôle valide de
+        l’Office of Management and Budget (OMB). Le numéro de contrôle de l’OMB
+        pour cette collecte est 3090-0325. Calculamos que tomará un minuto leer
+        las instrucciones, recopilar los datos y responder las preguntas. Envíe
+        solo comentarios relacionados con nuestro tiempo estimado, incluidas
+        sugerencias para reducir esta molestia, o cualquier otro aspecto
+        relacionado con esta recopilación de información a: Administración de
+        Servicios Generales, División de la Secretaría Reguladora (MVCB), a la
+        atención de Lois Mandell/IC 3090-0325, 1800 F Street, NW, Washington, D.
+        C. 20405.
     messages:
       activated_html: Su identidad ha sido verificada. Si necesita cambiar la
         información verificada, por favor, %{link_html}.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -229,6 +229,20 @@ fr:
       wrong_address: Pas la bonne adresse?
     images:
       come_back_later: Lettre avec un crochet
+    legal_statement:
+      information_collection: >-
+        Esta recopilación de información cumple con los requisitos del título 44
+        del U.S.C., § 3507, modificado por la sección 2 de la Ley de Reducción
+        de Trámites de 1995. No es necesario que responda a estas preguntas, a
+        menos que le mostremos un número de control válido de la Oficina de
+        Administración y Presupuesto (OMB). El número de control de la OMB para
+        esta recopilación es 3090-0325. Nous estimons qu’il faut une minute pour
+        lire les instructions, rassembler les preuves et répondre aux questions.
+        N’envoyez que des commentaires relatifs à notre estimation du temps, y
+        compris des suggestions pour réduire cette charge, ou tout autre aspect
+        de cette collecte d’informations à : General Services Administration,
+        Regulatory Secretariat Division (MVCB), ATTN : Lois Mandell/IC
+        3090-0325, 1800 F Street, NW, Washington, DC 20405.
     messages:
       activated_html: Votre identité a été vérifiée. Si vous souhaitez modifier votre
         information vérifiée, veuillez %{link_html}.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -369,7 +369,7 @@ Rails.application.routes.draw do
       get '/cancel/' => 'cancellations#new', as: :cancel
       put '/cancel' => 'cancellations#update'
       delete '/cancel' => 'cancellations#destroy'
-      get '/exit' => 'cancellations#exit'
+      get '/exit' => 'cancellations#exit', as: :exit
       get '/address' => 'address#new'
       post '/address' => 'address#update'
       get '/capture_doc' => 'hybrid_mobile/entry#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -369,6 +369,7 @@ Rails.application.routes.draw do
       get '/cancel/' => 'cancellations#new', as: :cancel
       put '/cancel' => 'cancellations#update'
       delete '/cancel' => 'cancellations#destroy'
+      get '/exit' => 'cancellations#exit'
       get '/address' => 'address#new'
       post '/address' => 'address#update'
       get '/capture_doc' => 'hybrid_mobile/entry#show'

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -140,7 +140,7 @@ RSpec.feature 'document capture step', :js do
       expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
     end
 
-    it 'logs event and return to sp whe click on submit and exit button', :js do
+    it 'logs event and return to sp when click on submit and exit button', :js do
       click_submit_exit_button
       expect(fake_analytics).to have_logged_event(
         'Frontend: IdV: exit optional questions',

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -134,6 +134,20 @@ RSpec.feature 'document capture step', :js do
 
       expect(DocAuthLog.find_by(user_id: user.id).state).to be_nil
     end
+
+    it 'return to sp when click on exit link', :js do
+      click_sp_exit_link(sp_name: sp_name)
+      expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
+    end
+
+    it 'logs event and return to sp whe click on submit and exit button', :js do
+      click_submit_exit_button
+      expect(fake_analytics).to have_logged_event(
+        'Frontend: IdV: exit optional questions',
+        hash_including('ids'),
+      )
+      expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
+    end
   end
 
   context 'standard mobile flow' do
@@ -160,6 +174,16 @@ RSpec.feature 'document capture step', :js do
         expect(page).to have_current_path(idv_phone_url)
         visit(idv_document_capture_url)
         expect(page).to have_current_path(idv_phone_url)
+      end
+    end
+
+    it 'return to sp when click on exit link', :js do
+      perform_in_browser(:mobile) do
+        visit_idp_from_oidc_sp_with_ial2
+        sign_in_and_2fa_user(user)
+        complete_doc_auth_steps_before_document_capture_step
+        click_sp_exit_link(sp_name: sp_name)
+        expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
       end
     end
   end

--- a/spec/javascript/packages/document-capture/components/document-capture-abandon-spec.jsx.tsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-abandon-spec.jsx.tsx
@@ -62,7 +62,7 @@ describe('DocumentCaptureAbandon', () => {
         </AnalyticsContextProvider>,
       );
       // header
-      expect(getByRole('heading', { name: 'header text', level: 3 })).to.be.ok();
+      expect(getByRole('heading', { name: 'header text', level: 2 })).to.be.ok();
 
       // content and exit link
       const exitLink = getByRole('link', { name: 'exit Login.gov and contact testSP' });

--- a/spec/javascript/packages/document-capture/components/document-capture-abandon-spec.jsx.tsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-abandon-spec.jsx.tsx
@@ -1,0 +1,199 @@
+import sinon from 'sinon';
+
+import { FlowContext } from '@18f/identity-verify-flow';
+import DocumentCaptureAbandon from '@18f/identity-document-capture/components/document-capture-abandon';
+import { I18nContext } from '@18f/identity-react-i18n';
+import { I18n } from '@18f/identity-i18n';
+import userEvent from '@testing-library/user-event';
+import type { Navigate } from '@18f/identity-url';
+import {
+  AnalyticsContextProvider,
+  ServiceProviderContextProvider,
+} from '@18f/identity-document-capture/context';
+import { expect } from 'chai';
+import { render } from '../../../support/document-capture';
+
+describe('DocumentCaptureAbandon', () => {
+  beforeEach(() => {
+    const config = document.createElement('script');
+    config.id = 'test-config';
+    config.type = 'application/json';
+    config.setAttribute('data-config', '');
+    config.textContent = JSON.stringify({ appName: 'Login.gov' });
+    document.body.append(config);
+  });
+  const trackEvent = sinon.spy();
+  const navigateSpy: Navigate = sinon.spy();
+  context('with service provider', () => {
+    const spName = 'testSP';
+    it('renders, track event and redirect', async () => {
+      const { getByRole, getByText } = render(
+        <AnalyticsContextProvider trackEvent={trackEvent}>
+          <ServiceProviderContextProvider
+            value={{
+              name: spName,
+              failureToProofURL: '',
+              getFailureToProofURL: () => '',
+            }}
+          >
+            <FlowContext.Provider
+              value={{
+                cancelURL: '/cancel',
+                exitURL: '/exit',
+                currentStep: 'document_capture',
+              }}
+            >
+              <I18nContext.Provider
+                value={
+                  new I18n({
+                    strings: {
+                      'doc_auth.exit_survey.header': 'header text',
+                      'doc_auth.exit_survey.content_html':
+                        'Please <a>exit %{app_name} and contact %{sp_name}</a> to find out what you can do.',
+                      'doc_auth.exit_survey.optional.button': 'Submit and exit %{app_name}',
+                    },
+                  })
+                }
+              >
+                <DocumentCaptureAbandon navigate={navigateSpy} />
+              </I18nContext.Provider>
+            </FlowContext.Provider>
+          </ServiceProviderContextProvider>
+        </AnalyticsContextProvider>,
+      );
+      // header
+      expect(getByRole('heading', { name: 'header text', level: 3 })).to.be.ok();
+
+      // content and exit link
+      const exitLink = getByRole('link', { name: 'exit Login.gov and contact testSP' });
+      expect(exitLink).to.be.ok();
+      expect(exitLink.getAttribute('href')).to.contain(
+        '/exit?step=document_capture&location=optional_question',
+      );
+
+      expect(getByText('doc_auth.exit_survey.optional.tag')).to.be.ok();
+      // legend
+      expect(getByText('doc_auth.exit_survey.optional.legend')).to.be.ok();
+      // checkboxes
+      expect(
+        getByRole('checkbox', { name: 'doc_auth.exit_survey.optional.id_types.us_passport' }),
+      ).to.be.ok();
+      expect(
+        getByRole('checkbox', { name: 'doc_auth.exit_survey.optional.id_types.resident_card' }),
+      ).to.be.ok();
+      const militaryId = getByRole('checkbox', {
+        name: 'doc_auth.exit_survey.optional.id_types.military_id',
+      });
+      expect(militaryId).to.be.ok();
+      expect(
+        getByRole('checkbox', { name: 'doc_auth.exit_survey.optional.id_types.tribal_id' }),
+      ).to.be.ok();
+      expect(
+        getByRole('checkbox', {
+          name: 'doc_auth.exit_survey.optional.id_types.voter_registration_card',
+        }),
+      ).to.be.ok();
+      const otherId = getByRole('checkbox', {
+        name: 'doc_auth.exit_survey.optional.id_types.other',
+      });
+      expect(otherId).to.be.ok();
+
+      // legal statement
+      expect(getByText('idv.legal_statement.information_collection')).to.be.ok();
+
+      // exit button
+      const exitButton = getByRole('button', { name: 'Submit and exit Login.gov' });
+      expect(exitButton).to.be.ok();
+      expect(exitButton.classList.contains('usa-button--outline')).to.be.true();
+
+      await userEvent.click(otherId);
+      await userEvent.click(militaryId);
+      await userEvent.click(exitButton);
+      expect(navigateSpy).to.be.called.calledWithMatch(
+        /exit\?step=document_capture&location=optional_question/,
+      );
+      expect(trackEvent).to.be.calledWithMatch(/IdV: exit optional questions/, {
+        ids: [
+          { name: 'us_passport', checked: false },
+          { name: 'resident_card', checked: false },
+          { name: 'military_id', checked: true },
+          { name: 'tribal_id', checked: false },
+          { name: 'voter_registration_card', checked: false },
+          { name: 'other', checked: true },
+        ],
+      });
+    });
+  });
+
+  context('without service provider', () => {
+    it('renders, track event and redirect', async () => {
+      const { getByRole, getByText } = render(
+        <AnalyticsContextProvider trackEvent={trackEvent}>
+          <ServiceProviderContextProvider
+            value={{ name: null, failureToProofURL: '', getFailureToProofURL: () => '' }}
+          >
+            <FlowContext.Provider
+              value={{
+                cancelURL: '/cancel',
+                exitURL: '/exit',
+                currentStep: 'document_capture',
+              }}
+            >
+              <I18nContext.Provider
+                value={
+                  new I18n({
+                    strings: {
+                      'doc_auth.exit_survey.header': 'header text',
+                      'doc_auth.exit_survey.content_nosp_html':
+                        '<a>Cancel verifying your identity with %{app_name}</a> and you can restart the process whenyou’re ready.',
+                      'doc_auth.exit_survey.optional.button': 'Submit and exit %{app_name}',
+                    },
+                  })
+                }
+              >
+                <DocumentCaptureAbandon navigate={navigateSpy} />
+              </I18nContext.Provider>
+            </FlowContext.Provider>
+          </ServiceProviderContextProvider>
+        </AnalyticsContextProvider>,
+      );
+
+      expect(
+        getByRole('link', { name: 'Cancel verifying your identity with Login.gov' }).getAttribute(
+          'href',
+        ),
+      ).to.contain('/cancel?step=document_capture&location=optional_question');
+
+      expect(getByText('doc_auth.exit_survey.optional.tag')).to.be.ok();
+
+      const usPassport = getByRole('checkbox', {
+        name: 'doc_auth.exit_survey.optional.id_types.us_passport',
+      });
+      expect(usPassport).to.be.ok();
+      const otherId = getByRole('checkbox', {
+        name: 'doc_auth.exit_survey.optional.id_types.other',
+      });
+      expect(otherId).to.be.ok();
+
+      const exitButton = getByRole('button', { name: 'Submit and exit Login.gov' });
+      expect(exitButton).to.be.ok();
+
+      await userEvent.click(otherId);
+      await userEvent.click(usPassport);
+      await userEvent.click(exitButton);
+      expect(navigateSpy).to.be.called.calledWithMatch(
+        /cancel\?step=document_capture&location=optional_question/,
+      );
+      expect(trackEvent).to.be.calledWithMatch(/IdV: exit optional questions/, {
+        ids: [
+          { name: 'us_passport', checked: true },
+          { name: 'resident_card', checked: false },
+          { name: 'military_id', checked: false },
+          { name: 'tribal_id', checked: false },
+          { name: 'voter_registration_card', checked: false },
+          { name: 'other', checked: true },
+        ],
+      });
+    });
+  });
+});

--- a/spec/javascript/packages/document-capture/components/document-capture-abandon-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-abandon-spec.tsx
@@ -145,7 +145,7 @@ describe('DocumentCaptureAbandon', () => {
                     strings: {
                       'doc_auth.exit_survey.header': 'header text',
                       'doc_auth.exit_survey.content_nosp_html':
-                        '<a>Cancel verifying your identity with %{app_name}</a> and you can restart the process whenyou’re ready.',
+                        '<a>Cancel verifying your identity with %{app_name}</a> and you can restart the process when you’re ready.',
                       'doc_auth.exit_survey.optional.button': 'Submit and exit %{app_name}',
                     },
                   })
@@ -181,7 +181,7 @@ describe('DocumentCaptureAbandon', () => {
       await userEvent.click(otherId);
       await userEvent.click(usPassport);
       await userEvent.click(exitButton);
-      expect(navigateSpy).to.be.called.calledWithMatch(
+      expect(navigateSpy).to.be.calledWithMatch(
         /cancel\?step=document_capture&location=optional_question/,
       );
       expect(trackEvent).to.be.calledWithMatch(/IdV: exit optional questions/, {

--- a/spec/javascript/packages/document-capture/components/document-capture-review-issues-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-review-issues-spec.jsx
@@ -67,9 +67,8 @@ describe('DocumentCaptureReviewIssues', () => {
       const backCapture = getByLabelText('doc_auth.headings.document_capture_back');
       expect(backCapture).to.be.ok();
       expect(getByText('back side error')).to.be.ok();
-      const submitButton = getByRole('button');
-      expect(submitButton).to.be.ok();
-      expect(within(submitButton).getByText('forms.buttons.submit.default')).to.be.ok();
+      expect(getByRole('button', { name: 'forms.buttons.submit.default' })).to.be.ok();
+      expect(getByRole('button', { name: 'doc_auth.exit_survey.optional.button' })).to.be.ok();
     });
 
     it('renders for a doc type failure', () => {
@@ -115,9 +114,8 @@ describe('DocumentCaptureReviewIssues', () => {
       const backCapture = getByLabelText('doc_auth.headings.document_capture_back');
       expect(backCapture).to.be.ok();
       expect(getByText('back side doc type error')).to.be.ok();
-      const submitButton = getByRole('button');
-      expect(submitButton).to.be.ok();
-      expect(within(submitButton).getByText('forms.buttons.submit.default')).to.be.ok();
+      expect(getByRole('button', { name: 'forms.buttons.submit.default' })).to.be.ok();
+      expect(getByRole('button', { name: 'doc_auth.exit_survey.optional.button' })).to.be.ok();
     });
   });
 });

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
@@ -82,4 +82,16 @@ describe('document-capture/components/documents-step', () => {
 
     expect(queryByText(notExpectedText)).to.not.exist();
   });
+
+  it('renders optional question part', () => {
+    const { getByRole, getByText } = render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <UploadContextProvider flowPath="standard">
+          <DocumentsStep />
+        </UploadContextProvider>
+      </DeviceContext.Provider>,
+    );
+    expect(getByRole('heading', { name: 'doc_auth.exit_survey.header', level: 3 })).to.be.ok();
+    expect(getByText('doc_auth.exit_survey.optional.button')).to.be.ok();
+  });
 });

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
@@ -91,7 +91,7 @@ describe('document-capture/components/documents-step', () => {
         </UploadContextProvider>
       </DeviceContext.Provider>,
     );
-    expect(getByRole('heading', { name: 'doc_auth.exit_survey.header', level: 3 })).to.be.ok();
+    expect(getByRole('heading', { name: 'doc_auth.exit_survey.header', level: 2 })).to.be.ok();
     expect(getByText('doc_auth.exit_survey.optional.button')).to.be.ok();
   });
 });

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -347,7 +347,7 @@ describe('document-capture/components/review-issues-step', () => {
     const { getByText, getByRole } = render(<ReviewIssuesStep {...DEFAULT_PROPS} />);
 
     await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
-    expect(getByRole('heading', { name: 'doc_auth.exit_survey.header', level: 3 })).to.be.ok();
+    expect(getByRole('heading', { name: 'doc_auth.exit_survey.header', level: 2 })).to.be.ok();
     expect(getByText('doc_auth.exit_survey.optional.button')).to.be.ok();
   });
 

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -343,6 +343,14 @@ describe('document-capture/components/review-issues-step', () => {
     expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
   });
 
+  it('renders optional questions', async () => {
+    const { getByText, getByRole } = render(<ReviewIssuesStep {...DEFAULT_PROPS} />);
+
+    await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+    expect(getByRole('heading', { name: 'doc_auth.exit_survey.header', level: 3 })).to.be.ok();
+    expect(getByText('doc_auth.exit_survey.optional.button')).to.be.ok();
+  });
+
   context('service provider context', () => {
     context('ial2', () => {
       it('renders with front and back inputs', async () => {

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -53,4 +53,12 @@ module DocumentCaptureStepHelper
   def click_try_again
     click_spinner_button_and_wait t('idv.failure.button.warning')
   end
+
+  def click_sp_exit_link(sp_name: 'Test SP')
+    click_on "exit Login.gov and contact #{sp_name}"
+  end
+
+  def click_submit_exit_button
+    click_on 'Submit and exit Login.gov'
+  end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-11139: Add optional question about other ID types
](https://cm-jira.usa.gov/browse/LG-11139)

## 🛠 Summary of changes
Add optional survey questions to document image capturing page.
Record user submission as analytics events.
Redirect user to SP specific or general account page when user chooses Exit or "Submit and exit".


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
With Service Provider:
- Step 1: Navigate to document capturing page, with Service Provider
- Step 2: Verify the new content displayed on the page
- Step 3: Click exit link, verify landing to SP failure to proof page
- Step 4: Repeat and choose ID types, click on button
- Step 5: Verify landing to SP failure to proof page and analytics events logged
Without Service Provider:
- Step 1: Navigate to document capturing page, with Service Provider
- Step 2: Verify the new content displayed on the page
- Step 3: Click exit link, verify landing to cancellation(confirmation) page
- Step 4: Repeat and choose ID types, click on button
- Step 5: Verify landing to cancellation(confirmation) page and analytics events logged


Sample event:
```json
{
  "name":"Frontend: IdV: exit optional questions",
  "properties":{
    "event_properties":{
      "ids":[
        {
          "name":"us_passport",
          "checked":false
        },
        {
          "name":"resident_card",
          "checked":false
        },
        {
          "name":"military_id",
          "checked":false
        },
        {
          "name":"tribal_id",
          "checked":false
        },
        {
          "name":"voter_registration_card",
          "checked":false
        },
        {
          "name":"other",
          "checked":false
        }
      ],
      "flow_path":"standard",
      "acuant_sdk_upgrade_a_b_testing_enabled":"false",
      "use_alternate_sdk":"false",
      "acuant_version":"11.9.1"
    },
    "new_event":true,
    "path":"/api/logger",
    "session_duration":19.410147,
    "user_id":"3321d388-1fc4-47bc-b7a0-5d59ef52d735",
    "locale":"en",
    "user_ip":"127.0.0.1",
    "hostname":"localhost",
    "pid":33993,
    "service_provider":null,
    "trace_id":null,
    "git_sha":"b2a23958",
    "git_branch":"feature/LG-11139-question-upon-exit",
    "user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36",
    "browser_name":"Chrome",
    "browser_version":"117.0.0.0",
    "browser_platform_name":"macOS",
    "browser_platform_version":"10.15.7",
    "browser_device_name":"Unknown",
    "browser_mobile":false,
    "browser_bot":false
  },
  "time":"2023-10-16T18:54:03.411Z",
  "id":"b3f499f4-fed1-41e6-b7ef-6e250c744a36",
  "visitor_id":"fc02aabb-3cb8-4923-af91-b26ac1487b47",
  "visit_id":"ce63dcbb-f9d8-4461-9823-8b2bd11d7942",
  "log_filename":"events.log"
}
```



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Without Service Provider:</summary>

English:
![En-Nosp](https://github.com/18F/identity-idp/assets/130466753/eb560001-47fc-46a9-864b-b17e8a8a9841)

Spanish:
![Nosp-Es](https://github.com/18F/identity-idp/assets/130466753/d3d869ac-c659-4f1c-b392-adb2dd33da32)

French:

![Nosp-Fr](https://github.com/18F/identity-idp/assets/130466753/512a294c-5449-4888-b65e-6c884b64ebdb)


</details>

<details>
<summary>With Service Provider:</summary>

English:
![En-Sp](https://github.com/18F/identity-idp/assets/130466753/38ebf91f-e780-4cb4-a646-b9b5f2642c9f)

Spanish:
![Sp-Es](https://github.com/18F/identity-idp/assets/130466753/13c36ad3-f01a-4d30-bc99-dde556dd22c5)

French:
![Sp-Fr](https://github.com/18F/identity-idp/assets/130466753/a0adeca1-0bf4-4977-b17f-cb4fd2d9ce91)


</details>
