### PR TITLE
LG-11278: Group authentication app setup fields with fieldset

### DIFF
--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -3,7 +3,7 @@
 <%= render PageHeadingComponent.new.with_content(t('headings.totp_setup.new')) %>
 
 <p>
-  <%= t('forms.totp_setup.totp_intro') %>
+  <span id="totp-intro"><%= t('forms.totp_setup.totp_intro') %></span>
   <%= new_tab_link_to(
         t('links.what_is_totp'),
         help_center_redirect_path(
@@ -17,46 +17,51 @@
 </p>
 
 <%= simple_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
-  <%= render ProcessListComponent.new(connected: true, class: 'margin-y-4') do |c| %>
-    <%= c.with_item(heading: t('forms.totp_setup.totp_step_1')) do %>
-      <p><%= t('forms.totp_setup.totp_step_1a') %></p>
-      <%= render ValidatedFieldComponent.new(
-            form: f,
-            name: :name,
-            required: true,
-            label: false,
-            wrapper_html: { class: 'margin-bottom-0' },
-            input_html: {
-              aria: { label: t('forms.totp_setup.totp_step_1') },
-              maxlength: 20,
-            },
-          ) %>
-    <% end %>
-    <%= c.with_item(heading: t('forms.totp_setup.totp_step_2')) %>
-    <%= c.with_item(heading: t('forms.totp_setup.totp_step_3')) do %>
-      <div class="text-center">
-        <%= image_tag @qrcode, size: 240, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
-      </div>
-      <p><%= t('instructions.mfa.authenticator.manual_entry') %></p>
-      <code class="display-block margin-y-2 font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold text-wrap-anywhere" id="qr-code">
-        <%= @code %>
-      </code>
-      <%= render ClipboardButtonComponent.new(clipboard_text: @code.upcase, outline: true) %>
-    <% end %>
-    <%= c.with_item(heading: t('forms.totp_setup.totp_step_4')) do %>
-      <%= render OneTimeCodeInputComponent.new(
-            form: f,
-            transport: nil,
-            code_length: TwoFactorAuthenticatable::OTP_LENGTH,
-            field_options: {
+  <fieldset aria-labelledby="totp-intro" class="padding-0 border-0 margin-y-4 margin-x-0">
+    <%= render ProcessListComponent.new(connected: true) do |c| %>
+      <%= c.with_item(heading: t('forms.totp_setup.totp_step_1')) do %>
+        <p><%= t('forms.totp_setup.totp_step_1a') %></p>
+        <%= render ValidatedFieldComponent.new(
+              form: f,
+              name: :name,
+              required: true,
               label: false,
+              wrapper_html: { class: 'margin-bottom-0' },
               input_html: {
-                aria: { label: t('forms.totp_setup.totp_step_4') },
+                aria: { label: t('forms.totp_setup.totp_step_1') },
+                maxlength: 20,
               },
-            },
-          ) %>
+            ) %>
+      <% end %>
+      <%= c.with_item(heading: t('forms.totp_setup.totp_step_2')) %>
+      <%= c.with_item(heading: t('forms.totp_setup.totp_step_3')) do %>
+        <div class="text-center">
+          <%= image_tag @qrcode, size: 240, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
+        </div>
+        <p><%= t('instructions.mfa.authenticator.manual_entry') %></p>
+        <code class="display-block margin-y-2 font-family-mono padding-y-2 padding-x-1 border-base-lighter border-1px text-bold text-wrap-anywhere" id="qr-code">
+          <%= @code %>
+        </code>
+        <%= render ClipboardButtonComponent.new(clipboard_text: @code.upcase, outline: true) %>
+      <% end %>
+      <%= c.with_item(heading: t('forms.totp_setup.totp_step_4')) do %>
+        <%= render OneTimeCodeInputComponent.new(
+              form: f,
+              transport: nil,
+              code_length: TwoFactorAuthenticatable::OTP_LENGTH,
+              field_options: {
+                label: false,
+                wrapper_html: {
+                  class: 'margin-bottom-0',
+                },
+                input_html: {
+                  aria: { label: t('forms.totp_setup.totp_step_4') },
+                },
+              },
+            ) %>
+      <% end %>
     <% end %>
-  <% end %>
+  </fieldset>
   <%= f.input(
         :remember_device,
         as: :boolean,

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe 'totp management' do
 
       click_link t('account.index.auth_app_add'), href: authenticator_setup_url
 
+      expect(
+        [
+          page.find_field(t('forms.totp_setup.totp_step_1')),
+          page.find_field(t('forms.totp_setup.totp_step_4')),
+        ],
+      ).to be_logically_grouped(t('forms.totp_setup.totp_intro'))
+
       secret = find('#qr-code').text
       fill_in 'name', with: 'foo'
       fill_in 'code', with: generate_totp_code(secret)

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -195,12 +195,6 @@ class AccessibleName
     '' if element['aria-hidden'] == 'true'
   end
 
-  def aria_label_name(element)
-    # "Otherwise, if computing a name, and if the current node has an aria-label attribute whose
-    # value is not the empty string, nor, when trimmed of white space, is not the empty string:"
-    element['aria-label']
-  end
-
   def aria_labelledby_name(element)
     # "if computing a name, and the current node has an aria-labelledby attribute that contains at
     # least one valid IDREF, and the current node is not already part of an aria-labelledby
@@ -211,6 +205,12 @@ class AccessibleName
       compact
 
     valid_labels.join('') if valid_labels.present?
+  end
+
+  def aria_label_name(element)
+    # "Otherwise, if computing a name, and if the current node has an aria-label attribute whose
+    # value is not the empty string, nor, when trimmed of white space, is not the empty string:"
+    element['aria-label']
   end
 
   def referenced_label_name(element)

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -140,20 +140,6 @@ RSpec::Matchers.define :have_name do |name|
   end
 end
 
-def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
-  expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
-  expect(page).to have_valid_idrefs
-  expect(page).to label_required_fields
-  expect(page).to have_valid_markup if validate_markup
-end
-
-def activate_skip_link
-  page.evaluate_script('document.activeElement.blur()')
-  page.active_element.send_keys(:tab)
-  expect(page.active_element).to have_content(t('shared.skip_link'), wait: 5)
-  page.active_element.send_keys(:enter)
-end
-
 class AccessibleName
   attr_reader :page
 
@@ -270,4 +256,18 @@ class AccessibleName
     # attribute, then use that attribute."
     element['title']
   end
+end
+
+def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
+  expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+  expect(page).to have_valid_idrefs
+  expect(page).to label_required_fields
+  expect(page).to have_valid_markup if validate_markup
+end
+
+def activate_skip_link
+  page.evaluate_script('document.activeElement.blur()')
+  page.active_element.send_keys(:tab)
+  expect(page.active_element).to have_content(t('shared.skip_link'), wait: 5)
+  page.active_element.send_keys(:enter)
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11278](https://cm-jira.usa.gov/browse/LG-11278)

## 🛠 Summary of changes

Adds a fieldset grouping to the TOTP setup screen, to logically group related fields.

Related resource: https://www.w3.org/TR/WCAG20-TECHS/H71.html

This is a non-visual change, as it labels the fieldset using `aria-labeledby` with an existing text on the page "Set up an authentication app to sign in using temporary security codes.".

Recommended to review with [whitespace changes hidden](https://github.com/18F/identity-idp/pull/9484/files?w=1) due to most view changes being the addition of a wrapping element that increases the tab level of most content.

## 📜 Testing Plan

You can inspect the grouping element with your browser DevTool's "Accessibility" inspector to confirm the named grouping:

![image](https://github.com/18F/identity-idp/assets/1779930/80820481-f85c-436c-979b-e3eb12f2a2cd)

You can also confirm with a screen reader that entering the form fields announces the group

![image](https://github.com/18F/identity-idp/assets/1779930/0c585fc3-fe90-409b-b33d-93b9966cf884)

## 👀 Screenshots

There are no visual changes, but here is the screen for reference:

![Screenshot 2023-10-31 at 10 33 21 AM](https://github.com/18F/identity-idp/assets/1779930/edd1cdc4-54a2-40a2-a92e-f90961d820a9)

