### PR TITLE
Remove unused key_pair_generation_percent configuration key

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -153,7 +153,6 @@ in_person_outage_emailed_by_date: 'November 1, 2024'
 in_person_send_proofing_notifications_enabled: false
 in_person_stop_expiring_enrollments: false
 include_slo_in_saml_metadata: false
-key_pair_generation_percent: 0
 logins_per_ip_track_only_mode: false
 # LexisNexis #####################################################
 lexisnexis_base_url: https://www.example.com


### PR DESCRIPTION
## 🛠 Summary of changes

Does what it says on the tin. The key was perhaps mistakenly re-added in #7228 after being removed in #7233.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
