### PR TITLE
LG-10889: image metric error

### DIFF
--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -127,16 +127,21 @@ module DocAuth
       end
 
       def handle_expected_http_error(http_response)
-        error = case http_response.status
-          when 438
-            Errors::IMAGE_LOAD_FAILURE
-          when 439
-            Errors::PIXEL_DEPTH_FAILURE
-          when 440
-            Errors::IMAGE_SIZE_FAILURE
-        end
+        errors = errors_from_http_status(http_response.status)
+        create_error_response(errors, create_http_exception(http_response))
+      end
 
-        create_error_response({ general: [error] }, create_http_exception(http_response))
+      def errors_from_http_status(status)
+        # todo: side specific message
+        error = case status
+        when 438
+          Errors::IMAGE_LOAD_FAILURE
+        when 439
+          Errors::PIXEL_DEPTH_FAILURE
+        when 440
+          Errors::IMAGE_SIZE_FAILURE
+                end
+        { general: [error] }
       end
 
       def handle_invalid_response(http_response)

--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -133,12 +133,12 @@ module DocAuth
 
       def errors_from_http_status(status)
         error = case status
-        when 438
-          Errors::IMAGE_LOAD_FAILURE
-        when 439
-          Errors::PIXEL_DEPTH_FAILURE
-        when 440
-          Errors::IMAGE_SIZE_FAILURE
+                when 438
+                  Errors::IMAGE_LOAD_FAILURE
+                when 439
+                  Errors::PIXEL_DEPTH_FAILURE
+                when 440
+                  Errors::IMAGE_SIZE_FAILURE
                 end
         { general: [error] }
       end

--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -132,7 +132,6 @@ module DocAuth
       end
 
       def errors_from_http_status(status)
-        # todo: side specific message
         error = case status
         when 438
           Errors::IMAGE_LOAD_FAILURE

--- a/app/services/doc_auth/acuant/requests/get_results_request.rb
+++ b/app/services/doc_auth/acuant/requests/get_results_request.rb
@@ -32,6 +32,29 @@ module DocAuth
         def timeout
           IdentityConfig.store.acuant_get_results_timeout
         end
+
+        def errors_from_http_status(status)
+          case status
+          when 438
+            {
+              general: [Errors::IMAGE_LOAD_FAILURE],
+              front: [Errors::IMAGE_LOAD_FAILURE_FIELD],
+              back: [Errors::IMAGE_LOAD_FAILURE_FIELD],
+            }
+          when 439
+            {
+              general: [Errors::PIXEL_DEPTH_FAILURE],
+              front: [Errors::PIXEL_DEPTH_FAILURE_FIELD],
+              back: [Errors::PIXEL_DEPTH_FAILURE_FIELD],
+            }
+          when 440
+            {
+              general: [Errors::IMAGE_SIZE_FAILURE],
+              front: [Errors::IMAGE_SIZE_FAILURE_FIELD],
+              back: [Errors::IMAGE_SIZE_FAILURE_FIELD],
+            }
+          end
+        end
       end
     end
   end

--- a/app/services/doc_auth/acuant/requests/upload_image_request.rb
+++ b/app/services/doc_auth/acuant/requests/upload_image_request.rb
@@ -41,6 +41,26 @@ module DocAuth
         def timeout
           IdentityConfig.store.acuant_upload_image_timeout
         end
+
+        def errors_from_http_status(status)
+          case status
+          when 438
+            {
+              general: [Errors::IMAGE_LOAD_FAILURE],
+              side.downcase.to_sym => [Errors::IMAGE_LOAD_FAILURE_FIELD],
+            }
+          when 439
+            {
+              general: [Errors::PIXEL_DEPTH_FAILURE],
+              side.downcase.to_sym => [Errors::PIXEL_DEPTH_FAILURE_FIELD],
+            }
+          when 440
+            {
+              general: [Errors::IMAGE_SIZE_FAILURE],
+              side.downcase.to_sym => [Errors::IMAGE_SIZE_FAILURE_FIELD],
+            }
+          end
+        end
       end
     end
   end

--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -2,8 +2,11 @@ module DocAuth
   module Errors
     # HTTP Status Codes
     IMAGE_LOAD_FAILURE = 'image_load_failure' # 438
+    IMAGE_LOAD_FAILURE_FIELD = 'image_load_failure_field' # 438
     PIXEL_DEPTH_FAILURE = 'pixel_depth_failure' # 439
+    PIXEL_DEPTH_FAILURE_FIELD = 'pixel_depth_failure_field'
     IMAGE_SIZE_FAILURE = 'image_size_failure' # 440
+    IMAGE_SIZE_FAILURE_FIELD = 'image_size_failure_field' # 440
     # Network
     NETWORK = 'network' # usually 500 or other unhandled error
     # Alerts
