### PR TITLE
LG-11260: Not ready section fix

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-not-ready.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-not-ready.tsx
@@ -14,13 +14,13 @@ export interface DocumentCaptureNotReadyProps {
 function DocumentCaptureNotReady({ navigate }: DocumentCaptureNotReadyProps) {
   const { t } = useI18n();
   const { trackEvent } = useContext(AnalyticsContext);
-  const { currentStep } = useContext(FlowContext);
+  const { currentStep, accountURL } = useContext(FlowContext);
   const { name: spName, failureToProofURL } = useContext(ServiceProviderContext);
   const appName = getConfigValue('appName');
   const handleExit = () => {
     trackEvent('IdV: docauth not ready link clicked');
     forceRedirect(
-      addSearchParams(spName ? failureToProofURL : '/account', {
+      addSearchParams(spName ? failureToProofURL : accountURL, {
         step: currentStep,
         location: 'not_ready',
       }),

--- a/app/javascript/packages/verify-flow/cancel.spec.tsx
+++ b/app/javascript/packages/verify-flow/cancel.spec.tsx
@@ -14,6 +14,7 @@ describe('Cancel', () => {
       const { getByText } = render(
         <FlowContext.Provider
           value={{
+            accountURL: 'http://example.test/account',
             cancelURL: 'http://example.test/cancel',
             exitURL: 'http://example.test/exit',
             currentStep: 'one',

--- a/app/javascript/packages/verify-flow/context/flow-context.tsx
+++ b/app/javascript/packages/verify-flow/context/flow-context.tsx
@@ -2,6 +2,10 @@ import { createContext } from 'react';
 
 export interface FlowContextValue {
   /**
+   * URL to the path of the account home
+   */
+  accountURL: string;
+  /**
    * URL to path for session cancel.
    */
   cancelURL: string;
@@ -18,6 +22,7 @@ export interface FlowContextValue {
 }
 
 const FlowContext = createContext<FlowContextValue>({
+  accountURL: '',
   cancelURL: '',
   exitURL: '',
   currentStep: '',

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -94,6 +94,7 @@ const {
   flowPath,
   cancelUrl: cancelURL,
   exitUrl: exitURL,
+  accountUrl: accountURL,
   idvInPersonUrl: inPersonURL,
   securityAndPrivacyHowItWorksUrl: securityAndPrivacyHowItWorksURL,
   inPersonFullAddressEntryEnabled,
@@ -158,6 +159,7 @@ const App = composeComponents(
     FlowContext.Provider,
     {
       value: {
+        accountURL,
         cancelURL,
         exitURL,
         currentStep: 'document_capture',

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -29,6 +29,7 @@
       flow_path: flow_path,
       cancel_url: idv_cancel_path(step: :document_capture),
       exit_url: idv_exit_path,
+      account_url: account_path,
       failure_to_proof_url: failure_to_proof_url,
       idv_in_person_url: (IdentityConfig.store.in_person_doc_auth_button_enabled && Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)) ? idv_in_person_url : nil,
       security_and_privacy_how_it_works_url: MarketingSite.security_and_privacy_how_it_works_url,

--- a/spec/javascript/packages/document-capture/components/document-capture-not-ready-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-not-ready-spec.tsx
@@ -39,6 +39,7 @@ describe('DocumentCaptureNotReady', () => {
             <FlowContext.Provider
               value={{
                 currentStep: 'document_capture',
+                accountURL: '/account',
                 cancelURL: '',
                 exitURL: '',
               }}
@@ -89,6 +90,7 @@ describe('DocumentCaptureNotReady', () => {
             <FlowContext.Provider
               value={{
                 currentStep: 'document_capture',
+                accountURL: '/account',
                 cancelURL: '',
                 exitURL: '',
               }}


### PR DESCRIPTION

## 🎫 Ticket

[LG-11260](https://cm-jira.usa.gov/browse/LG-11260): Fix account url, language preference.



## 🛠 Summary of changes

Not ready section cancel link should keep language preference.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Step 1: Enter doc auth flow, using no english language without SP
- [x] Step 2: On the doc capture pages
- [x] Step 3: Click on the related cancel in the not ready section
- [x] Step 4: It should go back to account home.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
