### PR TITLE
Start writing decrypted PII to the session based on profile ID

### DIFF
--- a/app/controllers/concerns/ial2_profile_concern.rb
+++ b/app/controllers/concerns/ial2_profile_concern.rb
@@ -1,9 +1,22 @@
 module Ial2ProfileConcern
   extend ActiveSupport::Concern
 
-  def cache_active_profile(raw_password)
+  def cache_profiles(raw_password)
+    pending_profile = current_user.pending_profile
+    if pending_profile.present?
+      cache_profile_and_handle_errors(raw_password, pending_profile)
+    end
+
+    active_profile = current_user.active_profile
+    if active_profile.present?
+      cache_profile_and_handle_errors(raw_password, active_profile)
+    end
+  end
+
+  private
+
+  def cache_profile_and_handle_errors(raw_password, profile)
     cacher = Pii::Cacher.new(current_user, user_session)
-    profile = current_user.active_or_pending_profile
     begin
       cacher.save(raw_password, profile)
     rescue Encryption::EncryptionError => err

--- a/app/controllers/password_capture_controller.rb
+++ b/app/controllers/password_capture_controller.rb
@@ -36,7 +36,7 @@ class PasswordCaptureController < ApplicationController
   end
 
   def handle_valid_password
-    cache_active_profile(password)
+    cache_profiles(password)
     session[:password_attempts] = 0
     redirect_to after_sign_in_path_for(current_user)
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -114,7 +114,7 @@ module Users
 
     def handle_valid_authentication
       sign_in(resource_name, resource)
-      cache_active_profile(auth_params[:password])
+      cache_profiles(auth_params[:password])
       create_user_event(:sign_in_before_2fa)
       EmailAddress.update_last_sign_in_at_on_user_id_and_email(
         user_id: current_user.id,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -68,7 +68,11 @@ module Idv
       self.profile_id = profile.id
       self.personal_key = profile.personal_key
 
-      move_pii_to_user_session(profile_maker.pii_attributes)
+      Pii::Cacher.new(current_user, user_session).save_decrypted_pii(
+        profile_maker.pii_attributes,
+        profile.id,
+      )
+
       associate_in_person_enrollment_with_profile if profile.in_person_verification_pending?
 
       if profile.gpo_verification_pending?
@@ -215,10 +219,6 @@ module Idv
 
     def new_idv_session
       {}
-    end
-
-    def move_pii_to_user_session(pii)
-      Pii::Cacher.new(current_user, user_session).save_decrypted_pii(pii)
     end
 
     def session

--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -28,7 +28,7 @@ class ReactivateAccountSession
   # @param [Pii::Attributes]
   def store_decrypted_pii(pii)
     reactivate_account_session[:validated_personal_key] = true
-    Pii::Cacher.new(@user, session).save_decrypted_pii(pii)
+    Pii::Cacher.new(@user, session).save_decrypted_pii(pii, @user.password_reset_profile.id)
     nil
   end
 

--- a/spec/services/reactivate_account_session_spec.rb
+++ b/spec/services/reactivate_account_session_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe ReactivateAccountSession do
-  let(:user) { build(:user) }
+  let(:user) { create(:user, :proofed) }
   let(:user_session) { {} }
 
   before do
+    user.active_profile.deactivate(:password_reset)
     @reactivate_account_session = ReactivateAccountSession.new(
       user: user,
       user_session: user_session,


### PR DESCRIPTION
This commit builds on #9509. That commit added the ability to write PII to the session under the profile ID associated with that PII.

This commit starts using the functionality added in that PR to start writing both the pending and active profile to the session. Additionally in places where PII is written to the session outside the context of password authentication the corresponding profile ID is passed to the PII cacher.
