### PR TITLE
Deploy RC 331 to Production

### DIFF
--- a/app/controllers/idv/unavailable_controller.rb
+++ b/app/controllers/idv/unavailable_controller.rb
@@ -5,16 +5,7 @@ module Idv
     before_action :redirect_if_idv_available_and_from_create_account
 
     def show
-      analytics.vendor_outage(
-        vendor_status: {
-          acuant: IdentityConfig.store.vendor_status_acuant,
-          lexisnexis_instant_verify: IdentityConfig.store.vendor_status_lexisnexis_instant_verify,
-          lexisnexis_trueid: IdentityConfig.store.vendor_status_lexisnexis_trueid,
-          sms: IdentityConfig.store.vendor_status_sms,
-          voice: IdentityConfig.store.vendor_status_voice,
-        },
-        redirect_from: from,
-      )
+      OutageStatus.new.track_event(analytics, redirect_from: from)
     end
 
     private

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -141,6 +141,7 @@ module Idv
         user_id: user_uuid,
         pii_like_keypaths: DocPiiForm.pii_like_keypaths,
         flow_path: params[:flow_path],
+        phone_with_camera: phone_with_camera,
       }
 
       @extra_attributes[:front_image_fingerprint] = front_image_fingerprint
@@ -300,6 +301,7 @@ module Idv
           client_image_metrics: image_metadata,
           async: false,
           flow_path: params[:flow_path],
+          phone_with_camera: phone_with_camera,
           vendor_request_time_in_ms: vendor_request_time_in_ms,
         ).except(:classification_info).
         merge(acuant_sdk_upgrade_ab_test_data).
@@ -472,6 +474,15 @@ module Idv
 
     def image_resubmission_check?
       IdentityConfig.store.doc_auth_check_failed_image_resubmission_enabled
+    end
+
+    def phone_with_camera
+      case params[:phone_with_camera]
+      when 'true'
+        true
+      when 'false'
+        false
+      end
     end
   end
 end

