### PR TITLE
LG-11520: Enable daily GPO expiration job

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -188,6 +188,11 @@ else
         cron: cron_24h,
         args: -> { [14.days.ago] },
       },
+      # Expire old GPO profiles
+      expire_gpo_profiles: {
+        class: 'GpoExpirationJob',
+        cron: cron_24h,
+      },
       # Monthly report checking in on key metrics
       monthly_key_metrics_report: {
         class: 'Reports::MonthlyKeyMetricsReport',


### PR DESCRIPTION
## 🎫 Ticket

[LG-11520](https://cm-jira.usa.gov/browse/LG-11520)

## 🛠 Summary of changes

Start running [`GpoExpirationJob`](https://github.com/18F/identity-idp/blob/main/app/jobs/gpo_expiration_job.rb) daily to expire old GPO profiles. See #9545 for more information. 