### PR TITLE
Jmax/lg 11294 add aria tags to cancel idv verify screen

### DIFF
--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -34,7 +34,9 @@
             method: :delete,
             big: true,
             wide: true,
-          ).with_content(t('idv.cancel.actions.start_over')) %>
+            form: { 'aria-label': t('idv.cancel.actions.start_over') },
+          ).with_content(t('idv.cancel.actions.start_over'))
+      %>
       <div class="margin-top-2">
         <%= render ButtonComponent.new(
               action: ->(**tag_options, &block) do
@@ -44,6 +46,7 @@
               big: true,
               wide: true,
               outline: true,
+              form: { 'aria-label': t('idv.cancel.actions.keep_going') },
             ).with_content(t('idv.cancel.actions.keep_going')) %>
       </div>
     </div>
@@ -65,7 +68,10 @@
             big: true,
             wide: true,
             outline: true,
-            form: { data: { form_steps_wait: '' } },
+            form: {
+              "aria-label": @presenter.exit_action_text,
+              data: { form_steps_wait: '' },
+            },
           ).with_content(@presenter.exit_action_text) %>
     </div>
   <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "0300e0665f4940ef0db57c7d483c5517e8b979314a36a15f699f192278339727",
+      "fingerprint": "406a2c5ea3d852268958d2db11c146841491b6e87cee9c583dd35f5f41898fb7",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/idv/cancellations/new.html.erb",
-      "line": 41,
+      "line": 43,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => ButtonComponent.new(:action => (lambda do\n button_to(idv_cancel_path(:step => params[:step]), { **tag_options }, &block)\n end), :method => :put, :big => true, :wide => true, :outline => true).with_content(t(\"idv.cancel.actions.keep_going\")), {})",
+      "code": "render(action => ButtonComponent.new(:action => (lambda do\n button_to(idv_cancel_path(:step => params[:step]), { **tag_options }, &block)\n end), :method => :put, :big => true, :wide => true, :outline => true, :form => ({ :\"aria-label\" => t(\"idv.cancel.actions.keep_going\") })).with_content(t(\"idv.cancel.actions.keep_going\")), {})",
       "render_path": [
         {
           "type": "controller",
@@ -37,13 +37,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "5bb8762cb8e92a80dabc5dbbe689746d93d00cb3caf4208917bb2f971307710b",
+      "fingerprint": "8b51f403181f74421f5681ada1096371e1f55fb03d0127db01b5e5da7dda3c51",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/idv/cancellations/new.html.erb",
       "line": 32,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => ButtonComponent.new(:action => (lambda do\n button_to(idv_session_path(:step => params[:step]), { **tag_options }, &block)\n end), :method => :delete, :big => true, :wide => true).with_content(t(\"idv.cancel.actions.start_over\")), {})",
+      "code": "render(action => ButtonComponent.new(:action => (lambda do\n button_to(idv_session_path(:step => params[:step]), { **tag_options }, &block)\n end), :method => :delete, :big => true, :wide => true, :form => ({ :\"aria-label\" => t(\"idv.cancel.actions.start_over\") })).with_content(t(\"idv.cancel.actions.start_over\")), {})",
       "render_path": [
         {
           "type": "controller",
@@ -71,13 +71,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "ffc1a9fa8c18bd803bf353cbaebf0c8ca890b71574cedc4efded0dda941a4719",
+      "fingerprint": "f7d01c6318e6ce369f9fe9bf59b6a3a323034b4b826e2a52a9a87b581d468598",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/idv/cancellations/new.html.erb",
-      "line": 62,
+      "line": 65,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => SpinnerButtonComponent.new(:action => (lambda do\n button_to(idv_cancel_path(:step => params[:step], :location => \"cancel\"), { **tag_options }, &block)\n end), :method => :delete, :big => true, :wide => true, :outline => true, :form => ({ :data => ({ :form_steps_wait => \"\" }) })).with_content(CancellationsPresenter.new(:sp_name => decorated_sp_session.sp_name, :url_options => url_options).exit_action_text), {})",
+      "code": "render(action => SpinnerButtonComponent.new(:action => (lambda do\n button_to(idv_cancel_path(:step => params[:step], :location => \"cancel\"), { **tag_options }, &block)\n end), :method => :delete, :big => true, :wide => true, :outline => true, :form => ({ :\"aria-label\" => CancellationsPresenter.new(:sp_name => decorated_sp_session.sp_name, :url_options => url_options).exit_action_text, :data => ({ :form_steps_wait => \"\" }) })).with_content(CancellationsPresenter.new(:sp_name => decorated_sp_session.sp_name, :url_options => url_options).exit_action_text), {})",
       "render_path": [
         {
           "type": "controller",
@@ -103,6 +103,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-09-14 11:53:14 -0400",
+  "updated": "2023-11-02 09:34:28 -0400",
   "brakeman_version": "6.0.1"
 }

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -28,7 +28,19 @@ RSpec.describe 'cancel IdV' do
       hash_including(step: 'agreement'),
     )
 
-    click_on t('idv.cancel.actions.keep_going')
+    expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
+      have_name(t('idv.cancel.actions.start_over')),
+    )
+
+    expect(page.find_button(t('idv.cancel.actions.account_page'))).to(
+      have_name(t('idv.cancel.actions.account_page')),
+    )
+
+    expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
+      have_name(t('idv.cancel.actions.keep_going')),
+    )
+
+    click_on(t('idv.cancel.actions.keep_going'))
 
     expect(current_path).to eq(original_path)
     expect(fake_analytics).to have_logged_event(
@@ -45,6 +57,18 @@ RSpec.describe 'cancel IdV' do
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation visited',
       hash_including(step: 'agreement'),
+    )
+
+    expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
+      have_name(t('idv.cancel.actions.start_over')),
+    )
+
+    expect(page.find_button(t('idv.cancel.actions.account_page'))).to(
+      have_name(t('idv.cancel.actions.account_page')),
+    )
+
+    expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
+      have_name(t('idv.cancel.actions.keep_going')),
     )
 
     click_on t('idv.cancel.actions.start_over')
@@ -64,6 +88,18 @@ RSpec.describe 'cancel IdV' do
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation visited',
       hash_including(step: 'agreement'),
+    )
+
+    expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
+      have_name(t('idv.cancel.actions.start_over')),
+    )
+
+    expect(page.find_button(t('idv.cancel.actions.account_page'))).to(
+      have_name(t('idv.cancel.actions.account_page')),
+    )
+
+    expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
+      have_name(t('idv.cancel.actions.keep_going')),
     )
 
     click_spinner_button_and_wait t('idv.cancel.actions.account_page')
@@ -94,6 +130,18 @@ RSpec.describe 'cancel IdV' do
         proofing_components: { document_check: 'mock', document_type: 'state_id' },
         request_came_from: 'idv/ssn#show',
         step: 'ssn',
+      )
+
+      expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
+        have_name(t('idv.cancel.actions.start_over')),
+      )
+
+      expect(page.find_button(t('idv.cancel.actions.account_page'))).to(
+        have_name(t('idv.cancel.actions.account_page')),
+      )
+
+      expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
+        have_name(t('idv.cancel.actions.keep_going')),
       )
 
       click_on t('idv.cancel.actions.keep_going')
@@ -142,6 +190,18 @@ RSpec.describe 'cancel IdV' do
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation visited',
         hash_including(step: 'agreement'),
+      )
+
+      expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
+        have_name(t('idv.cancel.actions.start_over')),
+      )
+
+      expect(page.find_button(t('idv.cancel.actions.exit', app_name: APP_NAME))).to(
+        have_name(t('idv.cancel.actions.exit', app_name: APP_NAME)),
+      )
+
+      expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
+        have_name(t('idv.cancel.actions.keep_going')),
       )
 
       click_spinner_button_and_wait t('idv.cancel.actions.exit', app_name: APP_NAME)

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -28,17 +28,9 @@ RSpec.describe 'cancel IdV' do
       hash_including(step: 'agreement'),
     )
 
