### PR TITLE
Modify the SP requirement for IdV to require the SP to request verification

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -3,7 +3,7 @@ module IdvSession
 
   included do
     before_action :redirect_unless_idv_session_user
-    before_action :redirect_if_sp_context_needed
+    before_action :redirect_unless_sp_requested_verification
   end
 
   def confirm_idv_needed
@@ -53,10 +53,16 @@ module IdvSession
     redirect_to root_url if !idv_session_user
   end
 
-  def redirect_if_sp_context_needed
-    return if sp_from_sp_session.present?
-    return unless IdentityConfig.store.idv_sp_required
+  def redirect_unless_sp_requested_verification
+    return if !IdentityConfig.store.idv_sp_required
     return if idv_session_user.profiles.any?
+
+    ial_context = IalContext.new(
+      ial: sp_session_ial,
+      service_provider: sp_from_sp_session,
+      user: idv_session_user,
+    )
+    return if ial_context.ial2_or_greater?
 
     redirect_to account_url
   end

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Idv::ByMail::RequestLetterController do
     end
 
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
   end
 

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Idv::CancellationsController do
   describe 'before_actions' do
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
   end
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Idv::EnterPasswordController do
     end
 
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
   end
 

--- a/spec/controllers/idv/forgot_password_controller_spec.rb
+++ b/spec/controllers/idv/forgot_password_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Idv::ForgotPasswordController do
   describe 'before_actions' do
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
   end
 

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Idv::OtpVerificationController do
 
   describe 'before_actions' do
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
   end
 

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Idv::PersonalKeyController do
     end
 
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
 
     describe '#confirm_profile_has_been_created' do

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Idv::PhoneController do
 
   describe 'before_actions' do
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
   end
 

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Idv::PhoneErrorsController do
   shared_examples_for 'an idv phone errors controller action' do
     describe 'before_actions' do
       it 'includes before_actions from IdvSession' do
-        expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+        expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
       end
     end
 

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Idv::ResendOtpController do
 
   describe 'before_actions' do
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
   end
 

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Idv::SessionErrorsController do
 
   describe 'before_actions' do
     it 'includes before_actions from IdvSession' do
-      expect(subject).to have_actions(:before, :redirect_if_sp_context_needed)
+      expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
   end
 


### PR DESCRIPTION
In #4634 we restricted the identity verification process to require a service provider for a user to undergo proofing. This commit added other features like a `idv_sp_required` for configuring this behavior to be enabled or disabled. This change  required an SP to be present but did not require the SP to actually request verification.

This commit changes the code so that `IalContext` is invoked to check if verification was in fact requested. This way users can't go to an SP that does not require verification and start the verification process by navigating to `/verify`.
