### PR TITLE
LG-11517: Always show "Use another method" option in SMS opt-in

### DIFF
--- a/app/controllers/two_factor_authentication/sms_opt_in_controller.rb
+++ b/app/controllers/two_factor_authentication/sms_opt_in_controller.rb
@@ -3,8 +3,8 @@ module TwoFactorAuthentication
     before_action :load_phone
 
     def new
-      @other_mfa_options_url = other_options_mfa_url
       @cancel_url = cancel_url
+      @presenter = TwoFactorAuthCode::SmsOptInPresenter.new
 
       analytics.sms_opt_in_visit(
         new_user: new_user?,
@@ -28,8 +28,8 @@ module TwoFactorAuthentication
         @phone_number_opt_out.opt_in
         redirect_to otp_send_url(otp_delivery_selection_form: { otp_delivery_preference: :sms })
       else
-        @other_mfa_options_url = other_options_mfa_url
         @cancel_url = cancel_url
+        @presenter = TwoFactorAuthCode::SmsOptInPresenter.new
 
         if !response.error
           # unsuccessful, but didn't throw an exception: already opted in last 30 days
@@ -59,14 +59,6 @@ module TwoFactorAuthentication
       end || PhoneConfiguration.new(phone: @phone_number_opt_out.formatted_phone)
     rescue ActiveRecord::RecordNotFound
       render_not_found
-    end
-
-    def other_options_mfa_url
-      if new_user?
-        authentication_methods_setup_path
-      elsif has_other_auth_methods? && !user_fully_authenticated?
-        login_two_factor_options_path
-      end
     end
 
     def cancel_url

--- a/app/presenters/two_factor_auth_code/sms_opt_in_presenter.rb
+++ b/app/presenters/two_factor_auth_code/sms_opt_in_presenter.rb
@@ -1,0 +1,9 @@
+module TwoFactorAuthCode
+  class SmsOptInPresenter < GenericDeliveryPresenter
+    def initialize; end
+
+    def redirect_location_step
+      :sms_opt_in
+    end
+  end
+end

--- a/app/views/two_factor_authentication/sms_opt_in/error.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/error.html.erb
@@ -13,22 +13,7 @@
 
 <p><%= t('two_factor_authentication.opt_in.wait_30d_opt_in') %></p>
 
-<%= render(
-      'shared/troubleshooting_options',
-      heading_tag: :h3,
-      heading: t('components.troubleshooting_options.default_heading'),
-      options: [
-        @other_mfa_options_url && {
-          url: @other_mfa_options_url,
-          text: t('two_factor_authentication.login_options_link_text'),
-        },
-        {
-          url: MarketingSite.contact_url,
-          text: t('links.contact_support', app_name: APP_NAME),
-          new_tab: true,
-        },
-      ].select(&:present?),
-    ) %>
+<%= render 'two_factor_authentication/troubleshooting_options', presenter: @presenter %>
 
 <%= render PageFooterComponent.new do %>
   <%= link_to cancel_link_text, @cancel_url %>

--- a/app/views/two_factor_authentication/sms_opt_in/new.html.erb
+++ b/app/views/two_factor_authentication/sms_opt_in/new.html.erb
@@ -20,12 +20,7 @@
               class: 'usa-button usa-button--wide usa-button--big',
               form_class: 'margin-y-5' %>
 
-<% if @other_mfa_options_url %>
-  <h2 class="margin-top-5"><%= t('two_factor_authentication.opt_in.cant_use_phone') %></h2>
-
-  <%= link_to t('two_factor_authentication.login_options_link_text'),
-              @other_mfa_options_url %>
-<% end %>
+<%= render 'two_factor_authentication/troubleshooting_options', presenter: @presenter %>
 
 <%= render PageFooterComponent.new do %>
   <%= link_to cancel_link_text, @cancel_url %>

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -9,7 +9,6 @@ en:
     cancel: Cancel
     cancel_account_creation: '‹ Cancel account creation'
     contact: Contact
-    contact_support: Contact %{app_name} Support
     continue_sign_in: Continue sign in
     create_account: Create an account
     exit_login: Exit %{app_name}

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -9,7 +9,6 @@ es:
     cancel: Cancelar
     cancel_account_creation: '‹ Cancelar la creación de cuenta'
     contact: Contactar
-    contact_support: Póngase en contacto con el soporte técnico de %{app_name}
     continue_sign_in: Continuar el inicio de sesión
     create_account: Crear cuenta
     exit_login: Salga de %{app_name}

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -9,7 +9,6 @@ fr:
     cancel: Annuler
     cancel_account_creation: '‹ Annuler la création du compte'
     contact: Contact
-    contact_support: Contactez %{app_name} le support
     continue_sign_in: Continuer la connexion
     create_account: Créer un compte
     exit_login: Quitter %{app_name}

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -89,7 +89,6 @@ en:
     mobile_terms_of_service: Mobile terms of service
     no_auth_option: No authentication option could be found for you to sign in.
     opt_in:
-      cant_use_phone: Can’t use your phone?
       error_retry: Sorry, we are having trouble opting you in. Please try again.
       opted_out_html: You’ve opted out of receiving text messages at
         %{phone_number_html}. You can opt in and receive a security code again

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -94,7 +94,6 @@ es:
     mobile_terms_of_service: Condiciones de servicio móvil
     no_auth_option: No se pudo encontrar ninguna opción de autenticación para iniciar sesión
     opt_in:
-      cant_use_phone: '¿No puede utilizar su teléfono?'
       error_retry: Lo sentimos, estamos teniendo problemas para aceptarlo. Por favor,
         inténtelo de nuevo.
       opted_out_html: Ha optado por no recibir mensajes de texto en el

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -99,7 +99,6 @@ fr:
     mobile_terms_of_service: Conditions de service mobile
     no_auth_option: Aucune option d’authentification n’a été trouvée pour vous connecter
     opt_in:
-      cant_use_phone: Vous ne pouvez pas utiliser votre téléphone?
       error_retry: Désolé, nous avons des difficultés à vous connecter. Veuillez réessayer.
       opted_out_html: Vous avez choisi de ne plus recevoir de SMS à
         %{phone_number_html}. Vous pouvez vous inscrire et recevoir à nouveau un

--- a/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/sms_opt_in_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe TwoFactorAuthentication::SmsOptInController do
         action
 
         expect(assigns[:phone_configuration]).to eq(user.phone_configurations.first)
+        expect(assigns[:presenter]).to be_kind_of(TwoFactorAuthCode::GenericDeliveryPresenter)
 
         expect(@analytics).to have_logged_event(
           'SMS Opt-In: Visited',
@@ -29,16 +30,6 @@ RSpec.describe TwoFactorAuthentication::SmsOptInController do
           new_user: false,
           phone_configuration_id: user.phone_configurations.first.id,
         )
-      end
-
-      context 'when the user has other auth methods' do
-        let(:user) { create(:user, :with_phone, :with_authentication_app) }
-
-        it 'has an other mfa options url' do
-          action
-
-          expect(assigns[:other_mfa_options_url]).to eq(login_two_factor_options_path)
-        end
       end
 
       context 'when the user is signing in through an SP' do
@@ -171,6 +162,7 @@ RSpec.describe TwoFactorAuthentication::SmsOptInController do
 
           expect(response).to render_template(:new)
           expect(flash[:error]).to be_present
+          expect(assigns[:presenter]).to be_kind_of(TwoFactorAuthCode::GenericDeliveryPresenter)
 
           expect(@analytics).to have_logged_event(
             'SMS Opt-In: Submitted',

--- a/spec/presenters/two_factor_auth_code/sms_opt_in_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/sms_opt_in_presenter_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe TwoFactorAuthCode::SmsOptInPresenter do
+  subject(:presenter) { TwoFactorAuthCode::SmsOptInPresenter.new }
+
+  describe '#redirect_location_step' do
+    subject(:redirect_location_step) { presenter.redirect_location_step }
+
+    it { expect(redirect_location_step).to be_present }
+  end
+end

--- a/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/sms_opt_in/error.html.erb_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe 'two_factor_authentication/sms_opt_in/error.html.erb' do
   let(:phone_configuration) { build(:phone_configuration, phone: '1 888-867-5309') }
-  let(:other_mfa_options_url) { nil }
+  let(:presenter) { TwoFactorAuthCode::SmsOptInPresenter.new }
   let(:cancel_url) { '/account' }
 
   before do
     assign(:phone_configuration, phone_configuration)
-    assign(:other_mfa_options_url, other_mfa_options_url)
+    assign(:presenter, presenter)
     assign(:cancel_url, cancel_url)
     allow(view).to receive(:user_signing_up?).and_return(false)
   end
@@ -18,39 +18,21 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/error.html.erb' do
     expect(rendered).to have_content('(***) ***-5309')
   end
 
-  context 'troubleshooting links' do
-    it 'links to the contact form in a new window' do
-      render
+  it 'renders troubleshooting options' do
+    render
 
-      expect(rendered).to have_link(
-        t('links.contact_support', app_name: APP_NAME),
-        href: MarketingSite.contact_url,
-        class: 'usa-link--external',
-      )
-    end
-
-    context 'without an other_mfa_options_url' do
-      let(:other_mfa_options_url) { nil }
-
-      it 'omits the other auth methods section' do
-        render
-
-        expect(rendered).to_not have_content(t('two_factor_authentication.opt_in.cant_use_phone'))
-        expect(rendered).to_not have_content(t('two_factor_authentication.login_options_link_text'))
-      end
-    end
-
-    context 'with an other_mfa_options_url' do
-      let(:other_mfa_options_url) { '/other' }
-
-      it 'links to other options' do
-        render
-
-        expect(rendered).to have_link(
-          t('two_factor_authentication.login_options_link_text'),
-          href: other_mfa_options_url,
-        )
-      end
-    end
+    expect(rendered).to have_link(
+      t('two_factor_authentication.login_options_link_text'),
+      href: login_two_factor_options_path,
+    )
+    expect(rendered).to have_link(
+      t('two_factor_authentication.learn_more'),
+      href: help_center_redirect_path(
+        category: 'get-started',
+        article: 'authentication-options',
+        flow: :two_factor_authentication,
+        step: :sms_opt_in,
+      ),
+    )
   end
 end

--- a/spec/views/two_factor_authentication/sms_opt_in/new.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/sms_opt_in/new.html.erb_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/new.html.erb' do
   let(:phone) { '1-888-867-5309' }
   let(:phone_configuration) { build(:phone_configuration, phone: phone) }
   let(:phone_number_opt_out) { PhoneNumberOptOut.create_or_find_with_phone(phone) }
-  let(:other_mfa_options_url) { nil }
+  let(:presenter) { TwoFactorAuthCode::SmsOptInPresenter.new }
   let(:cancel_url) { '/account' }
 
   before do
     assign(:phone_configuration, phone_configuration)
     assign(:phone_number_opt_out, phone_number_opt_out)
-    assign(:other_mfa_options_url, other_mfa_options_url)
+    assign(:presenter, presenter)
     assign(:cancel_url, cancel_url)
     allow(view).to receive(:user_signing_up?).and_return(false)
   end
@@ -21,30 +21,21 @@ RSpec.describe 'two_factor_authentication/sms_opt_in/new.html.erb' do
     expect(rendered).to have_content('(***) ***-5309')
   end
 
-  context 'other authentication methods' do
-    context 'without an other_mfa_options_url' do
-      let(:other_mfa_options_url) { nil }
+  it 'renders troubleshooting options' do
+    render
 
-      it 'omits the other auth methods section' do
-        render
-
-        expect(rendered).to_not have_content(t('two_factor_authentication.opt_in.cant_use_phone'))
-        expect(rendered).to_not have_content(t('two_factor_authentication.login_options_link_text'))
-      end
-    end
-
-    context 'with an other_mfa_options_url' do
-      let(:other_mfa_options_url) { '/other' }
-
-      it 'links to other options' do
-        render
-
-        expect(rendered).to have_content(t('two_factor_authentication.opt_in.cant_use_phone'))
-        expect(rendered).to have_link(
-          t('two_factor_authentication.login_options_link_text'),
-          href: other_mfa_options_url,
-        )
-      end
-    end
+    expect(rendered).to have_link(
+      t('two_factor_authentication.login_options_link_text'),
+      href: login_two_factor_options_path,
+    )
+    expect(rendered).to have_link(
+      t('two_factor_authentication.learn_more'),
+      href: help_center_redirect_path(
+        category: 'get-started',
+        article: 'authentication-options',
+        flow: :two_factor_authentication,
+        step: :sms_opt_in,
+      ),
+    )
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11517](https://cm-jira.usa.gov/browse/LG-11517)

## 🛠 Summary of changes

Updates the SMS opt-in screen to show the troubleshooting options module, always allowing a user to return to "Choose another authentication method" even if they don't have another MFA option available, so that the user can choose to reset (delete) their account if that's their only recourse.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create a new account
3. Add phone as only MFA method
4. Once you complete account creation and reach sign-in page, click "Forget all browsers" and confirm
5. Sign out
6. Sign in
7. Opt-out of SMS
   - Simulate this in local development by entering the following into a `rails console` session:
     ```
     PhoneNumberOptOut.create_or_find_with_phone(PhoneFormatter.format('+1 555-555-5555')) # swap with phone
     ```
   - To undo this later, delete the entry you created above:
     ```
     PhoneNumberOptOut.create_or_find_with_phone(PhoneFormatter.format('+1 555-555-5555')).delete # swap with phone
     ```
8. Cancel sign-in
9. Sign-in
10. Observe that you can "Choose another authentication method", and notably that you can then select to "deleting your account" on the MFA selection screen

## 👀 Screenshots

_SMS Opt-in Send Code:_

Other MFAs available?|Before|After
---|---|---
Yes|![sms-opt-in-before-multiple](https://github.com/18F/identity-idp/assets/1779930/2da0a092-8acb-40b5-86d7-54e1188dbabc)|![sms-opt-in-after](https://github.com/18F/identity-idp/assets/1779930/92053f93-2db6-49d6-a92e-062f798b7c0f)
No|![sms-opt-in-before-single](https://github.com/18F/identity-idp/assets/1779930/53d45bcb-ea0c-49c5-94a8-8f9c763cf1a0)|![sms-opt-in-after](https://github.com/18F/identity-idp/assets/1779930/92053f93-2db6-49d6-a92e-062f798b7c0f)

_SMS Opt-in Error:_

Other MFAs available?|Before|After
---|---|---
Yes|![sms-opt-in-error-before-multiple](https://github.com/18F/identity-idp/assets/1779930/2be882e8-a97f-4ff9-940f-63cc1e3801fa)|![sms-opt-in-error-after](https://github.com/18F/identity-idp/assets/1779930/19c15ea9-4bc6-4afe-a0e7-eaf078338621)
No|![sms-opt-in-error-before-single](https://github.com/18F/identity-idp/assets/1779930/457b1114-c92d-4677-855d-66c56b80f415)|![sms-opt-in-error-after](https://github.com/18F/identity-idp/assets/1779930/19c15ea9-4bc6-4afe-a0e7-eaf078338621)



