### PR TITLE
Move File Input component styles to document capture stylesheet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ lint_yarn_workspaces: ## Lints Yarn workspace packages
 	scripts/validate-workspaces.js
 
 lint_asset_bundle_size: ## Lints JavaScript and CSS compiled bundle size
-	find app/assets/builds/application.css -size -275000c | grep .
+	find app/assets/builds/application.css -size -270000c | grep .
 	find public/packs/js/application-*.digested.js -size -5000c | grep .
 
 lint_migrations:

--- a/app/assets/stylesheets/_uswds-form-controls.scss
+++ b/app/assets/stylesheets/_uswds-form-controls.scss
@@ -1,7 +1,6 @@
 @forward 'usa-checkbox';
 @forward 'usa-error-message';
 @forward 'usa-fieldset';
-@forward 'usa-file-input';
 @forward 'usa-form-group';
 @forward 'usa-hint';
 @forward 'usa-input';

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -6,7 +6,6 @@
 @forward 'btn';
 @forward 'card';
 @forward 'code';
-@forward 'file-input';
 @forward 'form-steps';
 @forward 'footer';
 @forward 'form';

--- a/app/javascript/packages/document-capture/components/_file-input.scss
+++ b/app/javascript/packages/document-capture/components/_file-input.scss
@@ -1,5 +1,6 @@
 @use 'uswds-core' as *;
-@use '../utilities/typography' as *;
+@use 'utilities/typography' as *;
+@forward 'usa-file-input';
 
 // ===============================================
 // Pending upstream Login Design System revisions:

--- a/app/javascript/packages/document-capture/styles.scss
+++ b/app/javascript/packages/document-capture/styles.scss
@@ -1,5 +1,6 @@
-@import './components/acuant-capture';
-@import './components/acuant-capture-canvas';
-@import './components/location-collection-item';
-@import './components/select-error';
-@import './components/optional-questions';
+@forward './components/acuant-capture';
+@forward './components/acuant-capture-canvas';
+@forward './components/file-input';
+@forward './components/location-collection-item';
+@forward './components/optional-questions';
+@forward './components/select-error';


### PR DESCRIPTION
## 🛠 Summary of changes

Moves default and custom styles for the [File Input component](https://designsystem.digital.gov/components/file-input/) into the document capture stylesheet, to reduce the size of the main application stylesheet, since this component is only used in document capture.

This also updates asset size budgets to be more aggressively small.

### Performance

```
NODE_ENV=production yarn build:css && brotli-size app/assets/builds/application.css
```

**Before:** 25.3kb
**After:** 24.6kb
**Diff:** -0.7kb (-2.8%)

## 📜 Testing Plan

Verify there are no visual regressions in the appearance of the File Input component in document capture.