### PR TITLE
Restructure analytics error_details as hash

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -192,9 +192,14 @@ module Idv
         extra: {
           address_edited: !!idv_session.address_edited,
           address_line2_present: !pii[:address2].blank?,
-          pii_like_keypaths: [[:errors, :ssn], [:response_body, :first_name],
-                              [:same_address_as_id],
-                              [:state_id, :state_id_jurisdiction]],
+          pii_like_keypaths: [
+            [:errors, :ssn],
+            [:proofing_results, :context, :stages, :resolution, :errors, :ssn],
+            [:proofing_results, :context, :stages, :residential_address, :errors, :ssn],
+            [:proofing_results, :context, :stages, :threatmetrix, :response_body, :first_name],
+            [:same_address_as_id],
+            [:proofing_results, :context, :stages, :state_id, :state_id_jurisdiction],
+          ],
         },
       )
       log_idv_verification_submitted_event(

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -110,7 +110,10 @@ module IdvStepConcern
 
   def extra_analytics_properties
     extra = {
-      pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
+      pii_like_keypaths: [
+        [:same_address_as_id],
+        [:proofing_results, :context, :stages, :state_id, :state_id_jurisdiction],
+      ],
     }
 
     unless flow_session.dig(:pii_from_user, :same_address_as_id).nil?

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -29,7 +29,11 @@ module Users
 
         analytics.personal_key_reactivation_submitted(
           **result.to_h,
-          pii_like_keypaths: [[:errors, :personal_key], [:error_details, :personal_key]],
+          pii_like_keypaths: [
+            [:errors, :personal_key],
+            [:error_details, :personal_key],
+            [:error_details, :personal_key, :personal_key],
+          ],
         )
         irs_attempts_api_tracker.personal_key_reactivation_submitted(
           success: result.success?,

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -49,10 +49,10 @@ module Idv
     def self.pii_like_keypaths
       keypaths = [[:pii]]
       attrs = %i[name dob dob_min_age address1 state zipcode jurisdiction]
-      keypaths << attrs
       attrs.each do |k|
         keypaths << [:errors, k]
         keypaths << [:error_details, k]
+        keypaths << [:error_details, k, k]
       end
       keypaths
     end

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -56,7 +56,9 @@ class FormResponse
   end
 
   def flatten_details(details)
-    details.transform_values { |errors| errors.pluck(:error) }
+    details.transform_values do |errors|
+      errors.map { |error| error[:type] || error[:error] }.index_with(true)
+    end
   end
 
   attr_reader :success

--- a/app/services/idv/flows/in_person_flow.rb
+++ b/app/services/idv/flows/in_person_flow.rb
@@ -47,7 +47,10 @@ module Idv
 
       def extra_analytics_properties
         extra = {
-          pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
+          pii_like_keypaths: [
+            [:same_address_as_id],
+            [:proofing_results, :context, :stages, :state_id, :state_id_jurisdiction],
+          ],
         }
         unless @flow_session[:pii_from_user]&.[](:same_address_as_id).nil?
           extra[:same_address_as_id] =

--- a/app/services/irs_attempts_api/tracker.rb
+++ b/app/services/irs_attempts_api/tracker.rb
@@ -6,7 +6,7 @@ module IrsAttemptsApi
     end
 
     def parse_failure_reason(result)
-      return result.to_h[:error_details] || result.errors.presence
+      return result.to_h[:error_details]&.transform_values(&:keys) || result.errors.presence
     end
   end
 end

--- a/app/services/password_reset_token_validator.rb
+++ b/app/services/password_reset_token_validator.rb
@@ -17,6 +17,7 @@ class PasswordResetTokenValidator
   attr_accessor :user
 
   def valid_token
-    errors.add(:user, 'token_expired', type: :user) unless user.reset_password_period_valid?
+    return if user.reset_password_period_valid?
+    errors.add(:user, 'token_expired', type: :token_expired)
   end
 end

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AccountReset::CancelController do
         success: false,
         errors: { token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)] },
         error_details: {
-          token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)],
+          token: { cancel_token_invalid: true },
         },
         user_id: 'anonymous-uuid',
       }
@@ -55,7 +55,7 @@ RSpec.describe AccountReset::CancelController do
       analytics_hash = {
         success: false,
         errors: { token: [t('errors.account_reset.cancel_token_missing', app_name: APP_NAME)] },
-        error_details: { token: [:blank] },
+        error_details: { token: { blank: true } },
         user_id: 'anonymous-uuid',
       }
 
@@ -100,7 +100,7 @@ RSpec.describe AccountReset::CancelController do
         success: false,
         errors: { token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)] },
         error_details: {
-          token: [t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)],
+          token: { cancel_token_invalid: true },
         },
       }
       expect(@analytics).to receive(:track_event).

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: 'anonymous-uuid',
         success: false,
         errors: invalid_token_error,
-        error_details: invalid_token_error,
+        error_details: { token: { granted_token_invalid: true } },
         mfa_method_counts: {},
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
@@ -60,7 +60,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: 'anonymous-uuid',
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_missing', app_name: APP_NAME)] },
-        error_details: { token: [:blank] },
+        error_details: { token: { blank: true } },
         mfa_method_counts: {},
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
@@ -86,9 +86,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: user.uuid,
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
-        error_details: {
-          token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)],
-        },
+        error_details: { token: { granted_token_expired: true } },
         mfa_method_counts: {},
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 2,
@@ -114,7 +112,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: 'anonymous-uuid',
         success: false,
         errors: invalid_token_error,
