### PR TITLE
Use ActiveRecord built-in validator for WebAuthn error validation

### DIFF
--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -11,8 +11,9 @@ class WebauthnVerificationForm
             :signature,
             :webauthn_configuration,
             presence: { message: proc { |object| object.instance_eval { generic_error_message } } }
+  validates :webauthn_error,
+            absence: { message: proc { |object| object.instance_eval { generic_error_message } } }
   validate :validate_assertion_response
-  validate :validate_webauthn_error
 
   attr_reader :url_options, :platform_authenticator
 
@@ -77,11 +78,6 @@ class WebauthnVerificationForm
   def validate_assertion_response
     return if webauthn_error.present? || webauthn_configuration.blank? || valid_assertion_response?
     errors.add(:authenticator_data, :invalid_authenticator_data, message: generic_error_message)
-  end
-
-  def validate_webauthn_error
-    return if webauthn_error.blank?
-    errors.add(:webauthn_error, :webauthn_error, message: generic_error_message)
   end
 
   def valid_assertion_response?

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
               client_data_json: { blank: true },
               signature: { blank: true },
               webauthn_configuration: { blank: true },
-              webauthn_error: { webauthn_error: true },
+              webauthn_error: { present: true },
             },
             context: UserSessionContext::AUTHENTICATION_CONTEXT,
             multi_factor_auth_method: 'webauthn_platform',

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe WebauthnVerificationForm do
         it 'returns unsuccessful result including client-side webauthn error text' do
           expect(result.to_h).to eq(
             success: false,
-            error_details: { webauthn_error: { webauthn_error: true } },
+            error_details: { webauthn_error: { present: true } },
             multi_factor_auth_method: 'webauthn',
             webauthn_configuration_id: webauthn_configuration.id,
             frontend_error: webauthn_error,


### PR DESCRIPTION
## 🛠 Summary of changes

Builds upon #9572, #9611, and #9613

Uses [ActiveRecord's built-in `absence` validator](https://guides.rubyonrails.org/active_record_validations.html#absence) to validate `webauthn_error`, in place of our ad-hoc validator.

**Why?**

- No need to reinvent the wheel
- More relevant error type descriptor of "present" vs. "webauthn_error"
- Since we're already adjusting `error_details` structure in next RC release, this is a good opportunity to make these sorts of revisions

## 📜 Testing Plan

Repeat testing plan from #9611, observing in event logs: `error_details: { webauthn_error: { present: true } }`