### PR TITLE
Revise title helper as getter setter

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module ApplicationHelper
   # Sets the page title
-  def title(title)
+  def title=(title)
     content_for(:title) { title }
   end
 
@@ -11,7 +11,7 @@ module ApplicationHelper
   # Shows the page title, or raises
   # @return [String]
   # @raise [MissingTitleError]
-  def page_title
+  def title
     content_for(:title).presence || (raise MissingTitleError, 'Missing title')
   rescue MissingTitleError => error
     if IdentityConfig.store.raise_on_missing_title

--- a/app/views/account_reset/cancel/show.html.erb
+++ b/app/views/account_reset/cancel/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account_reset.cancel_request.title') %>
+<% self.title = t('account_reset.cancel_request.title') %>
 
 <%= render PageHeadingComponent.new.with_content(t('account_reset.cancel_request.title')) %>
 

--- a/app/views/account_reset/confirm_delete_account/show.html.erb
+++ b/app/views/account_reset/confirm_delete_account/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account_reset.confirm_delete_account.title') %>
+<% self.title = t('account_reset.confirm_delete_account.title') %>
 <div class="margin-y-2 padding-y-6 padding-x-4 tablet:padding-x-6 border border-error rounded-xl position-relative">
   <%= render AlertIconComponent.new(
         icon_name: :delete,

--- a/app/views/account_reset/confirm_request/show.html.erb
+++ b/app/views/account_reset/confirm_request/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.verify_email') %>
+<% self.title = t('titles.verify_email') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify_email')) %>
 

--- a/app/views/account_reset/delete_account/show.html.erb
+++ b/app/views/account_reset/delete_account/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account_reset.delete_account.title') %>
+<% self.title = t('account_reset.delete_account.title') %>
 
 <%= render PageHeadingComponent.new.with_content(t('account_reset.delete_account.title')) %>
 

--- a/app/views/account_reset/pending/cancel.html.erb
+++ b/app/views/account_reset/pending/cancel.html.erb
@@ -1,4 +1,4 @@
-<% title t('account_reset.pending.cancelled') %>
+<% self.title = t('account_reset.pending.cancelled') %>
 
 <%= render PageHeadingComponent.new.with_content(t('account_reset.pending.cancelled')) %>
 

--- a/app/views/account_reset/pending/confirm.html.erb
+++ b/app/views/account_reset/pending/confirm.html.erb
@@ -1,4 +1,4 @@
-<% title t('account_reset.cancel_request.title') %>
+<% self.title = t('account_reset.cancel_request.title') %>
 
 <p><%= t('account_reset.pending.confirm') %></p>
 

--- a/app/views/account_reset/pending/show.html.erb
+++ b/app/views/account_reset/pending/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account_reset.pending.header') %>
+<% self.title = t('account_reset.pending.header') %>
 
 <%= render PageHeadingComponent.new.with_content(t('account_reset.pending.header')) %>
 

--- a/app/views/account_reset/recovery_options/show.html.erb
+++ b/app/views/account_reset/recovery_options/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account_reset.recovery_options.header') %>
+<% self.title = t('account_reset.recovery_options.header') %>
 <%= render PageHeadingComponent.new.with_content(t('account_reset.recovery_options.header')) %>
 
 <p>

--- a/app/views/account_reset/request/show.html.erb
+++ b/app/views/account_reset/request/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account_reset.request.title') %>
+<% self.title = t('account_reset.request.title') %>
 
 <%= render PageHeadingComponent.new.with_content(t('account_reset.request.title')) %>
 

--- a/app/views/accounts/connected_accounts/show.html.erb
+++ b/app/views/accounts/connected_accounts/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account.navigation.connected_accounts') %>
+<% self.title = t('account.navigation.connected_accounts') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.account.connected_accounts')) %>
 

--- a/app/views/accounts/history/show.html.erb
+++ b/app/views/accounts/history/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account.navigation.history') %>
+<% self.title = t('account.navigation.history') %>
 
 <%= render PageHeadingComponent.new.with_content(t('account.navigation.history')) %>
 

--- a/app/views/accounts/personal_keys/new.html.erb
+++ b/app/views/accounts/personal_keys/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('account.personal_key.get_new') %>
+<% self.title = t('account.personal_key.get_new') %>
 
 <%= render PageHeadingComponent.new.with_content(t('account.personal_key.get_new')) %>
 

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.account') %>
+<% self.title = t('titles.account') %>
 
 <% if @presenter.showing_any_partials? %>
   <div class="margin-bottom-4">

--- a/app/views/accounts/two_factor_authentication/show.html.erb
+++ b/app/views/accounts/two_factor_authentication/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('account.navigation.two_factor_authentication') %>
+<% self.title = t('account.navigation.two_factor_authentication') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.account.two_factor')) %>
 

--- a/app/views/banned_user/show.html.erb
+++ b/app/views/banned_user/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('banned_user.title') %>
+<% self.title = t('banned_user.title') %>
 
 <%= render AlertIconComponent.new(icon_name: :error, class: 'display-block margin-bottom-4') %>
 <%= render PageHeadingComponent.new.with_content(t('banned_user.title')) %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.passwords.change') %>
+<% self.title = t('titles.passwords.change') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.passwords.change')) %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.passwords.forgot') %>
+<% self.title = t('titles.passwords.forgot') %>
 
 <%= render 'shared/sp_alert', section: 'forgot_password' %>
 

