### PR TITLE
Don't redirect to PhoneQuestion from HybridHandoff if referer is nil

### DIFF
--- a/app/controllers/concerns/idv/phone_question_ab_test_concern.rb
+++ b/app/controllers/concerns/idv/phone_question_ab_test_concern.rb
@@ -14,6 +14,7 @@ module Idv
 
     def maybe_redirect_for_phone_question_ab_test
       return if phone_question_ab_test_bucket != :show_phone_question
+      return if request.referer.blank? # avoid redirect loop
       return if request.referer == idv_phone_question_url
       return if request.referer == idv_link_sent_url
       return if request.referer == idv_hybrid_handoff_url

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -201,6 +201,11 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
         expect(page).to have_current_path(idv_phone_question_path)
         click_link t('doc_auth.buttons.have_phone')
 
+        # added to test FlowPolicy behavior with PhoneQuestion
+        expect(page).to have_current_path(idv_hybrid_handoff_path)
+        visit(idv_link_sent_url)
+        expect(page).to have_current_path(idv_hybrid_handoff_path)
+
         freeze_time do
           idv_send_link_max_attempts.times do
             expect(page).to_not have_content(


### PR DESCRIPTION
We see that referer is nil if the user tries to visit idv_link_sent_url while still on HybridHandoff. Not sure why, but web search indicates that the user can turn off referer in the HTTP header, which would cause a redirect loop in #maybe_redirect_for_phone_question_ab_test. So this adds a check for nil referer in that method.

Discovered while doing local testing for #9465 

Research links:
https://api.rubyonrails.org/v5.0.1/classes/ActionController/Redirecting.html
https://blog.mozilla.org/security/2015/01/21/meta-referrer/

NOTE: we are reconsidering our life choices and may just re-implement #maybe_redirect_for_phone_question_ab_test to depend on a session value