### PR TITLE
Warn if there are configuration keys in the configuration file that are not loaded by the configuration store

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,7 +209,7 @@ specs:
     - cp -a keys.example keys
     - cp -a certs.example certs
     - cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt
-    - "echo -e \"test:\n  redis_url: 'redis://redis:6379/0'\n  redis_throttle_url: 'redis://redis:6379/1'\n  redis_irs_attempt_api_url: 'redis://redis:6379/2'\" > config/application.yml"
+    - "echo -e \"test:\n  redis_url: 'redis://redis:6379/0'\n  redis_throttle_url: 'redis://redis:6379/1'\" > config/application.yml"
     - bundle exec rake db:create db:migrate --trace
     - bundle exec rake db:seed
     - bundle exec rake knapsack:rspec["--format documentation --format RspecJunitFormatter --out rspec.xml --format json --out rspec_json/${CI_NODE_INDEX}.json"]

--- a/config/initializers/unused_identity_config_keys.rb
+++ b/config/initializers/unused_identity_config_keys.rb
@@ -1,3 +1,3 @@
-if !IdentityConfig.unused_keys.empty?
+if IdentityConfig.unused_keys.present?
   Rails.logger.warn({ name: 'unused_identity_config_keys', keys: IdentityConfig.unused_keys })
 end

--- a/config/initializers/unused_identity_config_keys.rb
+++ b/config/initializers/unused_identity_config_keys.rb
@@ -1,0 +1,3 @@
+if !IdentityConfig.unused_keys.empty?
+  Rails.logger.warn({ name: 'unused_identity_config_keys', keys: IdentityConfig.unused_keys })
+end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -6,7 +6,7 @@ class IdentityConfig
   VENDOR_STATUS_OPTIONS = %i[operational partial_outage full_outage]
 
   class << self
-    attr_reader :store, :key_types
+    attr_reader :store, :key_types, :unused_keys
   end
 
   CONVERTERS = {
@@ -492,6 +492,7 @@ class IdentityConfig
     config.add(:weekly_auth_funnel_report_config, type: :json)
 
     @key_types = config.key_types
+    @unused_keys = config_map.keys - config.written_env.keys
     @store = RedactedStruct.new('IdentityConfig', *config.written_env.keys, keyword_init: true).
       new(**config.written_env)
   end

--- a/spec/lib/identity_config_spec.rb
+++ b/spec/lib/identity_config_spec.rb
@@ -65,4 +65,10 @@ RSpec.describe IdentityConfig do
       end
     end
   end
+
+  describe '.unused_keys' do
+    it 'does not have any unused keys' do
+      expect(IdentityConfig.unused_keys).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

A small follow-up to #9566 to print out one class of unused configuration keys. This is specifically aimed at keys that are not defined in the configuration management, but are still defined in the configuration file. It is very likely this will find unused keys in deployed environments.

It would be better to log this to the log file, but logging is not set up at this point and in the interest of having a partial solution, I think this is an alright start.

Example output:

```
$ rails s
WARNING: There are defined configuration keys that are not loaded by the application. They are: [:disable_csp_unsafe_inline]
=> Booting Puma
=> Rails 7.1.1 application starting in development
```


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
