### PR TITLE
LG-11239: Add Phone Question Bucket to FE Logging

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -4,6 +4,7 @@ module Idv
     include DocumentCaptureConcern
     include IdvStepConcern
     include StepIndicatorConcern
+    include PhoneQuestionAbTestConcern
 
     before_action :confirm_not_rate_limited, except: [:update]
     before_action :confirm_hybrid_handoff_complete
@@ -47,6 +48,7 @@ module Idv
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
       }.merge(
         acuant_sdk_upgrade_a_b_testing_variables,
+        phone_question_ab_test_analytics_bucket,
       )
     end
 

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -43,7 +43,7 @@ module Idv
           failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         }.merge(
           acuant_sdk_upgrade_a_b_testing_variables,
-          phone_question_ab_test_analytics_bucket
+          phone_question_ab_test_analytics_bucket,
         )
       end
 

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -3,6 +3,7 @@ module Idv
     class DocumentCaptureController < ApplicationController
       include DocumentCaptureConcern
       include HybridMobileConcern
+      include PhoneQuestionAbTestConcern
 
       before_action :check_valid_document_capture_session
       before_action :override_csp_to_allow_acuant
@@ -42,6 +43,7 @@ module Idv
           failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         }.merge(
           acuant_sdk_upgrade_a_b_testing_variables,
+          phone_question_ab_test_analytics_bucket
         )
       end
 

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -34,7 +34,7 @@ module Idv
 
     def extra_view_variables
       { phone: idv_session.phone_for_mobile_flow }.merge(
-        phone_question_ab_test_analytics_bucket
+        phone_question_ab_test_analytics_bucket,
       )
     end
 

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -3,6 +3,7 @@ module Idv
     include DocumentCaptureConcern
     include IdvStepConcern
     include StepIndicatorConcern
+    include PhoneQuestionAbTestConcern
 
     before_action :confirm_not_rate_limited
     before_action :confirm_hybrid_handoff_complete
@@ -32,7 +33,9 @@ module Idv
     end
 
     def extra_view_variables
