### PR TITLE
Add option to collect multiple tables into a single .xlsx (LG-11200)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'barby', '~> 0.6.8'
 gem 'base32-crockford'
 gem 'bootsnap', '~> 1.0', require: false
 gem 'browser'
+gem 'caxlsx', require: false
 gem 'concurrent-ruby'
 gem 'connection_pool'
 gem 'cssbundling-rails'
@@ -128,6 +129,7 @@ group :test do
   gem 'rspec-retry'
   gem 'rspec_junit_formatter'
   gem 'shoulda-matchers', '~> 4.0', require: false
+  gem 'simple_xlsx_reader', require: false
   gem 'tableparser', require: false
   gem 'webmock'
   gem 'zonebie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    caxlsx (3.4.1)
+      htmlentities (~> 4.3, >= 4.3.4)
+      marcel (~> 1.0)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
     cbor (0.5.9.6)
     chunky_png (1.4.0)
     coderay (1.1.3)
@@ -614,6 +619,9 @@ GEM
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
+    simple_xlsx_reader (5.0.0)
+      nokogiri
+      rubyzip
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -720,6 +728,7 @@ DEPENDENCIES
   bullet (~> 7.0)
   bundler-audit
   capybara-webmock!
+  caxlsx
   concurrent-ruby
   connection_pool
   cssbundling-rails
@@ -799,6 +808,7 @@ DEPENDENCIES
   scrypt
   shoulda-matchers (~> 4.0)
   simple_form (>= 5.0.2)
+  simple_xlsx_reader
   simplecov (~> 0.22.0)
   simplecov-cobertura
   simplecov_json_formatter

--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -57,6 +57,7 @@ module Reports
         subject: "Monthly Key Metrics Report - #{date}",
         message: email_message,
         tables: email_tables,
+        attachment_format: :xlsx,
       ).deliver_now
     end
 

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -1,4 +1,5 @@
 require 'csv'
+require 'caxlsx'
 
 class ReportMailer < ActionMailer::Base
   include Mailable
@@ -38,12 +39,20 @@ class ReportMailer < ActionMailer::Base
   # @param [String] email
   # @param [String] subject
   # @param [String] env name of current deploy environment
+  # @param [:csv,:xlsx] attachment_format
   # @param [Array<Array<Hash,Array<String>>>] tables
   #   an array of tables (which are arrays of rows (arrays of strings))
   #   each table can have a first "row" that is a hash with options
   # @option opts [Boolean] :float_as_percent whether or not to render floats as percents
   # @option opts [Boolean] :title title of the table
-  def tables_report(email:, subject:, message:, tables:, env: Identity::Hostdata.env || 'local')
+  def tables_report(
+    email:,
+    subject:,
+    message:,
+    tables:,
+    env: Identity::Hostdata.env || 'local',
+    attachment_format: :csv
+  )
     @message = message
 
     @tables = tables.map(&:dup).each_with_index.map do |table, index|
@@ -54,16 +63,35 @@ class ReportMailer < ActionMailer::Base
       [options, *table]
     end
 
-    @tables.each do |options_and_table|
-      options, *table = options_and_table
+    case attachment_format
+    when :csv
+      @tables.each do |options_and_table|
+        options, *table = options_and_table
 
-      title = "#{options[:title].parameterize}.csv"
+        title = "#{options[:title].parameterize}.csv"
 
-      attachments[title] = CSV.generate do |csv|
-        table.each do |row|
-          csv << row
+        attachments[title] = CSV.generate do |csv|
+          table.each do |row|
+            csv << row
+          end
         end
       end
+    when :xlsx
+      Axlsx::Package.new do |package|
+        @tables.each do |options_and_table|
+          options, *table = options_and_table
+
+          package.workbook.add_worksheet(name: options[:title].byteslice(0...31)) do |sheet|
+            table.each do |row|
+              sheet.add_row(row)
+            end
+          end
+        end
+
+        attachments['report.xlsx'] = package.to_stream.read
+      end
+    else
+      raise ArgumentError, "unknown attachment_format=#{attachment_format}"
     end
 
     mail(to: email, subject: "[#{env}] #{subject}")

--- a/spec/jobs/reports/monthly_key_metrics_report_spec.rb
+++ b/spec/jobs/reports/monthly_key_metrics_report_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
       email: [agnes_email],
       subject: 'Monthly Key Metrics Report - 2021-03-02',
       tables: anything,
+      attachment_format: :xlsx,
     ).and_call_original
 
     subject.perform(report_date)
@@ -72,6 +73,7 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
       email: [agnes_email, feds_email],
       subject: 'Monthly Key Metrics Report - 2021-03-01',
       tables: anything,
+      attachment_format: :xlsx,
     ).and_call_original
 
     subject.perform(first_of_month_date)
@@ -83,12 +85,7 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
     expect_any_instance_of(Reporting::AccountReuseAndTotalIdentitiesReport).
       not_to receive(:total_identities_report)
 
-    expect(ReportMailer).not_to receive(:tables_report).with(
-      message: 'Report: monthly-key-metrics-report 2021-03-02',
-      email: [''],
-      subject: 'Monthly Key Metrics Report - 2021-03-02',
-      tables: anything,
-    ).and_call_original
+    expect(ReportMailer).not_to receive(:tables_report)
 
     subject.perform(report_date)
   end

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -13,6 +13,7 @@ class ReportMailerPreview < ActionMailer::Preview
       email: 'test@example.com',
       subject: 'Example Key Metrics Report',
       message: 'Key Metrics Report February 2021',
+      as_xlsx: true,
       tables: [
         [
           { title: 'February 2021 Active Users' },


### PR DESCRIPTION
## 🎫 Ticket

[LG-11200](https://cm-jira.usa.gov/browse/LG-11200)

## 🛠 Summary of changes

- Adds `attachment_format` option to the shared `ReportMailer.tables_report`
- The `caxlsx` gem has nice writing options compared to others, but no reading options, so we pull in two gems

| before | after |
| --- | --- |
| <img width="496" alt="Screenshot 2023-10-17 at 3 21 09 PM" src="https://github.com/18F/identity-idp/assets/458784/6aed0596-27b9-4446-8d7e-a730823de40d"> | <img width="496" alt="Screenshot 2023-10-17 at 3 20 59 PM" src="https://github.com/18F/identity-idp/assets/458784/704cf739-24b5-4b40-bb2b-dfcce5d62e79"> |
|  | <img width="746" alt="Screenshot 2023-10-17 at 3 21 47 PM" src="https://github.com/18F/identity-idp/assets/458784/23e453e4-c881-431b-b5ec-7a3247a4e204"> |




<!--
## 📜 Testi
ng Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
