### PR TITLE
Prepare publish normalize-yaml to NPM

### DIFF
--- a/app/javascript/packages/normalize-yaml/CHANGELOG.md
+++ b/app/javascript/packages/normalize-yaml/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v2.0.0
 
 ### Breaking Changes
 

--- a/app/javascript/packages/normalize-yaml/package.json
+++ b/app/javascript/packages/normalize-yaml/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "smartquotes": "^2.3.2",
-    "yaml": "^2.3.1"
+    "yaml": "^2.3.4"
   },
   "peerDependencies": {
     "prettier": ">=3"

--- a/app/javascript/packages/normalize-yaml/package.json
+++ b/app/javascript/packages/normalize-yaml/package.json
@@ -2,7 +2,7 @@
   "name": "@18f/identity-normalize-yaml",
   "private": false,
   "description": "Normalizes YAML files to ensure consistency and typographical quality",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "module",
   "main": "./index.js",
   "types": "./types/index.d.ts",

--- a/app/javascript/packages/rails-i18n-webpack-plugin/package.json
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/package.json
@@ -5,7 +5,7 @@
   "main": "rails-i18n-webpack-plugin.js",
   "dependencies": {
     "webpack-sources": "^2.3.0",
-    "yaml": "^2.3.1"
+    "yaml": "^2.3.4"
   },
   "peerDependencies": {
     "sinon": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7155,10 +7155,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
-  integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==
+yaml@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.4.tgz#53fc1d514be80aabf386dc6001eb29bf3b7523b2"
+  integrity sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
## 🛠 Summary of changes

Updates dependencies and version of `@18f/identity-normalize-yaml` in preparation for publishing to NPM.

Supports https://github.com/18F/identity-site/pull/1082, related to #9619.

## 📜 Testing Plan

`make normalize_yaml` passes.