### PR TITLE
LG-11464: Redirect /verify/activated to personal key page if unackowledged

### DIFF
--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -21,6 +21,11 @@ class IdvController < ApplicationController
   end
 
   def activated
+    if idv_session.personal_key.present?
+      redirect_to idv_personal_key_url
+      return
+    end
+
     redirect_to idv_url unless active_profile?
     idv_session.clear
   end

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -222,6 +222,24 @@ RSpec.describe IdvController do
 
         expect(response).to render_template(:activated)
       end
+
+      context 'user still has personal_key in idv_session' do
+        it 'redirects user to personal key acknowledgement' do
+          user = create(:profile, :active, :verified).user
+          idv_session = Idv::Session.new(
+            user_session: {},
+            current_user: user,
+            service_provider: nil,
+          )
+          allow(controller).to receive(:idv_session).and_return(idv_session)
+          stub_sign_in(user)
+          idv_session.personal_key = 'a-really-secure-key'
+
+          get :activated
+
+          expect(response).to redirect_to idv_personal_key_url
+        end
+      end
     end
 
     context 'user does not have an active profile' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11464](https://cm-jira.usa.gov/browse/LG-11464)

## 🛠 Summary of changes

If the user navigates to the `/verify/activated` URL but still have a `personal_key` in their `idv_session` (meaning they have not yet acknowledged it), redirect them back to the personal key page so they can acknowledge it.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Complete identity verification, but stop on the Personal key screen
- [ ] Navigate to `/verify/activated`
- [ ] Expect to be redirected back to the personal key screen
