### PR TITLE
Fix AnalyticsEventsDocumenter for symbol event names

### DIFF
--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -158,7 +158,8 @@ class AnalyticsEventsDocumenter
 
   # Naive attempt to pull tracked event string from source code
   def extract_event_name(method_object)
-    m = /track_event\(\s*[:"'](?<event_name>[^"']+)["',)]/.match(method_object.source)
+    m = /track_event\(\s*["'](?<event_name>[^"']+)["',)]/.match(method_object.source)
+    m ||= /track_event\(\s*:(?<event_name>[^,]+)[,)]/.match(method_object.source)
     m && m[:event_name]
   end
 

--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -156,10 +156,12 @@ class AnalyticsEventsDocumenter
 
   private
 
-  # Naive attempt to pull tracked event string from source code
+  # Naive attempt to pull tracked event string or symbol from source code
   def extract_event_name(method_object)
+    # track_event("some event name")
     m = /track_event\(\s*["'](?<event_name>[^"']+)["',)]/.match(method_object.source)
-    m ||= /track_event\(\s*:(?<event_name>[^,]+)[,)]/.match(method_object.source)
+    # track_event(:some_event_name)
+    m ||= /track_event\(\s*:(?<event_name>[\w_]+)[,)]/.match(method_object.source)
     m && m[:event_name]
   end
 

--- a/spec/lib/analytics_events_documenter_spec.rb
+++ b/spec/lib/analytics_events_documenter_spec.rb
@@ -288,5 +288,29 @@ RSpec.describe AnalyticsEventsDocumenter do
         )
       end
     end
+
+    context 'with a symbol name in a multi-line method call' do
+      let(:source_code) { <<~RUBY }
+        class AnalyticsEvents
+          # User submitted IDV password confirm page
+          # @param [Boolean] success
+          def idv_enter_password_submitted(
+            success:,
+            **extra
+          )
+            track_event(
+              :idv_enter_password_submitted,
+              success: success,
+              **extra,
+            )
+          end
+        end
+      RUBY
+
+      it 'parses the name correctly' do
+        expect(documenter.as_json[:events].first[:event_name]).
+          to eq('idv_enter_password_submitted')
+      end
+    end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

**Why**: The regex got tripped up by a method call on multiple lines

See screenshot below, `idv_enter_password_submitted` got parsed as:
```
  name: "idv_enter_password_submitted,\n    success: success,\n    deactivation_reason: deactivation_reason,\n    fraud_review_pending: fraud_review_pending,\n    gpo_verification_pending: gpo_verification_pending,\n    in_person_verification_pending: in_person_verification_pending,\n    fraud_rejection: fraud_rejection,\n    proofing_components: proofing_components,\n    **extra,\n  ",
```


## 👀 Screenshots

| screenshot |
| --- |
|  <img width="680" alt="Screenshot 2023-11-13 at 9 13 39 AM" src="https://github.com/18F/identity-idp/assets/458784/970bbad5-87dc-4882-858d-839dfa3f1205"> |
