### PR TITLE
LG-11271 change mail spammed language to rate_limited 

### DIFF
--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -27,7 +27,7 @@ module RateLimitConcern
   private
 
   def confirm_not_rate_limited_for_phone_and_letter_address_verification
-    if idv_attempter_rate_limited?(:proof_address) && Idv::GpoMail.new(current_user).mail_spammed?
+    if idv_attempter_rate_limited?(:proof_address) && Idv::GpoMail.new(current_user).rate_limited?
       rate_limit_redirect!(:proof_address)
       return true
     end

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -30,7 +30,7 @@ module Idv
         gpo_mail = Idv::GpoMail.new(current_user)
         @can_request_another_letter =
           FeatureManagement.gpo_verification_enabled? &&
-          !gpo_mail.mail_spammed? &&
+          !gpo_mail.rate_limited? &&
           !gpo_mail.profile_too_old?
 
         if pii_locked?

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -8,7 +8,7 @@ module Idv
       before_action :confirm_two_factor_authenticated
       before_action :confirm_idv_needed
       before_action :confirm_user_completed_idv_profile_step
-      before_action :confirm_mail_not_spammed
+      before_action :confirm_mail_not_rate_limited
       before_action :confirm_profile_not_too_old
 
       def index
@@ -82,7 +82,7 @@ module Idv
         current_user.gpo_verification_pending_profile&.gpo_verification_pending_at
       end
 
-      def confirm_mail_not_spammed
+      def confirm_mail_not_rate_limited
         redirect_to idv_enter_password_url if gpo_mail_service.rate_limited?
       end
 

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -83,7 +83,7 @@ module Idv
       end
 
       def confirm_mail_not_spammed
-        redirect_to idv_enter_password_url if gpo_mail_service.mail_spammed?
+        redirect_to idv_enter_password_url if gpo_mail_service.rate_limited?
       end
 
       def confirm_user_completed_idv_profile_step

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -217,7 +217,7 @@ module Idv
     def gpo_letter_available
       return @gpo_letter_available if defined?(@gpo_letter_available)
       @gpo_letter_available ||= FeatureManagement.gpo_verification_enabled? &&
-                                !Idv::GpoMail.new(current_user).mail_spammed?
+                                !Idv::GpoMail.new(current_user).rate_limited?
     end
 
     # Migrated from otp_delivery_method_controller

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -72,7 +72,7 @@ module Idv
     def set_gpo_letter_available
       return @gpo_letter_available if defined?(@gpo_letter_available)
       @gpo_letter_available ||= FeatureManagement.gpo_verification_enabled? &&
-                                !Idv::GpoMail.new(current_user).mail_spammed?
+                                !Idv::GpoMail.new(current_user).rate_limited?
     end
     # rubocop:enable Naming/MemoizedInstanceVariableName
   end

--- a/app/controllers/vendor_outage_controller.rb
+++ b/app/controllers/vendor_outage_controller.rb
@@ -16,6 +16,6 @@ class VendorOutageController < ApplicationController
   def gpo_letter_available?
     FeatureManagement.gpo_verification_enabled? &&
       current_user &&
-      !Idv::GpoMail.new(current_user).mail_spammed?
+      !Idv::GpoMail.new(current_user).rate_limited?
   end
 end

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -4,7 +4,7 @@ module Idv
       @current_user = current_user
     end
 
-    def mail_spammed?
+    def rate_limited?
       too_many_letter_requests_within_window? || last_letter_request_too_recent?
     end
 