--- a/app/views/devise/sessions/bounced.html.erb
+++ b/app/views/devise/sessions/bounced.html.erb
@@ -1,4 +1,4 @@
-<% title t('headings.sp_handoff_bounced', sp_name: @sp_name) %>
+<% self.title = t('headings.sp_handoff_bounced', sp_name: @sp_name) %>
 <%= render PageHeadingComponent.new.with_content(t('headings.sp_handoff_bounced', sp_name: @sp_name)) %>
 <p class='margin-top-2 margin-bottom-2'>
   <%= t(

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.visitors.index') %>
+<% self.title = t('titles.visitors.index') %>
 
 <% if decorated_sp_session.sp_name %>
   <%= render 'sign_up/registrations/sp_registration_heading' %>

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.passwords.change') %>
+<% self.title = t('titles.passwords.change') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.passwords.change')) %>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,7 +2,7 @@
   <%= render 'accounts/nav_auth', enable_mobile_nav: false, greeting: @presenter.header_personalization %>
 <% end %>
 
-<% title t('titles.account') %>
+<% self.title = t('titles.account') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.account.activity')) %>
 

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.verify_email') %>
+<% self.title = t('titles.verify_email') %>
 
 <% if @resend.present? %>
   <%= render 'forgot_password/resend_alert' %>

--- a/app/views/idv/activated.html.erb
+++ b/app/views/idv/activated.html.erb
@@ -1,4 +1,4 @@
-<% title t('idv.titles.activated') %>
+<% self.title = t('idv.titles.activated') %>
 
 <%= render PageHeadingComponent.new.with_content(t('idv.titles.activated')) %>
 

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -7,7 +7,7 @@
       ) %>
 <% end %>
 
-<% title t('titles.doc_auth.address') %>
+<% self.title = t('titles.doc_auth.address') %>
 
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.address')) %>
 

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('doc_auth.headings.lets_go') %>
+<% self.title = t('doc_auth.headings.lets_go') %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(

--- a/app/views/idv/by_mail/enter_code/index.html.erb
+++ b/app/views/idv/by_mail/enter_code/index.html.erb
@@ -8,9 +8,9 @@
 <% end %>
 
 <% if @user_did_not_receive_letter %>
-  <% title t('idv.gpo.did_not_receive_letter.title') %>
+  <% self.title = t('idv.gpo.did_not_receive_letter.title') %>
 <% else %>
-  <% title t('idv.gpo.title') %>
+  <% self.title = t('idv.gpo.title') %>
 <% end %>
 
 <% if !@can_request_another_letter %>

--- a/app/views/idv/by_mail/enter_code/rate_limited.html.erb
+++ b/app/views/idv/by_mail/enter_code/rate_limited.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.verify_profile') %>
+<% self.title = t('titles.verify_profile') %>
 
 <%= render PageHeadingComponent.new.with_content(t('idv.gpo.title')) %>
 

--- a/app/views/idv/by_mail/letter_enqueued/show.html.erb
+++ b/app/views/idv/by_mail/letter_enqueued/show.html.erb
@@ -7,7 +7,7 @@
       ) %>
 <% end %>
 
-<% title t('titles.idv.come_back_soon') %>
+<% self.title = t('titles.idv.come_back_soon') %>
 
 <%= image_tag(
       asset_url('come-back.svg'),

--- a/app/views/idv/by_mail/request_letter/index.html.erb
+++ b/app/views/idv/by_mail/request_letter/index.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.idv.get_letter') %>
+<% self.title = t('titles.idv.get_letter') %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
@@ -68,7 +68,7 @@
         )
     %>
   </p>
-  
+
 <% end %>
 
 <div class="margin-y-5">

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.idv.cancelled') %>
+<% self.title = t('titles.idv.cancelled') %>
 
 <%= render StatusPageComponent.new(status: :error) do |c| %>
   <% c.with_header { t('idv.cancel.headings.confirmation.hybrid') } %>

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.idv.cancellation_prompt') %>
+<% self.title = t('titles.idv.cancellation_prompt') %>
 
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
   <% if @hybrid_session %>

