### PR TITLE
Remove second MFA prompt exception for strict MFA requirement

### DIFF
--- a/app/controllers/concerns/second_mfa_reminder_concern.rb
+++ b/app/controllers/concerns/second_mfa_reminder_concern.rb
@@ -1,17 +1,10 @@
 module SecondMfaReminderConcern
   def user_needs_second_mfa_reminder?
-    return false if user_has_dismissed_second_mfa_reminder?
-    return false if second_mfa_enrollment_may_downgrade_for_service_provider_mfa_requirement?
-    return false if user_has_multiple_mfa_methods?
+    return false if user_has_dismissed_second_mfa_reminder? || user_has_multiple_mfa_methods?
     exceeded_sign_in_count_for_second_mfa_reminder? || exceeded_account_age_for_second_mfa_reminder?
   end
 
   private
-
-  def second_mfa_enrollment_may_downgrade_for_service_provider_mfa_requirement?
-    service_provider_mfa_policy.phishing_resistant_required? ||
-      service_provider_mfa_policy.piv_cac_required?
-  end
 
   def user_has_dismissed_second_mfa_reminder?
     current_user.second_mfa_reminder_dismissed_at.present?

--- a/spec/controllers/concerns/second_mfa_reminder_concern_spec.rb
+++ b/spec/controllers/concerns/second_mfa_reminder_concern_spec.rb
@@ -5,40 +5,18 @@ RSpec.describe SecondMfaReminderConcern do
     Class.new do
       include SecondMfaReminderConcern
 
-      attr_reader :current_user, :service_provider_mfa_policy
+      attr_reader :current_user
 
-      def initialize(current_user:, service_provider_mfa_policy:)
+      def initialize(current_user:)
         @current_user = current_user
-        @service_provider_mfa_policy = service_provider_mfa_policy
       end
     end
   end
   let(:user) { build(:user) }
-  let(:phishing_resistant_required) { false }
-  let(:piv_cac_required) { false }
-  let(:service_provider_mfa_policy) do
-    instance_double(
-      ServiceProviderMfaPolicy,
-      phishing_resistant_required?: phishing_resistant_required,
-      piv_cac_required?: piv_cac_required,
-    )
-  end
-  let(:instance) { test_class.new(current_user: user, service_provider_mfa_policy:) }
+  let(:instance) { test_class.new(current_user: user) }
 
   describe '#user_needs_second_mfa_reminder?' do
     subject(:user_needs_second_mfa_reminder) { instance.user_needs_second_mfa_reminder? }
-
-    shared_examples 'second mfa reminder with phishing-resistant required request' do
-      let(:phishing_resistant_required) { true }
-
-      it { expect(user_needs_second_mfa_reminder).to eq(false) }
-    end
-
-    shared_examples 'second mfa reminder with piv required request' do
-      let(:piv_cac_required) { true }
-
-      it { expect(user_needs_second_mfa_reminder).to eq(false) }
-    end
 
     context 'user has already dismissed second mfa reminder' do
       let(:user) { build(:user, second_mfa_reminder_dismissed_at: Time.zone.now) }
@@ -69,9 +47,6 @@ RSpec.describe SecondMfaReminderConcern do
         end
 
         it { expect(user_needs_second_mfa_reminder).to eq(true) }
-
-        it_behaves_like 'second mfa reminder with phishing-resistant required request'
-        it_behaves_like 'second mfa reminder with piv required request'
       end
 
       context 'user has exceeded account age threshold for reminder' do
@@ -83,9 +58,6 @@ RSpec.describe SecondMfaReminderConcern do
         end
 
         it { expect(user_needs_second_mfa_reminder).to eq(true) }
-
-        it_behaves_like 'second mfa reminder with phishing-resistant required request'
-        it_behaves_like 'second mfa reminder with piv required request'
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Follow-on to [LG-10022](https://cm-jira.usa.gov/browse/LG-10022) (#9124, #9263) and [LG-11101](https://cm-jira.usa.gov/browse/LG-11101) (#9388, #9335)

## 🛠 Summary of changes

Removes the exception to consider service provider MFA requirements as part of the second MFA reminder screen logic.

This is essentially a revert of #9263.

This exception was added in #9263 because, at the time, we only kept record of the user's most recently-used authentication method, and adding an MFA during a strict-AAL2 sign-in could cause the second MFA addition to "downgrade" to a lesser method. This was improved in #9335 by supporting multiple recent authentication methods to be considered as part of the strict-AAL2 sign-in, so it is no longer necessary to exclude these requests from the logic.

## 📜 Testing Plan

Repeat Testing Plan from #9263 and observe the opposite result at Step 8. 

After completing the steps, opt-in to the second MFA reminder and add a phishable MFA method (e.g. backup codes). Observe that you can continue back to the service provider without being re-prompted to authenticate using your stricter method.