--- a/app/javascript/packages/document-capture/components/document-capture-not-ready.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-not-ready.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@18f/identity-components';
+import { useI18n } from '@18f/identity-react-i18n';
+import { useContext } from 'react';
+import FlowContext from '@18f/identity-verify-flow/context/flow-context';
+import { addSearchParams, forceRedirect, Navigate } from '@18f/identity-url';
+import { getConfigValue } from '@18f/identity-config';
+import AnalyticsContext from '../context/analytics';
+import { ServiceProviderContext } from '../context';
+
+export interface DocumentCaptureNotReadyProps {
+  navigate?: Navigate;
+}
+
+function DocumentCaptureNotReady({ navigate }: DocumentCaptureNotReadyProps) {
+  const { t } = useI18n();
+  const { trackEvent } = useContext(AnalyticsContext);
+  const { currentStep } = useContext(FlowContext);
+  const { name: spName, failureToProofURL } = useContext(ServiceProviderContext);
+  const appName = getConfigValue('appName');
+  const handleExit = () => {
+    trackEvent('IdV: docauth not ready link clicked');
+    forceRedirect(
+      addSearchParams(spName ? failureToProofURL : '/account', {
+        step: currentStep,
+        location: 'not_ready',
+      }),
+      navigate,
+    );
+  };
+
+  return (
+    <>
+      <h2 className="h3">{t('doc_auth.not_ready.header')}</h2>
+      <p>
+        {spName
+          ? t('doc_auth.not_ready.content_sp', {
+              sp_name: spName,
+              app_name: appName,
+            })
+          : t('doc_auth.not_ready.content_nosp', {
+              app_name: appName,
+            })}
+      </p>
+      <Button isUnstyled className="margin-top-1" onClick={handleExit}>
+        {spName
+          ? t('doc_auth.not_ready.button_sp', { app_name: appName, sp_name: spName })
+          : t('doc_auth.not_ready.button_nosp')}
+      </Button>
+    </>
+  );
+}
+
+export default DocumentCaptureNotReady;

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { PageHeading } from '@18f/identity-components';
 import {
   FormStepError,
@@ -10,6 +11,8 @@ import { useI18n } from '@18f/identity-react-i18n';
 import UnknownError from './unknown-error';
 import TipList from './tip-list';
 import DocumentSideAcuantCapture from './document-side-acuant-capture';
+import DocumentCaptureNotReady from './document-capture-not-ready';
+import { FeatureFlagContext } from '../context';
 
 interface DocumentCaptureReviewIssuesProps {
   isFailedDocType: boolean;
@@ -43,6 +46,7 @@ function DocumentCaptureReviewIssues({
   hasDismissed,
 }: DocumentCaptureReviewIssuesProps) {
   const { t } = useI18n();
+  const { notReadySectionEnabled } = useContext(FeatureFlagContext);
   return (
     <>
       <PageHeading>{t('doc_auth.headings.review_issues')}</PageHeading>
@@ -78,6 +82,7 @@ function DocumentCaptureReviewIssues({
         />
       ))}
       <FormStepsButton.Submit />
+      {notReadySectionEnabled && <DocumentCaptureNotReady />}
       <Cancel />
     </>
   );

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -8,6 +8,8 @@ import DocumentSideAcuantCapture from './document-side-acuant-capture';
 import DeviceContext from '../context/device';
 import UploadContext from '../context/upload';
 import TipList from './tip-list';
+import DocumentCaptureNotReady from './document-capture-not-ready';
+import { FeatureFlagContext } from '../context';
 
 /**
  * @typedef {'front'|'back'} DocumentSide
@@ -43,7 +45,7 @@ function DocumentsStep({
   const { isMobile } = useContext(DeviceContext);
   const { isLastStep } = useContext(FormStepsContext);
   const { flowPath } = useContext(UploadContext);
-
+  const { notReadySectionEnabled } = useContext(FeatureFlagContext);
   return (
     <>
       {flowPath === 'hybrid' && <HybridDocCaptureWarning className="margin-bottom-4" />}
@@ -70,7 +72,7 @@ function DocumentsStep({
         />
       ))}
       {isLastStep ? <FormStepsButton.Submit /> : <FormStepsButton.Continue />}
-
+      {notReadySectionEnabled && <DocumentCaptureNotReady />}
       <Cancel />
     </>
   );

--- a/app/javascript/packages/document-capture/context/feature-flag.tsx
+++ b/app/javascript/packages/document-capture/context/feature-flag.tsx
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+
+export interface FeatureFlagContextProps {
+  /**
+   * Specify whether to show the not-ready section on doc capture screen.
+   * Populated from backend configuration
+   */
+  notReadySectionEnabled: boolean;
+}
+
+const FeatureFlagContext = createContext<FeatureFlagContextProps>({
+  notReadySectionEnabled: false,
+});
+
+FeatureFlagContext.displayName = 'FeatureFlagContext';
+
+export default FeatureFlagContext;

--- a/app/javascript/packages/document-capture/context/index.ts
+++ b/app/javascript/packages/document-capture/context/index.ts
@@ -16,3 +16,4 @@ export {
 } from './failed-capture-attempts';
 export type { DeviceContextValue } from './device';
 export { default as InPersonContext } from './in-person';
+export { default as FeatureFlagContext } from './feature-flag';

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -10,6 +10,7 @@ import {
   FailedCaptureAttemptsContextProvider,
   MarketingSiteContextProvider,
   InPersonContext,
+  FeatureFlagContext,
 } from '@18f/identity-document-capture';
 import { isCameraCapableMobile } from '@18f/identity-device';
 import { FlowContext } from '@18f/identity-verify-flow';
@@ -33,6 +34,7 @@ interface AppRootData {
   exitUrl: string;
   idvInPersonUrl?: string;
   securityAndPrivacyHowItWorksUrl: string;
+  uiNotReadySectionEnabled: string;
 }
 
 const appRoot = document.getElementById('document-capture-form')!;
@@ -99,6 +101,7 @@ const {
   inPersonOutageExpectedUpdateDate,
   usStatesTerritories = '',
   phoneWithCamera = '',
+  uiNotReadySectionEnabled = '',
 } = appRoot.dataset as DOMStringMap & AppRootData;
 
 let parsedUsStatesTerritories = [];
@@ -173,6 +176,14 @@ const App = composeComponents(
     {
       maxCaptureAttemptsBeforeNativeCamera: Number(maxCaptureAttemptsBeforeNativeCamera),
       maxSubmissionAttemptsBeforeNativeCamera: Number(maxSubmissionAttemptsBeforeNativeCamera),
+    },
+  ],
+  [
+    FeatureFlagContext.Provider,
+    {
+      value: {
+        notReadySectionEnabled: String(uiNotReadySectionEnabled) === 'true',
+      },
     },
   ],
   [

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -98,6 +98,7 @@ const {
   inPersonOutageMessageEnabled,
   inPersonOutageExpectedUpdateDate,
   usStatesTerritories = '',
+  phoneWithCamera = '',
 } = appRoot.dataset as DOMStringMap & AppRootData;
 
 let parsedUsStatesTerritories = [];
@@ -147,6 +148,7 @@ const App = composeComponents(
       isMockClient,
       formData,
       flowPath,
+      phoneWithCamera,
     },
   ],
   [

--- a/app/models/disposable_domain.rb
+++ b/app/models/disposable_domain.rb
@@ -1,0 +1,2 @@
+class DisposableDomain < ApplicationRecord
+end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3187,24 +3187,6 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when the user has added the MFA method webauthn to their account
-  # @param [Boolean] platform_authenticator indicates if webauthn_platform was used
-  # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
-  def multi_factor_auth_added_webauthn(
-    platform_authenticator:,
-    enabled_mfa_methods_count:, **extra
-  )
-    track_event(
-      'Multi-Factor Authentication: Added webauthn',
-      {
-        method_name: :webauthn,
-        platform_authenticator: platform_authenticator,
-        enabled_mfa_methods_count: enabled_mfa_methods_count,
-        **extra,
-      }.compact,
-    )
-  end
-
   # A user has downloaded their backup codes
   def multi_factor_auth_backup_code_download
     track_event('Multi-Factor Authentication: download backup code')
@@ -4810,18 +4792,27 @@ module AnalyticsEvents
   end
 
   # @param [Hash] platform_authenticator
-  # @param [Hash] errors
-  # @param [Integer] enabled_mfa_methods_count
   # @param [Boolean] success
+  # @param [Hash, nil] errors
+  # Tracks whether or not Webauthn setup was successful
+  def webauthn_setup_submitted(platform_authenticator:, success:, errors: nil, **extra)
+    track_event(
+      :webauthn_setup_submitted,
+      platform_authenticator: platform_authenticator,
+      success: success,
+      errors: errors,
+      **extra,
+    )
+  end
+
+  # @param [Hash] platform_authenticator
+  # @param [Integer] enabled_mfa_methods_count
   # Tracks when WebAuthn setup is visited
-  def webauthn_setup_visit(platform_authenticator:, errors:, enabled_mfa_methods_count:, success:,
-                           **extra)
+  def webauthn_setup_visit(platform_authenticator:, enabled_mfa_methods_count:, **extra)
     track_event(
       'WebAuthn Setup Visited',
       platform_authenticator: platform_authenticator,
-      errors: errors,
       enabled_mfa_methods_count: enabled_mfa_methods_count,
-      success: success,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -976,6 +976,7 @@ module AnalyticsEvents
   # @param [String] back_image_fingerprint Fingerprint of back image data
   # @param [String] getting_started_ab_test_bucket Which initial IdV screen the user saw
   # @param [String] phone_question_ab_test_bucket Prompt user with phone question before doc auth
+  # @param [String] phone_with_camera the result of the phone question a/b test
   # The document capture image uploaded was locally validated during the IDV process
   def idv_doc_auth_submitted_image_upload_form(
     success:,
@@ -988,6 +989,7 @@ module AnalyticsEvents
     back_image_fingerprint: nil,
     getting_started_ab_test_bucket: nil,
     phone_question_ab_test_bucket: nil,
+    phone_with_camera: nil,
     **extra
   )
     track_event(
@@ -1002,6 +1004,7 @@ module AnalyticsEvents
       back_image_fingerprint: back_image_fingerprint,
       getting_started_ab_test_bucket: getting_started_ab_test_bucket,
       phone_question_ab_test_bucket: phone_question_ab_test_bucket,
+      phone_with_camera: phone_with_camera,
       **extra,
     )
   end
@@ -1023,6 +1026,7 @@ module AnalyticsEvents
   # @param [String] back_image_fingerprint Fingerprint of back image data
   # @param [String] getting_started_ab_test_bucket Which initial IdV screen the user saw
   # @param [String] phone_question_ab_test_bucket Prompt user with phone question before doc auth
+  # @param [String] phone_with_camera the result of the phone question a/b test
   # The document capture image was uploaded to vendor during the IDV process
   def idv_doc_auth_submitted_image_upload_vendor(
     success:,
@@ -1041,6 +1045,7 @@ module AnalyticsEvents
     back_image_fingerprint: nil,
     getting_started_ab_test_bucket: nil,
     phone_question_ab_test_bucket: nil,
+    phone_with_camera: nil,
     **extra
   )
     track_event(
@@ -1062,6 +1067,7 @@ module AnalyticsEvents
       back_image_fingerprint: back_image_fingerprint,
       getting_started_ab_test_bucket: getting_started_ab_test_bucket,
       phone_question_ab_test_bucket: phone_question_ab_test_bucket,
+      phone_with_camera: phone_with_camera,
       **extra,
     )
   end

--- a/app/services/browser_support.rb
+++ b/app/services/browser_support.rb
@@ -1,18 +1,22 @@
 class BrowserSupport
   @cache = LruRedux::Cache.new(1_000)
 
+  # rubocop:disable Layout/LineLength
   BROWSERSLIST_TO_BROWSER_MAP = {
-    and_chr: ->(browser, version) { browser.android? && browser.chrome?(version) },
+    and_chr: ->(browser, version) { browser.android? && !browser.platform.android_webview? && browser.chrome?(version) },
     and_uc: ->(browser, version) { browser.android? && browser.uc_browser?(version) },
-    chrome: ->(browser, version) { browser.chrome?(version) },
+    android: ->(browser, version) { browser.platform.android_webview? && browser.send(:detect_version?, browser.version, version) },
+    chrome: ->(browser, version) { !browser.platform.android_webview? && browser.chrome?(version) },
     edge: ->(browser, version) { browser.edge?(version) },
     firefox: ->(browser, version) { browser.firefox?(version) },
     ios_saf: ->(browser, version) { browser.ios? && browser.safari?(version) },
     op_mini: ->(browser, version) { browser.opera_mini?(version) },
+    op_mob: ->(browser, version) { browser.platform.android? && browser.opera?(version) },
     opera: ->(browser, version) { browser.opera?(version) },
     safari: ->(browser, version) { browser.safari?(version) },
     samsung: ->(browser, version) { browser.samsung_browser?(version) },
   }.with_indifferent_access.freeze
+  # rubocop:enable Layout/LineLength
 
   class << self
     def supported?(user_agent)

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -160,7 +160,7 @@ locals:
                 poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
               },
             },
-          ).with_content(t('forms.buttons.continue')) %>
+          ).with_content(t('forms.buttons.submit.default')) %>
   </div>
 </div>
 

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -37,6 +37,7 @@
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
       doc_auth_selfie_capture: IdentityConfig.store.doc_auth_selfie_capture,