--- a/app/views/idv/enter_password/new.html.erb
+++ b/app/views/idv/enter_password/new.html.erb
@@ -1,4 +1,4 @@
-<% title @title %>
+<% self.title = @title %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(

--- a/app/views/idv/forgot_password/new.html.erb
+++ b/app/views/idv/forgot_password/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.idv.reset_password') %>
+<% self.title = t('titles.idv.reset_password') %>
 
 <%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
   <% c.with_header { t('idv.forgot_password.modal_header') } %>

--- a/app/views/idv/getting_started/show.html.erb
+++ b/app/views/idv/getting_started/show.html.erb
@@ -1,4 +1,4 @@
-<% title @title %>
+<% self.title = @title %>
 
 <%= render JavascriptRequiredComponent.new(
       header: t('idv.getting_started.no_js_header'),

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.doc_auth.hybrid_handoff') %>
+<% self.title = t('titles.doc_auth.hybrid_handoff') %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(

--- a/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
+++ b/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
@@ -7,7 +7,7 @@
       ) %>
 <% end %>
 
-<% title t('titles.doc_auth.switch_back') %>
+<% self.title = t('titles.doc_auth.switch_back') %>
 
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.instructions.switch_back')) %>
 

--- a/app/views/idv/in_person/address.html.erb
+++ b/app/views/idv/in_person/address.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.doc_auth.verify') %>
+<% self.title = t('titles.doc_auth.verify') %>
 
 <% if updating_address %>
   <%= render PageHeadingComponent.new.with_content(t('in_person_proofing.headings.update_address')) %>

--- a/app/views/idv/in_person/address/show.html.erb
+++ b/app/views/idv/in_person/address/show.html.erb
@@ -8,10 +8,10 @@
 <% end %>
 
 <% if updating_address %>
-  <% title t('in_person_proofing.headings.update_address') %>
+  <% self.title = t('in_person_proofing.headings.update_address') %>
   <%= render PageHeadingComponent.new.with_content(t('in_person_proofing.headings.update_address')) %>
 <% else %>
-  <% title t('in_person_proofing.headings.address') %>
+  <% self.title = t('in_person_proofing.headings.address') %>
   <%= render PageHeadingComponent.new.with_content(t('in_person_proofing.headings.address')) %>
 <% end %>
 

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('in_person_proofing.headings.barcode') %>
+<% self.title = t('in_person_proofing.headings.barcode') %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(

--- a/app/views/idv/in_person/ssn/show.html.erb
+++ b/app/views/idv/in_person/ssn/show.html.erb
@@ -18,7 +18,7 @@ locals:
       ) %>
 <% end %>
 
-<% title t('titles.doc_auth.ssn') %>
+<% self.title = t('titles.doc_auth.ssn') %>
 
 <% if updating_ssn %>
   <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.ssn_update')) %>

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.doc_auth.verify') %>
+<% self.title = t('titles.doc_auth.verify') %>
 
 <% if updating_state_id %>
   <%= render PageHeadingComponent.new.with_content(t('in_person_proofing.headings.update_state_id')) %>
@@ -122,7 +122,7 @@
           required: true,
         ) %>
   </div>
-    
+
   <h2> <%= t('in_person_proofing.headings.id_address') %> </h2>
     <%= render ValidatedFieldComponent.new(
           name: :identity_doc_address_state,

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -19,7 +19,7 @@ locals:
   <!-- Needed by form steps wait javascript -->
 </div>
 
-<% title t('titles.idv.verify_info') %>
+<% self.title = t('titles.idv.verify_info') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
 <div class='margin-top-4 margin-bottom-2'>

--- a/app/views/idv/in_person/verify_wait.html.erb
+++ b/app/views/idv/in_person/verify_wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { @meta_refresh.to_s } %>
-<% title t('titles.doc_auth.processing_images') %>
+<% self.title = t('titles.doc_auth.processing_images') %>
 
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.info.interstitial_eta')) %>

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -7,7 +7,7 @@
       ) %>
 <% end %>
 
-<% title t('titles.doc_auth.link_sent') %>
+<% self.title = t('titles.doc_auth.link_sent') %>
 
 <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-4') do %>
   <strong class="display-block"><%= t('doc_auth.info.keep_window_open') %></strong>

--- a/app/views/idv/mail_only_warning/show.html.erb
+++ b/app/views/idv/mail_only_warning/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('vendor_outage.alerts.pinpoint.idv.header') %>
+<% self.title = t('vendor_outage.alerts.pinpoint.idv.header') %>
 
 <%= render StepIndicatorComponent.new(
       steps: step_indicator_steps,

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -7,7 +7,7 @@
       ) %>
 <% end %>
 
-<% title t('titles.idv.enter_one_time_code') %>
+<% self.title = t('titles.idv.enter_one_time_code') %>
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.header_text')) %>
 

--- a/app/views/idv/personal_key/show.html.erb
+++ b/app/views/idv/personal_key/show.html.erb
@@ -7,7 +7,7 @@
       ) %>
 <% end %>
 
-<% title t('titles.idv.personal_key') %>
+<% self.title = t('titles.idv.personal_key') %>
 
 <%= render 'shared/personal_key',
            code: @code,

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -10,7 +10,7 @@
 <div id="form-steps-wait-alert">
 </div>
 
-<% title t('titles.idv.phone') %>
+<% self.title = t('titles.idv.phone') %>
 
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice], context: :idv)) %>
 

--- a/app/views/idv/phone_question/show.html.erb
+++ b/app/views/idv/phone_question/show.html.erb
@@ -1,4 +1,4 @@
-<% title @title %>
+<% self.title = @title %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
@@ -10,7 +10,7 @@
 <% end %>
 
 <%= render PageHeadingComponent.new.with_content(@title) %>
-  
+
 <div class="margin-top-4">
   <%= link_to(
         t('doc_auth.buttons.have_phone'),

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.failure.information_not_verified') %>
+<% self.title = t('titles.failure.information_not_verified') %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.doc_auth.doc_capture') %>
+<% self.title = t('titles.doc_auth.doc_capture') %>
 <% content_for :head do %>
   <%= tag.meta name: 'acuant-sdk-initialization-endpoint', content: IdentityConfig.store.acuant_sdk_initialization_endpoint %>
   <%= tag.meta name: 'acuant-sdk-initialization-creds', content: IdentityConfig.store.acuant_sdk_initialization_creds %>

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -17,7 +17,7 @@ else
   troubleshooting_heading = t('components.troubleshooting_options.default_heading')
 end %>
 
-<% title local_assigns.fetch(:title, heading) %>
+<% self.title = local_assigns.fetch(:title, heading) %>
 
 <% if local_assigns[:current_step] and defined?(step_indicator_steps) %>
   <% content_for(:pre_flash_content) do %>

--- a/app/views/idv/ssn/show.html.erb
+++ b/app/views/idv/ssn/show.html.erb
@@ -15,7 +15,7 @@ locals:
       ) %>
 <% end %>
 
-<% title t('titles.doc_auth.ssn') %>
+<% self.title = t('titles.doc_auth.ssn') %>
 
 <% if @ssn_form.updating_ssn? %>
   <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.ssn_update')) %>

