### PR TITLE
LG-11536 Use the correct PII in the session for the SAML handoff

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -169,7 +169,7 @@ module SamlIdpAuthConcern
 
   def decrypted_pii
     cacher = Pii::Cacher.new(current_user, user_session)
-    cacher.fetch
+    cacher.fetch(current_user&.active_profile&.id)
   end
 
   def build_asserted_attributes(principal)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-11536](https://cm-jira.usa.gov/browse/LG-11536)



## 🛠 Summary of changes

For a user signing in from a service provider using  SAML we want to send the active profile pii from the IDP. This commit does this.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
