### PR TITLE
LG-11537 Access the active profile in the userinfo endpoint

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -113,8 +113,8 @@ class OpenidConnectUserInfoPresenter
 
   def ial2_data
     @ial2_data ||= begin
-      if ial2_session? || ialmax_session?
-        out_of_band_session_accessor.load_pii
+      if (ial2_session? || ialmax_session?) && active_profile.present?
+        out_of_band_session_accessor.load_pii(active_profile.id)
       else
         Pii::Attributes.new_from_hash({})
       end
@@ -143,10 +143,14 @@ class OpenidConnectUserInfoPresenter
     identity.piv_cac_enabled?
   end
 
+  def active_profile
+    identity.user&.active_profile
+  end
+
   def verified_at
     return if identity&.service_provider_record&.ial.to_i < 2
 
-    identity.user.active_profile&.verified_at&.to_i
+    active_profile&.verified_at&.to_i
   end
 
   def out_of_band_session_accessor

--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -32,9 +32,9 @@ class OutOfBandSessionAccessor
   end
 
   # @return [Pii::Attributes, nil]
-  def load_pii
+  def load_pii(profile_id)
     session = session_data.dig('warden.user.user.session')
-    Pii::Cacher.new(nil, session).fetch if session
+    Pii::Cacher.new(nil, session).fetch(profile_id) if session
   end
 
   # @return [X509::Attributes]
@@ -53,10 +53,18 @@ class OutOfBandSessionAccessor
 
   # @api private
   # Only used for convenience in tests
+  def put_empty_user_session(expiration = 5.minutes)
+    data = { test_data: true }
+    put(data, expiration)
+  end
+
+  # @api private
+  # Only used for convenience in tests
   # @param [Pii::Attributes] pii
-  def put_pii(pii, expiration = 5.minutes)
+  def put_pii(profile_id, pii, expiration = 5.minutes)
     data = {
       decrypted_pii: pii.to_h.to_json,
+      encrypted_profiles: { profile_id.to_s => SessionEncryptor.new.kms_encrypt(pii.to_h.to_json) },
     }
 
     put(data, expiration)

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe OpenidConnect::UserInfoController do
         )
       end
       before do
-        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 50)
+        OutOfBandSessionAccessor.new(identity.rails_session_id).put_empty_user_session(50)
       end
 
       it 'renders user info' do

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe SamlIdpController do
     it 'accepts requests with correct cert and correct session index and renders logout response' do
       REDIS_POOL.with { |client| client.flushdb }
       session_accessor = OutOfBandSessionAccessor.new(session_id)
-      session_accessor.put_pii(foo: 'bar')
+      session_accessor.put_pii(123, foo: 'bar')
       saml_request = OneLogin::RubySaml::Logoutrequest.new
       encoded_saml_request = UriService.params(
         saml_request.create(right_cert_settings),
@@ -263,7 +263,7 @@ RSpec.describe SamlIdpController do
       )
 
       expect(response).to be_ok
-      expect(session_accessor.load_pii).to be_nil
+      expect(OutOfBandSessionAccessor.new(session_id).load_pii(123)).to be_nil
 
       logout_response = OneLogin::RubySaml::Logoutresponse.new(response.body)
       expect(logout_response.success?).to eq(true)

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -409,7 +409,11 @@ RSpec.describe OpenidConnectTokenForm do
 
     context 'with valid params' do
       before do
-        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 5.minutes.to_i)
+        OutOfBandSessionAccessor.new(
+          identity.rails_session_id,
+        ).put_empty_user_session(
+          5.minutes.to_i,
+        )
       end
 
       it 'has a properly-encoded id_token with an expiration that matches the expires_in' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -926,6 +926,7 @@ RSpec.describe User do
         it 'logs out the suspended user from the active session' do
           # Add information to session store to allow `exists?` check to work as desired
           OutOfBandSessionAccessor.new(mock_session_id).put_pii(
+            123,
             { first_name: 'Mario' },
             5.minutes.to_i,
           )

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   end
   let(:service_provider_ial) { 2 }
   let(:service_provider) { create(:service_provider, ial: service_provider_ial) }
-  let(:profile) { build(:profile, :active, :verified) }
+  let(:profile) { create(:profile, :active, :verified) }
   let(:identity) do
     build(
       :service_provider_identity,
@@ -140,7 +140,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
       end
 
       before do
-        OutOfBandSessionAccessor.new(rails_session_id).put_pii(pii, 5.minutes.to_i)
+        OutOfBandSessionAccessor.new(rails_session_id).put_pii(profile.id, pii, 5.minutes.to_i)
       end
 
       context 'when the identity has ial2 access' do

--- a/spec/requests/openid_connect_userinfo_spec.rb
+++ b/spec/requests/openid_connect_userinfo_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'OpenID Connect UserInfo controller' do
         user: create(:user),
       )
       authorization_header = "Bearer #{access_token}"