-    expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
-      have_name(t('idv.cancel.actions.start_over')),
-    )
-
-    expect(page.find_button(t('idv.cancel.actions.account_page'))).to(
-      have_name(t('idv.cancel.actions.account_page')),
-    )
-
-    expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
-      have_name(t('idv.cancel.actions.keep_going')),
-    )
+    expect(page).to have_button(t('idv.cancel.actions.start_over'))
+    expect(page).to have_button(t('idv.cancel.actions.account_page'))
+    expect(page).to have_button(t('idv.cancel.actions.keep_going'))
 
     click_on(t('idv.cancel.actions.keep_going'))
 
@@ -59,17 +51,9 @@ RSpec.describe 'cancel IdV' do
       hash_including(step: 'agreement'),
     )
 
-    expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
-      have_name(t('idv.cancel.actions.start_over')),
-    )
-
-    expect(page.find_button(t('idv.cancel.actions.account_page'))).to(
-      have_name(t('idv.cancel.actions.account_page')),
-    )
-
-    expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
-      have_name(t('idv.cancel.actions.keep_going')),
-    )
+    expect(page).to have_button(t('idv.cancel.actions.start_over'))
+    expect(page).to have_button(t('idv.cancel.actions.account_page'))
+    expect(page).to have_button(t('idv.cancel.actions.keep_going'))
 
     click_on t('idv.cancel.actions.start_over')
 
