### PR TITLE
Update ReportMailer to use EmailableReports struct

### DIFF
--- a/app/jobs/reports/authentication_report.rb
+++ b/app/jobs/reports/authentication_report.rb
@@ -14,14 +14,14 @@ module Reports
       subject = "Weekly Authentication Report - #{report_date}"
 
       report_configs.each do |report_hash|
-        tables = weekly_authentication_report_tables(report_hash['issuers'])
+        reports = weekly_authentication_emailable_reports(report_hash['issuers'])
 
         report_hash['emails'].each do |email|
           ReportMailer.tables_report(
             email:,
             subject:,
             message:,
-            tables:,
+            reports:,
             attachment_format: :csv,
           ).deliver_now
         end
@@ -30,11 +30,11 @@ module Reports
 
     private
 
-    def weekly_authentication_report_tables(issuers)
+    def weekly_authentication_emailable_reports(issuers)
       Reporting::AuthenticationReport.new(
         issuers:,
         time_range: report_date.all_week,
-      ).as_tables_with_options
+      ).as_emailable_reports
     end
 
     def report_configs

--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -43,11 +43,7 @@ module Reports
       ]
 
       reports.each do |report|
-        upload_to_s3(report.table, report_name: report.csv_name)
-      end
-
-      email_tables = reports.map do |report|
-        [report.email_options, *report.table]
+        upload_to_s3(report.table, report_name: report.filename)
       end
 
       email_message = "Report: #{REPORT_NAME} #{date}"
@@ -56,7 +52,7 @@ module Reports
         email: email_addresses,
         subject: "Monthly Key Metrics Report - #{date}",
         message: email_message,
-        tables: email_tables,
+        reports: reports,
         attachment_format: :xlsx,
       ).deliver_now
     end

--- a/app/services/reporting/account_deletion_rate_report.rb
+++ b/app/services/reporting/account_deletion_rate_report.rb
@@ -15,13 +15,11 @@ module Reporting
 
     def account_deletion_emailable_report
       EmailableReport.new(
-        email_options: {
-          title: 'Account deletion rate (last 30 days)',
-          float_as_percent: true,
-          precision: 4,
-        },
+        title: 'Account deletion rate (last 30 days)',
+        float_as_percent: true,
+        precision: 4,
         table: account_deletion_report,
-        csv_name: 'account_deletion_rate',
+        filename: 'account_deletion_rate',
       )
     end
 

--- a/app/services/reporting/account_reuse_and_total_identities_report.rb
+++ b/app/services/reporting/account_reuse_and_total_identities_report.rb
@@ -30,12 +30,10 @@ module Reporting
 
     def account_reuse_emailable_report
       EmailableReport.new(
-        email_options: {
-          title: "IDV app reuse rate #{stats_month}",
-          float_as_percent: true,
-          precision: 4,
-        },
-        csv_name: 'account_reuse',
+        title: "IDV app reuse rate #{stats_month}",
+        float_as_percent: true,
+        precision: 4,
+        filename: 'account_reuse',
         table: account_reuse_report,
       )
     end
@@ -49,9 +47,9 @@ module Reporting
 
     def total_identities_emailable_report
       EmailableReport.new(
-        email_options: { title: 'Total proofed identities' },
+        title: 'Total proofed identities',
         table: total_identities_report,
-        csv_name: 'total_profiles',
+        filename: 'total_profiles',
       )
     end
 

--- a/app/services/reporting/emailable_report.rb
+++ b/app/services/reporting/emailable_report.rb
@@ -16,7 +16,7 @@ module Reporting
     :filename,
     :title,
     :float_as_percent,
-    :precision
+    :precision,
   ) do
     alias_method :float_as_percent?, :float_as_percent
   end

--- a/app/services/reporting/emailable_report.rb
+++ b/app/services/reporting/emailable_report.rb
@@ -1,3 +1,23 @@
 module Reporting
