### PR TITLE
Add Selfie to FE: Conditional Passiveliveness Script Load

### DIFF
--- a/app/javascript/packages/document-capture/context/acuant.tsx
+++ b/app/javascript/packages/document-capture/context/acuant.tsx
@@ -90,6 +90,8 @@ interface AcuantContextProviderProps {
   cameraSrc: string;
   /**
    * Passive Liveness (Selfie) JavaScript source URL.
+   * If this is undefined, it means the selfie feature is
+   * disabled.
    */
   passiveLivenessSrc: string;
   /**
@@ -108,12 +110,6 @@ interface AcuantContextProviderProps {
    * Minimum acceptable sharpness score for images.
    */
   sharpnessThreshold: number;
-  /**
-   * Whether or not selfie capture is enabled.
-   * Used here to determine whether or not to load
-   * the passive liveness script
-   */
-  selfieCaptureEnabled: boolean;
   /**
    * Child element
    */
@@ -226,7 +222,6 @@ function AcuantContextProvider({
   endpoint = null,
   glareThreshold = DEFAULT_ACCEPTABLE_GLARE_SCORE,
   sharpnessThreshold = DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
-  selfieCaptureEnabled = false,
   children,
 }: AcuantContextProviderProps) {
   const { isMobile } = useContext(DeviceContext);
@@ -241,6 +236,7 @@ function AcuantContextProvider({
   const [isCameraSupported, setIsCameraSupported] = useState(isMobile ? null : false);
   const [isActive, setIsActive] = useState(false);
   const [acuantCaptureMode, setAcuantCaptureMode] = useState<AcuantCaptureMode>('AUTO');
+  const selfieCaptureEnabled: Boolean = !!passiveLivenessSrc;
 
   const value = useObjectMemo({
     isReady,

--- a/app/javascript/packages/document-capture/context/acuant.tsx
+++ b/app/javascript/packages/document-capture/context/acuant.tsx
@@ -328,8 +328,8 @@ function AcuantContextProvider({
       passiveLivenessScript.async = true;
       passiveLivenessScript.src = passiveLivenessSrc;
       passiveLivenessScript.onerror = () => setIsError(true);
-      document.body.appendChild(passiveLivenessScript);
     }
+    document.body.appendChild(passiveLivenessScript);
 
     return () => {
       window.acuantConfig = originalAcuantConfig;

--- a/app/javascript/packages/document-capture/context/acuant.tsx
+++ b/app/javascript/packages/document-capture/context/acuant.tsx
@@ -89,11 +89,15 @@ interface AcuantContextProviderProps {
    */
   cameraSrc: string;
   /**
+   * OpenCV JavaScript source URL. Required for passive liveness.
+   */
+  passiveLivenessOpenCVSrc: string;
+  /**
    * Passive Liveness (Selfie) JavaScript source URL.
    * If this is undefined, it means the selfie feature is
    * disabled.
    */
-  passiveLivenessSrc: string;
+  passiveLivenessSrc: string | undefined;
   /**
    * SDK credentials.
    */
@@ -217,6 +221,7 @@ const getActualAcuantCamera = (): AcuantCameraInterface => {
 function AcuantContextProvider({
   sdkSrc,
   cameraSrc,
+  passiveLivenessOpenCVSrc,
   passiveLivenessSrc,
   credentials = null,
   endpoint = null,
@@ -236,7 +241,6 @@ function AcuantContextProvider({
   const [isCameraSupported, setIsCameraSupported] = useState(isMobile ? null : false);
   const [isActive, setIsActive] = useState(false);
   const [acuantCaptureMode, setAcuantCaptureMode] = useState<AcuantCaptureMode>('AUTO');
-  const selfieCaptureEnabled: Boolean = !!passiveLivenessSrc;
 
   const value = useObjectMemo({
     isReady,
@@ -320,12 +324,18 @@ function AcuantContextProvider({
     // Create the empty script regardless of whether we load
     // to make the cleanup function simpler
     const passiveLivenessScript = document.createElement('script');
-    if (selfieCaptureEnabled) {
+    // Open CV script load. Open CV is required only for passive liveness
+    const passiveLivenessOpenCVScript = document.createElement('script');
+    if (passiveLivenessSrc) {
       passiveLivenessScript.async = true;
       passiveLivenessScript.src = passiveLivenessSrc;
       passiveLivenessScript.onerror = () => setIsError(true);
+      passiveLivenessOpenCVScript.async = true;
+      passiveLivenessOpenCVScript.src = passiveLivenessOpenCVSrc;
+      passiveLivenessOpenCVScript.onerror = () => setIsError(true);
     }
     document.body.appendChild(passiveLivenessScript);
+    document.body.appendChild(passiveLivenessOpenCVScript);
 
     return () => {
       window.acuantConfig = originalAcuantConfig;
@@ -333,6 +343,7 @@ function AcuantContextProvider({
       document.body.removeChild(sdkScript);
       document.body.removeChild(cameraScript);
       document.body.removeChild(passiveLivenessScript);
+      document.body.removeChild(passiveLivenessOpenCVScript);
     };
   }, []);
 

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -128,6 +128,7 @@ const App = composeComponents(
     {
       sdkSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantJavascriptWebSdk.min.js`,
       cameraSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantCamera.min.js`,
+      passiveLivenessOpenCVSrc: acuantVersion && `/acuant/${acuantVersion}/opencv.min.js`,
       passiveLivenessSrc: getSelfieCaptureEnabled()
         ? acuantVersion && `/acuant/${acuantVersion}/AcuantPassiveLiveness.min.js`
         : undefined,

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -122,12 +122,13 @@ const App = composeComponents(
     {
       sdkSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantJavascriptWebSdk.min.js`,
       cameraSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantCamera.min.js`,
-      passiveLivenessSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantPassiveLiveness.min.js`,
+      passiveLivenessSrc: true // pending selfieCaptureEnabled featureflag
+        ? acuantVersion && `/acuant/${acuantVersion}/AcuantPassiveLiveness.min.js`
+        : undefined,
       credentials: getMetaContent('acuant-sdk-initialization-creds'),
       endpoint: getMetaContent('acuant-sdk-initialization-endpoint'),
       glareThreshold,
       sharpnessThreshold,
-      selfieCaptureEnabled: true, // Todo replace with code from #9536
     },
   ],
   [

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -128,7 +128,7 @@ const App = composeComponents(
     {
       sdkSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantJavascriptWebSdk.min.js`,
       cameraSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantCamera.min.js`,
-      passiveLivenessSrc: true // pending selfieCaptureEnabled featureflag
+      passiveLivenessSrc: getSelfieCaptureEnabled()
         ? acuantVersion && `/acuant/${acuantVersion}/AcuantPassiveLiveness.min.js`
         : undefined,
       credentials: getMetaContent('acuant-sdk-initialization-creds'),

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -122,10 +122,12 @@ const App = composeComponents(
     {
       sdkSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantJavascriptWebSdk.min.js`,
       cameraSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantCamera.min.js`,
+      passiveLivenessSrc: acuantVersion && `/acuant/${acuantVersion}/AcuantPassiveLiveness.min.js`,
       credentials: getMetaContent('acuant-sdk-initialization-creds'),
       endpoint: getMetaContent('acuant-sdk-initialization-endpoint'),
       glareThreshold,
       sharpnessThreshold,
+      selfieCaptureEnabled: true, // Todo replace with code from #9536
     },
   ],
   [


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-11377

## 🛠 Summary of changes

This is PR 2 of 3 that will meet the ACs of LG-11377
1. [#9536](https://github.com/18F/identity-idp/pull/9536) Add the feature flag
2. [#9546](https://github.com/18F/identity-idp/pull/9546) (this PR) Make `AcuantPassiveLiveness` available in the FE (loading the script).
4. (no PR yet) Add the selfie UI.

This PR loads the acuant passive liveness script when the feature flag is turned on. Otherwise the script is not loaded. More useful context is in [this Slack thread](https://gsa-tts.slack.com/archives/C056RD1NEHW/p1699036617111389).

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes. Testing is dev only, since you have to force the feature flag on.

- [ ] On desktop (or phone) Go to the page where you upload the front/back of the id.
- [ ] Open your browser's dev tools, find the "sources" panel where it lists which JS scripts are loaded. You should see an `AcuantCamera` script and several others but not a `AcuantPassiveLiveness` script or a 'opencv' script.
- [ ] Force the `IdentityConfig.store.doc_auth_selfie_capture` feature flag to be `{:enabled: true}`
- [ ] Restart the application
- [ ] Back to the dev tools, you should now see the `AcuantPassiveLiveness` script and an `opencv` script being loaded as well.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
