### PR TITLE
Start using the new enter password url

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -21,7 +21,7 @@ module IdvSession
   def confirm_phone_or_address_confirmed
     return if idv_session.address_confirmed? || idv_session.phone_confirmed?
 
-    redirect_to idv_review_url
+    redirect_to idv_enter_password_url
   end
 
   def idv_session

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -99,7 +99,7 @@ module IdvStepConcern
 
   def confirm_verify_info_step_needed
     return unless idv_session.verify_info_step_complete?
-    redirect_to idv_review_url
+    redirect_to idv_enter_password_url
   end
 
   def confirm_address_step_complete

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -34,7 +34,7 @@ module Idv
           flash[:success] = t('idv.messages.gpo.another_letter_on_the_way')
           redirect_to idv_letter_enqueued_url
         else
-          redirect_to idv_review_url
+          redirect_to idv_enter_password_url
         end
       end
 
@@ -83,7 +83,7 @@ module Idv
       end
 
       def confirm_mail_not_spammed
-        redirect_to idv_review_url if gpo_mail_service.mail_spammed?
+        redirect_to idv_enter_password_url if gpo_mail_service.mail_spammed?
       end
 
       def confirm_user_completed_idv_profile_step

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -105,7 +105,7 @@ module Idv
       irs_attempts_api_tracker.idv_password_entered(success: false)
 
       flash[:error] = t('idv.errors.incorrect_password')
-      redirect_to idv_review_url
+      redirect_to idv_enter_password_url
     end
 
     def gpo_mail_service
@@ -186,7 +186,7 @@ module Idv
         reason: 'Request exception',
       )
       flash[:error] = t('idv.failure.exceptions.internal_error')
-      redirect_to idv_review_url
+      redirect_to idv_enter_password_url
     end
   end
 end

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -34,7 +34,7 @@ module Idv
         idv_session.user_phone_confirmation = true
         save_in_person_notification_phone
         flash[:success] = t('idv.messages.enter_password.phone_verified')
-        redirect_to idv_review_url
+        redirect_to idv_enter_password_url
       else
         handle_otp_confirmation_failure
       end
@@ -44,7 +44,7 @@ module Idv
 
     def confirm_step_needed
       return unless idv_session.user_phone_confirmation
-      redirect_to idv_review_url
+      redirect_to idv_enter_password_url
     end
 
     def confirm_otp_sent

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -73,7 +73,7 @@ module Idv
           send_phone_confirmation_otp_and_handle_result
         end
       else
-        redirect_to idv_review_url
+        redirect_to idv_enter_password_url
       end
     end
 

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -46,7 +46,7 @@ module Idv
 
     def confirm_idv_phone_step_needed
       return unless user_fully_authenticated?
-      redirect_to idv_review_url if idv_session.user_phone_confirmation == true
+      redirect_to idv_enter_password_url if idv_session.user_phone_confirmation == true
     end
 
     def confirm_idv_phone_step_submitted

--- a/app/controllers/idv/resend_otp_controller.rb
+++ b/app/controllers/idv/resend_otp_controller.rb
@@ -30,7 +30,7 @@ module Idv
 
     def confirm_user_phone_confirmation_needed
       return unless idv_session.user_phone_confirmation
-      redirect_to idv_review_url
+      redirect_to idv_enter_password_url
     end
 
     def confirm_user_phone_confirmation_session_started

