### PR TITLE
Add automated communication to account reinstatement (LG-11330)

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -401,6 +401,20 @@ class UserMailer < ActionMailer::Base
     end
   end
 
+  def suspension_confirmed
+    @help_text = t('user_mailer.suspension_confirmed.contact_agency')
+
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: t('user_mailer.suspension_confirmed.subject'))
+    end
+  end
+
+  def account_reinstated
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: t('user_mailer.account_reinstated.subject'))
+    end
+  end
+
   private
 
   def email_should_receive_nonessential_notifications?(email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -137,6 +137,7 @@ class User < ApplicationRecord
     email_addresses.map do |email_address|
       SuspendedEmail.find_with_email(email_address.email)&.destroy
     end
+    send_email_to_all_addresses(:account_reinstated)
   end
 
   def pending_profile

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4517,11 +4517,6 @@ module AnalyticsEvents
     )
   end
 
-  # We sent an email to the user confirming that they will remain suspended
-  def user_suspension_confirmed
-    track_event(:user_suspension_confirmed)
-  end
-
   # Tracks when user suspended
   # @param [Boolean] success
   # @param [String] error_message
@@ -4546,6 +4541,11 @@ module AnalyticsEvents
       'User Suspension: Please call visited', # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
       **extra,
     )
+  end
+
+  # We sent an email to the user confirming that they will remain suspended
+  def user_suspension_confirmed
+    track_event(:user_suspension_confirmed)
   end
 
   # Tracks when USPS in-person proofing enrollment is created

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -273,11 +273,6 @@ module AnalyticsEvents
     track_event('Account Reset: Cancel Account Recovery Options') # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
   end
 
-  # We sent an email to the user confirming that they will remain suspended
-  def confirm_suspended
-    track_event(:user_suspension_confirmed)
-  end
-
   # @param [String] redirect_url URL user was directed to
   # @param [String, nil] step which step
   # @param [String, nil] location which part of a step, if applicable
@@ -4520,6 +4515,11 @@ module AnalyticsEvents
         **extra,
       }.compact,
     )
+  end
+
+  # We sent an email to the user confirming that they will remain suspended
+  def user_suspension_confirmed
+    track_event(:user_suspension_confirmed)
   end
 
   # Tracks when user suspended

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -273,6 +273,11 @@ module AnalyticsEvents
     track_event('Account Reset: Cancel Account Recovery Options') # rubocop:disable IdentityIdp/AnalyticsEventNameLinter
   end
 
+  # We sent an email to the user confirming that they will remain suspended
+  def confirm_suspended
+    track_event(:user_suspension_confirmed)
+  end
+
   # @param [String] redirect_url URL user was directed to
   # @param [String, nil] step which step
   # @param [String, nil] location which part of a step, if applicable

--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -103,13 +103,14 @@
                                       <tr>
                                         <th>
                                           <p>
