### PR TITLE
Add analytics property for WebAuthn sign-in frontend error

### DIFF
--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -141,6 +141,7 @@ class WebauthnVerificationForm
     {
       multi_factor_auth_method: auth_method,
       webauthn_configuration_id: webauthn_configuration&.id,
-    }
+      frontend_error: webauthn_error.presence,
+    }.compact
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3123,6 +3123,7 @@ module AnalyticsEvents
   # @param [String] area_code
   # @param [String] country_code
   # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
+  # @param [String] frontend_error Name of error that occurred in frontend during submission
   # Multi-Factor Authentication
   def multi_factor_auth(
     success:,
@@ -3140,6 +3141,7 @@ module AnalyticsEvents
     area_code: nil,
     country_code: nil,
     phone_fingerprint: nil,
+    frontend_error: nil,
     **extra
   )
     track_event(
@@ -3159,6 +3161,7 @@ module AnalyticsEvents
       area_code: area_code,
       country_code: country_code,
       phone_fingerprint: phone_fingerprint,
+      frontend_error:,
       **extra,
     )
   end

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -291,6 +291,7 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
             multi_factor_auth_method_created_at:
               second_webauthn_platform_configuration.created_at.strftime('%s%L'),
             webauthn_configuration_id: nil,
+            frontend_error: 'NotAllowedError',
           )
 
           patch :confirm, params: params

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe WebauthnVerificationForm do
           )
         end
       end
+
+      context 'with client-side webauthn error as blank string' do
+        let(:webauthn_error) { '' }
+
+        it 'returns successful result excluding frontend_error' do
+          expect(result.to_h).to eq(
+            success: true,
+            multi_factor_auth_method: 'webauthn',
+            webauthn_configuration_id: webauthn_configuration.id,
+          )
+        end
+      end
     end
 
     context 'when the input is invalid' do
@@ -136,13 +148,12 @@ RSpec.describe WebauthnVerificationForm do
             success: false,
             error_details: { webauthn_configuration: { blank: true } },
             multi_factor_auth_method: 'webauthn',
-            webauthn_configuration_id: nil,
           )
         end
       end
 
       context 'when a client-side webauthn error is present' do
-        let(:webauthn_error) { 'Unexpected error!' }
+        let(:webauthn_error) { 'NotAllowedError' }
 
         it 'returns unsuccessful result including client-side webauthn error text' do
           expect(result.to_h).to eq(
@@ -150,6 +161,7 @@ RSpec.describe WebauthnVerificationForm do
             error_details: { webauthn_error: { webauthn_error: true } },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: webauthn_error,
           )
         end
       end


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-11399](https://cm-jira.usa.gov/browse/LG-11399)

## 🛠 Summary of changes

This adds a new property `frontend_error` to unsuccessful WebAuthn sign-ins. 

While it doesn't appear this property is actively used in any dashboards, the availability of this value inadvertently regressed as part of #9572, which previously logged the specific error name as part of the `error_details` property. 

An alternative implementation could try to incorporate this as the "type" of the error detail, but the case mismatch between e.g. incoming `NotAllowedError` and expected detail type formatting of `not_allowed_error` could create some confusion.

## 📜 Testing Plan

1. (Prerequisite) Have an account with Security Key or Face or Touch Unlock as an associated MFA
2. Run `make watch_events` in a separate terminal process
3. Go to http://localhost:3000
4. Sign in
5. (If not prompted for MFA, click "Forget all browsers", confirm, sign out, and start over from Step 3)
6. When prompted WebAuthn, click "Use face or touch unlock" or "Use security key"
7. Cancel the dialog that's shown
8. Observe in event log that you see "Multi-Factor Authentication" event including "NotAllowedError"