--- a/app/views/idv/enter_password/new.html.erb
+++ b/app/views/idv/enter_password/new.html.erb
@@ -17,7 +17,7 @@
 
 <%= simple_form_for(
       current_user,
-      url: idv_review_path,
+      url: idv_enter_password_path,
       html: { autocomplete: 'off', method: :put, class: 'margin-top-4' },
     ) do |f| %>
   <%= render PasswordToggleComponent.new(

--- a/app/views/idv/forgot_password/new.html.erb
+++ b/app/views/idv/forgot_password/new.html.erb
@@ -11,7 +11,7 @@
 
   <% c.with_action_button(
        action: ->(**tag_options, &block) do
-         link_to(idv_review_path, **tag_options, &block)
+         link_to(idv_enter_password_path, **tag_options, &block)
        end,
      ) { t('idv.forgot_password.try_again') } %>
 

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Idv::ByMail::RequestLetterController do
         and_return(true)
       get :index
 
-      expect(response).to redirect_to idv_review_path
+      expect(response).to redirect_to idv_enter_password_path
     end
 
     it 'allows a user to request another letter' do
@@ -143,7 +143,7 @@ RSpec.describe Idv::ByMail::RequestLetterController do
 
         put :create
 
-        expect(response).to redirect_to idv_review_path
+        expect(response).to redirect_to idv_enter_password_path
         expect(subject.idv_session.address_verification_mechanism).to eq :gpo
       end
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Idv::EnterPasswordController do
         post :show, params: { user: { password: '' } }
 
         expect(flash[:error]).to eq t('idv.errors.incorrect_password')
-        expect(response).to redirect_to idv_review_path
+        expect(response).to redirect_to idv_enter_password_path
       end
     end
 
@@ -119,7 +119,7 @@ RSpec.describe Idv::EnterPasswordController do
 
       it 'redirects to new' do
         expect(flash[:error]).to eq t('idv.errors.incorrect_password')
-        expect(response).to redirect_to idv_review_path
+        expect(response).to redirect_to idv_enter_password_path
       end
 
       it 'tracks irs password entered event (idv_password_entered)' do
@@ -249,7 +249,7 @@ RSpec.describe Idv::EnterPasswordController do
       it 'redirects to original path' do
         put :create, params: { user: { password: 'wrong' } }
 
-        expect(response).to redirect_to idv_review_path
+        expect(response).to redirect_to idv_enter_password_path
 
         expect(@analytics).to have_logged_event(
           'IdV: review complete',
@@ -490,7 +490,7 @@ RSpec.describe Idv::EnterPasswordController do
             it 'allows the user to retry the request' do
               put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
               expect(flash[:error]).to eq t('idv.failure.exceptions.internal_error')
-              expect(response).to redirect_to idv_review_path
+              expect(response).to redirect_to idv_enter_password_path
 
               stub_request_enroll
 

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Idv::HybridHandoffController do
         it 'redirects to review' do
           get :show, params: { redo: true }
 
-          expect(response).to redirect_to(idv_review_url)
+          expect(response).to redirect_to(idv_enter_password_url)
         end
       end
     end

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Idv::OtpVerificationController do
 
       it 'redirects to the review step' do
         get :show
-        expect(response).to redirect_to(idv_review_path)
+        expect(response).to redirect_to(idv_enter_password_path)
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe Idv::OtpVerificationController do
 
       it 'redirects to the review step' do
         put :update, params: otp_code_param
-        expect(response).to redirect_to(idv_review_path)
+        expect(response).to redirect_to(idv_enter_password_path)
       end
     end
 

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Idv::PersonalKeyController do
       it 'redirects to review url' do
         get :show
 
-        expect(response).to redirect_to idv_review_url
+        expect(response).to redirect_to idv_enter_password_url
       end
     end
   end
@@ -236,7 +236,7 @@ RSpec.describe Idv::PersonalKeyController do
       it 'redirects to review url' do
         patch :update
 
-        expect(response).to redirect_to idv_review_url
+        expect(response).to redirect_to idv_enter_password_url
       end
     end
 

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Idv::PhoneController do
         subject.idv_session.vendor_phone_confirmation = true
         get :new
 
-        expect(response).to redirect_to idv_review_path
+        expect(response).to redirect_to idv_enter_password_path
       end
     end
 

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Idv::PhoneErrorsController do
           it 'redirects to the review url' do
             get action
 
-            expect(response).to redirect_to(idv_review_url)
+            expect(response).to redirect_to(idv_enter_password_url)
           end
           it 'does not log an event' do
             expect(@analytics).not_to receive(:track_event).with(

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Idv::ResendOtpController do
 
       it 'redirects to the enter password step' do
         post :create
-        expect(response).to redirect_to(idv_review_path)
+        expect(response).to redirect_to(idv_enter_password_path)
       end
     end
 

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Idv::VerifyInfoController do
 
         get :show
 
-        expect(response).to redirect_to(idv_review_url)
+        expect(response).to redirect_to(idv_enter_password_url)
       end
     end
 

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'Accessibility on IDV pages', :js do
       visit idv_path
       complete_all_doc_auth_steps_before_password_step
 
-      expect(page).to have_current_path(idv_review_path)
+      expect(page).to have_current_path(idv_enter_password_path)
       expect_page_to_have_no_accessibility_violations(page)
     end
 

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe 'Identity verification', :js do
   end
 
   def validate_enter_password_page
-    expect(page).to have_current_path(idv_review_path)
+    expect(page).to have_current_path(idv_enter_password_path)
     expect(page).to have_content(t('idv.messages.enter_password.message', app_name: APP_NAME))
     expect(page).to have_content(t('idv.messages.enter_password.phone_verified'))
 
@@ -262,7 +262,7 @@ RSpec.describe 'Identity verification', :js do
     fill_in 'Password', with: 'this is not the right password'
     click_idv_continue
     expect(page).to have_content(t('idv.errors.incorrect_password'))
-    expect(page).to have_current_path(idv_review_path)
+    expect(page).to have_current_path(idv_enter_password_path)
   end
 
   def validate_enter_password_submit(user)
@@ -308,7 +308,7 @@ RSpec.describe 'Identity verification', :js do
   end
 
   def try_to_skip_ahead_before_signing_in
-    visit idv_review_path
+    visit idv_enter_password_path
     expect(current_path).to eq(root_path)
   end
 
@@ -336,7 +336,7 @@ RSpec.describe 'Identity verification', :js do
   end
 
   def try_to_skip_ahead_from_phone
-    visit idv_review_path
+    visit idv_enter_password_path
     expect(page).to have_current_path(idv_phone_path)
   end
 

--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'phone otp rate limiting', :js do
       click_submit_default
 
       expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-      expect(current_path).to eq(idv_review_path)
+      expect(current_path).to eq(idv_enter_password_path)
     end
   end
 end

--- a/spec/features/idv/proof_address_rate_limit_spec.rb
+++ b/spec/features/idv/proof_address_rate_limit_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'address proofing rate limit' do
       click_on t('idv.buttons.mail.send')
 
       expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-      expect(current_path).to eq(idv_review_path)
+      expect(current_path).to eq(idv_enter_password_path)
       fill_in 'Password', with: user.password
       click_idv_continue
       expect(page).to have_current_path(idv_letter_enqueued_path)
@@ -59,7 +59,7 @@ RSpec.feature 'address proofing rate limit' do
       click_submit_default
 
       expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-      expect(current_path).to eq(idv_review_path)
+      expect(current_path).to eq(idv_enter_password_path)
       fill_in 'Password', with: user.password
       click_idv_continue
       expect(current_path).to eq(idv_personal_key_path)

--- a/spec/features/idv/steps/forgot_password_step_spec.rb
+++ b/spec/features/idv/steps/forgot_password_step_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'forgot password step', :js do
     click_link t('idv.forgot_password.link_text')
     click_link t('idv.forgot_password.try_again')
 
-    expect(page.current_path).to eq(idv_review_path)
+    expect(page.current_path).to eq(idv_enter_password_path)
   end
 
   it 'allows the user to reset their password' do

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'phone otp verification step spec', :js do
     complete_idv_steps_before_phone_otp_verification_step(user)
 
     # Attempt to bypass the step
-    visit idv_review_path
+    visit idv_enter_password_path
     expect(current_path).to eq(idv_otp_verification_path)
 
     # Enter an incorrect otp
@@ -25,7 +25,7 @@ RSpec.feature 'phone otp verification step spec', :js do
     click_submit_default
 
     expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-    expect(page).to have_current_path(idv_review_path)
+    expect(page).to have_current_path(idv_enter_password_path)
   end
 
   it 'rejects OTPs after they are expired' do
@@ -58,7 +58,7 @@ RSpec.feature 'phone otp verification step spec', :js do
     click_submit_default
 
     expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-    expect(page).to have_current_path(idv_review_path)
+    expect(page).to have_current_path(idv_enter_password_path)
   end
 
   it 'redirects back to the step with an error if Telephony raises an error on resend' do

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'idv phone step', :js do
 
       visit idv_phone_path
       expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-      expect(page).to have_current_path(idv_review_path)
+      expect(page).to have_current_path(idv_enter_password_path)
 
       fill_in 'Password', with: user_password
       click_continue

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'idv request letter step' do
     click_on t('idv.buttons.mail.send')
 
     expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-    expect(page).to have_current_path(idv_review_path)
+    expect(page).to have_current_path(idv_enter_password_path)
 
     complete_enter_password_step
     expect(page).to have_content(t('idv.messages.gpo.letter_on_the_way'))

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -175,7 +175,7 @@ module DocAuthHelper
     fill_out_phone_form_ok if find('#idv_phone_form_phone').value.blank?
     click_continue
     verify_phone_otp
-    expect(page).to have_current_path(idv_review_path, wait: 10)
+    expect(page).to have_current_path(idv_enter_password_path, wait: 10)
     expect_page_to_have_no_accessibility_violations(page) if expect_accessible
   end
 

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -52,7 +52,7 @@ RSpec.shared_examples 'verification step max attempts' do |step, sp|
 
       fill_out_phone_form_ok
       verify_phone_otp
-      expect(page).to have_current_path(idv_review_path, wait: 10)
+      expect(page).to have_current_path(idv_enter_password_path, wait: 10)
     end
   end
 


### PR DESCRIPTION
The change in #9375 renamed the review controller to the "enter password" controller. This commit introduced a new path, but did not start using it to support the 50/50 state when that change was deployed.

This commit starts using the new path but does not remove the old ones. This is also to prevent 404s in the 50/50 state. A follow up will be needed to remove the old routes after this is deployed.
