### PR TITLE
Make Pii::Cacher#fetch_string a private method

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -99,7 +99,7 @@ module SignUp
     end
 
     def pii
-      Pii::Cacher.new(current_user, user_session).fetch&.to_h || {}
+      Pii::Cacher.new(current_user, user_session).fetch || Pii::Attributes.new
     end
 
     def send_in_person_completion_survey

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -99,8 +99,7 @@ module SignUp
     end
 
     def pii
-      pii_string = Pii::Cacher.new(current_user, user_session).fetch_string
-      JSON.parse(pii_string || '{}', symbolize_names: true)
+      Pii::Cacher.new(current_user, user_session).fetch&.to_h || {}
     end
 
     def send_in_person_completion_survey

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -40,13 +40,5 @@ module Pii
     def ==(other)
       eql?(other)
     end
-
-    private
-
-    def assign_all_members
-      self.class.members.each do |member|
-        self[member] = self[member]
-      end
-    end
   end
 end

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -16,7 +16,8 @@ module Pii
     # the state in the state id address, which may not be the state that issued the ID
     :identity_doc_address_state,
     :ssn, :dob, :phone,
-    *DEPRECATED_PII_ATTRIBUTES
+    *DEPRECATED_PII_ATTRIBUTES,
+    keyword_init: true,
   ) do
     def self.new_from_hash(hash)
       attrs = new
@@ -30,11 +31,6 @@ module Pii
       return new if pii_json.blank?
       pii = JSON.parse(pii_json, symbolize_names: true)
       new_from_hash(pii)
-    end
-
-    def initialize(*args)
-      super
-      assign_all_members
     end
 
     def eql?(other)

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -17,7 +17,7 @@ module Pii
     :identity_doc_address_state,
     :ssn, :dob, :phone,
     *DEPRECATED_PII_ATTRIBUTES,
-    keyword_init: true,
+    keyword_init: true
   ) do
     def self.new_from_hash(hash)
       attrs = new

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -30,6 +30,19 @@ module Pii
       Pii::Attributes.new_from_json(pii_string)
     end
 
+    def exists_in_session?
+      return user_session[:decrypted_pii] || user_session[:encrypted_pii]
+    end
+
+    def delete
+      user_session.delete(:decrypted_pii)
+      user_session.delete(:encrypted_pii)
+    end
+
+    private
+
+    attr_reader :user, :user_session
+
     # Between requests, the decrypted PII bundle is encrypted with KMS and moved to the
     # 'encrypted_pii' key by the SessionEncryptor.
     #
@@ -46,19 +59,6 @@ module Pii
 
       decrypted
     end
-
-    def exists_in_session?
-      return user_session[:decrypted_pii] || user_session[:encrypted_pii]
-    end
-
-    def delete
-      user_session.delete(:decrypted_pii)
-      user_session.delete(:encrypted_pii)
-    end
-
-    private
-
-    attr_reader :user, :user_session
 
     def rotate_fingerprints(profile)
       KeyRotator::HmacFingerprinter.new.rotate(

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CompletionsPresenter do
   let(:current_user) { create(:user, :fully_registered, identities: identities) }
   let(:current_sp) { create(:service_provider, friendly_name: 'Friendly service provider') }
   let(:decrypted_pii) do
-    {
+    Pii::Attributes.new(
       first_name: 'Testy',
       last_name: 'Testerson',
       ssn: '900123456',
@@ -24,7 +24,7 @@ RSpec.describe CompletionsPresenter do
       zipcode: '20405',
       dob: '1990-01-01',
       phone: '+12022121000',
-    }
+    )
   end
   let(:requested_attributes) do
     [


### PR DESCRIPTION
The `Pii::Cacher#fetch_string` method gets the raw PII JSON blob and returns it. This is called by the `#fetch` in the `Pii::Cacher` and converted to `Pii::Attributes`.

Outside of the `Pii::Cacher` this method is called in one place by the IdP. This is in the completions controller to get the PII which is ultimately parsed into a hash. The same can be acheived by taking the result of `Pii::Cacher#fetch` and calling `#to_h` on it. This commit does that so the `#fetch_string` method can be made part of the private API.

Making this method part of the private API will make it easier to modify the way the cacher works to support encrypting and decrypting both active and pending profiles in the future.