@@ -80,6 +83,10 @@ module DocAuth
 
     # rubocop:disable Layout/LineLength
     USER_DISPLAY = {
+      # Http status
+      IMAGE_LOAD_FAILURE => { long_msg: IMAGE_LOAD_FAILURE, long_msg_plural: IMAGE_LOAD_FAILURE, field_msg: IMAGE_LOAD_FAILURE_FIELD },
+      PIXEL_DEPTH_FAILURE => { long_msg: PIXEL_DEPTH_FAILURE, long_msg_plural: PIXEL_DEPTH_FAILURE, field_msg: PIXEL_DEPTH_FAILURE_FIELD },
+      IMAGE_SIZE_FAILURE => { long_msg: IMAGE_SIZE_FAILURE, long_msg_plural: IMAGE_SIZE_FAILURE, field_msg: IMAGE_SIZE_FAILURE_FIELD },
       # Image metrics
       DPI_LOW => { long_msg: DPI_LOW_ONE_SIDE, long_msg_plural: DPI_LOW_BOTH_SIDES, field_msg: DPI_LOW_FIELD },
       SHARP_LOW => { long_msg: SHARP_LOW_ONE_SIDE, long_msg_plural: SHARP_LOW_BOTH_SIDES, field_msg: SHARP_LOW_FIELD },

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -127,6 +127,13 @@ module DocAuth
                    }
                  end
         return nil unless errors