-                                            <%= (t('mailer.no_reply') + ' ' + t(
-                                                  'mailer.help',
-                                                  link: link_to(
+                                            <%= t('mailer.no_reply') %>
+                                            <%= @help_text || t(
+                                                  'mailer.help_html',
+                                                  link_html: link_to(
                                                     MarketingSite.nice_help_url,
                                                     MarketingSite.help_url,
                                                   ),
-                                                )).html_safe %>
+                                                ) %>
                                           </p>
                                         </th>
                                       </tr>

--- a/app/views/user_mailer/account_reinstated.html.erb
+++ b/app/views/user_mailer/account_reinstated.html.erb
@@ -1,0 +1,13 @@
+<table class="spacer">
+  <tbody>
+    <tr>
+      <td class="s10" height="10px">
+        &nbsp;
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  <%= t('user_mailer.account_reinstated.we_have_finished_reviewing', app_name: APP_NAME) %>
+</p>

--- a/app/views/user_mailer/suspension_confirmed.html.erb
+++ b/app/views/user_mailer/suspension_confirmed.html.erb
@@ -1,0 +1,13 @@
+<table class="spacer">
+  <tbody>
+    <tr>
+      <td class="s10" height="10px">
+        &nbsp;
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  <%= t('user_mailer.suspension_confirmed.remain_locked', app_name: APP_NAME) %>
+</p>

--- a/config/locales/mailer/en.yml
+++ b/config/locales/mailer/en.yml
@@ -4,7 +4,7 @@ en:
     about: About %{app_name}
     email_reuse_notice:
       subject: This email address is already associated with an account.
-    help: If you need help, visit %{link}
+    help_html: If you need help, visit %{link_html}
     logo: '%{app_name} logo'
     no_reply: Please do not reply to this message.
     privacy_policy: Privacy policy

--- a/config/locales/mailer/es.yml
+++ b/config/locales/mailer/es.yml
@@ -4,7 +4,7 @@ es:
     about: Sobre %{app_name}
     email_reuse_notice:
       subject: Este email ya está asociado a una cuenta.
-    help: Si necesita ayuda, visite %{link}
+    help_html: Si necesita ayuda, visite %{link_html}
     logo: '%{app_name} logo'
     no_reply: Por favor, no responda a este mensaje.
     privacy_policy: Póliza de privacidad

--- a/config/locales/mailer/fr.yml
+++ b/config/locales/mailer/fr.yml
@@ -4,7 +4,7 @@ fr:
     about: À propos de %{app_name}
     email_reuse_notice:
       subject: Cette adresse courriel est déjà associée à un compte.
-    help: Si vous avez besoin d’aide, visitez le site %{link}
+    help_html: Si vous avez besoin d’aide, visitez le site %{link_html}
     logo: '%{app_name} logo'
     no_reply: Veuillez ne pas répondre à ce message.
     privacy_policy: Politique de confidentialité

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -1,6 +1,10 @@
 ---
 en:
   user_mailer:
+    account_reinstated:
+      subject: Your account is unlocked
+      we_have_finished_reviewing: We have finished reviewing your %{app_name} account
+        and you can now log back in with your account information.
     account_rejected:
       intro: We couldn’t verify your identity with %{app_name}. Please contact the
         agency whose service you are trying to access.
@@ -303,3 +307,8 @@ en:
         center a call at %{contact_number} and provide this code -
         %{support_code}.
       subject: We couldn’t reset your password
+    suspension_confirmed:
+      contact_agency: Please contact the agency whose service you are trying to access.
+      remain_locked: We have completed our review of your %{app_name} account and your
+        account will remain locked.
+      subject: Your account is locked

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -1,6 +1,10 @@
 ---
 es:
   user_mailer:
+    account_reinstated:
+      subject: Tu cuenta está desbloqueada
+      we_have_finished_reviewing: Hemos terminado de revisar su cuenta de %{app_name}
+        y ya puede volver a iniciar sesión con los datos de su cuenta.
     account_rejected:
       intro: No hemos podido verificar su identidad con %{app_name}. Por favor,
         póngase en contacto con la agencia a cuyo servicio está intentando
@@ -320,3 +324,8 @@ es:
         centro de atención al número %{contact_number} y proporcione este código
         - %{support_code}.
       subject: No pudimos restablecer su contraseña
+    suspension_confirmed:
+      contact_agency: Póngase en contacto con la agencia a cuyo servicio trata de acceder.
+      remain_locked: Ya hemos completado la revisión de su cuenta de %{app_name} así
+        que su cuenta continuará bloqueada.
+      subject: Su cuenta está bloqueada

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -4,7 +4,7 @@ fr:
     account_reinstated:
       subject: Votre compte est déverrouillé
       we_have_finished_reviewing: Nous avons terminé l’examen de votre compte
-        Login.gov et vous pouvez maintenant vous reconnecter avec les
+        %{app_name} et vous pouvez maintenant vous reconnecter avec les
         informations de votre compte.
     account_rejected:
       intro: Nous n’avons pas pu vérifier votre identité avec %{app_name}. Veuillez

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -1,6 +1,11 @@
 ---
 fr:
   user_mailer:
+    account_reinstated:
+      subject: Votre compte est déverrouillé
+      we_have_finished_reviewing: Nous avons terminé l’examen de votre compte
+        Login.gov et vous pouvez maintenant vous reconnecter avec les
+        informations de votre compte.
     account_rejected:
       intro: Nous n’avons pas pu vérifier votre identité avec %{app_name}. Veuillez
         contacter l’agence dont vous essayez d’accéder au service.
@@ -334,3 +339,8 @@ fr:
         appeler notre centre d’appels au %{contact_number} et fournir ce code -
         %{support_code}.
       subject: Nous n’avons pas pu réinitialiser votre mot de passe
+    suspension_confirmed:
+      contact_agency: Veuillez contacter l’agence dont vous essayez d’accéder au service.
+      remain_locked: Nous avons terminé l’examen de votre compte %{app_name} et votre
+        compte restera verrouillé.
+      subject: Votre compte est verrouillé

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -111,6 +111,7 @@ class ActionAccount
         when :confirm_suspend
           if user.suspended?
             user.send_email_to_all_addresses(:suspension_confirmed)
+            analytics(user).confirm_suspended
             log_texts << log_text[:user_emailed]
           else
             log_texts << log_text[:user_is_not_suspended]
@@ -145,6 +146,12 @@ class ActionAccount
         uuids: users.map(&:uuid),
         messages:,
         table:,
+      )
+    end
+
+    def analytics(user)
+      Analytics.new(
+        user: user, request: nil, session: {}, sp: nil,
       )
     end
   end

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -111,7 +111,7 @@ class ActionAccount
         when :confirm_suspend
           if user.suspended?
             user.send_email_to_all_addresses(:suspension_confirmed)
