### PR TITLE
LG-11435: Track frontend analytics for changed country in phone input

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -10,7 +10,7 @@ class FrontendLogController < ApplicationController
 
   # Please try to keep this list alphabetical as well!
   # rubocop:disable Layout/LineLength
-  EVENT_MAP = {
+  LEGACY_EVENT_MAP = {
     'Frontend Error' => FrontendErrorLogger.method(:track_error),
     'IdV: Acuant SDK loaded' => :idv_acuant_sdk_loaded,
     'IdV: back image added' => :idv_back_image_added,
@@ -45,6 +45,11 @@ class FrontendLogController < ApplicationController
     'User prompted before navigation and still on page' => :user_prompted_before_navigation_and_still_on_page,
   }.freeze
   # rubocop:enable Layout/LineLength
+
+  ALLOWED_EVENTS = [
+  ].freeze
+
+  EVENT_MAP = ALLOWED_EVENTS.index_by(&:to_s).merge(LEGACY_EVENT_MAP).freeze
 
   def create
     result = frontend_logger.track_event(log_params[:event], log_params[:payload].to_h)

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -47,6 +47,7 @@ class FrontendLogController < ApplicationController
   # rubocop:enable Layout/LineLength
 
   ALLOWED_EVENTS = [
+    :phone_input_country_changed,
   ].freeze
 
   EVENT_MAP = ALLOWED_EVENTS.index_by(&:to_s).merge(LEGACY_EVENT_MAP).freeze

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -46,8 +46,8 @@ class FrontendLogController < ApplicationController
   }.freeze
   # rubocop:enable Layout/LineLength
 