-        error_details: invalid_token_error,
+        error_details: { token: { granted_token_invalid: true } },
       }
       expect(@analytics).to receive(:track_event).
         with('Account Reset: granted token validation', properties)
@@ -134,9 +132,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: user.uuid,
         success: false,
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
-        error_details: {
-          token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)],
-        },
+        error_details: { token: { granted_token_expired: true } },
       }
       expect(@analytics).to receive(:track_event).
         with('Account Reset: granted token validation', properties)

--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -166,7 +166,6 @@ RSpec.describe Idv::ByMail::EnterCodeController do
 
   describe '#create' do
     let(:otp_code_error_message) { { otp: [t('errors.messages.confirmation_code_incorrect')] } }
-    let(:otp_code_incorrect) { { otp: [:confirmation_code_incorrect] } }
     let(:success_properties) { { success: true, failure_reason: nil } }
 
     subject(:action) do
@@ -387,11 +386,11 @@ RSpec.describe Idv::ByMail::EnterCodeController do
           which_letter: nil,
           letter_count: 1,
           attempts: 1,
-          error_details: otp_code_incorrect,
+          error_details: { otp: { confirmation_code_incorrect: true } },
           pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         )
         expect(@irs_attempts_api_tracker).to receive(:idv_gpo_verification_submitted).
-          with(success: false, failure_reason: otp_code_incorrect)
+          with(success: false, failure_reason: { otp: [:confirmation_code_incorrect] })
 
         action
 
@@ -425,7 +424,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
             which_letter: nil,
             letter_count: 1,
             attempts: 1,
-            error_details: otp_code_incorrect,
+            error_details: { otp: { confirmation_code_incorrect: true } },
             pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
           }
           expect(@analytics).to receive(:track_event).with(
@@ -474,7 +473,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
             which_letter: nil,
             letter_count: 1,
             attempts: 1,
-            error_details: otp_code_incorrect,
+            error_details: { otp: { confirmation_code_incorrect: true } },
             pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
           ).exactly(max_attempts - 1).times
           expect(@analytics).to receive(:track_event).with(

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Idv::ImageUploadsController do
             front: ['Please fill in this field.'],
           },
           error_details: {
-            front: [:blank],
+            front: { blank: true },
           },
           user_id: user.uuid,
           attempts: 1,
@@ -123,7 +123,7 @@ RSpec.describe Idv::ImageUploadsController do
             front: [I18n.t('doc_auth.errors.not_a_file')],
           },
           error_details: {
-            front: [I18n.t('doc_auth.errors.not_a_file')],
+            front: { not_a_file: true },
           },
           user_id: user.uuid,
           attempts: 1,
@@ -261,7 +261,7 @@ RSpec.describe Idv::ImageUploadsController do
             limit: [I18n.t('errors.doc_auth.rate_limited_heading')],
           },
           error_details: {
-            limit: [I18n.t('errors.doc_auth.rate_limited_heading')],
+            limit: { rate_limited: true },
           },
           user_id: user.uuid,
           attempts: IdentityConfig.store.doc_auth_max_attempts,
@@ -603,7 +603,7 @@ RSpec.describe Idv::ImageUploadsController do
                 name: [I18n.t('doc_auth.errors.alerts.full_name_check')],
               },
               error_details: {
-                name: [I18n.t('doc_auth.errors.alerts.full_name_check')],
+                name: { name: true },
               },
               attention_with_barcode: false,
               user_id: user.uuid,
@@ -703,7 +703,7 @@ RSpec.describe Idv::ImageUploadsController do
                 state: [I18n.t('doc_auth.errors.general.no_liveness')],
               },
               error_details: {
-                state: [:wrong_length],
+                state: { wrong_length: true },
               },
               attention_with_barcode: false,
               user_id: user.uuid,
@@ -803,7 +803,7 @@ RSpec.describe Idv::ImageUploadsController do
                 dob: [I18n.t('doc_auth.errors.alerts.birth_date_checks')],
               },
               error_details: {
-                dob: [I18n.t('doc_auth.errors.alerts.birth_date_checks')],
+                dob: { dob: true },
               },
               attention_with_barcode: false,
               user_id: user.uuid,

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -75,7 +75,10 @@ RSpec.describe Idv::InPerson::SsnController do
         irs_reproofing: false,
         step: 'ssn',
         same_address_as_id: true,
-        pii_like_keypaths: [[:same_address_as_id], [:state_id, :state_id_jurisdiction]],
+        pii_like_keypaths: [
+          [:same_address_as_id],
+          [:proofing_results, :context, :stages, :state_id, :state_id_jurisdiction],
+        ],
       }.merge(ab_test_args)
     end
 
@@ -199,7 +202,7 @@ RSpec.describe Idv::InPerson::SsnController do
           errors: {
             ssn: ['Enter a nine-digit Social Security number'],
           },
-          error_details: { ssn: [:invalid] },
+          error_details: { ssn: { invalid: true } },
           same_address_as_id: true,
           pii_like_keypaths: [[:same_address_as_id], [:errors, :ssn], [:error_details, :ssn]],
         }.merge(ab_test_args)

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -239,12 +239,6 @@ RSpec.describe Idv::PhoneController do
       allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
     end
     context 'when form is invalid' do
