### PR TITLE
Switch put_pii to keyword arguments

### DIFF
--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -61,7 +61,8 @@ class OutOfBandSessionAccessor
   # @api private
   # Only used for convenience in tests
   # @param [Pii::Attributes] pii
-  def put_pii(profile_id, pii, expiration = 5.minutes)
+  # @param [#to_s] profile_id
+  def put_pii(profile_id:, pii:, expiration: 5.minutes)
     data = {
       decrypted_pii: pii.to_h.to_json,
       encrypted_profiles: { profile_id.to_s => SessionEncryptor.new.kms_encrypt(pii.to_h.to_json) },

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe SamlIdpController do
     it 'accepts requests with correct cert and correct session index and renders logout response' do
       REDIS_POOL.with { |client| client.flushdb }
       session_accessor = OutOfBandSessionAccessor.new(session_id)
-      session_accessor.put_pii(123, foo: 'bar')
+      session_accessor.put_pii(profile_id: 123, pii: { foo: 'bar' })
       saml_request = OneLogin::RubySaml::Logoutrequest.new
       encoded_saml_request = UriService.params(
         saml_request.create(right_cert_settings),

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -926,9 +926,9 @@ RSpec.describe User do
         it 'logs out the suspended user from the active session' do
           # Add information to session store to allow `exists?` check to work as desired
           OutOfBandSessionAccessor.new(mock_session_id).put_pii(
-            123,
-            { first_name: 'Mario' },
-            5.minutes.to_i,
+            profile_id: 123,
+            pii: { first_name: 'Mario' },
+            expiration: 5.minutes.to_i,
           )
 
           expect(OutOfBandSessionAccessor.new(mock_session_id).exists?).to eq true

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -140,7 +140,11 @@ RSpec.describe OpenidConnectUserInfoPresenter do
       end
 
       before do
-        OutOfBandSessionAccessor.new(rails_session_id).put_pii(profile.id, pii, 5.minutes.to_i)
+        OutOfBandSessionAccessor.new(rails_session_id).put_pii(
+          profile_id: profile.id,
+          pii: pii,
+          expiration: 5.minutes.to_i,
+        )
       end
 
       context 'when the identity has ial2 access' do

--- a/spec/services/access_token_verifier_spec.rb
+++ b/spec/services/access_token_verifier_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe AccessTokenVerifier do
       before do
         identity.save!
         OutOfBandSessionAccessor.new(identity.rails_session_id).put_pii(
-          123,
-          {},
-          5,
+          profile_id: 123,
+          pii: {},
+          expiration: 5,
         )
       end
 

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#ttl' do
     it 'returns the remaining time-to-live of the session data in redis' do
-      store.put_pii(profile_id, { first_name: 'Fakey' }, 5.minutes.to_i)
+      store.put_pii(
+        profile_id: profile_id,
+        pii: { first_name: 'Fakey' },
+        expiration: 5.minutes.to_i,
+      )
 
       expect(store.ttl).to be_within(1).of(5.minutes.to_i)
     end
@@ -22,7 +26,11 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#load_pii' do
     it 'loads PII from the session' do
-      store.put_pii(profile_id, { dob: '1970-01-01' }, 5.minutes.to_i)
+      store.put_pii(
+        profile_id: profile_id,
+        pii: { dob: '1970-01-01' },
+        expiration: 5.minutes.to_i,
+      )
 
       pii = store.load_pii(profile_id)
       expect(pii).to be_kind_of(Pii::Attributes)
@@ -42,7 +50,11 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#destroy' do
     it 'destroys the session' do
-      store.put_pii(profile_id, { first_name: 'Fakey' }, 5.minutes.to_i)
+      store.put_pii(
+        profile_id: profile_id,
+        pii: { first_name: 'Fakey' },
+        expiration: 5.minutes.to_i,
+      )
       store.destroy
 
       expect(store.load_pii(profile_id)).to be_nil


### PR DESCRIPTION
Implementing my own post-hoc suggestion in previous PR https://github.com/18f/identity-idp/pull/9596#discussion_r1394530601


**Why**: Provides additional clarity, makes it harder to mix up than ordered arguments

(peer-reviewed version of 8240c4bd63e6db3f553587425f54872db4e497dd, which was reverted in #9604)