### PR TITLE
LG-11023 Unpublish old come_back_later URL and republish old enter_code URL

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -406,9 +406,11 @@ Rails.application.routes.draw do
 
       get '/by_mail/letter_enqueued' => 'by_mail/letter_enqueued#show', as: :letter_enqueued
 
-      # Redirects for old verify by mail routes
-      get '/come_back_later' => redirect('/verify/by_mail/letter_enqueued', status: 301)
-      get '/by_mail' => redirect('/verify/by_mail/enter_code', status: 301)
+      # We re-mapped `/verify/by_mail` to `/verify/by_mail/enter_code`. However, we sent emails to
+      # users with a link to `/verify/by_mail?did_not_receive_letter=1`. We need to continue
+      # supporting that feature so we are maintaining this URL mapped to that action. Rendering a
+      # redirect here will strip the query parameter.
+      get '/by_mail' => 'by_mail/enter_code#index'
     end
 
     root to: 'users/sessions#new'


### PR DESCRIPTION
We made changes to the routes for the verify by mail code entry and come back later URLs.

The come_back_later URL has a reasonably low amount of traffic to it. This commit unpublishes it for that reason.

The enter_code URL does have traffic to it. Currently it redirects which strips a query param included in the URL. To support that query param this commit republishes it so that query parameter works.