-      let(:improbable_phone_error) do
-        {
-          phone: [:improbable_phone],
-          otp_delivery_preference: [:inclusion],
-        }
-      end
       let(:improbable_phone_message) { t('errors.messages.improbable_phone') }
       let(:improbable_otp_message) { 'is not included in the list' }
       let(:improbable_phone_number) { '703' }
@@ -285,7 +279,10 @@ RSpec.describe Idv::PhoneController do
         expect(@irs_attempts_api_tracker).to receive(:idv_phone_submitted).with(
           success: false,
           phone_number: improbable_phone_number,
-          failure_reason: improbable_phone_error,
+          failure_reason: {
+            phone: [:improbable_phone],
+            otp_delivery_preference: [:inclusion],
+          },
         )
 
         put :create, params: improbable_phone_form
@@ -296,7 +293,10 @@ RSpec.describe Idv::PhoneController do
             phone: [improbable_phone_message],
             otp_delivery_preference: [improbable_otp_message],
           },
-          error_details: improbable_phone_error,
+          error_details: {
+            phone: { improbable_phone: true },
+            otp_delivery_preference: { inclusion: true },
+          },
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
           country_code: nil,
           area_code: nil,

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Idv::SsnController do
           errors: {
             ssn: [t('idv.errors.pattern_mismatch.ssn')],
           },
-          error_details: { ssn: [:invalid] },
+          error_details: { ssn: { invalid: true } },
           pii_like_keypaths: [[:same_address_as_id], [:errors, :ssn], [:error_details, :ssn]],
         }.merge(ab_test_args)
       end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -765,7 +765,7 @@ RSpec.describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { authn_context: [t('errors.messages.unauthorized_authn_context')] },
-          error_details: { authn_context: [:unauthorized_authn_context] },
+          error_details: { authn_context: { unauthorized_authn_context: true } },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: ['http://idmanagement.gov/ns/assurance/loa/5'],
           authn_context_comparison: 'exact',
@@ -984,7 +984,7 @@ RSpec.describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { service_provider: [t('errors.messages.unauthorized_service_provider')] },
-          error_details: { service_provider: [:unauthorized_service_provider] },
+          error_details: { service_provider: { unauthorized_service_provider: true } },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: request_authn_contexts,
           authn_context_comparison: 'exact',
@@ -1026,8 +1026,8 @@ RSpec.describe SamlIdpController do
             authn_context: [t('errors.messages.unauthorized_authn_context')],
           },
           error_details: {
-            authn_context: [:unauthorized_authn_context],
-            service_provider: [:unauthorized_service_provider],
+            authn_context: { unauthorized_authn_context: true },
+            service_provider: { unauthorized_service_provider: true },
           },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: ['http://idmanagement.gov/ns/assurance/loa/5'],
@@ -1417,7 +1417,7 @@ RSpec.describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { nameid_format: [t('errors.messages.unauthorized_nameid_format')] },
-          error_details: { nameid_format: [:unauthorized_nameid_format] },
+          error_details: { nameid_format: { unauthorized_nameid_format: true } },
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
           authn_context: request_authn_contexts,
           authn_context_comparison: 'exact',

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -2,12 +2,10 @@ require 'rails_helper'
 
 RSpec.describe SignUp::EmailConfirmationsController do
   describe '#create' do
-    let(:token_not_found_error) { { confirmation_token: [:not_found] } }
-    let(:token_expired_error) { { confirmation_token: [:expired] } }
     let(:analytics_token_error_hash) do
       {
         success: false,
-        error_details: token_not_found_error,
+        error_details: { confirmation_token: { not_found: true } },
         errors: { confirmation_token: ['not found'] },
         user_id: nil,
       }
@@ -16,7 +14,7 @@ RSpec.describe SignUp::EmailConfirmationsController do
       {
         email: nil,
         success: false,
-        failure_reason: token_not_found_error,
+        failure_reason: { confirmation_token: [:not_found] },
       }
     end
 
@@ -117,7 +115,7 @@ RSpec.describe SignUp::EmailConfirmationsController do
       analytics_hash = {
         success: false,
         errors: { confirmation_token: [t('errors.messages.expired')] },
-        error_details: token_expired_error,
+        error_details: { confirmation_token: { expired: true } },
         user_id: email_address.user.uuid,
       }
 
@@ -127,7 +125,7 @@ RSpec.describe SignUp::EmailConfirmationsController do
       expect(@irs_attempts_api_tracker).to receive(:user_registration_email_confirmation).with(
         email: email_address.email,
         success: false,
-        failure_reason: token_expired_error,
+        failure_reason: { confirmation_token: [:expired] },
       )
 
       get :create, params: { confirmation_token: 'foo' }
@@ -149,7 +147,7 @@ RSpec.describe SignUp::EmailConfirmationsController do
       analytics_hash = {
         success: false,
         errors: { confirmation_token: [t('errors.messages.expired')] },
-        error_details: token_expired_error,
+        error_details: { confirmation_token: { expired: true } },
         user_id: user.uuid,
       }
 
