### PR TITLE
LG-11270 Remove obsolete too much mail message on enter password controller

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -27,11 +27,6 @@ module Idv
       @title = title
       @heading = heading
 
-      flash_now = flash.now
-      if gpo_mail_service.mail_spammed?
-        flash_now[:error] = t('idv.errors.mail_limit_reached')
-      end
-
       @verifying_by_mail = address_verification_method == 'gpo'
     end
 

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -55,7 +55,6 @@ en:
         start_over: Start over verifying your identity
     errors:
       incorrect_password: The password you entered is not correct.
-      mail_limit_reached: You have requested too much mail in the last month.
       pattern_mismatch:
         ssn: 'Enter a nine-digit Social Security number'
         zipcode: Enter a 5 or 9 digit ZIP Code

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -57,7 +57,6 @@ es:
         start_over: Empezar de nuevo a verificar su identidad
     errors:
       incorrect_password: La contraseña que ingresó no es correcta.
-      mail_limit_reached: Usted ha solicitado demasiado correo en el último mes.
       pattern_mismatch:
         ssn: 'Ingrese un número de Seguro Social de nueve dígitos'
         zipcode: Ingresa un código postal de 5 o 9 dígitos

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -59,7 +59,6 @@ fr:
         start_over: Recommencez la vérification de votre identité
     errors:
       incorrect_password: Le mot de passe que vous avez inscrit est incorrect.
-      mail_limit_reached: Vous avez demandé trop de lettres au cours du dernier mois.
       pattern_mismatch:
         ssn: 'Entrez un numéro de sécurité sociale à neuf chiffres'
         zipcode: Entrez un code postal à 5 ou 9 chiffres

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -222,36 +222,6 @@ RSpec.describe Idv::EnterPasswordController do
       end
     end
 
-    context 'user has not requested too much mail' do
-      before do
-        idv_session.address_verification_mechanism = 'gpo'
-        gpo_mail_service = instance_double(Idv::GpoMail)
-        allow(Idv::GpoMail).to receive(:new).with(user).and_return(gpo_mail_service)
-        allow(gpo_mail_service).to receive(:mail_spammed?).and_return(false)
-      end
-
-      it 'displays a success message' do
-        get :new
-
-        expect(flash.now[:error]).to be_nil
-      end
-    end
-
-    context 'user has requested too much mail' do
-      before do
-        idv_session.address_verification_mechanism = 'gpo'
-        gpo_mail_service = instance_double(Idv::GpoMail)
-        allow(Idv::GpoMail).to receive(:new).with(user).and_return(gpo_mail_service)
-        allow(gpo_mail_service).to receive(:mail_spammed?).and_return(true)
-      end
-
-      it 'displays a helpful error message' do
-        get :new
-
-        expect(flash.now[:error]).to eq t('idv.errors.mail_limit_reached')
-      end
-    end
-
     it 'redirects to the verify info controller if the user has not completed it' do
       controller.idv_session.resolution_successful = nil
 


### PR DESCRIPTION
changelog: User-Facing Improvements, IdV, remove obsolete too much mail message

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-11270](https://cm-jira.usa.gov/browse/LG-11270)



## 🛠 Summary of changes

We removed the too much mail flash error message on the enter password controller.



## 📜 Testing Plan
If testing locally add these config variables
```
minimum_wait_before_another_usps_letter_in_hours: 0
max_mail_events: 1
```

- [ ] Start IdV
- [ ] Choose verify by mail
- [ ] Request the maximum number of letters allowed (1, with the settings above)
- [ ] Cancel and restart IdV
- [ ] Verify by phone
- [ ] Check to see that there is no error banner on the re-enter password step


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
