### PR TITLE
Tweaks to GPO expiration job + rake task

### DIFF
--- a/app/jobs/gpo_expiration_job.rb
+++ b/app/jobs/gpo_expiration_job.rb
@@ -64,7 +64,10 @@ class GpoExpirationJob < ApplicationJob
 
   def with_statement_timeout(timeout)
     ActiveRecord::Base.transaction do
-      ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = '#{timeout.seconds}s'")
+      quoted_timeout = ActiveRecord::Base.connection.quote("#{timeout.seconds}s")
+      ActiveRecord::Base.connection.execute(
+        "SET LOCAL statement_timeout = #{quoted_timeout}",
+      )
       yield
     end
   end

--- a/lib/tasks/backfill_gpo_expiration.rake
+++ b/lib/tasks/backfill_gpo_expiration.rake
@@ -14,33 +14,31 @@ namespace :profiles do
     min_profile_age = (ENV['MIN_PROFILE_AGE_IN_DAYS'].to_i || 100).days
     update_profiles = ENV['UPDATE_PROFILES'] == 'true'
 
-    job = GpoExpirationJob.new
-
-    profiles = job.gpo_profiles_that_should_be_expired(
-      as_of: Time.zone.now,
-      min_profile_age: min_profile_age,
-    )
-
     count = 0
+    earliest = nil
+    latest = nil
 
-    profiles.find_each do |profile|
+    on_profile_expired = ->(profile:, gpo_verification_pending_at:) do
       count += 1
 
-      gpo_verification_pending_at = profile.gpo_verification_pending_at
-
-      if gpo_verification_pending_at.blank?
-        raise "Profile #{profile.id} does not have gpo_verification_pending_at"
-      end
+      earliest = [earliest, gpo_verification_pending_at].compact.min
+      latest = [latest, gpo_verification_pending_at].compact.max
 
       puts "#{profile.id},#{gpo_verification_pending_at.iso8601}"
 
-      if update_profiles
-        warn "Expired #{count} profiles" if count % 100 == 0
-        job.expire_profile(profile: profile)
-      elsif count % 100 == 0
-        warn "Found #{count} profiles"
+      if count % 100 == 0
+        verb = update_profiles ? 'Expired' : 'Found'
+        warn "#{verb} #{count} profiles (earliest: #{earliest}, latest: #{latest})"
       end
     end
+
+    job = GpoExpirationJob.new(on_profile_expired: on_profile_expired)
+
+    job.perform(
+      now: Time.zone.now,
+      min_profile_age: min_profile_age,
+      dry_run: !update_profiles,
+    )
   end
 
   ##

--- a/lib/tasks/backfill_gpo_expiration.rake
+++ b/lib/tasks/backfill_gpo_expiration.rake
@@ -13,6 +13,7 @@ namespace :profiles do
   task backfill_gpo_expiration: :environment do |_task, _args|
     min_profile_age = (ENV['MIN_PROFILE_AGE_IN_DAYS'].to_i || 100).days
     update_profiles = ENV['UPDATE_PROFILES'] == 'true'
+    statement_timeout = ENV['STATEMENT_TIMEOUT_IN_SECONDS'].to_i.seconds || 10.minutes
 
     count = 0
     earliest = nil
@@ -38,6 +39,7 @@ namespace :profiles do
       now: Time.zone.now,
       min_profile_age: min_profile_age,
       dry_run: !update_profiles,
+      statement_timeout: statement_timeout,
     )
   end
 


### PR DESCRIPTION
I ran into some issues with Postgres statement timeouts when attempting to run the GPO expiration rake task I wrote in #9545. So I took the opportunity to clean up a few things, including:

- Make the rake task invoke the job's `.perform` method directly rather than duplicating the loop that the job runs in the rake task itself
- Add a configurable statement timeout so I can tweak it without needing a deploy
- Note earliest + latest timestamps found in rake task output