-  EmailableReport = Struct.new(:email_options, :table, :csv_name)
+  # Represents tabular data and how to render the table in an email body and
+  # name it as an attachment
+  # @!attribute [rw] table
+  #   @return [Array<Array<String>>]
+  # @!attribute [rw] filename
+  #   @return [String] filename for attachment
+  # @!attribute [rw] title
+  #   @return [String] title for table in email body
+  # @!attribute [rw] float_as_percent
+  #   @return [Boolean] whether or not floating point values should be rendered as percents
+  # @!attribute [rw] precision
+  #   @return [Integer] number of digits of precision for rendering as percent
+  EmailableReport = Struct.new(
+    :table,
+    :filename,
+    :title,
+    :float_as_percent,
+    :precision
+  ) do
+    alias_method :float_as_percent?, :float_as_percent
+  end
 end

--- a/app/services/reporting/monthly_active_users_count_report.rb
+++ b/app/services/reporting/monthly_active_users_count_report.rb
@@ -17,11 +17,9 @@ module Reporting
 
     def monthly_active_users_count_emailable_report
       EmailableReport.new(
-        email_options: {
-          title: "#{report_month_year} Active Users",
-        },
+        title: "#{report_month_year} Active Users",
         table: monthly_active_users_count_report,
-        csv_name: 'monthly_active_users_count',
+        filename: 'monthly_active_users_count',
       )
     end
 

--- a/app/services/reporting/total_user_count_report.rb
+++ b/app/services/reporting/total_user_count_report.rb
@@ -17,9 +17,9 @@ module Reporting
 
     def total_user_count_emailable_report
       EmailableReport.new(
-        email_options: { title: 'Total user count (all-time)' },
+        title: 'Total user count (all-time)',
         table: total_user_count_report,
-        csv_name: 'total_user_count',
+        filename: 'total_user_count',
       )
     end
 

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -1,12 +1,11 @@
 <%#
 - @message: text to put in the beginning of the email
-- @tables: an array of tables, expects first "row" to be an options hash
+- @reports: an array of EmailableReport
 %>
 <%= @message %><br>
-<% @tables.each do |table| %>
-  <% options, header, *rows = table %>
-
-  <h2><%= options[:title] %></h2>
+<% @reports.each do |report| %>
+  <% header, *rows = report.table %>
+  <h2><%= report.title %></h2>
 
   <table class="usa-table">
     <thead>
@@ -21,8 +20,8 @@
         <tr>
           <% row.each do |cell| %>
             <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
-              <% if cell.is_a?(Float) && options[:float_as_percent] %>
-                <%= number_to_percentage(cell * 100, precision: options[:precision] || 2) %>
+              <% if cell.is_a?(Float) && report.float_as_percent? %>
+                <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
               <% else %>
                 <%= number_with_delimiter(cell) %>
               <% end %>

--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -67,7 +67,7 @@ module Reporting
           title: 'Overview',
           table: overview_table,
         ),
-        Reporting::EmailableReport(
+        Reporting::EmailableReport.new(
           title: 'Authentication Funnel Metrics',
           table: funnel_metrics_table,
         ),

--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -61,10 +61,16 @@ module Reporting
       ]
     end
 
-    def as_tables_with_options
+    def as_emailable_reports
       [
-        [{ title: 'Overview' }, *overview_table],
-        [{ title: 'Authentication Funnel Metrics' }, *funnel_metrics_table],
+        Reporting::EmailableReport.new(
+          title: 'Overview',
+          table: overview_table,
+        ),
+        Reporting::EmailableReport(
+          title: 'Authentication Funnel Metrics',
+          table: funnel_metrics_table,
+        ),
       ]
     end
 

--- a/lib/reporting/monthly_proofing_report.rb
+++ b/lib/reporting/monthly_proofing_report.rb
@@ -29,7 +29,7 @@ module Reporting
     end
 
     # @param [Array<String>] issuers
