### PR TITLE
Deploy RC 332 to Production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ variables:
   ECR_REGISTRY: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
   IDP_CI_SHA: 'sha256:26bcd68d39085d0e9dbfe272ec3f95158a272dcc2e25f5152b1d8e4600cf1cac'
   PKI_IMAGE_TAG: 'main'
+  DASHBOARD_IMAGE_TAG: 'ab661426de8de0b4cce094f8c862ad3ce6d97274'
 
 default:
   image: '${ECR_REGISTRY}/idp/ci@${IDP_CI_SHA}'
@@ -95,6 +96,8 @@ install:
 build-review-image:
   stage: review
   needs: []
+  environment:
+    name: review/$CI_COMMIT_REF_NAME
   interruptible: true
   variables:
     BRANCH_TAGGING_STRING: ''
@@ -112,6 +115,8 @@ build-review-image:
     entrypoint: ['']
   script:
     - mkdir -p /kaniko/.docker
+    - echo ${CI_ENVIRONMENT_SLUG}
+    - echo $CI_ENVIRONMENT_SLUG
     - |-
       KANIKOCFG="\"credsStore\":\"ecr-login\""
       if [ "x${http_proxy}" != "x" -o "x${https_proxy}" != "x" ]; then
@@ -129,7 +134,7 @@ build-review-image:
       --cache-ttl=168h
       --cache=true
       --compressed-caching=false
-      --build-arg "http_proxy=${http_proxy}" --build-arg "https_proxy=${https_proxy}" --build-arg "no_proxy=${no_proxy}"
+      --build-arg "http_proxy=${http_proxy}" --build-arg "https_proxy=${https_proxy}" --build-arg "no_proxy=${no_proxy}" --build-arg "ARG_CI_ENVIRONMENT_SLUG=${CI_ENVIRONMENT_SLUG}"
 
 check_changelog:
   stage: test
@@ -345,6 +350,7 @@ trigger_devops:
     - if: $CI_COMMIT_BRANCH == "main"
   trigger: lg/identity-devops
 
+
 review-app:
   stage: review
   allow_failure: true
@@ -382,7 +388,8 @@ review-app:
         {"name": "LOGIN_HOST_ROLE", "value": "idp" },
         {"name": "LOGIN_SKIP_REMOTE_CONFIG", "value": "true" },
         {"name": "PIV_CAC_SERVICE_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"},
-        {"name": "PIV_CAC_VERIFY_TOKEN_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"}
+        {"name": "PIV_CAC_VERIFY_TOKEN_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov/"},
+        {"name": "DASHBOARD_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app-dashboard.review-app.identitysandbox.gov"}
       ]
       EOF
       )
@@ -429,6 +436,23 @@ review-app:
       ]
       EOF
       )
+    - |-
+      export DASHBOARD_ENV=$(cat <<EOF
+      [
+        {"name": "POSTGRES_SSLMODE", "value": "prefer"},
+        {"name": "POSTGRES_DB", "value": "dashboard"},
+        {"name": "POSTGRES_HOST","value": "$CI_ENVIRONMENT_SLUG-login-chart-dashboard-pg.review-apps"},
+        {"name": "POSTGRES_USERNAME", "value": "postgres"},
+        {"name": "POSTGRES_PASSWORD", "value": "postgres"},
+        {"name": "NEW_RELIC_ENABLED", "value": "false"},
+        {"name": "SAML_SP_ISSUER", "value": "https://$CI_ENVIRONMENT_SLUG-review-app-dashboard.review-app.identitysandbox.gov"},
+        {"name": "IDP_URL", "value": "https://$CI_ENVIRONMENT_SLUG.review-app.identitysandbox.gov"},
+        {"name": "IDP_SP_URL", "value": "https://$CI_ENVIRONMENT_SLUG.review-app.identitysandbox.gov"},
+        {"name": "POST_LOGOUT_URL", "value": "https://$CI_ENVIRONMENT_SLUG-review-app-dashboard.review-app.identitysandbox.gov"},
+        {"name": "DOMAIN_NAME", "value": "$CI_ENVIRONMENT_SLUG-review-app-dashboard.review-app.identitysandbox.gov"}
+      ]
+      EOF
+      )
     - git clone -b main --single-branch https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.login.gov/lg-public/identity-idp-helm-chart.git
     - >-
       helm upgrade --install --namespace review-apps
@@ -439,11 +463,16 @@ review-app:
       --set worker.image.tag="${CI_COMMIT_SHA}"
       --set pivcac.image.repository="${ECR_REGISTRY}/identity-pivcac/review"
       --set pivcac.image.tag="${PKI_IMAGE_TAG}"
+      --set dashboard.image.repository="${ECR_REGISTRY}/identity-dashboard/review"
+      --set dashboard.image.tag="${DASHBOARD_IMAGE_TAG}"
+      --set-json dashboard.env="$DASHBOARD_ENV"
+      --set-json dashboard.enabled=true
       --set-json idp.env="$IDP_ENV"
       --set-json worker.env="$WORKER_ENV"
       --set-json pivcac.env="$PIVCAC_ENV"
       --set-json idp.ingress.hosts="[{\"host\": \"$CI_ENVIRONMENT_SLUG.review-app.identitysandbox.gov\", \"paths\": [{\"path\": \"/\", \"pathType\": \"Prefix\"}]}]"
       --set-json pivcac.ingress.hosts="[{\"host\": \"$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov\", \"paths\": [{\"path\": \"/\", \"pathType\": \"Prefix\"}]}]"
+      --set-json dashboard.ingress.hosts="[{\"host\": \"$CI_ENVIRONMENT_SLUG-review-app-dashboard.review-app.identitysandbox.gov\", \"paths\": [{\"path\": \"/\", \"pathType\": \"Prefix\"}]}]"
       $CI_ENVIRONMENT_SLUG ./identity-idp-helm-chart
     - echo "DNS may take a while to propagate, so be patient if it doesn't show up right away"
     - echo "To access the rails console, first run 'aws-vault exec sandbox-power -- aws eks update-kubeconfig --name review_app'"
@@ -452,6 +481,8 @@ review-app:
     - echo https://$CI_ENVIRONMENT_SLUG.review-app.identitysandbox.gov
     - echo "Address of PIVCAC review app:"
     - echo https://$CI_ENVIRONMENT_SLUG-review-app.pivcac.identitysandbox.gov