@@ -90,17 +74,9 @@ RSpec.describe 'cancel IdV' do
       hash_including(step: 'agreement'),
     )
 
-    expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
-      have_name(t('idv.cancel.actions.start_over')),
-    )
-
-    expect(page.find_button(t('idv.cancel.actions.account_page'))).to(
-      have_name(t('idv.cancel.actions.account_page')),
-    )
-
-    expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
-      have_name(t('idv.cancel.actions.keep_going')),
-    )
+    expect(page).to have_button(t('idv.cancel.actions.start_over'))
+    expect(page).to have_button(t('idv.cancel.actions.account_page'))
+    expect(page).to have_button(t('idv.cancel.actions.keep_going'))
 
     click_spinner_button_and_wait t('idv.cancel.actions.account_page')
 
@@ -132,17 +108,9 @@ RSpec.describe 'cancel IdV' do
         step: 'ssn',
       )
 
-      expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
-        have_name(t('idv.cancel.actions.start_over')),
-      )
-
-      expect(page.find_button(t('idv.cancel.actions.account_page'))).to(
-        have_name(t('idv.cancel.actions.account_page')),
-      )
-
-      expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
-        have_name(t('idv.cancel.actions.keep_going')),
-      )
+      expect(page).to have_button(t('idv.cancel.actions.start_over'))
+      expect(page).to have_button(t('idv.cancel.actions.account_page'))
+      expect(page).to have_button(t('idv.cancel.actions.keep_going'))
 
       click_on t('idv.cancel.actions.keep_going')
 
@@ -192,17 +160,9 @@ RSpec.describe 'cancel IdV' do
         hash_including(step: 'agreement'),
       )
 
-      expect(page.find_button(t('idv.cancel.actions.start_over'))).to(
-        have_name(t('idv.cancel.actions.start_over')),
-      )
-
-      expect(page.find_button(t('idv.cancel.actions.exit', app_name: APP_NAME))).to(
-        have_name(t('idv.cancel.actions.exit', app_name: APP_NAME)),
-      )
-
-      expect(page.find_button(t('idv.cancel.actions.keep_going'))).to(
-        have_name(t('idv.cancel.actions.keep_going')),
-      )
+      expect(page).to have_button(t('idv.cancel.actions.start_over'))
+      expect(page).to have_button(t('idv.cancel.actions.exit', app_name: APP_NAME))
+      expect(page).to have_button(t('idv.cancel.actions.keep_going'))
 
       click_spinner_button_and_wait t('idv.cancel.actions.exit', app_name: APP_NAME)
 

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe 'cancel IdV' do
       hash_including(step: 'agreement'),
     )
 
+    expect(page).to have_unique_form_landmark_labels
+
     expect(page).to have_button(t('idv.cancel.actions.start_over'))
     expect(page).to have_button(t('idv.cancel.actions.account_page'))
     expect(page).to have_button(t('idv.cancel.actions.keep_going'))
@@ -51,6 +53,8 @@ RSpec.describe 'cancel IdV' do
       hash_including(step: 'agreement'),
     )
 
+    expect(page).to have_unique_form_landmark_labels
+
     expect(page).to have_button(t('idv.cancel.actions.start_over'))
     expect(page).to have_button(t('idv.cancel.actions.account_page'))
     expect(page).to have_button(t('idv.cancel.actions.keep_going'))
@@ -73,6 +77,8 @@ RSpec.describe 'cancel IdV' do
       'IdV: cancellation visited',
       hash_including(step: 'agreement'),
     )
+
+    expect(page).to have_unique_form_landmark_labels
 
     expect(page).to have_button(t('idv.cancel.actions.start_over'))
     expect(page).to have_button(t('idv.cancel.actions.account_page'))