-    # @param [Range<Time>] date
+    # @param [Range<Time>] time_range
     def initialize(
       time_range:,
       verbose: false,
@@ -55,9 +55,9 @@ module Reporting
 
     def document_upload_proofing_emailable_report
       EmailableReport.new(
-        email_options: { title: 'Document upload proofing rates' },
+        title: 'Document upload proofing rates',
         table: proofing_report,
-        csv_name: 'document_upload_proofing',
+        filename: 'document_upload_proofing',
       )
     end
 

--- a/spec/jobs/reports/authentication_report_spec.rb
+++ b/spec/jobs/reports/authentication_report_spec.rb
@@ -23,29 +23,33 @@ RSpec.describe Reports::AuthenticationReport do
   end
 
   describe '#perform' do
-    let(:tables) do
+    let(:reports) do
       [
-        [
-          { title: 'Overview' },
-          ['Report Timeframe', '2023-10-01 00:00:00 UTC to 2023-10-01 23:59:59 UTC'],
-          ['Report Generated', '2023-10-02'],
-          ['Issuer', 'some:issuer'],
-          ['Total # of IAL1 Users', '75'],
-        ],
-        [
-          { title: 'Authentication Metrics Report' },
-          ['Metric', 'Number of accounts', '% of total from start'],
-          ['New Users Started IAL1 Verification', '100', '100%'],
-          ['New Users Completed IAL1 Password Setup', '85', '85%'],
-          ['New Users Completed IAL1 MFA', '80', '80%'],
-          ['New IAL1 Users Consented to Partner', '75', '75%'],
-          ['AAL2 Authentication Requests from Partner', '12', '12%'],
-          ['AAL2 Authenticated Requests', '50', '50%'],
-        ],
+        Reporting::EmailableReport.new(
+          title: 'Overview',
+          table: [
+            ['Report Timeframe', '2023-10-01 00:00:00 UTC to 2023-10-01 23:59:59 UTC'],
+            ['Report Generated', '2023-10-02'],
+            ['Issuer', 'some:issuer'],
+            ['Total # of IAL1 Users', '75'],
+          ],
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Authentication Metrics Report',
+          table: [
+            ['Metric', 'Number of accounts', '% of total from start'],
+            ['New Users Started IAL1 Verification', '100', '100%'],
+            ['New Users Completed IAL1 Password Setup', '85', '85%'],
+            ['New Users Completed IAL1 MFA', '80', '80%'],
+            ['New IAL1 Users Consented to Partner', '75', '75%'],
+            ['AAL2 Authentication Requests from Partner', '12', '12%'],
+            ['AAL2 Authenticated Requests', '50', '50%'],
+          ],
+        ),
       ]
     end
 
-    let(:weekly_report) { double(Reporting::AuthenticationReport, as_tables_with_options: tables) }
+    let(:weekly_report) { double(Reporting::AuthenticationReport, as_emailable_reports: reports) }
 
     before do
       expect(Reporting::AuthenticationReport).to receive(:new).with(
@@ -61,7 +65,7 @@ RSpec.describe Reports::AuthenticationReport do
         email:,
         subject: "Weekly Authentication Report - #{report_date}",
         message: "Report: authentication-report #{report_date}",
-        tables:,
+        reports:,
         attachment_format: :csv,
       )
 

--- a/spec/jobs/reports/monthly_key_metrics_report_spec.rb
+++ b/spec/jobs/reports/monthly_key_metrics_report_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
       message: 'Report: monthly-key-metrics-report 2021-03-02',
       email: [agnes_email],
       subject: 'Monthly Key Metrics Report - 2021-03-02',
-      tables: anything,
+      reports: anything,
       attachment_format: :xlsx,
     ).and_call_original
 
@@ -72,7 +72,7 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
       message: 'Report: monthly-key-metrics-report 2021-03-01',
       email: [agnes_email, feds_email],
       subject: 'Monthly Key Metrics Report - 2021-03-01',
