### PR TITLE
LG-11441 - Fix Flakey In-person Enrollment test

### DIFF
--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -137,7 +137,7 @@ class InPersonEnrollment < ApplicationRecord
 
   def days_to_due_date
     today = Time.zone.now.utc
-    (((due_date - today) / 3600) / 24).to_i
+    (due_date - today).seconds.in_days.to_i
   end
 
   def eligible_for_notification?

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -136,8 +136,8 @@ class InPersonEnrollment < ApplicationRecord
   end
 
   def days_to_due_date
-    today = DateTime.now
-    (today...due_date).count
+    today = Time.zone.now.utc
+    (((due_date - today) / 3600) / 24).to_i
   end
 
   def eligible_for_notification?

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -387,10 +387,10 @@ RSpec.describe InPersonEnrollment, type: :model do
   describe 'due_date and days_to_due_date' do
     let(:validity_in_days) { 10 }
     let(:days_ago_established_at) { 7 }
-    let(:today) { Time.zone.now }
-    let(:nine_days_ago) { today - 9.days }
-    let(:nine_and_a_half_days_ago) { today - 9.5.days }
-    let(:ten_days_ago) { today - 10.days }
+    let(:today) { 0 }
+    let(:nine) { 9 }
+    let(:nine_and_a_half) { 9.5 }
+    let(:ten) { 10 }
 
     before do
       allow(IdentityConfig.store).
@@ -427,10 +427,12 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: nine_days_ago,
+            enrollment_established_at: nine.days.ago,
           )
-          expect(enrollment.days_to_due_date).to eq(1)
-          expect(enrollment.due_date).to eq(today + 1.day)
+          expect(enrollment.days_to_due_date).to eq((validity_in_days - nine).to_i)
+          expect(enrollment.due_date).to(
+            eq((validity_in_days - nine).days.from_now),
+            )
         end
       end
 
@@ -438,10 +440,12 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: nine_and_a_half_days_ago,
+            enrollment_established_at: nine_and_a_half.days.ago,
           )
-          expect(enrollment.days_to_due_date).to eq(0)
-          expect(enrollment.due_date).to eq(today + 0.5.days)
+          expect(enrollment.days_to_due_date).to eq((validity_in_days - nine_and_a_half).to_i)
+          expect(enrollment.due_date).to(
+            eq((validity_in_days - nine_and_a_half).days.from_now),
+            )
         end
       end
 
@@ -449,10 +453,12 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: ten_days_ago,
+            enrollment_established_at: ten.days.ago,
           )
-          expect(enrollment.days_to_due_date).to eq(0)
-          expect(enrollment.due_date).to eq(today)
+          expect(enrollment.days_to_due_date).to eq((validity_in_days - ten).to_i)
+          expect(enrollment.due_date).to(
+            eq((validity_in_days - ten).days.from_now),
+            )
         end
       end
     end

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -417,6 +417,41 @@ RSpec.describe InPersonEnrollment, type: :model do
         expect(enrollment.days_to_due_date).to eq(validity_in_days - days_ago_established_at)
       end
     end
+
+    context 'check edges to confirm date calculation is correct' do
+      it 'returns the correct due date and days to due date with 1 day left' do
+        freeze_time do
+          enrollment = create(
+            :in_person_enrollment,
+            enrollment_established_at: Time.zone.now - 9.days,
+          )
+          expect(enrollment.days_to_due_date).to eq(1)
+          expect(enrollment.due_date).to eq(Time.zone.now + 1.day)
+        end
+      end
+
+      it 'returns the correct due date and days to due date with 0.5 days left' do
+        freeze_time do
+          enrollment = create(
+            :in_person_enrollment,
+            enrollment_established_at: Time.zone.now - 9.5.days,
+          )
+          expect(enrollment.days_to_due_date).to eq(0)
+          expect(enrollment.due_date).to eq(Time.zone.now + 0.5.days)
+        end
+      end
+
+      it 'returns the correct due date and days to due date with 0 days left' do
+        freeze_time do
+          enrollment = create(
+            :in_person_enrollment,
+            enrollment_established_at: Time.zone.now - 10.days,
+          )
+          expect(enrollment.days_to_due_date).to eq(0)
+          expect(enrollment.due_date).to eq(Time.zone.now)
+        end
+      end
+    end
   end
 
   describe 'eligible_for_notification?' do

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -386,11 +386,6 @@ RSpec.describe InPersonEnrollment, type: :model do
 
   describe 'due_date and days_to_due_date' do
     let(:validity_in_days) { 10 }
-    let(:days_ago_established_at) { 7 }
-    let(:today) { 0 }
-    let(:nine) { 9 }
-    let(:nine_and_a_half) { 9.5 }
-    let(:ten) { 10 }
 
     before do
       allow(IdentityConfig.store).
