### PR TITLE
Update 18f/identity-design-system to 8.0.1

### DIFF
--- a/app/javascript/packages/clipboard-button/package.json
+++ b/app/javascript/packages/clipboard-button/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@18f/identity-design-system": "^8.0.0"
+    "@18f/identity-design-system": "^8.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:css": "build-sass app/assets/stylesheets/*.css.scss app/components/*.scss --load-path=app/assets/stylesheets --out-dir=app/assets/builds"
   },
   "dependencies": {
-    "@18f/identity-design-system": "^8.0.0",
+    "@18f/identity-design-system": "^8.0.1",
     "@babel/core": "^7.20.7",
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-react": "^7.14.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@18f/identity-design-system@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@18f/identity-design-system/-/identity-design-system-8.0.0.tgz#8fa0d2610d80d57653fab98aa79c241fc4265627"
-  integrity sha512-QNrtTf3pBuM7tNBqfN8wnm0QPr82FaCerD6V+qADn3fC6cfoQiC13mEtvn2yq4sdwsJETcMqs0KCcqBLuP8luQ==
+"@18f/identity-design-system@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@18f/identity-design-system/-/identity-design-system-8.0.1.tgz#72176fe0e8f0418c87caca42f57d9bb370346a55"
+  integrity sha512-SnVw2Cp2HYaR9bMCQ7RtCjze4j4BOEp83GXB44uMBkOmtk0JViM7BlerHR9XtJ9FH4ke2MnvVx4ScuBbSRhsIQ==
   dependencies:
     "@uswds/uswds" "^3.6.1"
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `@18f/identity-design-system` to the latest version (8.0.1) to resolve an issue affecting the appearance of accordion expander icons.

See release notes: https://github.com/18F/identity-design-system/releases/tag/v8.0.1

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in
3. Click "Edit password" in account dashboard
4. If prompted, MFA again
5. Hover the "Password safety tips"
6. Observe the icon doesn't change

Alternatively, go to http://localhost:3000/components/inspect/accordion/preview and hover the accordion expander.

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/f74df0e4-8420-4335-a1af-57b8b8674d62)|![image](https://github.com/18F/identity-idp/assets/1779930/a46a0cce-fb02-4dfc-a474-9fb0fd6fc90b)