-      tables: anything,
+      reports: anything,
       attachment_format: :xlsx,
     ).and_call_original
 

--- a/spec/lib/reporting/authentication_report_spec.rb
+++ b/spec/lib/reporting/authentication_report_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe Reporting::AuthenticationReport do
     end
   end
 
-  describe '#as_tables_with_names' do
+  describe '#as_emailable_reports' do
     it 'adds a "first row" hash with a title for tables_report mailer' do
-      tables = report.as_tables_with_options
+      reports = report.as_emailable_reports
       aggregate_failures do
-        tables.each do |table|
-          expect(table[0][:title]).to_not be nil
+        reports.each do |report|
+          expect(report.title).to be_present
         end
       end
     end

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -14,48 +14,66 @@ class ReportMailerPreview < ActionMailer::Preview
       subject: 'Example Key Metrics Report',
       message: 'Key Metrics Report February 2021',
       attachment_format: :xlsx,
-      tables: [
-        [
-          { title: 'February 2021 Active Users' },
-          ['Monthly Active Users', 'Value'],
-          ['IAL1', 1],
-          ['IDV', 1],
-          ['Total', 2],
-        ],
-        [
-          { title: 'Total user count (all-time)' },
-          ['All-time user count'],
-          [2289411],
-        ],
-        [
-          { title: 'Account deletion rate (last 30 days)', float_as_percent: true, precision: 4 },
-          ['Deleted Users',	'Total Users', 'Deletion Rate'],
-          [137, 7434, 0.18429222],
-        ],
-        [
-          { title: 'IDV app reuse rate Feb-2021', float_as_percent: true, precision: 4 },
-          ['Num. SPs', 'Num. users', 'Percentage'],
-          [2, 207422, 0.105164],
-          [3, 6700, 0.003397],
-          [4, 254, 0.000129],
-          [5, 26, 0.000013],
-          [6, 1, 0.000001],
-          ['Total (all >1)', 214403, 0.108703],
-        ],
-        [
-          { title: 'Total proofed identities' },
-          ['Total proofed identities (Feb-2021)'],
-          [1972368],
-        ],
-        [
-          { title: 'Document upload proofing rates', float_as_percent: true, precision: 4 },
-          ['metric', 'num_users', 'percent'],
-          ['image_submitted', 5, 5.0 / 5],
-          ['verified', 2, 2.0 / 5],
-          ['not_verified_started_gpo', 1, 1.0 / 5],
-          ['not_verified_started_in_person', 1, 1.0 / 5],
-          ['not_verified_started_fraud_review', 1, 1.0 / 5],
-        ],
+      reports: [
+        Reporting::EmailableReport.new(
+          title: 'February 2021 Active Users',
+          table: [
+            ['Monthly Active Users', 'Value'],
+            ['IAL1', 1],
+            ['IDV', 1],
+            ['Total', 2],
+          ],
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Total user count (all-time)',
+          table: [
+            ['All-time user count'],
+            [2289411],
+          ],
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Account deletion rate (last 30 days)',
+          float_as_percent: true,
+          precision: 4,
+          table: [
+            ['Deleted Users',	'Total Users', 'Deletion Rate'],
+            [137, 7434, 0.18429222],
+          ],
+        ),
+        Reporting::EmailableReport.new(
+          title: 'IDV app reuse rate Feb-2021',
+          float_as_percent: true,
+          precision: 4,
+          table: [
+            ['Num. SPs', 'Num. users', 'Percentage'],
+            [2, 207422, 0.105164],
+            [3, 6700, 0.003397],
+            [4, 254, 0.000129],
+            [5, 26, 0.000013],
+            [6, 1, 0.000001],
+            ['Total (all >1)', 214403, 0.108703],
+          ],
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Total proofed identities',
+          table: [
+            ['Total proofed identities (Feb-2021)'],
+            [1972368],
+          ],
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Document upload proofing rates',
+          float_as_percent: true,
+          precision: 4,
+          table: [
+            ['metric', 'num_users', 'percent'],
+            ['image_submitted', 5, 5.0 / 5],
+            ['verified', 2, 2.0 / 5],
+            ['not_verified_started_gpo', 1, 1.0 / 5],
+            ['not_verified_started_in_person', 1, 1.0 / 5],
+            ['not_verified_started_fraud_review', 1, 1.0 / 5],
+          ],
+        ),
       ],
     )
   end
