### PR TITLE
Fix translation for email footer help text (account suspension)

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -402,9 +402,9 @@ class UserMailer < ActionMailer::Base
   end
 
   def suspension_confirmed
-    @help_text = t('user_mailer.suspension_confirmed.contact_agency')
-
     with_user_locale(user) do
+      @help_text = t('user_mailer.suspension_confirmed.contact_agency')
+
       mail(to: email_address.email, subject: t('user_mailer.suspension_confirmed.subject'))
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -899,6 +899,17 @@ RSpec.describe UserMailer, type: :mailer do
     it 'does not link to the help center' do
       expect(mail.html_part.body).to_not include(MarketingSite.nice_help_url)
     end
+
+    context 'in another language' do
+      let(:user) { build(:user, email_language: :es ) }
+
+      it 'translates the footer help text correctly' do
+        expect(mail.html_part.body).
+          to include(t('user_mailer.suspension_confirmed.contact_agency', locale: :es))
+        expect(mail.html_part.body).
+          to_not include(t('user_mailer.suspension_confirmed.contact_agency', locale: :en))
+      end
+    end
   end
 
   describe '#account_reinstated' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -901,7 +901,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     context 'in another language' do
-      let(:user) { build(:user, email_language: :es ) }
+      let(:user) { build(:user, email_language: :es) }
 
       it 'translates the footer help text correctly' do
         expect(mail.html_part.body).


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes translation

## 👀 Screenshots

| before | after |
| --- | --- |
|  <img width="583" alt="Screenshot 2023-11-03 at 10 22 18 AM" src="https://github.com/18F/identity-idp/assets/458784/ed5ebc0e-9219-43c2-9695-5743ea767da4"> |  <img width="590" alt="Screenshot 2023-11-03 at 10 33 27 AM" src="https://github.com/18F/identity-idp/assets/458784/49cea649-460c-44fe-b580-fa3849f25d1b"> |



