### PR TITLE
LG-11569: Add feature flag for reorienting SDK capture

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -87,6 +87,7 @@ doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_not_ready_section_enabled: false
 doc_auth_selfie_capture: '{"enabled":false}'
+doc_auth_sdk_capture_orientation: '{"horizontal": 100, "vertical": 0}'
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
 doc_capture_request_valid_for_minutes: 15
 email_from: no-reply@login.gov

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -186,6 +186,7 @@ class IdentityConfig
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_s3_request_timeout, type: :integer)
     config.add(:doc_auth_selfie_capture, type: :json, options: { symbolize_names: true })
+    config.add(:doc_auth_sdk_capture_orientation, type: :json, options: { symbolize_names: true })
     config.add(:doc_auth_supported_country_codes, type: :json)
     config.add(:doc_auth_vendor, type: :string)
     config.add(:doc_auth_vendor_randomize, type: :boolean)


### PR DESCRIPTION
## 🎫 Ticket

[LG-11569](https://cm-jira.usa.gov/browse/LG-11569)

## 🛠 Summary of changes

Adding a feature flag to control whether users see the horizontal or vertical version of the SDK. This change just sets up the feature flag for future work.

I used this format for the flag because we want to be able to split the
number of users who see horizontal or vertical.

## 📜 Testing Plan

- [ ] Log into the Rails console
- [ ] Look for `IdentityConfig.store.doc_auth_sdk_capture_orientation`
- [ ] Make sure you see: `{:horizontal=>100, :vertical=>0}`

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

<img width="710" alt="image" src="https://github.com/18F/identity-idp/assets/35475380/fa1d2329-d828-453d-bc4f-7cfde752c1cc">

</details>

<details>
<summary>After:</summary>

<img width="720" alt="image" src="https://github.com/18F/identity-idp/assets/35475380/f0ee43b1-40a4-4b17-99ba-5380d47d82ca">

</details>