@@ -159,7 +157,7 @@ RSpec.describe SignUp::EmailConfirmationsController do
       expect(@irs_attempts_api_tracker).to receive(:user_registration_email_confirmation).with(
         email: email_address.email,
         success: false,
-        failure_reason: token_expired_error,
+        failure_reason: { confirmation_token: [:expired] },
       )
 
       get :create, params: { confirmation_token: 'foo' }

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -61,15 +61,6 @@ RSpec.describe SignUp::PasswordsController do
 
     context 'with an invalid password' do
       let!(:user) { create(:user, :unconfirmed, confirmation_token: token) }
-      let(:analytics_hash) do
-        {
-          success: false,
-          errors: errors,
-          error_details: error_details,
-          user_id: user.uuid,
-          request_id_present: false,
-        }
-      end
 
       before do
         stub_analytics
@@ -79,70 +70,74 @@ RSpec.describe SignUp::PasswordsController do
       context 'with a password that is too short' do
         let(:password) { 'NewVal' }
         let(:password_confirmation) { 'NewVal' }
-        let(:errors) do
-          {
-            password:
-              [t(
-                'errors.attributes.password.too_short',
-                count: Devise.password_length.first,
-              )],
-            password_confirmation:
-              [I18n.t('errors.messages.too_short', count: Devise.password_length.first)],
-          }
-        end
-        let(:error_details) do
-          {
-            password: [:too_short],
-            password_confirmation: [:too_short],
-          }
-        end
 
         it 'tracks an invalid password event' do
-          expect(@analytics).to receive(:track_event).
-            with(
-              'User Registration: Email Confirmation',
-              { errors: {}, error_details: nil, success: true, user_id: user.uuid },
-            )
-          expect(@analytics).to receive(:track_event).
-            with('Password Creation', analytics_hash)
-
           expect(@irs_attempts_api_tracker).to receive(:user_registration_password_submitted).
             with(
               success: false,
-              failure_reason: error_details,
+              failure_reason: {
+                password: [:too_short],
+                password_confirmation: [:too_short],
+              },
             )
           expect(@irs_attempts_api_tracker).not_to receive(:user_registration_email_confirmation)
 
           subject
+
+          expect(@analytics).to have_logged_event(
+            'User Registration: Email Confirmation',
+            errors: {},
+            error_details: nil,
+            success: true,
+            user_id: user.uuid,
+          )
+          expect(@analytics).to have_logged_event(
+            'Password Creation',
+            success: false,
+            errors: {
+              password: [
+                t('errors.attributes.password.too_short', count: Devise.password_length.first),
+              ],
+              password_confirmation: [
+                t('errors.messages.too_short', count: Devise.password_length.first),
+              ],
+            },
+            error_details: {
+              password: { too_short: true },
+              password_confirmation: { too_short: true },
+            },
+            user_id: user.uuid,
+            request_id_present: false,
+          )
         end
       end
 
       context 'when password confirmation does not match' do
         let(:password) { 'NewVal!dPassw0rd' }
         let(:password_confirmation) { 'bad match password' }
-        let(:errors) do
-          {
-            password_confirmation:
-              [t('errors.messages.password_mismatch')],
-          }
-        end
-        let(:error_details) do
-          {
-            password_confirmation: [t('errors.messages.password_mismatch')],
-          }
-        end
 
         it 'tracks invalid password_confirmation error' do
-          expect(@analytics).to receive(:track_event).
-            with(
-              'User Registration: Email Confirmation',
-              { errors: {}, error_details: nil, success: true, user_id: user.uuid },
-            )
-
-          expect(@analytics).to receive(:track_event).
-            with('Password Creation', analytics_hash)
-
           subject
+
+          expect(@analytics).to have_logged_event(
+            'User Registration: Email Confirmation',
+            errors: {},
+            error_details: nil,
+            success: true,
+            user_id: user.uuid,
+          )
+          expect(@analytics).to have_logged_event(
+            'Password Creation',
+            success: false,
+            errors: {
+              password_confirmation: [t('errors.messages.password_mismatch')],
+            },
+            error_details: {
+              password_confirmation: { mismatch: true },
+            },
+            user_id: user.uuid,
+            request_id_present: false,
+          )
         end
       end
     end

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
         success: false,
         rate_limited: false,
         errors: { email: [t('valid_email.validations.email.invalid')] },
