### PR TITLE
LG-11534 Load the active profile from the session on broken personal key

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -198,7 +198,7 @@ class ApplicationController < ActionController::Base
     if pii_unlocked
       cacher = Pii::Cacher.new(current_user, user_session)
       profile = current_user.active_profile
-      user_session[:personal_key] = profile.encrypt_recovery_pii(cacher.fetch)
+      user_session[:personal_key] = profile.encrypt_recovery_pii(cacher.fetch(profile.id))
       profile.save!
 
       analytics.broken_personal_key_regenerated


### PR DESCRIPTION
In #9509 we added the ability to specify which profile to fetch PII from when reading PII from the session.

This commit uses the active profiles PII when encrypting recovery PII for the active profile when the active profile has a broken personal key.
