### PR TITLE
LG-11461 add FlowPolicy#undo_steps_from! and add to #update through document capture

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -44,6 +44,10 @@ module IdvStepConcern
     idv_session.flow_path
   end
 
+  def flow_policy
+    @flow_policy ||= Idv::FlowPolicy.new(idv_session: idv_session, user: current_user)
+  end
+
   def confirm_hybrid_handoff_needed
     if params[:redo]
       idv_session.redo_document_capture = true
@@ -118,10 +122,6 @@ module IdvStepConcern
         flow_session[:pii_from_user][:same_address_as_id].to_s == 'true'
     end
     extra
-  end
-
-  def flow_policy
-    @flow_policy ||= Idv::FlowPolicy.new(idv_session: idv_session, user: current_user)
   end
 
   def confirm_step_allowed

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -135,7 +135,7 @@ module IdvStepConcern
     url_for(controller: step_info.controller, action: step_info.action)
   end
 
-  def undo_steps_from_controller!
+  def clear_invalid_steps!
     flow_policy.undo_steps_from_controller!(controller: self.class)
   end
 end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -44,10 +44,6 @@ module IdvStepConcern
     idv_session.flow_path
   end
 
-  def flow_policy
-    @flow_policy ||= Idv::FlowPolicy.new(idv_session: idv_session, user: current_user)
-  end
-
   def confirm_hybrid_handoff_needed
     if params[:redo]
       idv_session.redo_document_capture = true
@@ -124,6 +120,10 @@ module IdvStepConcern
     extra
   end
 
+  def flow_policy
+    @flow_policy ||= Idv::FlowPolicy.new(idv_session: idv_session, user: current_user)
+  end
+
   def confirm_step_allowed
     return if flow_policy.controller_allowed?(controller: self.class)
 
@@ -133,5 +133,9 @@ module IdvStepConcern
   def url_for_latest_step
     step_info = flow_policy.info_for_latest_step
     url_for(controller: step_info.controller, action: step_info.action)
+  end
+
+  def undo_steps_from!(step:)
+    flow_policy.undo_steps_from!(step: step)
   end
 end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -135,7 +135,7 @@ module IdvStepConcern
     url_for(controller: step_info.controller, action: step_info.action)
   end
 
-  def undo_steps_from!(step:)
-    flow_policy.undo_steps_from!(step: step)
+  def undo_steps_from_controller!
+    flow_policy.undo_steps_from_controller!(controller: self.class)
   end
 end

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -21,7 +21,7 @@ module Idv
     end
 
     def update
-      undo_steps_from!(step: :agreement)
+      undo_steps_from_controller!
       skip_to_capture if params[:skip_hybrid_handoff]
 
       result = Idv::ConsentForm.new.submit(consent_form_params)

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -21,7 +21,7 @@ module Idv
     end
 
     def update
-      undo_steps_from_controller!
+      clear_invalid_steps!
       skip_to_capture if params[:skip_hybrid_handoff]
 
       result = Idv::ConsentForm.new.submit(consent_form_params)

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -21,6 +21,7 @@ module Idv
     end
 
     def update
+      flow_policy.undo_steps_from!(step: :agreement)
       skip_to_capture if params[:skip_hybrid_handoff]
 
       result = Idv::ConsentForm.new.submit(consent_form_params)

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -21,7 +21,7 @@ module Idv
     end
 
     def update
-      flow_policy.undo_steps_from!(step: :agreement)
+      undo_steps_from!(step: :agreement)
       skip_to_capture if params[:skip_hybrid_handoff]
 
       result = Idv::ConsentForm.new.submit(consent_form_params)

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -48,6 +48,7 @@ module Idv
         controller: controller_name,
         next_steps: [:hybrid_handoff, :document_capture, :phone_question, :how_to_verify],
         preconditions: ->(idv_session:, user:) { idv_session.welcome_visited },
+        undo_step: ->(idv_session:, user:) { idv_session.idv_consent_given = nil },
       )
     end
 

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -22,7 +22,7 @@ module Idv
     end
 
     def update
-      flow_policy.undo_steps_from!(step: :document_capture)
+      undo_steps_from!(step: :document_capture)
       idv_session.redo_document_capture = nil # done with this redo
       # Not used in standard flow, here for data consistency with hybrid flow.
       document_capture_session.confirm_ocr

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -22,7 +22,7 @@ module Idv
     end
 
     def update
