### PR TITLE
fLG-11185 Rename review events to enter password

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -46,7 +46,7 @@ module Idv
 
       redirect_to next_step
 
-      analytics.idv_enter_password_complete(
+      analytics.idv_enter_password_submitted(
         success: true,
         fraud_review_pending: idv_session.profile.fraud_review_pending?,
         fraud_rejection: idv_session.profile.fraud_rejection?,
@@ -93,7 +93,7 @@ module Idv
     def confirm_current_password
       return if valid_password?
 
-      analytics.idv_enter_password_complete(
+      analytics.idv_enter_password_submitted(
         success: false,
         gpo_verification_pending: current_user.gpo_verification_pending_profile?,
         # note: this always returns false as of 8/23

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1090,7 +1090,7 @@ module AnalyticsEvents
   # @param [Boolean] in_person_verification_pending
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
-  def idv_enter_password_complete(
+  def idv_enter_password_submitted(
     success:,
     fraud_review_pending:,
     fraud_rejection:,
@@ -1101,7 +1101,7 @@ module AnalyticsEvents
     **extra
   )
     track_event(
-      'IdV: review complete',
+      :idv_enter_password_submitted,
       success: success,
       deactivation_reason: deactivation_reason,
       fraud_review_pending: fraud_review_pending,
@@ -1124,7 +1124,7 @@ module AnalyticsEvents
     **extra
   )
     track_event(
-      'IdV: review info visited',
+      :idv_enter_password_visited,
       address_verification_method: address_verification_method,
       proofing_components: proofing_components,
       **extra,

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -29,7 +29,7 @@ module Idv
       idv_phone_otp_delivery_selection_visit
       idv_phone_otp_delivery_selection_submitted
       idv_proofing_resolution_result_missing
-      idv_enter_password_complete
+      idv_enter_password_submitted
       idv_enter_password_visited
       idv_please_call_visited
       idv_start_over

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Idv::EnterPasswordController do
         expect(response).to redirect_to idv_enter_password_path
 
         expect(@analytics).to have_logged_event(
-          'IdV: review complete',
+          :idv_enter_password_submitted,
           success: false,
           fraud_review_pending: false,
           fraud_rejection: false,
@@ -276,7 +276,7 @@ RSpec.describe Idv::EnterPasswordController do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         expect(@analytics).to have_logged_event(
-          'IdV: review complete',
+          :idv_enter_password_submitted,
           success: true,
           fraud_review_pending: false,
           fraud_rejection: false,
@@ -612,7 +612,7 @@ RSpec.describe Idv::EnterPasswordController do
                   it 'logs events' do
                     put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
                     expect(@analytics).to have_logged_event(
-                      'IdV: review complete',
+                      :idv_enter_password_submitted,
                       success: true,
                       fraud_review_pending: fraud_review_pending?,
                       fraud_rejection: false,

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -116,11 +116,11 @@ RSpec.feature 'Analytics Regression', js: true do
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review info visited' => {
+      :idv_enter_password_visited => {
         address_verification_method: 'phone', acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review complete' => {
+      :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
@@ -224,11 +224,11 @@ RSpec.feature 'Analytics Regression', js: true do
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review info visited' => {
+      :idv_enter_password_visited => {
         address_verification_method: 'phone', acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review complete' => {
+      :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
@@ -317,7 +317,7 @@ RSpec.feature 'Analytics Regression', js: true do
       'IdV: request letter visited' => {
         letter_already_sent: false,
       },
-      'IdV: review info visited' => {
+      :idv_enter_password_visited => {
         address_verification_method: 'gpo', acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
@@ -325,7 +325,7 @@ RSpec.feature 'Analytics Regression', js: true do
         enqueued_at: Time.zone.now.utc, resend: false, phone_step_attempts: 0, first_letter_requested_at: Time.zone.now.utc, hours_since_first_letter: 0, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
-      'IdV: review complete' => {
+      :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: true, in_person_verification_pending: false, deactivation_reason: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
@@ -434,11 +434,11 @@ RSpec.feature 'Analytics Regression', js: true do
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review info visited' => {
+      :idv_enter_password_visited => {
         acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, address_verification_method: 'phone',
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review complete' => {
+      :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, deactivation_reason: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },


### PR DESCRIPTION
## 🎫 Ticket

[LG-11185](https://cm-jira.usa.gov/browse/LG-11185)

## 🛠 Summary of changes

Old event names:

`IdV: review info visited`
`IdV: review complete`

The new event names now align with our typical scheme, based on the controller name:

`IdV: enter password visited`
`IdV: enter password submitted`

[This PR in the devops repo ](https://github.com/18F/identity-devops/pull/6789)carries these event names into existing dashboards/funnels.