### PR TITLE
Remove unreachable "otp_code" auth method

### DIFF
--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -61,11 +61,8 @@ class OtpVerificationForm
   end
 
   def extra_analytics_attributes
-    multi_factor_auth_method_created_at = phone_configuration&.created_at&.strftime('%s%L')
-
     {
-      multi_factor_auth_method: 'otp_code',
-      multi_factor_auth_method_created_at: multi_factor_auth_method_created_at,
+      multi_factor_auth_method_created_at: phone_configuration&.created_at&.strftime('%s%L'),
     }
   end
 end

--- a/spec/forms/otp_verification_form_spec.rb
+++ b/spec/forms/otp_verification_form_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe OtpVerificationForm do
       it 'returns a successful response' do
         expect(result.to_h).to eq(
           success: true,
-          multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
         )
       end
@@ -47,7 +46,6 @@ RSpec.describe OtpVerificationForm do
           error_details: {
             code: { blank: true, wrong_length: true },
           },
-          multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
         )
       end
@@ -69,7 +67,6 @@ RSpec.describe OtpVerificationForm do
           error_details: {
             code: { user_otp_missing: true },
           },
-          multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
         )
       end
@@ -91,7 +88,6 @@ RSpec.describe OtpVerificationForm do
           error_details: {
             code: { wrong_length: true, incorrect: true },
           },
-          multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
         )
       end
@@ -113,7 +109,6 @@ RSpec.describe OtpVerificationForm do
           error_details: {
             code: { pattern_mismatch: true, incorrect: true },
           },
-          multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
         )
       end
@@ -138,7 +133,6 @@ RSpec.describe OtpVerificationForm do
           error_details: {
             code: { user_otp_expired: true },
           },
-          multi_factor_auth_method: 'otp_code',
           multi_factor_auth_method_created_at: phone_configuration.created_at.strftime('%s%L'),
         )
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes an unused reference to "otp_code" as a `multi_factor_auth_method` value, in order to avoid confusion for a value that's never logged.

I stumbled across this when searching possible `multi_factor_auth_method` values in the codebase. After verifying there are no results in CloudWatch for `filter properties.event_properties.multi_factor_auth_method = 'otp_code'`, I noticed that this would be unused, due to how the form's extra analytics are overridden:

https://github.com/18F/identity-idp/blob/fb94aadf8d526f02a725df9a8a9f5721fbb87e75/app/controllers/two_factor_authentication/otp_verification_controller.rb#L129

https://github.com/18F/identity-idp/blob/fb94aadf8d526f02a725df9a8a9f5721fbb87e75/app/controllers/two_factor_authentication/otp_verification_controller.rb#L151-L156

## 📜 Testing Plan

This is a refactor expected to be covered by existing test coverage.

```
rspec spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb spec/forms/otp_verification_form_spec.rb
```

You could also verify that MFA'ing with a phone continues to log events with `multi_factor_auth_method` equal to the delivery method of your authenticator ("sms" or "voice").