-      undo_steps_from_controller!
+      clear_invalid_steps!
       idv_session.redo_document_capture = nil # done with this redo
       # Not used in standard flow, here for data consistency with hybrid flow.
       document_capture_session.confirm_ocr

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -60,6 +60,10 @@ module Idv
         controller: controller_name,
         next_steps: [:success], # [:ssn],
         preconditions: ->(idv_session:, user:) { idv_session.flow_path == 'standard' },
+        undo_step: ->(idv_session:, user:) do
+          idv_session.pii_from_doc = nil
+          idv_session.invalidate_in_person_pii_from_user!
+        end,
       )
     end
 

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -22,7 +22,7 @@ module Idv
     end
 
     def update
-      undo_steps_from!(step: :document_capture)
+      undo_steps_from_controller!
       idv_session.redo_document_capture = nil # done with this redo
       # Not used in standard flow, here for data consistency with hybrid flow.
       document_capture_session.confirm_ocr

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -22,6 +22,7 @@ module Idv
     end
 
     def update
+      flow_policy.undo_steps_from!(step: :document_capture)
       idv_session.redo_document_capture = nil # done with this redo
       # Not used in standard flow, here for data consistency with hybrid flow.
       document_capture_session.confirm_ocr

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -13,7 +13,7 @@ module Idv
     end
 
     def update
-      undo_steps_from_controller!
+      clear_invalid_steps!
       result = Idv::HowToVerifyForm.new.submit(how_to_verify_form_params)
 
       analytics.idv_doc_auth_how_to_verify_submitted(

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -13,7 +13,7 @@ module Idv
     end
 
     def update
-      undo_steps_from!(step: :how_to_verify)
+      undo_steps_from_controller!
       result = Idv::HowToVerifyForm.new.submit(how_to_verify_form_params)
 
       analytics.idv_doc_auth_how_to_verify_submitted(

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -13,7 +13,7 @@ module Idv
     end
 
     def update
-      flow_policy.undo_steps_from!(step: :how_to_verify)
+      undo_steps_from!(step: :how_to_verify)
       result = Idv::HowToVerifyForm.new.submit(how_to_verify_form_params)
 
       analytics.idv_doc_auth_how_to_verify_submitted(

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -39,6 +39,7 @@ module Idv
         preconditions: ->(idv_session:, user:) do
           self.enabled?
         end,
+        undo_step: ->(idv_session:, user:) { true }, # clear any saved data
       )
     end
 

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -13,6 +13,7 @@ module Idv
     end
 
     def update
+      flow_policy.undo_steps_from!(step: :how_to_verify)
       result = Idv::HowToVerifyForm.new.submit(how_to_verify_form_params)
 
       analytics.idv_doc_auth_how_to_verify_submitted(

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -40,7 +40,7 @@ module Idv
         preconditions: ->(idv_session:, user:) do
           self.enabled?
         end,
-        undo_step: ->(idv_session:, user:) { true }, # clear any saved data
+        undo_step: ->(idv_session:, user:) {}, # clear any saved data
       )
     end
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -41,6 +41,7 @@ module Idv
         controller: controller_name,
         next_steps: [:link_sent, :document_capture],
         preconditions: ->(idv_session:, user:) { idv_session.idv_consent_given },
+        undo_step: ->(idv_session:, user:) { idv_session.flow_path = nil },
       )
     end
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -24,6 +24,7 @@ module Idv
     end
 
     def update
+      flow_policy.undo_steps_from!(step: :hybrid_handoff)
       irs_attempts_api_tracker.idv_document_upload_method_selected(
         upload_method: params[:type],
       )

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -24,7 +24,7 @@ module Idv
     end
 
     def update
-      flow_policy.undo_steps_from!(step: :hybrid_handoff)
+      undo_steps_from!(step: :hybrid_handoff)
       irs_attempts_api_tracker.idv_document_upload_method_selected(
         upload_method: params[:type],
       )

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -24,7 +24,7 @@ module Idv
     end
 
     def update
-      undo_steps_from!(step: :hybrid_handoff)
+      undo_steps_from_controller!
       irs_attempts_api_tracker.idv_document_upload_method_selected(
         upload_method: params[:type],
       )

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -24,7 +24,7 @@ module Idv
     end
 
     def update
-      undo_steps_from_controller!
+      clear_invalid_steps!
       irs_attempts_api_tracker.idv_document_upload_method_selected(
         upload_method: params[:type],
       )

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -20,7 +20,7 @@ module Idv
     end
 
     def update
-      undo_steps_from!(step: :link_sent)
+      undo_steps_from_controller!
       analytics.idv_doc_auth_link_sent_submitted(**analytics_arguments)
 
       return render_document_capture_cancelled if document_capture_session&.cancelled_at

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -47,7 +47,10 @@ module Idv
         controller: controller_name,
         next_steps: [:success], # [:ssn],
         preconditions: ->(idv_session:, user:) { idv_session.flow_path == 'hybrid' },
-        undo_step: ->(idv_session:, user:) { true },
+        undo_step: ->(idv_session:, user:) do
+          idv_session.pii_from_doc = nil
+          idv_session.invalidate_in_person_pii_from_user!
+        end,
       )
     end
 

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -46,6 +46,7 @@ module Idv
         controller: controller_name,
         next_steps: [:success], # [:ssn],
         preconditions: ->(idv_session:, user:) { idv_session.flow_path == 'hybrid' },