@@ -107,6 +113,8 @@ RSpec.describe 'cancel IdV' do
         request_came_from: 'idv/ssn#show',
         step: 'ssn',
       )
+
+      expect(page).to have_unique_form_landmark_labels
 
       expect(page).to have_button(t('idv.cancel.actions.start_over'))
       expect(page).to have_button(t('idv.cancel.actions.account_page'))
@@ -163,6 +171,8 @@ RSpec.describe 'cancel IdV' do
       expect(page).to have_button(t('idv.cancel.actions.start_over'))
       expect(page).to have_button(t('idv.cancel.actions.exit', app_name: APP_NAME))
       expect(page).to have_button(t('idv.cancel.actions.keep_going'))
+
+      expect(page).to have_unique_form_landmark_labels
 
       click_spinner_button_and_wait t('idv.cancel.actions.exit', app_name: APP_NAME)
 

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -149,7 +149,7 @@ RSpec::Matchers.define :have_unique_form_landmark_labels do
   match do |page|
     labels = landmarks(page).map { |element| AccessibleName.new(page:).computed_name(element) }
 
-    labels.none?(&:nil?) && labels.uniq.length == labels.length
+    labels.one? || labels.compact.uniq.length == labels.length
   end
 
   failure_message do |page|

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -208,6 +208,15 @@ class AccessibleName
     nil
   end
 
+  def button_to_name(element)
+    # Handle the special case where the element is a button generated
+    # with Rails' `button_to` helper. In this case, the aria tags go
+    # on the enclosing form which `button_to` generates.
+    element.tag_name == 'button' && element.ancestor('form.button_to')['aria-label']
+  rescue Capybara::ElementNotFound
+    nil
+  end
+
   def ancestor_label_text_name(element)
     # "Otherwise, if the current node is a control embedded within the label"
     descendent_name(element.find(:xpath, 'ancestor::label'))

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -168,8 +168,7 @@ class AccessibleName
       aria_label_name(element) ||
       referenced_label_name(element) ||
       ancestor_label_text_name(element) ||
-      fieldset_legend_name(element) ||
-      name_for_button_to(element)
+      fieldset_legend_name(element)
   end
 
   private
@@ -205,15 +204,6 @@ class AccessibleName
     # (e.g. HTML label) that defines a text alternative, return that alternative in the form of a
     # flat string as defined by the host language"
     descendent_name(page.find("label[for='#{element['id']}']"))
-  rescue Capybara::ElementNotFound
-    nil
-  end
-
-  def name_for_button_to(element)
-    # Handle the special case where the element is a button generated
-    # with Rails' `button_to` helper. In this case, the aria tags go
-    # on the enclosing form which `button_to` generates.
-    element.tag_name == 'button' && element.ancestor('form.button_to')['aria-label']
   rescue Capybara::ElementNotFound
     nil
   end

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -168,7 +168,8 @@ class AccessibleName
       aria_label_name(element) ||
       referenced_label_name(element) ||
       ancestor_label_text_name(element) ||
-      fieldset_legend_name(element)
+      fieldset_legend_name(element) ||
+      name_for_button_to(element)
   end
 
   private
@@ -208,7 +209,7 @@ class AccessibleName
     nil
   end
 
-  def button_to_name(element)
+  def name_for_button_to(element)
     # Handle the special case where the element is a button generated
     # with Rails' `button_to` helper. In this case, the aria tags go
     # on the enclosing form which `button_to` generates.

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -135,7 +135,7 @@ RSpec::Matchers.define :have_name do |name|
   failure_message do |element|
     <<-STR.squish
       Expected element would have computed name "#{name}".
-      Found #{computed_name(element)}.
+      Found #{AccessibleName.new(page:).computed_name(element)}.
     STR
   end
 end

