### PR TITLE
LG-10913 remove ssn redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -377,15 +377,6 @@ Rails.application.routes.draw do
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
 
-      # DEPRECATION NOTICE
-      # Usage of the /in_person_proofing/ssn routes is deprecated.
-      # Use the /in_person/ssn routes instead.
-      #
-      # These have been left in temporarily to prevent any impact to users
-      # during the deprecation process.
-      get '/in_person_proofing/ssn' => redirect('/verify/in_person/ssn', status: 307)
-      put '/in_person_proofing/ssn' => redirect('/verify/in_person/ssn', status: 307)
-
       get '/in_person' => 'in_person#index'
       get '/in_person/ready_to_verify' => 'in_person/ready_to_verify#show',
           as: :in_person_ready_to_verify

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -377,12 +377,6 @@ Rails.application.routes.draw do
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
 
-      # DEPRECATION NOTICE
-      # Usage of the /in_person_proofing/ssn routes is deprecated.
-      # Use the /in_person/ssn routes instead.
-      #
-      # These have been left in temporarily to prevent any impact to users
-      # during the deprecation process.
       get '/in_person_proofing/address' => 'in_person/address#show'
 
       get '/in_person' => 'in_person#index'


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-10913)

## 🛠 Summary of changes

Deleted redirects for GET and PUT methods from `/in_person_proofing/ssn`. This route used to handle the old FSM navigation, but with the deprecation and removal of the IPP SSN FSM step and subsequent replacement with a controller, this route is no longer needed. The redirects were put in place to ensure a seamless rollout for users.

## 📜 Testing Plan

- [ ] Confirm that attempting a GET or PUT request to `/in_person_proofing/ssn` returns a 404 error rather than a 307. 