-      { phone: idv_session.phone_for_mobile_flow }
+      { phone: idv_session.phone_for_mobile_flow }.merge(
+        phone_question_ab_test_analytics_bucket
+      )
     end
 
     private

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -65,7 +65,9 @@ export class DocumentCapturePolling {
 
   bind() {
     this.toggleFormVisible(false);
-    this.trackEvent('IdV: Link sent capture doc polling started');
+    this.trackEvent('IdV: Link sent capture doc polling started', {
+      phoneQuestionAbTestBucket: this.phoneQuestionAbTestBucket,
+    });
     this.schedulePoll();
     this.bindPromptOnNavigate(true);
     this.elements.backLink.addEventListener('click', () => this.bindPromptOnNavigate(false));

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -59,10 +59,12 @@ export class DocumentCapturePolling {
     elements,
     statusEndpoint,
     trackEvent = defaultTrackEvent,
+    phoneQuestionAbTestBucket,
   }: DocumentCapturePollingOptions) {
     this.elements = elements;
     this.statusEndpoint = statusEndpoint;
     this.trackEvent = trackEvent;
+    this.phoneQuestionAbTestBucket = phoneQuestionAbTestBucket;
   }
 
   bind() {

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -18,6 +18,8 @@ interface DocumentCapturePollingOptions {
 
   elements: DocumentCapturePollingElements;
 
+  phoneQuestionAbTestBucket: string | undefined;
+
   trackEvent?: typeof defaultTrackEvent;
 }
 
@@ -41,11 +43,17 @@ export class DocumentCapturePolling {
 
   statusEndpoint: string;
 
-  trackEvent: typeof defaultTrackEvent;
+  trackEvent: typeof defaultTrackEvent = (event, payload) =>
+    defaultTrackEvent(event, {
+      ...payload,
+      phone_question_ab_test_bucket: this.phoneQuestionAbTestBucket,
+    });
 
   pollAttempts = 0;
 
   cleanUpPromptOnNavigate: (() => void) | undefined;
+
+  phoneQuestionAbTestBucket: string | undefined;
 
   constructor({
     elements,

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -43,11 +43,7 @@ export class DocumentCapturePolling {
 
   statusEndpoint: string;
 
-  trackEvent: typeof defaultTrackEvent = (event, payload) =>
-    defaultTrackEvent(event, {
-      ...payload,
-      phone_question_ab_test_bucket: this.phoneQuestionAbTestBucket,
-    });
+  trackEvent: typeof defaultTrackEvent;
 
   pollAttempts = 0;
 

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -100,6 +100,7 @@ export class DocumentCapturePolling {
     this.trackEvent('IdV: Link sent capture doc polling complete', {
       isCancelled: result === ResultType.CANCELLED,
       isRateLimited: result === ResultType.RATE_LIMITED,
+      phoneQuestionAbTestBucket: this.phoneQuestionAbTestBucket,
     });
     this.bindPromptOnNavigate(false);
     if (redirect) {

--- a/app/javascript/packages/document-capture-polling/index.ts
+++ b/app/javascript/packages/document-capture-polling/index.ts
@@ -66,7 +66,7 @@ export class DocumentCapturePolling {
   bind() {
     this.toggleFormVisible(false);
     this.trackEvent('IdV: Link sent capture doc polling started', {
-      phoneQuestionAbTestBucket: this.phoneQuestionAbTestBucket,
+      phone_question_ab_test_bucket: this.phoneQuestionAbTestBucket,
     });
     this.schedulePoll();
     this.bindPromptOnNavigate(true);
@@ -100,7 +100,7 @@ export class DocumentCapturePolling {
     this.trackEvent('IdV: Link sent capture doc polling complete', {
       isCancelled: result === ResultType.CANCELLED,
       isRateLimited: result === ResultType.RATE_LIMITED,
-      phoneQuestionAbTestBucket: this.phoneQuestionAbTestBucket,
+      phone_question_ab_test_bucket: this.phoneQuestionAbTestBucket,
     });
     this.bindPromptOnNavigate(false);
     if (redirect) {

--- a/app/javascript/packs/doc-capture-polling.ts
+++ b/app/javascript/packs/doc-capture-polling.ts
@@ -4,6 +4,9 @@ new DocumentCapturePolling({
   statusEndpoint: document
     .querySelector('[data-status-endpoint]')
     ?.getAttribute('data-status-endpoint') as string,
+  phoneQuestionAbTestBucket: document
+    .querySelector('[data-phone-question-ab-test-bucket')
+    ?.getAttribute('data-phone-question-ab-test-bucket') as string,
   elements: {
     backLink: document.querySelector('.link-sent-back-link') as HTMLAnchorElement,
     form: document.querySelector('.link-sent-continue-button-form') as HTMLFormElement,

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -53,14 +53,20 @@ function getMetaContent(name): string | null {
 const device: DeviceContextValue = { isMobile: isCameraCapableMobile() };
 
 const trackEvent: typeof baseTrackEvent = (event, payload) => {
-  const { flowPath, acuantSdkUpgradeABTestingEnabled, useAlternateSdk, acuantVersion } =
-    appRoot.dataset;
+  const {
+    flowPath,
+    acuantSdkUpgradeABTestingEnabled,
+    useAlternateSdk,
+    acuantVersion,
+    phoneQuestionAbTestBucket,
+  } = appRoot.dataset;
   return baseTrackEvent(event, {
     ...payload,
     flow_path: flowPath,
     acuant_sdk_upgrade_a_b_testing_enabled: acuantSdkUpgradeABTestingEnabled,
     use_alternate_sdk: useAlternateSdk,
     acuant_version: acuantVersion,
+    phone_question_ab_test_bucket: phoneQuestionAbTestBucket,
   });
 };
 

--- a/app/views/idv/document_capture/show.html.erb
+++ b/app/views/idv/document_capture/show.html.erb
@@ -7,4 +7,5 @@
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
+      phone_question_ab_test_bucket: phone_question_ab_test_bucket,
     ) %>

--- a/app/views/idv/hybrid_mobile/document_capture/show.html.erb
+++ b/app/views/idv/hybrid_mobile/document_capture/show.html.erb
@@ -7,4 +7,5 @@
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
+      phone_question_ab_test_bucket: phone_question_ab_test_bucket,
     ) %>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -41,7 +41,10 @@
 </div>
 
 <% if FeatureManagement.doc_capture_polling_enabled? %>
-  <%= content_tag 'script', '', data: { status_endpoint: idv_capture_doc_status_url } %>
+  <%= content_tag 'script', '', data: {
+    status_endpoint: idv_capture_doc_status_url,
+    phone_question_ab_test_bucket: phone_question_ab_test_bucket,
+  } %>
   <%= javascript_packs_tag_once 'doc-capture-polling' %>
 <% end %>
 

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -42,9 +42,9 @@
 
 <% if FeatureManagement.doc_capture_polling_enabled? %>
   <%= content_tag 'script', '', data: {
-    status_endpoint: idv_capture_doc_status_url,
-    phone_question_ab_test_bucket: phone_question_ab_test_bucket,
-  } %>
+        status_endpoint: idv_capture_doc_status_url,
+        phone_question_ab_test_bucket: phone_question_ab_test_bucket,
+      } %>
   <%= javascript_packs_tag_once 'doc-capture-polling' %>
 <% end %>
 

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -23,6 +23,7 @@
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
+      phone_question_ab_test_bucket: phone_question_ab_test_bucket,
       sp_name: sp_name,
       flow_path: flow_path,
       cancel_url: idv_cancel_path(step: :document_capture),

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -63,10 +63,10 @@ RSpec.feature 'Analytics Regression', js: true do
         flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false
       },
       'Frontend: IdV: front image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, 'phone_question_ab_test_bucket' => 'bypass_phone_question'
       },
       'Frontend: IdV: back image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, 'phone_question_ab_test_bucket' => 'bypass_phone_question'
       },
       'IdV: doc auth image upload form submitted' => {
         success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question
@@ -168,10 +168,10 @@ RSpec.feature 'Analytics Regression', js: true do
         flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false
       },
       'Frontend: IdV: front image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, 'phone_question_ab_test_bucket' => 'bypass_phone_question'
       },
       'Frontend: IdV: back image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, 'phone_question_ab_test_bucket' => 'bypass_phone_question'
       },
       'IdV: doc auth image upload form submitted' => {
         success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question
@@ -255,10 +255,10 @@ RSpec.feature 'Analytics Regression', js: true do
         flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false
       },
       'Frontend: IdV: front image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, 'phone_question_ab_test_bucket' => 'bypass_phone_question'
       },
       'Frontend: IdV: back image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, 'phone_question_ab_test_bucket' => 'bypass_phone_question'
       },
       'IdV: doc auth image upload form submitted' => {
         success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -63,10 +63,10 @@ RSpec.feature 'Analytics Regression', js: true do
         flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false
       },
       'Frontend: IdV: front image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
       },
       'Frontend: IdV: back image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
       },
       'IdV: doc auth image upload form submitted' => {
         success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question
@@ -168,10 +168,10 @@ RSpec.feature 'Analytics Regression', js: true do
         flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false
       },
       'Frontend: IdV: front image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
       },
       'Frontend: IdV: back image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
       },
       'IdV: doc auth image upload form submitted' => {
         success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question
@@ -255,10 +255,10 @@ RSpec.feature 'Analytics Regression', js: true do
         flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false
       },
       'Frontend: IdV: front image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
       },
       'Frontend: IdV: back image added' => {
-        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean
+        'width' => 284, 'height' => 38, 'mimeType' => 'image/png', 'source' => 'upload', 'size' => 3694, 'attempt' => 1, 'flow_path' => 'standard', 'acuant_sdk_upgrade_a_b_testing_enabled' => 'false', 'use_alternate_sdk' => anything, 'acuant_version' => anything, 'acuantCaptureMode' => 'AUTO', 'fingerprint' => anything, 'failedImageResubmission' => boolean, "phone_question_ab_test_bucket" => "bypass_phone_question"
       },
       'IdV: doc auth image upload form submitted' => {
         success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question

--- a/spec/javascript/packages/document-capture-polling/index-spec.js
+++ b/spec/javascript/packages/document-capture-polling/index-spec.js
@@ -96,6 +96,7 @@ describe('DocumentCapturePolling', () => {
       {
         isCancelled: false,
         isRateLimited: false,
+        phoneQuestionAbTestBucket: 'bypass_phone_question',
       },
     );
   });
@@ -135,6 +136,7 @@ describe('DocumentCapturePolling', () => {
       {
         isCancelled: true,
         isRateLimited: false,
+        phoneQuestionAbTestBucket: 'bypass_phone_question',
       },
     );
     expect(subject.elements.form.submit).to.have.been.called();
@@ -159,6 +161,7 @@ describe('DocumentCapturePolling', () => {
       {
         isCancelled: false,
         isRateLimited: true,
+        phoneQuestionAbTestBucket: 'bypass_phone_question',
       },
     );
     expect(window.location.hash).to.equal('#rate_limited');

--- a/spec/javascript/packages/document-capture-polling/index-spec.js
+++ b/spec/javascript/packages/document-capture-polling/index-spec.js
@@ -70,7 +70,7 @@ describe('DocumentCapturePolling', () => {
 
     expect(trackEvent).to.have.been.calledOnceWithExactly(
       'IdV: Link sent capture doc polling started',
-      { phoneQuestionAbTestBucket: 'bypass_phone_question' },
+      { phone_question_ab_test_bucket: 'bypass_phone_question' },
     );
   });
 
@@ -89,14 +89,14 @@ describe('DocumentCapturePolling', () => {
     expect(subject.elements.form.submit).to.have.been.called();
     expect(trackEvent).to.have.been.calledWithExactly(
       'IdV: Link sent capture doc polling started',
-      { phoneQuestionAbTestBucket: 'bypass_phone_question' },
+      { phone_question_ab_test_bucket: 'bypass_phone_question' },
     );
     expect(trackEvent).to.have.been.calledWithExactly(
       'IdV: Link sent capture doc polling complete',
       {
         isCancelled: false,
         isRateLimited: false,
-        phoneQuestionAbTestBucket: 'bypass_phone_question',
+        phone_question_ab_test_bucket: 'bypass_phone_question',
       },
     );
   });
@@ -129,14 +129,14 @@ describe('DocumentCapturePolling', () => {
 
     expect(trackEvent).to.have.been.calledWithExactly(
       'IdV: Link sent capture doc polling started',
-      { phoneQuestionAbTestBucket: 'bypass_phone_question' },
+      { phone_question_ab_test_bucket: 'bypass_phone_question' },
     );
     expect(trackEvent).to.have.been.calledWithExactly(
       'IdV: Link sent capture doc polling complete',
       {
         isCancelled: true,
         isRateLimited: false,
-        phoneQuestionAbTestBucket: 'bypass_phone_question',
+        phone_question_ab_test_bucket: 'bypass_phone_question',
       },
     );
     expect(subject.elements.form.submit).to.have.been.called();
@@ -154,14 +154,14 @@ describe('DocumentCapturePolling', () => {
 
     expect(trackEvent).to.have.been.calledWithExactly(
       'IdV: Link sent capture doc polling started',
-      { phoneQuestionAbTestBucket: 'bypass_phone_question' },
+      { phone_question_ab_test_bucket: 'bypass_phone_question' },
     );
     expect(trackEvent).to.have.been.calledWithExactly(
       'IdV: Link sent capture doc polling complete',
       {
         isCancelled: false,
         isRateLimited: true,
-        phoneQuestionAbTestBucket: 'bypass_phone_question',
+        phone_question_ab_test_bucket: 'bypass_phone_question',
       },
     );
     expect(window.location.hash).to.equal('#rate_limited');

--- a/spec/javascript/packages/document-capture-polling/index-spec.js
+++ b/spec/javascript/packages/document-capture-polling/index-spec.js
@@ -68,7 +68,10 @@ describe('DocumentCapturePolling', () => {
     sandbox.clock.tick(DOC_CAPTURE_POLL_INTERVAL);
     expect(global.fetch).to.have.been.calledTwice();
 
-    expect(trackEvent).to.have.been.calledOnceWith('IdV: Link sent capture doc polling started');
+    expect(trackEvent).to.have.been.calledOnceWithExactly(
+      'IdV: Link sent capture doc polling started',
+      { phoneQuestionAbTestBucket: 'bypass_phone_question' },
+    );
   });
 
   it('submits when done', async () => {

--- a/spec/javascript/packages/document-capture-polling/index-spec.js
+++ b/spec/javascript/packages/document-capture-polling/index-spec.js
@@ -40,6 +40,7 @@ describe('DocumentCapturePolling', () => {
         ),
       },
       trackEvent,
+      phoneQuestionAbTestBucket: 'bypass_phone_question',
     });
     subject.bind();
   });

--- a/spec/javascript/packages/document-capture-polling/index-spec.js
+++ b/spec/javascript/packages/document-capture-polling/index-spec.js
@@ -87,11 +87,17 @@ describe('DocumentCapturePolling', () => {
     await flushPromises(); // Flush `json`
 
     expect(subject.elements.form.submit).to.have.been.called();
-    expect(trackEvent).to.have.been.calledWith('IdV: Link sent capture doc polling started');
-    expect(trackEvent).to.have.been.calledWith('IdV: Link sent capture doc polling complete', {
-      isCancelled: false,
-      isRateLimited: false,
-    });
+    expect(trackEvent).to.have.been.calledWithExactly(
+      'IdV: Link sent capture doc polling started',
+      { phoneQuestionAbTestBucket: 'bypass_phone_question' },
+    );
+    expect(trackEvent).to.have.been.calledWithExactly(
+      'IdV: Link sent capture doc polling complete',
+      {
+        isCancelled: false,
+        isRateLimited: false,
+      },
+    );
   });
 
   it('redirects if given redirect URL on success', async () => {
@@ -120,11 +126,17 @@ describe('DocumentCapturePolling', () => {
     await flushPromises(); // Flush `fetch`
     await flushPromises(); // Flush `json`
 
-    expect(trackEvent).to.have.been.calledWith('IdV: Link sent capture doc polling started');
-    expect(trackEvent).to.have.been.calledWith('IdV: Link sent capture doc polling complete', {
-      isCancelled: true,
-      isRateLimited: false,
-    });
+    expect(trackEvent).to.have.been.calledWithExactly(
+      'IdV: Link sent capture doc polling started',
+      { phoneQuestionAbTestBucket: 'bypass_phone_question' },
+    );
+    expect(trackEvent).to.have.been.calledWithExactly(
+      'IdV: Link sent capture doc polling complete',
+      {
+        isCancelled: true,
+        isRateLimited: false,
+      },
+    );
     expect(subject.elements.form.submit).to.have.been.called();
   });
 
@@ -138,11 +150,17 @@ describe('DocumentCapturePolling', () => {
     await flushPromises(); // Flush `fetch`
     await flushPromises(); // Flush `json`
 
-    expect(trackEvent).to.have.been.calledWith('IdV: Link sent capture doc polling started');
-    expect(trackEvent).to.have.been.calledWith('IdV: Link sent capture doc polling complete', {
-      isCancelled: false,
-      isRateLimited: true,
-    });
+    expect(trackEvent).to.have.been.calledWithExactly(
+      'IdV: Link sent capture doc polling started',
+      { phoneQuestionAbTestBucket: 'bypass_phone_question' },
+    );
+    expect(trackEvent).to.have.been.calledWithExactly(
+      'IdV: Link sent capture doc polling complete',
+      {
+        isCancelled: false,
+        isRateLimited: true,
+      },
+    );
     expect(window.location.hash).to.equal('#rate_limited');
   });
 

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
   let(:in_person_proofing_enabled_issuer) { nil }
   let(:acuant_sdk_upgrade_a_b_testing_enabled) { false }
   let(:use_alternate_sdk) { false }
+  let(:phone_question_ab_test_bucket) { :bypass_phone_question }
   let(:acuant_version) { '1.3.3.7' }
 
   before do
@@ -41,6 +42,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
+      phone_question_ab_test_bucket: phone_question_ab_test_bucket, 
     }
   end
 

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
-      phone_question_ab_test_bucket: phone_question_ab_test_bucket, 
+      phone_question_ab_test_bucket: phone_question_ab_test_bucket,
     }
   end
 


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-11239

## 🛠 Summary of changes

This ticket adds information to the FE logs about which group the user is in for our "phone question" A/B test. Each user will either be
- In the "nothing changed", A group, `:bypass_phone_question`
- Or in the the "sees the phone question", B group, `:show_phone_question`

## 📜 Testing Plan

Note: If you're a person without a local dev environment, you can follow the testing steps below in stage or this PR's branch and review the logs in cloudwatch instead of locally.

- [ ] Checkout this branch
- [ ] In your local developer setup remove the logs by running `make setup`
- [ ] Log in and go through the whole IDV process locally.
- [ ] Look at the logs you just generated locally in `log/events.log`
    - [ ] Verify that the `Frontend: IdV: Acuant SDK loaded` event has a `phone_question_ab_test_bucket` property.
    - [ ] Verify that the `Frontend: IdV: front image clicked` event has a `phone_question_ab_test_bucket` property.
    - [ ] Verify that the `Frontend: IdV: front image added` event has a `phone_question_ab_test_bucket` property.
    - [ ] Verify that the `Frontend: IdV: back image clicked` event has a `phone_question_ab_test_bucket` property.
    - [ ] Verify that the `Frontend: IdV: back image clicked` event has a `phone_question_ab_test_bucket` property.
    - [ ] Verify that the `Frontend: IdV: Link sent capture doc polling started` event has a `phone_question_ab_test_bucket` property.
    - [ ] Verify that the `Frontend: IdV: Link sent capture doc polling complete` event has a `phone_question_ab_test_bucket` property.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
