### PR TITLE
Fix CloudwatchClient error when run with a nil timezone

### DIFF
--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -166,7 +166,7 @@ module Reporting
     rescue Aws::CloudWatchLogs::Errors::InvalidParameterException => err
       if err.message.match?(/End time should not be before the service was generally available/)
         # rubocop:disable Layout/LineLength
-        log(:warn, "query end_time=#{end_time} (#{Time.zone.at(end_time)}) is before Cloudwatch Insights availability, skipping")
+        log(:warn, "query end_time=#{end_time} (#{Time.at(end_time)}) is before Cloudwatch Insights availability, skipping")
         # rubocop:enable Layout/LineLength
         Aws::CloudWatchLogs::Types::GetQueryResultsResponse.new(results: [])
       else

--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -165,9 +165,9 @@ module Reporting
       wait_for_query_result(query_id)
     rescue Aws::CloudWatchLogs::Errors::InvalidParameterException => err
       if err.message.match?(/End time should not be before the service was generally available/)
-        # rubocop:disable Layout/LineLength
+        # rubocop:disable Layout/LineLength, Rails/TimeZone
         log(:warn, "query end_time=#{end_time} (#{Time.at(end_time)}) is before Cloudwatch Insights availability, skipping")
-        # rubocop:enable Layout/LineLength
+        # rubocop:enable Layout/LineLength, Rails/TimeZone
         Aws::CloudWatchLogs::Types::GetQueryResultsResponse.new(results: [])
       else
         raise err

--- a/spec/lib/reporting/cloudwatch_client_spec.rb
+++ b/spec/lib/reporting/cloudwatch_client_spec.rb
@@ -233,6 +233,9 @@ RSpec.describe Reporting::CloudwatchClient do
             ),
           },
         }
+
+        # override Zonebie
+        allow(Time).to receive(:zone).and_return(nil)
       end
 
       it 'logs a warning and returns an empty array for that range' do


### PR DESCRIPTION
when we run the `./bin/query-cloudwatch` script, we're running outside of Rails, so `Time.zone` is nil, so we get errors like this. Switching to `Time.at` lets us work around this

Example:

```bash
identity-idp/lib/reporting/cloudwatch_client.rb:169:in `rescue in fetch_one': undefined method `at' for nil:NilClass (NoMethodError)

        log(:warn, "query end_time=#{end_time} (#{Time.zone.at(end_time)}) is before Cloudwatch Insights availability, skipping")
                                                           ^^^
  from identity-idp/lib/reporting/cloudwatch_client.rb:155:in `fetch_one'
  from identity-idp/lib/reporting/cloudwatch_client.rb:88:in `block (2 levels) in fetch'
.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.179.0/lib/seahorse/client/plugins/raise_response_errors.rb:17:in `call': End time should not be before the service was generally available (Service: AWSLogs; Status Code: 400; Error Code: InvalidParameterException; Request ID: c53d3718-df37-436c-a510-02675dd2141c; Proxy: null) (Aws::CloudWatchLogs::Errors::InvalidParameterException)
```
