### PR TITLE
Pin "now" in the active users report (LG-11703)

### DIFF
--- a/app/jobs/reports/monthly_key_metrics_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_report.rb
@@ -12,7 +12,7 @@ module Reports
       super(*args, **rest)
     end
 
-    def perform(date = Time.zone.yesterday)
+    def perform(date = Time.zone.yesterday.end_of_day)
       @report_date = date
 
       email_addresses = emails.select(&:present?)

--- a/app/services/reporting/active_users_count_report.rb
+++ b/app/services/reporting/active_users_count_report.rb
@@ -133,7 +133,7 @@ module Reporting
         CalendarService.fiscal_start_date(report_date)..CalendarService.fiscal_q4_start(report_date),
         CalendarService.fiscal_start_date(report_date)..CalendarService.fiscal_end_date(report_date).next_day(1),
       ].map do |range|
-        range.begin.beginning_of_day..range.end.prev_day(1).end_of_day
+        range.begin.beginning_of_day..([range.end.prev_day(1).end_of_day, report_date].min)
       end
     end
     # rubocop:enable Layout/LineLength

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -197,7 +197,7 @@ else
       monthly_key_metrics_report: {
         class: 'Reports::MonthlyKeyMetricsReport',
         cron: cron_24h,
-        args: -> { [Time.zone.yesterday] },
+        args: -> { [Time.zone.yesterday.end_of_day] },
       },
       # Job to backfill encrypted_pii_recovery_multi_region on users
       multi_region_kms_migration_user_migration: {

--- a/spec/services/reporting/active_users_count_report_spec.rb
+++ b/spec/services/reporting/active_users_count_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reporting::ActiveUsersCountReport do
-  let(:report_date) { Date.new(2023, 3, 1) }
+  let(:report_date) { Date.new(2023, 3, 31) }
 
   subject(:report) { Reporting::ActiveUsersCountReport.new(report_date) }
   let(:sp1) { create(:service_provider) }
@@ -55,11 +55,11 @@ RSpec.describe Reporting::ActiveUsersCountReport do
 
       expected_table = [
         ['Active Users', 'IAL1', 'IDV', 'Total', 'Range start', 'Range end'],
-        ['Current month', 1, 1, 2, Date.new(2023, 3, 1), Date.new(2023, 3, 31)],
+        ['Current month', 0, 0, 0, Date.new(2023, 3, 1), Date.new(2023, 3, 31)],
         ['Fiscal year Q1', 1, 1, 2, Date.new(2022, 10, 1), Date.new(2022, 12, 31)],
-        ['Fiscal year Q2 cumulative', 2, 2, 4, Date.new(2022, 10, 1), Date.new(2023, 3, 31)],
-        ['Fiscal year Q3 cumulative', 2, 2, 4, Date.new(2022, 10, 1), Date.new(2023, 6, 30)],
-        ['Fiscal year Q4 cumulative', 2, 2, 4, Date.new(2022, 10, 1), Date.new(2023, 9, 30)],
+        ['Fiscal year Q2 cumulative', 1, 1, 2, Date.new(2022, 10, 1), Date.new(2023, 3, 31)],
+        ['Fiscal year Q3 cumulative', 1, 1, 2, Date.new(2022, 10, 1), Date.new(2023, 3, 31)],
+        ['Fiscal year Q4 cumulative', 1, 1, 2, Date.new(2022, 10, 1), Date.new(2023, 3, 31)],
       ]
 
       emailable_report = report.active_users_count_emailable_report
@@ -92,8 +92,8 @@ RSpec.describe Reporting::ActiveUsersCountReport do
         ['Active Users (APG)', 'IAL1', 'IDV', 'Total', 'Range start', 'Range end'],
         ['Fiscal year Q1', 0, 0, 0, Date.new(2022, 10, 1), Date.new(2022, 12, 31)],
         ['Fiscal year Q2 cumulative', 2, 0, 2, Date.new(2022, 10, 1), Date.new(2023, 3, 31)],
-        ['Fiscal year Q3 cumulative', 2, 0, 2, Date.new(2022, 10, 1), Date.new(2023, 6, 30)],
-        ['Fiscal year Q4 cumulative', 2, 0, 2, Date.new(2022, 10, 1), Date.new(2023, 9, 30)],
+        ['Fiscal year Q3 cumulative', 2, 0, 2, Date.new(2022, 10, 1), Date.new(2023, 3, 31)],
+        ['Fiscal year Q4 cumulative', 2, 0, 2, Date.new(2022, 10, 1), Date.new(2023, 3, 31)],
       ]
 
       emailable_report = report.active_users_count_apg_emailable_report


### PR DESCRIPTION
## 🎫 Ticket

[LG-11703](https://cm-jira.usa.gov/browse/LG-11703)

## 🛠 Summary of changes

Updates the active users count so that the "now" or the end time is fixed. This means we can:
1.  consistently re-run old reports
2. have less skew between generating multiple rows of the report while live data is still being added (problem observed in the ticket)


## 👀 Screenshots

| before | after |
| --- | ---- |
|  <img width="685" alt="Screenshot 2023-11-28 at 12 37 49 PM" src="https://github.com/18F/identity-idp/assets/458784/5252b275-ebe5-427e-8ec5-7e778a279547"> |   <img width="685" alt="Screenshot 2023-11-28 at 12 37 27 PM" src="https://github.com/18F/identity-idp/assets/458784/15156c4a-ab68-437b-8dd0-04f0af88aa06"> |


