### PR TITLE
Add mutex around cloudwatch client progress bar

### DIFF
--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -67,6 +67,7 @@ module Reporting
       end
 
       if show_progress?
+        @progress_bar_mutex = Mutex.new
         @progress_bar = ProgressBar.create(
           starting_at: 0,
           total: queue.size,
@@ -86,7 +87,7 @@ module Reporting
             end_time = range.end.to_i
 
             response = fetch_one(query:, start_time:, end_time:)
-            @progress_bar&.increment
+            with_progress_bar(&:increment)
 
             if ensure_complete_logs? && has_more_results?(response.results.size)
               log(:info, "more results, bisecting: start_time=#{start_time} end_time=#{end_time}")
@@ -95,7 +96,7 @@ module Reporting
               # -1 for current work finishing, +2 for new threads enqueued
               in_progress[range_id] += 1
 
-              @progress_bar&.total += 2
+              with_progress_bar { |progress_bar| progress_bar.total += 2 }
 
               queue << [(start_time..(mid - 1)), range_id]
               queue << [(mid..end_time), range_id]
@@ -131,7 +132,7 @@ module Reporting
       end
 
       until (num_in_progress = in_progress.sum(&:last)).zero?
-        @progress_bar&.refresh
+        with_progress_bar(&:refresh)
         log(:debug, "waiting, num_in_progress=#{num_in_progress}, queue_size=#{queue.size}")
         sleep wait_duration
       end
@@ -141,7 +142,7 @@ module Reporting
       each_result_queue&.close
       result_thread&.value
 
-      @progress_bar&.finish
+      with_progress_bar(&:finish)
 
       results
     ensure
@@ -198,7 +199,9 @@ module Reporting
       if logger
         int_level = Logger.const_get(level.upcase)
         if @progress_bar && int_level >= logger.level
-          @progress_bar.log("#{level.upcase}: #{message}")
+          with_progress_bar do |progress_bar|
+            progress_bar.log("#{level.upcase}: #{message}")
+          end
         else
           logger.add(int_level) { message }
         end
@@ -272,6 +275,13 @@ module Reporting
       end
     end
     # rubocop:enable Rails/TimeZone
+
+    # @yield [ProgressBar]
+    def with_progress_bar
+      @progress_bar_mutex&.synchronize do
+        yield @progress_bar
+      end
+    end
 
     def aws_client
       @aws_client ||= Aws::CloudWatchLogs::Client.new(region: 'us-west-2')


### PR DESCRIPTION
Bug report from @Sgtpluck in Slack

> ```
> WARNING: Your progress bar is currently at 3038 out of 3038 and cannot be incremented. In v2.0.0 this will become a ProgressBar::InvalidProgressError.
> ```

I am not able to repro this easily myself but I am nearly certain it's a multithreaded issue, so an easy way to manage this with with a mutex