-        error_details: { email: [:invalid] },
+        error_details: { email: { invalid: true } },
         email_already_exists: false,
         user_id: 'anonymous-uuid',
         domain_name: 'invalid',

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
 
         properties = {
           success: false,
-          error_details: { code: [:wrong_length, 'incorrect'] },
+          error_details: { code: { wrong_length: true, incorrect: true } },
           confirmation_for_add_phone: false,
           context: 'authentication',
           multi_factor_auth_method: 'sms',
@@ -204,7 +204,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
 
         properties = {
           success: false,
-          error_details: { code: [:wrong_length, 'incorrect'] },
+          error_details: { code: { wrong_length: true, incorrect: true } },
           confirmation_for_add_phone: false,
           context: 'authentication',
           multi_factor_auth_method: 'sms',
@@ -546,7 +546,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
             properties = {
               success: false,
               errors: nil,
-              error_details: { code: [:wrong_length, 'incorrect'] },
+              error_details: { code: { wrong_length: true, incorrect: true } },
               confirmation_for_add_phone: true,
               context: 'confirmation',
               multi_factor_auth_method: 'sms',

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
         properties = {
           success: false,
           errors: { personal_key: [t('errors.messages.personal_key_incorrect')] },
-          error_details: { personal_key: [:personal_key_incorrect] },
+          error_details: { personal_key: { personal_key_incorrect: true } },
           multi_factor_auth_method: 'personal-key',
           multi_factor_auth_method_created_at: personal_key_generated_at.strftime('%s%L'),
         }

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
         result = { context: 'authentication',
                    multi_factor_auth_method: 'webauthn',
                    success: false,
-                   error_details: { authenticator_data: ['invalid_authenticator_data'] },
+                   error_details: { authenticator_data: { invalid_authenticator_data: true } },
                    webauthn_configuration_id: webauthn_configuration.id,
                    multi_factor_auth_method_created_at: webauthn_configuration.created_at.
                      strftime('%s%L') }
@@ -280,11 +280,11 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
           expect(@analytics).to receive(:track_mfa_submit_event).with(
             success: false,
             error_details: {
-              authenticator_data: [:blank],
-              client_data_json: [:blank],
-              signature: [:blank],
-              webauthn_configuration: [:blank],
-              webauthn_error: [webauthn_error],
+              authenticator_data: { blank: true },
+              client_data_json: { blank: true },
+              signature: { blank: true },
+              webauthn_configuration: { blank: true },
+              webauthn_error: { webauthn_error: true },
             },
             context: UserSessionContext::AUTHENTICATION_CONTEXT,
             multi_factor_auth_method: 'webauthn_platform',

--- a/spec/controllers/users/edit_phone_controller_spec.rb
+++ b/spec/controllers/users/edit_phone_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Users::EditPhoneController do
         attributes = {
           success: false,
           errors: hash_including(:delivery_preference),
-          error_details: { delivery_preference: [:inclusion] },
+          error_details: { delivery_preference: { inclusion: true } },
           delivery_preference: 'noise',
           make_default_number: true,
           phone_configuration_id: phone_configuration.id,

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -132,14 +132,12 @@ RSpec.describe Users::PasswordsController do
         end
 
         it 'renders edit' do
-          password_short_error = {
-            password: [:too_short],
-            password_confirmation: [:too_short],
-          }
-
           expect(@irs_attempts_api_tracker).to receive(:logged_in_password_change).with(
             success: false,
-            failure_reason: password_short_error,
+            failure_reason: {
+              password: [:too_short],
+              password_confirmation: [:too_short],
+            },
           )
 
           patch :update, params: { update_user_password_form: params }
@@ -159,7 +157,10 @@ RSpec.describe Users::PasswordsController do
                 count: Devise.password_length.first,
               )],
             },
-            error_details: password_short_error,
+            error_details: {
+              password: { too_short: true },
+              password_confirmation: { too_short: true },
+            },
             pending_profile_present: false,
             active_profile_present: false,
             user_id: subject.current_user.uuid,
@@ -190,7 +191,7 @@ RSpec.describe Users::PasswordsController do
           expect(@irs_attempts_api_tracker).to receive(:logged_in_password_change).with(
             success: false,
             failure_reason: {
-              password_confirmation: [t('errors.messages.password_mismatch')],
+              password_confirmation: [:mismatch],
             },
           )
 
@@ -203,7 +204,7 @@ RSpec.describe Users::PasswordsController do
               password_confirmation: [t('errors.messages.password_mismatch')],
             },
             error_details: {
-              password_confirmation: [t('errors.messages.password_mismatch')],
+              password_confirmation: { mismatch: true },
             },
             pending_profile_present: false,
             active_profile_present: false,

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe Users::PhoneSetupController do
           ],
         },
         error_details: {
-          phone: [
-            :improbable_phone,
-            t('two_factor_authentication.otp_delivery_preference.voice_unsupported', location: ''),
-          ],
+          phone: {
+            improbable_phone: true,
+            voice_unsupported: true,
+          },
         },
         otp_delivery_preference: 'sms',
         area_code: nil,

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
     t('errors.attributes.password.too_short.other', count: Devise.password_length.first)
   end
   let(:success_properties) { { success: true, failure_reason: nil } }
-  let(:token_expired_error) { 'token_expired' }
   describe '#edit' do
     let(:user) { instance_double('User', uuid: '123') }
     let(:email_address) { instance_double('EmailAddress') }
@@ -24,7 +23,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
     end
 
     context 'no user matches token' do
-      let(:user_blank_error) { { user: [:blank] } }
       let(:token) { 'foo' }
       before do
         session[:reset_password_token] = token
@@ -33,7 +31,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         {
           success: false,
           errors: { user: ['invalid_token'] },
-          error_details: user_blank_error,
+          error_details: { user: { blank: true } },
           user_id: nil,
         }
       end
@@ -41,7 +39,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       it 'redirects to page where user enters email for password reset token' do
         expect(@irs_attempts_api_tracker).to receive(:forgot_password_email_confirmed).with(
           success: false,
-          failure_reason: user_blank_error,
+          failure_reason: { user: [:blank] },
         )
 
         get :edit
@@ -54,7 +52,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
     end
 
     context 'token expired' do