-  ALLOWED_EVENTS = [
-    :phone_input_country_changed,
+  ALLOWED_EVENTS = %i[
+    phone_input_country_changed
   ].freeze
 
   EVENT_MAP = ALLOWED_EVENTS.index_by(&:to_s).merge(LEGACY_EVENT_MAP).freeze

--- a/app/javascript/packages/analytics/README.md
+++ b/app/javascript/packages/analytics/README.md
@@ -12,7 +12,7 @@ Track an event or error from your code using exported function members.
 import { trackEvent, trackError } from '@18f/identity-analytics';
 
 button.addEventListener('click', () => {
-  trackEvent('Button clicked', { success: true });
+  trackEvent('button_clicked', { success: true });
 });
 
 try {
@@ -33,7 +33,7 @@ import '@18f/identity-analytics/click-observer-element';
 The custom element will implement the analytics logging behavior, but all markup must already exist.
 
 ```html
-<lg-click-observer event-name="Button clicked">
+<lg-click-observer event-name="button_clicked">
   <button type="button">Click me!</button>
 </lg-click-observer>
 ```

--- a/app/javascript/packages/phone-input/index.spec.ts
+++ b/app/javascript/packages/phone-input/index.spec.ts
@@ -203,6 +203,10 @@ describe('PhoneInput', () => {
     expect(analytics.trackEvent).to.have.been.calledWith('phone_input_country_changed', {
       country_code: 'US',
     });
+
+    await userEvent.clear(phoneNumber);
+    await userEvent.type(phoneNumber, '+6');
+    expect(analytics.trackEvent).to.have.callCount(2);
   });
 
   it('renders as an accessible combobox', () => {

--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -128,17 +128,19 @@ export class PhoneInputElement extends HTMLElement {
    * Logs an event when the country code has been changed.
    */
   trackCountryChangeEvent() {
-    const { iso2 } = this.iti.getSelectedCountryData();
-    trackEvent('phone_input_country_changed', { country_code: iso2.toUpperCase() });
+    const countryCode = this.getSelectedCountryCode();
+    if (countryCode) {
+      trackEvent('phone_input_country_changed', { country_code: countryCode });
+    }
   }
 
   /**
    * Mirrors country change to the hidden select field, which holds the value for form submission.
    */
   syncCountryToCodeInput({ fireChangeEvent = true }: { fireChangeEvent?: boolean } = {}) {
-    const country = this.iti.getSelectedCountryData();
-    if (country.iso2 && this.codeInput) {
-      this.codeInput.value = country.iso2.toUpperCase();
+    const countryCode = this.getSelectedCountryCode();
+    if (countryCode) {
+      this.codeInput.value = countryCode;
       if (this.hasDropdown) {
         // Move value text from title attribute to the flag's hidden text element.
         // See: https://github.com/jackocnr/intl-tel-input/blob/d54b127/src/js/intlTelInput.js#L1191-L1197
@@ -267,16 +269,20 @@ export class PhoneInputElement extends HTMLElement {
   }
 
   handleCaptchaChallenge = (event: Event) => {
-    const { iso2 = 'us' } = this.iti.getSelectedCountryData();
+    const countryCode = this.getSelectedCountryCode();
     const isExempt =
       typeof this.captchaExemptCountries === 'boolean'
         ? this.captchaExemptCountries
-        : this.captchaExemptCountries.includes(iso2.toUpperCase());
+        : !countryCode || this.captchaExemptCountries.includes(countryCode);
 
     if (isExempt) {
       event.preventDefault();
     }
   };
+
+  getSelectedCountryCode(): string | undefined {
+    return (this.iti.getSelectedCountryData().iso2 as string | undefined)?.toUpperCase();
+  }
 }
 
 declare global {

--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -5,6 +5,7 @@ import type { CountryCode } from 'libphonenumber-js';
 import type { Plugin as IntlTelInputPlugin, Options } from 'intl-tel-input';
 import { replaceVariables } from '@18f/identity-i18n';
 import { CAPTCHA_EVENT_NAME } from '@18f/identity-captcha-submit-button/captcha-submit-button-element';
+import { trackEvent } from '@18f/identity-analytics';
 
 interface PhoneInputStrings {
   country_code_label: string;
@@ -61,6 +62,7 @@ export class PhoneInputElement extends HTMLElement {
     this.initializeIntlTelInput();
 
     this.textInput.addEventListener('countrychange', () => this.syncCountryToCodeInput());
+    this.textInput.addEventListener('countrychange', () => this.trackCountryChangeEvent());
     this.textInput.addEventListener('input', () => this.validate());
     this.codeInput.addEventListener('change', () => this.formatTextInput());
     this.codeInput.addEventListener('change', () => this.validate());
@@ -120,6 +122,14 @@ export class PhoneInputElement extends HTMLElement {
     } catch {
       return true;
     }
+  }
+
+  /**
+   * Logs an event when the country code has been changed.
+   */
+  trackCountryChangeEvent() {
+    const { iso2 } = this.iti.getSelectedCountryData();
+    trackEvent('phone_input_country_changed', { country_code: iso2.toUpperCase() });
   }
 
   /**

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3855,6 +3855,12 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String] country_code The new selected country code
+  # User changes the selected country in the frontend phone input component
+  def phone_input_country_changed(country_code:, **extra)
+    track_event(:phone_input_country_changed, country_code:, **extra)
+  end
+
   # @identity.idp.previous_event_name User Registration: piv cac disabled
   # @identity.idp.previous_event_name PIV CAC disabled
   # Tracks when user's piv cac is disabled

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -137,7 +137,7 @@ See [`@18f/identity-i18n` package documentation](../app/javascript/packages/i18n
 See [`@18f/identity-analytics` package documentation][analytics_package] for code examples detailing
 how to track an event in JavaScript.
 
-Any event logged from the frontend must be added to the `EVENT_MAP` allowlist in [`FrontendLogController`][frontend_log_controller.rb].
+Any event logged from the frontend must be added to the `ALLOWED_EVENTS` allowlist in [`FrontendLogController`][frontend_log_controller.rb].
 This mapping associates the event name logged from the frontend with the corresponding method from
 [AnalyticsEvents][analytics_events.rb] to be called. All properties will be passed automatically to
 the event from the frontend as long as they are defined in the method argument signature.
@@ -147,16 +147,13 @@ in the frontend, such as an A/B test bucket descriptor. In these scenarios, you 
 
 1. Add the value to the page markup, such as through an [HTML `data-` attribute][data_attributes],
 and reference that attribute in JavaScript.
-2. Define the mapped value in `EVENT_MAP` to a service class, such as how [frontend error logging][frontend_error_logging]
-is implemented.
-3. Implement a mixin to intercept and override the default behavior of an analytics event, such as
+2. Implement a mixin to intercept and override the default behavior of an analytics event, such as
 how [`Idv::AnalyticsEventEnhancer`][analytics_events_enhancer.rb] is implemented.
 
 [analytics_package]: ../app/javascript/packages/analytics/README.md
 [frontend_log_controller.rb]: https://github.com/18F/identity-idp/blob/main/app/controllers/frontend_log_controller.rb
 [analytics_events.rb]: https://github.com/18F/identity-idp/blob/main/app/services/analytics_events.rb
 [data_attributes]: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes
-[frontend_error_logging]: https://github.com/18F/identity-idp/blob/9c17164c0b8d9b4aefad74dde1a521c111b53aac/app/controllers/frontend_log_controller.rb#L14
 [analytics_events_enhancer.rb]: https://github.com/18F/identity-idp/blob/main/app/services/idv/analytics_events_enhancer.rb
 
 ## Components

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe FrontendLogController do
+  describe '.LEGACY_EVENT_MAP' do
+    it 'has keys sorted alphabetically' do
+      expect(described_class::LEGACY_EVENT_MAP.keys).
+        to eq(described_class::LEGACY_EVENT_MAP.keys.sort_by(&:downcase))
+    end
+  end
+
+  describe '.ALLOWED_EVENTS' do
+    it 'is sorted alphabetically' do
+      expect(described_class::ALLOWED_EVENTS).to eq(described_class::ALLOWED_EVENTS.sort)
+    end
+  end
+
   describe '#create' do
     subject(:action) { post :create, params: params, as: :json }
 
@@ -217,13 +230,6 @@ RSpec.describe FrontendLogController do
           expect(response).to have_http_status(:ok)
           expect(json[:success]).to eq(true)
         end
-      end
-    end
-
-    context 'with all events' do
-      it 'sorts keys alphabetically' do
-        expect(described_class::EVENT_MAP.keys).
-          to eq(described_class::EVENT_MAP.keys.sort_by(&:downcase))
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11435](https://cm-jira.usa.gov/browse/LG-11435)

## 🛠 Summary of changes

Tracks an analytics event when the selected country is changed in the frontend phone input element.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create an account
3. Complete account creation up to MFA selection screen
4. Choose phone as MFA method
5. In a separate process, run `make watch_events` to observe event logging
6. Enter an international phone number by whichever means you want (type, paste, change dropdown, etc)
7. Observe event logged "phone_input_country_changed" once for each time you changed country, with correct `country_code` property