### PR TITLE
Enhance errors.add linter to check symbol as second argument

### DIFF
--- a/lib/linters/errors_add_linter.rb
+++ b/lib/linters/errors_add_linter.rb
@@ -22,15 +22,12 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          unless node.arguments.last.type == :hash || errors_add_match?(node).nil?
-            return add_offense(node, location: :expression)
-          end
-          errors_add_match?(node) do |arguments|
-            type_node = arguments.last.pairs.find do |pair|
-              pair.key.sym_type? && pair.key.source == 'type'
-            end
-            add_offense(node, location: :expression) unless type_node
-          end
+          return unless errors_add_match?(node)
+          _attr, type, options = node.arguments
+          return if type && type.type == :sym
+          options = type if type && type.type == :hash
+          return if options && options.type == :hash && options.keys.map(&:value).include?(:type)
+          add_offense(node, location: :expression)
         end
       end
     end

--- a/spec/lib/linters/errors_add_linter_spec.rb
+++ b/spec/lib/linters/errors_add_linter_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do
     RUBY
   end
 
-  it 'registers no offense when defining hash as second argumetn including "type"' do
+  it 'registers no offense when defining hash as second argument including "type"' do
     expect_no_offenses(<<~RUBY)
       class MyModel
         def validate

--- a/spec/lib/linters/errors_add_linter_spec.rb
+++ b/spec/lib/linters/errors_add_linter_spec.rb
@@ -9,11 +9,22 @@ RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do
   let(:config) { RuboCop::Config.new }
   let(:cop) { RuboCop::Cop::IdentityIdp::ErrorsAddLinter.new(config) }
 
+  it 'registers an offense when neither type nor options are specified' do
+    expect_offense(<<~RUBY)
+      class MyModel
+        def my_method
+          errors.add(:number)
+          ^^^^^^^^^^^^^^^^^^^ IdentityIdp/ErrorsAddLinter: Please set a unique key for this error
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense when no options are passed' do
     expect_offense(<<~RUBY)
       class MyModel
         def my_method
-          errors.add(:number, "is negative")
+          errors.add(:number, 'is negative')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/ErrorsAddLinter: Please set a unique key for this error
         end
       end
@@ -24,7 +35,7 @@ RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do
     expect_offense(<<~RUBY)
       class MyModel
         def my_method
-          errors.add(:number, "is negative", foo: :bar)
+          errors.add(:number, 'is negative', foo: :bar)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/ErrorsAddLinter: Please set a unique key for this error
         end
       end
@@ -48,7 +59,31 @@ RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do
       class MyModel
         def validate
           if number.negative?
-            errors.add(:number, "is negative", type: :is_negative)
+            errors.add(:number, 'is negative', type: :is_negative)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers no offense when defining hash as second argumetn including "type"' do
+    expect_no_offenses(<<~RUBY)
+      class MyModel
+        def validate
+          if number.negative?
+            errors.add(:number, message: 'is negative', type: :is_negative)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers no offense when type symbool is defined as second argument' do
+    expect_no_offenses(<<~RUBY)
+      class MyModel
+        def validate
+          if number.negative?
+            errors.add(:number, :is_negative, message: 'is negative')
           end
         end
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Enhances our `errors.add` linter to allow the expected `type` symbol to be specified as the second argument of the `errors.add` call.

The context for this linter is that we want to have a way to query for errors within logs irrespective of locale, and having a symbol "type" supports this, and it's expected to be logged through the `error_details` property.

Example:

https://github.com/18F/identity-idp/blob/99916caf4f66f443a075cc152cdf3fdcd8348006/spec/services/form_response_spec.rb#L141-L153

In fact, due to an issue with `FormResponse`, _only_ this form of `errors.add` currently works as expected. See #9570 for a pull request fixing that behavior.

## 📜 Testing Plan

Build should have no failures.