+      ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,
     } %>
   <%= simple_form_for(
         :doc_auth,

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -35,6 +35,11 @@ locals:
 <% self.title = t('titles.idv.verify_info') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
+
+<p>
+  <%= t('idv.messages.verify_info') %>
+</p>
+
 <div class='margin-top-4 margin-bottom-2'>
   <div class="grid-row grid-gap grid-gap-2 padding-bottom-1">
     <dl class="grid-col-fill margin-y-0">
@@ -131,7 +136,7 @@ locals:
                 poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
               },
             },
-          ).with_content(t('forms.buttons.continue')) %>
+          ).with_content(t('forms.buttons.submit.default')) %>
   </div>
 </div>
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -85,6 +85,7 @@ doc_auth_error_sharpness_threshold: 40
 doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
+doc_auth_not_ready_section_enabled: false
 doc_auth_selfie_capture: '{"enabled":false}'
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
 doc_capture_request_valid_for_minutes: 15
@@ -382,11 +383,12 @@ development:
   database_worker_jobs_username: ''
   database_worker_jobs_host: ''
   database_worker_jobs_password: ''
-  doc_auth_selfie_capture: '{"enabled":false}' 
+  doc_auth_selfie_capture: '{"enabled":false}'
   doc_auth_vendor: 'mock'
   doc_auth_vendor_randomize: false
   doc_auth_vendor_randomize_percent: 0
   doc_auth_vendor_randomize_alternate_vendor: ''
+  doc_auth_not_ready_section_enabled: true
   domain_name: localhost:3000
   enable_rate_limiting: false
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
@@ -525,7 +527,7 @@ test:
   doc_auth_vendor_randomize: false
   doc_auth_vendor_randomize_percent: 0
   doc_auth_vendor_randomize_alternate_vendor: ''
-  doc_auth_selfie_capture: '{"enabled":false}' 
+  doc_auth_selfie_capture: '{"enabled":false}'
   doc_capture_polling_enabled: false
   domain_name: www.example.com
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -330,6 +330,8 @@ vendor_status_lexisnexis_phone_finder: 'operational'
 vendor_status_lexisnexis_trueid: 'operational'
 vendor_status_sms: 'operational'
 vendor_status_voice: 'operational'
+vendor_status_idv_scheduled_maintenance_start: ''
+vendor_status_idv_scheduled_maintenance_finish: ''
 verification_errors_report_configs: '[]'
 verify_gpo_key_attempt_window_in_minutes: 10
 verify_gpo_key_max_attempts: 5

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -14,6 +14,7 @@ production:
   database_worker_jobs_password: ['env', 'POSTGRES_WORKER_PASSWORD']
   database_worker_jobs_sslmode: ['env', 'POSTGRES_WORKER_SSLMODE']
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
+  rails_mailer_previews_enabled: true
   redis_throttle_url: ['env', 'REDIS_THROTTLE_URL']
   redis_url: ['env', 'REDIS_URL']
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -279,6 +279,15 @@ en:
         - '<strong>Verify by mail</strong>: We’ll mail a letter to your home
           address. This takes <strong>5 to 10 days</strong>.'
       welcome: 'You will need your:'
+    not_ready:
+      button_nosp: Cancel and return to your profile
+      button_sp: Exit %{app_name} and return to %{sp_name}
+      content_nosp: If you exit %{app_name} now, you will not have verified your
+        identity. You can return later to finish this process.
+      content_sp: If you exit %{app_name} now and return to %{sp_name}, you will not
+        have verified your identity. You can return later to finish this
+        process.
+      header: Not ready to add photos?
     phone_question:
       do_not_have: I don’t have a phone
     tips:

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -321,6 +321,15 @@ es:
         - '<strong>Verificar por correo</strong>: Le enviaremos una carta a su
           domicilio. Esto tarda entre <strong>5 y 10 días</strong>.'
       welcome: 'Necesitará su:'
+    not_ready:
+      button_nosp: Cancelar y volver a su perfil
+      button_sp: Salir de %{app_name} y volver a %{sp_name}
+      content_nosp: Si sale ahora de %{app_name}, no habrá verificado su identidad.
+        Puede volver más tarde para completar este proceso.
+      content_sp: Si sale ahora de %{app_name} y regresa a %{sp_name}, no habrá
+        verificado su identidad. Puede volver más tarde para completar este
+        proceso.
+      header: ¿No está listo para enviar las fotos?
     phone_question:
       do_not_have: No tengo teléfono
     tips:

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -333,6 +333,15 @@ fr:
           lettre à votre adresse personnelle. Cela prend <strong>5 à 10
           jours</strong>.'
       welcome: 'Vous aurez besoin de votre:'
+    not_ready:
+      button_nosp: Annuler et revenir à votre profil
+      button_sp: Quittez %{app_name} et retournez à %{sp_name}
+      content_nosp: Si vous quittez %{app_name}, votre identité n’aura pas été
+        vérifiée. Vous pourrez revenir plus tard pour terminer ce processus.
+      content_sp: Si vous quittez %{app_name} maintenant et revenez sur %{sp_name},
+        votre identité n’aura pas été vérifiée. Vous pourrez revenir plus tard
+        pour terminer ce processus.
+      header: Vous n’êtes pas prêt à ajouter des photos?
     phone_question:
       do_not_have: Je n’ai pas de téléphone
     tips:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -289,6 +289,8 @@ en:
           it.
         no_pii: TEST SITE - Do not use real personal information (demo purposes only) -
           TEST SITE
+      verify_info: We read your information from your ID. Review it and make any
+        updates before submitting for verification.
       verifying: Verifying…
     titles:
       activated: Your identity has already been verified

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -307,6 +307,8 @@ es:
           ellos.
         no_pii: SITIO DE PRUEBA - No utilice información personal real (sólo para
           propósitos de demostración) - SITIO DE PRUEBA
+      verify_info: Leímos sus datos en su identificación. Revíselos y modifíquelos si
+        es necesario antes de enviarlos para la verificación.
       verifying: Verificando…
     titles:
       activated: Ya se verificó tu identidad.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -317,6 +317,9 @@ fr:
           y accéder.
         no_pii: SITE DE TEST - N’utilisez pas de véritables données personnelles (il
           s’agit d’une démonstration seulement) - SITE DE TEST