--- a/app/views/idv/unavailable/show.html.erb
+++ b/app/views/idv/unavailable/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('idv.titles.unavailable') %>
+<% self.title = t('idv.titles.unavailable') %>
 
 <%= render StatusPageComponent.new(status: :error) do |c| %>
 

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -32,7 +32,7 @@ locals:
   <% end %>
 <% end %>
 
-<% title t('titles.idv.verify_info') %>
+<% self.title = t('titles.idv.verify_info') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
 <div class='margin-top-4 margin-bottom-2'>

--- a/app/views/idv/welcome/_welcome_default.html.erb
+++ b/app/views/idv/welcome/_welcome_default.html.erb
@@ -1,4 +1,4 @@
-<% title t('doc_auth.headings.welcome') %>
+<% self.title = t('doc_auth.headings.welcome') %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(

--- a/app/views/idv/welcome/_welcome_new.html.erb
+++ b/app/views/idv/welcome/_welcome_new.html.erb
@@ -1,4 +1,4 @@
-<% title @title %>
+<% self.title = @title %>
 
 <%= render JavascriptRequiredComponent.new(
       header: t('idv.getting_started.no_js_header'),

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -15,7 +15,7 @@
   <meta content="noindex,nofollow" name="robots" />
   <% end %>
 
-  <title><%= page_title %> | <%= APP_NAME %></title>
+  <title><%= title %> | <%= APP_NAME %></title>
 
   <%= javascript_tag(nonce: true) do %>
     document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.mfa_setup.suggest_second_mfa') %>
+<% self.title = t('titles.mfa_setup.suggest_second_mfa') %>
 
 <%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
 

--- a/app/views/openid_connect/authorization/error.html.erb
+++ b/app/views/openid_connect/authorization/error.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.openid_connect.authorization') %>
+<% self.title = t('titles.openid_connect.authorization') %>
 
 <ul>
   <% @authorize_form.errors.full_messages.each do |message| %>

--- a/app/views/openid_connect/logout/error.html.erb
+++ b/app/views/openid_connect/logout/error.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.openid_connect.logout') %>
+<% self.title = t('titles.openid_connect.logout') %>
 
 <ul>
   <% @logout_form.errors.full_messages.each do |message| %>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -1,4 +1,4 @@
-<% title t('openid_connect.logout.heading', app_name: APP_NAME) %>
+<% self.title = t('openid_connect.logout.heading', app_name: APP_NAME) %>
 
 <div class='text-center'>
   <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.visitors.index') %>
+<% self.title = t('titles.visitors.index') %>
 
 <%= render PageHeadingComponent.new.with_content(password_header) %>
 

--- a/app/views/reactivate_account/index.html.erb
+++ b/app/views/reactivate_account/index.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.reactivate_account') %>
+<% self.title = t('titles.reactivate_account') %>
 
 <div class="no-js">
   <%= render AlertComponent.new(

--- a/app/views/saml_idp/auth/error.html.erb
+++ b/app/views/saml_idp/auth/error.html.erb
@@ -1,4 +1,4 @@
-<% title t('saml_idp.auth.error.title') %>
+<% self.title = t('saml_idp.auth.error.title') %>
 
 <ul>
   <% @saml_request_validator.errors.full_messages.each do |message| %>

--- a/app/views/shared/wait.html.erb
+++ b/app/views/shared/wait.html.erb
@@ -1,4 +1,4 @@
 <%= content_for(:meta_refresh) { '15' } %>
-<% title t('titles.doc_auth.verify') %>
+<% self.title = t('titles.doc_auth.verify') %>
 
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.info.interstitial_eta')) %>

--- a/app/views/sign_up/cancellations/new.html.erb
+++ b/app/views/sign_up/cancellations/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('headings.cancellations.prompt') %>
+<% self.title = t('headings.cancellations.prompt') %>
 
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
   <% c.with_header { t('headings.cancellations.prompt') } %>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -1,4 +1,4 @@
-<% title @presenter.heading %>
+<% self.title = @presenter.heading %>
 <div class="text-center">
   <%= image_tag asset_url(@presenter.image_name), width: 140, alt: @presenter.image_alt, class: 'margin-bottom-2' %>
 </div>

--- a/app/views/sign_up/email_resend/new.html.erb
+++ b/app/views/sign_up/email_resend/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.confirmations.new') %>
+<% self.title = t('titles.confirmations.new') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.confirmations.new')) %>
 <%= simple_form_for(

--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.verify_email') %>
+<% self.title = t('titles.verify_email') %>
 
 <% if @resend_confirmation %>
   <%= render AlertComponent.new(

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.confirmations.show') %>
+<% self.title = t('titles.confirmations.show') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.confirmation.show_hdr')) %>
 

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.registrations.new') %>
+<% self.title = t('titles.registrations.new') %>
 
 <%= render 'shared/sp_alert', section: 'sign_up' %>
 

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -1,4 +1,4 @@
-<% title 'Enter PIV/CAC Test Information' %>
+<% self.title = 'Enter PIV/CAC Test Information' %>
 
 <%= render PageHeadingComponent.new.with_content('Enter PIV/CAC Test Information') %>
 

--- a/app/views/test/push_notification/index.html.erb
+++ b/app/views/test/push_notification/index.html.erb
@@ -1,4 +1,4 @@
-<% title 'Push Notification Events' %>
+<% self.title = 'Push Notification Events' %>
 
 <%= content_for(:meta_refresh) { '15' } %>
 

--- a/app/views/test/saml_test/decode_response.html.erb
+++ b/app/views/test/saml_test/decode_response.html.erb
@@ -1,4 +1,4 @@
-<% title 'Decoded SAML Response' %>
+<% self.title = 'Decoded SAML Response' %>
 
 <h3>Decoded SAML Response</h3>
 

--- a/app/views/test/saml_test/index.html.erb
+++ b/app/views/test/saml_test/index.html.erb
@@ -1,4 +1,4 @@
-<% title 'SAML Test Controller' %>
+<% self.title = 'SAML Test Controller' %>
 
 <h1>SAML Test Controller</h1>
 

--- a/app/views/test/telephony/index.html.erb
+++ b/app/views/test/telephony/index.html.erb
@@ -1,4 +1,4 @@
-<% title 'Outbound calls and messages' %>
+<% self.title = 'Outbound calls and messages' %>
 
 <%= content_for(:meta_refresh) { '15' } %>
 

--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.account_locked') %>
+<% self.title = t('titles.account_locked') %>
 
 <%= render StatusPageComponent.new(status: :error, icon: :lock) do |c| %>
   <% c.with_header { t('titles.account_locked') } %>

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.enter_2fa_code.security_code') %>
+<% self.title = t('titles.enter_2fa_code.security_code') %>
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.backup_code_header_text')) %>
 

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -1,4 +1,4 @@
-<% title @presenter.title %>
+<% self.title = @presenter.title %>
 
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice])) %>
 

--- a/app/views/two_factor_authentication/options/no_option.html.erb
+++ b/app/views/two_factor_authentication/options/no_option.html.erb
@@ -1,3 +1,3 @@
-<% title t('titles.no_auth_option') %>
+<% self.title = t('titles.no_auth_option') %>
 
 <%= t('two_factor_authentication.no_auth_option') %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.enter_2fa_code.one_time_code') %>
+<% self.title = t('titles.enter_2fa_code.one_time_code') %>
 
 <% if @landline_alert %>
   <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-2') do %>

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.enter_2fa_code.security_code') %>
+<% self.title = t('titles.enter_2fa_code.security_code') %>
 
 <%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.personal_key_header_text')) %>
 

--- a/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
+++ b/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.present_piv_cac') %>
+<% self.title = t('titles.present_piv_cac') %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 

--- a/app/views/two_factor_authentication/sms_opt_in/error.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/error.html.erb
@@ -1,4 +1,4 @@
-<% title t('two_factor_authentication.opt_in.title') %>
+<% self.title = t('two_factor_authentication.opt_in.title') %>
 
 <%= render AlertIconComponent.new(icon_name: :error, class: 'margin-bottom-2') %>
 

--- a/app/views/two_factor_authentication/sms_opt_in/new.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('two_factor_authentication.opt_in.title') %>
+<% self.title = t('two_factor_authentication.opt_in.title') %>
 
 <%= render AlertIconComponent.new(icon_name: :warning, class: 'margin-bottom-2') %>
 

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.enter_2fa_code.security_code') %>
+<% self.title = t('titles.enter_2fa_code.security_code') %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.present_webauthn') %>
+<% self.title = t('titles.present_webauthn') %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 

--- a/app/views/users/authorization_confirmation/new.html.erb
+++ b/app/views/users/authorization_confirmation/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.sign_up.confirmation') %>
+<% self.title = t('titles.sign_up.confirmation') %>
 
 <% if decorated_sp_session.sp_name %>
   <%= render 'sign_up/registrations/sp_registration_heading' %>

--- a/app/views/users/backup_code_setup/confirm_backup_codes.html.erb
+++ b/app/views/users/backup_code_setup/confirm_backup_codes.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.backup_codes') %>
+<% self.title = t('titles.backup_codes') %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.backup_codes')) %>
 

--- a/app/views/users/backup_code_setup/confirm_delete.html.erb
+++ b/app/views/users/backup_code_setup/confirm_delete.html.erb
@@ -1,4 +1,4 @@
-<% title t('forms.backup_code.confirm_delete') %>
+<% self.title = t('forms.backup_code.confirm_delete') %>
 
 <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-4') %>
 

--- a/app/views/users/backup_code_setup/create.html.erb
+++ b/app/views/users/backup_code_setup/create.html.erb
@@ -1,4 +1,4 @@
-<% title t('forms.backup_code.title') %>
+<% self.title = t('forms.backup_code.title') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code.title')) %>
 

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('forms.backup_code_regenerate.confirm') %>
+<% self.title = t('forms.backup_code_regenerate.confirm') %>
 
 <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-4') %>
 

--- a/app/views/users/backup_code_setup/index.html.erb
+++ b/app/views/users/backup_code_setup/index.html.erb
@@ -1,4 +1,4 @@
-<% title t('forms.backup_code.are_you_sure_title') %>
+<% self.title = t('forms.backup_code.are_you_sure_title') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code.are_you_sure_title')) %>
 

--- a/app/views/users/backup_code_setup/reminder.html.erb
+++ b/app/views/users/backup_code_setup/reminder.html.erb
@@ -1,4 +1,4 @@
-<% title t('forms.backup_code.title') %>
+<% self.title = t('forms.backup_code.title') %>
 
 <%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
 

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.confirmations.delete') %>
+<% self.title = t('titles.confirmations.delete') %>
 
 <%= render PageHeadingComponent.new.with_content(t('users.delete.heading')) %>
 

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.edit_info.phone') %>
+<% self.title = t('titles.edit_info.phone') %>
 <%= render PageHeadingComponent.new.with_content(t('headings.edit_info.phone')) %>
 
 <%= simple_form_for(

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.edit_info.email_language') %>
+<% self.title = t('titles.edit_info.email_language') %>
 
 <%= render PageHeadingComponent.new.with_content(t('account.email_language.edit_title')) %>
 

--- a/app/views/users/emails/confirm_delete.html.erb
+++ b/app/views/users/emails/confirm_delete.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.confirmations.delete') %>
+<% self.title = t('titles.confirmations.delete') %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.confirm_delete_message) %>
 

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.registrations.new') %>
+<% self.title = t('titles.registrations.new') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.add_email')) %>
 

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.verify_email') %>
+<% self.title = t('titles.verify_email') %>
 
 <% if @resend_confirmation %>
   <%= render AlertComponent.new(

--- a/app/views/users/forget_all_browsers/show.html.erb
+++ b/app/views/users/forget_all_browsers/show.html.erb
@@ -1,4 +1,4 @@
-<%= title t('titles.forget_all_browsers') %>
+<% self.title = t('titles.forget_all_browsers') %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.forget_all_browsers')) %>
 

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.edit_info.password') %>
+<% self.title = t('titles.edit_info.password') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.edit_info.password')) %>
 

--- a/app/views/users/personal_keys/show.html.erb
+++ b/app/views/users/personal_keys/show.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.personal_key') %>
+<% self.title = t('titles.personal_key') %>
 
 <%= render(
       'shared/personal_key',

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -1,4 +1,4 @@
-<%= title t('titles.add_info.phone') %>
+<% self.title = t('titles.add_info.phone') %>
 
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice])) %>
 

--- a/app/views/users/phone_setup/spam_protection.html.erb
+++ b/app/views/users/phone_setup/spam_protection.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.spam_protection') %>
+<% self.title = t('titles.spam_protection') %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.spam_protection')) %>
 

--- a/app/views/users/piv_cac_authentication_setup/error.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/error.html.erb
@@ -1,4 +1,4 @@
-<% title @presenter.title %>
+<% self.title = @presenter.title %>
 
 <%= render PageHeadingComponent.new do %>
   <%= @presenter.heading %>

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -1,4 +1,4 @@
-<% title @presenter.title %>
+<% self.title = @presenter.title %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.piv_cac_login.add')) %>
 

--- a/app/views/users/piv_cac_login/error.html.erb
+++ b/app/views/users/piv_cac_login/error.html.erb
@@ -1,4 +1,4 @@
-<% title @presenter.title %>
+<% self.title = @presenter.title %>
 
 <%= render PageHeadingComponent.new do %>
   <%= @presenter.heading %>

--- a/app/views/users/piv_cac_login/new.html.erb
+++ b/app/views/users/piv_cac_login/new.html.erb
@@ -1,4 +1,4 @@
-<% title @presenter.title %>
+<% self.title = @presenter.title %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 

--- a/app/views/users/piv_cac_setup/confirm_delete.html.erb
+++ b/app/views/users/piv_cac_setup/confirm_delete.html.erb
@@ -1,4 +1,4 @@
-<%= title t('forms.piv_cac_delete.confirm') %>
+<% self.title = t('forms.piv_cac_delete.confirm') %>
 
 <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-4') %>
 

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.piv_cac_login.add') %>
+<% self.title = t('titles.piv_cac_login.add') %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.piv_cac_login.add')) %>
 

--- a/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
@@ -1,4 +1,4 @@
-<% title t('headings.piv_cac_login.success') %>
+<% self.title = t('headings.piv_cac_login.success') %>
 
 <%= image_tag asset_url('alert/success.svg'), size: 90, class: 'margin-bottom-2' %>
 

--- a/app/views/users/rules_of_use/new.html.erb
+++ b/app/views/users/rules_of_use/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.registrations.new') %>
+<% self.title = t('titles.registrations.new') %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.rules_of_use')) %>
 

--- a/app/views/users/second_mfa_reminder/new.html.erb
+++ b/app/views/users/second_mfa_reminder/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('users.second_mfa_reminder.heading') %>
+<% self.title = t('users.second_mfa_reminder.heading') %>
 
 <%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
   <% c.with_header { t('users.second_mfa_reminder.heading') } %>

--- a/app/views/users/service_provider_inactive/index.html.erb
+++ b/app/views/users/service_provider_inactive/index.html.erb
@@ -1,4 +1,4 @@
-<% title t('service_providers.errors.inactive.heading', sp_name: @sp_name, app_name: APP_NAME) %>
+<% self.title = t('service_providers.errors.inactive.heading', sp_name: @sp_name, app_name: APP_NAME) %>
 
 <%= render AlertIconComponent.new(icon_name: :error) %>
 

--- a/app/views/users/service_provider_revoke/show.html.erb
+++ b/app/views/users/service_provider_revoke/show.html.erb
@@ -1,4 +1,4 @@
-<%= title t('titles.revoke_consent') %>
+<% self.title = t('titles.revoke_consent') %>
 
 <%= render PageHeadingComponent.new.with_content(t('titles.revoke_consent')) %>
 

--- a/app/views/users/totp_setup/confirm_delete.html.erb
+++ b/app/views/users/totp_setup/confirm_delete.html.erb
@@ -1,4 +1,4 @@
-<%= title t('forms.totp_delete.confirm') %>
+<% self.title = t('forms.totp_delete.confirm') %>
 
 <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-4') %>
 

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.totp_setup.new') %>
+<% self.title = t('titles.totp_setup.new') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.totp_setup.new')) %>
 

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -1,4 +1,4 @@
-<% title t('titles.two_factor_setup') %>
+<% self.title = t('titles.two_factor_setup') %>
 
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice], context: :voice, only_if_all: true)) %>
 

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('idv.titles.enter_password') %>
+<% self.title = t('idv.titles.enter_password') %>
 
 <%= render PageHeadingComponent.new.with_content(t('idv.titles.session.enter_password', app_name: APP_NAME)) %>
 

