### PR TITLE
Update rack-timeout exclusion paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ require_relative '../lib/email_delivery_observer'
 require_relative '../lib/good_job_connection_pool_size'
 require_relative '../lib/identity_cors'
 require_relative '../lib/version_headers'
+require_relative '../lib/idp/constants'
 
 Bundler.require(*Rails.groups)
 
@@ -85,7 +86,7 @@ module Identity
     config.time_zone = 'UTC'
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{yml}')]
-    config.i18n.available_locales = %w[en es fr]
+    config.i18n.available_locales = Idp::Constants::AVAILABLE_LOCALES
     config.i18n.default_locale = :en
     config.action_controller.per_form_csrf_tokens = true
 

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -3,12 +3,13 @@ require 'rack/timeout/base'
 module Rack
   class Timeout
     EXCLUDES = [
-      '/api/verify/images',
       '/verify/verify_info',
       '/verify/phone',
       '/verify/document_capture',
       '/verify/link_sent',
-    ]
+    ].flat_map do |path|
+      [path] + Idp::Constants::AVAILABLE_LOCALES.map { |locale| "/#{locale}#{path}" }
+    end + ['/api/verify/images']
 
     class << self
       attr_accessor :excludes

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -2,12 +2,12 @@ require 'rack/timeout/base'
 
 module Rack
   class Timeout
-    @excludes = [
+    EXCLUDES = [
       '/api/verify/images',
-      '/verify/doc_auth/document_capture',
-      '/verify/doc_auth/verify',
-      '/verify/capture_doc/document_capture',
-      '/verify/doc_auth/link_sent',
+      '/verify/verify_info',
+      '/verify/phone',
+      '/verify/document_capture',
+      '/verify/link_sent',
     ]
 
     class << self
@@ -15,7 +15,7 @@ module Rack
     end
 
     def call_with_excludes(env)
-      if env['REQUEST_URI']&.start_with?(*self.class.excludes)
+      if EXCLUDES.any? { |path| env['REQUEST_URI']&.start_with?(path) }
         @app.call(env)
       else
         call_without_excludes(env)

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -1,5 +1,6 @@
 module Idp
   module Constants
+    AVAILABLE_LOCALES = %w[en es fr]
     UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
     module Vendors
       ACUANT = 'acuant'


### PR DESCRIPTION
## 🛠 Summary of changes

Back in March, we experimented with [disabling async proofing](https://gsa-tts.slack.com/archives/C42TZ3K5H/p1678995313038359?thread_ts=1678994905.846599&cid=C42TZ3K5H). It failed due to the Rack::Timeout exception list being out of date. We've had a pretty significant re-structuring of the paths around identity verification since then as well. Now that it has mostly stabilized, this PR removes the routes that no longer exist and updates the routes to reflect valid routes. It also adds the internationalized versions of the routes.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
