### PR TITLE
Add feature spec coverage for SMS opt-in

### DIFF
--- a/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
@@ -53,8 +53,6 @@ RSpec.describe TwoFactorAuthentication::SmsOptInController do
     end
 
     context 'when loaded while adding a new phone' do
-      render_views
-
       let(:user) { create(:user) }
       let(:phone) { Faker::PhoneNumber.cell_phone_in_e164 }
       let(:opt_out_uuid) { PhoneNumberOptOut.create_or_find_with_phone(phone).uuid }


### PR DESCRIPTION
## 🛠 Summary of changes

Adds feature spec coverage for SMS opt-in behaviors introduced in #5894.

**Why?**

- To exercise the expected behaviors of opting in a phone that's previously opted out
- As an alternative regression spec to the fix introduced with #9493

## 📜 Testing Plan

```
rspec spec/features/two_factor_authentication/sign_in_spec.rb:62
```