### PR TITLE
Remove disable_csp_unsafe_inline configuration

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -68,7 +68,6 @@ database_worker_jobs_sslmode: 'verify-full'
 deliver_mail_async: false
 deleted_user_accounts_report_configs: '[]'
 development_mailer_deliver_method: letter_opener
-disable_csp_unsafe_inline: true
 disable_email_sending: true
 disable_logout_get_request: true
 disallow_all_web_crawlers: true

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,11 +25,6 @@ Rails.application.config.content_security_policy do |policy|
     script_src << "localhost:#{ENV['WEBPACK_PORT']}"
   end
 
-  if !IdentityConfig.store.disable_csp_unsafe_inline
-    script_src << :unsafe_inline
-    style_src << :unsafe_inline
-  end
-
   if IdentityConfig.store.rails_mailer_previews_enabled
     style_src << :unsafe_inline
     # CSP 2.0 only; overriden by x_frame_options in some browsers

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -168,7 +168,6 @@ class IdentityConfig
     config.add(:deleted_user_accounts_report_configs, type: :json)
     config.add(:deliver_mail_async, type: :boolean)
     config.add(:development_mailer_deliver_method, type: :symbol, enum: [:file, :letter_opener])
-    config.add(:disable_csp_unsafe_inline, type: :boolean)
     config.add(:disable_email_sending, type: :boolean)
     config.add(:disable_logout_get_request, type: :boolean)
     config.add(:disallow_all_web_crawlers, type: :boolean)


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the `disable_csp_unsafe_inline` configuration.

**Why?**

- It does not appear to be used
- It adds unnecessary risk to have a configuration responsible for controlling a security feature which requires a lot of mental gymnastics to navigate the negation and expected impact of the value (a value of "true" means "disabling" which means "not adding the exemption" which means "enforcement applies")

Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1699554919541029

## 📜 Testing Plan

Observe that CSP is unimpacted.

Build should pass.