--- a/app/views/users/verify_personal_key/new.html.erb
+++ b/app/views/users/verify_personal_key/new.html.erb
@@ -1,4 +1,4 @@
-<% title t('forms.personal_key.title') %>
+<% self.title = t('forms.personal_key.title') %>
 
 <%= simple_form_for('', url: create_verify_personal_key_path, method: 'post', html: { class: 'margin-top-8' }) do |f| %>
   <div class="padding-top-6 padding-bottom-1 padding-x-1 tablet:padding-x-4 position-relative border border-secondary rounded-xl">

--- a/app/views/users/verify_personal_key/rate_limited.html.erb
+++ b/app/views/users/verify_personal_key/rate_limited.html.erb
@@ -1,4 +1,4 @@
-<% title t('headings.verify_personal_key') %>
+<% self.title = t('headings.verify_personal_key') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify_personal_key')) %>
 

--- a/app/views/users/webauthn_setup/delete.html.erb
+++ b/app/views/users/webauthn_setup/delete.html.erb
@@ -1,7 +1,7 @@
 <% if @webauthn.platform_authenticator %>
-    <% title t('forms.webauthn_platform_delete.confirm') %>
+    <% self.title = t('forms.webauthn_platform_delete.confirm') %>
 <% else %>
-    <% title t('forms.webauthn_delete.confirm') %>
+    <% self.title = t('forms.webauthn_delete.confirm') %>
 <% end %>
 
 <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-4') %>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -1,4 +1,4 @@
