### PR TITLE
Switch MonthlyKeyMetricsReport to use positional args

### DIFF
--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -7,7 +7,7 @@ module Reports
 
     attr_reader :report_date
 
-    def initialize(*args, report_date: nil, **rest)
+    def initialize(report_date = nil, *args, **rest)
       @report_date = report_date
       super(*args, **rest)
     end

--- a/spec/jobs/reports/monthly_key_metrics_report_spec.rb
+++ b/spec/jobs/reports/monthly_key_metrics_report_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Reports::MonthlyKeyMetricsReport do
   let(:report_date) { Date.new(2021, 3, 2) }
-  subject(:report) { Reports::MonthlyKeyMetricsReport.new(report_date: report_date) }
+  subject(:report) { Reports::MonthlyKeyMetricsReport.new(report_date) }
 
   let(:name) { 'monthly-key-metrics-report' }
   let(:agnes_email) { 'fake@agnes_email.com' }


### PR DESCRIPTION
**Why**: So that #initialize matches #perform, just in case this affects the job runner