--- a/spec/support/matchers/aria_view_matchers.rb
+++ b/spec/support/matchers/aria_view_matchers.rb
@@ -1,9 +1,27 @@
+# Very minimal start on accessibility matchers for view specs.
+# Defines one matcher, specific to buttons generated with Rails'
+# `button_to` helper
+#
+# Matcher: `have_button_to_with_accessibility`
+# Use:
+#
+# expect(rendered).to have_button_to_with_accessibility('expected button text',
+#                                                       'expected button action')
+# or
+#
+# expect(rendered).to have_button_to_with_accessibility('expected button text',
+#                                                       'expected button action',
+#                                                       'expected aria label')
+#
+# In the first case, the expected aria-label attribute value will be
+# the expected button text.
+
 class HaveButtonToWithAccessibilityMatcher
   attr_reader :expected_button_text, :expected_action, :expected_aria_label, :actual
 
   def initialize(expected_button_text,
                  expected_action,
-                 expected_aria_label = expected_button_text)
+                 expected_aria_label)
     @expected_button_text = expected_button_text
     @expected_aria_label = expected_aria_label
     @expected_action = expected_action
@@ -19,10 +37,10 @@ class HaveButtonToWithAccessibilityMatcher
     return "expected to find button with text '#{expected_button_text}'" unless button
     return 'expected button to be in a (Rails) "button_to" form tag' unless enclosing_form
 
-    message = ''
-    message += aria_label_failure_message unless aria_label_ok?
-    message += action_failure_message unless action_ok?
-    message
+    messages = []
+    messages += aria_label_failure_message unless aria_label_ok?
+    messages += action_failure_message unless action_ok?
+    messages.join("\n")
   end
 
   private
@@ -56,8 +74,16 @@ class HaveButtonToWithAccessibilityMatcher
   end
 end
 
-RSpec::Matchers.define :have_button_to_with_accessibility do |expected_button_text, expected_action|
-  matcher = HaveButtonToWithAccessibilityMatcher.new(expected_button_text, expected_action)
+RSpec::Matchers.define :have_button_to_with_accessibility do |expected_button_text,
+                                                              expected_action,
+                                                              expected_aria_label =
+                                                                expected_button_text|
+  matcher = HaveButtonToWithAccessibilityMatcher.new(
+    expected_button_text,
+    expected_action,
+    expected_aria_label,
+  )
+
   match { |actual_text| matcher.match(actual_text) }
   failure_message { |actual_text| matcher.failure_message(actual_text) }
 end

--- a/spec/support/matchers/aria_view_matchers.rb
+++ b/spec/support/matchers/aria_view_matchers.rb
@@ -10,13 +10,12 @@ class HaveButtonToWithAccessibilityMatcher
   end
 
   def match(actual_text)
-    @actual ||= Capybara.string(actual_text)
+    @actual = Capybara.string(actual_text.strip)
 
     button && enclosing_form && aria_label_ok? && action_ok?
   end
 
-  def failure_message(actual_text)
-    @actual ||= Capybara.string(actual_text)
+  def failure_message(_actual_text)
     return "expected to find button with text '#{expected_button_text}'" unless button
     return 'expected button to be in a (Rails) "button_to" form tag' unless enclosing_form
 
@@ -29,8 +28,6 @@ class HaveButtonToWithAccessibilityMatcher
   private
 
   def button
-    puts "expected_button_text: #{expected_button_text.inspect}"
-
     actual.find_button(expected_button_text)
   rescue Capybara::ElementNotFound
     return nil

--- a/spec/support/matchers/aria_view_matchers.rb
+++ b/spec/support/matchers/aria_view_matchers.rb
@@ -1,0 +1,66 @@
+class HaveButtonToWithAccessibilityMatcher
+  attr_reader :expected_button_text, :expected_action, :expected_aria_label, :actual
+
+  def initialize(expected_button_text,
+                 expected_action,
+                 expected_aria_label = expected_button_text)
+    @expected_button_text = expected_button_text
+    @expected_aria_label = expected_aria_label
+    @expected_action = expected_action
+  end
+
+  def match(actual_text)
+    @actual ||= Capybara.string(actual_text)
+
+    button && enclosing_form && aria_label_ok? && action_ok?
+  end
+
+  def failure_message(actual_text)
+    @actual ||= Capybara.string(actual_text)
+    return "expected to find button with text '#{expected_button_text}'" unless button
+    return 'expected button to be in a (Rails) "button_to" form tag' unless enclosing_form
+
+    message = ''
+    message += aria_label_failure_message unless aria_label_ok?
+    message += action_failure_message unless action_ok?
+    message
+  end
+
+  private
+
+  def button
+    puts "expected_button_text: #{expected_button_text.inspect}"
+
+    actual.find_button(expected_button_text)
+  rescue Capybara::ElementNotFound
+    return nil
+  end
+
+  def enclosing_form
+    button&.ancestor('form.button_to')
+  rescue Capybara::ElementNotFound
+    return nil
+  end
+
+  def aria_label_ok?
+    enclosing_form && enclosing_form['aria-label'] == expected_aria_label
+  end
+
+  def aria_label_failure_message
+    "expected enclosing form to have an 'aria-label' attribute with value '#{expected_aria_label}'"
+  end
+
+  def action_ok?
+    enclosing_form && enclosing_form['action'] == expected_action
+  end
+
+  def action_failure_message
+    "expected enclosing form to have an 'action' attribute with value '#{expected_action}'"
+  end
+end
+
+RSpec::Matchers.define :have_button_to_with_accessibility do |expected_button_text, expected_action|
+  matcher = HaveButtonToWithAccessibilityMatcher.new(expected_button_text, expected_action)
+  match { |actual_text| matcher.match(actual_text) }
+  failure_message { |actual_text| matcher.failure_message(actual_text) }
+end

