### PR TITLE
Refactor WebauthnVerificationForm to handle error messages

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -36,7 +36,7 @@ module TwoFactorAuthentication
       if result.success?
         handle_valid_webauthn
       else
-        handle_invalid_webauthn
+        handle_invalid_webauthn(result)
       end
     end
 
@@ -54,24 +54,12 @@ module TwoFactorAuthentication
       redirect_to after_sign_in_path_for(current_user)
     end
 
-    def handle_invalid_webauthn
+    def handle_invalid_webauthn(result)
+      flash[:error] = result.first_error_message
+
       if platform_authenticator?
-        flash[:error] = t(
-          'two_factor_authentication.webauthn_error.try_again',
-          link: view_context.link_to(
-            t('two_factor_authentication.webauthn_error.additional_methods_link'),
-            login_two_factor_options_path,
-          ),
-        )
         redirect_to login_two_factor_webauthn_url(platform: 'true')
       else
-        flash[:error] = t(
-          'two_factor_authentication.webauthn_error.connect_html',
-          link_html: view_context.link_to(
-            t('two_factor_authentication.webauthn_error.additional_methods_link'),
-            login_two_factor_options_path,
-          ),
-        )
         redirect_to login_two_factor_webauthn_url
       end
     end
@@ -124,6 +112,8 @@ module TwoFactorAuthentication
     def form
       @form ||= WebauthnVerificationForm.new(
         user: current_user,
+        platform_authenticator: platform_authenticator?,
+        url_options:,
         challenge: user_session[:webauthn_challenge],
         protocol: request.protocol,
         authenticator_data: params[:authenticator_data],

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe WebauthnVerificationForm do
+  include Rails.application.routes.url_helpers
   include WebAuthnHelper
 
   let(:user) { create(:user) }
@@ -22,6 +23,8 @@ RSpec.describe WebauthnVerificationForm do
   subject(:form) do
     WebauthnVerificationForm.new(
       user: user,
+      platform_authenticator:,
+      url_options: {},
       challenge: challenge,
       protocol: protocol,
       authenticator_data: authenticator_data,
@@ -62,19 +65,6 @@ RSpec.describe WebauthnVerificationForm do
     end
 
     context 'when the input is invalid' do
-      context 'when user is missing' do
-        let(:user) { nil }
-
-        it 'returns unsuccessful result' do
-          expect(result.to_h).to eq(
-            success: false,
-            error_details: { user: { blank: true }, webauthn_configuration: { blank: true } },
-            multi_factor_auth_method: 'webauthn',
-            webauthn_configuration_id: nil,
-          )
-        end
-      end
-
       context 'when challenge is missing' do
         let(:challenge) { nil }
 


### PR DESCRIPTION
## 🎫 Ticket

Refactoring related to [LG-11399](https://cm-jira.usa.gov/browse/LG-11399), and similar in purpose to [LG-11135](https://cm-jira.usa.gov/browse/LG-11135) (which targets the equivalent setup form)

## 🛠 Summary of changes

Moves error message handling from `WebauthnVerificationController` to `WebauthnVerificationForm`.

**Why?**

- The form is already responsible for generating errors (including error messages)
   - Error messages are expected to be human-readable, which the previous error messages were not (e.g. "invalid_authenticator_data")
- Avoids fragmentation of logic concerning error messages related to WebAuthn verification
- Supports #9564 which seeks to add additional custom error messages for verification
   - Previously, this kind of case-specific error messages would have been hard to incorporate, and further fragment logic between the form and controller

## 📜 Testing Plan

Observe no regressions when signing in with WebAuthn (Security Key or Face or Touch Unlock), particularly in the display of error messages.

1. (Prerequisite) Have an account with Face or Touch Unlock or Security Key
2. Go to http://localhost:3000
3. Sign in
4. (If not prompted for MFA, click "Forget all browsers" from account dashboard, confirm, sign out, then start over from Step 3)
5. When prompted for MFA, click "Use face or touch unlock" or "Use security key"
6. Cancel the dialog prompt
7. Observe expected error message, and that included link to "use another authentication method" is functional