### PR TITLE
LG-11403 Remove the old review routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -348,9 +348,6 @@ Rails.application.routes.draw do
       post '/phone/resend_code' => 'resend_otp#create', as: :resend_otp
       get '/phone_confirmation' => 'otp_verification#show', as: :otp_verification
       put '/phone_confirmation' => 'otp_verification#update', as: :nil
-      # The `/review` route is deperecated in favor of `/enter_password`
-      get '/review' => 'enter_password#new'
-      put '/review' => 'enter_password#create'
       get '/enter_password' => 'enter_password#new'
       put '/enter_password' => 'enter_password#create'
       get '/phone_question' => 'phone_question#show'


### PR DESCRIPTION
In #9411 we moved all traffic from the old `/verify/review` path to the new `/verify/enter_password` path. We left the old paths around so that users getting redirected by old instances would not encounter a 404 error.

Once the changes in #9411 has been deployed for a day there should not be any more users visiting `/verify/review` and we can merge this change to remove that deprecated path.