+      verify_info: Nous lisons vos informations à partir de votre pièce d’identité.
+        Passez-les en revue et mettez-les à jour avant de les soumettre pour
+        vérification.
       verifying: Vérification…
     titles:
       activated: Votre identité a déjà été vérifiée

--- a/db/primary_migrate/20231024170146_create_email_data_table.rb
+++ b/db/primary_migrate/20231024170146_create_email_data_table.rb
@@ -1,0 +1,11 @@
+class CreateEmailDataTable < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension "citext"
+
+    create_table :disposable_domains do |t|
+      t.citext :name, null: false
+    end
+
+    add_index :disposable_domains, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_08_31_124437) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_24_172229) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -92,6 +93,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_31_124437) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["cookie_uuid"], name: "index_devices_on_cookie_uuid"
     t.index ["user_id", "last_used_at"], name: "index_device_user_id_last_used_at"
+  end
+
+  create_table "disposable_domains", force: :cascade do |t|
+    t.citext "name", null: false
+    t.index ["name"], name: "index_disposable_domains_on_name", unique: true
   end
 
   create_table "doc_auth_logs", force: :cascade do |t|

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -56,6 +56,25 @@ If not using macOS:
 
     You should now be able to go to open up your favorite browser, go to `localhost:3000` and see your local development environment running.
 
+### Simulating a partner authentication request
+
+Typically, a person who uses Login.gov will arrive from a partner application, and their experience
+on Login.gov will be customized to incorporate the name and logo of the partner. They will also be
+asked to consent to share their information with the partner before being sent back.
+
+To simulate a true end-to-end user experience, you can either...
+
+- Use the built-in test controller for SAML logins at http://localhost:3000/test/saml/login
+- Or, run a sample partner application, which is configured by default to run with your local IdP instance:
+   - OIDC: https://github.com/18F/identity-oidc-sinatra
+      - Runs at http://localhost:9292/
+   - SAML: https://github.com/18F/identity-saml-sinatra
+      - Runs at http://localhost:4567/
+
+Running the sample application requires a few additional steps, but can be useful if you want to
+test the experience of a user being redirected to an external site, or if you want to configure
+different options of the authentication request, such as AAL or IAL.
+
 ### Running tests locally
 
   Login.gov uses the following tools for our testing:

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -180,6 +180,7 @@ class IdentityConfig
     config.add(:doc_auth_error_dpi_threshold, type: :integer)
     config.add(:doc_auth_error_glare_threshold, type: :integer)
     config.add(:doc_auth_error_sharpness_threshold, type: :integer)
+    config.add(:doc_auth_not_ready_section_enabled, type: :boolean)
     config.add(:doc_auth_max_attempts, type: :integer)
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -477,6 +477,8 @@ class IdentityConfig
     config.add(:vendor_status_lexisnexis_trueid, type: :symbol, enum: VENDOR_STATUS_OPTIONS)
     config.add(:vendor_status_sms, type: :symbol, enum: VENDOR_STATUS_OPTIONS)
     config.add(:vendor_status_voice, type: :symbol, enum: VENDOR_STATUS_OPTIONS)
+    config.add(:vendor_status_idv_scheduled_maintenance_start, type: :string)
+    config.add(:vendor_status_idv_scheduled_maintenance_finish, type: :string)
     config.add(:verification_errors_report_configs, type: :json)
     config.add(:verify_gpo_key_attempt_window_in_minutes, type: :integer)
     config.add(:verify_gpo_key_max_attempts, type: :integer)

--- a/lib/tasks/disposable_domains.rake
+++ b/lib/tasks/disposable_domains.rake
@@ -1,0 +1,11 @@
+# rubocop:disable Rails/SkipsModelValidations
+require 'csv'
+namespace :disposable_domains do
+  task :load, %i[s3_url] => [:environment] do |_task, args|
+    file = Identity::Hostdata.secrets_s3.read_file(args[:s3_url])
+    names = file.split("\n")
+    DisposableDomain.insert_all(names.map { |name| { name: } })
+  end
+end
+# rake "disposable_domains:load['URL_HERE']"
+# rubocop:enable Rails/SkipsModelValidations

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
         )
 
         expect(@irs_attempts_api_tracker).to receive(:track_event).with(
@@ -271,6 +272,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
         )
 
         expect(@irs_attempts_api_tracker).to receive(:track_event).with(
@@ -374,6 +376,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -401,6 +404,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
           doc_type_supported: boolean,
         )
 
@@ -418,6 +422,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
           classification_info: a_kind_of(Hash),
         )
 
@@ -559,6 +564,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -586,6 +592,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
               doc_type_supported: boolean,
             )
 
@@ -608,6 +615,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
               classification_info: hash_including(
                 Front: hash_including(ClassName: 'Identification Card', CountryCode: 'USA'),
                 Back: hash_including(ClassName: 'Identification Card', CountryCode: 'USA'),
@@ -656,6 +664,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -683,6 +692,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
               doc_type_supported: boolean,
             )
 
@@ -705,6 +715,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
               classification_info: hash_including(
                 Front: hash_including(ClassName: 'Identification Card', CountryCode: 'USA'),
                 Back: hash_including(ClassName: 'Identification Card', CountryCode: 'USA'),
@@ -753,6 +764,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -780,6 +792,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
               doc_type_supported: boolean,
             )
 
@@ -802,6 +815,7 @@ RSpec.describe Idv::ImageUploadsController do
               back_image_fingerprint: an_instance_of(String),
               getting_started_ab_test_bucket: :welcome_default,
               phone_question_ab_test_bucket: :bypass_phone_question,
+              phone_with_camera: nil,
               classification_info: hash_including(:Front, :Back),
             )
 
@@ -870,6 +884,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -899,6 +914,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
           doc_type_supported: boolean,
         )
 
@@ -942,6 +958,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -973,6 +990,7 @@ RSpec.describe Idv::ImageUploadsController do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
           doc_type_supported: boolean,
         )
 

--- a/spec/controllers/idv/unavailable_controller_spec.rb
+++ b/spec/controllers/idv/unavailable_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Idv::UnavailableController, type: :controller do
           lexisnexis_trueid: :operational,
           sms: :operational,
           voice: :operational,
+          idv_scheduled_maintenance: :operational,
         },
       )
     end
@@ -52,6 +53,7 @@ RSpec.describe Idv::UnavailableController, type: :controller do
             lexisnexis_trueid: :operational,
             sms: :operational,
             voice: :operational,
