### PR TITLE
Add watch_events Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 	clobber_db \
 	clobber_assets \
 	clobber_logs \
+	watch_events \
 	docker_setup \
 	download_acuant_sdk \
 	fast_setup \
@@ -301,6 +302,9 @@ clobber_logs: ## Purges logs and tmp/
 	rm -rf tmp/encrypted_doc_storage
 	rm -rf tmp/letter_opener
 	rm -rf tmp/mails
+
+watch_events: ## Prints events logging as they happen
+	@tail -F -n0 log/events.log | jq "select(.name | test(\".*$$EVENT_NAME.*\"; \"i\")) | ."
 
 tidy: clobber_assets clobber_logs ## Remove assets, logs, and unused gems, but leave DB alone
 	bundle clean

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -101,7 +101,7 @@ make watch_events
 You can also watch for specific events by assigning the `EVENT_NAME` environment variable:
 
 ```
-EVENT_NAME="Account Page Visited" make watch_events
+EVENT_NAME="piv_cac_disabled" make watch_events
 ```
 
 [analytics-handbook]: https://handbook.login.gov/articles/analytics-events.html

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -77,18 +77,32 @@ properties to the Form object that get written during `#submit`
 
 ### Analytics
 
-At the end of the day, analytics events get dumped into `events.log` and contain
-information like user ID, service provider, user agent, etc.
+Analytics events are appended to `log/events.log` and contain information both common information as
+well as custom event properties. Common information includes service provider, user ID, browser
+details, and other information.
 
-Event names correspond to methods in the
-[AnalyticsEvents](../app/services/analytics_events.rb) mixin. We document these
-with YARD so that we can auto-generate
+Event names correspond to methods in the [AnalyticsEvents](../app/services/analytics_events.rb)
+mixin. We document these with YARD so that we can auto-generate
 [documentation on them in our handbook][analytics-handbook].
 
 > [!NOTE]
 > The convention to name events to match the method name is expected for all new analytics events,
 > but you will find a number of exceptions for analytics which had existed prior to this convention
 > being established.
+
+If you are adding or troubleshooting events, consider running the `watch_events` Makefile target in
+a separate terminal. This command will print formatted event data as it happens, so you can see what
+events are logged as you navigate the application in your local development environment.
+
+```
+make watch_events
+```
+
+You can also watch for specific events by assigning the `EVENT_NAME` environment variable:
+
+```
+EVENT_NAME="Account Page Visited" make watch_events
+```
 
 [analytics-handbook]: https://handbook.login.gov/articles/analytics-events.html
 


### PR DESCRIPTION
## 🛠 Summary of changes

Adds and documents a new `Makefile` helper command used to watch live event logging.

I've had a version of this command in my local `.zshrc` file, and recently I've found myself sharing it with others who are troubleshooting event logging in their local environment.

## 📜 Testing Plan

1. Run `make run` and `make watch_events` in separate terminal processes.
2. Go to http://localhost:3000
3. Navigate the application
4. Observe as events are pretty-printed as you navigate the application, using `jq`

## 👀 Screenshots

![image](https://github.com/18F/identity-idp/assets/1779930/3eaff240-80e6-4e3d-bfc6-730f18a8a2ff)

Appearance may vary by terminal customization settings
