### PR TITLE
The issue was actually integration not existing, not partner_account

### DIFF
--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -27,8 +27,8 @@ class DestroyableRecords
     stdout.puts '********'
     stdout.puts 'Integration:'
     if integration.nil?
-     stdout.puts "No associated integration"
-    else 
+      stdout.puts 'No associated integration'
+    else
       stdout.puts integration.attributes.to_yaml
     end
     stdout.puts "\n"
@@ -47,11 +47,11 @@ class DestroyableRecords
     stdout.puts '*******'
     stdout.puts 'These are the IAA orders that will be affected: \n'
     if iaa_orders.nil?
-     stdout.puts "No IAA orders will be affected"
-    else 
+      stdout.puts 'No IAA orders will be affected'
+    else
       stdout.puts 'These are the IAA orders that will be affected: \n'
       iaa_orders.each do |iaa_order|
-         stdout.puts "#{iaa_order.iaa_gtc.gtc_number} Order #{iaa_order.order_number}"
+        stdout.puts "#{iaa_order.iaa_gtc.gtc_number} Order #{iaa_order.order_number}"
       end
     end
     stdout.puts "\n"

--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -15,7 +15,7 @@ class DestroyableRecords
 
   def print_data
     stdout.puts "You are about to delete a service provider with issuer #{service_provider.issuer}"
-    if integration.partner_account.present?
+    if integration&.partner_account.present?
       stdout.puts "The partner is #{integration.partner_account.name}"
     end
     stdout.puts "\n\n"
@@ -26,7 +26,7 @@ class DestroyableRecords
 
     stdout.puts '********'
     stdout.puts 'Integration:'
-    stdout.puts integration.attributes.to_yaml
+    stdout.puts integration&.attributes.to_yaml
     stdout.puts "\n"
 
     stdout.puts '********'
@@ -42,7 +42,7 @@ class DestroyableRecords
 
     stdout.puts '*******'
     stdout.puts 'These are the IAA orders that will be affected: \n'
-    iaa_orders.each do |iaa_order|
+    iaa_orders&.each do |iaa_order|
       stdout.puts "#{iaa_order.iaa_gtc.gtc_number} Order #{iaa_order.order_number}"
     end
     stdout.puts "\n"
@@ -70,11 +70,11 @@ class DestroyableRecords
   private
 
   def integration_usages
-    integration.integration_usages
+    integration&.integration_usages
   end
 
   def iaa_orders
-    integration.iaa_orders
+    integration&.iaa_orders
   end
 
   def in_person_enrollments

--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -26,7 +26,11 @@ class DestroyableRecords
 
     stdout.puts '********'
     stdout.puts 'Integration:'
-    stdout.puts integration&.attributes.to_yaml
+    if integration.nil?
+     stdout.puts "No associated integration"
+    else 
+      stdout.puts integration.attributes.to_yaml
+    end
     stdout.puts "\n"
 
     stdout.puts '********'
@@ -42,8 +46,13 @@ class DestroyableRecords
 
     stdout.puts '*******'
     stdout.puts 'These are the IAA orders that will be affected: \n'
-    iaa_orders&.each do |iaa_order|
-      stdout.puts "#{iaa_order.iaa_gtc.gtc_number} Order #{iaa_order.order_number}"
+    if iaa_orders.nil?
+     stdout.puts "No IAA orders will be affected"
+    else 
+      stdout.puts 'These are the IAA orders that will be affected: \n'
+      iaa_orders.each do |iaa_order|
+         stdout.puts "#{iaa_order.iaa_gtc.gtc_number} Order #{iaa_order.order_number}"
+      end
     end
     stdout.puts "\n"
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10920](https://cm-jira.usa.gov/browse/LG-10920)

## 🛠 Summary of changes

There is additional checks required to have the rake task be able to continue through `destroyable_records.rb`. The issue is `integration` is nil, not `integration.partner_account` as I initially assumed based on the error.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
