### PR TITLE
Log if a user has a pending or active profile when updating their passsword

### DIFF
--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -15,7 +15,7 @@ class UpdateUserPasswordForm
     @password_confirmation = params[:password_confirmation]
     success = valid?
     process_valid_submission if success
-    FormResponse.new(success: success, errors: errors)
+    FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
   end
 
   private
@@ -41,5 +41,13 @@ class UpdateUserPasswordForm
 
   def encryptor
     @encryptor ||= ActiveProfileEncryptor.new(user, user_session, password)
+  end
+
+  def extra_analytics_attributes
+    {
+      active_profile_present: user.active_profile.present?,
+      pending_profile_present: user.pending_profile.present?,
+      user_id: user.uuid,
+    }
   end
 end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -30,8 +30,14 @@ RSpec.describe Users::PasswordsController do
         }
         patch :update, params: { update_user_password_form: params }
 
-        expect(@analytics).to have_received(:track_event).
-          with('Password Changed', success: true, errors: {})
+        expect(@analytics).to have_received(:track_event).with(
+          'Password Changed',
+          success: true,
+          errors: {},
+          pending_profile_present: false,
+          active_profile_present: false,
+          user_id: subject.current_user.uuid,
+        )
         expect(response).to redirect_to account_url
         expect(flash[:info]).to eq t('notices.password_changed')
         expect(flash[:personal_key]).to be_nil
@@ -154,6 +160,9 @@ RSpec.describe Users::PasswordsController do
               )],
             },
             error_details: password_short_error,
+            pending_profile_present: false,
+            active_profile_present: false,
+            user_id: subject.current_user.uuid,
           )
           expect(response).to render_template(:edit)
         end
@@ -196,6 +205,9 @@ RSpec.describe Users::PasswordsController do
             error_details: {
               password_confirmation: [t('errors.messages.password_mismatch')],
             },
+            pending_profile_present: false,
+            active_profile_present: false,
+            user_id: subject.current_user.uuid,
           )
           expect(response).to render_template(:edit)
         end

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
         subject.submit(params)
       end
 
-      it 'logs that the user does not have an active or pending profile' do
+      it 'logs that the user has a pending profile' do
         result = subject.submit(params)
 
         expect(result.extra).to include(


### PR DESCRIPTION
If a user updates their password with an active profile we re-encrypt the active profile with their password. We do not, however, re-encrypt pending profiles.

We are considering a change that would re-encrypt pending profiles if the data was decrypted and available in the session. Before we do we want to measure the impact this change would have. Currently we do not log if a user has a pendin g profile when updating their password so measuring impace is not possible.

This commit adds the necessary logging to make a decision about the feature described above.
