### PR TITLE
Add --deflate option to data-pull and action-account scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ gem 'webauthn', '~> 2.5.2'
 gem 'xmldsig', '~> 0.6'
 gem 'xmlenc', '~> 0.7', '>= 0.7.1'
 gem 'yard', require: false
+gem 'zlib', require: false
 
 # This version of the zxcvbn gem matches the data and behavior of the zxcvbn NPM package.
 # It should not be updated without verifying that the behavior still matches JS version 4.4.2.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,6 +702,7 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.34)
     zeitwerk (2.6.12)
+    zlib (3.0.0)
     zonebie (0.6.1)
     zxcvbn (0.1.9)
 
@@ -825,6 +826,7 @@ DEPENDENCIES
   xmldsig (~> 0.6)
   xmlenc (~> 0.7, >= 0.7.1)
   yard
+  zlib
   zonebie
   zxcvbn (= 0.1.9)
 

--- a/bin/oncall/otp-deliveries
+++ b/bin/oncall/otp-deliveries
@@ -90,7 +90,7 @@ class OtpDeliveries
       ]
     end
 
-    out.puts ScriptBase.format_output(table, format: output_format)
+    ScriptBase.render_output(table, format: output_format, stdout: out)
   end
 
   Result = Struct.new(

--- a/bin/oncall/otp-deliveries
+++ b/bin/oncall/otp-deliveries
@@ -90,7 +90,7 @@ class OtpDeliveries
       ]
     end
 
-    ScriptBase.render_output(table, format: output_format, stdout: out)
+    out.puts ScriptBase.format_output(table, format: output_format)
   end
 
   Result = Struct.new(

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -69,7 +69,7 @@ class ScriptBase
         Zlib::Deflate.deflate(
           (result.json || result.table).to_json,
           Zlib::BEST_COMPRESSION,
-        )
+        ),
       )
     elsif result.json
       stdout.puts result.json.to_json
@@ -78,6 +78,7 @@ class ScriptBase
     end
   end
 
+  # rubocop:disable Metrics/BlockLength
   def option_parser
     @option_parser ||= OptionParser.new do |opts|
       opts.banner = banner
@@ -115,6 +116,7 @@ class ScriptBase
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
 
   # @param [Array<Array<String>>] rows
   def self.render_output(rows, format:, stdout: STDOUT)

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -64,7 +64,13 @@ class ScriptBase
 
     if config.deflate?
       require 'zlib'
-      stdout.puts Zlib::Deflate.deflate((result.json || result.table).to_json, Zlib::BEST_COMPRESSION)
+      require 'base64'
+      stdout.puts Base64.encode64(
+        Zlib::Deflate.deflate(
+          (result.json || result.table).to_json,
+          Zlib::BEST_COMPRESSION,
+        )
+      )
     elsif result.json
       stdout.puts result.json.to_json
     else

--- a/spec/lib/script_base_spec.rb
+++ b/spec/lib/script_base_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ScriptBase do
 
         table = subtask_class.new.run(args: nil, config: nil).table
 
-        expect(JSON.parse(Zlib::Inflate.inflate(stdout.string))).to eq(table)
+        expect(JSON.parse(Zlib::Inflate.inflate(Base64.decode64(stdout.string)))).to eq(table)
       end
     end
   end

--- a/spec/lib/script_base_spec.rb
+++ b/spec/lib/script_base_spec.rb
@@ -4,7 +4,7 @@ require 'script_base'
 RSpec.describe ScriptBase do
   let(:subtask_class) do
     Class.new do
-      def run(args:, config:)
+      def run(args:, config:) # rubocop:disable Lint/UnusedMethodArgument
         ScriptBase::Result.new(
           table: [
             %w[header1 header2],

--- a/spec/lib/script_base_spec.rb
+++ b/spec/lib/script_base_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'script_base'
+
+RSpec.describe ScriptBase do
+  let(:subtask_class) do
+    Class.new do
+      def run(args:, config:)
+        ScriptBase::Result.new(
+          table: [
+            %w[header1 header2],
+            %w[value1 value2],
+          ],
+          subtask: 'example-subtask',
+          uuids: %w[a b c],
+        )
+      end
+    end
+  end
+
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+
+  describe '#run' do
+    let(:argv) { [] }
+
+    subject(:base) do
+      ScriptBase.new(
+        argv:,
+        stdout:,
+        stderr:,
+        subtask_class:,
+        banner: '',
+      )
+    end
+
+    context 'with --deflate' do
+      let(:argv) { %w[--deflate] }
+
+      it 'applies DEFLATE compression to the output' do
+        base.run
+
+        table = subtask_class.new.run(args: nil, config: nil).table
+
+        expect(JSON.parse(Zlib::Inflate.inflate(stdout.string))).to eq(table)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

SSM commands have a max output of about 63kb, and some of our export tasks output more data than that, so they get truncated.

This adds DEFLATE compression which seems to help pack down output, so we can export more. Some notes from example testing [(Slack link)](https://gsa-tts.slack.com/archives/C5E7EJWF7/p1697823732756599?thread_ts=1697751216.934009&cid=C5E7EJWF7):

| Format | Size |
| ---- | ---- |
| ASCII table (current) | 72,449 bytes |
| JSON of table data | 58,721 bytes |
| JSON then DEFLATE | 2,145 bytes (!!!!) |
| JSON then DEFLATE then Base64 | 2,908 bytes |


Other notes:
- The compression defaults to off so the calling script in devops will add it (devops PR coming soon)
- I'm currently deploying this to our sandbox to verify that binary output is OK with SSM-command

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
