### PR TITLE
LG-10996 Fix Spanish and French translation for Sign In

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,7 +7,7 @@
 <%= render TabNavigationComponent.new(
       label: t('account.login.tab_navigation'),
       routes: [
-        { text: t('links.next'), path: new_user_session_url },
+        { text: t('links.sign_in'), path: new_user_session_url },
         { text: t('links.create_account'), path: sign_up_email_url },
       ],
       class: 'margin-bottom-4',
@@ -47,7 +47,7 @@
           },
         },
       ) %>
-  <%= f.submit t('links.next'), full_width: true, wide: false %>
+  <%= f.submit t('links.sign_in'), full_width: true, wide: false %>
 <% end %>
 <% if @ial && desktop_device? %>
   <div class='margin-x-neg-1 margin-top-205'>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -9,7 +9,7 @@
 <%= render TabNavigationComponent.new(
       label: t('account.login.tab_navigation'),
       routes: [
-        { text: t('links.next'), path: new_user_session_url },
+        { text: t('links.sign_in'), path: new_user_session_url },
         { text: t('links.create_account'), path: sign_up_email_path },
       ],
       class: 'margin-bottom-4',

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -16,12 +16,12 @@ en:
     go_back: Go back
     help: Help
     new_tab: '(opens new tab)'
-    next: Sign in
     passwords:
       forgot: Forgot your password?
     privacy_policy: Privacy & security
     resend: Resend
     reverify: Please verify your identity again.
+    sign_in: Sign in
     sign_out: Sign out
     two_factor_authentication:
       send_another_code: Send another code

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -16,12 +16,12 @@ es:
     go_back: Regresa
     help: Ayuda
     new_tab: (abrir nueva pestaña)
-    next: Siguiente
     passwords:
       forgot: '¿Olvidó su contraseña?'
     privacy_policy: Privacidad y seguridad
     resend: Reenviar
     reverify: Verifique su identidad nuevamente.
+    sign_in: Iniciar sesión
     sign_out: Cerrar sesión
     two_factor_authentication:
       send_another_code: Enviar otro código

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -16,12 +16,12 @@ fr:
     go_back: Retourner
     help: Aide
     new_tab: '(ouvre un nouvel onglet)'
-    next: Suivant
     passwords:
       forgot: Vous avez oublié votre mot de passe?
     privacy_policy: Confidentialité et sécurité
     resend: Renvoyer
     reverify: Veuillez vérifier votre identité de nouveau.
+    sign_in: Connexion
     sign_out: Déconnexion
     two_factor_authentication:
       send_another_code: Envoyer un autre code

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -21,7 +21,7 @@ fr:
     privacy_policy: Confidentialité et sécurité
     resend: Renvoyer
     reverify: Veuillez vérifier votre identité de nouveau.
-    sign_in: Connexion
+    sign_in: Se connecter
     sign_out: Déconnexion
     two_factor_authentication:
       send_another_code: Envoyer un autre code

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -198,7 +198,7 @@ RSpec.feature 'Password Recovery' do
 
         fill_in t('account.index.email'), with: @user.email
         fill_in t('components.password_toggle.label'), with: 'NewVal!dPassw0rd'
-        click_button t('links.next')
+        click_button t('links.sign_in')
         fill_in_code_with_last_phone_otp
         click_submit_default
         click_agree_and_continue

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -111,7 +111,7 @@ module Features
     def fill_in_credentials_and_submit(email, password)
       fill_in t('account.index.email'), with: email
       fill_in t('account.index.password'), with: password
-      click_button t('links.next')
+      click_button t('links.sign_in')
     end
 
     def continue_as(email = nil, password = VALID_PASSWORD)

--- a/spec/views/sign_up/registrations/new.html.erb_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.erb_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'sign_up/registrations/new.html.erb' do
     render
 
     expect(rendered).to have_link(
-      t('links.next'),
+      t('links.sign_in'),
       href: new_user_session_url(request_id: nil),
     )
   end


### PR DESCRIPTION


<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10996](https://cm-jira.usa.gov/browse/LG-10996)


## 🛠 Summary of changes

Change the localization token from links.next to links.sign_in and update all instances of that token.
Revise [Spanish](https://github.com/18F/identity-site/blob/e6f6ada6b75899310cbf8164322d1b8edd128da9/content/_help/manage-your-account/change-your-email-address._es.md?plain=1#L16) and [French](https://github.com/18F/identity-site/blob/e6f6ada6b75899310cbf8164322d1b8edd128da9/content/_help/manage-your-account/change-your-email-address._fr.md?plain=1#L18) translation. Found in identity-site code.



## 📜 Testing Plan

- [ ] Visit http://localhost:3000
- [ ] Find the language switching drop-up in the footer and change to Spanish / French
- [ ] Sign In no longer translated to "Next" in the respective language.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