+        undo_step: ->(idv_session:, user:) { true },
       )
     end
 

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -20,6 +20,7 @@ module Idv
     end
 
     def update
+      flow_policy.undo_steps_from!(step: :link_sent)
       analytics.idv_doc_auth_link_sent_submitted(**analytics_arguments)
 
       return render_document_capture_cancelled if document_capture_session&.cancelled_at

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -20,7 +20,7 @@ module Idv
     end
 
     def update
-      flow_policy.undo_steps_from!(step: :link_sent)
+      undo_steps_from!(step: :link_sent)
       analytics.idv_doc_auth_link_sent_submitted(**analytics_arguments)
 
       return render_document_capture_cancelled if document_capture_session&.cancelled_at

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -20,7 +20,7 @@ module Idv
     end
 
     def update
-      undo_steps_from_controller!
+      clear_invalid_steps!
       analytics.idv_doc_auth_link_sent_submitted(**analytics_arguments)
 
       return render_document_capture_cancelled if document_capture_session&.cancelled_at

--- a/app/controllers/idv/phone_question_controller.rb
+++ b/app/controllers/idv/phone_question_controller.rb
@@ -16,7 +16,7 @@ module Idv
     end
 
     def phone_with_camera
-      undo_steps_from!(step: :phone_question)
+      undo_steps_from_controller!
       idv_session.phone_with_camera = true
       analytics.idv_doc_auth_phone_question_submitted(**analytics_arguments)
 
@@ -24,7 +24,7 @@ module Idv
     end
 
     def phone_without_camera
-      undo_steps_from!(step: :phone_question)
+      undo_steps_from_controller!
       idv_session.flow_path = 'standard'
       idv_session.phone_with_camera = false
       analytics.idv_doc_auth_phone_question_submitted(**analytics_arguments)

--- a/app/controllers/idv/phone_question_controller.rb
+++ b/app/controllers/idv/phone_question_controller.rb
@@ -16,7 +16,7 @@ module Idv
     end
 
     def phone_with_camera
-      undo_steps_from_controller!
+      clear_invalid_steps!
       idv_session.phone_with_camera = true
       analytics.idv_doc_auth_phone_question_submitted(**analytics_arguments)
 
@@ -24,7 +24,7 @@ module Idv
     end
 
     def phone_without_camera
-      undo_steps_from_controller!
+      clear_invalid_steps!
       idv_session.flow_path = 'standard'
       idv_session.phone_with_camera = false
       analytics.idv_doc_auth_phone_question_submitted(**analytics_arguments)

--- a/app/controllers/idv/phone_question_controller.rb
+++ b/app/controllers/idv/phone_question_controller.rb
@@ -16,7 +16,7 @@ module Idv
     end
 
     def phone_with_camera
-      flow_policy.undo_steps_from!(step: :phone_question)
+      undo_steps_from!(step: :phone_question)
       idv_session.phone_with_camera = true
       analytics.idv_doc_auth_phone_question_submitted(**analytics_arguments)
 
@@ -24,7 +24,7 @@ module Idv
     end
 
     def phone_without_camera
-      flow_policy.undo_steps_from!(step: :phone_question)
+      undo_steps_from!(step: :phone_question)
       idv_session.flow_path = 'standard'
       idv_session.phone_with_camera = false
       analytics.idv_doc_auth_phone_question_submitted(**analytics_arguments)