-      let(:user_token_error) { { user: [token_expired_error] } }
       let(:token) { 'foo' }
       before do
         session[:reset_password_token] = token
@@ -62,8 +59,8 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       let(:analytics_hash) do
         {
           success: false,
-          errors: user_token_error,
-          error_details: user_token_error,
+          errors: { user: ['token_expired'] },
+          error_details: { user: { token_expired: true } },
           user_id: '123',
         }
       end
@@ -76,12 +73,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       end
 
       context 'no user matches token' do
-        let(:user_blank_error) { { user: [:blank] } }
         let(:analytics_hash) do
           {
             success: false,
             errors: { user: ['invalid_token'] },
-            error_details: user_blank_error,
+            error_details: { user: { blank: true } },
             user_id: nil,
           }
         end
@@ -93,7 +89,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         it 'redirects to page where user enters email for password reset token' do
           expect(@irs_attempts_api_tracker).to receive(:forgot_password_email_confirmed).with(
             success: false,
-            failure_reason: user_blank_error,
+            failure_reason: { user: [:blank] },
           )
 
           get :edit
@@ -106,12 +102,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       end
 
       context 'token expired' do
-        let(:user_token_error) { { user: [token_expired_error] } }
         let(:analytics_hash) do
           {
             success: false,
-            errors: user_token_error,
-            error_details: user_token_error,
+            errors: { user: ['token_expired'] },
+            error_details: { user: { token_expired: true } },
             user_id: '123',
           }
         end
@@ -125,7 +120,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         it 'redirects to page where user enters email for password reset token' do
           expect(@irs_attempts_api_tracker).to receive(:forgot_password_email_confirmed).with(
             success: false,
-            failure_reason: user_token_error,
+            failure_reason: { user: [:token_expired] },
           )
 
           get :edit
@@ -192,18 +187,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
   end
 
   describe '#update' do
-    let(:password_short_error) { { password: [:too_short] } }
-
-    let(:password_token_error) { { reset_password_token: [token_expired_error] } }
     context 'user submits new password after token expires' do
-      let(:reset_password_error_details) do
-        {
-          **password_short_error,
-          password_confirmation: [:too_short],
-          **password_token_error,
-        }
-      end
-
       it 'redirects to page where user enters email for password reset token' do
         stub_analytics
         stub_attempts_tracker
@@ -211,7 +195,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
 
         expect(@irs_attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
           success: false,
-          failure_reason: reset_password_error_details,
+          failure_reason: {
+            password: [:too_short],
+            password_confirmation: [:too_short],
+            reset_password_token: [:token_expired],
+          },
         )
 
         raw_reset_token, db_confirmation_token =
@@ -240,9 +228,13 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
               'errors.messages.too_short.other',
               count: Devise.password_length.first,
             )],
-            **password_token_error,
+            reset_password_token: ['token_expired'],
           },
-          error_details: reset_password_error_details,
+          error_details: {
+            password: { too_short: true },
+            password_confirmation: { too_short: true },
+            reset_password_token: { token_expired: true },
+          },
           user_id: user.uuid,
           profile_deactivated: false,
           pending_profile_invalidated: false,
@@ -287,8 +279,8 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
             )],
           },
           error_details: {
-            password: [:too_short],
-            password_confirmation: [:too_short],
+            password: { too_short: true },
+            password_confirmation: { too_short: true },
           },
           user_id: user.uuid,
           profile_deactivated: false,
@@ -340,7 +332,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
             password_confirmation: [t('errors.messages.password_mismatch')],
           },
           error_details: {
-            password_confirmation: [t('errors.messages.password_mismatch')],
+            password_confirmation: { mismatch: true },
           },
           user_id: user.uuid,
           profile_deactivated: false,
@@ -353,7 +345,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         expect(@irs_attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
           success: false,
           failure_reason: {
-            password_confirmation: [t('errors.messages.password_mismatch')],
+            password_confirmation: [:mismatch],
           },
         )
 
@@ -709,7 +701,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         analytics_hash = {
           success: false,
           errors: { email: [t('valid_email.validations.email.invalid')] },
-          error_details: { email: [:invalid] },
+          error_details: { email: { invalid: true } },
           user_id: 'nonexistent-uuid',
           confirmed: false,
           active_profile: false,

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Users::TotpSetupController, devise: true do
 
           result = {
             success: false,
-            error_details: { name: [:blank] },
+            error_details: { name: { blank: true } },
             errors: { name: [t('errors.messages.blank')] },
             totp_secret_present: true,
             multi_factor_auth_method: 'totp',

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -88,7 +88,13 @@ RSpec.describe Users::VerifyPersonalKeyController do
     let(:personal_key_bad_params) { { personal_key: 'baaad' } }
     let(:personal_key_error) { { personal_key: [error_text] } }
     let(:failure_properties) { { success: false, failure_reason: personal_key_error } }
-    let(:pii_like_keypaths_errors) { [[:errors, :personal_key], [:error_details, :personal_key]] }
+    let(:pii_like_keypaths_errors) do
+      [
+        [:errors, :personal_key],
+        [:error_details, :personal_key],
+        [:error_details, :personal_key, :personal_key],
+      ]
+    end
     let(:response_ok) { FormResponse.new(success: true, errors: {}) }
     let(:response_bad) { FormResponse.new(success: false, errors: personal_key_error, extra: {}) }
 
@@ -163,7 +169,7 @@ RSpec.describe Users::VerifyPersonalKeyController do
         expect(@analytics).to receive(:track_event).with(
           'Personal key reactivation: Personal key form submitted',
           errors: { personal_key: ['Please fill in this field.', error_text] },
-          error_details: { personal_key: [:blank, :personal_key_incorrect] },
+          error_details: { personal_key: { blank: true, personal_key: true } },
           success: false,
           pii_like_keypaths: pii_like_keypaths_errors,
         ).once

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -392,10 +392,7 @@ RSpec.describe Users::WebauthnSetupController do
                 'errors.webauthn_platform_setup.attestation_error',
                 link: MarketingSite.contact_url,
               )] },