-<% title @presenter.page_title %>
+<% self.title = @presenter.page_title %>
 
 <%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2' %>
 

--- a/spec/views/account_reset/cancel/show.html.erb_spec.rb
+++ b/spec/views/account_reset/cancel/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'account_reset/cancel/show.html.erb' do
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('account_reset.cancel_request.title'))
+    expect(view).to receive(:title=).with(t('account_reset.cancel_request.title'))
 
     render
   end

--- a/spec/views/account_reset/confirm_delete_account/show.html.erb_spec.rb
+++ b/spec/views/account_reset/confirm_delete_account/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'account_reset/confirm_delete_account/show.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('account_reset.confirm_delete_account.title'))
+    expect(view).to receive(:title=).with(t('account_reset.confirm_delete_account.title'))
 
     render
   end

--- a/spec/views/account_reset/confirm_request/show.html.erb_spec.rb
+++ b/spec/views/account_reset/confirm_request/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'account_reset/confirm_request/show.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.verify_email'))
+    expect(view).to receive(:title=).with(t('titles.verify_email'))
 
     render
   end

--- a/spec/views/account_reset/delete_account/show.html.erb_spec.rb
+++ b/spec/views/account_reset/delete_account/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'account_reset/delete_account/show.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('account_reset.delete_account.title'))
+    expect(view).to receive(:title=).with(t('account_reset.delete_account.title'))
 
     render
   end

