### PR TITLE
Modify `Pii::Cacher#save_decrypted_pii_json` to be `Pii:Cacher#save_decrypted_pii`

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -69,11 +69,11 @@ module Idv
       self.personal_key = profile.personal_key
 
       move_pii_to_user_session(profile_maker.pii_attributes)
-      associate_in_person_enrollment_with_profile
+      associate_in_person_enrollment_with_profile if profile.in_person_verification_pending?
 
-      if address_verification_mechanism == 'gpo'
+      if profile.in_person_verification_pending?
         create_gpo_entry(profile_maker.pii_attributes)
-      elsif !profile.active? && current_user.has_in_person_enrollment?
+      elsif profile.in_person_verification_pending?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
           current_user,
           profile_maker.pii_attributes,
@@ -98,8 +98,6 @@ module Idv
     end
 
     def associate_in_person_enrollment_with_profile
-      return unless current_user.has_in_person_enrollment?
-
       current_user.establishing_in_person_enrollment.update(profile: profile)
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -71,7 +71,7 @@ module Idv
       move_pii_to_user_session(profile_maker.pii_attributes)
       associate_in_person_enrollment_with_profile if profile.in_person_verification_pending?
 
-      if profile.in_person_verification_pending?
+      if profile.gpo_verification_pending?
         create_gpo_entry(profile_maker.pii_attributes)
       elsif profile.in_person_verification_pending?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -16,7 +16,6 @@ module Idv
       personal_key
       phone_for_mobile_flow
       phone_with_camera
-      pii
       pii_from_doc
       previous_phone_step_params
       profile_id
@@ -66,32 +65,24 @@ module Idv
 
       profile.activate unless profile.reason_not_to_activate
 
-      self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id
       self.personal_key = profile.personal_key
 
-      cache_encrypted_pii(user_password)
+      move_pii_to_user_session(profile_maker.pii_attributes)
       associate_in_person_enrollment_with_profile
 
-      if profile.active?
-        move_pii_to_user_session
-      elsif address_verification_mechanism == 'gpo'
-        create_gpo_entry
-      elsif current_user.has_in_person_enrollment?
+      if address_verification_mechanism == 'gpo'
+        create_gpo_entry(profile_maker.pii_attributes)
+      elsif !profile.active? && current_user.has_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
           current_user,
-          pii,
+          profile_maker.pii_attributes,
         )
       end
     end
 
     def gpo_verification_needed?
       !phone_confirmed? || address_verification_mechanism == 'gpo'
-    end
-
-    def cache_encrypted_pii(password)
-      cacher = Pii::Cacher.new(current_user, session)
-      cacher.save(password, profile)
     end
 
     def vendor_params
@@ -112,9 +103,7 @@ module Idv
       current_user.establishing_in_person_enrollment.update(profile: profile)
     end
 
-    def create_gpo_entry
-      move_pii_to_user_session
-      self.pii = Pii::Cacher.new(current_user, user_session).fetch if pii.is_a?(String)
+    def create_gpo_entry(pii)
       confirmation_maker = GpoConfirmationMaker.new(
         pii: pii, service_provider: service_provider,
         profile: profile
@@ -230,10 +219,8 @@ module Idv
       {}
     end
 
-    def move_pii_to_user_session
-      return if session[:decrypted_pii].blank?
-      decrypted_pii = session.delete(:decrypted_pii)
-      Pii::Cacher.new(current_user, user_session).save_decrypted_pii_json(decrypted_pii)
+    def move_pii_to_user_session(pii)
+      Pii::Cacher.new(current_user, user_session).save_decrypted_pii(pii)
     end
 
     def session

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -13,13 +13,13 @@ module Pii
 
     def save(user_password, profile = user.active_profile)
       decrypted_pii = profile.decrypt_pii(user_password) if profile
-      save_decrypted_pii_json(decrypted_pii.to_json) if decrypted_pii
+      save_decrypted_pii(decrypted_pii) if decrypted_pii
       rotate_fingerprints(profile) if stale_fingerprints?(profile)
       user_session[:decrypted_pii]
     end
 
-    def save_decrypted_pii_json(decrypted_pii_json)
-      user_session[:decrypted_pii] = decrypted_pii_json
+    def save_decrypted_pii(decrypted_pii)
+      user_session[:decrypted_pii] = decrypted_pii.to_json
       nil
     end
 

--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -28,8 +28,7 @@ class ReactivateAccountSession
   # @param [Pii::Attributes]
   def store_decrypted_pii(pii)
     reactivate_account_session[:validated_personal_key] = true
-    pii_json = pii.to_json
-    Pii::Cacher.new(@user, session).save_decrypted_pii_json(pii_json)
+    Pii::Cacher.new(@user, session).save_decrypted_pii(pii)
     nil
   end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,6 +47,8 @@ Rails.application.configure do
       :email_addresses,
       :proofing_component,
       :account_reset_request,
+      :pending_in_person_enrollment,
+      :establishing_in_person_enrollment,
     ].each do |association|
       Bullet.add_safelist(type: :n_plus_one_query, class_name: 'User', association: association)
     end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,11 +44,11 @@ Rails.application.configure do
       :auth_app_configurations,
       :backup_code_configurations,
       :webauthn_configurations,
