### PR TITLE
LG-11688 Enforce the IdV available rule in a concern

### DIFF
--- a/app/controllers/concerns/idv/availability_concern.rb
+++ b/app/controllers/concerns/idv/availability_concern.rb
@@ -1,0 +1,15 @@
+module Idv
+  module AvailabilityConcern
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :redirect_if_idv_unavailable
+    end
+
+    def redirect_if_idv_unavailable
+      return if FeatureManagement.idv_available?
+
+      redirect_to idv_unavailable_url
+    end
+  end
+end

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class AddressController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvStepConcern
 
     before_action :confirm_not_rate_limited_after_doc_auth

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class AgreementController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvStepConcern
     include StepIndicatorConcern
 

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module ByMail
     class EnterCodeController < ApplicationController
+      include Idv::AvailabilityConcern
       include IdvSession
       include Idv::StepIndicatorConcern
       include FraudReviewConcern

--- a/app/controllers/idv/by_mail/enter_code_rate_limited_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_rate_limited_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module ByMail
     class EnterCodeRateLimitedController < ApplicationController
+      include Idv::AvailabilityConcern
       include IdvSession
       include FraudReviewConcern
 

--- a/app/controllers/idv/by_mail/letter_enqueued_controller.rb
+++ b/app/controllers/idv/by_mail/letter_enqueued_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module ByMail
     class LetterEnqueuedController < ApplicationController
+      include Idv::AvailabilityConcern
       include IdvSession
       include Idv::StepIndicatorConcern
 

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module ByMail
     class RequestLetterController < ApplicationController
+      include Idv::AvailabilityConcern
       include IdvStepConcern
       skip_before_action :confirm_no_pending_gpo_profile
       include Idv::StepIndicatorConcern

--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class CancellationsController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
     include GoBackHelper
 

--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -1,5 +1,7 @@
 module Idv
   class CaptureDocStatusController < ApplicationController
+    include Idv::AvailabilityConcern
+
     before_action :confirm_two_factor_authenticated
 
     respond_to :json

--- a/app/controllers/idv/confirm_start_over_controller.rb
+++ b/app/controllers/idv/confirm_start_over_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class ConfirmStartOverController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
     include StepIndicatorConcern
     include GoBackHelper

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class DocumentCaptureController < ApplicationController
+    include Idv::AvailabilityConcern
     include AcuantConcern
     include DocumentCaptureConcern
     include IdvStepConcern

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -1,5 +1,7 @@
 module Idv
   class EnterPasswordController < ApplicationController
+    include Idv::AvailabilityConcern
+
     before_action :personal_key_confirmed
 
     include IdvStepConcern

--- a/app/controllers/idv/forgot_password_controller.rb
+++ b/app/controllers/idv/forgot_password_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class ForgotPasswordController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
 
     before_action :confirm_two_factor_authenticated

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class HowToVerifyController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvStepConcern
     include RenderConditionConcern
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class HybridHandoffController < ApplicationController
+    include Idv::AvailabilityConcern
     include ActionView::Helpers::DateHelper
     include IdvStepConcern
     include StepIndicatorConcern

--- a/app/controllers/idv/hybrid_mobile/capture_complete_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/capture_complete_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module HybridMobile
     class CaptureCompleteController < ApplicationController
+      include Idv::AvailabilityConcern
       include HybridMobileConcern
 
       before_action :check_valid_document_capture_session

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module HybridMobile
     class DocumentCaptureController < ApplicationController
+      include Idv::AvailabilityConcern
       include DocumentCaptureConcern
       include HybridMobileConcern
       include PhoneQuestionAbTestConcern

--- a/app/controllers/idv/hybrid_mobile/entry_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/entry_controller.rb
@@ -3,6 +3,7 @@ module Idv
     # Controller responsible for taking a `document-capture-session` UUID and configuring
     # the user's Session to work when they're forwarded on to document capture.
     class EntryController < ApplicationController
+      include Idv::AvailabilityConcern
       include HybridMobileConcern
 
       def show

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module InPerson
     class AddressController < ApplicationController
+      include Idv::AvailabilityConcern
       include IdvStepConcern
 
       before_action :render_404_if_in_person_residential_address_controller_enabled_not_set

--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module InPerson
     class ReadyToVerifyController < ApplicationController
+      include Idv::AvailabilityConcern
       include IdvSession
       include RenderConditionConcern
       include StepIndicatorConcern

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module InPerson
     class SsnController < ApplicationController
+      include Idv::AvailabilityConcern
       include IdvStepConcern
       include StepIndicatorConcern
       include Steps::ThreatMetrixStepHelper

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -3,6 +3,7 @@ require 'json'
 module Idv
   module InPerson
     class UspsLocationsController < ApplicationController
+      include Idv::AvailabilityConcern
       include RenderConditionConcern
       include UspsInPersonProofing
       include EffectiveUser

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   module InPerson
     class VerifyInfoController < ApplicationController
