### PR TITLE
LG-11197: Update labels for account page verified information

### DIFF
--- a/app/views/accounts/_pii.html.erb
+++ b/app/views/accounts/_pii.html.erb
@@ -20,7 +20,7 @@
   <div class="grid-row margin-bottom-1 margin-top-0">
     <div class="grid-col-12">
       <h2 class="margin-0">
-        <%= t('headings.account.profile_info') %>
+        <%= t('headings.account.verified_information') %>
         <%= image_tag asset_url('lock.svg'), width: 8, height: 10 %>
       </h2>
     </div>
@@ -28,7 +28,7 @@
   <div class="border-bottom border-primary-light">
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
       <div class="tablet:grid-col-4 text-bold">
-        <%= t('account.index.full_name') %>
+        <%= t('account.verified_information.full_name') %>
       </div>
       <div class="tablet:grid-col-8 padding-x-1 truncate">
         <%= pii.full_name %>
@@ -36,7 +36,7 @@
     </div>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
       <div class="tablet:grid-col-4 text-bold">
-        <%= t('account.index.address') %>
+        <%= t('account.verified_information.address') %>
       </div>
       <div class="tablet:grid-col-8 padding-x-1">
         <%= render 'shared/address', address: pii %>
@@ -44,7 +44,7 @@
     </div>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
       <div class="tablet:grid-col-4 text-bold">
-        <%= t('account.index.dob') %>
+        <%= t('account.verified_information.dob') %>
       </div>
       <div class="tablet:grid-col-8 padding-x-1">
         <%= pii.dob %>
@@ -52,7 +52,7 @@
     </div>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
       <div class="tablet:grid-col-4 text-bold">
-        <%= t('account.index.ssn') %>
+        <%= t('account.verified_information.ssn') %>
       </div>
       <div class="tablet:grid-col-8 padding-x-1">
         ***-**-****
@@ -60,7 +60,7 @@
     </div>
     <div class="padding-1 grid-row border-top border-left border-right border-primary-light">
       <div class="tablet:grid-col-4 text-bold">
-        <%= t('account.index.phone') %>
+        <%= t('account.verified_information.phone_number') %>
       </div>
       <div class="tablet:grid-col-8 padding-x-1">
         <%= PhoneFormatter.format(pii.phone) %>

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -23,7 +23,6 @@ en:
         text/SMS code or a security key) each time you want to access your
         account.
     index:
-      address: Current address
       auth_app_add: Add app
       auth_app_disabled: not enabled
       auth_app_enabled: enabled
@@ -34,12 +33,10 @@ en:
       continue_to_service_provider: Continue to %{service_provider}
       default: default
       device: '%{browser} on %{os}'
-      dob: Date of birth
       email: Email address
       email_add: Add new email
       email_addresses: Email addresses
       email_preferences: Email preferences
-      full_name: Full name
       password: Password
       phone: Phone numbers
       phone_add: Add phone
@@ -49,7 +46,6 @@ en:
         instructions: Your profile was recently deactivated due to a password reset.
         link: Reactivate your profile now.
       sign_in_location_and_ip: From %{ip} (IP address potentially located in %{location})
-      ssn: Social Security number
       totp_confirm_delete: Yes, remove authentication app
       unknown_location: unknown location
       verification:
@@ -120,4 +116,10 @@ en:
     security:
       link: Learn more at the Help Center
       text: Your profile information is locked for your security.
+    verified_information:
+      address: Address
+      dob: Date of birth
+      full_name: Full name
+      phone_number: Phone number
+      ssn: Social Security number
     welcome: Welcome

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -24,7 +24,6 @@ es:
         de múltiples factores (como texto / código de SMS o una clave de
         seguridad) cada vez que desee acceder a su cuenta.
     index:
-      address: Dirección actual
       auth_app_add: Agregar aplicación
       auth_app_disabled: no permitido
       auth_app_enabled: permitido
@@ -35,12 +34,10 @@ es:
       continue_to_service_provider: Continuar con %{service_provider}
       default: defecto
       device: '%{browser} en %{os}'
-      dob: Fecha de nacimiento
       email: Dirección de correo electrónico
       email_add: Agregar nuevo correo electrónico
       email_addresses: Correos electrónicos
       email_preferences: Preferencias de correo electrónico
-      full_name: Nombre completo
       password: Contraseña
       phone: Teléfono
       phone_add: Añadir teléfono
@@ -50,7 +47,6 @@ es:
         instructions: Su perfil ha sido desactivado debido a un cambio de contraseña.
         link: Reactive su perfil ahora.
       sign_in_location_and_ip: Desde %{ip} (la dirección IP probablemente se encuentra en %{location})
-      ssn: Número de Seguro Social
       totp_confirm_delete: Sí, eliminar la aplicación de autenticación
       unknown_location: ubicación desconocida
       verification:
@@ -121,4 +117,10 @@ es:
     security:
       link: Obtenga más información en el Centro de ayuda
       text: Para su seguridad, la información de su perfil está bloqueada.
+    verified_information:
+      address: Dirección
+      dob: Fecha de nacimiento
+      full_name: Nombre completo
+      phone_number: Número de teléfono
+      ssn: Número de Seguro Social
     welcome: Bienvenido/a

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -25,7 +25,6 @@ fr:
         texte / SMS ou une clé de sécurité) chaque fois que vous souhaitez
         accéder à votre compte.
     index:
