### PR TITLE
Remove "transitional" compatibility from changelog script

### DIFF
--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -6,7 +6,6 @@ CHANGELOG_REGEX =
   %r{^(?:\* )?changelog: ?(?<category>[\w -]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}i
 CATEGORIES = [
   'User-Facing Improvements',
-  'Improvements', # Temporary for transitional period
   'Bug Fixes',
   'Internal',
   'Upcoming Features',
@@ -106,7 +105,7 @@ def generate_invalid_changes(git_log)
 end
 
 def closest_change_category(change)
-  category = CATEGORIES.
+  CATEGORIES.
     map do |category|
       CategoryDistance.new(
         category,
@@ -116,10 +115,6 @@ def closest_change_category(change)
     filter { |category_distance| category_distance.distance <= MAX_CATEGORY_DISTANCE }.
     max { |category_distance| category_distance.distance }&.
     category
-
-  # Temporarily normalize legacy category in transitional period
-  category = 'User-Facing Improvements' if category == 'Improvements'
-  category
 end
 
 # Get the last valid changelog line for every Pull Request and tie it to the commit subject.


### PR DESCRIPTION
## 🛠 Summary of changes

Removes code introduced with the renamed "Improvements" category in #7511 which was meant to support developers through a transition period. Since this rename has been live for almost a year, it should be safe to say that we've completed the transition.

## 📜 Testing Plan

```
rspec spec/scripts/changelog_check_spec.rb
```