-            analytics(user).confirm_suspended
+            analytics(user).user_suspension_confirmed
             log_texts << log_text[:user_emailed]
           else
             log_texts << log_text[:user_is_not_suspended]

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -38,6 +38,7 @@ class ActionAccount
 
           * #{basename} reinstate-user uuid1 uuid2
 
+          * #{basename} confirm-suspend-user uuid1 uuid2
         Options:
     EOS
   end
@@ -52,6 +53,7 @@ class ActionAccount
       'review-pass' => ReviewPass,
       'suspend-user' => SuspendUser,
       'reinstate-user' => ReinstateUser,
+      'confirm-suspend-user' => ConfirmSuspendUser,
     }[name]
   end
 
@@ -70,8 +72,9 @@ class ActionAccount
         error_activating: "There was an error activating the user's profile. Please try again.",
         past_eligibility: 'User is past the 30 day review eligibility.',
         missing_uuid: 'Error: Could not find user with that UUID',
+        user_emailed: 'User has been emailed',
         user_suspended: 'User has been suspended',
-        user_reinstated: 'User has been reinstated',
+        user_reinstated: 'User has been reinstated and the user has been emailed',
         user_already_suspended: 'User has already been suspended',
         user_is_not_suspended: 'User is not suspended',
       }
@@ -105,6 +108,15 @@ class ActionAccount
           else
             log_texts << log_text[:user_is_not_suspended]
           end
+        when :confirm_suspend
+          if user.suspended?
+            user.send_email_to_all_addresses(:suspension_confirmed)
+            log_texts << log_text[:user_emailed]
+          else
+            log_texts << log_text[:user_is_not_suspended]
+          end
+        else
+          raise "unknown subtask=#{action}"
         end
 
         log_texts.each do |text|
@@ -129,7 +141,7 @@ class ActionAccount
       end
 
       ScriptBase::Result.new(
-        subtask: "#{action}-user",
+        subtask: "#{action.to_s.dasherize}-user",
         uuids: users.map(&:uuid),
         messages:,
         table:,
@@ -337,6 +349,18 @@ class ActionAccount
         args:,
         config:,
         action: :reinstate,
+      )
+    end
+  end
+
+  class ConfirmSuspendUser
+    include UserActions
+
+    def run(args:, config:)
+      perform_user_action(
+        args:,
+        config:,
+        action: :confirm_suspend,
       )
     end
   end

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -313,6 +313,12 @@ RSpec.describe ActionAccount do
       let(:config) { ScriptBase::Config.new(include_missing:) }
       subject(:result) { subtask.run(args:, config:) }
 
+      let(:analytics) { FakeAnalytics.new }
+
+      before do
+        allow(subtask).to receive(:analytics).and_return(analytics)
+      end
+
       it 'emails users that are suspended', aggregate_failures: true do
         expect { result }.to(change { ActionMailer::Base.deliveries.count }.by(1))
 
@@ -327,6 +333,8 @@ RSpec.describe ActionAccount do
 
         expect(result.subtask).to eq('confirm-suspend-user')
         expect(result.uuids).to match_array([user.uuid, suspended_user.uuid])
+
+        expect(analytics).to have_logged_event(:user_suspension_confirmed)
       end
     end
   end

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -284,17 +284,48 @@ RSpec.describe ActionAccount do
       let(:config) { ScriptBase::Config.new(include_missing:) }
       subject(:result) { subtask.run(args:, config:) }
 
