### PR TITLE
LG-11553 Remove recovery PII re-encryption from `PersonalKeyVerificationController`

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3781,13 +3781,6 @@ module AnalyticsEvents
     track_event('Personal key reactivation: Account reactivated with personal key')
   end
 
-  # Account reactivated with personal key as MFA
-  def personal_key_reactivation_sign_in
-    track_event(
-      'Personal key reactivation: Account reactivated with personal key as MFA',
-    )
-  end
-
   # @param [Boolean] success
   # @param [Hash] errors
   # @param [Hash] pii_like_keypaths


### PR DESCRIPTION
The `PersonalKeyVerificationController` is used to verify a personal key as an MFA method and allow a user to sign in. When this is done a new personal key is issued.

This controller had code for re-encrypting the users profile with the newly issued personal key. However, a user with an active profile was never able to reach this path. The `check_personal_key_enabled` calls `TwoFactorAuthentication::PersonalKeyPolicy#enabled?`. This method returns false if the user has any profiles.

Since this code path is unreachable this commit removes it.

I was not able to find any tests covering this re-encryption behavior.