--- a/spec/views/account_reset/recovery_options/show.html.erb_spec.rb
+++ b/spec/views/account_reset/recovery_options/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'account_reset/recovery_options/show.html.erb' do
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('account_reset.recovery_options.header'))
+    expect(view).to receive(:title=).with(t('account_reset.recovery_options.header'))
 
     render
   end

--- a/spec/views/account_reset/request/show.html.erb_spec.rb
+++ b/spec/views/account_reset/request/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'account_reset/request/show.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('account_reset.request.title'))
+    expect(view).to receive(:title=).with(t('account_reset.request.title'))
 
     render
   end

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'accounts/show.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.account'))
+    expect(view).to receive(:title=).with(t('titles.account'))
 
     render
   end

--- a/spec/views/devise/passwords/edit.html.erb_spec.rb
+++ b/spec/views/devise/passwords/edit.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'devise/passwords/edit.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.passwords.change'))
+    expect(view).to receive(:title=).with(t('titles.passwords.change'))
 
     render
   end

--- a/spec/views/devise/passwords/new.html.erb_spec.rb
+++ b/spec/views/devise/passwords/new.html.erb_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'devise/passwords/new.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.passwords.forgot'))
+    expect(view).to receive(:title=).with(t('titles.passwords.forgot'))
 
     render
   end

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.visitors.index'))
+    expect(view).to receive(:title=).with(t('titles.visitors.index'))
 
     render
   end

--- a/spec/views/forgot_password/show.html.erb_spec.rb
+++ b/spec/views/forgot_password/show.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'forgot_password/show.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.verify_email'))
+    expect(view).to receive(:title=).with(t('titles.verify_email'))
 
     render
   end

--- a/spec/views/idv/activated.html.erb_spec.rb
+++ b/spec/views/idv/activated.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'idv/activated.html.erb' do
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('idv.titles.activated'))
+    expect(view).to receive(:title=).with(t('idv.titles.activated'))
 
     render
   end

--- a/spec/views/idv/enter_password/new.html.erb_spec.rb
+++ b/spec/views/idv/enter_password/new.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'idv/enter_password/new.html.erb' do
       end
 
       it 'has a localized title' do
-        expect(view).to receive(:title).with(t('titles.idv.enter_password'))
+        expect(view).to receive(:title=).with(t('titles.idv.enter_password'))
 
         render
       end
@@ -47,7 +47,7 @@ RSpec.describe 'idv/enter_password/new.html.erb' do
       end
 
       it 'has a localized title' do