--- a/app/controllers/idv/phone_question_controller.rb
+++ b/app/controllers/idv/phone_question_controller.rb
@@ -39,6 +39,7 @@ module Idv
           AbTests::IDV_PHONE_QUESTION.bucket(user.uuid) == :show_phone_question &&
             idv_session.idv_consent_given
         end,
+        undo_step: ->(idv_session:, user:) { idv_session.phone_with_camera = nil },
       )
     end
 

--- a/app/controllers/idv/phone_question_controller.rb
+++ b/app/controllers/idv/phone_question_controller.rb
@@ -16,6 +16,7 @@ module Idv
     end
 
     def phone_with_camera
+      flow_policy.undo_steps_from!(step: :phone_question)
       idv_session.phone_with_camera = true
       analytics.idv_doc_auth_phone_question_submitted(**analytics_arguments)
 
@@ -23,6 +24,7 @@ module Idv
     end
 
     def phone_without_camera
+      flow_policy.undo_steps_from!(step: :phone_question)
       idv_session.flow_path = 'standard'
       idv_session.phone_with_camera = false
       analytics.idv_doc_auth_phone_question_submitted(**analytics_arguments)

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -23,7 +23,7 @@ module Idv
     end
 
     def update
-      undo_steps_from!(step: :welcome)
+      undo_steps_from_controller!
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
 
       create_document_capture_session

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -39,6 +39,7 @@ module Idv
         controller: controller_name,
         next_steps: [:agreement],
         preconditions: ->(idv_session:, user:) { true },
+        undo_step: ->(idv_session:, user:) { true },
       )
     end
 

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -23,6 +23,7 @@ module Idv
     end
 
     def update
+      flow_policy.undo_steps_from!(step: :welcome)
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
 
       create_document_capture_session
@@ -39,7 +40,7 @@ module Idv
         controller: controller_name,
         next_steps: [:agreement],
         preconditions: ->(idv_session:, user:) { true },
-        undo_step: ->(idv_session:, user:) { true },
+        undo_step: ->(idv_session:, user:) { idv_session.welcome_visited = nil },
       )
     end
 

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -23,7 +23,7 @@ module Idv
     end
 
     def update
-      undo_steps_from_controller!
+      clear_invalid_steps!
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
 
       create_document_capture_session

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -23,7 +23,7 @@ module Idv
     end
 
     def update
-      flow_policy.undo_steps_from!(step: :welcome)
+      undo_steps_from!(step: :welcome)
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
 
       create_document_capture_session

--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -18,13 +18,13 @@ module Idv
       steps[latest_step]
     end
 
-    def undo_steps_from(step:)
+    def undo_steps_from!(step:)
       return if step == :success
 
       steps[step].undo_step.call(idv_session: idv_session, user: user)
 
       steps[step].next_steps.each do |next_step|
-        undo_steps_from(step: next_step)
+        undo_steps_from!(step: next_step)
       end
     end
 

--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -18,14 +18,11 @@ module Idv
       steps[latest_step]
     end
 
-    def undo_steps_from!(step:)
-      return if step == :success
-
-      steps[step].undo_step.call(idv_session: idv_session, user: user)
-
-      steps[step].next_steps.each do |next_step|
-        undo_steps_from!(step: next_step)
-      end
+    def undo_steps_from_controller!(controller:)
+      controller_name = controller.ancestors.include?(ApplicationController) ?
+                        controller.controller_name : controller
+      key = controller_to_key(controller: controller_name)
+      undo_steps_from!(key: key)
     end
 
     private
@@ -63,6 +60,16 @@ module Idv
 
     def step_allowed?(key:)
       steps[key].preconditions.call(idv_session: idv_session, user: user)
+    end
+
+    def undo_steps_from!(key:)
+      return if key == :success
+
+      steps[key].undo_step.call(idv_session: idv_session, user: user)
+
+      steps[key].next_steps.each do |next_step|
+        undo_steps_from!(key: next_step)
+      end
     end
 
     def controller_to_key(controller:)

--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -8,7 +8,7 @@ module Idv
     end
 
     def controller_allowed?(controller:)
-      controller_name = controller.ancestors.include?(ApplicationController) ?
+      controller_name = controller < ApplicationController ?
                           controller.controller_name : controller
       key = controller_to_key(controller: controller_name)
       step_allowed?(key: key)
@@ -19,7 +19,7 @@ module Idv
     end
 
     def undo_steps_from_controller!(controller:)
