### PR TITLE
LG-11538 Show the PII from the active profile on the completions screen

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -99,7 +99,8 @@ module SignUp
     end
 
     def pii
-      Pii::Cacher.new(current_user, user_session).fetch || Pii::Attributes.new
+      Pii::Cacher.new(current_user, user_session).fetch(current_user.active_profile&.id) ||
+        Pii::Attributes.new
     end
 
     def send_in_person_completion_survey


### PR DESCRIPTION
In #9509 we added the ability to specify which profile to fetch PII from when reading PII from the session.

This commit uses the active profile's ID to fetch PII on the completions screen. The completions screen should always be showing PII of the active profile.
