### PR TITLE
LG-11230 Redirect browser back button to “your letter is on the way”

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -9,10 +9,16 @@ module IdvStepConcern
   included do
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
+    before_action :confirm_letter_recently_enqueued
     before_action :confirm_no_pending_gpo_profile
     before_action :confirm_no_pending_in_person_enrollment
     before_action :handle_fraud
     before_action :check_for_mail_only_outage
+  end
+
+  def confirm_letter_recently_enqueued
+    # idv session should be clear when user returns to enter code
+    redirect_to idv_letter_enqueued_url if letter_recently_enqueued?
   end
 
   def confirm_no_pending_gpo_profile
@@ -118,6 +124,11 @@ module IdvStepConcern
         flow_session[:pii_from_user][:same_address_as_id].to_s == 'true'
     end
     extra
+  end
+
+  def letter_recently_enqueued?
+    current_user&.gpo_verification_pending_profile? &&
+      idv_session.address_verification_mechanism == 'gpo'
   end
 
   def flow_policy

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -18,11 +18,11 @@ module IdvStepConcern
 
   def confirm_letter_recently_enqueued
     # idv session should be clear when user returns to enter code
-    redirect_to idv_letter_enqueued_url if letter_recently_enqueued?
+    return redirect_to idv_letter_enqueued_url if letter_recently_enqueued?
   end
 
   def confirm_no_pending_gpo_profile
-    redirect_to idv_verify_by_mail_enter_code_url if current_user&.gpo_verification_pending_profile?
+    redirect_to idv_verify_by_mail_enter_code_url if letter_not_recently_enqueued?
   end
 
   def confirm_no_pending_in_person_enrollment
@@ -129,6 +129,11 @@ module IdvStepConcern
   def letter_recently_enqueued?
     current_user&.gpo_verification_pending_profile? &&
       idv_session.address_verification_mechanism == 'gpo'
+  end
+
+  def letter_not_recently_enqueued?
+    current_user&.gpo_verification_pending_profile? &&
+      !idv_session.address_verification_mechanism
   end
 
   def flow_policy

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -8,7 +8,6 @@ module Idv
       prepend_before_action :note_if_user_did_not_receive_letter
       before_action :confirm_two_factor_authenticated
       before_action :confirm_verification_needed
-      before_action :confirm_letter_recently_enqueued
 
       def index
         # GPO reminder emails include an "I did not receive my letter!" link that results in
@@ -136,15 +135,6 @@ module Idv
       def confirm_verification_needed
         return if current_user.gpo_verification_pending_profile?
         redirect_to account_url
-      end
-
-      def confirm_letter_recently_enqueued
-        # idv session should be clear when user returns to enter code
-        redirect_to idv_letter_enqueued_url if letter_recently_enqueued?
-      end
-
-      def letter_recently_enqueued?
-        idv_session.address_verification_mechanism == 'gpo'
       end
 
       def threatmetrix_enabled?

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -8,6 +8,7 @@ module Idv
       prepend_before_action :note_if_user_did_not_receive_letter
       before_action :confirm_two_factor_authenticated
       before_action :confirm_verification_needed
+      before_action :confirm_letter_recently_enqueued
 
       def index
         # GPO reminder emails include an "I did not receive my letter!" link that results in
@@ -135,6 +136,15 @@ module Idv
       def confirm_verification_needed
         return if current_user.gpo_verification_pending_profile?
         redirect_to account_url
+      end
+
+      def confirm_letter_recently_enqueued
+        # idv session should be clear when user returns to enter code
+        redirect_to idv_letter_enqueued_url if letter_recently_enqueued?
+      end
+
+      def letter_recently_enqueued?
+        idv_session.address_verification_mechanism == 'gpo'
       end
 
       def threatmetrix_enabled?

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -1,12 +1,10 @@
 module Idv
   module ByMail
     class RequestLetterController < ApplicationController
-      include IdvSession
+      include IdvStepConcern
+      skip_before_action :confirm_no_pending_gpo_profile
       include Idv::StepIndicatorConcern
-      include Idv::AbTestAnalyticsConcern
 
-      before_action :confirm_two_factor_authenticated
-      before_action :confirm_idv_needed
       before_action :confirm_user_completed_idv_profile_step
       before_action :confirm_mail_not_rate_limited
       before_action :confirm_profile_not_too_old

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -319,6 +319,42 @@ RSpec.describe 'IdvStepConcern' do
     end
   end
 