--- a/spec/views/idv/cancellations/new.html.erb_spec.rb
+++ b/spec/views/idv/cancellations/new.html.erb_spec.rb
@@ -14,22 +14,32 @@ RSpec.describe 'idv/cancellations/new.html.erb' do
     render
   end
 
-  it 'renders action to start over' do
-    expect(rendered).to have_button(t('idv.cancel.actions.start_over'))
+  it 'renders an action to keep going, with the correct aria attributes' do
+    expect(rendered).to have_button_to_with_accessibility(
+      t('idv.cancel.actions.keep_going'),
+      idv_cancel_path(step: params[:step]),
+    )
   end
 
-  it 'renders action to keep going' do
-    expect(rendered).to have_text(t('idv.cancel.actions.keep_going'))
+  it 'renders action to start over, with the correct aria attributes' do
+    expect(rendered).to have_button_to_with_accessibility(
+      t('idv.cancel.actions.start_over'),
+      idv_session_path(step: params[:step]),
+    )
   end
 
-  it 'renders action to exit and go to account page' do
+  it 'renders action to exit and go to account page, with the correct aria attributes' do
     expect(rendered).to have_content(t('idv.cancel.headings.exit.without_sp'))
     t(
       'idv.cancel.description.exit.without_sp',
       app_name: APP_NAME,
       account_page_text: t('idv.cancel.description.account_page'),
     ).each { |expected_p| expect(rendered).to have_content(expected_p) }
-    expect(rendered).to have_button(t('idv.cancel.actions.account_page'))
+
+    expect(rendered).to have_button_to_with_accessibility(
+      t('idv.cancel.actions.account_page'),
+      idv_cancel_path(step: params[:step], location: 'cancel'),
+    )
   end
 
   context 'with hybrid flow' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11294](https://cm-jira.usa.gov/browse/LG-11294)

## 🛠 Summary of changes

- Added `aria-label` attributes to the Rails-generated (via the `button_to` helper) `<form>` tags for the buttons on the 'cancel IdV' screen (the buttons are 'No, keep going', 'Start over', and either 'Go to account page' or 'Exit <<SP>>'
- Added view spec support for testing `button_to` generated forms for aria attributes
- Added feature spec support for testing aria labeling on form landmarks

## 📜 Testing Plan

[The review app for testing is here](https://review-jmax-lg-11-3mz833.review-app.identitysandbox.gov/)

- [ ] Create a user and enter IdV
- [ ] Select 'Cancel' from any of the IdV screens
- [ ] You are now on the 'Cancel IdV' screen. Use the browser's View Source to inspect the HTML, and verify that each of the buttons has the corret 'aria-label' attribute on its enclosing form.
- [ ] Exit IdV, log out, and then start IdV from the Sinatra sample SP app.
- [ ] Examine the HTML for the 'Cancel IdV' screen again, and verify that the aria-label tags are still present.


## 👀 Screenshots

<details>
<summary>Start over button</summary>

![start_over](https://github.com/18F/identity-idp/assets/101212334/c9922b71-9652-4598-a204-1e3ebfb5b75f)

</details>

<details>
<summary>Keep going button</summary>

![keep_going](https://github.com/18F/identity-idp/assets/101212334/3ba2fedb-6b4d-4ef9-86a5-40ba554819cc)

</details>

<details>
<summary>Account page button</summary>

![account_page](https://github.com/18F/identity-idp/assets/101212334/1d94da7b-aeea-46a4-bbbc-0c02d43d3203)

</details>
