### PR TITLE
Deploy RC 327.1 to Prod

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -10,7 +10,6 @@ import { useI18n } from '@18f/identity-react-i18n';
 import UnknownError from './unknown-error';
 import TipList from './tip-list';
 import DocumentSideAcuantCapture from './document-side-acuant-capture';
-import DocumentCaptureAbandon from './document-capture-abandon';
 
 interface DocumentCaptureReviewIssuesProps {
   isFailedDocType: boolean;
@@ -79,7 +78,6 @@ function DocumentCaptureReviewIssues({
         />
       ))}
       <FormStepsButton.Submit />
-      <DocumentCaptureAbandon />
       <Cancel />
     </>
   );

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -8,7 +8,6 @@ import DocumentSideAcuantCapture from './document-side-acuant-capture';
 import DeviceContext from '../context/device';
 import UploadContext from '../context/upload';
 import TipList from './tip-list';
-import DocumentCaptureAbandon from './document-capture-abandon';
 
 /**
  * @typedef {'front'|'back'} DocumentSide
@@ -72,7 +71,6 @@ function DocumentsStep({
       ))}
       {isLastStep ? <FormStepsButton.Submit /> : <FormStepsButton.Continue />}
 
-      <DocumentCaptureAbandon />
       <Cancel />
     </>
   );

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -134,20 +134,6 @@ RSpec.feature 'document capture step', :js do
 
       expect(DocAuthLog.find_by(user_id: user.id).state).to be_nil
     end
-
-    it 'return to sp when click on exit link', :js do
-      click_sp_exit_link(sp_name: sp_name)
-      expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
-    end
-
-    it 'logs event and return to sp when click on submit and exit button', :js do
-      click_submit_exit_button
-      expect(fake_analytics).to have_logged_event(
-        'Frontend: IdV: exit optional questions',
-        hash_including('ids'),
-      )
-      expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
-    end
   end
 
   context 'standard mobile flow' do
@@ -174,16 +160,6 @@ RSpec.feature 'document capture step', :js do
         expect(page).to have_current_path(idv_phone_url)
         visit(idv_document_capture_url)
         expect(page).to have_current_path(idv_phone_url)
-      end
-    end
-
-    it 'return to sp when click on exit link', :js do
-      perform_in_browser(:mobile) do
-        visit_idp_from_oidc_sp_with_ial2
-        sign_in_and_2fa_user(user)
-        complete_doc_auth_steps_before_document_capture_step
-        click_sp_exit_link(sp_name: sp_name)
-        expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
       end
     end
   end

--- a/spec/javascript/packages/document-capture/components/document-capture-review-issues-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-review-issues-spec.jsx
@@ -68,7 +68,6 @@ describe('DocumentCaptureReviewIssues', () => {
       expect(backCapture).to.be.ok();
       expect(getByText('back side error')).to.be.ok();
       expect(getByRole('button', { name: 'forms.buttons.submit.default' })).to.be.ok();
-      expect(getByRole('button', { name: 'doc_auth.exit_survey.optional.button' })).to.be.ok();
     });
 
     it('renders for a doc type failure', () => {
@@ -115,7 +114,6 @@ describe('DocumentCaptureReviewIssues', () => {
       expect(backCapture).to.be.ok();
       expect(getByText('back side doc type error')).to.be.ok();
       expect(getByRole('button', { name: 'forms.buttons.submit.default' })).to.be.ok();
-      expect(getByRole('button', { name: 'doc_auth.exit_survey.optional.button' })).to.be.ok();
     });
   });
 });

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
@@ -82,16 +82,4 @@ describe('document-capture/components/documents-step', () => {
 
     expect(queryByText(notExpectedText)).to.not.exist();
   });
-
-  it('renders optional question part', () => {
-    const { getByRole, getByText } = render(
-      <DeviceContext.Provider value={{ isMobile: true }}>
-        <UploadContextProvider flowPath="standard">
-          <DocumentsStep />
-        </UploadContextProvider>
-      </DeviceContext.Provider>,
-    );
-    expect(getByRole('heading', { name: 'doc_auth.exit_survey.header', level: 2 })).to.be.ok();
-    expect(getByText('doc_auth.exit_survey.optional.button')).to.be.ok();
-  });
 });

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -343,14 +343,6 @@ describe('document-capture/components/review-issues-step', () => {
     expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
   });
 
-  it('renders optional questions', async () => {
-    const { getByText, getByRole } = render(<ReviewIssuesStep {...DEFAULT_PROPS} />);
-
-    await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
-    expect(getByRole('heading', { name: 'doc_auth.exit_survey.header', level: 2 })).to.be.ok();
-    expect(getByText('doc_auth.exit_survey.optional.button')).to.be.ok();
-  });
-
   context('service provider context', () => {
     context('ial2', () => {
       it('renders with front and back inputs', async () => {


### PR DESCRIPTION
## User-Facing Improvements
- Doc Auth: Remove optional questions from capture screen. ([#9468](https://github.com/18F/identity-idp/pull/9468))