### PR TITLE
LG-11344: Prompt at most once for WebAuthn authentication

### DIFF
--- a/app/components/webauthn_verify_button_component.html.erb
+++ b/app/components/webauthn_verify_button_component.html.erb
@@ -18,9 +18,7 @@
       <%= t('two_factor_authentication.webauthn_authenticating') %>
     </p>
   </div>
-  <%= render ButtonComponent.new(
-        big: true,
-        wide: true,
+  <%= render SubmitButtonComponent.new(
         class: 'webauthn-verify-button__button display-block margin-y-3',
       ).with_content(content) %>
   <%= hidden_field_tag :credential_id, '' %>

--- a/app/javascript/packages/webauthn/webauthn-verify-button-element.spec.ts
+++ b/app/javascript/packages/webauthn/webauthn-verify-button-element.spec.ts
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import quibble from 'quibble';
 import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import '@18f/identity-submit-button/submit-button-element';
 import type { WebauthnVerifyButtonDataset } from './webauthn-verify-button-element';
 
 describe('WebauthnVerifyButtonElement', () => {
@@ -30,9 +31,11 @@ describe('WebauthnVerifyButtonElement', () => {
           <div class="webauthn-verify-button__spinner" hidden>
             <p>Authenticating</p>
           </div>
-          <button class="webauthn-verify-button__button">
-            Authenticate
-          </button>
+          <lg-submit-button>
+            <button class="webauthn-verify-button__button">
+              Authenticate
+            </button>
+          </lg-submit-button>
           <input type="hidden" name="credential_id" value="">
           <input type="hidden" name="authenticator_data" value="">
           <input type="hidden" name="signature" value="">
@@ -79,6 +82,16 @@ describe('WebauthnVerifyButtonElement', () => {
       userChallenge: '[1,2]',
       credentials: [{}],
     });
+  });
+
+  it('calls to verify at most one time', async () => {
+    createElement();
+
+    const button = screen.getByRole('button', { name: 'Authenticate' });
+    await userEvent.click(button);
+    await userEvent.click(button);
+
+    expect(verifyWebauthnDevice).to.have.been.calledOnce();
   });
 
   it('submits with error name as input on thrown expected error', async () => {

--- a/app/javascript/packages/webauthn/webauthn-verify-button-element.ts
+++ b/app/javascript/packages/webauthn/webauthn-verify-button-element.ts
@@ -1,4 +1,5 @@
 import { trackError } from '@18f/identity-analytics';
+import type SubmitButtonElement from '@18f/identity-submit-button/submit-button-element';
 import verifyWebauthnDevice from './verify-webauthn-device';
 import type { VerifyCredentialDescriptor } from './verify-webauthn-device';
 import isExpectedWebauthnError from './is-expected-error';
@@ -18,6 +19,10 @@ class WebauthnVerifyButtonElement extends HTMLElement {
 
   get button(): HTMLButtonElement {
     return this.querySelector('.webauthn-verify-button__button')!;
+  }
+
+  get submitButton(): SubmitButtonElement {
+    return this.querySelector('lg-submit-button')!;
   }
 
   get spinner(): HTMLElement {
@@ -42,6 +47,7 @@ class WebauthnVerifyButtonElement extends HTMLElement {
 
   async verify() {
     this.spinner.hidden = false;
+    this.submitButton.activate();
 
     const { userChallenge, credentials } = this;
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -64,11 +64,7 @@
           checked: @presenter.remember_device_box_checked?,
         },
       ) %>
-  <%= submit_tag(
-        @presenter.button_text,
-        id: 'continue-button',
-        class: 'display-block usa-button usa-button--big usa-button--wide margin-y-5',
-      ) %>
+  <%= render SubmitButtonComponent.new(class: 'display-block margin-y-5').with_content(@presenter.button_text) %>
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>

--- a/spec/components/webauthn_verify_button_component_spec.rb
+++ b/spec/components/webauthn_verify_button_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe WebauthnVerifyButtonComponent, type: :component do
 
     expect(element.attr('data-credentials')).to eq('[]')
     expect(element.attr('data-user-challenge')).to eq('[]')
-    expect(rendered).to have_button(content)
+    expect(rendered).to have_css('lg-submit-button', text: content)
   end
 
   it 'renders hidden fields' do

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -25,7 +25,7 @@ module WebAuthnHelper
   end
 
   def mock_submit_without_pressing_button_on_hardware_key_on_setup
-    first('#continue-button').click
+    click_continue
   end
 
   def mock_press_button_on_hardware_key_on_setup
@@ -37,11 +37,10 @@ module WebAuthnHelper
     set_hidden_field('attestation_object', attestation_object)
     set_hidden_field('client_data_json', setup_client_data_json)
 
-    button = first('#continue-button')
     if javascript_enabled?
       page.evaluate_script('document.querySelector("form").submit()')
     else
-      button.click
+      click_continue
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11344](https://cm-jira.usa.gov/browse/LG-11344)

## 🛠 Summary of changes

Disables button for Face or Touch Unlock sign-in or setup when clicked, to avoid a scenario where multiple clicks due to a delay in the OS prompt may cause the user to see multiple prompt windows.

## 📜 Testing Plan

Sign-in:

1. Prerequisite: Have a user with Face or Touch Unlock (see "Account creation" instructions)
2. Go to http://localhost:3000
3. Sign in
4. (If directed immediately to Account page, click "Forget all browsers", confirm, then sign out and start over)
5. When prompted for Face or Touch Unlock, click "Use face or touch unlock" multiple times very quickly, ideally before the prompt is shown
6. Continue signing in
7. Observe that (a) you are still able to sign-in successfully and (b) you only saw a single prompt for your credential

Account creation: 

1. Prerequisite: Use iPhone, Android, an equivalent simulation, or an environment where `show_unsupported_passkey_platform_authentication_setup` is `true` (e.g. local development)
2. Go to http://localhost:3000
3. Click "Create an account"
4. Continue account creation up to MFA selection
5. Select "Face or touch unlock" as your MFA and continue
6. Enter a nickname
7. Click "Continue" multiple times very quickly, ideally before the prompt is shown
8. Continue account creation
9. Observe that (a) you are still able to enroll the MFA successfully and (b) you only saw a single prompt for your credential

## 👀 Screenshots

In the screenshots below, observe that the darker button indicates the active, disabled state of the button, as implemented through `SubmitButtonComponent`.

Account creation:

Before|After
---|---
![ft-setup-before](https://github.com/18F/identity-idp/assets/1779930/54d898db-41ba-4c84-a633-68448f57ad63)|![ft-setup-after](https://github.com/18F/identity-idp/assets/1779930/5e908f19-e691-4cbf-a216-c73244cc893c)

Sign in:

Before|After
---|---
![ft-signin-before](https://github.com/18F/identity-idp/assets/1779930/bb367eb7-3158-4b59-b54b-5f50bb611e24)|![ft-signin-after](https://github.com/18F/identity-idp/assets/1779930/80f5b372-bc8e-48af-83a3-63cb7066f61c)
