### PR TITLE
Add missing title for SMS opt-in

### DIFF
--- a/app/views/two_factor_authentication/sms_opt_in/new.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/new.html.erb
@@ -1,3 +1,5 @@
+<% title t('two_factor_authentication.opt_in.title') %>
+
 <%= render AlertIconComponent.new(icon_name: :warning, class: 'margin-bottom-2') %>
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.opt_in.title')) %>

--- a/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe TwoFactorAuthentication::SmsOptInController do
     end
 
     context 'when loaded while adding a new phone' do
+      render_views
+
       let(:user) { create(:user) }
       let(:phone) { Faker::PhoneNumber.cell_phone_in_e164 }
       let(:opt_out_uuid) { PhoneNumberOptOut.create_or_find_with_phone(phone).uuid }


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an error from missing title for SMS opt-in.

Regressed in #9447.

Slack: https://gsa-tts.slack.com/archives/C0NGESUN5/p1698769857824419

## 📜 Testing Plan

```
rspec spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
```