-      address: Adresse actuelle
       auth_app_add: Ajouter une application
       auth_app_disabled: non activée
       auth_app_enabled: activée
@@ -36,12 +35,10 @@ fr:
       continue_to_service_provider: Continuer à %{service_provider}
       default: défaut
       device: '%{browser} sur %{os}'
-      dob: Date de naissance
       email: Adresse e-mail
       email_add: Ajouter un nouvel e-mail
       email_addresses: Adresses courriel
       email_preferences: Préférences de messagerie
-      full_name: Nom complet
       password: Mot de passe
       phone: Numéro de téléphone
       phone_add: Ajouter un téléphone
@@ -53,7 +50,6 @@ fr:
           personnelle pour réactiver votre profil.
         link: Réactivez votre profil maintenant.
       sign_in_location_and_ip: '%{ip} (adresse IP probablement située dans %{location})'
-      ssn: Numéro d’assurance sociale
       totp_confirm_delete: Oui, supprimez l’application d’authentification
       unknown_location: lieu inconnu
       verification:
@@ -131,4 +127,10 @@ fr:
     security:
       link: En apprendre davantage dans le Centre d’aide
       text: L’information de votre profil est verrouillée pour votre sécurité.
+    verified_information:
+      address: Adresse
+      dob: Date de naissance
+      full_name: Nom complet
+      phone_number: Numéro de téléphone
+      ssn: Numéro d’assurance sociale
     welcome: Bienvenue

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -9,11 +9,11 @@ en:
       events: Events
       federal_employee_id: Federal employee ID
       login_info: Your account
-      profile_info: Profile information
       reactivate: Reactivate your account
       two_factor: Your authentication methods
       unphishable: Unphishable
       verified_account: Verified Account
+      verified_information: Verified information
     add_email: Add a new email address
     add_info:
       phone: Add a phone number

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -9,11 +9,11 @@ es:
       events: Eventos
       federal_employee_id: Identificación de empleado federal
       login_info: Su cuenta
-      profile_info: Información de perfil
       reactivate: Reactive su cuenta
       two_factor: Tus métodos de autenticación
       unphishable: Incapaz de phish
       verified_account: Cuenta verificada
+      verified_information: Información verificada
     add_email: Añadir una nueva dirección de correo electrónico
     add_info:
       phone: Agregar un número de teléfono

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -9,11 +9,11 @@ fr:
       events: Événements
       federal_employee_id: Identification des employés fédéraux
       login_info: Votre compte
-      profile_info: Information du profil
       reactivate: Réactivez votre compte
       two_factor: Vos méthodes d’authentification
       unphishable: Incapable de phishing
       verified_account: Compte vérifié
+      verified_information: Informations vérifiées
     add_email: Ajouter une nouvelle adresse e-mail
     add_info:
       phone: Ajouter un numéro de téléphone

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -20,7 +20,7 @@ es:
         su cuenta. Compartiremos esta información con el organismo asociado: '
       ial2_reverified_consent_info: 'Como volvió a verificar su identidad, necesitamos
         su permiso para compartir esta información con %{sp}: '
-      phone: Teléfono
+      phone: Número de teléfono
       social_security_number: Número de Seguro Social
       verified_at: Actualizado en
       x509_issuer: Emisor PIV/CAC

--- a/spec/support/idv_examples/clearing_and_restarting.rb
+++ b/spec/support/idv_examples/clearing_and_restarting.rb
@@ -45,10 +45,10 @@ RSpec.shared_examples 'clearing and restarting idv' do
 
     visit account_path
 
-    expect(page).to_not have_content(t('headings.account.profile_info'))
-    expect(page).to_not have_content(t('account.index.address'))
-    expect(page).to_not have_content(t('account.index.dob'))
-    expect(page).to_not have_content(t('account.index.full_name'))
-    expect(page).to_not have_content(t('account.index.ssn'))
+    expect(page).to_not have_content(t('headings.account.verified_information'))
+    expect(page).to_not have_content(t('account.verified_information.address'))
+    expect(page).to_not have_content(t('account.verified_information.dob'))
+    expect(page).to_not have_content(t('account.verified_information.full_name'))
+    expect(page).to_not have_content(t('account.verified_information.ssn'))
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11197](https://cm-jira.usa.gov/browse/LG-11197)

## 🛠 Summary of changes

Updates labels used in the "profile information" (now "verified information") section on the account dashboard to be more accurate.

## 📜 Testing Plan

1. Prerequisite: Have a verified account (go to http://localhost:3000/verify with an unverified account to verify)
2. Go to http://localhost:3000
3. Sign in
4. On account dashboard, observe labels for verified information

## 👀 Screenshots

Before|After
---|---
![Screenshot 2023-10-18 at 10 51 16 AM](https://github.com/18F/identity-idp/assets/1779930/83e7274a-cc62-4bba-b928-468c970587c8)|![Screenshot 2023-10-18 at 4 37 54 PM](https://github.com/18F/identity-idp/assets/1779930/2fff4e42-6f8f-4237-99e0-e69aa01f1d1e)