### PR TITLE
Log service_provider for RackAttack events

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -257,6 +257,7 @@ ActiveSupport::Notifications.subscribe(
 ) do |_name, _start, _finish, _request_id, payload|
   req = payload[:request]
   user = req.env['warden'].user || AnonymousUser.new
-  analytics = Analytics.new(user: user, request: req, session: {}, sp: nil)
+  sp = req.env.fetch('rack.session', {}).dig('sp', 'issuer')
+  analytics = Analytics.new(user: user, request: req, session: {}, sp: sp)
   analytics.rate_limit_triggered(type: req.env['rack.attack.matched'])
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -167,7 +167,6 @@ RSpec.describe 'throttling requests' do
       it 'logs the service provider' do
         analytics = FakeAnalytics.new
         allow(Analytics).to receive(:new).and_return(analytics)
-        allow(analytics).to receive(:track_event)
 
         client_id = 'urn:gov:gsa:openidconnect:sp:server'
         state = SecureRandom.hex
@@ -194,7 +193,7 @@ RSpec.describe 'throttling requests' do
 
         expect(Analytics).to have_received(:new).with(include(sp: client_id)).at_least(:once)
         expect(analytics).
-          to have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
+          to have_logged_event('Rate Limit Triggered', type: 'req/ip')
       end
     end
   end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -192,8 +192,7 @@ RSpec.describe 'throttling requests' do
         end
 
         expect(Analytics).to have_received(:new).with(include(sp: client_id)).at_least(:once)
-        expect(analytics).
-          to have_logged_event('Rate Limit Triggered', type: 'req/ip')
+        expect(analytics).to have_logged_event('Rate Limit Triggered', type: 'req/ip')
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

This PR adds the `sp` argument when constructing analytics for the RackAttack `rate_limit_triggered` event.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
