### PR TITLE
Update devise to fix deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     device_detector (1.0.7)
-    devise (4.8.1)
+    devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)


### PR DESCRIPTION
## 🛠 Summary of changes

The changes in #9357 included some deprecations that I missed. Example:

```
DEPRECATION WARNING: DeprecatedConstantAccessor.deprecate_constant without a deprecator is deprecated (called from <top (required)> at /Users/andrewmduthie/Documents/Code/identity-idp/config/application.rb:20)
Run options: include {:locations=>{"./spec/features/two_factor_authentication/sign_in_spec.rb"=>[62]}}
```

The deprecation comes from devise and was fixed in https://github.com/heartcombo/devise/pull/5599. Updating devise removes the warning.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
