### PR TITLE
Remove USWDS prose styles from application stylesheet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ lint_yarn_workspaces: ## Lints Yarn workspace packages
 	scripts/validate-workspaces.js
 
 lint_asset_bundle_size: ## Lints JavaScript and CSS compiled bundle size
-	find app/assets/builds/application.css -size -350000c | grep .
-	find public/packs/js/application-*.digested.js -size -8000c | grep .
+	find app/assets/builds/application.css -size -275000c | grep .
+	find public/packs/js/application-*.digested.js -size -5000c | grep .
 
 lint_migrations:
 	scripts/migration_check

--- a/app/assets/stylesheets/_uswds.scss
+++ b/app/assets/stylesheets/_uswds.scss
@@ -18,7 +18,6 @@
 @forward 'usa-modal';
 @forward 'usa-nav';
 @forward 'usa-process-list';
-@forward 'usa-prose';
 @forward 'usa-sidenav';
 @forward 'usa-skipnav';
 @forward 'usa-step-indicator';

--- a/app/components/accordion_component.html.erb
+++ b/app/components/accordion_component.html.erb
@@ -10,7 +10,7 @@
     </button>
   </div>
   <div id="accordion-<%= unique_id %>" class="usa-accordion__container">
-    <div class="usa-accordion__content usa-prose">
+    <div class="usa-accordion__content">
       <%= content %>
     </div>
   </div>


### PR DESCRIPTION
## 🛠 Summary of changes

Removes [USWDS Prose component](https://designsystem.digital.gov/components/prose/) styles from the application stylesheet, to further optimize its output size and compile times.

We only had a single reference to this in the accordion component. While the [source example component code for accordion](https://designsystem.digital.gov/components/accordion/#component-code) does prescribe `usa-prose`, the only meaningful impact I could tell is the enforcement of a maximum width on the text. Since our Figma references for the accordion component don't apply this maximum text width (cc @nickttng) and we generally don't use "prose" styling, I think it should be safe and consistent to remove.

This also updates asset size budgets to be more aggressively small.

An upstream pull request to USWDS at https://github.com/uswds/uswds/pull/5577 will further optimize size by about 0.1kb Brotli'd when paired with this change. I couldn't find an elegant way to monkey-patch it here.

### Performance

```
NODE_ENV=production yarn build:css && brotli-size app/assets/builds/application.css
```

**Before:** 26.9kb
**After:** 25.3kb
**Diff:** -1.6kb (-5.9%)

## 📜 Testing Plan

Verify there are no visual regressions, particularly in the use of accordion components.