### PR TITLE
LG-11343: removes a no longer needed alert banner

### DIFF
--- a/app/views/idv/by_mail/enter_code/index.html.erb
+++ b/app/views/idv/by_mail/enter_code/index.html.erb
@@ -25,10 +25,6 @@
   <% end %>
 <% end %>
 
-<%= render AlertComponent.new(type: :warning, class: 'margin-bottom-3') do %>
-  <%= t('idv.gpo.change_to_verification_code_html') %>
-<% end %>
-
 <%= render AlertComponent.new(type: :info, class: 'margin-bottom-4', text_tag: 'div') do %>
   <p>
     <%= t('idv.gpo.alert_info') %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -180,8 +180,6 @@ en:
       alert_info: 'We sent a letter with your verification code to:'
       alert_rate_limit_warning_html: You can’t request more letters right now. Your
         previous letter request was on <strong>%{date_letter_was_sent}</strong>.
-      change_to_verification_code_html: 'The <strong>one-time code</strong> from your
-        letter is now referred to as <strong>verification code</strong>.'
       clear_and_start_over: Clear your information and start over
       did_not_receive_letter:
         form:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -190,8 +190,6 @@ es:
       alert_rate_limit_warning_html: No puede solicitar más cartas ahora mismo. Su
         solicitud de carta anterior la hizo el
         <strong>%{date_letter_was_sent}</strong>.
-      change_to_verification_code_html: 'El <strong>código único</strong> de su carta
-        ahora se conoce como <strong>código de verificación</strong>.'
       clear_and_start_over: Borrar su información y empezar de nuevo
       did_not_receive_letter:
         form:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -195,9 +195,6 @@ fr:
       alert_rate_limit_warning_html: Vous ne pouvez pas demander d’autres lettres pour
         le moment. Votre précédente demande de lettre a été effectuée le
         <strong>%{date_letter_was_sent}</strong>.
-      change_to_verification_code_html: 'Le <strong>code à usage unique</strong>
-        figurant dans votre lettre est désormais appelé <strong>code de
-        vérification</strong>.'
       clear_and_start_over: Supprimez vos données et recommencez
       did_not_receive_letter:
         form:

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -154,7 +154,12 @@ RSpec.feature 'idv enter letter code step' do
 
       expect(current_path).to eq idv_verify_by_mail_enter_code_path
       expect(page).to have_content t('idv.gpo.alert_info')
-      expect(page).to have_content strip_tags(t('idv.gpo.change_to_verification_code_html'))
+      # The following test ensures that removed content is actually removed. The text
+      # is hardcoded since the i18n entries have been removed. Once we're satisfied,
+      # this can be removed.
+      expect(page).not_to have_content(
+        'The one-time code from your letter is now referred to as verification code',
+      )
       expect(page).to have_content t('idv.gpo.wrong_address')
       expect(page).to have_content Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:address1]
       verify_no_rate_limit_banner

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -154,12 +154,6 @@ RSpec.feature 'idv enter letter code step' do
 
       expect(current_path).to eq idv_verify_by_mail_enter_code_path
       expect(page).to have_content t('idv.gpo.alert_info')
-      # The following test ensures that removed content is actually removed. The text
-      # is hardcoded since the i18n entries have been removed. Once we're satisfied,
-      # this can be removed.
-      expect(page).not_to have_content(
-        'The one-time code from your letter is now referred to as verification code',
-      )
       expect(page).to have_content t('idv.gpo.wrong_address')
       expect(page).to have_content Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:address1]
       verify_no_rate_limit_banner


### PR DESCRIPTION
## 🎫 Ticket

[LG-11343](https://cm-jira.usa.gov/browse/LG-11343)

## 🛠 Summary of changes

Removes the alert banner telling users the one-time code is now called verification code. Enough time has passed that any letters sent with the "one-time code" language have expired.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV, but request a letter
- [ ] Go to the enter_code page
- [ ] Verify that there is not an alert banner saying "The **one-time code** from your letter is now referred to as **verification code**"

## 👀 Screenshots

<details>
<summary>Before:</summary>
<img width="639" alt="lg-11343-before" src="https://github.com/18F/identity-idp/assets/2583060/a1fbcb2d-a10b-4bcb-9439-1b423fe56913">

</details>

<details>
<summary>After:</summary>
<img width="632" alt="lg-11343-after" src="https://github.com/18F/identity-idp/assets/2583060/8e5e08ee-b2d8-4754-9411-d080d5e4f084">

</details>