-      controller_name = controller.ancestors.include?(ApplicationController) ?
+      controller_name = controller < ApplicationController ?
                         controller.controller_name : controller
       key = controller_to_key(controller: controller_name)
       undo_steps_from!(key: key)

--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -18,6 +18,16 @@ module Idv
       steps[latest_step]
     end
 
+    def undo_steps_from(step:)
+      return if step == :success
+
+      steps[step].undo_step.call(idv_session: idv_session, user: user)
+
+      steps[step].next_steps.each do |next_step|
+        undo_steps_from(step: next_step)
+      end
+    end
+
     private
 
     def latest_step(current_step: :root)
@@ -39,6 +49,7 @@ module Idv
           controller: AccountsController.controller_name,
           next_steps: [:welcome],
           preconditions: ->(idv_session:, user:) { true },
+          undo_step: ->(idv_session:, user:) { true },
         ),
         welcome: Idv::WelcomeController.step_info,
         agreement: Idv::AgreementController.step_info,

--- a/app/policies/idv/step_info.rb
+++ b/app/policies/idv/step_info.rb
@@ -2,18 +2,19 @@ module Idv
   class StepInfo
     include ActiveModel::Validations
 
-    attr_reader :key, :controller, :action, :next_steps, :preconditions
+    attr_reader :key, :controller, :action, :next_steps, :preconditions, :undo_step
 
     validates :controller, presence: true
     validates :action, presence: true
     validate :next_steps_validation, :preconditions_validation
 
-    def initialize(key:, controller:, next_steps:, preconditions:, action: :show)
+    def initialize(key:, controller:, next_steps:, preconditions:, undo_step:, action: :show)
       @key = key
       @controller = controller
       @action = action
       @next_steps = next_steps
       @preconditions = preconditions
+      @undo_step = undo_step
 
       raise ArgumentError unless valid?
     end
@@ -27,6 +28,12 @@ module Idv
     def preconditions_validation
       unless preconditions.is_a?(Proc)
         errors.add(:preconditions, type: :invalid_argument, message: 'preconditions must be a Proc')
+      end
+    end
+
+    def undo_step_validation
+      unless undo_step.is_a?(Proc)
+        errors.add(:undo_step, type: :invalid_argument, message: 'undo_step must be a Proc')
       end
     end
   end

--- a/app/policies/idv/step_info.rb
+++ b/app/policies/idv/step_info.rb
@@ -6,7 +6,7 @@ module Idv
 
     validates :controller, presence: true
     validates :action, presence: true
-    validate :next_steps_validation, :preconditions_validation
+    validate :next_steps_validation, :preconditions_validation, :undo_step_validation
 
     def initialize(key:, controller:, next_steps:, preconditions:, undo_step:, action: :show)
       @key = key

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -143,6 +143,12 @@ module Idv
       user_session.dig('idv/in_person', :pii_from_user)
     end
 
+    def invalidate_in_person_pii_from_user!
+      if user_session.dig('idv/in_person', :pii_from_user)
+        user_session['idv/in_person'][:pii_from_user] = nil
+      end
+    end
+
     def document_capture_complete?
       pii_from_doc || has_pii_from_user_in_flow_session || verify_info_step_complete?
     end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Idv::AgreementController do
     end
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from_controller!)
+      expect(subject).to receive(:clear_invalid_steps!)
 
       put :update, params: params
     end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Idv::AgreementController do
     end
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from!).with(step: :agreement)
+      expect(subject).to receive(:undo_steps_from_controller!)
 
       put :update, params: params
     end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -124,6 +124,12 @@ RSpec.describe Idv::AgreementController do
       }.compact
     end
 
+    it 'invalidates future steps' do
+      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :agreement)
+
+      put :update, params: params
+    end
+
     it 'sends analytics_submitted event with consent given' do
       put :update, params: params
 

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Idv::AgreementController do
     end
 
     it 'invalidates future steps' do
-      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :agreement)
+      expect(subject).to receive(:undo_steps_from!).with(step: :agreement)
 
       put :update, params: params
     end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Idv::DocumentCaptureController do
     let(:result) { { success: true, errors: {} } }
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from_controller!)
+      expect(subject).to receive(:clear_invalid_steps!)
 
       put :update
     end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -166,9 +166,9 @@ RSpec.describe Idv::DocumentCaptureController do
     let(:result) { { success: true, errors: {} } }
 
     it 'invalidates future steps' do
-      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :document_capture)
+      expect(subject).to receive(:undo_steps_from!).with(step: :document_capture)
 
