### PR TITLE
Bring back scheduled IDV maintenance (LG-11306)

### DIFF
--- a/app/controllers/idv/unavailable_controller.rb
+++ b/app/controllers/idv/unavailable_controller.rb
@@ -5,16 +5,7 @@ module Idv
     before_action :redirect_if_idv_available_and_from_create_account
 
     def show
-      analytics.vendor_outage(
-        vendor_status: {
-          acuant: IdentityConfig.store.vendor_status_acuant,
-          lexisnexis_instant_verify: IdentityConfig.store.vendor_status_lexisnexis_instant_verify,
-          lexisnexis_trueid: IdentityConfig.store.vendor_status_lexisnexis_trueid,
-          sms: IdentityConfig.store.vendor_status_sms,
-          voice: IdentityConfig.store.vendor_status_voice,
-        },
-        redirect_from: from,
-      )
+      OutageStatus.new.track_event(analytics, redirect_from: from)
     end
 
     private

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -23,11 +23,6 @@ module Idv
     end
 
     def update
-      if !FeatureManagement.idv_available?
-        redirect_to idv_unavailable_url
-        return
-      end
-
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
 
       create_document_capture_session

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -23,6 +23,11 @@ module Idv
     end
 
     def update
+      if !FeatureManagement.idv_available?
+        redirect_to idv_unavailable_url
+        return
+      end
+
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
 
       create_document_capture_session

--- a/app/services/outage_status.rb
+++ b/app/services/outage_status.rb
@@ -86,7 +86,7 @@ class OutageStatus
     end
   end
 
-  def track_event(analytics)
+  def track_event(analytics, redirect_from: nil)
     raise ArgumentError, 'analytics instance required' if analytics.nil?
 
     analytics.vendor_outage(
@@ -98,6 +98,7 @@ class OutageStatus
         voice: IdentityConfig.store.vendor_status_voice,
         idv_scheduled_maintenance: idv_scheduled_maintenance_status,
       },
+      redirect_from: redirect_from,
     )
   end
 end

--- a/app/services/outage_status.rb
+++ b/app/services/outage_status.rb
@@ -1,7 +1,12 @@
 class OutageStatus
   include ActionView::Helpers::TranslationHelper
 
-  IDV_VENDORS = %i[acuant lexisnexis_instant_verify lexisnexis_trueid].freeze
+  IDV_VENDORS = %i[
+    acuant
+    lexisnexis_instant_verify
+    lexisnexis_trueid
+    idv_scheduled_maintenance
+  ].freeze
   PHONE_VENDORS = %i[sms voice].freeze
   ALL_VENDORS = (IDV_VENDORS + PHONE_VENDORS).freeze
 
@@ -15,6 +20,8 @@ class OutageStatus
       IdentityConfig.store.vendor_status_lexisnexis_trueid
     when :lexisnexis_phone_finder
       IdentityConfig.store.vendor_status_lexisnexis_phone_finder
+    when :idv_scheduled_maintenance
+      idv_scheduled_maintenance_status
     when :sms
       IdentityConfig.store.vendor_status_sms
     when :voice
@@ -49,6 +56,24 @@ class OutageStatus
     all_vendor_outage?([:lexisnexis_phone_finder])
   end
 
+  def idv_scheduled_maintenance_status
+    if idv_scheduled_maintenance?
+      :full_outage
+    else
+      :operational
+    end
+  end
+
+  # @return [Boolean] returns true when we are currently within a scheduled maintenance window
+  def idv_scheduled_maintenance?(now: Time.zone.now)
+    start = IdentityConfig.store.vendor_status_idv_scheduled_maintenance_start
+    finish = IdentityConfig.store.vendor_status_idv_scheduled_maintenance_finish
+
+    if start.present? && finish.present?
+      (start.in_time_zone('UTC')...finish.in_time_zone('UTC')).cover?(now)
+    end
+  end
+
   # Returns an appropriate error message based upon the type of outage or what the user was doing
   # when they encountered the outage.
   #
