### PR TITLE
Re-order database migration tasks to run seed last and ensure grant_readonly_access runs

### DIFF
--- a/deploy/migrate
+++ b/deploy/migrate
@@ -17,7 +17,7 @@ which bundle
 export RAILS_ENV=production
 export MIGRATION_STATEMENT_TIMEOUT=600000 # 10 minutes, units are 1/1000 of a second
 
-bundle exec rake db:create db:migrate db:seed db:grant_readonly_access --trace
+bundle exec rake db:create db:migrate db:grant_readonly_access db:seed --trace
 
 set +x
 


### PR DESCRIPTION
## 🛠 Summary of changes

The database seed task handles a lot more than the readonly_access task and the seed task is allowed to fail. This change moves the readonly_access before the seed task, so that we can more reliably set readonly permissions.

Prompted by the issues in this [Slack thread](https://gsa-tts.slack.com/archives/C0NGESUN5/p1700491992907039).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
