### PR TITLE
Include TypeScript types in frontend naming conventions

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -39,7 +39,7 @@ margins or borders.
 - Variables and functions (excluding React components) should be named as camelCase, e.g. `const myFavoriteNumber = 1;`.
    - Only the first letter of an abbreviation should be capitalized, e.g. `const userId = 10;`.
    - All letters of an acronym should be capitalized, e.g. `const siteURL = 'https://example.com';`.
-- Classes and React components should be named as PascalCase (upper camel case), e.g. `class MyCustomElement {}`.
+- Classes, React components, and TypeScript types should be named as PascalCase (upper camel case), e.g. `class MyCustomElement {}`.
 - Constants should be named as SCREAMING_SNAKE_CASE, e.g. `const MEANING_OF_LIFE = 42;`.
 - TypeScript enums should be named as PascalCase with SCREAMING_SNAKE_CASE members, e.g. `enum Color { RED = '#f00'; }`.
 


### PR DESCRIPTION
## 🛠 Summary of changes

Includes TypeScript types in the naming conventions guidance.

This is meant to cover naming of `interface`s, `type`s, and `enum`s (and perhaps others?)

Examples:

https://github.com/18F/identity-idp/blob/71b5a2be9837de48f9676da6d7b25d59cd42dded/app/javascript/packages/i18n/index.ts#L1

https://github.com/18F/identity-idp/blob/71b5a2be9837de48f9676da6d7b25d59cd42dded/app/javascript/packages/i18n/index.ts#L6

https://github.com/18F/identity-idp/blob/71b5a2be9837de48f9676da6d7b25d59cd42dded/app/javascript/packages/memorable-date/index.ts#L5

Extracted from #9564

## 📜 Testing Plan

Review updated guidance and confirm that it promotes expected conventions.