+            idv_scheduled_maintenance: :operational,
           },
         )
       end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -69,10 +69,10 @@ RSpec.feature 'Analytics Regression', js: true do
         width: 284, height: 38, mimeType: 'image/png', source: 'upload', size: 3694, attempt: 1, flow_path: 'standard', acuant_sdk_upgrade_a_b_testing_enabled: 'false', use_alternate_sdk: anything, acuant_version: anything, acuantCaptureMode: 'AUTO', fingerprint: anything, failedImageResubmission: boolean, phone_question_ab_test_bucket: 'bypass_phone_question', phone_with_camera: nil, documentType: nil, dpi: nil, glare: nil, glareScoreThreshold: nil, isAssessedAsBlurry: nil, isAssessedAsGlare: nil, isAssessedAsUnsupported: nil, moire: nil, sharpness: nil, sharpnessScoreThreshold: nil, assessment: nil
       },
       'IdV: doc auth image upload form submitted' => {
-        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question
+        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil
       },
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, classification_info: {}
+        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, classification_info: {}, phone_with_camera: nil
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false
@@ -177,10 +177,10 @@ RSpec.feature 'Analytics Regression', js: true do
         width: 284, height: 38, mimeType: 'image/png', source: 'upload', size: 3694, attempt: 1, flow_path: 'hybrid', acuant_sdk_upgrade_a_b_testing_enabled: 'false', use_alternate_sdk: anything, acuant_version: anything, acuantCaptureMode: 'AUTO', fingerprint: anything, failedImageResubmission: boolean, phone_question_ab_test_bucket: 'bypass_phone_question', documentType: nil, dpi: nil, glare: nil, glareScoreThreshold: nil, isAssessedAsBlurry: nil, isAssessedAsGlare: nil, isAssessedAsUnsupported: nil, moire: nil, sharpness: nil, sharpnessScoreThreshold: nil, assessment: nil, phone_with_camera: nil
       },
       'IdV: doc auth image upload form submitted' => {
-        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'hybrid', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question
+        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'hybrid', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil
       },
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'hybrid', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, classification_info: {}
+        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'hybrid', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, classification_info: {}, phone_with_camera: nil
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'hybrid', step: 'document_capture', acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, analytics_id: 'Doc Auth', irs_reproofing: false
@@ -282,10 +282,10 @@ RSpec.feature 'Analytics Regression', js: true do
         width: 284, height: 38, mimeType: 'image/png', source: 'upload', size: 3694, attempt: 1, flow_path: 'standard', acuant_sdk_upgrade_a_b_testing_enabled: 'false', use_alternate_sdk: anything, acuant_version: anything, acuantCaptureMode: 'AUTO', fingerprint: anything, failedImageResubmission: boolean, phone_question_ab_test_bucket: 'bypass_phone_question', phone_with_camera: nil, documentType: nil, dpi: nil, glare: nil, glareScoreThreshold: nil, isAssessedAsBlurry: nil, isAssessedAsGlare: nil, isAssessedAsUnsupported: nil, moire: nil, sharpness: nil, sharpnessScoreThreshold: nil, assessment: nil
       },
       'IdV: doc auth image upload form submitted' => {
-        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question
+        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil
       },
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, classification_info: {}
+        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, classification_info: {}, phone_with_camera: nil
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false
@@ -369,9 +369,9 @@ RSpec.feature 'Analytics Regression', js: true do
         width: 284, height: 38, mimeType: 'image/png', source: 'upload', size: 3694, attempt: 1, flow_path: 'standard', acuant_sdk_upgrade_a_b_testing_enabled: 'false', use_alternate_sdk: anything, acuant_version: anything, acuantCaptureMode: 'AUTO', fingerprint: anything, failedImageResubmission: boolean, phone_question_ab_test_bucket: 'bypass_phone_question', phone_with_camera: nil, documentType: nil, dpi: nil, glare: nil, glareScoreThreshold: nil, isAssessedAsBlurry: nil, isAssessedAsGlare: nil, isAssessedAsUnsupported: nil, moire: nil, sharpness: nil, sharpnessScoreThreshold: nil, assessment: nil
       },
       'IdV: doc auth image upload form submitted' => {
-        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question
+        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil
       },
-      'IdV: doc auth image upload vendor submitted' => hash_including(success: true, flow_path: 'standard', attention_with_barcode: true, doc_auth_result: 'Attention'),
+      'IdV: doc auth image upload vendor submitted' => hash_including(success: true, flow_path: 'standard', attention_with_barcode: true, doc_auth_result: 'Attention', phone_with_camera: nil),
       'IdV: verify in person troubleshooting option clicked' => {
         flow_path: 'standard',
       },

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -9,10 +9,12 @@ RSpec.feature 'document capture step', :js do
   let(:user) { user_with_2fa }
   let(:fake_analytics) { FakeAnalytics.new }
   let(:sp_name) { 'Test SP' }
+  let(:enable_not_ready) { true }
   before do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ServiceProviderSession).to receive(:sp_name).and_return(sp_name)
-
+    allow(IdentityConfig.store).to receive(:doc_auth_not_ready_section_enabled).
+      and_return(enable_not_ready)
     visit_idp_from_oidc_sp_with_ial2
 
     sign_in_and_2fa_user(user)
@@ -133,6 +135,16 @@ RSpec.feature 'document capture step', :js do
       attach_and_submit_images
 
       expect(DocAuthLog.find_by(user_id: user.id).state).to be_nil
+    end
+    context 'not ready section' do
+      it 'renders not ready section when enabled' do
+        expect(page).to have_content(
+          I18n.t(
+            'doc_auth.not_ready.content_sp', sp_name: sp_name,
+                                             app_name: APP_NAME
+          ),
+        )
+      end
     end
   end
 

--- a/spec/features/idv/doc_auth/phone_question_spec.rb
+++ b/spec/features/idv/doc_auth/phone_question_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'phone question step' do
     complete_doc_auth_steps_before_hybrid_handoff_step
   end
 
-  context 'phone question answered' do
+  context 'phone question answered', :js do
     let(:analytics_name) { 'IdV: doc auth phone question submitted' }
 
     describe '#camera_with_phone' do
@@ -47,6 +47,16 @@ RSpec.feature 'phone question step' do
         expect(current_path).to eq(idv_cancel_path)
         click_on t('idv.cancel.actions.keep_going')
         expect(page).to have_current_path(idv_hybrid_handoff_path(redo: true))
+        complete_hybrid_handoff_step
+        attach_and_submit_images
+        expect(fake_analytics).to have_logged_event(
+          'IdV: doc auth image upload form submitted',
+          hash_including(phone_with_camera: true),
+        )
+        expect(fake_analytics).to have_logged_event(
+          'IdV: doc auth image upload vendor submitted',
+          hash_including(phone_with_camera: true),
+        )
       end
     end
 
@@ -57,6 +67,15 @@ RSpec.feature 'phone question step' do
         expect(fake_analytics).to have_logged_event(
           :idv_doc_auth_phone_question_submitted,
           hash_including(step: 'phone_question', phone_with_camera: false),
+        )
+        attach_and_submit_images
+        expect(fake_analytics).to have_logged_event(
+          'IdV: doc auth image upload form submitted',
+          hash_including(phone_with_camera: false),
+        )
+        expect(fake_analytics).to have_logged_event(
+          'IdV: doc auth image upload vendor submitted',
+          hash_including(phone_with_camera: false),
         )
       end
     end

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
 
       visit idv_verify_info_url
 
-      click_idv_continue
+      complete_verify_step
 
       expect(page).to have_current_path(idv_phone_path)
 
@@ -107,7 +107,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
       let(:use_bad_ssn) { true }
 
       it 'shows a troubleshooting option to allow the user to cancel and return to SP' do