-      OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 50)
+      OutOfBandSessionAccessor.new(identity.rails_session_id).put_empty_user_session(50)
       get api_openid_connect_userinfo_path,
           headers: { 'HTTP_AUTHORIZATION' => authorization_header }
       expect(response.headers['Set-Cookie']).to_not include(APPLICATION_SESSION_COOKIE_KEY)

--- a/spec/services/access_token_verifier_spec.rb
+++ b/spec/services/access_token_verifier_spec.rb
@@ -51,7 +51,11 @@ RSpec.describe AccessTokenVerifier do
       let(:access_token) { identity.access_token }
       before do
         identity.save!
-        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 5)
+        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii(
+          123,
+          {},
+          5,
+        )
       end
 
       it 'is successful' do
@@ -65,7 +69,7 @@ RSpec.describe AccessTokenVerifier do
     context 'with a valid access_token' do
       before do
         identity.save!
-        OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii({}, 5)
+        OutOfBandSessionAccessor.new(identity.rails_session_id).put_empty_user_session(5)
       end
       let(:access_token) { identity.access_token }
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -102,7 +102,9 @@ RSpec.describe IdTokenBuilder do
       let(:custom_expiration) { nil }
       let(:expiration) { 100 }
 
-      before { OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii(nil, expiration) }
+      before do
+        OutOfBandSessionAccessor.new(identity.rails_session_id).put_empty_user_session(expiration)
+      end
 
       it 'sets the expiration to the ttl of the session key in redis' do
         expect(decoded_payload[:exp]).to be_within(3.seconds).of(now.to_i + expiration)

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#ttl' do
     it 'returns the remaining time-to-live of the session data in redis' do
-      store.put_pii({ first_name: 'Fakey' }, 5.minutes.to_i)
+      store.put_pii(123, { first_name: 'Fakey' }, 5.minutes.to_i)
 
       expect(store.ttl).to be_within(1).of(5.minutes.to_i)
     end
@@ -21,9 +21,9 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#load_pii' do
     it 'loads PII from the session' do
-      store.put_pii({ dob: '1970-01-01' }, 5.minutes.to_i)
+      store.put_pii(123, { dob: '1970-01-01' }, 5.minutes.to_i)
 
-      pii = store.load_pii
+      pii = store.load_pii(123)
       expect(pii).to be_kind_of(Pii::Attributes)
       expect(pii.dob).to eq('1970-01-01')
     end
@@ -41,10 +41,10 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#destroy' do
     it 'destroys the session' do
-      store.put_pii({ first_name: 'Fakey' }, 5.minutes.to_i)
+      store.put_pii(123, { first_name: 'Fakey' }, 5.minutes.to_i)
       store.destroy
 
-      expect(store.load_pii).to be_nil
+      expect(store.load_pii(123)).to be_nil
     end
   end
 end

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe OutOfBandSessionAccessor do
   let(:session_uuid) { SecureRandom.uuid }
+  let(:profile_id) { 123 }
 
   subject(:store) { described_class.new(session_uuid) }
 
@@ -13,7 +14,7 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#ttl' do
     it 'returns the remaining time-to-live of the session data in redis' do
-      store.put_pii(123, { first_name: 'Fakey' }, 5.minutes.to_i)
+      store.put_pii(profile_id, { first_name: 'Fakey' }, 5.minutes.to_i)
 
       expect(store.ttl).to be_within(1).of(5.minutes.to_i)
     end
@@ -21,9 +22,9 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#load_pii' do
     it 'loads PII from the session' do
-      store.put_pii(123, { dob: '1970-01-01' }, 5.minutes.to_i)
+      store.put_pii(profile_id, { dob: '1970-01-01' }, 5.minutes.to_i)
 
-      pii = store.load_pii(123)
+      pii = store.load_pii(profile_id)
       expect(pii).to be_kind_of(Pii::Attributes)
       expect(pii.dob).to eq('1970-01-01')
     end
@@ -41,10 +42,10 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#destroy' do
     it 'destroys the session' do
-      store.put_pii(123, { first_name: 'Fakey' }, 5.minutes.to_i)
+      store.put_pii(profile_id, { first_name: 'Fakey' }, 5.minutes.to_i)
       store.destroy
 
-      expect(store.load_pii(123)).to be_nil
+      expect(store.load_pii(profile_id)).to be_nil
     end
   end
 end


### PR DESCRIPTION
In #9509 we added the ability to specify which profile to fetch PII from when reading PII from the session.

This commit applies that capability to the OpenID Connect UserInfo endpoint to ensure that only the active profile's PII is used there.

The user info endpoint is used by service providers to access PII after auth. As a result it is not a request made by users and does not have a user session. To read PII we use the out-of-band session accessor's `#load_pii` method. This commit adds a `profile_id` arg to that method and passes in the active profile's ID when reading PII.
