### PR TITLE
LG-11439 Opt-in IPP: redirect if agreement step not completed

### DIFF
--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -38,7 +38,7 @@ module Idv
         controller: controller_name,
         next_steps: [:hybrid_handoff, :document_capture],
         preconditions: ->(idv_session:, user:) do
-          self.enabled?
+          self.enabled? && idv_session.idv_consent_given
         end,
         undo_step: ->(idv_session:, user:) {}, # clear any saved data
       )

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Idv::HowToVerifyController do
     stub_sign_in(user)
     stub_analytics
     subject.idv_session.welcome_visited = true
+    subject.idv_session.idv_consent_given = true
   end
 
   describe '#step_info' do
@@ -31,6 +32,18 @@ RSpec.describe Idv::HowToVerifyController do
       get :show
 
       expect(response).to render_template :show
+    end
+
+    context 'agreement step not completed' do
+      before do
+        subject.idv_session.idv_consent_given = nil
+      end
+
+      it 'redirects to agreement path' do
+        get :show
+
+        expect(response).to redirect_to idv_agreement_path
+      end
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11439](https://cm-jira.usa.gov/browse/LG-11439)


## 🛠 Summary of changes

On how to verify page check that agreement step has been completed. If it hasn't the user will now be redirected back to the agreement page. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Set `in_person_residential_address_controller_enabled` flag to true
- [x] Create an account and arrive at `/agreement`
- [x] Do not check the box
- [x] Change url to `/verify/how_to_verify`
- [x] Confirm that you are redirected back to `/agreement`
- [x] Check the box
- [x] Click continue
- [x] Confirm that you are directed to `/how_to_verify`