@@ -71,6 +96,7 @@ class OutageStatus
         lexisnexis_trueid: IdentityConfig.store.vendor_status_lexisnexis_trueid,
         sms: IdentityConfig.store.vendor_status_sms,
         voice: IdentityConfig.store.vendor_status_voice,
+        idv_scheduled_maintenance: idv_scheduled_maintenance_status,
       },
     )
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -329,6 +329,8 @@ vendor_status_lexisnexis_phone_finder: 'operational'
 vendor_status_lexisnexis_trueid: 'operational'
 vendor_status_sms: 'operational'
 vendor_status_voice: 'operational'
+vendor_status_idv_scheduled_maintenance_start: ''
+vendor_status_idv_scheduled_maintenance_finish: ''
 verification_errors_report_configs: '[]'
 verify_gpo_key_attempt_window_in_minutes: 10
 verify_gpo_key_max_attempts: 5

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -476,6 +476,8 @@ class IdentityConfig
     config.add(:vendor_status_lexisnexis_trueid, type: :symbol, enum: VENDOR_STATUS_OPTIONS)
     config.add(:vendor_status_sms, type: :symbol, enum: VENDOR_STATUS_OPTIONS)
     config.add(:vendor_status_voice, type: :symbol, enum: VENDOR_STATUS_OPTIONS)
+    config.add(:vendor_status_idv_scheduled_maintenance_start, type: :string)
+    config.add(:vendor_status_idv_scheduled_maintenance_finish, type: :string)
     config.add(:verification_errors_report_configs, type: :json)
     config.add(:verify_gpo_key_attempt_window_in_minutes, type: :integer)
     config.add(:verify_gpo_key_max_attempts, type: :integer)

--- a/spec/controllers/idv/unavailable_controller_spec.rb
+++ b/spec/controllers/idv/unavailable_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Idv::UnavailableController, type: :controller do
           lexisnexis_trueid: :operational,
           sms: :operational,
           voice: :operational,
+          idv_scheduled_maintenance: :operational,
         },
       )
     end
@@ -52,6 +53,7 @@ RSpec.describe Idv::UnavailableController, type: :controller do
             lexisnexis_trueid: :operational,
             sms: :operational,
             voice: :operational,
+            idv_scheduled_maintenance: :operational,
           },
         )
       end

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -248,24 +248,6 @@ RSpec.feature 'IdV Outage Spec' do
       )
     end
 
-    it 'prevents a user who reset their password from reactivating profile with no personal key',
-       email: true do
-      personal_key_from_pii(user, pii)
-      trigger_reset_password_and_click_email_link(user.email)
-      reset_password(user, new_password)
-
-      visit new_user_session_path
-      signin(user.email, new_password)
-      fill_in_code_with_last_phone_otp
-      click_submit_default
-
-      click_link t('account.index.reactivation.link')
-      click_on t('links.account.reactivate.without_key')
-      click_on t('forms.buttons.continue')
-
-      expect(page).to have_content(t('idv.unavailable.idv_explanation.without_sp'))
-    end
-
     it 'prevents a user from creating an account' do
       visit_idp_from_sp_with_ial2(:oidc)
       click_link t('links.create_account')
@@ -285,6 +267,24 @@ RSpec.feature 'IdV Outage Spec' do
       let("vendor_status_#{service}".to_sym) { :full_outage }
 
       it_behaves_like 'IDV is unavailable'
+
+      it 'prevents a user who reset their password from reactivating profile with no personal key',
+         email: true do
+        personal_key_from_pii(user, pii)
+        trigger_reset_password_and_click_email_link(user.email)
+        reset_password(user, new_password)
+
+        visit new_user_session_path
+        signin(user.email, new_password)
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        click_link t('account.index.reactivation.link')
+        click_on t('links.account.reactivate.without_key')
+        click_on t('forms.buttons.continue')
+
+        expect(page).to have_content(t('idv.unavailable.idv_explanation.without_sp'))
+      end
     end
   end
 

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -288,7 +288,7 @@ RSpec.feature 'IdV Outage Spec' do
     end
   end
 