@@ -404,10 +399,10 @@ RSpec.describe InPersonEnrollment, type: :model do
       freeze_time do
         enrollment = create(
           :in_person_enrollment,
-          enrollment_established_at: days_ago_established_at.days.ago,
+          enrollment_established_at: (validity_in_days - 3).days.ago,
         )
         expect(enrollment.due_date).to(
-          eq((validity_in_days - days_ago_established_at).days.from_now),
+          eq(3.days.from_now),
         )
       end
     end
@@ -416,9 +411,9 @@ RSpec.describe InPersonEnrollment, type: :model do
       freeze_time do
         enrollment = create(
           :in_person_enrollment,
-          enrollment_established_at: days_ago_established_at.days.ago,
+          enrollment_established_at: (validity_in_days - 3).days.ago,
         )
-        expect(enrollment.days_to_due_date).to eq(validity_in_days - days_ago_established_at)
+        expect(enrollment.days_to_due_date).to eq(3)
       end
     end
 
@@ -427,12 +422,12 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: nine.days.ago,
+            enrollment_established_at: (validity_in_days - 1).days.ago,
           )
-          expect(enrollment.days_to_due_date).to eq((validity_in_days - nine).to_i)
+          expect(enrollment.days_to_due_date).to eq(1)
           expect(enrollment.due_date).to(
-            eq((validity_in_days - nine).days.from_now),
-            )
+            eq(Time.zone.now + 1.day),
+          )
         end
       end
 
@@ -440,12 +435,12 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: nine_and_a_half.days.ago,
+            enrollment_established_at: (validity_in_days - 0.5).days.ago,
           )
-          expect(enrollment.days_to_due_date).to eq((validity_in_days - nine_and_a_half).to_i)
+          expect(enrollment.days_to_due_date).to eq(0)
           expect(enrollment.due_date).to(
-            eq((validity_in_days - nine_and_a_half).days.from_now),
-            )
+            eq(Time.zone.now + 0.5.days),
+          )
         end
       end
 
@@ -453,12 +448,12 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: ten.days.ago,
+            enrollment_established_at: validity_in_days.days.ago,
           )
-          expect(enrollment.days_to_due_date).to eq((validity_in_days - ten).to_i)
+          expect(enrollment.days_to_due_date).to eq(0)
           expect(enrollment.due_date).to(
-            eq((validity_in_days - ten).days.from_now),
-            )
+            eq(Time.zone.now),
+          )
         end
       end
     end

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -387,6 +387,10 @@ RSpec.describe InPersonEnrollment, type: :model do
   describe 'due_date and days_to_due_date' do
     let(:validity_in_days) { 10 }
     let(:days_ago_established_at) { 7 }
+    let(:today) { Time.zone.now }
+    let(:nine_days_ago) { today - 9.days }
+    let(:nine_and_a_half_days_ago) { today - 9.5.days }
+    let(:ten_days_ago) { today - 10.days }
 
     before do
       allow(IdentityConfig.store).
@@ -423,10 +427,10 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: Time.zone.now - 9.days,
+            enrollment_established_at: nine_days_ago,
           )
           expect(enrollment.days_to_due_date).to eq(1)
-          expect(enrollment.due_date).to eq(Time.zone.now + 1.day)
+          expect(enrollment.due_date).to eq(today + 1.day)
         end
       end
 
@@ -434,10 +438,10 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: Time.zone.now - 9.5.days,
+            enrollment_established_at: nine_and_a_half_days_ago,
           )
           expect(enrollment.days_to_due_date).to eq(0)
-          expect(enrollment.due_date).to eq(Time.zone.now + 0.5.days)
+          expect(enrollment.due_date).to eq(today + 0.5.days)
         end
       end
 
@@ -445,10 +449,10 @@ RSpec.describe InPersonEnrollment, type: :model do
         freeze_time do
           enrollment = create(
             :in_person_enrollment,
-            enrollment_established_at: Time.zone.now - 10.days,
+            enrollment_established_at: ten_days_ago,
           )
           expect(enrollment.days_to_due_date).to eq(0)
-          expect(enrollment.due_date).to eq(Time.zone.now)
+          expect(enrollment.due_date).to eq(today)
         end
       end
     end


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-11441)

## 🛠 Summary of changes

The issue appears not to be with the spec, but rather with how we were calculating the difference between the start date and the current date. Now using the `Time` object to perform simple subtraction between the start date and current date.

## 📜 Testing Plan

Make sure that `/spec/models/in_person_enrollment_spec.rb` doesn't fail intermittently.