-      :email_addresses,
       :proofing_component,
       :account_reset_request,
       :pending_in_person_enrollment,
       :establishing_in_person_enrollment,
+      :registration_log,
     ].each do |association|
       Bullet.add_safelist(type: :n_plus_one_query, class_name: 'User', association: association)
     end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,8 +46,6 @@ Rails.application.configure do
       :webauthn_configurations,
       :proofing_component,
       :account_reset_request,
-      :pending_in_person_enrollment,
-      :establishing_in_person_enrollment,
       :registration_log,
     ].each do |association|
       Bullet.add_safelist(type: :n_plus_one_query, class_name: 'User', association: association)

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Idv::PersonalKeyController do
       gpo_verification_needed: false,
       in_person_verification_needed: false,
     )
-    idv_session.pii = profile_maker.pii_attributes
     idv_session.profile_id = profile.id
     idv_session.personal_key = profile.personal_key
     subject.idv_session.address_verification_mechanism = 'phone'
@@ -155,7 +154,7 @@ RSpec.describe Idv::PersonalKeyController do
 
       expect(PersonalKeyGenerator.new(user).verify(code)).to eq true
       expect(user.profiles.first.recover_pii(normalize_personal_key(code))).to eq(
-        subject.idv_session.pii,
+        Pii::Attributes.new_from_hash(applicant),
       )
     end
 

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Users::PasswordsController do
       it 'updates the user password and regenerates personal key' do
         user = create(:user, :proofed)
         stub_sign_in(user)
