### PR TITLE
Start writing idv_session.personal_key_acknowledged

### DIFF
--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -31,7 +31,7 @@ module Idv
         fraud_rejection: fraud_rejection?,
       )
 
-      idv_session.acknowledge_personal_key
+      idv_session.acknowledge_personal_key!
 
       redirect_to next_step
     end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -30,7 +30,9 @@ module Idv
         fraud_review_pending: fraud_review_pending?,
         fraud_rejection: fraud_rejection?,
       )
-      idv_session.personal_key = nil
+
+      idv_session.acknowledge_personal_key
+
       redirect_to next_step
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -86,7 +86,7 @@ module Idv
       end
     end
 
-    def acknowledge_personal_key
+    def acknowledge_personal_key!
       session.delete(:personal_key)
       session[:personal_key_acknowledged] = true
     end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -14,6 +14,7 @@ module Idv
       idv_phone_step_document_capture_session_uuid
       mail_only_warning_shown
       personal_key
+      personal_key_acknowledged
       phone_for_mobile_flow
       phone_with_camera
       pii_from_doc
@@ -83,6 +84,11 @@ module Idv
           profile_maker.pii_attributes,
         )
       end
+    end
+
+    def acknowledge_personal_key
+      session.delete(:personal_key)
+      session[:personal_key_acknowledged] = true
     end
 
     def gpo_verification_needed?

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -209,6 +209,12 @@ RSpec.describe Idv::PersonalKeyController do
         expect(subject.user_session[:need_personal_key_confirmation]).to eq(false)
       end
 
+      it 'sets idv_session.personal_key_acknowledged' do
+        expect { patch :update }.to change {
+                                      idv_session.personal_key_acknowledged
+                                    }.from(nil).to eql(true)
+      end
+
       it 'logs key submitted event' do
         patch :update
 

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -75,6 +75,20 @@ RSpec.describe Idv::Session do
     end
   end
 
+  describe '#acknowledge_personal_key' do
+    before do
+      subject.personal_key = 'ABCD1234'
+    end
+    it 'clears personal_key' do
+      expect { subject.acknowledge_personal_key }.to change { subject.personal_key }.to eql(nil)
+    end
+    it 'sets personal_key_acknowledged' do
+      expect { subject.acknowledge_personal_key }.to change {
+                                                       subject.personal_key_acknowledged
+                                                     }.from(nil).to eql(true)
+    end
+  end
+
   describe '#add_failed_phone_step_number' do
     it 'adds uniq phone numbers in e164 format' do
       subject.add_failed_phone_step_number('+1703-555-1212')

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -75,17 +75,17 @@ RSpec.describe Idv::Session do
     end
   end
 
-  describe '#acknowledge_personal_key' do
+  describe '#acknowledge_personal_key!' do
     before do
       subject.personal_key = 'ABCD1234'
     end
     it 'clears personal_key' do
-      expect { subject.acknowledge_personal_key }.to change { subject.personal_key }.to eql(nil)
+      expect { subject.acknowledge_personal_key! }.to change { subject.personal_key }.to eql(nil)
     end
     it 'sets personal_key_acknowledged' do
-      expect { subject.acknowledge_personal_key }.to change {
-                                                       subject.personal_key_acknowledged
-                                                     }.from(nil).to eql(true)
+      expect { subject.acknowledge_personal_key! }.to change {
+                                                        subject.personal_key_acknowledged
+                                                      }.from(nil).to eql(true)
     end
   end
 


### PR DESCRIPTION
We currently track that the user has viewed / acknowledged their personal key in a couple of ways:

1. If `user_session[:need_personal_key_confirmation] == true`, we know they _have not_ acknowledged their personal key
2. If user has a profile, but `idv_session.personal_key` is blank, then they _probably_ acknowledged their personal key

This PR:

- Adds an `acknowledge_personal_key!` method to `idv_session`
- Updates the personal key controller to call that method
- Adds `personal_key_acknowledged` flag to `idv_session`

(The ultimate goal will be to unify the tracking of personal key acknowledgement in `idv_session`, but there are 50/50 deployment considerations that mean this PR needs to go out first.)