### PR TITLE
Remove GpoExpirationJob::initialize

### DIFF
--- a/app/jobs/gpo_expiration_job.rb
+++ b/app/jobs/gpo_expiration_job.rb
@@ -1,9 +1,8 @@
 class GpoExpirationJob < ApplicationJob
   queue_as :low
 
-  def initialize(*args, analytics: nil, on_profile_expired: nil, **rest)
+  def initialize(*args, analytics: nil, **rest)
     @analytics = analytics
-    @on_profile_expired = on_profile_expired
     super(*args, **rest)
   end
 
@@ -29,11 +28,6 @@ class GpoExpirationJob < ApplicationJob
         end
 
         expire_profile(profile: profile) unless dry_run
-
-        on_profile_expired&.call(
-          profile: profile,
-          gpo_verification_pending_at: gpo_verification_pending_at,
-        )
       end
     end
   end
@@ -47,8 +41,6 @@ class GpoExpirationJob < ApplicationJob
   end
 
   private
-
-  attr_reader :on_profile_expired
 
   def expire_profile(profile:)
     gpo_verification_pending_at = profile.gpo_verification_pending_at

--- a/app/jobs/gpo_expiration_job.rb
+++ b/app/jobs/gpo_expiration_job.rb
@@ -1,11 +1,6 @@
 class GpoExpirationJob < ApplicationJob
   queue_as :low
 
-  def initialize(*args, analytics: nil, **rest)
-    @analytics = analytics
-    super(*args, **rest)
-  end
-
   def perform(
     dry_run: false,
     limit: nil,

--- a/app/jobs/gpo_expiration_job.rb
+++ b/app/jobs/gpo_expiration_job.rb
@@ -1,9 +1,10 @@
 class GpoExpirationJob < ApplicationJob
   queue_as :low
 
-  def initialize(analytics: nil, on_profile_expired: nil)
+  def initialize(*args, analytics: nil, on_profile_expired: nil, **rest)
     @analytics = analytics
     @on_profile_expired = on_profile_expired
+    super(*args, **rest)
   end
 
   def perform(

--- a/spec/jobs/gpo_expiration_job_spec.rb
+++ b/spec/jobs/gpo_expiration_job_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe GpoExpirationJob do
     allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).and_return(
       usps_confirmation_max_days,
     )
+    allow(subject).to receive(:analytics).and_return(analytics)
   end
 
   describe '#gpo_profiles_that_should_be_expired' do

--- a/spec/jobs/gpo_expiration_job_spec.rb
+++ b/spec/jobs/gpo_expiration_job_spec.rb
@@ -113,22 +113,6 @@ RSpec.describe GpoExpirationJob do
       )
     end
 
-    context 'when a callback is provided' do
-      it 'calls it for expired profiles' do
-        profile = users[:user_with_one_expired_gpo_profile].reload.gpo_verification_pending_profile
-        gpo_verification_pending_at = profile.gpo_verification_pending_at
-
-        on_profile_expired = spy
-        expect(on_profile_expired).to receive(:call).with(
-          profile: profile,
-          gpo_verification_pending_at: gpo_verification_pending_at,
-        )
-
-        job = described_class.new(analytics: analytics, on_profile_expired: on_profile_expired)
-        job.perform
-      end
-    end
-
     context('when dry_run is specified') do
       it 'does not write changes' do
         job.perform(dry_run: true)


### PR DESCRIPTION
`GpoExpirationJob`, added in #9545 and enabled in #9622, is [raising a `NoMethodError`](https://onenr.io/08jqZ7LexQl) when it's  run via good_job. This is due to the initializer missing a `super` call.

This PR removes the `initialize` method.