-  context 'during an IDV maintenance window' do
+  context 'during an IDV maintenance window', js: true do
     before do
       allow(IdentityConfig.store).to receive(:vendor_status_idv_scheduled_maintenance_start).
         and_return('2023-01-01T00:00:00Z')

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -238,48 +238,66 @@ RSpec.feature 'IdV Outage Spec' do
     end
   end
 
+  shared_examples_for 'IDV is unavailable' do
+    let(:user) { user_with_2fa }
+
+    it 'prevents an existing ial1 user from verifying their identity' do
+      sign_in_with_idv_required(user: user, sms_or_totp: :sms)
+      expect(page).to have_content(
+        strip_tags(t('idv.unavailable.idv_explanation.with_sp_html', sp: 'Test SP')),
+      )
+    end
+
+    it 'prevents a user who reset their password from reactivating profile with no personal key',
+       email: true do
+      personal_key_from_pii(user, pii)
+      trigger_reset_password_and_click_email_link(user.email)
+      reset_password(user, new_password)
+
+      visit new_user_session_path
+      signin(user.email, new_password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      click_link t('account.index.reactivation.link')
+      click_on t('links.account.reactivate.without_key')
+      click_on t('forms.buttons.continue')
+
+      expect(page).to have_content(t('idv.unavailable.idv_explanation.without_sp'))
+    end
+
+    it 'prevents a user from creating an account' do
+      visit_idp_from_sp_with_ial2(:oidc)
+      click_link t('links.create_account')
+      expect(page).to have_content(
+        strip_tags(
+          t(
+            'idv.unavailable.idv_explanation.with_sp_html',
+            sp: 'Test SP',
+          ),
+        ),
+      )
+    end
+  end
+
   %w[acuant lexisnexis_instant_verify lexisnexis_trueid].each do |service|
     context "vendor_status_#{service} set to full_outage", js: true do
-      let(:user) { user_with_2fa }
       let("vendor_status_#{service}".to_sym) { :full_outage }
 
-      it 'prevents an existing ial1 user from verifying their identity' do
-        sign_in_with_idv_required(user: user, sms_or_totp: :sms)
-        expect(page).to have_content(
-          strip_tags(t('idv.unavailable.idv_explanation.with_sp_html', sp: 'Test SP')),
-        )
-      end
-
-      it 'prevents a user who reset their password from reactivating profile with no personal key',
-         email: true do
-        personal_key_from_pii(user, pii)
-        trigger_reset_password_and_click_email_link(user.email)
-        reset_password(user, new_password)
-
-        visit new_user_session_path
-        signin(user.email, new_password)
-        fill_in_code_with_last_phone_otp
-        click_submit_default
-
-        click_link t('account.index.reactivation.link')
-        click_on t('links.account.reactivate.without_key')
-        click_on t('forms.buttons.continue')
-
-        expect(page).to have_content(t('idv.unavailable.idv_explanation.without_sp'))
-      end
-
-      it 'prevents a user from creating an account' do
-        visit_idp_from_sp_with_ial2(:oidc)
-        click_link t('links.create_account')
-        expect(page).to have_content(
-          strip_tags(
-            t(
-              'idv.unavailable.idv_explanation.with_sp_html',
-              sp: 'Test SP',
-            ),
-          ),
-        )
-      end
+      it_behaves_like 'IDV is unavailable'
     end
+  end
+
+  context 'during an IDV maintenance window' do
+    before do
+      allow(IdentityConfig.store).to receive(:vendor_status_idv_scheduled_maintenance_start).
+        and_return('2023-01-01T00:00:00Z')
+      allow(IdentityConfig.store).to receive(:vendor_status_idv_scheduled_maintenance_finish).
+        and_return('2023-01-01T23:59:59Z')
+
+      travel_to(Time.zone.parse('2023-01-01T12:00:00Z'))
+    end
+
+    it_behaves_like 'IDV is unavailable'
   end
 end


### PR DESCRIPTION
## Ticket

[LG-11306](https://cm-jira.usa.gov/browse/LG-11306)

## Summary of changes

- Redo of #4202 after it was removed in #8858, to fit with current vendor maintenance configuration

**Background**: We have some upcoming IDV vendor unavailability this weekend, this lets us schedule maintenance without having to manually set configs