### PR TITLE
Add a title to the in person address template

### DIFF
--- a/app/views/idv/in_person/address/show.html.erb
+++ b/app/views/idv/in_person/address/show.html.erb
@@ -8,8 +8,10 @@
 <% end %>
 
 <% if updating_address %>
+  <% title t('in_person_proofing.headings.update_address') %>
   <%= render PageHeadingComponent.new.with_content(t('in_person_proofing.headings.update_address')) %>
 <% else %>
+  <% title t('in_person_proofing.headings.address') %>
   <%= render PageHeadingComponent.new.with_content(t('in_person_proofing.headings.address')) %>
 <% end %>
 


### PR DESCRIPTION
This commit changed the app to require templates to declare a title: https://github.com/18F/identity-idp/commit/4d69e9de84fdfbd44597fa6ec60a355ae448dd08

It looks like this was able to sneak through without a title declaration in the In-Person flow on in the address show template. This commit adds a title declaration to that template.