-        expect(view).to receive(:title).with(t('titles.idv.enter_password_letter'))
+        expect(view).to receive(:title=).with(t('titles.idv.enter_password_letter'))
 
         render
       end

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'idv/shared/_error.html.erb' do
       let(:params) { { heading: heading } }
 
       it 'sets title as defaulting to heading' do
-        expect(view).to receive(:title).with(heading)
+        expect(view).to receive(:title=).with(heading)
 
         render 'idv/shared/error', **params
       end
@@ -109,7 +109,7 @@ RSpec.describe 'idv/shared/_error.html.erb' do
       let(:params) { { heading: heading, title: title } }
 
       it 'sets title' do
-        expect(view).to receive(:title).with(title)
+        expect(view).to receive(:title=).with(title)
 
         render 'idv/shared/error', **params
       end

--- a/spec/views/idv/unavailable/show.html.erb_spec.rb
+++ b/spec/views/idv/unavailable/show.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'idv/unavailable/show.html.erb' do
   end
 
   it 'sets a title' do
-    expect(view).to receive(:title).with(t('idv.titles.unavailable'))
+    expect(view).to receive(:title=).with(t('idv.titles.unavailable'))
     render
   end
   it 'has an h1' do

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'layouts/application.html.erb' do
     allow(view).to receive(:current_user).and_return(User.new)
     controller.request.path_parameters[:controller] = 'users/sessions'
     controller.request.path_parameters[:action] = 'new'
-    view.title(title_content) if title_content
+    view.title = title_content if title_content
   end
 
   context 'no content for nav present' do

--- a/spec/views/mfa_confirmation/show.html.erb_spec.rb
+++ b/spec/views/mfa_confirmation/show.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'mfa_confirmation/show.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.mfa_setup.suggest_second_mfa'))
+    expect(view).to receive(:title=).with(t('titles.mfa_setup.suggest_second_mfa'))
 
     render
   end

--- a/spec/views/sign_up/email_resend/new.html.erb_spec.rb
+++ b/spec/views/sign_up/email_resend/new.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'sign_up/email_resend/new.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.confirmations.new'))
+    expect(view).to receive(:title=).with(t('titles.confirmations.new'))
 
     render
   end

--- a/spec/views/sign_up/emails/show.html.erb_spec.rb
+++ b/spec/views/sign_up/emails/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'sign_up/emails/show.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.verify_email'))
+    expect(view).to receive(:title=).with(t('titles.verify_email'))
 
     render
   end

--- a/spec/views/sign_up/registrations/new.html.erb_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.erb_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'sign_up/registrations/new.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.registrations.new'))
+    expect(view).to receive(:title=).with(t('titles.registrations.new'))
 
     render
   end

--- a/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'two_factor_authentication/options/index.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with( \
+    expect(view).to receive(:title=).with( \
       t('two_factor_authentication.login_options_title'),
     )
 

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'two_factor_authentication/otp_verification/show.html.erb' do
 
     context 'common OTP delivery screen behavior' do
       it 'has a localized title' do
-        expect(view).to receive(:title).with(t('titles.enter_2fa_code.one_time_code'))
+        expect(view).to receive(:title=).with(t('titles.enter_2fa_code.one_time_code'))
 
         render
       end

--- a/spec/views/two_factor_authentication/personal_key_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/personal_key_verification/show.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'two_factor_authentication/personal_key_verification/show.html.er
   it_behaves_like 'an otp form'
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.enter_2fa_code.security_code'))
+    expect(view).to receive(:title=).with(t('titles.enter_2fa_code.security_code'))
 
     render
   end

--- a/spec/views/users/backup_code_setup/create.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/create.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'users/backup_code_setup/create.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('forms.backup_code.title'))
+    expect(view).to receive(:title=).with(t('forms.backup_code.title'))
 
     render
   end

--- a/spec/views/users/backup_code_setup/index.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'users/backup_code_setup/index.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(
+    expect(view).to receive(:title=).with(
       t('forms.backup_code.are_you_sure_title'),
     )
 

--- a/spec/views/users/backup_code_setup/reminder.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/reminder.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'users/backup_code_setup/reminder.html.erb' do
   it 'has a localized title' do
-    expect(view).to receive(:title).with( \
+    expect(view).to receive(:title=).with( \
       t('forms.backup_code.title'),
     )
 

--- a/spec/views/users/emails/verify.html.erb_spec.rb
+++ b/spec/views/users/emails/verify.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'users/emails/verify.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.verify_email'))
+    expect(view).to receive(:title=).with(t('titles.verify_email'))
 
     render
   end

--- a/spec/views/users/passwords/edit.html.erb_spec.rb
+++ b/spec/views/users/passwords/edit.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'users/passwords/edit.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.edit_info.password'))
+    expect(view).to receive(:title=).with(t('titles.edit_info.password'))
 
     render
   end

--- a/spec/views/users/webauthn_setup/new.html.erb_spec.rb
+++ b/spec/views/users/webauthn_setup/new.html.erb_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'users/webauthn_setup/new.html.erb' do
     end
 
     it 'has a localized title' do
-      expect(view).to receive(:title).with(presenter.page_title)
+      expect(view).to receive(:title=).with(presenter.page_title)
 
       render
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Changes `page_title` and `title` paired getter / setter helpers to be implemented as `title` and `title=` methods.

Previously: https://github.com/18F/identity-idp/pull/9522#discussion_r1380733488

Process was a project-wide RegExp replacement:

Search: `<%=? title (.+?) %>`
Replace: `<% self.title = $1 %>`