### PR TITLE
Update Lograge configuration to ignore active ping controller

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
 
   routes.default_url_options[:protocol] = 'https' if ENV['HTTPS'] == 'on'
 
-  config.lograge.ignore_actions = ['Users::SessionsController#active']
+  config.lograge.ignore_actions = ['Api::Internal::SessionsController#show']
 
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,5 +39,5 @@ Rails.application.configure do
     config.logger = ActiveSupport::Logger.new(STDOUT)
   end
   config.log_level = :info
-  config.lograge.ignore_actions = ['Users::SessionsController#active']
+  config.lograge.ignore_actions = ['Api::Internal::SessionsController#show']
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Lograge configuration to ignore the active session polling route introduced in #7966.

**Why?**

- Avoid referencing a controller action that doesn't exist (`'Users::SessionsController#active'` was removed in #7966)
- The presence of this configuration indicates we intended to ignore the session activity route from request logging, and the updated configuration value is the equivalent controller action
- ~This may actually do the thing that #7966 intended as far as avoiding a database query for the active session route, which ([as I discovered later](https://github.com/18F/identity-idp/pull/7966#issuecomment-1591165493)) wasn't happening as expected _**due to**_ Lograge-related behaviors applying to the route~ **Edit:** See note below. We're not quite there! **Edit 2:** See #9544 for the _quite there_.
- Avoid request logging for a very noisy route ([see related query](https://gsa-tts.slack.com/archives/C0NGESUN5/p1699042189012309?thread_ts=1699025376.007689&cid=C0NGESUN5))

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1699041988555609?thread_ts=1699025376.007689&cid=C0NGESUN5

## 📜 Testing Plan

1. Build assets with `yarn build && yarn build:css`
2. Set short session check delay and frequency in `config/application.yml`:
    ```
    session_check_delay: 0
    session_check_frequency: 1
    ```
3. Start server with `rails s`
4. Go to http://localhost:3000
5. Sign in
6. In terminal, note that you're not seeing any request logging that looks like...
    ```
    {"method":"GET","path":"/api/internal/sessions" ...}
    ```

Note about database queries: The database query for `User Load` still happens unfortunately, and a `binding.pry` in `ApplicationController#append_info_to_payload` indicates that Lograge is still calling `append_info_to_payload` for these actions despite the fact that they're ignored. ~It'll be worth checking to see if that's a bug or if some workaround can be made, since it seems unexpected that it would be called.~ **Edit:** See #9544.