### PR TITLE
Remove ineffective invalid CSS

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -11,7 +11,6 @@
   // Temporary: To be backported to design system. Unstyled buttons should inherit the appearance
   // of a link.
   display: inline;
-  width: auto;
 }
 
 .usa-button:disabled.usa-button--active,

--- a/app/assets/stylesheets/components/_list.scss
+++ b/app/assets/stylesheets/components/_list.scss
@@ -6,7 +6,6 @@
       background-image: url('/alert/success.svg');
       background-repeat: no-repeat;
       content: '';
-      display: inline-block;
       float: left;
       height: 1rem;
       margin-top: 0.33rem;


### PR DESCRIPTION
## 🛠 Summary of changes

Removes two styles which would have no effect, due to invalid combinations.

I came aware of these with automated validation tools in Chrome and VSCode.

![Screenshot 2023-10-30 at 8 43 39 AM](https://github.com/18F/identity-idp/assets/1779930/cac3f5cf-2703-414c-a511-21b730599e01)

![Screenshot 2023-10-30 at 8 43 57 AM](https://github.com/18F/identity-idp/assets/1779930/36dd4021-d0b0-4aa1-b4dc-74beb70b5ccc)

I couldn't easily run an audit over all CSS with Chrome's validator (though I did find [the source](https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/panels/elements/CSSRuleValidator.ts;l=27?q=%22property%20prevents%22&ss=chromium)). Running VSCode's validator over the compiled CSS did reveal another upstream issue in USWDS, tracked at https://github.com/uswds/uswds/pull/5587 .

## 📜 Testing Plan

Verify no regressions in appearance of unstyled buttons and success-bullet lists.