### PR TITLE
Add feature specs for expected skip link behavior

### DIFF
--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -110,7 +110,7 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
     expect_page_to_have_no_accessibility_violations(page)
 
     activate_skip_link
-    page.active_element.send_keys :tab
+    page.active_element.send_keys(:tab)
     expect(page.active_element).to match_css('a', text: t('account.index.email_add'), wait: 5)
   end
 

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -108,6 +108,9 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
     visit account_path
 
     expect_page_to_have_no_accessibility_violations(page)
+    expect_page_to_have_skip_link(page) do
+      expect(page.active_element).to match_css('a', text: t('account.index.email_add'), wait: 5)
+    end
   end
 
   scenario 'delete email page' do

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -108,9 +108,10 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
     visit account_path
 
     expect_page_to_have_no_accessibility_violations(page)
-    expect_page_to_have_skip_link(page) do
-      expect(page.active_element).to match_css('a', text: t('account.index.email_add'), wait: 5)
-    end
+
+    activate_skip_link
+    page.active_element.send_keys :tab
+    expect(page.active_element).to match_css('a', text: t('account.index.email_add'), wait: 5)
   end
 
   scenario 'delete email page' do

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -6,6 +6,9 @@ RSpec.feature 'Accessibility on pages that do not require authentication', :js d
     visit root_path
 
     expect_page_to_have_no_accessibility_violations(page)
+    expect_page_to_have_skip_link(page) do
+      expect(page.active_element).to match_css('a', text: t('links.sign_in'), wait: 5)
+    end
   end
 
   scenario 'forgot password page' do

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -6,9 +6,10 @@ RSpec.feature 'Accessibility on pages that do not require authentication', :js d
     visit root_path
 
     expect_page_to_have_no_accessibility_violations(page)
-    expect_page_to_have_skip_link(page) do
-      expect(page.active_element).to match_css('a', text: t('links.sign_in'), wait: 5)
-    end
+
+    activate_skip_link
+    page.active_element.send_keys :tab
+    expect(page.active_element).to match_css('a', text: t('links.sign_in'), wait: 5)
   end
 
   scenario 'forgot password page' do

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Accessibility on pages that do not require authentication', :js d
     expect_page_to_have_no_accessibility_violations(page)
 
     activate_skip_link
-    page.active_element.send_keys :tab
+    page.active_element.send_keys(:tab)
     expect(page.active_element).to match_css('a', text: t('links.sign_in'), wait: 5)
   end
 

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -235,3 +235,14 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
   expect(page).to be_uniquely_titled
   expect(page).to have_valid_markup if validate_markup
 end
+
+def expect_page_to_have_skip_link(page, &block)
+  page.active_element.send_keys(:tab)
+  expect(page.active_element).to have_content(t('shared.skip_link'), wait: 5)
+
+  if block.present?
+    page.active_element.send_keys(:enter)
+    page.active_element.send_keys(:tab)
+    yield
+  end
+end

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -237,7 +237,7 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
 end
 
 def activate_skip_link
-  page.evaluate_script('document.activeElement.blur()') if page.active_element.tag_name != 'body'
+  page.evaluate_script('document.activeElement.blur()')
   page.active_element.send_keys(:tab)
   expect(page.active_element).to have_content(t('shared.skip_link'), wait: 5)
   page.active_element.send_keys(:enter)

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -236,13 +236,9 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
   expect(page).to have_valid_markup if validate_markup
 end
 
-def expect_page_to_have_skip_link(page, &block)
+def activate_skip_link
+  page.evaluate_script('document.activeElement = null') if page.active_element.tag_name != 'body'
   page.active_element.send_keys(:tab)
   expect(page.active_element).to have_content(t('shared.skip_link'), wait: 5)
-
-  if block.present?
-    page.active_element.send_keys(:enter)
-    page.active_element.send_keys(:tab)
-    yield
-  end
+  page.active_element.send_keys(:enter)
 end

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -237,7 +237,7 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
 end
 
 def activate_skip_link
-  page.evaluate_script('document.activeElement = null') if page.active_element.tag_name != 'body'
+  page.evaluate_script('document.activeElement.blur()') if page.active_element.tag_name != 'body'
   page.active_element.send_keys(:tab)
   expect(page.active_element).to have_content(t('shared.skip_link'), wait: 5)
   page.active_element.send_keys(:enter)


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a pair of feature specs which cover expected behavior for skip links in (a) default screens and (b) the account page, which behaves differently by skipping repeated navigation.

I was motivated to add this after noticing in #9436 that specs did not fail, indicating a lack of test coverage for the existence of the skip link.

## 📜 Testing Plan

```
rspec spec/features/accessibility/user_pages_spec.rb spec/features/accessibility/visitor_pages_spec.rb
```