-        click_idv_continue
+        complete_verify_step
         expect(page).to have_link(
           t('links.cancel'),
           href: idv_cancel_path(step: :invalid_session),

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       expect(page).to have_content('12345')
       expect(page).to have_content('Apt 3E')
 
-      click_idv_continue
+      complete_verify_step
 
       expect(fake_analytics).to have_logged_event(
         'IdV: doc auth verify proofing results',
@@ -90,7 +90,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
         **fake_pii_details,
         ssn: DocAuthHelper::GOOD_SSN,
       )
-      click_idv_continue
+      complete_verify_step
 
       expect(fake_analytics).to have_logged_event(
         'IdV: doc auth verify proofing results',
@@ -108,7 +108,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     )
     fill_out_ssn_form_with_ssn_that_fails_resolution
     click_idv_continue
-    click_idv_continue
+    complete_verify_step
 
     expect(page).to have_current_path(idv_session_errors_warning_path)
     expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
@@ -127,7 +127,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     fill_out_ssn_form_with_ssn_that_raises_exception
 
     click_idv_continue
-    click_idv_continue
+    complete_verify_step
 
     expect(fake_analytics).to have_logged_event(
       'IdV: doc auth exception visited',
@@ -157,13 +157,13 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
         with({ limiter_context: 'single-session' })
 
       (max_resolution_attempts - 2).times do
-        click_idv_continue
+        complete_verify_step
         expect(page).to have_current_path(idv_session_errors_warning_path)
         click_try_again
       end
 
       # Check that last attempt shows correct warning text
-      click_idv_continue
+      complete_verify_step
       expect(page).to have_current_path(idv_session_errors_warning_path)
       expect(page).to have_content(
         strip_tags(
@@ -172,7 +172,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       )
       click_try_again
 
-      click_idv_continue
+      complete_verify_step
       expect(page).to have_current_path(idv_session_errors_failure_path)
       expect(page).not_to have_css('.step-indicator__step--current', text: text, wait: 5)
       expect(fake_analytics).to have_logged_event(
@@ -187,7 +187,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
         sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_verify_step
-        click_idv_continue
+        complete_verify_step
 
         expect(page).to have_current_path(idv_phone_path)
         expect(RateLimiter.new(user: user, rate_limit_type: :idv_resolution)).to be_limited
@@ -215,7 +215,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       fill_out_ssn_form_with_ssn_that_fails_resolution
       click_idv_continue
       (max_ssn_attempts - 1).times do
-        click_idv_continue
+        complete_verify_step
         expect(page).to have_current_path(idv_session_errors_warning_path)
         click_try_again
       end
@@ -224,7 +224,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     it 'rate limits ssn and continues when it expires' do
       expect(fake_attempts_tracker).to receive(:idv_verification_rate_limited).at_least(1).times.
         with({ limiter_context: 'multi-session' })
-      click_idv_continue
+      complete_verify_step
       expect(page).to have_current_path(idv_session_errors_ssn_failure_path)
       expect(fake_analytics).to have_logged_event(
         'Rate Limit Reached',
@@ -238,7 +238,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       travel_to(IdentityConfig.store.idv_attempt_window_in_hours.hours.from_now + 1) do
         sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_verify_step
-        click_idv_continue
+        complete_verify_step
 
         expect(page).to have_current_path(idv_phone_path)
       end
@@ -256,7 +256,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
 
       fill_in t('idv.form.ssn_label'), with: '900456789'
       click_button t('forms.buttons.submit.update')
-      click_idv_continue
+      complete_verify_step
 
       expect(page).to have_current_path(idv_phone_path)
       expect(fake_analytics).not_to have_logged_event(
@@ -297,7 +297,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
 
         sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_verify_step
-        click_idv_continue
+        complete_verify_step
 
         expect(DocAuthLog.find_by(user_id: user.id).aamva).not_to be_nil
       end
@@ -321,7 +321,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
 
         sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_verify_step
-        click_idv_continue
+        complete_verify_step
 
         expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
       end
@@ -344,7 +344,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
         visit_idp_from_sp_with_ial1(:oidc)
         sign_in_and_2fa_user(user)
         complete_doc_auth_steps_before_verify_step
-        click_idv_continue
+        complete_verify_step
 
         expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
       end
@@ -359,12 +359,12 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       allow(DocumentCaptureSession).to receive(:find_by).
         and_return(nil)
 
-      click_idv_continue
+      complete_verify_step
       expect(fake_analytics).to have_logged_event('IdV: proofing resolution result missing')
       expect(page).to have_content(t('idv.failure.timeout'))
       expect(page).to have_current_path(idv_verify_info_path)
       allow(DocumentCaptureSession).to receive(:find_by).and_call_original
-      click_idv_continue
+      complete_verify_step
       expect(page).to have_current_path(idv_phone_path)
     end
 
@@ -381,7 +381,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       allow(DocumentCaptureSession).to receive(:find_by).
         and_return(nil)
 
-      click_idv_continue
+      complete_verify_step
       expect(page).to have_content(t('idv.failure.timeout'))
       expect(page).to have_current_path(idv_verify_info_path)
       allow(DocumentCaptureSession).to receive(:find_by).and_call_original
@@ -396,11 +396,11 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       allow(DocumentCaptureSession).to receive(:find_by).
         and_return(nil)
 
-      click_idv_continue
+      complete_verify_step
       expect(page).to have_content(t('idv.failure.timeout'))
       expect(page).to have_current_path(idv_verify_info_path)
       allow(DocumentCaptureSession).to receive(:find_by).and_call_original
-      click_idv_continue
+      complete_verify_step
       expect(page).to have_current_path(idv_phone_path)
     end
   end
@@ -418,7 +418,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     end
 
     it 'redirects to the gpo page when continuing from verify info page' do
-      click_idv_continue
+      complete_verify_step
       expect(page).to have_current_path(idv_request_letter_path)
 
       click_on 'Cancel'

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       click_idv_continue
 
       expect(page).to have_content(t('headings.verify'))
-      click_idv_continue
+      complete_verify_step
 
       prefilled_phone = page.find(id: 'idv_phone_form_phone').value
 
@@ -252,7 +252,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:last_name])
         expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:address1])
 
-        click_idv_continue
+        complete_verify_step
       end
     end
   end
@@ -308,7 +308,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:last_name])
         expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:address1])
 
-        click_idv_continue
+        complete_verify_step
       end
     end
   end
@@ -342,7 +342,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       click_idv_continue
 
       expect(page).to have_content(t('headings.verify'))
-      click_idv_continue
+      complete_verify_step
 
       prefilled_phone = page.find(id: 'idv_phone_form_phone').value
 

--- a/spec/features/idv/steps/in_person/verify_info_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_info_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true do
     complete_state_id_step(user)
     fill_out_ssn_form_with_ssn_that_fails_resolution
     click_idv_continue
-    click_idv_continue
+    complete_verify_step(user)
 
     expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))
     click_on t('idv.failure.button.warning')
@@ -161,7 +161,7 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true do
     complete_location_step(user)
     complete_state_id_step(user)
     complete_ssn_step(user)