-      it 'Suspend a user that is not suspended already', aggregate_failures: true do
+      it 'suspends users that are not suspended already', aggregate_failures: true do
+        expect { result }.to(change { ActionMailer::Base.deliveries.count }.by(1))
+
         expect(result.table).to match_array(
           [
             ['uuid', 'status'],
             [user.uuid, 'User is not suspended'],
-            [suspended_user.uuid, 'User has been reinstated'],
+            [suspended_user.uuid, 'User has been reinstated and the user has been emailed'],
             ['uuid-does-not-exist', 'Error: Could not find user with that UUID'],
           ],
         )
 
         expect(result.subtask).to eq('reinstate-user')
+        expect(result.uuids).to match_array([user.uuid, suspended_user.uuid])
+      end
+    end
+  end
+
+  describe ActionAccount::ConfirmSuspendUser do
+    subject(:subtask) { ActionAccount::ConfirmSuspendUser.new }
+
+    describe '#run' do
+      let(:user) { create(:user) }
+      let(:suspended_user) { create(:user, :suspended) }
+      let(:args) { [suspended_user.uuid, user.uuid, 'uuid-does-not-exist'] }
+      let(:include_missing) { true }
+      let(:config) { ScriptBase::Config.new(include_missing:) }
+      subject(:result) { subtask.run(args:, config:) }
+
+      it 'emails users that are suspended', aggregate_failures: true do
+        expect { result }.to(change { ActionMailer::Base.deliveries.count }.by(1))
+
+        expect(result.table).to match_array(
+          [
+            ['uuid', 'status'],
+            [suspended_user.uuid, 'User has been emailed'],
+            [user.uuid, 'User is not suspended'],
+            ['uuid-does-not-exist', 'Error: Could not find user with that UUID'],
+          ],
+        )
+
+        expect(result.subtask).to eq('confirm-suspend-user')
         expect(result.uuids).to match_array([user.uuid, suspended_user.uuid])
       end
     end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -194,6 +194,20 @@ class UserMailerPreview < ActionMailer::Preview
     ).gpo_reminder
   end
 
+  def suspension_confirmed
+    UserMailer.with(
+      user: user,
+      email_address: email_address_record,
+    ).suspension_confirmed
+  end
+
+  def account_reinstated
+    UserMailer.with(
+      user: user,
+      email_address: email_address_record,
+    ).account_reinstated
+  end
+
   private
 
   def user

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -887,4 +887,26 @@ RSpec.describe UserMailer, type: :mailer do
       )
     end
   end
+
+  describe '#suspension_confirmed' do
+    let(:mail) do
+      UserMailer.with(user: user, email_address: email_address).suspension_confirmed
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+
+    it 'does not link to the help center' do
+      expect(mail.html_part.body).to_not include(MarketingSite.nice_help_url)
+    end
+  end
+
+  describe '#account_reinstated' do
+    let(:mail) do
+      UserMailer.with(user: user, email_address: email_address).account_reinstated
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+  end
 end

--- a/spec/views/layouts/user_mailer.html.erb_spec.rb
+++ b/spec/views/layouts/user_mailer.html.erb_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'layouts/user_mailer.html.erb' do
   it 'includes the support text and link' do
     expect(rendered).to have_content(t('mailer.no_reply'))
     expect(rendered).to have_content(
-      t('mailer.help', app_name: APP_NAME, link: MarketingSite.nice_help_url),
+      t('mailer.help_html', app_name: APP_NAME, link_html: MarketingSite.nice_help_url),
     )
     expect(rendered).to have_link(MarketingSite.nice_help_url, href: MarketingSite.help_url)
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11330](https://cm-jira.usa.gov/browse/LG-11330)

## 🛠 Summary of changes

- Adds automated emails for reinstated users
- Adds new task to confirm suspension (just sends an email)


## 👀 Screenshots

| email | screenshot |
| --- | ---- |
| reinstated |  <img width="583" alt="Screenshot 2023-11-01 at 10 45 23 AM" src="https://github.com/18F/identity-idp/assets/458784/614b72de-0783-4f71-8fcf-3be4822b7702"> |
| confirm suspension | <img width="586" alt="Screenshot 2023-11-01 at 10 45 31 AM" src="https://github.com/18F/identity-idp/assets/458784/0519a853-b2cc-4a2e-ac1c-cf1ceef153e3"> |