-      put :update 
+      put :update
     end
 
     it 'sends analytics_submitted event' do

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Idv::DocumentCaptureController do
     let(:result) { { success: true, errors: {} } }
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from!).with(step: :document_capture)
+      expect(subject).to receive(:undo_steps_from_controller!)
 
       put :update
     end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -165,6 +165,12 @@ RSpec.describe Idv::DocumentCaptureController do
     end
     let(:result) { { success: true, errors: {} } }
 
+    it 'invalidates future steps' do
+      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :document_capture)
+
+      put :update 
+    end
+
     it 'sends analytics_submitted event' do
       allow(result).to receive(:success?).and_return(true)
       allow(subject).to receive(:handle_stored_result).and_return(result)

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Idv::HowToVerifyController do
 
   describe '#update' do
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from_controller!)
+      expect(subject).to receive(:clear_invalid_steps!)
 
       put :update
     end

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Idv::HowToVerifyController do
 
   describe '#update' do
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from!).with(step: :how_to_verify)
+      expect(subject).to receive(:undo_steps_from_controller!)
 
       put :update
     end

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -33,4 +33,12 @@ RSpec.describe Idv::HowToVerifyController do
       expect(response).to render_template :show
     end
   end
+
+  describe '#update' do
+    it 'invalidates future steps' do
+      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :how_to_verify)
+
+      put :update
+    end
+  end
 end

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Idv::HowToVerifyController do
 
   describe '#update' do
     it 'invalidates future steps' do
-      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :how_to_verify)
+      expect(subject).to receive(:undo_steps_from!).with(step: :how_to_verify)
 
       put :update
     end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Idv::HybridHandoffController do
       let(:document_capture_session_uuid) { '09228b6d-dd39-4925-bf82-b69104095517' }
 
       it 'invalidates future steps' do
-        expect(subject).to receive(:undo_steps_from_controller!)
+        expect(subject).to receive(:clear_invalid_steps!)
 
         put :update, params: params
       end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Idv::HybridHandoffController do
     end
 
     context 'hybrid_handoff already visited' do
-      it 'shows hybrid_handoff' do
+      it 'shows hybrid_handoff for standard' do
         subject.idv_session.flow_path = 'standard'
 
         get :show
@@ -98,7 +98,7 @@ RSpec.describe Idv::HybridHandoffController do
         expect(response).to render_template :show
       end
 
-      it 'shows hybrid_handoff' do
+      it 'shows hybrid_handoff for hybrid' do
         subject.idv_session.flow_path = 'hybrid'
 
         get :show
@@ -219,6 +219,12 @@ RSpec.describe Idv::HybridHandoffController do
       end
 
       let(:document_capture_session_uuid) { '09228b6d-dd39-4925-bf82-b69104095517' }
+
+      it 'invalidates future steps' do
+        expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :hybrid_handoff)
+
+        put :update, params: params
+      end
 
       it 'sends analytics_submitted event for hybrid' do
         put :update, params: params

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Idv::HybridHandoffController do
       let(:document_capture_session_uuid) { '09228b6d-dd39-4925-bf82-b69104095517' }
 
       it 'invalidates future steps' do
-        expect(subject).to receive(:undo_steps_from!).with(step: :hybrid_handoff)
+        expect(subject).to receive(:undo_steps_from_controller!)
 
         put :update, params: params
       end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Idv::HybridHandoffController do
       let(:document_capture_session_uuid) { '09228b6d-dd39-4925-bf82-b69104095517' }
 
       it 'invalidates future steps' do
-        expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :hybrid_handoff)
+        expect(subject).to receive(:undo_steps_from!).with(step: :hybrid_handoff)
 
         put :update, params: params
       end

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Idv::LinkSentController do
     end
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from!).with(step: :link_sent)
+      expect(subject).to receive(:undo_steps_from_controller!)
 
       put :update
     end

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Idv::LinkSentController do
     end
 
     it 'invalidates future steps' do
-      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :link_sent)
+      expect(subject).to receive(:undo_steps_from!).with(step: :link_sent)
 
       put :update
     end

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Idv::LinkSentController do
     end
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from_controller!)
+      expect(subject).to receive(:clear_invalid_steps!)
 
       put :update
     end

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe Idv::LinkSentController do
       }.merge(ab_test_args)
     end
 
+    it 'invalidates future steps' do
+      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :link_sent)
+
+      put :update
+    end
+
     it 'sends analytics_submitted event' do
       put :update
 