-    click_idv_continue
+    complete_verify_step(user)
 
     expect(page).to have_content(t('titles.idv.phone'))
     expect(fake_analytics).to have_logged_event(

--- a/spec/features/idv/threat_metrix_pending_spec.rb
+++ b/spec/features/idv/threat_metrix_pending_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Users pending ThreatMetrix review', :js do
     complete_doc_auth_steps_before_ssn_step
     select 'Reject', from: :mock_profiling_result
     complete_ssn_step
-    click_idv_continue
+    complete_verify_step
     complete_phone_step(user)
     complete_enter_password_step(user)
     acknowledge_and_confirm_personal_key
@@ -117,7 +117,7 @@ RSpec.feature 'Users pending ThreatMetrix review', :js do
       complete_doc_auth_steps_before_ssn_step
       select 'No Result', from: :mock_profiling_result
       complete_ssn_step
-      click_idv_continue
+      complete_verify_step
 
       expect(page).to have_content(t('idv.failure.sessions.exception'))
       expect(page).to have_current_path(idv_session_errors_exception_path)

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
         )
 
         expect(fake_analytics).to have_logged_event(
@@ -147,6 +148,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           doc_type_supported: boolean,
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
         )
       end
 
@@ -210,6 +212,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
         )
       end
 
@@ -344,6 +347,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           back_image_fingerprint: an_instance_of(String),
           getting_started_ab_test_bucket: :welcome_default,
           phone_question_ab_test_bucket: :bypass_phone_question,
+          phone_with_camera: nil,
           side: 'both',
         )
       end

--- a/spec/javascript/packages/document-capture/components/document-capture-not-ready-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-not-ready-spec.tsx
@@ -1,0 +1,127 @@
+import sinon from 'sinon';
+
+import { FlowContext } from '@18f/identity-verify-flow';
+import { I18nContext } from '@18f/identity-react-i18n';
+import { I18n } from '@18f/identity-i18n';
+import userEvent from '@testing-library/user-event';
+import type { Navigate } from '@18f/identity-url';
+import {
+  AnalyticsContextProvider,
+  ServiceProviderContextProvider,
+} from '@18f/identity-document-capture/context';
+import DocumentCaptureNotReady from '@18f/identity-document-capture/components/document-capture-not-ready';
+import { expect } from 'chai';
+import { render } from '../../../support/document-capture';
+
+describe('DocumentCaptureNotReady', () => {
+  beforeEach(() => {
+    const config = document.createElement('script');
+    config.id = 'test-config';
+    config.type = 'application/json';
+    config.setAttribute('data-config', '');
+    config.textContent = JSON.stringify({ appName: 'Login.gov' });
+    document.body.append(config);
+  });
+  const trackEvent = sinon.spy();
+  const navigateSpy: Navigate = sinon.spy();
+  context('with service provider', () => {
+    const spName = 'testSP';
+    it('renders, track event and redirect', async () => {
+      const { getByRole } = render(
+        <AnalyticsContextProvider trackEvent={trackEvent}>
+          <ServiceProviderContextProvider
+            value={{
+              name: spName,
+              failureToProofURL: 'http://example.test/url/to/failure-to-proof',
+              getFailureToProofURL: () => '',
+            }}
+          >
+            <FlowContext.Provider
+              value={{
+                currentStep: 'document_capture',
+                cancelURL: '',
+                exitURL: '',
+              }}
+            >
+              <I18nContext.Provider
+                value={
+                  new I18n({
+                    strings: {
+                      'doc_auth.not_ready.header': 'header text',
+                      'doc_auth.not_ready.content_sp':
+                        'If you exit %{app_name} and return to %{sp_name}.',
+                      'doc_auth.not_ready.button_sp': 'Exit %{app_name} and return to %{sp_name}',
+                    },
+                  })
+                }
+              >
+                <DocumentCaptureNotReady navigate={navigateSpy} />
+              </I18nContext.Provider>
+            </FlowContext.Provider>
+          </ServiceProviderContextProvider>
+        </AnalyticsContextProvider>,
+      );
+      // header
+      expect(getByRole('heading', { name: 'header text', level: 2 })).to.be.ok();
+
+      // content and exit link
+      const exitLink = getByRole('button', { name: 'Exit Login.gov and return to testSP' });
+      expect(exitLink).to.be.ok();
+      await userEvent.click(exitLink);
+      expect(navigateSpy).to.be.called.calledWithMatch(
+        /failure-to-proof\?step=document_capture&location=not_ready/,
+      );
+      expect(trackEvent).to.be.calledWithMatch(/IdV: docauth not ready link clicked/);
+    });
+  });
+
+  context('without service provider', () => {
+    it('renders, track event and redirect', async () => {
+      const { getByRole } = render(
+        <AnalyticsContextProvider trackEvent={trackEvent}>
+          <ServiceProviderContextProvider
+            value={{
+              name: null,
+              failureToProofURL: 'http://example.test/url/to/failure-to-proof',
+              getFailureToProofURL: () => '',
+            }}
+          >
+            <FlowContext.Provider
+              value={{
+                currentStep: 'document_capture',
+                cancelURL: '',
+                exitURL: '',
+              }}
+            >
+              <I18nContext.Provider
+                value={
+                  new I18n({
+                    strings: {
+                      'doc_auth.not_ready.header': 'header text',
+                      'doc_auth.not_ready.content_nosp':
+                        'If you exit %{app_name} now, you will not have verified your identity.',
+                      'doc_auth.not_ready.button_nosp': 'Cancel and return to your profile',
+                    },
+                  })
+                }
+              >
+                <DocumentCaptureNotReady navigate={navigateSpy} />
+              </I18nContext.Provider>
+            </FlowContext.Provider>
+          </ServiceProviderContextProvider>
+        </AnalyticsContextProvider>,
+      );
+      // header
+      expect(getByRole('heading', { name: 'header text', level: 2 })).to.be.ok();
+
+      // content and exit link
+      const exitLink = getByRole('button', { name: 'Cancel and return to your profile' });
+      expect(exitLink).to.be.ok();
+      await userEvent.click(exitLink);
+      expect(navigateSpy).to.be.called.calledWithMatch(
+        /account\?step=document_capture&location=not_ready/,
+      );
+      expect(trackEvent).to.be.calledWithMatch(/IdV: docauth not ready link clicked/);
+    });
+  });
+});

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
@@ -1,12 +1,15 @@
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
+import { expect } from 'chai';
 import { t } from '@18f/identity-i18n';
 import {
   DeviceContext,
   UploadContextProvider,
   FailedCaptureAttemptsContextProvider,
+  FeatureFlagContext,
 } from '@18f/identity-document-capture';
 import DocumentsStep from '@18f/identity-document-capture/components/documents-step';
+import { composeComponents } from '@18f/identity-compose-components';
 import { render } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
 
@@ -81,5 +84,40 @@ describe('document-capture/components/documents-step', () => {
     const notExpectedText = t('doc_auth.hybrid_flow_warning.explanation_non_sp_html');
 
     expect(queryByText(notExpectedText)).to.not.exist();
+  });
+
+  context('not ready section', () => {
+    it('is rendered when enabled', () => {
+      const App = composeComponents(
+        [
+          FeatureFlagContext.Provider,
+          {
+            value: {
+              notReadySectionEnabled: true,
+            },
+          },
+        ],
+        [DocumentsStep],
+      );
+      const { getByRole } = render(<App />);
+      expect(getByRole('heading', { name: 'doc_auth.not_ready.header', level: 2 })).to.be.ok();
+      const button = getByRole('button', { name: 'doc_auth.not_ready.button_nosp' });
+      expect(button).to.be.ok();
+    });
+    it('is not rendered when disabled', () => {
+      const App = composeComponents(
+        [
+          FeatureFlagContext.Provider,
+          {
+            value: {
+              notReadySectionEnabled: false,
+            },
+          },
+        ],
+        [DocumentsStep],
+      );
+      const { queryByRole } = render(<App />);
+      expect(queryByRole('heading', { name: 'doc_auth.not_ready.header', level: 2 })).to.be.null();
+    });
   });
 });

