### PR TITLE
Update Prettier to v3.1

### DIFF
--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -64,9 +64,8 @@ function webauthn() {
         (document.getElementById('client_data_json') as HTMLInputElement).value =
           result.clientDataJSON;
         if (result.authenticatorDataFlagsValue) {
-          (
-            document.getElementById('authenticator_data_value') as HTMLInputElement
-          ).value = `${result.authenticatorDataFlagsValue}`;
+          (document.getElementById('authenticator_data_value') as HTMLInputElement).value =
+            `${result.authenticatorDataFlagsValue}`;
         }
         if (result.transports) {
           (document.getElementById('transports') as HTMLInputElement).value =

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "mocha": "^10.0.0",
     "mq-polyfill": "^1.1.8",
     "msw": "^1.3.2",
-    "prettier": "^3.0.3",
+    "prettier": "^3.1.0",
     "quibble": "^0.6.17",
     "react-test-renderer": "^17.0.2",
     "sinon": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5478,10 +5478,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
-  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+prettier@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.0.tgz#c6d16474a5f764ea1a4a373c593b779697744d5e"
+  integrity sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==
 
 pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
## 🛠 Summary of changes

Update Prettier to v3.1

**Why?**

- Avoid future maintenance burden of version drift

## 📜 Testing Plan

`yarn lint` passes