--- a/spec/controllers/idv/phone_question_controller_spec.rb
+++ b/spec/controllers/idv/phone_question_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Idv::PhoneQuestionController do
     let(:analytics_name) { :idv_doc_auth_phone_question_submitted }
 
     it 'invalidates future steps' do
-      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :phone_question)
+      expect(subject).to receive(:undo_steps_from!).with(step: :phone_question)
 
       get :phone_with_camera
     end
@@ -173,9 +173,9 @@ RSpec.describe Idv::PhoneQuestionController do
     let(:analytics_name) { :idv_doc_auth_phone_question_submitted }
 
     it 'invalidates future steps' do
-      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :phone_question)
+      expect(subject).to receive(:undo_steps_from!).with(step: :phone_question)
 
-      get :phone_without_camera 
+      get :phone_without_camera
     end
 
     it 'redirects to document_capture' do

--- a/spec/controllers/idv/phone_question_controller_spec.rb
+++ b/spec/controllers/idv/phone_question_controller_spec.rb
@@ -144,6 +144,12 @@ RSpec.describe Idv::PhoneQuestionController do
   describe '#phone_with_camera' do
     let(:analytics_name) { :idv_doc_auth_phone_question_submitted }
 
+    it 'invalidates future steps' do
+      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :phone_question)
+
+      get :phone_with_camera
+    end
+
     it 'redirects to hybrid handoff' do
       get :phone_with_camera
 
@@ -165,6 +171,12 @@ RSpec.describe Idv::PhoneQuestionController do
 
   describe '#phone_without_camera' do
     let(:analytics_name) { :idv_doc_auth_phone_question_submitted }
+
+    it 'invalidates future steps' do
+      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :phone_question)
+
+      get :phone_without_camera 
+    end
 
     it 'redirects to document_capture' do
       get :phone_without_camera

--- a/spec/controllers/idv/phone_question_controller_spec.rb
+++ b/spec/controllers/idv/phone_question_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Idv::PhoneQuestionController do
     let(:analytics_name) { :idv_doc_auth_phone_question_submitted }
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from!).with(step: :phone_question)
+      expect(subject).to receive(:undo_steps_from_controller!)
 
       get :phone_with_camera
     end
@@ -173,7 +173,7 @@ RSpec.describe Idv::PhoneQuestionController do
     let(:analytics_name) { :idv_doc_auth_phone_question_submitted }
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from!).with(step: :phone_question)
+      expect(subject).to receive(:undo_steps_from_controller!)
 
       get :phone_without_camera
     end

--- a/spec/controllers/idv/phone_question_controller_spec.rb
+++ b/spec/controllers/idv/phone_question_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Idv::PhoneQuestionController do
     let(:analytics_name) { :idv_doc_auth_phone_question_submitted }
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from_controller!)
+      expect(subject).to receive(:clear_invalid_steps!)
 
       get :phone_with_camera
     end
@@ -173,7 +173,7 @@ RSpec.describe Idv::PhoneQuestionController do
     let(:analytics_name) { :idv_doc_auth_phone_question_submitted }
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from_controller!)
+      expect(subject).to receive(:clear_invalid_steps!)
 
       get :phone_without_camera
     end

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -139,6 +139,12 @@ RSpec.describe Idv::WelcomeController do
       expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
+    it 'invalidates future steps' do
+      expect(subject.flow_policy).to receive(:undo_steps_from).with(step: :welcome)
+
+      put :update
+    end
+
     it 'creates a document capture session' do
       expect { put :update }.
         to change { subject.idv_session.document_capture_session_uuid }.from(nil)

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Idv::WelcomeController do
     end
 
     it 'invalidates future steps' do
-      expect(subject.flow_policy).to receive(:undo_steps_from).with(step: :welcome)
+      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :welcome)
 
       put :update
     end

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Idv::WelcomeController do
     end
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from_controller!)
+      expect(subject).to receive(:clear_invalid_steps!)
 
       put :update
     end

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Idv::WelcomeController do
     end
 
     it 'invalidates future steps' do
-      expect(subject).to receive(:undo_steps_from!).with(step: :welcome)
+      expect(subject).to receive(:undo_steps_from_controller!)
 
       put :update
     end

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Idv::WelcomeController do
     end
 
     it 'invalidates future steps' do
