### PR TITLE
Add analytics section to frontend documentation

### DIFF
--- a/app/javascript/packages/analytics/README.md
+++ b/app/javascript/packages/analytics/README.md
@@ -2,12 +2,6 @@
 
 Utilities and custom elements for logging events and errors in the application.
 
-By default, events logged from the frontend will have their names prefixed with "Frontend:". This
-behavior occurs in [`FrontendLogController`][frontend_log_controller.rb]. You can avoid the prefix
-by assigning an event mapping method in the controller's `EVENT_MAP` constant.
-
-[frontend_log_controller.rb]: https://github.com/18F/identity-idp/blob/main/app/controllers/frontend_log_controller.rb
-
 ## Usage
 
 ### Programmatic Event Tracking

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -120,6 +120,32 @@ to deduplicate resolved package versions within the Yarn lockfile.
 
 See [`@18f/identity-i18n` package documentation](../app/javascript/packages/i18n/README.md).
 
+### Analytics
+
+See [`@18f/identity-analytics` package documentation](../app/javascript/packages/i18n/README.md) for
+code examples detailing how to track an event in JavaScript.
+
+Any event logged from the frontend must be added to the `EVENT_MAP` allowlist in [`FrontendLogController`][frontend_log_controller.rb].
+This mapping associates the event name logged from the frontend with the corresponding method from
+[AnalyticsEvents][analytics_events.rb] to be called. All properties will be passed automatically to
+the event from the frontend as long as they are defined in the method argument signature.
+
+There may be some situations where you need to append a value known by the server to an event logged
+in the frontend, such as an A/B test bucket descriptor. In these scenarios, you have a few options:
+
+1. Add the value to the page markup, such as through an [HTML `data-` attribute][data_attributes],
+and reference that attribute in JavaScript.
+2. Define the mapped value in `EVENT_MAP` to a service class, such as how [frontend error logging][frontend_error_logging]
+is implemented.
+3. Implement a mixin to intercept and override the default behavior of an analytics event, such as
+how [`Idv::AnalyticsEventEnhancer`][analytics_events_enhancer.rb] is implemented.
+
+[frontend_log_controller.rb]: https://github.com/18F/identity-idp/blob/main/app/controllers/frontend_log_controller.rb
+[analytics_events.rb]: https://github.com/18F/identity-idp/blob/main/app/services/analytics_events.rb
+[data_attributes]: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes
+[frontend_error_logging]: https://github.com/18F/identity-idp/blob/9c17164c0b8d9b4aefad74dde1a521c111b53aac/app/controllers/frontend_log_controller.rb#L14
+[analytics_events_enhancer.rb]: https://github.com/18F/identity-idp/blob/main/app/services/idv/analytics_events_enhancer.rb
+
 ## Components
 
 ### Design System

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -122,8 +122,8 @@ See [`@18f/identity-i18n` package documentation](../app/javascript/packages/i18n
 
 ### Analytics
 
-See [`@18f/identity-analytics` package documentation](../app/javascript/packages/i18n/README.md) for
-code examples detailing how to track an event in JavaScript.
+See [`@18f/identity-analytics` package documentation][analytics_package] for code examples detailing
+how to track an event in JavaScript.
 
 Any event logged from the frontend must be added to the `EVENT_MAP` allowlist in [`FrontendLogController`][frontend_log_controller.rb].
 This mapping associates the event name logged from the frontend with the corresponding method from
@@ -140,6 +140,7 @@ is implemented.
 3. Implement a mixin to intercept and override the default behavior of an analytics event, such as
 how [`Idv::AnalyticsEventEnhancer`][analytics_events_enhancer.rb] is implemented.
 
+[analytics_package]: ../app/javascript/packages/analytics/README.md
 [frontend_log_controller.rb]: https://github.com/18F/identity-idp/blob/main/app/controllers/frontend_log_controller.rb
 [analytics_events.rb]: https://github.com/18F/identity-idp/blob/main/app/services/analytics_events.rb
 [data_attributes]: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a new section "Analytics" to the [frontend developer documentation](https://github.com/18F/identity-idp/blob/main/docs/frontend.md), as an action item from the 2023-10-18 Engineering Huddle discussion.

## 📜 Testing Plan

1. Go to https://github.com/18F/identity-idp/blob/aduth-frontend-analytics-docs/docs/frontend.md#analytics
2. See if it reads well enough to cover common usage patterns