### PR TITLE
Add "new verified users" to Monthly Key Metrics Report (LG-11164)

### DIFF
--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -51,7 +51,6 @@ module Reports
       @reports ||= [
         # Number of verified users (total) - LG-11148
         active_users_count_report.active_users_count_emailable_report,
-        # Total Annual Users - LG-11150
         total_user_count_report.total_user_count_emailable_report,
         proofing_rate_report.proofing_rate_emailable_report,
         account_deletion_rate_report.account_deletion_emailable_report,

--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -50,7 +50,6 @@ module Reports
     def reports
       @reports ||= [
         # Number of verified users (total) - LG-11148
-        # Number of verified users (new) - LG-11164
         active_users_count_report.active_users_count_emailable_report,
         # Total Annual Users - LG-11150
         total_user_count_report.total_user_count_emailable_report,

--- a/app/services/reporting/total_user_count_report.rb
+++ b/app/services/reporting/total_user_count_report.rb
@@ -10,7 +10,7 @@ module Reporting
 
     def total_user_count_report
       [
-        ['Metric', 'Users', 'Verified users', 'Time Range Start', 'Time Range End'],
+        ['Metric', 'All Users', 'Verified users', 'Time Range Start', 'Time Range End'],
         ['All-time count', total_user_count, verified_user_count, '-', report_date.to_date],
         [
           'New users count',

--- a/spec/services/reporting/total_user_count_report_spec.rb
+++ b/spec/services/reporting/total_user_count_report_spec.rb
@@ -8,16 +8,22 @@ RSpec.describe Reporting::TotalUserCountReport do
 
   let(:expected_report) do
     [
-      ['Metric', 'Value', 'Time Range Start', 'Time Range End'],
-      ['All-time user count', expected_total_count, '-', Date.new(2021, 3, 1)],
-      ['Total verified users', expected_verified_count, '-', Date.new(2021, 3, 1)],
+      ['Metric', 'Users', 'Verified users', 'Time Range Start', 'Time Range End'],
+      ['All-time count', expected_total_count, expected_verified_count, '-', Date.new(2021, 3, 1)],
       [
-        'New verified users',
+        'New users count',
+        expected_new_count,
         expected_new_verified_count,
         Date.new(2021, 3, 1),
         Date.new(2021, 3, 31),
       ],
-      ['Total annual users', expected_annual_count, Date.new(2020, 3, 1), Date.new(2021, 3, 1)],
+      [
+        'Annual users count',
+        expected_annual_count,
+        expected_annual_verified_count,
+        Date.new(2020, 10, 1),
+        Date.new(2021, 9, 30),
+      ],
     ]
   end
 
@@ -38,8 +44,10 @@ RSpec.describe Reporting::TotalUserCountReport do
       before { create(:user) }
       let(:expected_total_count) { 1 }
       let(:expected_verified_count) { 0 }
+      let(:expected_new_count) { 1 }
       let(:expected_new_verified_count) { 0 }
       let(:expected_annual_count) { expected_total_count }
+      let(:expected_annual_verified_count) { 0 }
 
       it_behaves_like 'a report with the specified counts'
     end
@@ -50,8 +58,10 @@ RSpec.describe Reporting::TotalUserCountReport do
 
       let(:expected_total_count) { 2 }
       let(:expected_verified_count) { 0 }
+      let(:expected_new_count) { 1 }
       let(:expected_new_verified_count) { 0 }
       let(:expected_annual_count) { 1 }
+      let(:expected_annual_verified_count) { 0 }
 
       it_behaves_like 'a report with the specified counts'
     end
@@ -65,8 +75,10 @@ RSpec.describe Reporting::TotalUserCountReport do
       end
       let(:expected_total_count) { 2 }
       let(:expected_verified_count) { 1 }
+      let(:expected_new_count) { 2 }
       let(:expected_new_verified_count) { 1 }
       let(:expected_annual_count) { expected_total_count }
+      let(:expected_annual_verified_count) { 1 }
 
       it_behaves_like 'a report with the specified counts'
     end
@@ -80,8 +92,10 @@ RSpec.describe Reporting::TotalUserCountReport do
       # A suspended user is still a total user:
       let(:expected_total_count) { 1 }
       let(:expected_verified_count) { 0 }
+      let(:expected_new_count) { 1 }
       let(:expected_new_verified_count) { 0 }
       let(:expected_annual_count) { 1 }
+      let(:expected_annual_verified_count) { 0 }
 
       it_behaves_like 'a report with the specified counts'
     end
@@ -92,8 +106,10 @@ RSpec.describe Reporting::TotalUserCountReport do
       # A user with a fraud rejection is still a total user
       let(:expected_total_count) { 1 }
       let(:expected_verified_count) { 0 }
+      let(:expected_new_count) { 1 }
       let(:expected_new_verified_count) { 0 }
       let(:expected_annual_count) { 1 }
+      let(:expected_annual_verified_count) { 0 }
 
       it_behaves_like 'a report with the specified counts'
     end

--- a/spec/services/reporting/total_user_count_report_spec.rb
+++ b/spec/services/reporting/total_user_count_report_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe Reporting::TotalUserCountReport do
   let(:expected_report) do
     [
       ['Metric', 'Value', 'Time Range Start', 'Time Range End'],
-      ['All-time user count', expected_total_count, '-', '2021-03-01'],
-      ['Total verified users', expected_verified_count, '-', '2021-03-01'],
-      ['Total annual users', expected_annual_count, '2020-03-01', '2021-03-01'],
+      ['All-time user count', expected_total_count, '-', Date.new(2021, 3, 1)],
+      ['Total verified users', expected_verified_count, '-', Date.new(2021, 3, 1)],
+      [
+        'New verified users',
+        expected_new_verified_count,
+        Date.new(2021, 3, 1),
+        Date.new(2021, 3, 31),
+      ],
+      ['Total annual users', expected_annual_count, Date.new(2020, 3, 1), Date.new(2021, 3, 1)],
     ]
   end
 
@@ -21,8 +27,10 @@ RSpec.describe Reporting::TotalUserCountReport do
 
   describe '#total_user_count_report' do
     shared_examples 'a report with the specified counts' do
-      it 'returns a report with the expected counts' do
-        expect(subject.total_user_count_report).to eq expected_report
+      it 'returns a report with the expected counts', aggregate_failures: true do
+        report.total_user_count_report.zip(expected_report).each do |actual, expected|
+          expect(actual).to eq(expected)
+        end
       end
     end
 
@@ -30,6 +38,7 @@ RSpec.describe Reporting::TotalUserCountReport do
       before { create(:user) }
       let(:expected_total_count) { 1 }
       let(:expected_verified_count) { 0 }
+      let(:expected_new_verified_count) { 0 }
       let(:expected_annual_count) { expected_total_count }
 
       it_behaves_like 'a report with the specified counts'
@@ -41,6 +50,7 @@ RSpec.describe Reporting::TotalUserCountReport do
 
       let(:expected_total_count) { 2 }
       let(:expected_verified_count) { 0 }
+      let(:expected_new_verified_count) { 0 }
       let(:expected_annual_count) { 1 }
 
       it_behaves_like 'a report with the specified counts'
@@ -55,6 +65,7 @@ RSpec.describe Reporting::TotalUserCountReport do
       end
       let(:expected_total_count) { 2 }
       let(:expected_verified_count) { 1 }
+      let(:expected_new_verified_count) { 1 }
       let(:expected_annual_count) { expected_total_count }
 
       it_behaves_like 'a report with the specified counts'
@@ -69,6 +80,7 @@ RSpec.describe Reporting::TotalUserCountReport do
       # A suspended user is still a total user:
       let(:expected_total_count) { 1 }
       let(:expected_verified_count) { 0 }
+      let(:expected_new_verified_count) { 0 }
       let(:expected_annual_count) { 1 }
 
       it_behaves_like 'a report with the specified counts'
@@ -80,6 +92,7 @@ RSpec.describe Reporting::TotalUserCountReport do
       # A user with a fraud rejection is still a total user
       let(:expected_total_count) { 1 }
       let(:expected_verified_count) { 0 }
+      let(:expected_new_verified_count) { 0 }
       let(:expected_annual_count) { 1 }
 
       it_behaves_like 'a report with the specified counts'

--- a/spec/services/reporting/total_user_count_report_spec.rb
+++ b/spec/services/reporting/total_user_count_report_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reporting::TotalUserCountReport do
 
   let(:expected_report) do
     [
-      ['Metric', 'Users', 'Verified users', 'Time Range Start', 'Time Range End'],
+      ['Metric', 'All Users', 'Verified users', 'Time Range Start', 'Time Range End'],
       ['All-time count', expected_total_count, expected_verified_count, '-', Date.new(2021, 3, 1)],
       [
         'New users count',


### PR DESCRIPTION
## 🎫 Ticket

[LG-11164](https://cm-jira.usa.gov/browse/LG-11164)

## 🛠 Summary of changes

Updates total users count section of Monthly Key Metrics Report
- "New verified" means new since the last month
- "Annual" means fiscal year-to-date
- Shows "total users" and "verified users" for each of these



## 👀 Screenshots

| before | after | 
| --- | --- |
|  <img width="611" alt="Screenshot 2023-11-02 at 3 54 37 PM" src="https://github.com/18F/identity-idp/assets/458784/b0fd002c-5b2a-4830-b6a2-962986a62053"> |  <img width="767" alt="Screenshot 2023-11-02 at 3 54 19 PM" src="https://github.com/18F/identity-idp/assets/458784/2cac1f5e-f8ed-423c-8f93-be37d0d66936"> |