+    - echo "Address of Dashboard review app:"
+    - echo https://$CI_ENVIRONMENT_SLUG-review-app-dashboard.review-app.identitysandbox.gov
   environment:
     name: review/$CI_COMMIT_REF_NAME
     url: https://$CI_ENVIRONMENT_SLUG.review-app.identitysandbox.gov

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,7 +209,7 @@ specs:
     - cp -a keys.example keys
     - cp -a certs.example certs
     - cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt
-    - "echo -e \"test:\n  redis_url: 'redis://redis:6379/0'\n  redis_throttle_url: 'redis://redis:6379/1'\n  redis_irs_attempt_api_url: 'redis://redis:6379/2'\" > config/application.yml"
+    - "echo -e \"test:\n  redis_url: 'redis://redis:6379/0'\n  redis_throttle_url: 'redis://redis:6379/1'\" > config/application.yml"
     - bundle exec rake db:create db:migrate --trace
     - bundle exec rake db:seed
     - bundle exec rake knapsack:rspec["--format documentation --format RspecJunitFormatter --out rspec.xml --format json --out rspec_json/${CI_NODE_INDEX}.json"]

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -46,7 +46,7 @@ module Idv
 
       redirect_to next_step
 
-      analytics.idv_enter_password_complete(
+      analytics.idv_enter_password_submitted(
         success: true,
         fraud_review_pending: idv_session.profile.fraud_review_pending?,
         fraud_rejection: idv_session.profile.fraud_rejection?,
@@ -93,7 +93,7 @@ module Idv
     def confirm_current_password
       return if valid_password?
 
-      analytics.idv_enter_password_complete(
+      analytics.idv_enter_password_submitted(
         success: false,
         gpo_verification_pending: current_user.gpo_verification_pending_profile?,
         # note: this always returns false as of 8/23

--- a/app/jobs/gpo_expiration_job.rb
+++ b/app/jobs/gpo_expiration_job.rb
@@ -1,0 +1,76 @@
+class GpoExpirationJob < ApplicationJob
+  queue_as :low
+
+  def initialize(analytics: nil)
+    @analytics = analytics
+  end
+
+  def expire_profile(profile:)
+    gpo_verification_pending_at = profile.gpo_verification_pending_at
+
+    profile.deactivate_due_to_gpo_expiration
+
+    analytics.idv_gpo_expired(
+      user_id: profile.user.uuid,
+      user_has_active_profile: profile.user.active_profile.present?,
+      letters_sent: profile.gpo_confirmation_codes.count,
+      gpo_verification_pending_at: gpo_verification_pending_at,
+    )
+  end
+
+  def perform(now: Time.zone.now, limit: nil, min_profile_age: nil)
+    profiles = gpo_profiles_that_should_be_expired(as_of: now, min_profile_age: min_profile_age)
+
+    if limit.present?
+      profiles = profiles.limit(limit)
+    end
+
+    profiles.find_each do |profile|
+      expire_profile(profile: profile)
+    end
+  end
+
+  def gpo_profiles_that_should_be_expired(as_of:, min_profile_age: nil)
+    Profile.
+      and(are_pending_gpo_verification).
+      and(user_cant_request_more_letters(as_of: as_of)).
+      and(most_recent_code_has_expired(as_of: as_of)).
+      and(are_old_enough(as_of: as_of, min_profile_age: min_profile_age))
+  end
+
+  private
+
+  def analytics
+    @analytics ||= Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
+  end
+
+  def are_old_enough(as_of:, min_profile_age:)
+    return Profile.all if min_profile_age.blank?
+
+    max_created_at = as_of - min_profile_age
+
+    return Profile.where(created_at: ..max_created_at)
+  end
+
+  def are_pending_gpo_verification
+    Profile.where.not(gpo_verification_pending_at: nil)
+  end
+
+  def most_recent_code_has_expired(as_of:)
+    # Any Profile where the most recent code was sent *before*
+    # usps_confirmation_max_days days ago is now expired
+    max_code_sent_at = as_of - IdentityConfig.store.usps_confirmation_max_days.days
+
+    Profile.where(
+      id: GpoConfirmationCode.
+        select(:profile_id).
+        group(:profile_id).
+        having('max(code_sent_at) < ?', max_code_sent_at),
+    )
+  end
+
+  def user_cant_request_more_letters(as_of:)
+    max_created_at = as_of - IdentityConfig.store.gpo_max_profile_age_to_send_letter_in_days.days
+    Profile.where(created_at: [..max_created_at])
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -173,6 +173,15 @@ class Profile < ApplicationRecord
     in_person_verification_pending_at.present?
   end
 
+  def deactivate_due_to_gpo_expiration
+    raise 'Profile is not pending GPO verification' if gpo_verification_pending_at.nil?
+    update!(
+      active: false,
+      gpo_verification_pending_at: nil,
+      gpo_verification_expired_at: Time.zone.now,
+    )
+  end
+
   def deactivate_for_in_person_verification
     update!(active: false, in_person_verification_pending_at: Time.zone.now)
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1158,7 +1158,7 @@ module AnalyticsEvents
   # @param [Boolean] in_person_verification_pending
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
-  def idv_enter_password_complete(
+  def idv_enter_password_submitted(
     success:,
     fraud_review_pending:,
     fraud_rejection:,
@@ -1169,7 +1169,7 @@ module AnalyticsEvents
     **extra
   )
     track_event(
-      'IdV: review complete',
+      :idv_enter_password_submitted,
       success: success,
       deactivation_reason: deactivation_reason,
       fraud_review_pending: fraud_review_pending,
@@ -1192,7 +1192,7 @@ module AnalyticsEvents
     **extra
   )
     track_event(
-      'IdV: review info visited',
+      :idv_enter_password_visited,
       address_verification_method: address_verification_method,
       proofing_components: proofing_components,
       **extra,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1465,6 +1465,28 @@ module AnalyticsEvents
     track_event('IdV: gpo confirm start over visited', **extra)
   end
 
+  # The user ran out of time to complete their address verification by mail.
+  # @param [String] user_id UUID of the user who expired
+  # @param [Boolean] user_has_active_profile Whether the user currently has an active profile
+  # @param [Integer] letters_sent Total # of GPO letters sent for this profile
+  # @param [Time] gpo_verification_pending_at Date/time when profile originally entered GPO flow
+  def idv_gpo_expired(
+    user_id:,
+    user_has_active_profile:,
+    letters_sent:,
+    gpo_verification_pending_at:,
+    **extra
+  )
+    track_event(
+      :idv_gpo_expired,
+      user_id: user_id,
+      user_has_active_profile: user_has_active_profile,
+      letters_sent: letters_sent,
+      gpo_verification_pending_at: gpo_verification_pending_at,
+      **extra,
+    )
+  end
+
   # A GPO reminder email was sent to the user
   # @param [String] user_id UUID of user who we sent a reminder to
   def idv_gpo_reminder_email_sent(user_id:, **extra)

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -29,7 +29,7 @@ module Idv
       idv_phone_otp_delivery_selection_visit
       idv_phone_otp_delivery_selection_submitted
       idv_proofing_resolution_result_missing
-      idv_enter_password_complete
+      idv_enter_password_submitted
       idv_enter_password_visited
       idv_please_call_visited
       idv_start_over

--- a/app/views/idv/by_mail/enter_code/index.html.erb
+++ b/app/views/idv/by_mail/enter_code/index.html.erb
@@ -25,10 +25,6 @@
   <% end %>
 <% end %>
 
-<%= render AlertComponent.new(type: :warning, class: 'margin-bottom-3') do %>
-  <%= t('idv.gpo.change_to_verification_code_html') %>
-<% end %>
-
 <%= render AlertComponent.new(type: :info, class: 'margin-bottom-4', text_tag: 'div') do %>
   <p>
     <%= t('idv.gpo.alert_info') %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -68,7 +68,6 @@ database_worker_jobs_sslmode: 'verify-full'
 deliver_mail_async: false
 deleted_user_accounts_report_configs: '[]'
 development_mailer_deliver_method: letter_opener
-disable_csp_unsafe_inline: true
 disable_email_sending: true
 disable_logout_get_request: true
 disallow_all_web_crawlers: true

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -153,7 +153,6 @@ in_person_outage_emailed_by_date: 'November 1, 2024'
 in_person_send_proofing_notifications_enabled: false
 in_person_stop_expiring_enrollments: false
 include_slo_in_saml_metadata: false
-key_pair_generation_percent: 0
 logins_per_ip_track_only_mode: false
 # LexisNexis #####################################################
 lexisnexis_base_url: https://www.example.com

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -35,3 +35,4 @@ production:
   usps_auth_token_refresh_job_enabled: false
   lexisnexis_threatmetrix_mock_enabled: true
   enable_usps_verification: true
+  seed_agreements_data: false

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,11 +25,6 @@ Rails.application.config.content_security_policy do |policy|
     script_src << "localhost:#{ENV['WEBPACK_PORT']}"
   end
 
-  if !IdentityConfig.store.disable_csp_unsafe_inline
-    script_src << :unsafe_inline
-    style_src << :unsafe_inline
-  end
-
   if IdentityConfig.store.rails_mailer_previews_enabled
     style_src << :unsafe_inline
     # CSP 2.0 only; overriden by x_frame_options in some browsers

--- a/config/initializers/unused_identity_config_keys.rb
+++ b/config/initializers/unused_identity_config_keys.rb
@@ -1,0 +1,3 @@
+if IdentityConfig.unused_keys.present?
+  Rails.logger.warn({ name: 'unused_identity_config_keys', keys: IdentityConfig.unused_keys })
+end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -127,9 +127,9 @@ en:
       choose_another_method: choose another authentication method
       general_error: We were unable to add face or touch unlock. Please try again or
         choose another method.
-      not_supported: Sorry, your browser does not support FIDO platform
-        authenticators. The latest versions of Chrome, Firefox, Edge, and Safari
-        support FIDO platform authenticators.
+      not_supported: Your browser doesn’t support face or touch unlock. Use the latest
+        version of Google Chrome, Microsoft Edge or Safari to use face or touch
+        unlock.
       unique_name: That name is already taken. Please choose a different name.
     webauthn_setup:
       additional_methods_link: choose another authentication method
@@ -139,7 +139,7 @@ en:
         https://fidoalliance.org/certification/fido-certified-products/ and if
         you believe this is our error, please contact at %{link}.
       general_error_html: We were unable to add the security key. Please try again or %{link_html}.
-      not_supported: Sorry, your browser does not support FIDO security keys. The
-        latest versions of Chrome, Firefox, Edge, and Safari support FIDO
-        security keys.
+      not_supported: Your browser doesn’t support security keys. Use the latest
+        version of Google Chrome, Microsoft Edge, Mozilla Firefox or Safari to
+        use security keys.
       unique_name: That name is already taken. Please choose a different name.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -137,8 +137,9 @@ es:
       choose_another_method: elija otro método de autenticación
       general_error: No pudimos agregar el desbloqueo con la cara o con la huella
         digital. Inténtelo de nuevo o elija otro método de autenticación.
-      not_supported: Lo sentimos, pero su navegador no es compatible con el desbloqueo
-        facial o táctil.
+      not_supported: Su navegador no permite el desbloqueo facial o con la huella
+        digital. Use la última versión de Google Chrome, Microsoft Edge o Safari
+        para usar el desbloqueo facial o con la huella digital.
       unique_name: Ese nombre de dispositivo ha sido utilizado. Por favor, seleccione
         un nombre de dispositivo diferente.
     webauthn_setup:
@@ -153,7 +154,7 @@ es:
         %{link}.
       general_error_html: No hemos podido añadir la clave de seguridad. Inténtelo de
         nuevo o %{link_html}.
-      not_supported: Lo sentimos, su navegador no admite las claves de seguridad FIDO.
-        Las últimas versiones de Chrome, Firefox, Edge y Safari son compatibles
-        con las claves de seguridad FIDO.
+      not_supported: Tu navegador no es compatible con llaves de seguridad. Utiliza la
+        última versión de Google Chrome, Microsoft Edge, Mozilla Firefox o
+        Safari para utilizar llaves de seguridad.
       unique_name: El nombre ya fue escogido. Por favor, elija un nombre diferente.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -148,8 +148,10 @@ fr:
       general_error: Nous n’avons pas pu ajouter le déverrouillage facial ni le
         déverrouillage tactile. Veuillez réessayer ou choisir une autre méthode
         d’authentification.
-      not_supported: Nous sommes désolés, mais votre navigateur ne prend pas en charge
-        le déverrouillage du visage ou du toucher.
+      not_supported: Votre navigateur ne prend pas en charge le déverrouillage par
+        reconnaissance faciale ou tactile. Utilisez la dernière version de
+        Google Chrome, Microsoft Edge ou Safari pour utiliser le déverrouillage
+        par reconnaissance faciale ou tactile.
       unique_name: Ce nom d’appareil a été utilisé. Veuillez sélectionner un autre nom
         d’appareil.
     webauthn_setup:
@@ -163,7 +165,7 @@ fr:
         %{link}.
       general_error_html: Nous n’avons pas pu ajouter la clé de sécurité. Veuillez
         réessayer ou %{link_html}.
-      not_supported: Désolé, votre navigateur ne supporte pas les clés de sécurité
-        FIDO. Les dernières versions de Chrome, Firefox, Edge et Safari prennent
-        en charge les clés de sécurité FIDO.
+      not_supported: Votre navigateur ne prend pas en charge les clés de sécurité.
+        Utilisez la dernière version de Google Chrome, Microsoft Edge, Mozilla
+        Firefox ou Safari pour utiliser les clés de sécurité.
       unique_name: Ce nom est déjà pris. Veuillez choisir un autre nom.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -180,8 +180,6 @@ en:
       alert_info: 'We sent a letter with your verification code to:'
       alert_rate_limit_warning_html: You can’t request more letters right now. Your
         previous letter request was on <strong>%{date_letter_was_sent}</strong>.
-      change_to_verification_code_html: 'The <strong>one-time code</strong> from your
-        letter is now referred to as <strong>verification code</strong>.'
       clear_and_start_over: Clear your information and start over
       did_not_receive_letter:
         form:

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -190,8 +190,6 @@ es:
       alert_rate_limit_warning_html: No puede solicitar más cartas ahora mismo. Su
         solicitud de carta anterior la hizo el
         <strong>%{date_letter_was_sent}</strong>.
-      change_to_verification_code_html: 'El <strong>código único</strong> de su carta
-        ahora se conoce como <strong>código de verificación</strong>.'
       clear_and_start_over: Borrar su información y empezar de nuevo
       did_not_receive_letter:
         form:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -195,9 +195,6 @@ fr:
       alert_rate_limit_warning_html: Vous ne pouvez pas demander d’autres lettres pour
         le moment. Votre précédente demande de lettre a été effectuée le
         <strong>%{date_letter_was_sent}</strong>.
-      change_to_verification_code_html: 'Le <strong>code à usage unique</strong>
-        figurant dans votre lettre est désormais appelé <strong>code de
-        vérification</strong>.'
       clear_and_start_over: Supprimez vos données et recommencez
       did_not_receive_letter:
         form:

--- a/db/primary_migrate/20231102211426_add_gpo_verification_expired_at_to_profiles.rb
+++ b/db/primary_migrate/20231102211426_add_gpo_verification_expired_at_to_profiles.rb
@@ -1,0 +1,8 @@
+class AddGpoVerificationExpiredAtToProfiles < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :profiles, :gpo_verification_expired_at, :datetime
+    add_index :profiles, :gpo_verification_expired_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_24_172229) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_02_211426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -456,9 +456,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_24_172229) do
     t.datetime "in_person_verification_pending_at"
     t.text "encrypted_pii_multi_region"
     t.text "encrypted_pii_recovery_multi_region"
+    t.datetime "gpo_verification_expired_at"
     t.index ["fraud_pending_reason"], name: "index_profiles_on_fraud_pending_reason"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
+    t.index ["gpo_verification_expired_at"], name: "index_profiles_on_gpo_verification_expired_at"
     t.index ["gpo_verification_pending_at"], name: "index_profiles_on_gpo_verification_pending_at"
     t.index ["name_zip_birth_year_signature"], name: "index_profiles_on_name_zip_birth_year_signature"
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"
@@ -627,6 +629,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_24_172229) do
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "bounced_at", precision: nil
     t.datetime "reminder_sent_at", precision: nil
+    t.datetime "expiration_notice_sent_at", precision: nil
+    t.index ["expiration_notice_sent_at"], name: "index_usps_confirmation_codes_on_expiration_notice_sent_at"
     t.index ["otp_fingerprint"], name: "index_usps_confirmation_codes_on_otp_fingerprint"
     t.index ["profile_id"], name: "index_usps_confirmation_codes_on_profile_id"
     t.index ["reminder_sent_at"], name: "index_usps_confirmation_codes_on_reminder_sent_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -629,8 +629,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_211426) do
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "bounced_at", precision: nil
     t.datetime "reminder_sent_at", precision: nil
-    t.datetime "expiration_notice_sent_at", precision: nil
-    t.index ["expiration_notice_sent_at"], name: "index_usps_confirmation_codes_on_expiration_notice_sent_at"
     t.index ["otp_fingerprint"], name: "index_usps_confirmation_codes_on_otp_fingerprint"
     t.index ["profile_id"], name: "index_usps_confirmation_codes_on_profile_id"
     t.index ["reminder_sent_at"], name: "index_usps_confirmation_codes_on_reminder_sent_at"

--- a/dockerfiles/idp_review_app.Dockerfile
+++ b/dockerfiles/idp_review_app.Dockerfile
@@ -1,6 +1,8 @@
 FROM ruby:3.2.2-slim
 
 # Set environment variables
+ARG ARG_CI_ENVIRONMENT_SLUG="placeholder"
+ENV CI_ENVIRONMENT_SLUG=${ARG_CI_ENVIRONMENT_SLUG}
 ENV RAILS_ROOT /app
 ENV RAILS_ENV production
 ENV NODE_ENV production
@@ -29,6 +31,8 @@ ENV ASSET_HOST http://localhost:3000
 ENV DOMAIN_NAME localhost:3000
 ENV PIV_CAC_SERVICE_URL https://localhost:8443/
 ENV PIV_CAC_VERIFY_TOKEN_URL https://localhost:8443/ 
+
+RUN echo Env Value : $CI_ENVIRONMENT_SLUG
 
 # Prevent documentation installation
 RUN echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/00_nodoc && \
@@ -120,17 +124,6 @@ COPY --chown=app:app ./babel.config.js ./babel.config.js
 COPY --chown=app:app ./webpack.config.js ./webpack.config.js
 COPY --chown=app:app ./.browserslistrc ./.browserslistrc
 
-# Setup config files
-COPY --chown=app:app config/agencies.localdev.yml $RAILS_ROOT/config/agencies.yaml
-COPY --chown=app:app config/iaa_gtcs.localdev.yml $RAILS_ROOT/config/iaa_gtcs.yaml
-COPY --chown=app:app config/iaa_orders.localdev.yml $RAILS_ROOT/config/iaa_orders.yaml
-COPY --chown=app:app config/iaa_statuses.localdev.yml $RAILS_ROOT/config/iaa_statuses.yaml
-COPY --chown=app:app config/integration_statuses.localdev.yml $RAILS_ROOT/config/integration_statuses.yaml
-COPY --chown=app:app config/integrations.localdev.yml $RAILS_ROOT/config/integrations.yaml
-COPY --chown=app:app config/partner_account_statuses.localdev.yml $RAILS_ROOT/config/partner_account_statuses.yaml
-COPY --chown=app:app config/partner_accounts.localdev.yml $RAILS_ROOT/config/partner_accounts.yaml
-COPY --chown=app:app config/service_providers.localdev.yml $RAILS_ROOT/config/service_providers.yaml
-
 # Copy keys
 COPY --chown=app:app keys.example $RAILS_ROOT/keys
 
@@ -151,6 +144,18 @@ RUN openssl req -x509 -sha256 -nodes -newkey rsa:2048 -days 1825 \
 
 # Precompile assets
 RUN bundle exec rake assets:precompile --trace
+
+# Setup config files
+COPY --chown=app:app config/agencies.localdev.yml $RAILS_ROOT/config/agencies.yml
+COPY --chown=app:app config/iaa_gtcs.localdev.yml $RAILS_ROOT/config/iaa_gtcs.yml
+COPY --chown=app:app config/iaa_orders.localdev.yml $RAILS_ROOT/config/iaa_orders.yml
+COPY --chown=app:app config/iaa_statuses.localdev.yml $RAILS_ROOT/config/iaa_statuses.yml
+COPY --chown=app:app config/integration_statuses.localdev.yml $RAILS_ROOT/config/integration_statuses.yml
+COPY --chown=app:app config/integrations.localdev.yml $RAILS_ROOT/config/integrations.yml
+COPY --chown=app:app config/partner_account_statuses.localdev.yml $RAILS_ROOT/config/partner_account_statuses.yml
+COPY --chown=app:app config/partner_accounts.localdev.yml $RAILS_ROOT/config/partner_accounts.yml
+COPY --chown=app:app certs.example $RAILS_ROOT/certs
+RUN ./scripts/review_app_service_providers.rb > $RAILS_ROOT/config/service_providers.yml
 
 # Expose the port the app runs on
 EXPOSE 3000

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -39,7 +39,7 @@ margins or borders.
 - Variables and functions (excluding React components) should be named as camelCase, e.g. `const myFavoriteNumber = 1;`.
    - Only the first letter of an abbreviation should be capitalized, e.g. `const userId = 10;`.
    - All letters of an acronym should be capitalized, e.g. `const siteURL = 'https://example.com';`.
-- Classes and React components should be named as PascalCase (upper camel case), e.g. `class MyCustomElement {}`.
+- Classes, React components, and TypeScript types should be named as PascalCase (upper camel case), e.g. `class MyCustomElement {}`.
 - Constants should be named as SCREAMING_SNAKE_CASE, e.g. `const MEANING_OF_LIFE = 42;`.
 - TypeScript enums should be named as PascalCase with SCREAMING_SNAKE_CASE members, e.g. `enum Color { RED = '#f00'; }`.
 

--- a/lib/cleanup/destroy_unused_providers.rb
+++ b/lib/cleanup/destroy_unused_providers.rb
@@ -8,6 +8,15 @@ require './lib/cleanup/destroyable_records'
 #
 # This script iterates over a list of those issuers, outputs the data that is to be deleted, and
 # then requires user confirmation before deleting the issuer and associated models.
+#
+#
+# As of 11/2/2023: The rake task isn't working, to remove unused providers log into a box in the
+# environment you want to remove unused providers from. Enter into a rails console and enter the
+# following commands:
+# > require 'cleanup/destroy_unused_providers'
+# > issuers=['list','of','issuers','to','remove']
+# > dup = DestroyUnusedProviders.new(issuers)
+# > dup.run
 
 class DestroyUnusedProviders
   attr_reader :destroy_list, :stdin, :stdout

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -168,7 +168,6 @@ class IdentityConfig
     config.add(:deleted_user_accounts_report_configs, type: :json)
     config.add(:deliver_mail_async, type: :boolean)
     config.add(:development_mailer_deliver_method, type: :symbol, enum: [:file, :letter_opener])
-    config.add(:disable_csp_unsafe_inline, type: :boolean)
     config.add(:disable_email_sending, type: :boolean)
     config.add(:disable_logout_get_request, type: :boolean)
     config.add(:disallow_all_web_crawlers, type: :boolean)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -6,7 +6,7 @@ class IdentityConfig
   VENDOR_STATUS_OPTIONS = %i[operational partial_outage full_outage]
 
   class << self
-    attr_reader :store, :key_types
+    attr_reader :store, :key_types, :unused_keys
   end
 
   CONVERTERS = {
@@ -492,6 +492,7 @@ class IdentityConfig
     config.add(:weekly_auth_funnel_report_config, type: :json)
 
     @key_types = config.key_types
+    @unused_keys = config_map.keys - config.written_env.keys
     @store = RedactedStruct.new('IdentityConfig', *config.written_env.keys, keyword_init: true).
       new(**config.written_env)
   end

--- a/lib/linters/errors_add_linter.rb
+++ b/lib/linters/errors_add_linter.rb
@@ -22,15 +22,12 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          unless node.arguments.last.type == :hash || errors_add_match?(node).nil?
-            return add_offense(node, location: :expression)
-          end
-          errors_add_match?(node) do |arguments|
-            type_node = arguments.last.pairs.find do |pair|
-              pair.key.sym_type? && pair.key.source == 'type'
-            end
-            add_offense(node, location: :expression) unless type_node
-          end
+          return unless errors_add_match?(node)
+          _attr, type, options = node.arguments
+          return if type && type.type == :sym
+          options = type if type && type.type == :hash
+          return if options && options.type == :hash && options.keys.map(&:value).include?(:type)
+          add_offense(node, location: :expression)
         end
       end
     end

--- a/lib/tasks/backfill_gpo_expiration.rake
+++ b/lib/tasks/backfill_gpo_expiration.rake
@@ -1,0 +1,69 @@
+namespace :profiles do
+  desc 'Backfill the gpo_verification_expired_at value'
+
+  ##
+  # Usage:
+  #
+  # Print pending updates
+  # bundle exec rake profiles:backfill_gpo_expiration > profiles.csv
+  #
+  # Commit updates
+  # bundle exec rake profiles:backfill_gpo_expiration UPDATE_PROFILES=true > profiles.csv
+  #
+  task backfill_gpo_expiration: :environment do |_task, _args|
+    min_profile_age = (ENV['MIN_PROFILE_AGE_IN_DAYS'].to_i || 100).days
+    update_profiles = ENV['UPDATE_PROFILES'] == 'true'
+
+    job = GpoExpirationJob.new
+
+    profiles = job.gpo_profiles_that_should_be_expired(
+      as_of: Time.zone.now,
+      min_profile_age: min_profile_age,
+    )
+
+    count = 0
+
+    profiles.find_each do |profile|
+      count += 1
+
+      gpo_verification_pending_at = profile.gpo_verification_pending_at
+
+      if gpo_verification_pending_at.blank?
+        raise "Profile #{profile.id} does not have gpo_verification_pending_at"
+      end
+
+      puts "#{profile.id},#{gpo_verification_pending_at.iso8601}"
+
+      if update_profiles
+        warn "Expired #{count} profiles" if count % 100 == 0
+        job.expire_profile(profile: profile)
+      elsif count % 100 == 0
+        warn "Found #{count} profiles"
+      end
+    end
+  end
+
+  ##
+  # Usage:
+  #
+  # Rollback the above:
+  #
+  # bundle exec rake profiles:rollback_backfill_gpo_expiration < profiles.csv
+  #
+  task rollback_backfill_gpo_expiration: :environment do |_task, _args|
+    profile_data = STDIN.read.split("\n").map do |profile_row|
+      profile_row.split(',')
+    end
+
+    warn "Updating #{profile_data.count} records"
+
+    profile_data.each do |profile_datum|
+      profile_id, gpo_verification_pending_at = profile_datum
+      Profile.where(id: profile_id).update!(
+        gpo_verification_pending_at: Time.zone.parse(gpo_verification_pending_at),
+        gpo_verification_expired_at: nil,
+      )
+      warn profile_id
+    end
+  end
+end

--- a/lib/tasks/disposable_domains.rake
+++ b/lib/tasks/disposable_domains.rake
@@ -2,6 +2,8 @@
 require 'csv'
 namespace :disposable_domains do
   task :load, %i[s3_url] => [:environment] do |_task, args|
+    # Need to increase statement timeout since command takes a long time.
+    ActiveRecord::Base.connection.execute 'SET statement_timeout = 200000'
     file = Identity::Hostdata.secrets_s3.read_file(args[:s3_url])
     names = file.split("\n")
     DisposableDomain.insert_all(names.map { |name| { name: } })

--- a/scripts/review_app_service_providers.rb
+++ b/scripts/review_app_service_providers.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+dashboard_url = "https://#{ENV.fetch('CI_ENVIRONMENT_SLUG')}-review-app-dashboard.review-app.identitysandbox.gov"
+
+hash = {
+  'production' => {
+    'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard' => {
+      'friendly_name' => 'Dashboard',
+      'agency' => 'GSA',
+      'agency_id' => 2,
+      'logo' => '18f.svg',
+      'certs' => ['identity_dashboard_cert'],
+      'return_to_sp_url' => dashboard_url,
+      'redirect_uris' => [
+        "#{dashboard_url}/auth/logindotgov/callback",
+        dashboard_url,
+      ],
+      'push_notification_url' => "#{dashboard_url}/api/security_events",
+    },
+  },
+}
+
+puts hash.to_yaml

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Idv::EnterPasswordController do
         expect(response).to redirect_to idv_enter_password_path
 
         expect(@analytics).to have_logged_event(
-          'IdV: review complete',
+          :idv_enter_password_submitted,
           success: false,
           fraud_review_pending: false,
           fraud_rejection: false,
@@ -276,7 +276,7 @@ RSpec.describe Idv::EnterPasswordController do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         expect(@analytics).to have_logged_event(
-          'IdV: review complete',
+          :idv_enter_password_submitted,
           success: true,
           fraud_review_pending: false,
           fraud_rejection: false,
@@ -612,7 +612,7 @@ RSpec.describe Idv::EnterPasswordController do
                   it 'logs events' do
                     put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
                     expect(@analytics).to have_logged_event(
-                      'IdV: review complete',
+                      :idv_enter_password_submitted,
                       success: true,
                       fraud_review_pending: fraud_review_pending?,
                       fraud_rejection: false,

--- a/spec/factories/gpo_confirmation_codes.rb
+++ b/spec/factories/gpo_confirmation_codes.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :gpo_confirmation_code do
     profile
     otp_fingerprint { Pii::Fingerprinter.fingerprint('ABCDE12345') }
+    code_sent_at { 1.day.ago }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -205,12 +205,30 @@ FactoryBot.define do
     end
 
     trait :with_pending_gpo_profile do
-      after :build do |user|
-        profile = create(:profile, :with_pii, gpo_verification_pending_at: 1.day.ago, user: user)
-        gpo_code = create(:gpo_confirmation_code)
-        profile.gpo_confirmation_codes << gpo_code
-        device = create(:device, user: user)
-        create(:event, user: user, device: device, event_type: :gpo_mail_sent)
+      transient do
+        code_sent_at { created_at }
+      end
+
+      after :create do |user, context|
+        profile = create(
+          :profile,
+          :with_pii,
+          gpo_verification_pending_at: context.code_sent_at,
+          user: user,
+          created_at: context.created_at,
+        )
+        create(
+          :gpo_confirmation_code,
+          profile: profile,
+          code_sent_at: context.code_sent_at,
+        )
+        create(
+          :event,
+          user: user,
+          device: create(:device, user: user),
+          event_type: :gpo_mail_sent,
+          created_at: context.code_sent_at,
+        )
       end
     end
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -116,11 +116,11 @@ RSpec.feature 'Analytics Regression', js: true do
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review info visited' => {
+      :idv_enter_password_visited => {
         address_verification_method: 'phone', acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review complete' => {
+      :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
@@ -224,11 +224,11 @@ RSpec.feature 'Analytics Regression', js: true do
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review info visited' => {
+      :idv_enter_password_visited => {
         address_verification_method: 'phone', acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review complete' => {
+      :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
@@ -317,7 +317,7 @@ RSpec.feature 'Analytics Regression', js: true do
       'IdV: request letter visited' => {
         letter_already_sent: false,
       },
-      'IdV: review info visited' => {
+      :idv_enter_password_visited => {
         address_verification_method: 'gpo', acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
@@ -325,7 +325,7 @@ RSpec.feature 'Analytics Regression', js: true do
         enqueued_at: Time.zone.now.utc, resend: false, phone_step_attempts: 0, first_letter_requested_at: Time.zone.now.utc, hours_since_first_letter: 0, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
-      'IdV: review complete' => {
+      :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: true, in_person_verification_pending: false, deactivation_reason: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
@@ -434,11 +434,11 @@ RSpec.feature 'Analytics Regression', js: true do
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review info visited' => {
+      :idv_enter_password_visited => {
         acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, address_verification_method: 'phone',
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
-      'IdV: review complete' => {
+      :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, getting_started_ab_test_bucket: :welcome_default, phone_question_ab_test_bucket: :bypass_phone_question, phone_with_camera: nil, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, deactivation_reason: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -154,7 +154,6 @@ RSpec.feature 'idv enter letter code step' do
 
       expect(current_path).to eq idv_verify_by_mail_enter_code_path
       expect(page).to have_content t('idv.gpo.alert_info')
-      expect(page).to have_content strip_tags(t('idv.gpo.change_to_verification_code_html'))
       expect(page).to have_content t('idv.gpo.wrong_address')
       expect(page).to have_content Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:address1]
       verify_no_rate_limit_banner

--- a/spec/jobs/gpo_expiration_job_spec.rb
+++ b/spec/jobs/gpo_expiration_job_spec.rb
@@ -1,0 +1,176 @@
+require 'rails_helper'
+
+RSpec.describe GpoExpirationJob do
+  include Rails.application.routes.url_helpers
+
+  subject(:job) { described_class.new(analytics: analytics) }
+
+  let(:analytics) { FakeAnalytics.new }
+
+  let(:usps_confirmation_max_days) { 30 }
+
+  let(:gpo_max_profile_age_to_send_letter_in_days) { 30 }
+
+  let(:expired_timestamp) { Time.zone.now.round - usps_confirmation_max_days.days - 1.hour }
+
+  let(:not_expired_timestamp) { Time.zone.now.round - (usps_confirmation_max_days / 2).days }
+
+  let!(:users) do
+    {
+      user_with_one_expired_gpo_profile: create(
+        :user,
+        :with_pending_gpo_profile,
+        created_at: expired_timestamp,
+      ),
+      user_with_one_unexpired_gpo_profile: create(
+        :user,
+        :with_pending_gpo_profile,
+        created_at: not_expired_timestamp,
+      ),
+      user_with_one_expired_code_and_one_unexpired_code: create(
+        :user,
+        :with_pending_gpo_profile,
+        created_at: expired_timestamp,
+      ).tap do |user|
+        profile = user.gpo_verification_pending_profile
+        create(:gpo_confirmation_code, profile: profile, code_sent_at: not_expired_timestamp)
+      end,
+    }
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(:gpo_max_profile_age_to_send_letter_in_days).and_return(
+      gpo_max_profile_age_to_send_letter_in_days,
+    )
+    allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).and_return(
+      usps_confirmation_max_days,
+    )
+  end
+
+  describe '#gpo_profiles_that_should_be_expired' do
+    it 'returns the correct profiles' do
+      profiles = job.gpo_profiles_that_should_be_expired(as_of: Time.zone.now)
+
+      expect(
+        profiles.map(&:user),
+      ).to contain_exactly(
+        users[:user_with_one_expired_gpo_profile],
+      )
+    end
+
+    context 'when users can request letters beyond initial code expiration period' do
+      let(:gpo_max_profile_age_to_send_letter_in_days) { 45 }
+
+      it 'returns profiles for the correct users' do
+        profiles = job.gpo_profiles_that_should_be_expired(as_of: Time.zone.now)
+        expect(profiles.count).to eql(0)
+      end
+    end
+
+    context 'when we are enforcing a minimum profile age' do
+      let!(:really_old_user) do
+        create(
+          :user,
+          :with_pending_gpo_profile,
+          created_at: expired_timestamp - 5.years,
+        )
+      end
+      it 'only wants to expire the really old profile' do
+        profiles = job.gpo_profiles_that_should_be_expired(
+          as_of: Time.zone.now,
+          min_profile_age: 2.years,
+        )
+        expect(profiles.map(&:user)).to contain_exactly(
+          really_old_user,
+        )
+      end
+    end
+  end
+
+  describe '#perform' do
+    it 'expires the profile' do
+      profile = users[:user_with_one_expired_gpo_profile].reload.gpo_verification_pending_profile
+      freeze_time do
+        expect { job.perform }.to change {
+                                    profile.reload.gpo_verification_expired_at
+                                  }.to eql(Time.zone.now)
+      end
+    end
+
+    it 'clears gpo_verification_pending_at' do
+      profile = users[:user_with_one_expired_gpo_profile].reload.gpo_verification_pending_profile
+      expect { job.perform }.to change { profile.reload.gpo_verification_pending_at }.to eql(nil)
+    end
+
+    it 'logged an analytics event' do
+      job.perform
+      expect(analytics).to have_logged_event(
+        :idv_gpo_expired,
+        user_id: users[:user_with_one_expired_gpo_profile].uuid,
+        user_has_active_profile: false,
+        letters_sent: 1,
+        gpo_verification_pending_at: be_within(1.second).of(expired_timestamp),
+      )
+    end
+
+    context 'when the user has an active profile' do
+      let!(:active_profile) do
+        create(:profile, :active, user: users[:user_with_one_expired_gpo_profile])
+      end
+      it 'includes that information in analytics event' do
+        job.perform
+
+        expect(analytics).to have_logged_event(
+          :idv_gpo_expired,
+          user_id: users[:user_with_one_expired_gpo_profile].uuid,
+          user_has_active_profile: true,
+          letters_sent: 1,
+          gpo_verification_pending_at: be_within(1.second).of(expired_timestamp),
+        )
+      end
+    end
+
+    context 'when the user has multiple codes sent' do
+      let!(:extra_code) do
+        create(
+          :gpo_confirmation_code,
+          profile: users[:user_with_one_expired_gpo_profile].gpo_verification_pending_profile,
+          code_sent_at: expired_timestamp,
+        )
+      end
+
+      it 'we note that in the analytics event' do
+        job.perform
+
+        expect(analytics).to have_logged_event(
+          :idv_gpo_expired,
+          user_id: users[:user_with_one_expired_gpo_profile].uuid,
+          user_has_active_profile: false,
+          letters_sent: 2,
+          gpo_verification_pending_at: be_within(1.second).of(expired_timestamp),
+        )
+      end
+    end
+
+    describe 'limit' do
+      let(:limit) { 3 }
+      before do
+        (0..limit).each do
+          create(
+            :user,
+            :with_pending_gpo_profile,
+            created_at: expired_timestamp,
+          )
+        end
+      end
+      it 'limits the number of records affected' do
+        initial_count = Profile.where.not(gpo_verification_pending_at: nil).count
+
+        job.perform(limit: limit)
+
+        expect(Profile.where.not(gpo_verification_pending_at: nil).count).
+          to eql(initial_count - limit)
+      end
+    end
+  end
+end

--- a/spec/lib/identity_config_spec.rb
+++ b/spec/lib/identity_config_spec.rb
@@ -65,4 +65,10 @@ RSpec.describe IdentityConfig do
       end
     end
   end
+
+  describe '.unused_keys' do
+    it 'does not have any unused keys' do
+      expect(IdentityConfig.unused_keys).to be_empty
+    end
+  end
 end

--- a/spec/lib/linters/errors_add_linter_spec.rb
+++ b/spec/lib/linters/errors_add_linter_spec.rb
@@ -9,11 +9,22 @@ RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do
   let(:config) { RuboCop::Config.new }
   let(:cop) { RuboCop::Cop::IdentityIdp::ErrorsAddLinter.new(config) }
 
+  it 'registers an offense when neither type nor options are specified' do
+    expect_offense(<<~RUBY)
+      class MyModel
+        def my_method
+          errors.add(:number)
+          ^^^^^^^^^^^^^^^^^^^ IdentityIdp/ErrorsAddLinter: Please set a unique key for this error
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense when no options are passed' do
     expect_offense(<<~RUBY)
       class MyModel
         def my_method
-          errors.add(:number, "is negative")
+          errors.add(:number, 'is negative')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/ErrorsAddLinter: Please set a unique key for this error
         end
       end
@@ -24,7 +35,7 @@ RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do
     expect_offense(<<~RUBY)
       class MyModel
         def my_method
-          errors.add(:number, "is negative", foo: :bar)
+          errors.add(:number, 'is negative', foo: :bar)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/ErrorsAddLinter: Please set a unique key for this error
         end
       end
@@ -48,7 +59,31 @@ RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do
       class MyModel
         def validate
           if number.negative?
-            errors.add(:number, "is negative", type: :is_negative)
+            errors.add(:number, 'is negative', type: :is_negative)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers no offense when defining hash as second argument including "type"' do
+    expect_no_offenses(<<~RUBY)
+      class MyModel
+        def validate
+          if number.negative?
+            errors.add(:number, message: 'is negative', type: :is_negative)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers no offense when type symbool is defined as second argument' do
+    expect_no_offenses(<<~RUBY)
+      class MyModel
+        def validate
+          if number.negative?
+            errors.add(:number, :is_negative, message: 'is negative')
           end
         end
       end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1054,6 +1054,45 @@ RSpec.describe Profile do
     end
   end
 
+  describe '#deactivate_due_to_gpo_expiration' do
+    let(:profile) { create(:profile, :verify_by_mail_pending, user: user) }
+
+    it 'sets gpo_verification_expired_at' do
+      freeze_time do
+        expect do
+          profile.deactivate_due_to_gpo_expiration
+        end.to change { profile.gpo_verification_expired_at }.to eql(Time.zone.now)
+      end
+    end
+
+    it 'clears gpo_verification_pending_at' do
+      expect do
+        profile.deactivate_due_to_gpo_expiration
+      end.to change { profile.gpo_verification_pending_at }.to eql(nil)
+    end
+
+    it 'maintains active = false' do
+      expect do
+        profile.deactivate_due_to_gpo_expiration
+      end.not_to change { profile.active }.from(false)
+    end
+
+    it 'does not set a deactivation_reason' do
+      expect do
+        profile.deactivate_due_to_gpo_expiration
+      end.not_to change { profile.deactivation_reason }.from(nil)
+    end
+
+    context 'not pending gpo' do
+      let(:profile) { create(:profile, user: user) }
+      it 'raises' do
+        expect do
+          profile.deactivate_due_to_gpo_expiration
+        end.to raise_error
+      end
+    end
+  end
+
   describe '#reject_for_fraud' do
     before do
       # This is necessary because UserMailer reaches into the


### PR DESCRIPTION
## User-Facing Improvements
- MFA setup:  error language update for security keys or face/touch unlock ([#9562](https://github.com/18F/identity-idp/pull/9562))
- Verify by Mail: Removed an alert banner no longer needed. ([#9571](https://github.com/18F/identity-idp/pull/9571))

## Internal
- Automated Testing: Improve accuracy of error type linter ([#9569](https://github.com/18F/identity-idp/pull/9569))
- Configuration: Remove unused key_pair_generation_percent configuration key ([#9566](https://github.com/18F/identity-idp/pull/9566))
- Configuration: Remove unused CSP configuration ([#9573](https://github.com/18F/identity-idp/pull/9573))
- Configuration: Warn if there are configuration keys in the configuration file that are not loaded by the configuration store ([#9575](https://github.com/18F/identity-idp/pull/9575))
- Documentation: Include TypeScript types in frontend naming conventions ([#9574](https://github.com/18F/identity-idp/pull/9574))
- Emails: Add statement timeout since its too long a query ([#9567](https://github.com/18F/identity-idp/pull/9567))
- Identity verification: Add background job to expire old GPO profiles. ([#9545](https://github.com/18F/identity-idp/pull/9545))
- ServiceProvider Management: Add documentation on how to remove unused providers ([#9520](https://github.com/18F/identity-idp/pull/9520))
- Development: Add dashboard integration to IDP review app ([#9563](https://github.com/18F/identity-idp/pull/9563))