-              error_details: { name: [I18n.t(
-                'errors.webauthn_platform_setup.attestation_error',
-                link: MarketingSite.contact_url,
-              )] },
+              error_details: { name: { attestation_error: true } },
               in_account_creation_flow: false,
               mfa_method_counts: {},
               multi_factor_auth_method: 'webauthn_platform',

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -93,16 +93,7 @@ RSpec.describe Idv::PhoneForm do
           unregistered_phone = '+400258567234'
           result = subject.submit(phone: unregistered_phone)
           expect(result.success?).to eq false
-          expect(result.to_h).to include(
-            {
-              error_details: {
-                phone: [t(
-                  'two_factor_authentication.otp_delivery_preference.sms_unsupported',
-                  location: 'Romania',
-                )],
-              },
-            },
-          )
+          expect(result.to_h).to include(error_details: { phone: { sms_unsupported: true } })
         end
       end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
           expect(result.to_h).to eq(
             success: false,
             errors: { response_type: ['is not included in the list'] },
-            error_details: { response_type: [:inclusion] },
+            error_details: { response_type: { inclusion: true } },
             client_id: client_id,
             prompt: 'select_account',
             allow_prompt_login: true,

--- a/spec/forms/otp_verification_form_spec.rb
+++ b/spec/forms/otp_verification_form_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: [:blank, :wrong_length],
+            code: { blank: true, wrong_length: true },
           },
           multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
@@ -67,7 +67,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: ['user_otp_missing'],
+            code: { user_otp_missing: true },
           },
           multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
@@ -89,7 +89,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: [:wrong_length, 'incorrect'],
+            code: { wrong_length: true, incorrect: true },
           },
           multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
@@ -111,7 +111,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: ['pattern_mismatch', 'incorrect'],
+            code: { pattern_mismatch: true, incorrect: true },
           },
           multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
@@ -136,7 +136,7 @@ RSpec.describe OtpVerificationForm do
         expect(result.to_h).to eq(
           success: false,
           error_details: {
-            code: ['user_otp_expired'],
+            code: { user_otp_expired: true },
           },
           multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),

--- a/spec/forms/totp_setup_form_spec.rb
+++ b/spec/forms/totp_setup_form_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe TotpSetupForm do
 
         expect(form.submit.to_h).to include(
           success: false,
-          error_details: { name: [:blank] },
+          error_details: { name: { blank: true } },
           errors: { name: [t('errors.messages.blank')] },
         )
         expect(user.auth_app_configurations.any?).to eq false
@@ -95,7 +95,7 @@ RSpec.describe TotpSetupForm do
 
         expect(form2.submit.to_h).to include(
           success: false,
-          error_details: { name: [t('errors.piv_cac_setup.unique_name')] },
+          error_details: { name: { unique_name: true } },
           errors: { name: [t('errors.piv_cac_setup.unique_name')] },
         )
       end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -215,10 +215,7 @@ RSpec.describe WebauthnSetupForm do
             'errors.webauthn_setup.attestation_error',
             link: MarketingSite.contact_url,
           )] },
-          error_details: { name: [I18n.t(
-            'errors.webauthn_setup.attestation_error',
-            link: MarketingSite.contact_url,
-          )] },
+          error_details: { name: { attestation_error: true } },
           **extra_attributes,
         )
       end

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe WebauthnVerificationForm do
         it 'returns unsuccessful result' do
           expect(result.to_h).to eq(
             success: false,
-            error_details: { user: [:blank], webauthn_configuration: [:blank] },
+            error_details: { user: { blank: true }, webauthn_configuration: { blank: true } },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: nil,
           )
