### PR TITLE
Fix icon in report mailer email

### DIFF
--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -8,11 +8,10 @@
   text-align: right;
 }
 
-.usa-alert__email.usa-alert--info {
+.usa-alert.usa-alert--info.usa-alert--email {
   .usa-alert__body {
     &:before {
-      background-image: none;
-      content: '\2139';
+      background-image: url('email/info.png');
     }
   }
 }

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -7,3 +7,12 @@
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
+
+.usa-alert__email.usa-alert--info {
+  .usa-alert__body {
+    &:before {
+      background-image: none;
+      content: '\2139';
+    }
+  }
+}

--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -39,7 +39,7 @@ module Reports
     def preamble(env: Identity::Hostdata.env || 'local')
       ERB.new(<<~ERB).result(binding).html_safe # rubocop:disable Rails/OutputSafety
         <% if env != 'prod' %>
-          <div class="usa-alert usa-alert--info usa-alert__email">
+          <div class="usa-alert usa-alert--info usa-alert--email">
             <div class="usa-alert__body">
               <%#
                 NOTE: our AlertComponent doesn't support heading content like this uses,

--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -39,7 +39,7 @@ module Reports
     def preamble(env: Identity::Hostdata.env || 'local')
       ERB.new(<<~ERB).result(binding).html_safe # rubocop:disable Rails/OutputSafety
         <% if env != 'prod' %>
-          <div class="usa-alert usa-alert--info">
+          <div class="usa-alert usa-alert--info usa-alert__email">
             <div class="usa-alert__body">
               <%#
                 NOTE: our AlertComponent doesn't support heading content like this uses,


### PR DESCRIPTION
In https://github.com/18F/identity-idp/pull/9538, we added an alert info box for non-production environments.

However, email clients don't have good support for SVG usually. A [previous workaround for IPP](https://github.com/18F/identity-idp/pull/6585#issuecomment-1187577858) re-did the alert component and linked an image, so this PR copies that approach and also links an image (PNG).


## 👀 Screenshots

| before | after |
| --- | ---- |
|  <img width="385" alt="Screenshot 2023-11-06 at 8 17 44 AM" src="https://github.com/18F/identity-idp/assets/458784/49fb5083-32df-4795-a43e-dd73d77b2983"> |  <img width="378" alt="Screenshot 2023-11-06 at 9 26 41 AM" src="https://github.com/18F/identity-idp/assets/458784/e8d629c4-9296-4c80-9e58-ffc15f28e371">| 
| <img width="465" alt="Screenshot 2023-11-06 at 9 27 25 AM" src="https://github.com/18F/identity-idp/assets/458784/de708a2d-7782-44e0-bed2-e02925799dc2"> | <img width="460" alt="Screenshot 2023-11-06 at 9 26 54 AM" src="https://github.com/18F/identity-idp/assets/458784/e9b4c06e-e3e4-466d-83d6-c2f5755ff4fc"> | 

