### PR TITLE
Rescue errors when running remote data-pull, action-account (LG-11359)

### DIFF
--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -88,7 +88,7 @@ class ScriptBase
 
     stderr.puts "#{err.class.name}: #{err.message}"
 
-    exit 1 # rubodop:disable Rails/Exit
+    exit 1 # rubocop:disable Rails/Exit
   end
 
   # rubocop:disable Metrics/BlockLength

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -88,7 +88,7 @@ class ScriptBase
 
     stderr.puts "#{err.class.name}: #{err.message}"
 
-    exit 1
+    exit 1 # rubodop:disable Rails/Exit
   end
 
   # rubocop:disable Metrics/BlockLength

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -77,10 +77,14 @@ class ScriptBase
       self.class.render_output(result.table, format: config.format, stdout: stdout)
     end
   rescue => err
-    stdout.puts [
-      ['Error', 'Message'],
-      [err.class.name, err.message],
-    ].to_json
+    self.class.render_output(
+      [
+        ['Error', 'Message'],
+        [err.class.name, err.message],
+      ],
+      format: config.format,
+      stdout: stdout,
+    )
 
     stderr.puts "#{err.class.name}: #{err.message}"
 

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -76,6 +76,15 @@ class ScriptBase
     else
       self.class.render_output(result.table, format: config.format, stdout: stdout)
     end
+  rescue => err
+    stdout.puts [
+      ['Error', 'Message'],
+      [err.class.name, err.message],
+    ].to_json
+
+    stderr.puts "#{err.class.name}: #{err.message}"
+
+    exit 1
   end
 
   # rubocop:disable Metrics/BlockLength

--- a/spec/lib/script_base_spec.rb
+++ b/spec/lib/script_base_spec.rb
@@ -54,13 +54,17 @@ RSpec.describe ScriptBase do
         end
       end
 
+      before do
+        base.config.format = :csv
+      end
+
       it 'logs the error message to stderr but not the backtrace' do
         expect(base).to receive(:exit).with(1)
 
         expect { base.run }.to_not raise_error
 
         expect(stderr.string.chomp).to eq('RuntimeError: some dangerous error')
-        expect(JSON.parse(stdout.string)).to eq(
+        expect(CSV.parse(stdout.string)).to eq(
           [
             %w[Error Message],
             ['RuntimeError', 'some dangerous error'],


### PR DESCRIPTION
## 🎫 Ticket

[LG-11359](https://cm-jira.usa.gov/browse/LG-11359)

## 🛠 Summary of changes

Fixes scripts so that we don't log stacktraces like this

| screenshot |
| ---- |
| <img width="698" alt="Screenshot 2023-10-25 at 12 45 07 PM" src="https://github.com/18F/identity-idp/assets/458784/290c87f3-352c-4bb4-900b-8c999144e869"> |

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
