### PR TITLE
build-sass: Use native Node.js parseArgs utility

### DIFF
--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Breaking Changes
+
+- Requires Node.js v18 or newer
+
 ## 2.0.0
 
 ### Breaking Changes

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -3,9 +3,9 @@
 /* eslint-disable no-console */
 
 import { mkdir } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
 import { watch } from 'chokidar';
 import { fileURLToPath } from 'url';
-import { parseArgs } from '@pkgjs/parseargs'; // Note: Use native util.parseArgs after Node v18
 import { buildFile } from './index.js';
 import getDefaultLoadPaths from './get-default-load-paths.js';
 import getErrorSassStackPaths from './get-error-sass-stack-paths.js';
@@ -26,9 +26,8 @@ const { values: flags, positionals: fileArgs } = parseArgs({
   },
 });
 
-const isWatching = flags.watch;
-const outDir = flags['out-dir'];
-const loadPaths = [...flags['load-path'], ...getDefaultLoadPaths()];
+const { watch: isWatching, 'out-dir': outDir, 'load-path': loadPaths = [] } = flags;
+loadPaths.push(...getDefaultLoadPaths());
 
 /** @type {BuildOptions & SyncSassOptions} */
 const options = { outDir, loadPaths, optimize: isProduction };

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -29,6 +29,10 @@ const { values: flags, positionals: fileArgs } = parseArgs({
 const { watch: isWatching, 'out-dir': outDir, 'load-path': loadPaths = [] } = flags;
 loadPaths.push(...getDefaultLoadPaths());
 
+if (!outDir) {
+  throw new TypeError('Output directory must be provided using the `--out-dir` option.');
+}
+
 /** @type {BuildOptions & SyncSassOptions} */
 const options = { outDir, loadPaths, optimize: isProduction };
 

--- a/app/javascript/packages/build-sass/package.json
+++ b/app/javascript/packages/build-sass/package.json
@@ -4,6 +4,9 @@
   "private": false,
   "description": "Stylesheet compilation utility with reasonable defaults and fast performance.",
   "type": "module",
+  "engines": {
+    "node": ">= 18"
+  },
   "bin": {
     "build-sass": "./cli.js"
   },
@@ -25,7 +28,6 @@
   "homepage": "https://github.com/18f/identity-idp",
   "dependencies": {
     "@aduth/is-dependency": "^1.0.0",
-    "@pkgjs/parseargs": "^0.11.0",
     "browserslist": "^4.22.1",
     "chokidar": "^3.5.3",
     "lightningcss": "^1.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,11 +1216,6 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@pkgjs/parseargs@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
-  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
-
 "@pkgr/utils@^2.3.1":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.4.2.tgz#9e638bbe9a6a6f165580dc943f138fd3309a2cbc"


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `@18f/identity-build-sass` to use the native [Node.js `util.parseArgs`](https://nodejs.org/api/util.html#utilparseargsconfig) in place of the third-party package polyfill.

This is a public, published package, so there is a consideration of downstream impact of using a feature in a newer version of Node.js. However, since this package is largely for internal projects, and the feature has been supported since 2 LTS releases, I think it's reasonable to drop support for Node.js v16 and older.

The benefit is largely in reducing download size and vulnerability surface area incurred through use of third-party packages.

## 📜 Testing Plan

Observe no regressions in building CSS:

```
make run
```

1. Go to http://localhost:3000
2. Observe no visual regressions