### PR TITLE
Add environment to the body of the monthly key metrics report (LG-11418)

### DIFF
--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -1,6 +1,7 @@
 @forward 'uswds-core';
 @forward 'usa-prose';
 @forward 'usa-table';
+@forward 'usa-alert';
 
 .table-number {
   font-variant-numeric: tabular-nums;

--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -36,14 +36,31 @@ module Reports
 
     # Explanatory text to go before the report in the email
     # @return [String]
-    def preamble
-      <<~HTML.html_safe # rubocop:disable Rails/OutputSafety
+    def preamble(env: Identity::Hostdata.env || 'local')
+      ERB.new(<<~ERB).result(binding).html_safe # rubocop:disable Rails/OutputSafety
+        <% if env != 'prod' %>
+          <div class="usa-alert usa-alert--info">
+            <div class="usa-alert__body">
+              <%#
+                NOTE: our AlertComponent doesn't support heading content like this,
+                so for a one-off outside the Rails pipeline it was easier to inline the HTML
+                like this.
+              %>
+              <h2 class="usa-alert__heading">
+                Non-Production Report
+              </h2>
+              <p class="usa-alert__text">
+                This was generated in the <strong><%= env %></strong> environment.
+              </p>
+            </div>
+          </div>
+        <% end %>
         <p>
           For more information on how each of these metrics are calculated, take a look at our
           <a href="https://handbook.login.gov/articles/monthly-key-metrics-explainer.html">
           Monthly Key Metrics Report Explainer document</a>.
         </p>
-      HTML
+      ERB
     end
 
     def reports

--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -42,9 +42,8 @@ module Reports
           <div class="usa-alert usa-alert--info">
             <div class="usa-alert__body">
               <%#
-                NOTE: our AlertComponent doesn't support heading content like this,
-                so for a one-off outside the Rails pipeline it was easier to inline the HTML
-                like this.
+                NOTE: our AlertComponent doesn't support heading content like this uses,
+                so for a one-off outside the Rails pipeline it was easier to inline the HTML here.
               %>
               <h2 class="usa-alert__heading">
                 Non-Production Report

--- a/spec/jobs/reports/monthly_key_metrics_report_spec.rb
+++ b/spec/jobs/reports/monthly_key_metrics_report_spec.rb
@@ -113,12 +113,26 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
   end
 
   describe '#preamble' do
-    subject(:preamble) { report.preamble }
+    let(:env) { 'prod' }
+    subject(:preamble) { report.preamble(env:) }
 
     it 'has a preamble that is valid HTML' do
       expect(preamble).to be_html_safe
 
       expect { Nokogiri::XML(preamble) { |config| config.strict } }.to_not raise_error
+    end
+
+    context 'in a non-prod environment' do
+      let(:env) { 'staging' }
+
+      it 'has an alert with the environment name' do
+        expect(preamble).to be_html_safe
+
+        doc = Nokogiri::XML(preamble)
+
+        alert = doc.at_css('.usa-alert')
+        expect(alert.text).to include(env)
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11418](https://cm-jira.usa.gov/browse/LG-11418)

## 🛠 Summary of changes

The email subject lines already have the environment name such as `[prod] Foobar report` however GMail likes to collapse multiple environments into the same thread.

This PR adds alert content to the body of the email so it's clearer without having to click into subject within a message in a GMail thread.

## 👀 Screenshots

| note | screenshot |
|----| ---- |
| expected rendering |  <img width="627" alt="Screenshot 2023-11-03 at 12 05 05 PM" src="https://github.com/18F/identity-idp/assets/458784/7a0706ae-70d6-4f5d-8f13-5caa055c98bc"> |
| visual glitch when window is too wide |  <img width="713" alt="Screenshot 2023-11-03 at 12 05 14 PM" src="https://github.com/18F/identity-idp/assets/458784/96989801-48bc-4a7b-ac7d-1c138be08dac"> |


