### PR TITLE
LG-11422: Provide Sender ID for UK SMS

### DIFF
--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -14,6 +14,7 @@ class PinpointSupportedCountries
     BY
     EG
     FR
+    GB
     JO
     PH
     TH


### PR DESCRIPTION
## 🎫 Ticket

[LG-11422](https://cm-jira.usa.gov/browse/LG-11422)

## 🛠 Summary of changes

Adds UK to the set of sender ID countries so that the preconfigured sender ID is provided for SMS to the country.

Source for how Sender ID is configured using our single static Sender ID:

https://github.com/18F/identity-idp/blob/a1df4929df4387a55406f2d14fd5d0e1e6b79768/config/initializers/telephony.rb#L16-L19

Reference that Sender ID is supported without registration (see "Yes" under "Supports Sender ID", notably not "Registration required"):

https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html

Reference that "GB" is the country identifier:

https://github.com/18F/identity-idp/blob/a1df4929df4387a55406f2d14fd5d0e1e6b79768/config/pinpoint_supported_countries.yml#L317-L321

Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1698267798949799

## 📜 Testing Plan

I'm not aware that there's a way to test this.