### PR TITLE
Return false from `expired_for_interval?` if the last auth event was not a remember device event

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -64,9 +64,8 @@ module RememberDeviceConcern
   end
 
   def has_remember_device_auth_event?
-    auth_methods_session.auth_events.any? do |auth_event|
-      auth_event[:auth_method] == TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
-    end
+    auth_methods_session.last_auth_event&.fetch(:auth_method) ==
+      TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE
   end
 
   def handle_valid_remember_device_cookie(remember_device_cookie:)

--- a/spec/features/remember_device/signed_in_sp_expiration.rb
+++ b/spec/features/remember_device/signed_in_sp_expiration.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'SP expiration while signed in' do
+  include SamlAuthHelper
+
+  ##
+  # This test is a regression spec for a specific bug in `remember_device_expired_for_sp?`
+  #
+  # See https://github.com/18F/identity-idp/pull/9458
+  #
+  scenario 'signed in user with expired remember device does not get stuck in MFA loop' do
+    user = sign_up_and_set_password
+    user.password = Features::SessionHelper::VALID_PASSWORD
+
+    select_2fa_option('phone')
+    fill_in :new_phone_form_phone, with: '2025551212'
+    click_send_one_time_code
+    check t('forms.messages.remember_device')
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+    skip_second_mfa_prompt
+
+    first(:button, t('links.sign_out')).click
+
+    sign_in_user(user)
+
+    travel_to(5.seconds.from_now) do
+      visit_idp_from_sp_with_ial1_aal2(:oidc)
+
+      expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+      expect(page).to have_content(t('two_factor_authentication.header_text'))
+
+      fill_in_code_with_last_phone_otp
+      uncheck t('forms.messages.remember_device')
+      click_submit_default
+
+      expect(page).to have_current_path(sign_up_completed_path)
+    end
+  end
+end


### PR DESCRIPTION
The remember device concern is used to check if the remember device interval is expired requiring a user to re-authenticate. That check is performed on these lines:

https://github.com/18F/identity-idp/blob/f8ee126760a802eaa33de4d0786c120c50f16961/app/controllers/saml_idp_controller.rb#L24


https://github.com/18F/identity-idp/blob/f8ee126760a802eaa33de4d0786c120c50f16961/app/controllers/openid_connect/authorization_controller.rb#L21

It looks like the `expired_for_interval?` was recently changed to return true if remember device was used at any point and is now expired (ref: https://github.com/18F/identity-idp/pull/9335/files#diff-82060fb86bc64910b8186479a6f620e6ba44b007ca059e082c468f29702cf142R56). As a result, a user is prompted to re-authenticate if their remember device session is expired, regardless of whether they have already re-authenticated.

This commit reverts to the original behavior to address this bug.
