### PR TITLE
Update Monthly Report email logic to match "yesterday" approach

### DIFF
--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -13,7 +13,7 @@ module Reports
       super(*args, **rest)
     end
 
-    def perform(date = Time.zone.today)
+    def perform(date = Time.zone.yesterday)
       @report_date = date
 
       email_addresses = emails.select(&:present?)
@@ -70,7 +70,7 @@ module Reports
 
     def emails
       emails = [IdentityConfig.store.team_agnes_email]
-      if report_date.day == 1
+      if report_date.next_day.day == 1
         emails << IdentityConfig.store.team_all_feds_email
         emails << IdentityConfig.store.team_all_contractors_email
       end

--- a/spec/jobs/reports/monthly_key_metrics_report_spec.rb
+++ b/spec/jobs/reports/monthly_key_metrics_report_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
       and_return(mock_proofing_rate_data)
   end
 
-  it 'sends out a report to the email listed with one total user' do
+  it 'sends out a report to just to team agnes' do
     expect(ReportMailer).to receive(:tables_report).once.with(
       email: [IdentityConfig.store.team_agnes_email],
       subject: 'Monthly Key Metrics Report - 2021-03-02',
@@ -74,22 +74,24 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
     report.perform(report_date)
   end
 
-  it 'sends out a report to the emails listed with two users' do
-    first_of_month_date = report_date - 1
+  context 'when queued from the first of the month' do
+    let(:report_date) { Date.new(2021, 3, 1).prev_day }
 
-    expect(ReportMailer).to receive(:tables_report).once.with(
-      email: [
-        IdentityConfig.store.team_agnes_email,
-        IdentityConfig.store.team_all_feds_email,
-        IdentityConfig.store.team_all_contractors_email,
-      ],
-      subject: 'Monthly Key Metrics Report - 2021-03-01',
-      reports: anything,
-      message: report.preamble,
-      attachment_format: :xlsx,
-    ).and_call_original
+    it 'sends out a report to everybody' do
+      expect(ReportMailer).to receive(:tables_report).once.with(
+        email: [
+          IdentityConfig.store.team_agnes_email,
+          IdentityConfig.store.team_all_feds_email,
+          IdentityConfig.store.team_all_contractors_email,
+        ],
+        subject: 'Monthly Key Metrics Report - 2021-02-28',
+        reports: anything,
+        message: report.preamble,
+        attachment_format: :xlsx,
+      ).and_call_original
 
-    report.perform(first_of_month_date)
+      report.perform(report_date)
+    end
   end
 
   it 'does not send out a report with no emails' do


### PR DESCRIPTION
- After changes in #9503 to make sending reports for the whole month easier, this updates the sending logic to check that for the last day of the month