+      include Idv::AvailabilityConcern
       include IdvStepConcern
       include StepIndicatorConcern
       include Steps::ThreatMetrixStepHelper

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class InPersonController < ApplicationController
+    include Idv::AvailabilityConcern
     include RenderConditionConcern
 
     check_or_render_not_found -> { InPersonConfig.enabled_for_issuer?(current_sp&.issuer) }

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class LinkSentController < ApplicationController
+    include Idv::AvailabilityConcern
     include DocumentCaptureConcern
     include IdvStepConcern
     include StepIndicatorConcern

--- a/app/controllers/idv/mail_only_warning_controller.rb
+++ b/app/controllers/idv/mail_only_warning_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class MailOnlyWarningController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
     include StepIndicatorConcern
 

--- a/app/controllers/idv/not_verified_controller.rb
+++ b/app/controllers/idv/not_verified_controller.rb
@@ -1,5 +1,7 @@
 module Idv
   class NotVerifiedController < ApplicationController
+    include Idv::AvailabilityConcern
+
     before_action :confirm_two_factor_authenticated
 
     def show

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class OtpVerificationController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
     include StepIndicatorConcern
     include PhoneOtpRateLimitable

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class PersonalKeyController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
     include StepIndicatorConcern
     include SecureHeadersConcern

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class PhoneController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvStepConcern
     include StepIndicatorConcern
     include PhoneOtpRateLimitable

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class PhoneErrorsController < ApplicationController
+    include Idv::AvailabilityConcern
     include StepIndicatorConcern
     include IdvSession
     include Idv::AbTestAnalyticsConcern

--- a/app/controllers/idv/phone_question_controller.rb
+++ b/app/controllers/idv/phone_question_controller.rb
@@ -1,6 +1,7 @@
 module Idv
   class PhoneQuestionController < ApplicationController
     include ActionView::Helpers::DateHelper
+    include Idv::AvailabilityConcern
     include IdvStepConcern
     include StepIndicatorConcern
 

--- a/app/controllers/idv/please_call_controller.rb
+++ b/app/controllers/idv/please_call_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class PleaseCallController < ApplicationController
+    include Idv::AvailabilityConcern
     include FraudReviewConcern
 
     before_action :confirm_two_factor_authenticated

--- a/app/controllers/idv/resend_otp_controller.rb
+++ b/app/controllers/idv/resend_otp_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class ResendOtpController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
     include PhoneOtpRateLimitable
     include PhoneOtpSendable

--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class SessionErrorsController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
     include StepIndicatorConcern
 

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class SessionsController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvSession
 
     before_action :confirm_two_factor_authenticated

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class SsnController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvStepConcern
     include StepIndicatorConcern
     include Steps::ThreatMetrixStepHelper

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class VerifyInfoController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvStepConcern
     include StepIndicatorConcern
     include VerifyInfoConcern

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -1,5 +1,6 @@
 module Idv
   class WelcomeController < ApplicationController
+    include Idv::AvailabilityConcern
     include IdvStepConcern
     include StepIndicatorConcern
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -307,11 +307,6 @@ Rails.application.routes.draw do
       get '/activated' => 'idv#activated'
     end
     scope '/verify', module: 'idv', as: 'idv' do
-      if !FeatureManagement.idv_available?
-        # IdV has been disabled.
-        match '/*path' => 'unavailable#show', via: %i[get post]
-      end
-
       get '/mail_only_warning' => 'mail_only_warning#show'
       get '/personal_key' => 'personal_key#show'
       post '/personal_key' => 'personal_key#update'

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -62,31 +62,6 @@ RSpec.feature 'IdV Outage Spec' do
       allow(IdentityConfig.store).to receive(key).
         and_return(send(key))
     end
-
-    # Configuration / vendor status changes can effect Rails routing tables.
-    # Force routes to be reloaded when we've modified configuration.
-    Rails.application.reload_routes!
-  end
-
-  after do
-    # Don't leave stale routes sitting around!
-    # - Reset all the feature flags that could cause route changes
-    # - Reload routes to reset the environment for any specs that run next
-
-    vendors.each do |service|
-      vendor_status_key = "vendor_status_#{service}".to_sym
-      allow(IdentityConfig.store).to receive(vendor_status_key).and_call_original
-    end
-
-    config_flags.each do |key|
-      allow(IdentityConfig.store).to receive(key).and_call_original
-    end
-
-    # Let e.g. frontend analytics requests to /api/logger settle before we reload routes
-    # to avoid flakiness in CI.
-    page.server.wait_for_pending_requests if page&.server
-
-    Rails.application.reload_routes!
   end
 
   context 'vendor_status_lexisnexis_phone_finder set to full_outage' do


### PR DESCRIPTION
We have been discussing feature flags that can be toggled while the applicaiton is running. This would be an issue for the feature flags that drive `FeatureManagement#idv_available?`. That method is used in the routes file to handle routing for IdV routes when IdV is unavailable. This means that to change those feature flags while the app is running carries a requirement to redraw routes.

This commit makes a change to move equivalent logic to the routes file to the `Idv::Availability` concern. This concern is then included in all of the controller that were previously affected by the rule in the routes file.