+  describe '#confirm_letter_recently_enqueued' do
+    controller(idv_step_controller_class) do
+      before_action :confirm_letter_recently_enqueued
+    end
+
+    before(:each) do
+      sign_in(user)
+      allow(subject).to receive(:current_user).and_return(user)
+      routes.draw do
+        get 'show' => 'anonymous#show'
+      end
+    end
+
+    context 'letter was not recently enqueued' do
+      it 'does not redirect' do
+        get :show
+
+        expect(response.body).to eq 'Hello'
+        expect(response).to_not redirect_to idv_letter_enqueued_url
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'letter was recently enqueued' do
+      let(:user) { create(:user, :with_pending_gpo_profile, :fully_registered) }
+
+      it 'redirects to letter enqueued page' do
+        idv_session.address_verification_mechanism = 'gpo'
+
+        get :show
+
+        expect(response).to redirect_to idv_letter_enqueued_url
+      end
+    end
+  end
+
   describe '#confirm_no_pending_in_person_enrollment' do
     controller(idv_step_controller_class) do
       before_action :confirm_no_pending_in_person_enrollment

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe 'Identity verification', :js do
 
       complete_enter_password_step(user)
 
+      try_to_go_back_from_come_back_later
       validate_come_back_later_page
       complete_come_back_later
       validate_return_to_sp
@@ -393,6 +394,13 @@ RSpec.describe 'Identity verification', :js do
     expect(page).to have_current_path(idv_verify_info_path)
     visit(idv_welcome_path)
     expect(page).to have_current_path(idv_verify_info_path)
+  end
+
+  def try_to_go_back_from_come_back_later
+    visit(idv_enter_password_path)
+    expect(page).to have_current_path(idv_letter_enqueued_path)
+    visit(idv_welcome_path)
+    expect(page).to have_current_path(idv_letter_enqueued_path)
   end
 
   def same_phone?(phone1, phone2)

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -76,9 +76,9 @@ RSpec.describe 'Identity verification', :js do
 
       complete_enter_password_step(user)
 
-      try_to_go_back_from_come_back_later
-      validate_come_back_later_page
-      complete_come_back_later
+      try_to_go_back_from_letter_enqueued
+      validate_letter_enqueued_page
+      complete_letter_enqueued
       validate_return_to_sp
 
       visit sign_out_url
@@ -276,7 +276,7 @@ RSpec.describe 'Identity verification', :js do
     expect(GpoConfirmation.count).to eq(0)
   end
 
-  def validate_come_back_later_page
+  def validate_letter_enqueued_page
     expect(page).to have_current_path(idv_letter_enqueued_path)
     expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
     expect(page).to have_content(t('idv.titles.come_back_later'))
@@ -396,8 +396,8 @@ RSpec.describe 'Identity verification', :js do
     expect(page).to have_current_path(idv_verify_info_path)
   end
 
-  def try_to_go_back_from_come_back_later
-    visit(idv_enter_password_path)
+  def try_to_go_back_from_letter_enqueued
+    go_back
     expect(page).to have_current_path(idv_letter_enqueued_path)
     visit(idv_welcome_path)
     expect(page).to have_current_path(idv_letter_enqueued_path)

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -87,13 +87,16 @@ RSpec.feature 'idv request letter step' do
 
         # Confirm that user cannot visit other IdV pages while unverified
         visit idv_agreement_path
-        expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
+        expect(page).to have_current_path(idv_letter_enqueued_path)
         visit idv_ssn_url
-        expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
+        expect(page).to have_current_path(idv_letter_enqueued_path)
         visit idv_verify_info_url
-        expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
+        expect(page).to have_current_path(idv_letter_enqueued_path)
 
         # complete verification: end to end gpo test
+        sign_out
+        sign_in_live_with_2fa(user)
+
         complete_gpo_verification(user)
         expect(user.identity_verified?).to be(true)
         expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
@@ -158,7 +161,7 @@ RSpec.feature 'idv request letter step' do
   context 'GPO verified user has reset their password and needs to re-verify with GPO again', :js do
     let(:user) { user_verified_with_gpo }
 
-    it 'shows the user a GPO index screen asking to send a letter' do
+    it 'shows the user the request letter page' do
       visit_idp_from_ial2_oidc_sp
       trigger_reset_password_and_click_email_link(user.email)
       reset_password_and_sign_back_in(user)

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -175,7 +175,7 @@ module DocAuthHelper
     click_button t('idv.gpo.form.submit')
   end
 
-  def complete_come_back_later
+  def complete_letter_enqueued
     # Exit Login.gov and return to SP
     click_on t('idv.cancel.actions.exit', app_name: APP_NAME)
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-11230](https://cm-jira.usa.gov/browse/LG-11230)



## 🛠 Summary of changes

If a user recently requested a letter and reached the letter enqueued page if they pressed the back button they would be taken to the the Enter Code screen. We want them to only reach the enter code screen once they get a letter or start a new session so this redirects them back to the letter enqueued screen.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through the IdV verify by mail flow.
- [ ] Once you reach the "letter enqueued" page press the back button.
- [ ] Confirm that you stay on the letter enqueued page
- [ ] Confirm that if you start a new session you reach the "Enter Code" page.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
