### PR TITLE
Check in schema changes for Rails 7.1 upgrade

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_31_124437) do
+ActiveRecord::Schema[7.1].define(version: 2023_08_31_124437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"

--- a/db/worker_jobs_schema.rb
+++ b/db/worker_jobs_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_18_163221) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_18_163221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Check in schema changes that result from running `make update` on current main from the Rails 7.1 upgrade 