### PR TITLE
LG 11432 Prevent duplicate F/T setup if user hits back button on second MFA prompt

### DIFF
--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -21,8 +21,7 @@ module Users
       )
       result = form.submit(new_params)
       @platform_authenticator = form.platform_authenticator?
-      if @platform_authenticator && in_account_creation_flow? &&
-         current_user.webauthn_configurations.platform_authenticators.present?
+      if ft_unlock_setup_successful_on_account_setup?
         redirect_to authentication_methods_setup_path
       end
       @presenter = WebauthnSetupPresenter.new(
@@ -111,6 +110,11 @@ module Users
     end
 
     private
+
+    def ft_unlock_setup_successful_on_account_setup?
+      @platform_authenticator && in_account_creation_flow? &&
+        current_user.webauthn_configurations.platform_authenticators.present?
+    end
 
     def set_webauthn_setup_presenter
       @presenter = SetupPresenter.new(

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -21,6 +21,10 @@ module Users
       )
       result = form.submit(new_params)
       @platform_authenticator = form.platform_authenticator?
+      if @platform_authenticator && in_account_creation_flow? &&
+         current_user.webauthn_configurations.platform_authenticators.present?
+        redirect_to authentication_methods_setup_path
+      end
       @presenter = WebauthnSetupPresenter.new(
         current_user: current_user,
         user_fully_authenticated: user_fully_authenticated?,

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -10,7 +10,7 @@ module Users
     before_action :apply_secure_headers_override
     before_action :set_webauthn_setup_presenter
     before_action :confirm_recently_authenticated_2fa
-    before_action :confirm_already_set_ft
+    before_action :validate_existing_platform_authenticator
 
     helper_method :in_multi_mfa_selection_flow?
 
@@ -109,18 +109,15 @@ module Users
 
     private
 
-    def confirm_already_set_ft
-      form = WebauthnVisitForm.new(
-        user: current_user,
-        url_options: url_options,
-        in_mfa_selection_flow: in_multi_mfa_selection_flow?,
-      )
-      result = form.submit(new_params)
-      @platform_authenticator = form.platform_authenticator?
-      if @platform_authenticator && in_account_creation_flow? && result &&
+    def validate_existing_platform_authenticator
+      if platform_authenticator? && in_account_creation_flow? &&
          current_user.webauthn_configurations.platform_authenticators.present?
         redirect_to authentication_methods_setup_path
-      end
+     end
+    end
+
+    def platform_authenticator?
+      params[:platform] == 'true'
     end
 
     def set_webauthn_setup_presenter

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -230,6 +230,18 @@ RSpec.describe Users::WebauthnSetupController do
           expect(additional_mfa_check).to be_truthy
         end
       end
+
+      context 'when the back button is clicked after platform is added' do
+        let(:user) { create(:user, :with_webauthn_platform) }
+        before do
+          controller.user_session[:in_account_creation_flow] = true
+        end
+        it 'should redirect to authentication methods setup' do
+          get :new, params: { platform: true }
+
+          expect(response).to redirect_to(authentication_methods_setup_path)
+        end
+      end
     end
 
     describe 'multiple MFA handling' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-11432](https://cm-jira.usa.gov/browse/LG-11432)


## 🛠 Summary of changes

Adds a check in the `new` method so that if the user is in the account creation flow and has already set a platform authenticator to redirect them to the authentication methods setup page.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go to http://localhost:3000 with a F/T supported device
- [ ] Create a new account
- [ ] Set F/T unlock as 1st MFA method
- [ ] At confirmation page when prompted to set up a second method hit the back button
- [ ] You should be redirected to authentication methods setup page.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
