### PR TITLE
Raise error when view missing title content block

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -15,10 +15,7 @@
   <meta content="noindex,nofollow" name="robots" />
   <% end %>
 
-  <%= content_tag(
-        'title',
-        content_for?(:title) ? raw("#{yield(:title)} | #{APP_NAME}") : APP_NAME,
-      ) %>
+  <title><%= yield(:title).presence || (raise 'Missing title') %> | <%= APP_NAME %></title>
 
   <%= javascript_tag(nonce: true) do %>
     document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');


### PR DESCRIPTION
## 🛠 Summary of changes

Updates base template to enforce the expectation that a controller view will assign a `content_for(:title)`, to satisfy descriptive purpose requirements of [WCAG SC 2.4.2 Page Titled](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html), something we already [partially enforce through accessibility matchers in specs](https://github.com/18F/identity-idp/blob/43e13033209c53764ac38b4555b3ebc635e1fd0d/spec/support/matchers/accessibility.rb#L214-L229).

_(Draft 'til I can see whether the build flags any existing issues)_

## 📜 Testing Plan

Build should pass.