### PR TITLE
Fix FormResponse to pick error details as type

### DIFF
--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -56,7 +56,7 @@ class FormResponse
   end
 
   def flatten_details(details)
-    details.transform_values { |errors| errors.pluck(:error) }
+    details.transform_values { |errors| errors.flat_map { |error| error[:type] || error[:error] } }
   end
 
   attr_reader :success

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -177,6 +177,25 @@ RSpec.describe FormResponse do
         expect(combined_response.to_h).to eq response_hash
       end
 
+      context 'with error detail symbol defined as type option on error' do
+        it 'returns a hash with success, errors, and error_details keys' do
+          errors = ActiveModel::Errors.new(build_stubbed(:user))
+          errors.add(:email_language, 'Language cannot be blank', type: :blank)
+          response = FormResponse.new(success: false, errors: errors)
+          response_hash = {
+            success: false,
+            errors: {
+              email_language: ['Language cannot be blank'],
+            },
+            error_details: {
+              email_language: [:blank],
+            },
+          }
+
+          expect(response.to_h).to eq response_hash
+        end
+      end
+
       context 'with serialize_error_details_only' do
         it 'excludes errors from the hash' do
           errors = ActiveModel::Errors.new(build_stubbed(:user))


### PR DESCRIPTION
## 🛠 Summary of changes

Improves `FormResponse`'s serialization of `error_details` to consistently opt for the symbol form of the individual error.

The specs already largely asserted for this behavior, but only when calling `errors.add` with a symbol as the second argument (see related #9569).

For context, `error_details` was added in #5048 as a way to support querying for errors within logs irrespective of locale by assigning a locale-independent symbol type. Therefore, including human-readable strings in `error_details` is counter to the original goal of the property.

Extracted from #9564

## 📜 Testing Plan

```
rspec spec/services/form_response_spec.rb
```