-      expect(subject.flow_policy).to receive(:undo_steps_from!).with(step: :welcome)
+      expect(subject).to receive(:undo_steps_from!).with(step: :welcome)
 
       put :update
     end

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -76,7 +76,9 @@ RSpec.feature 'doc auth redo document capture', js: true do
       complete_hybrid_handoff_step
 
       visit idv_verify_info_url
-
+      expect(page).to have_current_path(idv_document_capture_path)
+      DocAuth::Mock::DocAuthMockClient.reset!
+      attach_and_submit_images
       complete_verify_step
 
       expect(page).to have_current_path(idv_phone_path)

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe 'Identity verification', :js do
     expect(current_path).to eql(idv_welcome_path)
     complete_welcome_step
     expect(page).to have_current_path(idv_agreement_path)
-    expect(page).to have_checked_field(
+    expect(page).not_to have_checked_field(
       t('doc_auth.instructions.consent', app_name: APP_NAME),
       visible: :all,
     )

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -24,11 +24,7 @@ RSpec.describe 'Idv::FlowPolicy' do
     end
   end
 
-  context '#undo_steps_from!' do
-    it 'does not undo any steps if success' do
-      expect { subject.undo_steps_from!(step: :success) }.not_to change { idv_session }
-    end
-
+  context '#undo_steps_from_controller!' do
     context 'user is on document_capture step' do
       before do
         idv_session.welcome_visited = true
@@ -37,7 +33,7 @@ RSpec.describe 'Idv::FlowPolicy' do
       end
 
       it 'user goes back and submits welcome' do
-        subject.undo_steps_from!(step: :welcome)
+        subject.undo_steps_from_controller!(controller: Idv::WelcomeController)
 
         expect(idv_session.welcome_visited).to be_nil
         expect(idv_session.idv_consent_given).to be_nil

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -24,6 +24,28 @@ RSpec.describe 'Idv::FlowPolicy' do
     end
   end
 
+  context '#undo_steps_from!' do
+    it 'does not undo any steps if success' do
+      expect { subject.undo_steps_from!(step: :success) }.not_to change { idv_session }
+    end
+
+    context 'user is on document_capture step' do
+      before do
+        idv_session.welcome_visited = true
+        idv_session.idv_consent_given = true
+        idv_session.flow_path = 'standard'
+      end
+
+      it 'user goes back and submits welcome' do
+        subject.undo_steps_from!(step: :welcome)
+
+        expect(idv_session.welcome_visited).to be_nil
+        expect(idv_session.idv_consent_given).to be_nil
+        expect(idv_session.flow_path).to be_nil
+      end
+    end
+  end
+
   context 'each step in the flow' do
     before do
       allow(Idv::PhoneConfirmationSession).to receive(:from_h).

--- a/spec/policies/idv/step_info_spec.rb
+++ b/spec/policies/idv/step_info_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe 'Idv::StepInfo' do
   let(:controller) { ApplicationController.controller_name }
   let(:next_steps) { [] }
   let(:preconditions) { ->(idv_session:, user:) { true } }
+  let(:undo_step) { ->(idv_session:, user:) { true } }
   subject do
     Idv::StepInfo.new(
       key: :my_key,
       controller: controller,
       next_steps: next_steps,
       preconditions: preconditions,
+      undo_step: undo_step,
     )
   end
 
@@ -30,6 +32,14 @@ RSpec.describe 'Idv::StepInfo' do
   end
 
   context 'when given an invalid preconditions' do
+    let(:preconditions) { 'foo' }
+
+    it 'raises an ArgumentError' do
+      expect { subject }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'when given an invalid undo_step' do
     let(:preconditions) { 'foo' }
 
     it 'raises an ArgumentError' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11461](https://cm-jira.usa.gov/browse/LG-11461)

## 🛠 Summary of changes

This is an addition to  #9589 to invalidate future steps when a user uses the back button and submits a previous step. We added the new call to `#update` for welcome, agreement, link_sent, hybrid_handoff, how_to_verify, phone_question, and document_capture.

Each step_info now has an undo_step parameter which is a proc that unsets whatever the current step sets. 

FlowPolicy has a new method, `undo_steps_from!` which recursively undoes all of the next steps after the current step.

IdvStepConcern has a new helper method `clear_invalid_steps!` that should be called at the beginning of the #update method of each IdV controller that allows the back button.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Start IdV
- [ ]  Go up to document capture
- [ ] Use the back button to go back to the welcome step
- [ ]  Submit welcome
- [ ]  Expect agreement box to be unchecked
