### PR TITLE
LG-11302: Add aria labels to forms on hybrid handoff page

### DIFF
--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -47,7 +47,9 @@
           as: :doc_auth,
           url: url_for(type: :mobile, combined: true),
           method: 'PUT',
-          html: { autocomplete: 'off' },
+          html: { autocomplete: 'off',
+                  id: 'form-to-submit-photos-through-mobile',
+                  'aria-label': t('forms.buttons.send_link') },
         ) do |f| %>
       <%= render PhoneInputComponent.new(
             form: f,
@@ -80,6 +82,10 @@
           url: url_for(type: :desktop),
           method: 'PUT',
           class: 'margin-bottom-4',
+          html: {
+            id: 'form-to-submit-photos-through-desktop',
+            'aria-label': t('forms.buttons.upload_photos'),
+          },
         ) do |f| %>
       <%= f.submit t('forms.buttons.upload_photos'), outline: true %>
     <% end %>

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -24,6 +24,14 @@ RSpec.feature 'hybrid_handoff step send link and errors' do
       complete_doc_auth_steps_before_hybrid_handoff_step
     end
 
+    it 'has the forms with the expected aria attributes' do
+      mobile_form = find('#form-to-submit-photos-through-mobile')
+      desktop_form = find('#form-to-submit-photos-through-desktop')
+
+      expect(mobile_form).to have_name(t('forms.buttons.send_link'))
+      expect(desktop_form).to have_name(t('forms.buttons.upload_photos'))
+    end
+
     it 'proceeds to link sent page when user chooses to use phone' do
       expect(fake_attempts_tracker).to receive(
         :idv_document_upload_method_selected,

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -135,7 +135,7 @@ RSpec::Matchers.define :have_name do |name|
   failure_message do |element|
     <<-STR.squish
       Expected element would have computed name "#{name}".
-      Found #{computed_name(element)}.
+      Found #{AccessibleName.new(page:).computed_name(element)}.
     STR
   end
 end

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
       @phone_question_ab_test_bucket = :show_phone_question
     end
 
+    it 'has a form for starting mobile doc auth with an aria label tag' do
+      expect(rendered).to have_selector(
+        :xpath,
+        "//form[@aria-label=\"#{t('forms.buttons.send_link')}\"]",
+      )
+    end
+
+    it 'has a form for starting desktop doc auth with an aria label tag' do
+      expect(rendered).to have_selector(
+        :xpath,
+        "//form[@aria-label=\"#{t('forms.buttons.upload_photos')}\"]",
+      )
+    end
+
     it 'displays the expected headings from the "b" case' do
       expect(rendered).to have_selector('h1', text: t('doc_auth.headings.upload_from_phone'))
       expect(rendered).to have_selector('h2', text: t('doc_auth.headings.switch_to_phone'))
@@ -28,6 +42,20 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
   context 'without show phone question' do
     before do
       @phone_question_ab_test_bucket = :bypass_phone_question
+    end
+
+    it 'has a form for starting mobile doc auth with an aria label tag' do
+      expect(rendered).to have_selector(
+        :xpath,
+        "//form[@aria-label=\"#{t('forms.buttons.send_link')}\"]",
+      )
+    end
+
+    it 'has a form for starting desktop doc auth with an aria label tag' do
+      expect(rendered).to have_selector(
+        :xpath,
+        "//form[@aria-label=\"#{t('forms.buttons.upload_photos')}\"]",
+      )
     end
 
     it 'displays the expected headings from the "a" case' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11302](https://cm-jira.usa.gov/browse/LG-11302)

## 🛠 Summary of changes

An accessibility report revealed that the two forms on this page have a
label of `""`. This is not great since they're both the same and empty.

This commit adds an aria label to them, which will make it more
accessible by adding the forms to the landmarks of the page.

## 📜 Testing Plan

- [ ] Follow the flow to the `/verify/hybrid_handoff` page
- [ ] [Turn on VoiceOver](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac) or other screen reader
- [ ] (if using VoiceOver) [use the Rotor](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac) to go to the landmarks menu and confirm that between `Step progress` and `footer` you see the following:
    - [ ] Send link form
    - [ ] Upload photos form

## 👀 Screenshots

<details>
<summary>Before:</summary>

<img width="716" alt="before_aria_labels" src="https://github.com/18F/identity-idp/assets/35475380/6e3c0767-540f-481f-894b-063a57294a47">

</details>

<details>
<summary>After:</summary>

<img width="724" alt="after_aria_labels" src="https://github.com/18F/identity-idp/assets/35475380/0880e23c-4163-49c0-a9f4-f029f6e07245">

</details>

Co-authored-by: John Maxwell <john.maxwell@gsa.gov>
Co-authored-by: Brittany Greaner <brittany.greaner@gsa.gov>