### PR TITLE
Add JavaScript naming conventions to frontend documentation

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -39,7 +39,7 @@ margins or borders.
 - Variables should be named as camelCase, e.g. `const myFavoriteNumber = 1;`.
    - Only the first letter of an abbreviation should be capitalized, e.g. `const userId = 10;`.
    - All letters of an acronym should be capitalized, e.g. `const siteURL = 'https://example.com';`.
-- Classes should be named as PascalCase (upper camel case), e.g. `MyComponent`.
+- Classes and React components should be named as PascalCase (upper camel case), e.g. `class MyCustomElement {}`.
 - Constants should be named as SCREAMING_SNAKE_CASE, e.g. `const MEANING_OF_LIFE = 42;`.
 - TypeScript enums should be named as PascalCase with SCREAMING_SNAKE_CASE members, e.g. `enum Color { RED = '#f00'; }`.
 
@@ -226,8 +226,8 @@ For example, consider a **Password Input** component:
 - A ViewComponent file would be named `app/components/password_input_component.rb`
 - A stylesheet file would be named `app/assets/stylesheets/componewnts/_password-input.scss`
 - A stylesheet selector would be named `.password-input`, with child elements prefixed as `.password-input__`
-- A react component would be named `<PasswordInput />`
-- A react component file would be named `app/javascript/packages/password-input/password-input.tsx`
+- A React component would be named `<PasswordInput />`
+- A React component file would be named `app/javascript/packages/password-input/password-input.tsx`
 - A web component would be named `PasswordInputElement`
 - A web components file would be named `app/javascript/packages/password-input/password-input-element.ts`
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -37,8 +37,8 @@ margins or borders.
 
 - Files within `app/javascript` should be named as kebab-case, e.g. `./path-to/my-javascript.ts`.
 - Variables should be named as camelCase, e.g. `const myFavoriteNumber = 1;`.
-   - Only the first letter of an abbreviation should be capitalized, e.g. `const userId = 10;`
-   - All letters of an acronym should be capitalized, e.g. `const siteURL = 'https://example.com';`
+   - Only the first letter of an abbreviation should be capitalized, e.g. `const userId = 10;`.
+   - All letters of an acronym should be capitalized, e.g. `const siteURL = 'https://example.com';`.
 - Classes should be named as PascalCase (upper camel case), e.g. `MyComponent`.
 - Constants should be named as SCREAMING_SNAKE_CASE, e.g. `const MEANING_OF_LIFE = 42;`.
 - TypeScript enums should be named as PascalCase with SCREAMING_SNAKE_CASE members, e.g. `enum Color { RED = '#f00'; }`.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -33,6 +33,18 @@ margins or borders.
 - Packages are managed with [Yarn](https://classic.yarnpkg.com/), organized using [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)
 - JavaScript is transpiled, bundled, and minified via [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/)
 
+### Naming Conventions
+
+- Files within `app/javascript` should be named as kebab-case, e.g. `./path-to/my-javascript.ts`.
+- Variables should be named as camelCase, e.g. `const myFavoriteNumber = 1;`.
+   - Only the first letter of an abbreviation should be capitalized, e.g. `const userId = 10;`
+   - All letters of an acronym should be capitalized, e.g. `const siteURL = 'https://example.com';`
+- Classes should be named as PascalCase (upper camel case), e.g. `MyComponent`.
+- Constants should be named as SCREAMING_SNAKE_CASE, e.g. `const MEANING_OF_LIFE = 42;`.
+- TypeScript enums should be named as PascalCase with SCREAMING_SNAKE_CASE members, e.g. `enum Color { RED = '#f00'; }`.
+
+Related: [Component Naming Conventions](#naming)
+
 ### Prettier
 
 [Prettier](https://prettier.io/) is an opinionated code formatter which simplifies adherence to

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -36,7 +36,7 @@ margins or borders.
 ### Naming Conventions
 
 - Files within `app/javascript` should be named as kebab-case, e.g. `./path-to/my-javascript.ts`.
-- Variables should be named as camelCase, e.g. `const myFavoriteNumber = 1;`.
+- Variables and functions (excluding React components) should be named as camelCase, e.g. `const myFavoriteNumber = 1;`.
    - Only the first letter of an abbreviation should be capitalized, e.g. `const userId = 10;`.
    - All letters of an acronym should be capitalized, e.g. `const siteURL = 'https://example.com';`.
 - Classes and React components should be named as PascalCase (upper camel case), e.g. `class MyCustomElement {}`.


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a new section "Naming Conventions" to the JavaScript guidance found in the frontend documentation.

This should match reality, so hopefully nothing here is controversial, but open to feedback all the same, or gaps if I missed anything.

Reference discussion: https://github.com/18F/identity-idp/pull/9433#discussion_r1369182903

## 📜 Testing Plan

See preview: https://github.com/18F/identity-idp/blob/javascript-naming-conventions/docs/frontend.md#naming-conventions