### PR TITLE
LG-11091: rate limited hybrid handoff not route to phone question

### DIFF
--- a/app/controllers/concerns/idv/phone_question_ab_test_concern.rb
+++ b/app/controllers/concerns/idv/phone_question_ab_test_concern.rb
@@ -16,6 +16,8 @@ module Idv
       return if phone_question_ab_test_bucket != :show_phone_question
       return if request.referer == idv_phone_question_url
       return if request.referer == idv_link_sent_url
+      return if request.referer == idv_hybrid_handoff_url
+      return if request.referer == idv_hybrid_handoff_url(redo: true)
 
       redirect_to idv_phone_question_url
     end

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -34,3 +34,4 @@ production:
   usps_auth_token_refresh_job_enabled: false
   lexisnexis_threatmetrix_mock_enabled: true
   enable_usps_verification: true
+  idv_phone_question_a_b_testing: '{"bypass_phone_question":0, "show_phone_question":100}'

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -34,4 +34,3 @@ production:
   usps_auth_token_refresh_job_enabled: false
   lexisnexis_threatmetrix_mock_enabled: true
   enable_usps_verification: true
-  idv_phone_question_a_b_testing: '{"bypass_phone_question":0, "show_phone_question":100}'

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -176,8 +176,8 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
 
     context 'PhoneQuestion page' do
       before do
-        allow_any_instance_of(Idv::HybridHandoffController).to receive(:phone_question_ab_test_bucket).
-          and_return(:show_phone_question)
+        allow_any_instance_of(Idv::HybridHandoffController).
+          to receive(:phone_question_ab_test_bucket).and_return(:show_phone_question)
       end
 
       it 'rate limits sending the link' do

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -194,6 +194,9 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
           :idv_phone_send_link_rate_limited,
         ).with({ phone_number: '+1 415-555-0199' })
 
+        expect(page).to have_current_path(idv_phone_question_path)
+        click_link t('doc_auth.buttons.have_phone')
+
         freeze_time do
           idv_send_link_max_attempts.times do
             expect(page).to_not have_content(

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -174,6 +174,67 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
       end
     end
 
+    context 'PhoneQuestion page' do
+      before do
+        allow_any_instance_of(Idv::HybridHandoffController).to receive(:phone_question_ab_test_bucket).
+          and_return(:show_phone_question)
+      end
+
+      it 'rate limits sending the link' do
+        user = user_with_2fa
+        sign_in_and_2fa_user(user)
+        complete_doc_auth_steps_before_hybrid_handoff_step
+        timeout = distance_of_time_in_words(
+          RateLimiter.attempt_window_in_minutes(:idv_send_link).minutes,
+        )
+        allow(IdentityConfig.store).to receive(:idv_send_link_max_attempts).
+          and_return(idv_send_link_max_attempts)
+
+        expect(fake_attempts_tracker).to receive(
+          :idv_phone_send_link_rate_limited,
+        ).with({ phone_number: '+1 415-555-0199' })
+
+        freeze_time do
+          idv_send_link_max_attempts.times do
+            expect(page).to_not have_content(
+              I18n.t('errors.doc_auth.send_link_limited', timeout: timeout),
+            )
+
+            fill_in :doc_auth_phone, with: '415-555-0199'
+            click_send_link
+
+            expect(page).to have_current_path(idv_link_sent_path)
+
+            click_doc_auth_back_link
+          end
+
+          fill_in :doc_auth_phone, with: '415-555-0199'
+
+          click_send_link
+          expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
+          expect(page).to have_content(
+            I18n.t(
+              'errors.doc_auth.send_link_limited',
+              timeout: timeout,
+            ),
+          )
+        end
+        expect(fake_analytics).to have_logged_event(
+          'Rate Limit Reached',
+          limiter_type: :idv_send_link,
+        )
+
+        # Manual expiration is needed for now since the RateLimiter uses
+        # Redis ttl instead of expiretime
+        RateLimiter.new(rate_limit_type: :idv_send_link, user: user).reset!
+        travel_to(Time.zone.now + idv_send_link_attempt_window_in_minutes.minutes) do
+          fill_in :doc_auth_phone, with: '415-555-0199'
+          click_send_link
+          expect(page).to have_current_path(idv_link_sent_path)
+        end
+      end
+    end
+
     it 'includes expected URL parameters' do
       expect(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
         params = Rack::Utils.parse_nested_query URI(config[:link]).query


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
LG-11091

## 🛠 Summary of changes
Rate limiting has been refactored allowing users to advance to next Idv step for successful final attempts.  If doc auth rate limited,  do no redirect the user back to the phone question page when visiting the hybrid handoff page.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Begin the IDV in [review app](https://review-amirbey-so-jesyl4.review-app.identitysandbox.gov/)
- [ ] complete steps and rate limit send link by requesting a link ~5 times
- [ ] Verify that hybrid handoff is displayed with rate limited message banner at the top of the pge

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