--- a/app/views/idv/by_mail/enter_code/index.html.erb
+++ b/app/views/idv/by_mail/enter_code/index.html.erb
@@ -16,7 +16,7 @@
 <% if !@can_request_another_letter %>
   <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-4') do %>
     <%= t(
-          'idv.gpo.alert_spam_warning_html',
+          'idv.gpo.alert_rate_limit_warning_html',
           date_letter_was_sent: I18n.l(
             @last_date_letter_was_sent,
             format: :event_date,

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -175,8 +175,8 @@ en:
         JavaScript to continue this process.'
     gpo:
       alert_info: 'We sent a letter with your verification code to:'
-      alert_spam_warning_html: You can’t request more letters right now. Your previous
-        letter request was on <strong>%{date_letter_was_sent}</strong>.
+      alert_rate_limit_warning_html: You can’t request more letters right now. Your
+        previous letter request was on <strong>%{date_letter_was_sent}</strong>.
       change_to_verification_code_html: 'The <strong>one-time code</strong> from your
         letter is now referred to as <strong>verification code</strong>.'
       clear_and_start_over: Clear your information and start over

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -184,8 +184,9 @@ es:
         habilitar JavaScript para continuar con este proceso.'
     gpo:
       alert_info: 'Enviamos una carta con su código de verificación a:'
-      alert_spam_warning_html: No puede solicitar más cartas ahora mismo. Su solicitud
-        de carta anterior la hizo el <strong>%{date_letter_was_sent}</strong>.
+      alert_rate_limit_warning_html: No puede solicitar más cartas ahora mismo. Su
+        solicitud de carta anterior la hizo el
+        <strong>%{date_letter_was_sent}</strong>.
       change_to_verification_code_html: 'El <strong>código único</strong> de su carta
         ahora se conoce como <strong>código de verificación</strong>.'
       clear_and_start_over: Borrar su información y empezar de nuevo

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -189,8 +189,8 @@ fr:
         devez activer JavaScript pour poursuivre ce processus.'
     gpo:
       alert_info: 'Nous avons envoyé une lettre avec votre code de vérification à:'
-      alert_spam_warning_html: Vous ne pouvez pas demander d’autres lettres pour le
-        moment. Votre précédente demande de lettre a été effectuée le
+      alert_rate_limit_warning_html: Vous ne pouvez pas demander d’autres lettres pour
+        le moment. Votre précédente demande de lettre a été effectuée le
         <strong>%{date_letter_was_sent}</strong>.
       change_to_verification_code_html: 'Le <strong>code à usage unique</strong>
         figurant dans votre lettre est désormais appelé <strong>code de

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Idv::ByMail::RequestLetterController do
         :before,
         :confirm_two_factor_authenticated,
         :confirm_idv_needed,
-        :confirm_mail_not_spammed,
+        :confirm_mail_not_rate_limited,
         :confirm_profile_not_too_old,
       )
     end

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Idv::ByMail::RequestLetterController do
     end
 
     it 'redirects if the user has sent too much mail' do
-      allow(controller.gpo_mail_service).to receive(:mail_spammed?).and_return(true)
+      allow(controller.gpo_mail_service).to receive(:rate_limited?).and_return(true)
       allow(subject.idv_session).to receive(:address_mechanism_chosen?).
         and_return(true)
       get :index
@@ -63,7 +63,7 @@ RSpec.describe Idv::ByMail::RequestLetterController do
     end
 
     it 'allows a user to request another letter' do
-      allow(controller.gpo_mail_service).to receive(:mail_spammed?).and_return(false)
+      allow(controller.gpo_mail_service).to receive(:rate_limited?).and_return(false)
       get :index
 
       expect(response).to be_ok

--- a/spec/features/idv/clearing_and_restarting_spec.rb
+++ b/spec/features/idv/clearing_and_restarting_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'clearing IdV and restarting' do
 
   let(:user) { user_with_2fa }
 
-  context 'during GPO otp verification', js: true do
+  context 'during verification code entry', js: true do
     before do
       start_idv_from_sp
       complete_idv_steps_with_gpo_before_confirmation_step(user)

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'idv enter letter code step' do
   context 'coming from an "I did not receive my letter" link in a reminder email' do
     it 'renders an alternate ui', :js do
       visit idv_verify_by_mail_enter_code_url(did_not_receive_letter: 1)
-      verify_no_spam_warning_banner
+      verify_no_rate_limit_banner
       expect(current_path).to eql(new_user_session_path)
 
       fill_in_credentials_and_submit(user.email, user.password)
@@ -108,7 +108,7 @@ RSpec.feature 'idv enter letter code step' do
         sign_in_live_with_2fa(user)
 
         expect(current_path).to eq idv_verify_by_mail_enter_code_path
-        verify_no_spam_warning_banner
+        verify_no_rate_limit_banner
         expect(page).to have_content t('idv.messages.gpo.resend')
 
         fill_in t('idv.gpo.form.otp_label'), with: otp
@@ -138,7 +138,7 @@ RSpec.feature 'idv enter letter code step' do
         expect(current_path).to eq idv_verify_by_mail_enter_code_path
         expect(page).to have_content t('idv.messages.gpo.resend')
 
-        verify_no_spam_warning_banner
+        verify_no_rate_limit_banner
         gpo_confirmation_code
         fill_in t('idv.gpo.form.otp_label'), with: otp
         click_button t('idv.gpo.form.submit')
@@ -156,7 +156,7 @@ RSpec.feature 'idv enter letter code step' do
       expect(page).to have_content strip_tags(t('idv.gpo.change_to_verification_code_html'))
       expect(page).to have_content t('idv.gpo.wrong_address')
       expect(page).to have_content Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:address1]
