### PR TITLE
Remove logo attachment from reporting email

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -3,7 +3,7 @@ require 'csv'
 class ReportMailer < ActionMailer::Base
   include Mailable
 
-  before_action :attach_images
+  before_action :attach_images, except: [:tables_report]
 
   layout 'tables_report', only: [:tables_report]
 

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe ReportMailer, type: :mailer do
       )
     end
 
+    it 'does not attach the Login.gov logo' do
+      expect(mail.attachments.map(&:filename)).to_not include('logo.png')
+    end
+
     it 'renders the tables in HTML and attaches them as CSVs', aggregate_failures: true do
       doc = Nokogiri::HTML(mail.html_part.body.to_s)
 


### PR DESCRIPTION
## 🛠 Summary of changes

Due to some shared behavior, we were attaching the Login.gov logo to emails that don't strictly need them

| | before | after | 
| --| --- | ---- |
| Mailer preview |  <img width="496" alt="Screenshot 2023-10-17 at 2 33 41 PM" src="https://github.com/18F/identity-idp/assets/458784/c5b35145-f670-4d50-9d81-e9ac3e4b2063"> |  <img width="496" alt="Screenshot 2023-10-17 at 2 33 55 PM" src="https://github.com/18F/identity-idp/assets/458784/48a988f9-2182-40ec-97d1-063f25e98696"> |
| GMail |  <img width="289" alt="Screenshot 2023-10-17 at 2 35 54 PM" src="https://github.com/18F/identity-idp/assets/458784/5f36a7c8-7adc-41d8-8168-ddba8b8815ea"> | N/A |



<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