@@ -66,24 +84,30 @@ class ReportMailerPreview < ActionMailer::Preview
       subject: 'Example Report',
       message: 'Sample Message',
       attachment_format: :csv,
-      tables: [
-        [
-          ['Some', 'String'],
-          ['a', 'b'],
-          ['c', 'd'],
-        ],
-        [
-          { float_as_percent: true },
-          [nil, 'Int', 'Float as Percent'],
-          ['Row 1', 1, 0.5],
-          ['Row 2', 1, 1.5],
-        ],
-        [
-          { float_as_percent: false },
-          [nil, 'Gigantic Int', 'Float as Float'],
-          ['Row 1', 100_000_000, 1.0],
-          ['Row 2', 123_456_789, 1.5],
-        ],
+      reports: [
+        Reporting::EmailableReport.new(
+          table: [
+            ['Some', 'String'],
+            ['a', 'b'],
+            ['c', 'd'],
+          ],
+        ),
+        Reporting::EmailableReport.new(
+          float_as_percent: true,
+          table: [
+            [nil, 'Int', 'Float as Percent'],
+            ['Row 1', 1, 0.5],
+            ['Row 2', 1, 1.5],
+          ],
+        ),
+        Reporting::EmailableReport.new(
+          float_as_percent: false,
+          table: [
+            [nil, 'Gigantic Int', 'Float as Float'],
+            ['Row 1', 100_000_000, 1.0],
+            ['Row 2', 123_456_789, 1.5],
+          ],
+        ),
       ],
     )
   end

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -89,16 +89,18 @@ RSpec.describe ReportMailer, type: :mailer do
         message: 'My Report - Today',
         env: env,
         attachment_format: attachment_format,
-        tables: [
-          first_table,
-          [
-            { float_as_percent: true, title: 'Custom Table 2' },
-            *second_table,
-          ],
-          [
-            { float_as_percent: false, title: 'Custom Table 3 With Very Long Name' },
-            *third_table,
-          ],
+        reports: [
+          Reporting::EmailableReport.new(table: first_table),
+          Reporting::EmailableReport.new(
+            table: second_table,
+            float_as_percent: true,
+            title: 'Custom Table 2',
+          ),
+          Reporting::EmailableReport.new(
+            table: third_table,
+            float_as_percent: false,
+            title: 'Custom Table 3 With Very Long Name',
+          ),
         ],
       )
     end

--- a/spec/services/reporting/monthly_active_users_count_report_spec.rb
+++ b/spec/services/reporting/monthly_active_users_count_report_spec.rb
@@ -44,11 +44,9 @@ RSpec.describe Reporting::MonthlyActiveUsersCountReport do
       expect(monthly_active_users_count_table).to eq(expected_table)
 
       emailable_report = report.monthly_active_users_count_emailable_report
-      expect(emailable_report.email_options).to include(
-        title: 'February 2023 Active Users',
-      )
+      expect(emailable_report.title).to eq('February 2023 Active Users')
       expect(emailable_report.table).to eq monthly_active_users_count_table
-      expect(emailable_report.csv_name).to eq 'monthly_active_users_count'
+      expect(emailable_report.filename).to eq 'monthly_active_users_count'
     end
   end
 end


### PR DESCRIPTION
- Removes options hash, makes options first-class propreties
- Refactors existing reports

(I'm branching off of https://github.com/18F/identity-idp/pull/9405 because I didn't want to deal with merge conflicts in the `report_mailer.rb` file)

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