--- a/spec/services/browser_support_spec.rb
+++ b/spec/services/browser_support_spec.rb
@@ -42,8 +42,9 @@ RSpec.describe BrowserSupport do
 
     context 'with valid browser support config' do
       before do
-        allow(BrowserSupport).to receive(:browser_support_config).
-          and_return(['chrome 109', 'and_chr 108', 'ios_saf 14.5-14.8', 'op_mini all'])
+        allow(BrowserSupport).to receive(:browser_support_config).and_return(
+          ['chrome 109', 'and_chr 108', 'ios_saf 14.5-14.8', 'op_mini all', 'android 119'],
+        )
       end
 
       context 'with nil user agent' do
@@ -112,16 +113,81 @@ RSpec.describe BrowserSupport do
           it { expect(supported).to eq(true) }
         end
       end
-    end
 
-    context 'with user agent for platform-specific version support' do
-      let(:user_agent) do
-        # Android Chrome v108
-        'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) ' \
-          'Chrome/108.0.5481.153 Mobile Safari/537.36'
+      context 'with user agent for platform-specific version support' do
+        let(:user_agent) do
+          # Android Chrome v108
+          'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) ' \
+            'Chrome/108.0.5481.153 Mobile Safari/537.36'
+        end
+
+        it { expect(supported).to eq(true) }
       end
 
-      it { expect(supported).to eq(true) }
+      context 'with user agent for webview parsed as chrome' do
+        context 'with version below supported range' do
+          let(:user_agent) do
+            # Android WebView v109
+            'Mozilla/5.0 (Linux; Android 7.0; mione A55 Build/NRD90M; wv) AppleWebKit/537.36 ' \
+              '(KHTML, like Gecko) Version/4.0 Chrome/109.0.5414.85 Mobile Safari/537.36'
+          end
+
+          it { expect(supported).to eq(false) }
+        end
+
+        context 'with version within supported range' do
+          let(:user_agent) do
+            # Android WebView v119
+            'Mozilla/5.0 (Linux; Android 13; SM-A546B Build/TP1A.220624.014; wv) ' \
+              'AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/119.0.6045.66 Mobile ' \
+              'Safari/537.36'
+          end
+
+          it { expect(supported).to eq(true) }
+        end
+      end
+
+      context 'with opera desktop user agent' do
+        let(:user_agent) do
+          # Opera 83
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' \
+            'Chrome/103.0.5046.0 Safari/537.36 OPR/83.0.4254.70'
+        end
+
+        context 'with opera mobile supported range, but no support for desktop' do
+          before do
+            allow(BrowserSupport).to receive(:browser_support_config).and_return(['op_mob 73'])
+          end
+
+          it { expect(supported).to eq(false) }
+        end
+      end
+
+      context 'with opera mobile user agent' do
+        before do
+          allow(BrowserSupport).to receive(:browser_support_config).and_return(['op_mob 72'])
+        end
+
+        context 'with version within supported range' do
+          let(:user_agent) do
+            # Opera Mobile 72
+            'Mozilla/5.0 (Linux; Android 6.0.1; TX2) AppleWebKit/537.36 (KHTML, like Gecko) ' \
+              'Chrome/106.0.5249.126 Safari/537.36 OPR/72.9.3767.72992'
+          end
+
+          it { expect(supported).to eq(true) }
+        end
+
+        context 'with version below supported range' do
+          let(:user_agent) do
+            # Opera Mobile 71
+            'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 7) AppleWebKit/537.36 (KHTML, like Gecko) ' \
+              'Chrome/104.0.5112.97 Safari/537.36 OPR/71.3.3718.67322'
+          end
+
+          it { expect(supported).to eq(false) }
+        end
+      end
     end
   end
 end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -150,7 +150,7 @@ module DocAuthHelper
   end
 
   def complete_verify_step
-    click_idv_continue
+    click_idv_submit_default
   end
 
   def complete_doc_auth_steps_before_address_step(expect_accessible: false)
@@ -331,7 +331,7 @@ module DocAuthHelper
     complete_doc_auth_steps_before_ssn_step
     select threatmetrix, from: :mock_profiling_result
     complete_ssn_step
-    click_idv_continue
+    complete_verify_step
     complete_phone_step(user)
     complete_enter_password_step(user)
     acknowledge_and_confirm_personal_key

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -39,6 +39,10 @@ module IdvHelper
     click_spinner_button_and_wait t('forms.buttons.continue')
   end
 
+  def click_idv_submit_default
+    click_spinner_button_and_wait t('forms.buttons.submit.default')
+  end
+
   def click_idv_update
     click_on t('forms.buttons.submit.update')
   end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -136,7 +136,7 @@ module InPersonHelper
   end
 
   def complete_verify_step(_user = nil)
-    click_idv_continue
+    click_idv_submit_default
   end
 
   def complete_all_in_person_proofing_steps(user = user_with_2fa, same_address_as_id: true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,9 +2382,9 @@ camelcase@^6.0.0, camelcase@^6.3.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001541:
-  version "1.0.30001549"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001549.tgz#7d1a3dce7ea78c06ed72c32c2743ea364b3615aa"
-  integrity sha512-qRp48dPYSCYaP+KurZLhDYdVE+yEyht/3NlmcJgVQ2VMGt6JL36ndQ/7rgspdZsJuxDPFIo/OzBT2+GmIJ53BA==
+  version "1.0.30001561"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz#752f21f56f96f1b1a52e97aae98c57c562d5d9da"
+  integrity sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==
 
 chai-as-promised@^7.1.1:
   version "7.1.1"


### PR DESCRIPTION
## User-Facing Improvements
- Identity verification: Update experience for users not ready to upload documents. ([#9506](https://github.com/18F/identity-idp/pull/9506))
- Identity verification: Clarify text on "Verify info" screen ([#9556](https://github.com/18F/identity-idp/pull/9556))

## Internal
- Analytics: Add phone_with_camera to image upload events ([#9537](https://github.com/18F/identity-idp/pull/9537))
- Analytics: Create webauthn submit analytics event ([#9417](https://github.com/18F/identity-idp/pull/9417))
- Authentication: Disposable emails database loaded ([#9440](https://github.com/18F/identity-idp/pull/9440))
- Browser Support: Improve browser detection for browser support ([#9557](https://github.com/18F/identity-idp/pull/9557))
- Documentation: Add documentation for sample applications ([#9558](https://github.com/18F/identity-idp/pull/9558))
- Review apps: Enable mailer preview in review apps ([#9542](https://github.com/18F/identity-idp/pull/9542))
- Vendor outages: Add config to schedule IDV maintenance ([#9552](https://github.com/18F/identity-idp/pull/9552))