-        Pii::Cacher.new(user, controller.user_session).save_decrypted_pii_json(
-          { ssn: '111-222-3333' }.to_json,
+        Pii::Cacher.new(user, controller.user_session).save_decrypted_pii(
+          Pii::Attributes.new(ssn: '111-222-3333'),
         )
 
         params = {

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe Idv::Session do
           expect(profile.initiating_service_provider).to eq nil
           expect(profile.verified_at).to eq now
 
-          pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
-          expect(pii_from_sesison).to_not be_nil
-          expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
+          pii_from_session = Pii::Cacher.new(user, user_session).fetch
+          expect(pii_from_session).to_not be_nil
+          expect(pii_from_session.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
         end
       end
 
@@ -145,9 +145,9 @@ RSpec.describe Idv::Session do
         expect(profile.initiating_service_provider).to eq nil
         expect(profile.verified_at).to eq nil
 
-        pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
-        expect(pii_from_sesison).to_not be_nil
-        expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
+        pii_from_session = Pii::Cacher.new(user, user_session).fetch
+        expect(pii_from_session).to_not be_nil
+        expect(pii_from_session.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
       end
 
       context 'with establishing in person enrollment' do
@@ -174,9 +174,9 @@ RSpec.describe Idv::Session do
           expect(profile.initiating_service_provider).to eq nil
           expect(profile.verified_at).to eq nil
 
-          pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
-          expect(pii_from_sesison).to_not be_nil
-          expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn])
+          pii_from_session = Pii::Cacher.new(user, user_session).fetch
+          expect(pii_from_session).to_not be_nil
+          expect(pii_from_session.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn])
         end
 
         it 'creates a USPS enrollment' do
@@ -217,9 +217,9 @@ RSpec.describe Idv::Session do
         expect(profile.initiating_service_provider).to eq nil
         expect(profile.verified_at).to eq nil
 
-        pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
-        expect(pii_from_sesison).to_not be_nil
-        expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
+        pii_from_session = Pii::Cacher.new(user, user_session).fetch
+        expect(pii_from_session).to_not be_nil
+        expect(pii_from_session.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
       end
     end
 
@@ -241,9 +241,9 @@ RSpec.describe Idv::Session do
         expect(profile.initiating_service_provider).to eq nil
         expect(profile.verified_at).to eq nil
 
-        pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
-        expect(pii_from_sesison).to_not be_nil
-        expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
+        pii_from_session = Pii::Cacher.new(user, user_session).fetch
+        expect(pii_from_session).to_not be_nil
+        expect(pii_from_session.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
       end
     end
   end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -108,7 +108,6 @@ RSpec.describe Idv::Session do
         subject.address_verification_mechanism = 'phone'
         subject.vendor_phone_confirmation = true
         subject.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
-        allow(subject).to receive(:move_pii_to_user_session)
       end
 
       it 'completes the profile if the user has completed OTP phone confirmation' do
@@ -119,7 +118,6 @@ RSpec.describe Idv::Session do
           subject.create_profile_from_applicant_with_password(user.password)
           profile = subject.profile
 
-          expect(subject).to have_received(:move_pii_to_user_session)
           expect(profile.activated_at).to eq now
           expect(profile.active).to eq true
           expect(profile.deactivation_reason).to eq nil
@@ -127,6 +125,10 @@ RSpec.describe Idv::Session do
           expect(profile.gpo_verification_pending_at.present?).to eq false
           expect(profile.initiating_service_provider).to eq nil
           expect(profile.verified_at).to eq now
+
+          pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
+          expect(pii_from_sesison).to_not be_nil
+          expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
         end
       end
 
@@ -135,7 +137,6 @@ RSpec.describe Idv::Session do
         subject.create_profile_from_applicant_with_password(user.password)
         profile = subject.profile
 
-        expect(subject).not_to have_received(:move_pii_to_user_session)
         expect(profile.activated_at).to eq nil
         expect(profile.active).to eq false
         expect(profile.deactivation_reason).to eq nil
@@ -143,6 +144,10 @@ RSpec.describe Idv::Session do
         expect(profile.gpo_verification_pending_at.present?).to eq true
         expect(profile.initiating_service_provider).to eq nil
         expect(profile.verified_at).to eq nil
+
+        pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
+        expect(pii_from_sesison).to_not be_nil
+        expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
       end
 
       context 'with establishing in person enrollment' do
@@ -161,7 +166,6 @@ RSpec.describe Idv::Session do
           subject.create_profile_from_applicant_with_password(user.password)
           profile = subject.profile
 
-          expect(subject).not_to have_received(:move_pii_to_user_session)
           expect(profile.activated_at).to eq nil
           expect(profile.active).to eq false
           expect(profile.in_person_verification_pending?).to eq(true)
@@ -169,6 +173,10 @@ RSpec.describe Idv::Session do
           expect(profile.gpo_verification_pending_at.present?).to eq false
           expect(profile.initiating_service_provider).to eq nil
           expect(profile.verified_at).to eq nil
+
+          pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
+          expect(pii_from_sesison).to_not be_nil
+          expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn])
         end
 
         it 'creates a USPS enrollment' do
@@ -195,14 +203,12 @@ RSpec.describe Idv::Session do
       before do
         subject.address_verification_mechanism = 'gpo'
         subject.vendor_phone_confirmation = false
-        allow(subject).to receive(:move_pii_to_user_session)
       end
 
       it 'sets profile to pending gpo verification' do
         subject.create_profile_from_applicant_with_password(user.password)
         profile = subject.profile
 
-        expect(subject).to have_received(:move_pii_to_user_session)
         expect(profile.activated_at).to eq nil
         expect(profile.active).to eq false
         expect(profile.deactivation_reason).to eq nil
@@ -210,6 +216,10 @@ RSpec.describe Idv::Session do
         expect(profile.gpo_verification_pending_at.present?).to eq true
         expect(profile.initiating_service_provider).to eq nil
         expect(profile.verified_at).to eq nil
+
+        pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
+        expect(pii_from_sesison).to_not be_nil
+        expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
       end
     end
 
@@ -217,14 +227,12 @@ RSpec.describe Idv::Session do
       before do
         subject.address_verification_mechanism = 'phone'
         subject.vendor_phone_confirmation = false
-        allow(subject).to receive(:move_pii_to_user_session)
       end
 
       it 'does not complete the user profile' do
         subject.create_profile_from_applicant_with_password(user.password)
         profile = subject.profile
 
-        expect(subject).not_to have_received(:move_pii_to_user_session)
         expect(profile.activated_at).to eq nil
         expect(profile.active).to eq false
         expect(profile.deactivation_reason).to eq nil
@@ -232,6 +240,10 @@ RSpec.describe Idv::Session do
         expect(profile.gpo_verification_pending_at.present?).to eq true
         expect(profile.initiating_service_provider).to eq nil
         expect(profile.verified_at).to eq nil
+
+        pii_from_sesison = Pii::Cacher.new(user, user_session).fetch
+        expect(pii_from_sesison).to_not be_nil
+        expect(pii_from_sesison.ssn).to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn])
       end
     end
   end


### PR DESCRIPTION
The `#save_decrypted_pii_json` method consumed a JSON PII object and wrote it into the session under the `decrypted_pii` key.

This method was called in 2 places:

- The `ReactivateAccountController`
- The `Idv::Session`

In `ReactivateAccountController` the PII is available as `Pii::Attributes` and is converted to JSON to enable a call to `#save_decrypted_pii_json`.

In the `Idv::Session` the PII is available as `Pii::Attributes`, but prior to this commit underwent quite the Rube Goldberg process to find it's way into a JSON string that was then written to the session  by `save_decrypted_pii_json`.

This commit changes `save_decrypted_pii_json` to be `save_decrypted_pii` and take a `Pii::Attributes` instead of a JSON string argument. This will make it easier to implement a version of this method that handles multiple profiles when we start encrypting both the active and pending profile in the session.

This commit also short circuits the Rube Goldberg machine in `Idv::Session` and simply writes the attributes to the user session when the profile is created.