+        errors = errors.tap do |h|
+          if h.has_key?(:result)
+            h[:front] = h[:result]
+            h[:back] = h[:result]
+            h.delete(:result)
+          end
+        end
         message = [
           self.class.name,
           'Unexpected HTTP response',

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -105,25 +105,35 @@ module DocAuth
         data = parse_yaml(image.to_s)
         status = data.dig('http_status', side)
         return nil unless [500, 440, 438, 439].include?(status)
-        error = case status
-                when 438
-                  Errors::IMAGE_LOAD_FAILURE
-                when 439
-                  Errors::PIXEL_DEPTH_FAILURE
-                when 440
-                  Errors::IMAGE_SIZE_FAILURE
-                when 500
-                  Errors::NETWORK
-                end
-        return nil unless error
-        errors = { general: [error] }
+        errors = case status
+                 when 438
+                   {
+                     general: [Errors::IMAGE_LOAD_FAILURE],
+                     side.downcase.to_sym => [Errors::IMAGE_LOAD_FAILURE_FIELD],
+                   }
+                 when 439
+                   {
+                     general: [Errors::PIXEL_DEPTH_FAILURE],
+                     side.downcase.to_sym => [Errors::PIXEL_DEPTH_FAILURE_FIELD],
+                   }
+                 when 440
+                   {
+                     general: [Errors::IMAGE_SIZE_FAILURE],
+                     side.downcase.to_sym => [Errors::IMAGE_SIZE_FAILURE_FIELD],
+                   }
+                 when 500
+                   {
+                     general: [Errors::NETWORK],
+                   }
+                 end
+        return nil unless errors
         message = [
           self.class.name,
           'Unexpected HTTP response',
           status,
         ].join(' ')
         exception = DocAuth::RequestError.new(message, status)
-        return DocAuth::Response.new(
+        DocAuth::Response.new(
           success: false,
           errors: errors,
           exception: exception,

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -72,16 +72,24 @@ module DocAuth
         parsed_alerts == [ATTENTION_WITH_BARCODE_ALERT]
       end
 
-      def self.create_image_error_response(status)
-        error = case status
+      def self.create_image_error_response(status, side)
+        errors = case status
                 when 438
-                  Errors::IMAGE_LOAD_FAILURE
+                  {
+                    general: [Errors::IMAGE_LOAD_FAILURE],
+                    side.to_sym => [Errors::IMAGE_LOAD_FAILURE_FIELD],
+                  }
                 when 439
-                  Errors::PIXEL_DEPTH_FAILURE
+                  {
+                    general: [Errors::PIXEL_DEPTH_FAILURE],
+                    side.to_sym => [Errors::IMAGE_LOAD_FAILURE_FIELD],
+                  }
                 when 440
-                  Errors::IMAGE_SIZE_FAILURE
+                  {
+                    general: [Errors::IMAGE_SIZE_FAILURE],
+                    side.to_sym => [Errors::IMAGE_SIZE_FAILURE_FIELD],
+                  }
                 end
-        errors = { general: [error] }
         message = [
           'Unexpected HTTP response',
           status,

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -80,10 +80,13 @@ module DocAuthRouter
     DocAuth::Errors::GLARE_LOW_FIELD => 'doc_auth.errors.glare.failed_short',
     # i18n-tasks-use t('doc_auth.errors.http.image_load')
     DocAuth::Errors::IMAGE_LOAD_FAILURE => 'doc_auth.errors.http.image_load',
+    DocAuth::Errors::IMAGE_LOAD_FAILURE_FIELD => 'doc_auth.errors.http.image_load',
     # i18n-tasks-use t('doc_auth.errors.http.pixel_depth')
     DocAuth::Errors::PIXEL_DEPTH_FAILURE => 'doc_auth.errors.http.pixel_depth',
-    # i18n-tasks-use t('doc_auth.errors.http.image_size')
-    DocAuth::Errors::IMAGE_SIZE_FAILURE => 'doc_auth.errors.http.image_size',
+    DocAuth::Errors::PIXEL_DEPTH_FAILURE_FIELD => 'doc_auth.errors.http.pixel_depth',
+    # i18n-tasks-use t('doc_auth.errors.http.image_size.top_msg')
+    DocAuth::Errors::IMAGE_SIZE_FAILURE => 'doc_auth.errors.http.image_size.top_msg',
+    DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD => 'doc_auth.errors.http.image_size.failed_short',
     # i18n-tasks-use t('doc_auth.errors.general.fallback_field_level')
     DocAuth::Errors::FALLBACK_FIELD_LEVEL => 'doc_auth.errors.general.fallback_field_level',
   }.freeze

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -79,11 +79,11 @@ module DocAuthRouter
     # i18n-tasks-use t('doc_auth.errors.glare.failed_short')
     DocAuth::Errors::GLARE_LOW_FIELD => 'doc_auth.errors.glare.failed_short',
     # i18n-tasks-use t('doc_auth.errors.http.image_load')
-    DocAuth::Errors::IMAGE_LOAD_FAILURE => 'doc_auth.errors.http.image_load',
-    DocAuth::Errors::IMAGE_LOAD_FAILURE_FIELD => 'doc_auth.errors.http.image_load',
+    DocAuth::Errors::IMAGE_LOAD_FAILURE => 'doc_auth.errors.http.image_load.top_msg',
+    DocAuth::Errors::IMAGE_LOAD_FAILURE_FIELD => 'doc_auth.errors.http.image_load.failed_short',
     # i18n-tasks-use t('doc_auth.errors.http.pixel_depth')
-    DocAuth::Errors::PIXEL_DEPTH_FAILURE => 'doc_auth.errors.http.pixel_depth',
-    DocAuth::Errors::PIXEL_DEPTH_FAILURE_FIELD => 'doc_auth.errors.http.pixel_depth',
+    DocAuth::Errors::PIXEL_DEPTH_FAILURE => 'doc_auth.errors.http.pixel_depth.top_msg',
+    DocAuth::Errors::PIXEL_DEPTH_FAILURE_FIELD => 'doc_auth.errors.http.pixel_depth.failed_short',
     # i18n-tasks-use t('doc_auth.errors.http.image_size.top_msg')
     DocAuth::Errors::IMAGE_SIZE_FAILURE => 'doc_auth.errors.http.image_size.top_msg',
     DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD => 'doc_auth.errors.http.image_size.failed_short',
@@ -125,7 +125,9 @@ module DocAuthRouter
       error_keys = DocAuth::ErrorGenerator::ERROR_KEYS.dup
 
       error_keys.each do |category|
-        response.errors[category]&.map! do |plain_error|
+        cat_errors = response.errors[category]
+        next unless cat_errors
+        translated_cat_errors = cat_errors.map do |plain_error|
           error_key = ERROR_TRANSLATIONS[plain_error]
           if error_key
             I18n.t(error_key)
@@ -134,6 +136,7 @@ module DocAuthRouter
             I18n.t('doc_auth.errors.general.no_liveness')
           end
         end
+        response.errors[category] = translated_cat_errors
       end
     end
 

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -78,14 +78,17 @@ module DocAuthRouter
     DocAuth::Errors::GLARE_LOW_BOTH_SIDES => 'doc_auth.errors.glare.top_msg_plural',
     # i18n-tasks-use t('doc_auth.errors.glare.failed_short')
     DocAuth::Errors::GLARE_LOW_FIELD => 'doc_auth.errors.glare.failed_short',
-    # i18n-tasks-use t('doc_auth.errors.http.image_load')
+    # i18n-tasks-use t('doc_auth.errors.http.image_load.top_msg')
     DocAuth::Errors::IMAGE_LOAD_FAILURE => 'doc_auth.errors.http.image_load.top_msg',
+    # i18n-tasks-use t('doc_auth.errors.http.image_load.failed_short')
     DocAuth::Errors::IMAGE_LOAD_FAILURE_FIELD => 'doc_auth.errors.http.image_load.failed_short',
-    # i18n-tasks-use t('doc_auth.errors.http.pixel_depth')
+    # i18n-tasks-use t('doc_auth.errors.http.pixel_depth.top_msg')
     DocAuth::Errors::PIXEL_DEPTH_FAILURE => 'doc_auth.errors.http.pixel_depth.top_msg',
+    # i18n-tasks-use t('doc_auth.errors.http.pixel_depth.failed_short')
     DocAuth::Errors::PIXEL_DEPTH_FAILURE_FIELD => 'doc_auth.errors.http.pixel_depth.failed_short',
     # i18n-tasks-use t('doc_auth.errors.http.image_size.top_msg')
     DocAuth::Errors::IMAGE_SIZE_FAILURE => 'doc_auth.errors.http.image_size.top_msg',
+    # i18n-tasks-use t('doc_auth.errors.http.image_size.failed_short')
     DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD => 'doc_auth.errors.http.image_size.failed_short',
     # i18n-tasks-use t('doc_auth.errors.general.fallback_field_level')
     DocAuth::Errors::FALLBACK_FIELD_LEVEL => 'doc_auth.errors.general.fallback_field_level',

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -90,8 +90,10 @@ en:
       http:
         image_load: The image file that you added is not supported. Please take new
           photos of your ID and try again.
-        image_size: Your image size is too large or too small. Please add images of your
-          ID that are about 2025 x 1275 pixels.
+        image_size:
+          failed_short: Image file is not supported, please try again.
+          top_msg: Your image size is too large or too small. Please add images of your ID
+            that are about 2025 x 1275 pixels.
         pixel_depth: The pixel depth of your image file is not supported. Please take
           new photos of your ID and try again. Supported image pixel depth is
           24-bit RGB.

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -88,15 +88,19 @@ en:
         top_msg_plural: We couldn’t read your ID. Your photos may have glare. Make sure
           that the flash on your camera is off and try taking new pictures.
       http:
-        image_load: The image file that you added is not supported. Please take new
-          photos of your ID and try again.
+        image_load:
+          failed_short: The image file that you added is not supported.
+          top_msg: The image file that you added is not supported. Please take new photos
+            of your ID and try again.
         image_size:
           failed_short: Image file is not supported, please try again.
           top_msg: Your image size is too large or too small. Please add images of your ID
             that are about 2025 x 1275 pixels.
-        pixel_depth: The pixel depth of your image file is not supported. Please take
-          new photos of your ID and try again. Supported image pixel depth is
-          24-bit RGB.
+        pixel_depth:
+          failed_short: The pixel depth of your image file is not supported.
+          top_msg: The pixel depth of your image file is not supported. Please take new
+            photos of your ID and try again. Supported image pixel depth is
+            24-bit RGB.
       not_a_file: The selection was not a valid file.
       pii:
         birth_date_min_age: Your birthday does not meet the minimum age requirement.

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -89,7 +89,7 @@ en:
           that the flash on your camera is off and try taking new pictures.
       http:
         image_load:
-          failed_short: The image file that you added is not supported.
+          failed_short: Image file is not supported, please try again.
           top_msg: The image file that you added is not supported. Please take new photos
             of your ID and try again.
         image_size:
@@ -97,7 +97,7 @@ en:
           top_msg: Your image size is too large or too small. Please add images of your ID
             that are about 2025 x 1275 pixels.
         pixel_depth:
-          failed_short: The pixel depth of your image file is not supported.
+          failed_short: Image file is not supported, please try again.
           top_msg: The pixel depth of your image file is not supported. Please take new
             photos of your ID and try again. Supported image pixel depth is
             24-bit RGB.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -114,9 +114,10 @@ es:
       http:
         image_load: El archivo de imagen que ha añadido no es compatible. Por favor,
           tome nuevas fotos de su identificación y vuelva a intentarlo.
-        image_size: El tamaño de la imagen es demasiado grande o demasiado pequeño.
-          Añada imágenes de su documento de identidad de unos 2025 x 1275
-          píxeles.
+        image_size:
+          failed_short: El archivo de imagen no es compatible, inténtalo de nuevo.
+          top_msg: El tamaño de la imagen es demasiado grande o demasiado pequeño. Añada
+            imágenes de su documento de identidad de unos 2025 x 1275 píxeles.
         pixel_depth: No es compatible con la profundidad de píxeles de su archivo de
           imagen. Tome nuevas fotos de su documento de identidad e inténtelo
           nuevamente. La profundidad de píxeles de la imagen admitida es de 24

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -113,16 +113,15 @@ es:
           desactivado e intente tomar nuevas fotos.
       http:
         image_load:
-          failed_short: El archivo de imagen que ha añadido no es compatible.
+          failed_short: El archivo de la imagen no es compatible. Inténtalo de nuevo.
           top_msg: El archivo de imagen que ha añadido no es compatible. Por favor, tome
             nuevas fotos de su identificación y vuelva a intentarlo.
         image_size:
-          failed_short: El archivo de imagen no es compatible, inténtalo de nuevo.
+          failed_short: El archivo de la imagen no es compatible. Inténtalo de nuevo.
           top_msg: El tamaño de la imagen es demasiado grande o demasiado pequeño. Añada
             imágenes de su documento de identidad de unos 2025 x 1275 píxeles.
         pixel_depth:
-          failed_short: No es compatible con la profundidad de píxeles de su archivo de
-            imagen.
+          failed_short: El archivo de la imagen no es compatible. Inténtalo de nuevo.
           top_msg: No es compatible con la profundidad de píxeles de su archivo de imagen.
             Tome nuevas fotos de su documento de identidad e inténtelo
             nuevamente. La profundidad de píxeles de la imagen admitida es de 24

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -112,16 +112,21 @@ es:
           tengan reflejos. Asegúrese de que el flash de su cámara esté
           desactivado e intente tomar nuevas fotos.
       http:
-        image_load: El archivo de imagen que ha añadido no es compatible. Por favor,
-          tome nuevas fotos de su identificación y vuelva a intentarlo.
+        image_load:
+          failed_short: El archivo de imagen que ha añadido no es compatible.
+          top_msg: El archivo de imagen que ha añadido no es compatible. Por favor, tome
+            nuevas fotos de su identificación y vuelva a intentarlo.
         image_size:
           failed_short: El archivo de imagen no es compatible, inténtalo de nuevo.
           top_msg: El tamaño de la imagen es demasiado grande o demasiado pequeño. Añada
             imágenes de su documento de identidad de unos 2025 x 1275 píxeles.
-        pixel_depth: No es compatible con la profundidad de píxeles de su archivo de
-          imagen. Tome nuevas fotos de su documento de identidad e inténtelo
-          nuevamente. La profundidad de píxeles de la imagen admitida es de 24
-          bits RGB.
+        pixel_depth:
+          failed_short: No es compatible con la profundidad de píxeles de su archivo de
+            imagen.
+          top_msg: No es compatible con la profundidad de píxeles de su archivo de imagen.
+            Tome nuevas fotos de su documento de identidad e inténtelo
+            nuevamente. La profundidad de píxeles de la imagen admitida es de 24
+            bits RGB.
       not_a_file: La selección no era un archivo válido.
       pii:
         birth_date_min_age: Tu cumpleaños no cumple con el requisito de edad mínima.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -117,18 +117,22 @@ fr:
           peuvent avoir des reflets. Assurez-vous que le flash de votre appareil
           photo est désactivé puis essayez de prendre de nouvelles photos.
       http:
-        image_load: Le fichier image que vous avez ajouté n’est pas pris en charge.
-          Veuillez prendre de nouvelles photos de votre pièce d’identité et
-          réessayer.
+        image_load:
+          failed_short: Le fichier image que vous avez ajouté n’est pas pris en charge.
+          top_msg: Le fichier image que vous avez ajouté n’est pas pris en charge.
+            Veuillez prendre de nouvelles photos de votre pièce d’identité et
+            réessayer.
         image_size:
           failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
           top_msg: La taille de votre image est trop grande ou trop petite. Veuillez
             ajouter des images de votre pièce d’identité d’environ 2025 x 1275
             pixels.
-        pixel_depth: La profondeur de pixel de votre fichier image n’est pas supportée.
-          Veuillez prendre de nouvelles photos de votre pièce d’identité et
-          réessayer. La profondeur de pixel de l’image prise en charge est de 24
-          bits RGB.
+        pixel_depth:
+          failed_short: La profondeur de pixel de votre fichier image n’est pas supportée.
+          top_msg: La profondeur de pixel de votre fichier image n’est pas supportée.
+            Veuillez prendre de nouvelles photos de votre pièce d’identité et
+            réessayer. La profondeur de pixel de l’image prise en charge est de
+            24 bits RGB.
       not_a_file: La sélection n’était pas un fichier valide.
       pii:
         birth_date_min_age: Votre anniversaire ne correspond pas à l’âge minimum requis.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -120,9 +120,11 @@ fr:
         image_load: Le fichier image que vous avez ajouté n’est pas pris en charge.
           Veuillez prendre de nouvelles photos de votre pièce d’identité et
           réessayer.
-        image_size: La taille de votre image est trop grande ou trop petite. Veuillez
-          ajouter des images de votre pièce d’identité d’environ 2025 x 1275
-          pixels.
+        image_size:
+          failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
+          top_msg: La taille de votre image est trop grande ou trop petite. Veuillez
+            ajouter des images de votre pièce d’identité d’environ 2025 x 1275
+            pixels.
         pixel_depth: La profondeur de pixel de votre fichier image n’est pas supportée.
           Veuillez prendre de nouvelles photos de votre pièce d’identité et
           réessayer. La profondeur de pixel de l’image prise en charge est de 24

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -118,7 +118,7 @@ fr:
           photo est désactivé puis essayez de prendre de nouvelles photos.
       http:
         image_load:
-          failed_short: Le fichier image que vous avez ajouté n’est pas pris en charge.
+          failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
           top_msg: Le fichier image que vous avez ajouté n’est pas pris en charge.
             Veuillez prendre de nouvelles photos de votre pièce d’identité et
             réessayer.
@@ -128,7 +128,7 @@ fr:
             ajouter des images de votre pièce d’identité d’environ 2025 x 1275
             pixels.
         pixel_depth:
-          failed_short: La profondeur de pixel de votre fichier image n’est pas supportée.
+          failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
           top_msg: La profondeur de pixel de votre fichier image n’est pas supportée.
             Veuillez prendre de nouvelles photos de votre pièce d’identité et
             réessayer. La profondeur de pixel de l’image prise en charge est de

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -305,6 +305,47 @@ RSpec.describe Idv::ImageUploadsController do
       end
     end
 
+    context 'when image upload fails with 4xx status' do
+      before do
+        status = 440
+        errors = { general: [DocAuth::Errors::IMAGE_SIZE_FAILURE],
+                   front: [DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD] }
+        message = [
+          self.class.name,
+          'Unexpected HTTP response',
+          status,
+        ].join(' ')
+        exception = DocAuth::RequestError.new(message, status)
+        response = DocAuth::Response.new(
+          success: false,
+          errors: errors,
+          exception: exception,
+          extra: { vendor: 'Mock' },
+        )
+        DocAuth::Mock::DocAuthMockClient.mock_response!(
+          method: :post_front_image,
+          response: response,
+        )
+      end
+
+      it 'returns error response' do
+        action
+        expect(response.status).to eq(400)
+        expect(json[:success]).to eq(false)
+        expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
+        expect(json[:errors]).to eq [
+          {
+            field: 'general',
+            message: I18n.t('doc_auth.errors.http.image_size.top_msg'),
+          },
+          {
+            field: 'front',
+            message: I18n.t('doc_auth.errors.http.image_size.failed_short'),
+          },
+        ]
+      end
+    end
+
     context 'when image upload succeeds' do
       it 'returns a successful response and modifies the session' do
         action

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -189,6 +189,23 @@ RSpec.feature 'doc auth redo document capture', js: true do
     end
   end
 
+  shared_examples_for 'inline error for 4xx status shown' do |status|
+    it "shows inline error for status #{status}" do
+      error = case status
+              when 438
+                t('doc_auth.errors.http.image_load.failed_short')
+              when 439
+                t('doc_auth.errors.http.pixel_depth.failed_short')
+              when 440
+                t('doc_auth.errors.http.image_size.failed_short')
+              end
+      expect(page).to have_css(
+        '.usa-error-message[role="alert"]',
+        text: error,
+      )
+    end
+  end
+
   context 'error due to data issue with 2xx status code', allow_browser_log: true do
     before do
       sign_in_and_2fa_user
@@ -232,6 +249,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
       attach_and_submit_images
       click_try_again
     end
+    it_behaves_like 'inline error for 4xx status shown', 440
     it_behaves_like 'image re-upload not allowed'
   end
 

--- a/spec/services/doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/services/doc_auth/acuant/acuant_client_spec.rb
@@ -217,8 +217,8 @@ RSpec.describe DocAuth::Acuant::AcuantClient do
     end
   end
 
-  context 'when there is unexpected http status code' do
-    shared_examples 'with http status 4xx' do |status|
+  context 'when there is expected rxx http status code' do
+    shared_examples 'with http status' do |status|
       it "generate response for status #{status} " do
         instance_id = 'this-is-a-test-instance-id'
         url = URI.join(
@@ -259,8 +259,8 @@ RSpec.describe DocAuth::Acuant::AcuantClient do
         end
       end
     end
-    it_should_behave_like 'with http status 4xx', 440
-    it_should_behave_like 'with http status 4xx', 439
-    it_should_behave_like 'with http status 4xx', 438
+    it_should_behave_like 'with http status', 440
+    it_should_behave_like 'with http status', 439
+    it_should_behave_like 'with http status', 438
   end
 end

--- a/spec/services/doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/services/doc_auth/acuant/acuant_client_spec.rb
@@ -216,4 +216,51 @@ RSpec.describe DocAuth::Acuant::AcuantClient do
       )
     end
   end
+
+  context 'when there is unexpected http status code' do
+    shared_examples 'with http status 4xx' do |status|
+      it "generate response for status #{status} " do
+        instance_id = 'this-is-a-test-instance-id'
+        url = URI.join(
+          assure_id_url, "/AssureIDService/Document/#{instance_id}/Image"
+        )
+        stub_request(:post, url).with(query: { side: 0, light: 0 }).to_return(
+          body: '',
+          status: status,
+        )
+
+        result = subject.post_front_image(
+          instance_id: instance_id,
+          image: DocAuthImageFixtures.document_front_image,
+        )
+        expect(result.exception.message).not_to be_nil
+        case status
+        when 440
+          expect(result.errors).to eql(
+            {
+              general: [DocAuth::Errors::IMAGE_SIZE_FAILURE],
+              front: [DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD],
+            },
+          )
+        when 438
+          expect(result.errors).to eql(
+            {
+              general: [DocAuth::Errors::IMAGE_LOAD_FAILURE],
+              front: [DocAuth::Errors::IMAGE_LOAD_FAILURE_FIELD],
+            },
+          )
+        when 439
+          expect(result.errors).to eql(
+            {
+              general: [DocAuth::Errors::PIXEL_DEPTH_FAILURE],
+              front: [DocAuth::Errors::PIXEL_DEPTH_FAILURE_FIELD],
+            },
+          )
+        end
+      end
+    end
+    it_should_behave_like 'with http status 4xx', 440
+    it_should_behave_like 'with http status 4xx', 439
+    it_should_behave_like 'with http status 4xx', 438
+  end
 end

--- a/spec/services/doc_auth/acuant/requests/get_results_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/get_results_request_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe DocAuth::Acuant::Requests::GetResultsRequest do
     it 'get general error for 4xx' do
       stub_request(:get, url).to_return(status: 440)
       response = described_class.new(config: config, instance_id: instance_id).fetch
-      expect(response.errors).to have_key(:general)
+      expect(response.errors).to include(:general, :front, :back)
       expect(response.network_error?).to eq(false)
     end
 

--- a/spec/services/doc_auth/acuant/requests/upload_image_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/upload_image_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe DocAuth::Acuant::Requests::UploadImageRequest do
     end
 
     context 'when http status is 4xx' do
-      shared_examples 'http unexpected 4xx status' do |http_status, general_failure, side_failure|
+      shared_examples 'http expected 4xx status' do |http_status, general_failure, side_failure|
         it "generate errors for #{http_status}" do
           request_stub = stub_request(:post, url).with(
             query: { side: 0, light: 0 },
@@ -52,11 +52,11 @@ RSpec.describe DocAuth::Acuant::Requests::UploadImageRequest do
         end
       end
 
-      it_should_behave_like 'http unexpected 4xx status', 440, 'image_size_failure',
+      it_should_behave_like 'http expected 4xx status', 440, 'image_size_failure',
                             'image_size_failure_field'
-      it_should_behave_like 'http unexpected 4xx status', 438, 'image_load_failure',
+      it_should_behave_like 'http expected 4xx status', 438, 'image_load_failure',
                             'image_load_failure_field'
-      it_should_behave_like 'http unexpected 4xx status', 439, 'pixel_depth_failure',
+      it_should_behave_like 'http expected 4xx status', 439, 'pixel_depth_failure',
                             'pixel_depth_failure_field'
     end
   end

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
     end
   end
 
-  context 'with a failed result of unknow document type' do
+  context 'with a failed result' do
     let(:http_response) do
       instance_double(
         Faraday::Response,

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -218,7 +218,10 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
       )
       expect(response).to be_a(DocAuth::Response)
       expect(response.success?).to eq(false)
-      expect(response.errors).to eq(general: [DocAuth::Errors::IMAGE_SIZE_FAILURE])
+      expect(response.errors).to eq(
+        { general: [DocAuth::Errors::IMAGE_SIZE_FAILURE],
+          front: [DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD] },
+      )
     end
   end
 end

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe DocAuthRouter do
         expect(response.errors).to eq(general: [I18n.t('doc_auth.errors.http.image_load.top_msg')])
         expect(response.exception.message).to eq('Test 438 HTTP failure')
       end
-      it 'translate general message with side related inline error message' do
+      it 'translate related inline error messages for both sides' do
         DocAuth::Mock::DocAuthMockClient.mock_response!(
           method: :post_images,
           response: DocAuth::Response.new(
@@ -255,7 +255,7 @@ RSpec.describe DocAuthRouter do
             errors: {
               general: [DocAuth::Errors::IMAGE_SIZE_FAILURE],
               front: [DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD],
-              back: [DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD],
+              back: [DocAuth::Errors::IMAGE_SIZE_FAILURE],
             },
             exception: DocAuth::RequestError.new('Test 440 HTTP failure', 440),
           ),
@@ -269,6 +269,27 @@ RSpec.describe DocAuthRouter do
           back: [I18n.t('doc_auth.errors.http.image_size.failed_short')],
         )
         expect(response.exception.message).to eq('Test 440 HTTP failure')
+      end
+      it 'translate related side specific inline error message' do
+        DocAuth::Mock::DocAuthMockClient.mock_response!(
+          method: :post_images,
+          response: DocAuth::Response.new(
+            success: false,
+            errors: {
+              general: [DocAuth::Errors::PIXEL_DEPTH_FAILURE],
+              front: [DocAuth::Errors::PIXEL_DEPTH_FAILURE_FIELD],
+            },
+            exception: DocAuth::RequestError.new('Test 439 HTTP failure', 439),
+          ),
+        )
+
+        response = proxy.post_images(front_image: 'a', back_image: 'b')
+
+        expect(response.errors).to eq(
+          general: [I18n.t('doc_auth.errors.http.pixel_depth.top_msg')],
+          front: [I18n.t('doc_auth.errors.http.pixel_depth.failed_short')],
+        )
+        expect(response.exception.message).to eq('Test 439 HTTP failure')
       end
     end
 

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe DocAuthRouter do
             errors: {
               general: [DocAuth::Errors::IMAGE_SIZE_FAILURE],
               front: [DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD],
-              back: [DocAuth::Errors::IMAGE_SIZE_FAILURE],
+              back: [DocAuth::Errors::IMAGE_SIZE_FAILURE_FIELD],
             },
             exception: DocAuth::RequestError.new('Test 440 HTTP failure', 440),
           ),

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -248,7 +248,7 @@ module DocAuthHelper
   def mock_doc_auth_acuant_http_4xx_status(status, method = :post_front_image)
     DocAuth::Mock::DocAuthMockClient.mock_response!(
       method: method,
-      response: DocAuth::Mock::ResultResponse.create_image_error_response(status),
+      response: DocAuth::Mock::ResultResponse.create_image_error_response(status, 'front'),
     )
   end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-10889](https://cm-jira.usa.gov/browse-LG-10889): Fix bug where user does not see inline errors when Acuant AssureID service encountered errors indicated by http status code 438, 439, 440.

## 🛠 Summary of changes
Add inline error message for Acuant response status code specific to 438, 439 and 440.

## 📜 Testing Plan

Testing in dev.

Http status 438:
- [x] Step 1 Enter doc auth flow
- [x] Step 2 Upload test yml file to both front and back
```yaml
http_status:
  back:  438
```
- [x] Step 3 Verify specific inline error for back image

Http status 439:
- [ ] Step 1 Enter doc auth flow
- [ ] Step 2 Upload test yml file to both front and back
```yaml
http_status:
  front:  439
```
- [x] Step 3 Verify specific inline error for front image

Http status 440:
- [x] Step 1 Enter doc auth flow
- [ ] Step 2 Upload test yml file to both front and back
```yaml
http_status:
  front:  440
```
- [x] Step 3 Verify specific inline error for front image


In higher environment:

This is Acuant specific, so testing is not straight forward, basic testing can be done with images not satisfying size requirement which is 2025 x 1275 pixels.

## 👀 Screenshots

<details>
<summary>Http status 438: image load failure</summary>

English:

![438-inline-En](https://github.com/18F/identity-idp/assets/130466753/1c74229d-7ee6-4d69-ae50-1a063d9ba26d)

Spanish:
![438-inline-Es](https://github.com/18F/identity-idp/assets/130466753/2d425b96-b661-4415-9789-a33b488e3ead)

French:
![438-inline-Fr](https://github.com/18F/identity-idp/assets/130466753/20697e91-a049-4f83-acdd-e48d7c8f664f)

</details>

<details>
<summary>Http status 439: pixel depth</summary>

English:

![439-inline-En](https://github.com/18F/identity-idp/assets/130466753/2538aec4-5bff-4c86-91d2-347eb2f29824)

Spanish:
![439-inline-Es](https://github.com/18F/identity-idp/assets/130466753/38144bc2-686c-40ec-8d09-7cddcf38b303)

French:
![439-inline-Fr](https://github.com/18F/identity-idp/assets/130466753/5b80889a-de9f-4222-baa0-abe7f71c9b68)

</details>

<details>
<summary>Http status 440: image size </summary>

English:
![440-inline-En](https://github.com/18F/identity-idp/assets/130466753/309f946a-ef76-4796-98a5-c7ab4d1dc0bd)

Spanish:

![440-inline-Es](https://github.com/18F/identity-idp/assets/130466753/fc33cac9-9e1f-4b4e-aa64-0f79711651b2)

French:

![440-inline-Fr](https://github.com/18F/identity-idp/assets/130466753/531cc3ef-d31c-4fc7-acf6-e13798304aa2)
</details>
