### PR TITLE
LG-11466: Don't allow going back to personal key

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -11,6 +11,8 @@ module IdvSession
               decorated_sp_session.requested_more_recent_verification? ||
               idv_session_user.reproof_for_irs?(service_provider: current_sp)
 
+    return if !idv_session.personal_key_acknowledged && idv_session.personal_key.present?
+
     redirect_to idv_activated_url
   end
 

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -35,8 +35,6 @@ module Idv
 
       init_profile
 
-      user_session[:need_personal_key_confirmation] = true
-
       flash[:success] =
         if gpo_user_flow?
           t('idv.messages.gpo.letter_on_the_way')

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -9,6 +9,7 @@ module Idv
     before_action :confirm_two_factor_authenticated
     before_action :confirm_phone_or_address_confirmed
     before_action :confirm_profile_has_been_created
+    before_action :confirm_personal_key_not_acknowledged
 
     def show
       analytics.idv_personal_key_visited(
@@ -50,6 +51,10 @@ module Idv
       else
         after_sign_in_path_for(current_user)
       end
+    end
+
+    def confirm_personal_key_not_acknowledged
+      redirect_to next_step if idv_session.personal_key_acknowledged
     end
 
     def confirm_profile_has_been_created

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -21,8 +21,6 @@ module Idv
     end
 
     def update
-      user_session[:need_personal_key_confirmation] = false
-
       analytics.idv_personal_key_submitted(
         address_verification_method: address_verification_method,
         deactivation_reason: idv_session.profile&.deactivation_reason,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -99,6 +99,11 @@ module Idv
       applicant.merge('uuid' => current_user.uuid)
     end
 
+    def profile_id=(value)
+      session[:profile_id] = value
+      @profile = nil
+    end
+
     def profile
       @profile ||= Profile.find_by(id: profile_id)
     end

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -126,10 +126,35 @@ RSpec.describe 'IdvStepConcern' do
         allow(subject).to receive(:current_user).and_return(user)
       end
 
-      it 'redirects to activated page' do
-        get :show
+      context 'and user has not yet acknowledged personal key' do
+        before do
+          idv_session.personal_key = 'ABCD-1234'
+        end
+        it 'does not redirect' do
+          get :show
+          expect(response).not_to redirect_to idv_activated_url
+        end
 
-        expect(response).to redirect_to idv_activated_url
+        context 'but they do not have a personal key to acknowledge' do
+          before do
+            idv_session.personal_key = nil
+          end
+          it 'redirects to activated page' do
+            get :show
+            expect(response).to redirect_to idv_activated_url
+          end
+        end
+      end
+
+      context 'and user has acknowledged personal key' do
+        before do
+          idv_session.acknowledge_personal_key!
+        end
+        it 'redirects to activated page' do
+          get :show
+
+          expect(response).to redirect_to idv_activated_url
+        end
       end
     end
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -296,8 +296,6 @@ RSpec.describe Idv::EnterPasswordController do
       it 'redirects to confirmation path after user presses the back button' do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
-        expect(subject.user_session[:need_personal_key_confirmation]).to eq(true)
-
         allow_any_instance_of(User).to receive(:active_profile).and_return(true)
         get :new
         expect(response).to redirect_to idv_personal_key_path

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -202,13 +202,6 @@ RSpec.describe Idv::PersonalKeyController do
         expect(response).to redirect_to account_path
       end
 
-      it 'clears need_personal_key_confirmation session state' do
-        subject.user_session[:need_personal_key_confirmation] = true
-        patch :update
-
-        expect(subject.user_session[:need_personal_key_confirmation]).to eq(false)
-      end
-
       it 'sets idv_session.personal_key_acknowledged' do
         expect { patch :update }.to change {
                                       idv_session.personal_key_acknowledged

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -292,6 +292,29 @@ RSpec.describe Idv::Session do
     end
   end
 
+  describe '#profile' do
+    it 'is nil by default' do
+      expect(subject.profile).to eql(nil)
+    end
+
+    it 'can be set via profile_id' do
+      profile = create(:profile)
+      subject.profile_id = profile.id
+      expect(subject.profile).to eql(profile)
+    end
+
+    it 'can be changed' do
+      profile1 = create(:profile)
+      profile2 = create(:profile)
+
+      subject.profile_id = profile1.id
+      expect(subject.profile).to eql(profile1)
+
+      subject.profile_id = profile2.id
+      expect(subject.profile).to eql(profile2)
+    end
+  end
+
   describe '#address_mechanism_chosen?' do
     context 'phone verification chosen' do
       before do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-11466](https://cm-jira.usa.gov/browse/LG-11466)

## 🛠 Summary of changes

#9595 started tracking whether the user has acknowledged their personal key in `idv_session`. This PR:

- Removes references to the old `user_session[:need_personal_key_confirmation]` flag
- Updates any logic that relied on that flag to use `idv_session.personal_key_acknowledged` instead

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Verify your identity using the GPO flow. Verify you cannot go back to the personal key page once the flow completes
- Verify your identity using the IPP flow. Verify you cannot go back to the personal key page once the flow completes
- Verify your identity using the remote unsupervised flow. Verify you cannot go back to the personal key page once the flow completes

