### PR TITLE
Add DB timeouts to MonthlyKeyMetricsReports parts

### DIFF
--- a/app/services/reporting/account_deletion_rate_report.rb
+++ b/app/services/reporting/account_deletion_rate_report.rb
@@ -26,11 +26,15 @@ module Reporting
     private
 
     def deleted_user_count
-      @deleted_user_count ||= DeletedUser.where(user_created_at: start_date..end_date).count
+      @deleted_user_count ||= Reports::BaseReport.transaction_with_timeout do
+        DeletedUser.where(user_created_at: start_date..end_date).count
+      end
     end
 
     def user_count
-      @user_count ||= User.where(created_at: start_date..end_date).count
+      @user_count ||= Reports::BaseReport.transaction_with_timeout do
+        User.where(created_at: start_date..end_date).count
+      end
     end
 
     def users_and_deleted_for_period

--- a/app/services/reporting/monthly_active_users_count_report.rb
+++ b/app/services/reporting/monthly_active_users_count_report.rb
@@ -26,7 +26,9 @@ module Reporting
     private
 
     def active_users_count
-      @active_users_count ||= Db::Identity::SpActiveUserCounts.overall(range.begin, range.end).first
+      @active_users_count ||= Reports::BaseReport.transaction_with_timeout do
+        Db::Identity::SpActiveUserCounts.overall(range.begin, range.end).first
+      end
     end
 
     def total_ial1_active

--- a/app/services/reporting/total_user_count_report.rb
+++ b/app/services/reporting/total_user_count_report.rb
@@ -26,7 +26,9 @@ module Reporting
     private
 
     def total_user_count
-      User.where('created_at <= ?', report_date).count
+      Reports::BaseReport.transaction_with_timeout do
+        User.where('created_at <= ?', report_date).count
+      end
     end
   end
 end


### PR DESCRIPTION
The reports have been running quietly in prod and timing out because the queries are taking too long, this addresses that