@@ -82,8 +82,8 @@ RSpec.describe WebauthnVerificationForm do
           expect(result.to_h).to eq(
             success: false,
             error_details: {
-              challenge: [:blank],
-              authenticator_data: ['invalid_authenticator_data'],
+              challenge: { blank: true },
+              authenticator_data: { invalid_authenticator_data: true },
             },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
@@ -98,7 +98,7 @@ RSpec.describe WebauthnVerificationForm do
           expect(result.to_h).to eq(
             success: false,
             error_details: {
-              authenticator_data: [:blank, 'invalid_authenticator_data'],
+              authenticator_data: { blank: true, invalid_authenticator_data: true },
             },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
@@ -113,8 +113,8 @@ RSpec.describe WebauthnVerificationForm do
           expect(result.to_h).to eq(
             success: false,
             error_details: {
-              client_data_json: [:blank],
-              authenticator_data: ['invalid_authenticator_data'],
+              client_data_json: { blank: true },
+              authenticator_data: { invalid_authenticator_data: true },
             },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
@@ -129,8 +129,8 @@ RSpec.describe WebauthnVerificationForm do
           expect(result.to_h).to eq(
             success: false,
             error_details: {
-              signature: [:blank],
-              authenticator_data: ['invalid_authenticator_data'],
+              signature: { blank: true },
+              authenticator_data: { invalid_authenticator_data: true },
             },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
@@ -144,7 +144,7 @@ RSpec.describe WebauthnVerificationForm do
         it 'returns unsuccessful result' do
           expect(result.to_h).to eq(
             success: false,
-            error_details: { webauthn_configuration: [:blank] },
+            error_details: { webauthn_configuration: { blank: true } },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: nil,
           )
@@ -157,7 +157,7 @@ RSpec.describe WebauthnVerificationForm do
         it 'returns unsuccessful result including client-side webauthn error text' do
           expect(result.to_h).to eq(
             success: false,
-            error_details: { webauthn_error: [webauthn_error] },
+            error_details: { webauthn_error: { webauthn_error: true } },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
           )
@@ -172,7 +172,7 @@ RSpec.describe WebauthnVerificationForm do
         it 'returns unsuccessful result' do
           expect(result.to_h).to eq(
             success: false,
-            error_details: { authenticator_data: ['invalid_authenticator_data'] },
+            error_details: { authenticator_data: { invalid_authenticator_data: true } },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
           )
@@ -188,7 +188,7 @@ RSpec.describe WebauthnVerificationForm do
         it 'returns unsucessful result' do
           expect(result.to_h).to eq(
             success: false,
-            error_details: { authenticator_data: ['invalid_authenticator_data'] },
+            error_details: { authenticator_data: { invalid_authenticator_data: true } },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
           )

--- a/spec/support/doc_pii_helper.rb
+++ b/spec/support/doc_pii_helper.rb
@@ -2,14 +2,27 @@ module DocPiiHelper
   def pii_like_keypaths
     [
       [:pii],
-      [:name, :dob, :dob_min_age, :address1, :state, :zipcode, :jurisdiction],
-      [:errors, :name], [:error_details, :name],
-      [:errors, :dob], [:error_details, :dob],
-      [:errors, :dob_min_age], [:error_details, :dob_min_age],
-      [:errors, :address1], [:error_details, :address1],
-      [:errors, :state], [:error_details, :state],
-      [:errors, :zipcode], [:error_details, :zipcode],
-      [:errors, :jurisdiction], [:error_details, :jurisdiction]
+      [:errors, :name],
+      [:error_details, :name],
+      [:error_details, :name, :name],
+      [:errors, :dob],
+      [:error_details, :dob],
+      [:error_details, :dob, :dob],
+      [:errors, :dob_min_age],
+      [:error_details, :dob_min_age],
+      [:error_details, :dob_min_age, :dob_min_age],
+      [:errors, :address1],
+      [:error_details, :address1],
+      [:error_details, :address1, :address1],
+      [:errors, :state],
+      [:error_details, :state],
+      [:error_details, :state, :state],
+      [:errors, :zipcode],
+      [:error_details, :zipcode],
+      [:error_details, :zipcode, :zipcode],
+      [:errors, :jurisdiction],
+      [:error_details, :jurisdiction],
+      [:error_details, :jurisdiction, :jurisdiction],
     ]
   end
 end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -56,7 +56,7 @@ class FakeAnalytics < Analytics
               ERROR
             end
 
-            check_recursive.call(val, [key])
+            check_recursive.call(val, current_keypath)
           end
         when Array
           value.each { |val| check_recursive.call(val, keypath) }

--- a/spec/support/fake_attempts_tracker.rb
+++ b/spec/support/fake_attempts_tracker.rb
@@ -15,7 +15,7 @@ module IrsAttemptsApiTrackingHelper
     end
 
     def parse_failure_reason(result)
-      return result.to_h[:error_details] || result.errors.presence
+      return result.to_h[:error_details]&.transform_values(&:keys) || result.errors.presence
     end
 
     def track_mfa_submit_event(_attributes)


### PR DESCRIPTION
This is a revival of #7454, aiming to supersede #9570. I'd hoped to use the original pull request, but it's not currently possible to reopen.

Interestingly, #7454 already incorporated the "fix" being proposed at #9570 with the fallback to the `type` property.

> ## 🛠 Summary of changes
> Revises the structure of `FormResponse` `error_details` handling to serialize a `FormResponse` error details as a hash, in order to improve querying supports for analytics logging, since CloudWatch does not support querying within an array field value.
> 
> Related Slack thread: https://gsa-tts.slack.com/archives/C0NGESUN5/p1670357411732859
> 
> ```
> # Before (Does not work!)
> filter 'user_otp_expired' in properties.event_properties.error_details.code
> 
> # After
> filter properties.event_properties.error_details.code.user_otp_expired = true
> # Or: filter ispresent(properties.event_properties.error_details.code.user_otp_expired)
> ```
> 
> Based on a search of dashboard Terraform code, we do not currently reference this field, so a breaking change should be alright.
> 
> _Draft while I work through any lingering specs which need to be updated to new format._
> 
> ## 📜 Testing Plan
> * Specs pass

