### PR TITLE
Fix bug with missing require in email-deliveries script

### DIFF
--- a/bin/oncall/email-deliveries
+++ b/bin/oncall/email-deliveries
@@ -4,6 +4,7 @@
 Dir.chdir(__dir__) { require 'bundler/setup' }
 
 require 'active_support'
+require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/enumerable' # index_by
 require 'active_support/core_ext/integer/time'
 require 'optparse'


### PR DESCRIPTION
## 🛠 Summary of changes

The script makes use of `#present?` and fails without the require:

```
/Users/mitchellehenke/projects/identity-idp/lib/reporting/cloudwatch_client.rb:231:in `slice_time_range': undefined method `present?' for nil:NilClass (NoMethodError)

      if time_slices.present?
                    ^^^^^^^^^
        from /Users/mitchellehenke/projects/identity-idp/lib/reporting/cloudwatch_client.rb:64:in `fetch'
        from bin/oncall/email-deliveries:91:in `block in query_data'
        from /Users/mitchellehenke/projects/identity-idp/lib/reporting/unknown_progress_bar.rb:24:in `wrap'
        from bin/oncall/email-deliveries:90:in `query_data'
        from bin/oncall/email-deliveries:60:in `run'
        from bin/oncall/email-deliveries:150:in `<main>'
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