-      verify_no_spam_warning_banner
+      verify_no_rate_limit_banner
 
       click_on t('idv.gpo.clear_and_start_over')
 
@@ -178,7 +178,7 @@ RSpec.feature 'idv enter letter code step' do
     sign_in_live_with_2fa(user)
 
     expect(current_path).to eq idv_verify_by_mail_enter_code_path
-    verify_spam_warning_banner_present(another_gpo_confirmation_code.updated_at)
+    verify_rate_limit_banner_present(another_gpo_confirmation_code.updated_at)
 
     click_on t('idv.messages.clear_and_start_over')
 
@@ -222,12 +222,12 @@ RSpec.feature 'idv enter letter code step' do
     end
 
     it 'shows a warning message and does not allow the user to request another letter' do
-      verify_spam_warning_banner_present(code_sent_at)
+      verify_rate_limit_banner_present(code_sent_at)
       expect(page).not_to have_content t('idv.messages.gpo.resend')
     end
   end
 
-  def verify_no_spam_warning_banner
+  def verify_no_rate_limit_banner
     expect(page).not_to have_content(
       t(
         'idv.gpo.alert_rate_limit_warning_html',
@@ -239,7 +239,7 @@ RSpec.feature 'idv enter letter code step' do
     )
   end
 
-  def verify_spam_warning_banner_present(code_sent_at = Time.zone.now)
+  def verify_rate_limit_banner_present(code_sent_at = Time.zone.now)
     expect(page).to have_content strip_tags(
       t(
         'idv.gpo.alert_rate_limit_warning_html',

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -230,7 +230,7 @@ RSpec.feature 'idv enter letter code step' do
   def verify_no_spam_warning_banner
     expect(page).not_to have_content(
       t(
-        'idv.gpo.alert_spam_warning_html',
+        'idv.gpo.alert_rate_limit_warning_html',
         date_letter_was_sent: I18n.l(
           Time.zone.now,
           format: :event_date,
@@ -242,7 +242,7 @@ RSpec.feature 'idv enter letter code step' do
   def verify_spam_warning_banner_present(code_sent_at = Time.zone.now)
     expect(page).to have_content strip_tags(
       t(
-        'idv.gpo.alert_spam_warning_html',
+        'idv.gpo.alert_rate_limit_warning_html',
         date_letter_was_sent: I18n.l(
           code_sent_at,
           format: :event_date,

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'idv enter letter code step' do
       and_return(threatmetrix_enabled ? :enabled : :disabled)
   end
 
-  it_behaves_like 'gpo otp verification'
+  it_behaves_like 'verification code entry'
 
   context 'ThreatMetrix disabled, but we have ThreatMetrix status on proofing component' do
     let(:threatmetrix_enabled) { false }
@@ -41,14 +41,14 @@ RSpec.feature 'idv enter letter code step' do
         fraud_pending_reason: 'threatmetrix_review',
       )
     end
-    it_behaves_like 'gpo otp verification'
+    it_behaves_like 'verification code entry'
   end
 
   context 'ThreatMetrix enabled' do
     let(:threatmetrix_enabled) { true }
 
     context 'ThreatMetrix says "pass"' do
-      it_behaves_like 'gpo otp verification'
+      it_behaves_like 'verification code entry'
     end
 
     context 'ThreatMetrix says "review"' do
@@ -61,7 +61,7 @@ RSpec.feature 'idv enter letter code step' do
           fraud_pending_reason: 'threatmetrix_review',
         )
       end
-      it_behaves_like 'gpo otp verification'
+      it_behaves_like 'verification code entry'
     end
 
     context 'ThreatMetrix says "reject"' do
@@ -74,11 +74,11 @@ RSpec.feature 'idv enter letter code step' do
           fraud_pending_reason: 'threatmetrix_reject',
         )
       end
-      it_behaves_like 'gpo otp verification'
+      it_behaves_like 'verification code entry'
     end
 
     context 'No ThreatMetrix result on proofing component' do
-      it_behaves_like 'gpo otp verification'
+      it_behaves_like 'verification code entry'
     end
   end
 

--- a/spec/services/idv/gpo_mail_spec.rb
+++ b/spec/services/idv/gpo_mail_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe Idv::GpoMail do
       and_return(minimum_wait_before_another_usps_letter_in_hours)
   end
 
-  describe '#mail_spammed?' do
+  describe '#rate_limited?' do
     context 'when no letters have been requested' do
       it 'returns false' do
-        expect(subject.mail_spammed?).to eq false
+        expect(subject.rate_limited?).to eq false
       end
     end
 
@@ -31,14 +31,14 @@ RSpec.describe Idv::GpoMail do
       end
 
       it 'is true' do
-        expect(subject.mail_spammed?).to eq true
+        expect(subject.rate_limited?).to eq true
       end
 
       context 'but the window limit is disabled due to a 0 window size' do
         let(:letter_request_events_window_days) { 0 }
 
         it 'is false' do
-          expect(subject.mail_spammed?).to eq false
+          expect(subject.rate_limited?).to eq false
         end
       end
 
@@ -46,7 +46,7 @@ RSpec.describe Idv::GpoMail do
         let(:max_letter_request_events) { 0 }
 
         it 'is false' do
-          expect(subject.mail_spammed?).to eq false
+          expect(subject.rate_limited?).to eq false
         end
       end
     end
@@ -57,14 +57,14 @@ RSpec.describe Idv::GpoMail do
       end
 
       it 'is true' do
-        expect(subject.mail_spammed?).to eq true
+        expect(subject.rate_limited?).to eq true
       end
 
       context 'but the too-recent limit is disabled' do
         let(:minimum_wait_before_another_usps_letter_in_hours) { 0 }
 
         it 'is false' do
-          expect(subject.mail_spammed?).to eq false
+          expect(subject.rate_limited?).to eq false
         end
       end
 
@@ -79,7 +79,7 @@ RSpec.describe Idv::GpoMail do
         end
 
         it 'returns false' do
-          expect(subject.mail_spammed?).to be false
+          expect(subject.rate_limited?).to be false
         end
       end
     end

--- a/spec/support/idv_examples/verification_code_entry.rb
+++ b/spec/support/idv_examples/verification_code_entry.rb
@@ -1,7 +1,7 @@
-RSpec.shared_examples 'gpo otp verification' do
+RSpec.shared_examples 'verification code entry' do
   include IdvStepHelper
 
-  it 'prompts for one-time code at sign in' do
+  it 'prompts for verification code at sign in' do
     sign_in_live_with_2fa(user)
 
     expect(current_path).to eq idv_verify_by_mail_enter_code_path
@@ -26,7 +26,7 @@ RSpec.shared_examples 'gpo otp verification' do
     expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
   end
 
-  it 'renders an error for an expired GPO OTP' do
+  it 'renders an error for an expired verification code' do
     sign_in_live_with_2fa(user)
 
     gpo_confirmation_code.update(


### PR DESCRIPTION
## 🎫 Ticket

[LG-11271](https://cm-jira.usa.gov/browse/LG-11271)

## 🛠 Summary of changes

This is a code cleanup PR to align with our current language around rate limits and verification codes.
- Rename `GpoMail#mail_spammed?` to `#rate_limited?`
- Related renaming of translation tags and spec methods
- Rename shared examples `gpo otp verification` to `verification code entry`

## 📜 Testing Plan

Automated testing in CI
