### PR TITLE
Restore width collapse for unstyled buttons

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -7,10 +7,12 @@
   margin-right: 0;
 }
 
+// Upstream: https://github.com/uswds/uswds/pull/5631
 .usa-button--unstyled {
   // Temporary: To be backported to design system. Unstyled buttons should inherit the appearance
   // of a link.
   display: inline;
+  width: auto;
 }
 
 .usa-button:disabled.usa-button--active,


### PR DESCRIPTION
## 🎫 Ticket

[LG-11639](https://cm-jira.usa.gov/browse/LG-11639), [LG-11640](https://cm-jira.usa.gov/browse/LG-11640)

## 🛠 Summary of changes

Fixes an issue where unstyled buttons can appear as vertically stacked at smaller viewport sizes.

Regressed in #9478, due to inaccurate DevTools recommendation.

This should ideally be a default style of USWDS. See upstream pull request at https://github.com/uswds/uswds/pull/5631.

## 📜 Testing Plan

Verify that in affected screens, buttons appear as inline at small viewport sizes.

1. Go to http://localhost:300
2. Click "Create an account"
3. Enter an email address
4. Check Rules of Use
5. Click Submit
6. In "Check your email screen", observe button appears as inline to text.

## 👀 Screenshots

Screen|Before|After
---|---|---
Email Confirmation|![button-email-before](https://github.com/18F/identity-idp/assets/1779930/70cb3780-c77e-400b-9566-9c38f0c787f3)|![button-email-after](https://github.com/18F/identity-idp/assets/1779930/7567ece7-3812-47ba-ad09-106ec6000153)
Document Capture|![button-upload-before](https://github.com/18F/identity-idp/assets/1779930/9e7c32f4-dd88-4567-a83b-deb313f9aae7)|![button-upload-after](https://github.com/18F/identity-idp/assets/1779930/1e712808-0546-4ba1-bb19-ce8b5a719371)
Personal Key|![button-pkey-before](https://github.com/18F/identity-idp/assets/1779930/3265b6a5-9042-4d29-92f7-a2cc4664a929)|![button-pkey-after](https://github.com/18F/identity-idp/assets/1779930/e110b8ac-55a0-44fd-b801-86b01c99559b)