### PR TITLE
LG-11454: Add rename support for face or touch unlock

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -16,7 +16,7 @@
 }
 
 .usa-button:disabled.usa-button--active,
-.usa-button--disabled.usa-button--active {
+[aria-disabled='true'].usa-button--active {
   &:not(
       .usa-button--unstyled,
       .usa-button--secondary,
@@ -24,8 +24,38 @@
       .usa-button--accent-warm,
       .usa-button--base,
       .usa-button--outline,
-      .usa-button--inverse
+      .usa-button--inverse,
+      .usa-button--danger
     ) {
     @include set-text-and-bg('primary-darker', $context: 'Button');
+  }
+}
+
+// Upstream: https://github.com/18F/identity-design-system/pull/383
+.usa-button--danger.usa-button--outline {
+  &:not(:disabled, [aria-disabled='true']) {
+    background-color: color('white');
+    box-shadow: inset 0 0 0 $theme-button-stroke-width color('secondary');
+    color: color('secondary');
+
+    &:hover,
+    &.usa-button--hover {
+      background-color: color('secondary-lightest');
+      box-shadow: inset 0 0 0 $theme-button-stroke-width color('secondary-dark');
+      color: color('secondary-dark');
+    }
+  }
+
+  &:active,
+  &.usa-button--active {
+    &,
+    &:focus,
+    &.usa-button--focus,
+    &:hover,
+    &.usa-button--hover {
+      background-color: color('secondary-lighter');
+      box-shadow: inset 0 0 0 $theme-button-stroke-width color('secondary-darker');
+      color: color('secondary-darker');
+    }
   }
 }

--- a/app/components/manageable_authenticator_component.html.erb
+++ b/app/components/manageable_authenticator_component.html.erb
@@ -1,0 +1,120 @@
+<%= content_tag(
+      :'lg-manageable-authenticator',
+      **tag_options,
+      'api-url': manage_api_url,
+      'configuration-name': configuration.name,
+      'unique-id': unique_id,
+      'reauthenticate-at': reauthenticate_at.iso8601,
+      'reauthentication-url': reauthentication_url,
+    ) do %>
+  <%= content_tag(
+        :script,
+        strings.
+          slice(:renamed, :delete_confirm, :deleted).
+          transform_keys { |key| key.to_s.camelcase(:lower) }.
+          to_json,
+        {
+          type: 'application/json',
+          class: 'manageable-authenticator__strings',
+        },
+        false,
+      ) %>
+  <%= tag.div(
+        class: 'manageable-authenticator__edit',
+        tabindex: '-1',
+        role: 'group',
+        aria: { labelledby: "manageable-authenticator-manage-accessible-label-#{unique_id}" },
+      ) do %>
+    <%= render AlertComponent.new(
+          type: :success,
+          class: 'manageable-authenticator__alert',
+          tabindex: '-1',
+        ) %>
+    <form class="manageable-authenticator__rename">
+      <%= tag.input(
+            class: 'manageable-authenticator__rename-input usa-input width-full',
+            aria: { label: t('components.manageable_authenticator.nickname') },
+            value: configuration.name,
+          ) %>
+      <div class="display-flex margin-top-205">
+        <%= render SpinnerButtonComponent.new(
+              type: :submit,
+              wrapper_options: { class: 'manageable-authenticator__save-rename-button' },
+              action_message: t('components.manageable_authenticator.saving'),
+              long_wait_duration: Float::INFINITY,
+            ).with_content(t('components.manageable_authenticator.save')) %>
+        <%= render ButtonComponent.new(
+              type: :button,
+              outline: true,
+              class: 'margin-left-1 manageable-authenticator__cancel-rename-button',
+            ).with_content(t('components.manageable_authenticator.cancel')) %>
+      </div>
+    </form>
+    <div class="manageable-authenticator__details">
+      <span class="usa-sr-only"><%= t('components.manageable_authenticator.nickname') %>:</span>
+      <strong class="manageable-authenticator__name manageable-authenticator__details-name">
+        <%= configuration.name %>
+      </strong>
+      <div>
+        <%= t(
+              'components.manageable_authenticator.created_on',
+              date: l(configuration.created_at, format: :event_date),
+            ) %>
+      </div>
+      <div class="grid-row margin-top-205">
+        <div class="grid-col-auto grid-row display-flex">
+          <%= render ButtonComponent.new(
+                type: :button,
+                class: 'manageable-authenticator__rename-button',
+              ).with_content(t('components.manageable_authenticator.rename')) %>
+          <%= render SpinnerButtonComponent.new(
+                type: :button,
+                danger: true,
+                outline: true,
+                wrapper_options: { class: 'manageable-authenticator__delete-button' },
+                class: 'margin-left-1',
+                action_message: t('components.manageable_authenticator.deleting'),
+                long_wait_duration: Float::INFINITY,
+              ).with_content(t('components.manageable_authenticator.delete')) %>
+        </div>
+        <div class="grid-col-fill text-right">
+          <%= render ButtonComponent.new(
+                type: :button,
+                outline: true,
+                class: 'manageable-authenticator__done-button',
+              ).with_content(t('components.manageable_authenticator.done')) %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  <div class="manageable-authenticator__summary">
+    <div class="manageable-authenticator__name manageable-authenticator__summary-name"><%= configuration.name %></div>
+    <div class="manageable-authenticator__actions">
+      <%= render ButtonComponent.new(
+            action: ->(**tag_options, &block) { link_to(manage_url, **tag_options, &block) },
+            type: :button,
+            unstyled: true,
+            class: 'no-js',
+          ) do %>
+        <span aria-hidden="true">
+          <%= t('components.manageable_authenticator.manage') %>
+        </span>
+        <span class="usa-sr-only">
+          <%= strings[:manage_accessible_label] %>: <%= tag.span(configuration.name, class: 'manageable-authenticator__name') %>
+        </span>
+      <% end %>
+      <%= render ButtonComponent.new(
+            type: :button,
+            unstyled: true,
+            class: 'js manageable-authenticator__manage-button',
+          ) do %>
+        <span aria-hidden="true">
+          <%= t('components.manageable_authenticator.manage') %>
+        </span>
+        <span class="usa-sr-only" id="manageable-authenticator-manage-accessible-label-<%= unique_id %>">
+          <%= strings[:manage_accessible_label] %>: <%= tag.span(configuration.name, class: 'manageable-authenticator__name') %>
+        </span>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/manageable_authenticator_component.rb
+++ b/app/components/manageable_authenticator_component.rb
@@ -1,0 +1,57 @@
+class ManageableAuthenticatorComponent < BaseComponent
+  attr_reader :configuration,
+              :user_session,
+              :manage_api_url,
+              :manage_url,
+              :custom_strings,
+              :tag_options
+
+  def initialize(
+    configuration:,
+    user_session:,
+    manage_api_url:,
+    manage_url:,
+    custom_strings: {},
+    **tag_options
+  )
+    if ![:name, :id, :created_at].all? { |method| configuration.respond_to?(method) }
+      raise ArgumentError, '`configuration` must respond to `name`, `id`, `created_at`'
+    end
+
+    @configuration = configuration
+    @user_session = user_session
+    @manage_api_url = manage_api_url
+    @manage_url = manage_url
+    @custom_strings = custom_strings
+    @tag_options = tag_options
+  end
+
+  def reauthentication_url
+    account_reauthentication_path(manage_authenticator: unique_id)
+  end
+
+  def unique_id
+    @unique_id ||= [configuration.class.name.downcase, configuration.id].join('-')
+  end
+
+  def strings
+    default_strings.merge(custom_strings)
+  end
+
+  delegate :reauthenticate_at, to: :auth_methods_session
+
+  private
+
+  def auth_methods_session
+    @auth_methods_session ||= AuthMethodsSession.new(user_session:)
+  end
+
+  def default_strings
+    {
+      renamed: t('components.manageable_authenticator.renamed'),
+      delete_confirm: t('components.manageable_authenticator.delete_confirm'),
+      deleted: t('components.manageable_authenticator.deleted'),
+      manage_accessible_label: t('components.manageable_authenticator.manage_accessible_label'),
+    }
+  end
+end

--- a/app/components/manageable_authenticator_component.scss
+++ b/app/components/manageable_authenticator_component.scss
@@ -1,0 +1,77 @@
+@use 'uswds-core' as *;
+
+.manageable-authenticator__edit {
+  @include u-margin-y(1.5);
+  @include u-padding(2);
+  @include u-border(1px, 'primary-light');
+  @include u-radius('lg');
+  display: none;
+
+  .manageable-authenticator--editing & {
+    display: block;
+  }
+
+  .manageable-authenticator--deleted & {
+    @include u-padding(0);
+    @include u-border(0);
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+}
+
+.manageable-authenticator__alert {
+  @include u-margin-bottom(2);
+  display: none;
+
+  .manageable-authenticator--alert-visible & {
+    display: block;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+}
+
+.manageable-authenticator__rename {
+  display: none;
+
+  .manageable-authenticator--renaming & {
+    display: block;
+  }
+}
+
+.manageable-authenticator__details {
+  .manageable-authenticator--renaming &,
+  .manageable-authenticator--deleted & {
+    display: none;
+  }
+}
+
+.manageable-authenticator__details-name {
+  display: block;
+}
+
+.manageable-authenticator__summary {
+  @include grid-row;
+  @include u-padding(1);
+  @include u-border(1px, 'primary-light');
+
+  lg-manageable-authenticator + lg-manageable-authenticator & {
+    border-top: none;
+  }
+
+  .manageable-authenticator--editing &,
+  .manageable-authenticator--deleted & {
+    display: none;
+  }
+}
+
+.manageable-authenticator__summary-name {
+  @include grid-col('fill');
+}
+
+.manageable-authenticator__actions {
+  @include grid-col('auto');
+}

--- a/app/components/manageable_authenticator_component.ts
+++ b/app/components/manageable_authenticator_component.ts
@@ -1,0 +1,1 @@
+import '@18f/identity-manageable-authenticator/manageable-authenticator-element';

--- a/app/components/spinner_button_component.html.erb
+++ b/app/components/spinner_button_component.html.erb
@@ -1,4 +1,10 @@
-<%= content_tag(:'lg-spinner-button', class: css_class, 'spin-on-click': spin_on_click) do %>
+<%= content_tag(
+      :'lg-spinner-button',
+      **wrapper_options,
+      class: css_class,
+      'spin-on-click': spin_on_click,
+      'long-wait-duration-ms': long_wait_duration.in_milliseconds,
+    ) do %>
   <%= render ButtonComponent.new(type: :button, **button_options) do %>
     <span class="spinner-button__content"><%= content %></span>
     <span class="spinner-dots spinner-dots--centered" aria-hidden="true">

--- a/app/components/spinner_button_component.rb
+++ b/app/components/spinner_button_component.rb
@@ -1,17 +1,37 @@
 class SpinnerButtonComponent < BaseComponent
-  attr_reader :action_message, :button_options, :outline, :spin_on_click
+  DEFAULT_LONG_WAIT_DURATION = 15.seconds
+
+  attr_reader :action_message,
+              :button_options,
+              :outline,
+              :long_wait_duration,
+              :spin_on_click,
+              :wrapper_options
 
   # @param [String] action_message Message describing the action being performed, shown visually to
   #                                users when the animation has been active for a long time, and
   #                                immediately to users of assistive technology.
-  def initialize(action_message: nil, spin_on_click: nil, **button_options)
+  # @param [Boolean] spin_on_click Whether to start the spinning animation immediately on click.
+  # @param [ActiveSupport::Duration] long_wait_duration Time until the action message becomes
+  # visible.
+  def initialize(
+    action_message: nil,
+    spin_on_click: nil,
+    long_wait_duration: DEFAULT_LONG_WAIT_DURATION,
+    wrapper_options: {},
+    **button_options
+  )
     @action_message = action_message
     @button_options = button_options
     @outline = button_options[:outline]
+    @long_wait_duration = long_wait_duration
     @spin_on_click = spin_on_click
+    @wrapper_options = wrapper_options
   end
 
   def css_class
-    'spinner-button--outline' if outline
+    classes = [*wrapper_options[:class]]
+    classes << 'spinner-button--outline' if outline
+    classes
   end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -19,11 +19,11 @@ class AccountsController < ApplicationController
     )
   end
 
-  # This action is used to re-authenticate when PII on the account page is locked on `show` action
-  # This allows users to view their PII after reauthenticating their MFA.
-
   def reauthentication
-    user_session[:stored_location] = account_url
+    # This route sends a user through reauthentication and returns them to the account page, since
+    # some actions within the account dashboard require a fresh reauthentication (e.g. managing an
+    # MFA method or viewing verified profile information).
+    user_session[:stored_location] = account_url(params.permit(:manage_authenticator))
     user_session[:context] = 'reauthentication'
 
     redirect_to login_two_factor_options_path

--- a/app/javascript/packages/manageable-authenticator/README.md
+++ b/app/javascript/packages/manageable-authenticator/README.md
@@ -1,0 +1,15 @@
+# `@18f/identity-manageable-authenticator`
+
+Custom element for inline management of an authentication method.
+
+## Usage
+
+### Custom Element
+
+Importing the element will register the `<lg-manageable-authenticator>` custom element:
+
+```ts
+import '@18f/identity-manageable-authenticator/manageable-authenticator-element';
+```
+
+The custom element will implement all JavaScript behaviors for the element, but the `<lg-manageable-authenticator>` markup must already exist.

--- a/app/javascript/packages/manageable-authenticator/manageable-authenticator-element.spec.ts
+++ b/app/javascript/packages/manageable-authenticator/manageable-authenticator-element.spec.ts
@@ -1,0 +1,447 @@
+import quibble from 'quibble';
+import { screen, waitFor } from '@testing-library/dom';
+import baseUserEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import type { SetupServer } from 'msw/node';
+import type { SinonStub } from 'sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
+
+describe('ManageableAuthenticatorElement', () => {
+  const sandbox = useSandbox({ useFakeTimers: true });
+  const { clock } = sandbox;
+  const userEvent = baseUserEvent.setup({ advanceTimers: clock.tick });
+  let forceSubmit: SinonStub;
+  let server: SetupServer;
+
+  function createElement() {
+    document.body.innerHTML = `
+      <lg-manageable-authenticator
+        api-url="${window.location.origin}/api/manage"
+        configuration-name="configuration-name"
+        unique-id="configuration-123"
+        reauthenticate-at="2023-12-07T00:10:00.000Z"
+        reauthentication-url="#reauthenticate"
+      >
+        <script type="application/json" class="manageable-authenticator__strings">
+          {"renamed":"Renamed","delete_confirm":"Are you sure?","deleted":"Deleted"}
+        </script>
+        <div class="manageable-authenticator__edit" tabindex="-1" role="group" aria-labelledby="manageable-authenticator-manage-accessible-label-configuration-123">
+          <div class="usa-alert manageable-authenticator__alert" tabindex="-1" role="status">
+            <div class="usa-alert__body">
+              <p class="usa-alert__text"></p>
+            </div>
+          </div>
+          <form class="manageable-authenticator__rename">
+            <input class="manageable-authenticator__rename-input" aria-label="Nickname" value="configuration-name">
+            <lg-spinner-button class="manageable-authenticator__save-rename-button" long-wait-duration-ms="Infinity">
+              <button name="button" type="submit" class="usa-button">
+                <span class="spinner-button__content">Save</span>
+                <span class="spinner-dots spinner-dots--centered" aria-hidden="true">
+                  <span class="spinner-dots__dot"></span>
+                  <span class="spinner-dots__dot"></span>
+                  <span class="spinner-dots__dot"></span>
+                </span>
+              </button>
+              <div role="status" data-message="Saving…" class="spinner-button__action-message"></div>
+            </lg-spinner-button>
+            <button name="button" type="button" class="manageable-authenticator__cancel-rename-button">Cancel</button>
+          </div>
+        </form>
+        <div class="manageable-authenticator__details">
+          <span class="usa-sr-only">Nickname:</span>
+          <strong class="manageable-authenticator__name manageable-authenticator__details-name">
+            configuration-name
+          </strong>
+          <button name="button" type="button" class="manageable-authenticator__rename-button">Rename</button>
+          <lg-spinner-button class="manageable-authenticator__delete-button" long-wait-duration-ms="Infinity">
+            <button name="button" type="button" class="usa-button">
+              <span class="spinner-button__content">Delete</span>
+              <span class="spinner-dots spinner-dots--centered" aria-hidden="true">
+                <span class="spinner-dots__dot"></span>
+                <span class="spinner-dots__dot"></span>
+                <span class="spinner-dots__dot"></span>
+              </span>
+            </button>
+            <div role="status" data-message="Deleting…" class="spinner-button__action-message"></div>
+          </lg-spinner-button>
+          <button name="button" type="button" class="manageable-authenticator__done-button">Done</button>
+        </div>
+        <div class="manageable-authenticator__summary">
+          <div class="manageable-authenticator__name manageable-authenticator__summary-name">configuration-name</div>
+          <div class="manageable-authenticator__actions">
+            <button name="button" type="button" class="manageable-authenticator__manage-button">
+              <span aria-hidden="true">Manage</span>
+              <span class="usa-sr-only" id="manageable-authenticator-manage-accessible-label-configuration-123">
+                Manage <span class="manageable-authenticator__name">configuration-name</span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </lg-manageable-authenticator>
+    `;
+
+    return document.body.querySelector('lg-manageable-authenticator')!;
+  }
+
+  before(async () => {
+    forceSubmit = sandbox.stub();
+    quibble('@18f/identity-url', { forceSubmit });
+    await Promise.all([
+      import('./manageable-authenticator-element'),
+      import('@18f/identity-spinner-button/spinner-button-element'),
+    ]);
+    server = setupServer();
+    server.listen();
+  });
+
+  beforeEach(() => {
+    sandbox.clock.setSystemTime(new Date('2023-12-07T00:00:00Z'));
+    server.resetHandlers();
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  it('shows initial manage state', () => {
+    const element = createElement();
+
+    expect(element.classList.contains('manageable-authenticator--editing')).to.be.false();
+  });
+
+  context('when selected after reauthentication', () => {
+    beforeEach(() => {
+      jsdom.reconfigure({ url: 'http://example.test/?manage_authenticator=configuration-123' });
+    });
+
+    it('shows initial manage state', () => {
+      const initialHistoryLength = window.history.length;
+      sandbox.spy(HTMLElement.prototype, 'scrollIntoView');
+      const element = createElement();
+
+      expect(element.classList.contains('manageable-authenticator--editing')).to.be.true();
+      expect(window.location.href).to.equal('http://example.test/');
+      expect(window.history).to.have.lengthOf(initialHistoryLength);
+      expect(HTMLElement.prototype.scrollIntoView).to.have.been.called();
+    });
+  });
+
+  describe('clicking manage', () => {
+    it('toggles edit details', async () => {
+      const element = createElement();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+
+      const detailPanel = screen.getByRole('group');
+
+      await waitFor(() =>
+        expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+      );
+      expect(document.activeElement).to.equal(detailPanel);
+    });
+
+    context('with reauthentication required', () => {
+      beforeEach(() => {
+        sandbox.clock.setSystemTime(new Date('2023-12-07T15:00:00Z'));
+      });
+
+      it('redirects the user to reauthenticate', async () => {
+        createElement();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+
+        await expect(forceSubmit).to.eventually.be.calledWith('#reauthenticate');
+      });
+    });
+  });
+
+  describe('viewing manage details', () => {
+    it('cancels and returns focus to manage button when clicking done', async () => {
+      const element = createElement();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+      await waitFor(() =>
+        expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+      expect(element.classList.contains('manageable-authenticator--editing')).to.be.false();
+      expect(document.activeElement).to.equal(
+        screen.getByRole('button', { name: 'Manage configuration-name' }),
+      );
+    });
+
+    it('cancels and returns focus to manage button when pressing escape', async () => {
+      const element = createElement();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+      await waitFor(() =>
+        expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+      );
+
+      await userEvent.keyboard('{Escape}');
+      expect(element.classList.contains('manageable-authenticator--editing')).to.be.false();
+      expect(document.activeElement).to.equal(
+        screen.getByRole('button', { name: 'Manage configuration-name' }),
+      );
+    });
+  });
+
+  describe('renaming', () => {
+    it('focuses the input at the end of the current name', async () => {
+      const element = createElement();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+      await waitFor(() =>
+        expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+      const renameInput = screen.getByRole<HTMLInputElement>('textbox', { name: 'Nickname' });
+      expect(document.activeElement).to.equal(renameInput);
+
+      await userEvent.keyboard('appended');
+      expect(renameInput.value).to.equal('configuration-nameappended');
+    });
+
+    it('cancels (resets edit state) and returns focus to manage button when pressing escape', async () => {
+      const element = createElement();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+      await waitFor(() =>
+        expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+      expect(element.classList.contains('manageable-authenticator--renaming')).to.be.true();
+
+      await userEvent.keyboard('{Escape}');
+      expect(element.classList.contains('manageable-authenticator--editing')).to.be.false();
+      expect(element.classList.contains('manageable-authenticator--renaming')).to.be.false();
+      expect(document.activeElement).to.equal(
+        screen.getByRole('button', { name: 'Manage configuration-name' }),
+      );
+    });
+
+    context('successful response from server when submitting rename', () => {
+      beforeEach(() => {
+        server.use(
+          rest.put('/api/manage', (_req, res, ctx) =>
+            res(ctx.json({ success: true }), ctx.status(200)),
+          ),
+        );
+      });
+
+      it('returns the user to summary details with new name for successful save', async () => {
+        const element = createElement();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+        await waitFor(() =>
+          expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+        await userEvent.keyboard('-new');
+        const saveButton = screen.getByRole('button', { name: 'Save' });
+
+        // Check for spinning while saving
+        await userEvent.click(saveButton);
+        expect(saveButton.closest('.spinner-button--spinner-active')).to.exist();
+
+        // Change for ARIA live region content update
+        const alert = screen
+          .getAllByRole('status')
+          .find((candidate) => !candidate.closest('lg-spinner-button'))!;
+        expect(alert.textContent!.trim()).to.be.empty();
+        await waitFor(() => expect(alert.textContent!.trim()).to.equal('Renamed'));
+        expect(alert.classList.contains('usa-alert--success')).to.be.true();
+        expect(alert.classList.contains('usa-alert--error')).to.be.false();
+
+        // Check return to details
+        expect(element.classList.contains('manageable-authenticator--renaming')).to.be.false();
+        expect(element.classList.contains('manageable-authenticator--editing')).to.be.true();
+
+        // Check for focus target
+        const detailPanel = screen.getByRole('group', { name: 'Manage configuration-name-new' });
+        expect(document.activeElement).to.equal(detailPanel);
+
+        // Check for new name
+        expect(screen.getAllByText('configuration-name-new')).not.to.be.empty();
+
+        // Check for spinner button reset
+        await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+        expect(saveButton.closest('.spinner-button--spinner-active')).not.to.exist();
+      });
+    });
+
+    context('failed response from server when submitting rename', () => {
+      beforeEach(() => {
+        server.use(
+          rest.put('/api/manage', (_req, res, ctx) =>
+            res(ctx.json({ error: 'Uh oh!' }), ctx.status(400)),
+          ),
+        );
+      });
+
+      it('keeps the user on the rename panel and displays the received error', async () => {
+        const element = createElement();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+        await waitFor(() =>
+          expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+        await userEvent.keyboard('-new');
+        const saveButton = screen.getByRole('button', { name: 'Save' });
+        await userEvent.click(saveButton);
+
+        // Change for ARIA live region content update
+        const alert = screen
+          .getAllByRole('status')
+          .find((candidate) => !candidate.closest('lg-spinner-button'))!;
+        expect(alert.textContent!.trim()).to.be.empty();
+        await waitFor(() => expect(alert.textContent!.trim()).to.equal('Uh oh!'));
+        expect(alert.classList.contains('usa-alert--success')).to.be.false();
+        expect(alert.classList.contains('usa-alert--error')).to.be.true();
+
+        // Check still renaming
+        expect(element.classList.contains('manageable-authenticator--renaming')).to.be.true();
+        expect(element.classList.contains('manageable-authenticator--editing')).to.be.true();
+
+        // Check for focus target
+        expect(document.activeElement).to.equal(saveButton);
+
+        // Check that new name was not assigned
+        expect(screen.queryAllByText('configuration-name-new')).to.be.empty();
+
+        // Check for spinner button reset
+        expect(saveButton.closest('.spinner-button--spinner-active')).not.to.exist();
+      });
+    });
+
+    context('with reauthentication required', () => {
+      it('redirects the user to reauthenticate', async () => {
+        const element = createElement();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+        await waitFor(() =>
+          expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+        await userEvent.keyboard('-new');
+
+        sandbox.clock.setSystemTime(new Date('2023-12-07T15:00:00Z'));
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await expect(forceSubmit).to.eventually.be.calledWith('#reauthenticate');
+      });
+    });
+  });
+
+  describe('deleting', () => {
+    it('prompts the user and resets button if they cancel', async () => {
+      const element = createElement();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+      await waitFor(() =>
+        expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+      );
+
+      sandbox.stub(window, 'confirm').returns(false);
+      const deleteButton = screen.getByRole('button', { name: 'Delete' });
+      await userEvent.click(deleteButton);
+
+      expect(document.activeElement).to.equal(deleteButton);
+      expect(deleteButton.closest('.spinner-button--spinner-active')).not.to.exist();
+    });
+
+    context('successful response from server when deleting', () => {
+      beforeEach(() => {
+        server.use(
+          rest.delete('/api/manage', (_req, res, ctx) =>
+            res(ctx.json({ success: true }), ctx.status(200)),
+          ),
+        );
+      });
+
+      it('deletes the authenticator and displays a confirmation message', async () => {
+        const element = createElement();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+        await waitFor(() =>
+          expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+        );
+
+        sandbox.stub(window, 'confirm').returns(true);
+        const deleteButton = screen.getByRole('button', { name: 'Delete' });
+        await userEvent.click(deleteButton);
+
+        const alert = screen
+          .getAllByRole('status')
+          .find((candidate) => !candidate.closest('lg-spinner-button'))!;
+        expect(alert.textContent!.trim()).to.be.empty();
+        await waitFor(() => expect(alert.textContent!.trim()).to.equal('Deleted'));
+
+        expect(alert.classList.contains('usa-alert--success')).to.be.true();
+        expect(alert.classList.contains('usa-alert--error')).to.be.false();
+        expect(document.activeElement).to.equal(alert);
+        expect(element.classList.contains('manageable-authenticator--deleted')).to.be.true();
+      });
+    });
+
+    context('failed response from server when deleting', () => {
+      beforeEach(() => {
+        server.use(
+          rest.delete('/api/manage', (_req, res, ctx) =>
+            res(ctx.json({ error: 'Uh oh!' }), ctx.status(400)),
+          ),
+        );
+      });
+
+      it('displays the error message', async () => {
+        const element = createElement();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+        await waitFor(() =>
+          expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+        );
+
+        sandbox.stub(window, 'confirm').returns(true);
+        const deleteButton = screen.getByRole('button', { name: 'Delete' });
+        await userEvent.click(deleteButton);
+
+        const alert = screen
+          .getAllByRole('status')
+          .find((candidate) => !candidate.closest('lg-spinner-button'))!;
+        expect(alert.textContent!.trim()).to.be.empty();
+        await waitFor(() => expect(alert.textContent!.trim()).to.equal('Uh oh!'));
+
+        expect(alert.classList.contains('usa-alert--success')).to.be.false();
+        expect(alert.classList.contains('usa-alert--error')).to.be.true();
+        expect(document.activeElement).to.equal(deleteButton);
+        expect(deleteButton.closest('.spinner-button--spinner-active')).not.to.exist();
+        expect(element.classList.contains('manageable-authenticator--deleted')).to.be.false();
+      });
+    });
+
+    context('with reauthentication required', () => {
+      it('redirects the user to reauthenticate', async () => {
+        const element = createElement();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Manage configuration-name' }));
+        await waitFor(() =>
+          expect(element.classList.contains('manageable-authenticator--editing')).to.be.true(),
+        );
+
+        sandbox.stub(window, 'confirm').returns(true);
+        sandbox.clock.setSystemTime(new Date('2023-12-07T15:00:00Z'));
+        await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+        await expect(forceSubmit).to.eventually.be.calledWith('#reauthenticate');
+      });
+    });
+  });
+});

--- a/app/javascript/packages/manageable-authenticator/manageable-authenticator-element.ts
+++ b/app/javascript/packages/manageable-authenticator/manageable-authenticator-element.ts
@@ -1,0 +1,242 @@
+import { request } from '@18f/identity-request';
+import { forceSubmit } from '@18f/identity-url';
+import type { SpinnerButtonElement } from '@18f/identity-spinner-button/spinner-button-element';
+
+interface ErrorResponse {
+  error: string;
+}
+
+interface Strings {
+  renamed: string;
+
+  deleteConfirm: string;
+
+  deleted: string;
+}
+
+class ManageableAuthenticatorElement extends HTMLElement {
+  connectedCallback() {
+    this.manageButton.addEventListener('click', () => this.#handleManageClick());
+    this.doneButton.addEventListener('click', () => this.toggleEditing(false));
+    this.renameButton.addEventListener('click', () => this.toggleRenaming(true));
+    this.deleteButton.addEventListener('click', () => this.delete());
+    this.cancelRenameButton.addEventListener('click', () => this.toggleRenaming(false));
+    this.renameForm.addEventListener('submit', (event) => this.#handleRenameSubmit(event));
+    this.addEventListener('keydown', (event) => this.#handleKeyDown(event));
+
+    this.#editIfSelectedFromReauthentication();
+  }
+
+  get strings(): Strings {
+    return JSON.parse(this.querySelector('.manageable-authenticator__strings')!.textContent!);
+  }
+
+  get manageButton(): HTMLButtonElement {
+    return this.querySelector<HTMLButtonElement>('.manageable-authenticator__manage-button')!;
+  }
+
+  get doneButton(): HTMLButtonElement {
+    return this.querySelector<HTMLButtonElement>('.manageable-authenticator__done-button')!;
+  }
+
+  get editContainer(): HTMLElement {
+    return this.querySelector<HTMLElement>('.manageable-authenticator__edit')!;
+  }
+
+  get renameButton(): HTMLButtonElement {
+    return this.querySelector<HTMLButtonElement>('.manageable-authenticator__rename-button')!;
+  }
+
+  get deleteButton(): SpinnerButtonElement {
+    return this.querySelector<SpinnerButtonElement>('.manageable-authenticator__delete-button')!;
+  }
+
+  get renameInput(): HTMLInputElement {
+    return this.querySelector<HTMLInputElement>('.manageable-authenticator__rename-input')!;
+  }
+
+  get renameForm(): HTMLFormElement {
+    return this.querySelector<HTMLFormElement>('.manageable-authenticator__rename')!;
+  }
+
+  get saveRenameButton(): SpinnerButtonElement {
+    return this.querySelector<SpinnerButtonElement>(
+      '.manageable-authenticator__save-rename-button',
+    )!;
+  }
+
+  get cancelRenameButton(): HTMLButtonElement {
+    return this.querySelector<HTMLButtonElement>(
+      '.manageable-authenticator__cancel-rename-button',
+    )!;
+  }
+
+  get alert(): HTMLElement {
+    return this.querySelector<HTMLElement>('.manageable-authenticator__alert')!;
+  }
+
+  get uniqueId(): string {
+    return this.getAttribute('unique-id')!;
+  }
+
+  get apiURL(): string {
+    return this.getAttribute('api-url')!;
+  }
+
+  get reauthenticationURL(): string {
+    return this.getAttribute('reauthentication-url')!;
+  }
+
+  get reauthenticateAt(): Date {
+    return new Date(this.getAttribute('reauthenticate-at')!);
+  }
+
+  get name(): string {
+    return this.getAttribute('configuration-name')!;
+  }
+
+  set name(name: string) {
+    this.setAttribute('configuration-name', name);
+
+    this.querySelectorAll('.manageable-authenticator__name').forEach((nameElement) => {
+      nameElement.textContent = name;
+    });
+  }
+
+  toggleEditing(isEditing: boolean) {
+    this.toggleRenaming(false);
+
+    this.classList.toggle('manageable-authenticator--editing', isEditing);
+
+    const focusTarget = isEditing ? this.editContainer : this.manageButton;
+    focusTarget.focus();
+
+    this.#setAlertMessage(null);
+  }
+
+  toggleRenaming(isRenaming: boolean) {
+    this.classList.toggle('manageable-authenticator--renaming', isRenaming);
+
+    this.renameInput.value = this.name;
+
+    const focusTarget = isRenaming ? this.renameInput : this.editContainer;
+    focusTarget.focus();
+
+    if (isRenaming) {
+      this.renameInput.setSelectionRange(
+        this.renameInput.value.length,
+        this.renameInput.value.length,
+      );
+    }
+
+    this.#setAlertMessage(null);
+  }
+
+  async delete() {
+    // Disable reason: This is an intentional user-facing confirmation prompt.
+    /* eslint-disable-next-line no-alert */
+    if (!window.confirm(this.strings.deleteConfirm)) {
+      this.deleteButton.toggleSpinner(false);
+      return;
+    }
+
+    await this.#checkForReauthentication();
+
+    const response = await request(this.apiURL, { method: 'DELETE', read: false });
+    if (response.ok) {
+      this.classList.add('manageable-authenticator--deleted');
+      this.#setAlertMessage(this.strings.deleted, { type: 'success' });
+      this.alert.focus();
+    } else {
+      const { error } = (await response.json()) as ErrorResponse;
+      this.deleteButton.toggleSpinner(false);
+      this.#setAlertMessage(error, { type: 'error' });
+    }
+  }
+
+  #isReauthenticationRequired() {
+    return this.reauthenticateAt < new Date();
+  }
+
+  #editIfSelectedFromReauthentication() {
+    const url = new URL(window.location.href);
+    const selectedAuthenticator = url.searchParams.get('manage_authenticator');
+
+    if (selectedAuthenticator === this.uniqueId) {
+      this.toggleEditing(true);
+      url.searchParams.delete('manage_authenticator');
+      window.history.replaceState(null, '', url.toString());
+      this.editContainer.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' });
+    }
+  }
+
+  #setAlertMessage(message: string | null, { type }: { type?: 'error' | 'success' } = {}) {
+    this.classList.toggle('manageable-authenticator--alert-visible', !!message);
+    if (message) {
+      this.alert.classList.toggle('usa-alert--error', type === 'error');
+      this.alert.classList.toggle('usa-alert--success', type === 'success');
+      this.alert.querySelector('.usa-alert__text')!.textContent = message;
+    }
+  }
+
+  #handleKeyDown(event: KeyboardEvent) {
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault();
+        this.toggleEditing(false);
+        break;
+
+      default:
+    }
+  }
+
+  async #handleManageClick() {
+    await this.#checkForReauthentication();
+    this.toggleEditing(true);
+  }
+
+  async #handleRenameSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    await this.#checkForReauthentication();
+    const name = this.renameInput.value;
+    const response = await request(this.apiURL, {
+      method: 'PUT',
+      json: { name },
+      read: false,
+    });
+
+    this.saveRenameButton.toggleSpinner(false);
+
+    if (response.ok) {
+      this.name = name;
+      this.toggleRenaming(false);
+      this.editContainer.focus();
+      this.#setAlertMessage(this.strings.renamed, { type: 'success' });
+    } else {
+      const { error } = (await response.json()) as ErrorResponse;
+      this.#setAlertMessage(error, { type: 'error' });
+    }
+  }
+
+  #checkForReauthentication(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.#isReauthenticationRequired()) {
+        forceSubmit(this.reauthenticationURL);
+      } else {
+        resolve();
+      }
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lg-manageable-authenticator': ManageableAuthenticatorElement;
+  }
+}
+
+if (!customElements.get('lg-manageable-authenticator')) {
+  customElements.define('lg-manageable-authenticator', ManageableAuthenticatorElement);
+}
+
+export default ManageableAuthenticatorElement;

--- a/app/javascript/packages/manageable-authenticator/package.json
+++ b/app/javascript/packages/manageable-authenticator/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@18f/identity-manageable-authenticator",
+  "version": "1.0.0",
+  "private": true
+}

--- a/app/javascript/packages/spinner-button/spinner-button-element.spec.ts
+++ b/app/javascript/packages/spinner-button/spinner-button-element.spec.ts
@@ -9,16 +9,21 @@ describe('SpinnerButtonElement', () => {
   const { clock } = sandbox;
   const userEvent = baseUserEvent.setup({ advanceTimers: clock.tick });
 
-  const longWaitDurationMs = 1000;
-
   interface WrapperOptions {
     actionMessage?: string;
     spinOnClick?: boolean;
     inForm?: boolean;
     isButtonTo?: boolean;
+    longWaitDurationMs?: number;
   }
 
-  function createWrapper({ actionMessage, spinOnClick, inForm, isButtonTo }: WrapperOptions = {}) {
+  function createWrapper({
+    actionMessage,
+    spinOnClick,
+    inForm,
+    isButtonTo,
+    longWaitDurationMs = 1000,
+  }: WrapperOptions = {}) {
     let button = `
       <button class="usa-button">
         <span class="spinner-button__content">Click Me</span>
@@ -141,7 +146,8 @@ describe('SpinnerButtonElement', () => {
   });
 
   it('shows action message visually after long delay', async () => {
-    const wrapper = createWrapper({ actionMessage: 'Verifying...' });
+    const longWaitDurationMs = 1000;
+    const wrapper = createWrapper({ actionMessage: 'Verifying...', longWaitDurationMs });
     const status = getByRole(wrapper, 'status');
     const button = screen.getByRole('button', { name: 'Click Me' });
 
@@ -152,6 +158,16 @@ describe('SpinnerButtonElement', () => {
     expect(status.classList.contains('usa-sr-only')).to.be.true();
     clock.tick(1);
     expect(status.classList.contains('usa-sr-only')).to.be.false();
+  });
+
+  it('does not show visual action message when given infinite delay', async () => {
+    const longWaitDurationMs = Infinity;
+    createWrapper({ actionMessage: 'Verifying...', longWaitDurationMs });
+    const button = screen.getByRole('button', { name: 'Click Me' });
+
+    sandbox.spy(window, 'setTimeout');
+    await userEvent.click(button);
+    expect(window.setTimeout).not.to.have.been.called();
   });
 
   it('supports external dispatched events to control spinner', () => {

--- a/app/javascript/packages/spinner-button/spinner-button-element.ts
+++ b/app/javascript/packages/spinner-button/spinner-button-element.ts
@@ -4,11 +4,6 @@ interface SpinnerButtonElements {
   actionMessage: HTMLElement;
 }
 
-/**
- * Default time after which to show action message, in milliseconds.
- */
-const DEFAULT_LONG_WAIT_DURATION_MS = 15000;
-
 export class SpinnerButtonElement extends HTMLElement {
   elements: SpinnerButtonElements;
 
@@ -57,7 +52,7 @@ export class SpinnerButtonElement extends HTMLElement {
    * Time after which to show action message, in milliseconds.
    */
   get longWaitDurationMs(): number {
-    return Number(this.getAttribute('long-wait-duration-ms')) || DEFAULT_LONG_WAIT_DURATION_MS;
+    return Number(this.getAttribute('long-wait-duration-ms'));
   }
 
   showSpinner = () => this.toggleSpinner(true);
@@ -77,7 +72,7 @@ export class SpinnerButtonElement extends HTMLElement {
     }
 
     window.clearTimeout(this.#longWaitTimeout);
-    if (isVisible) {
+    if (isVisible && Number.isFinite(this.longWaitDurationMs)) {
       this.#longWaitTimeout = window.setTimeout(
         () => this.handleLongWait(),
         this.longWaitDurationMs,

--- a/app/javascript/packages/url/force-submit.spec.ts
+++ b/app/javascript/packages/url/force-submit.spec.ts
@@ -1,0 +1,62 @@
+import type { SinonSpy } from 'sinon';
+import { useSandbox } from '@18f/identity-test-helpers';
+import forceSubmit from './force-submit';
+
+describe('forceSubmit', () => {
+  const sandbox = useSandbox();
+
+  beforeEach(() => {
+    sandbox.stub(HTMLFormElement.prototype, 'submit');
+  });
+
+  it('removes unload protection and submits with default method', () => {
+    sandbox.stub(window, 'onbeforeunload');
+    sandbox.stub(window, 'onunload');
+
+    forceSubmit('/example');
+
+    expect(HTMLFormElement.prototype.submit).to.have.been.called();
+    expect(window.onbeforeunload).to.be.null();
+    expect(window.onunload).to.be.null();
+    const call = (HTMLFormElement.prototype.submit as SinonSpy).getCall(0);
+    const form: HTMLFormElement = call.thisValue;
+    expect(form.method).to.equal('post');
+    expect(form.action).to.equal(new URL('/example', window.location.href).toString());
+    const csrfInput = form.querySelector<HTMLInputElement>('[name="authenticity_token"]');
+    expect(csrfInput).to.be.null();
+    const methodInput = form.querySelector<HTMLInputElement>('[name="_method"]');
+    expect(methodInput).to.be.null();
+  });
+
+  context('with method', () => {
+    it('submits with provided method', () => {
+      forceSubmit('/example', { method: 'PUT' });
+
+      const call = (HTMLFormElement.prototype.submit as SinonSpy).getCall(0);
+      const form: HTMLFormElement = call.thisValue;
+      expect(form.method).to.equal('post');
+      const methodInput = form.querySelector<HTMLInputElement>('[name="_method"]');
+      expect(methodInput!.value).to.equal('PUT');
+      expect(methodInput!.type).to.equal('hidden');
+    });
+  });
+
+  context('with csrf token present', () => {
+    beforeEach(() => {
+      const csrfMeta = document.createElement('meta');
+      csrfMeta.name = 'csrf-token';
+      csrfMeta.content = 'csrf-token-value';
+      document.body.appendChild(csrfMeta);
+    });
+
+    it('submits with CSRF token', () => {
+      forceSubmit('/example');
+
+      const call = (HTMLFormElement.prototype.submit as SinonSpy).getCall(0);
+      const form: HTMLFormElement = call.thisValue;
+      const csrfInput = form.querySelector<HTMLInputElement>('[name="authenticity_token"]');
+      expect(csrfInput!.value).to.equal('csrf-token-value');
+      expect(csrfInput!.type).to.equal('hidden');
+    });
+  });
+});

--- a/app/javascript/packages/url/force-submit.ts
+++ b/app/javascript/packages/url/force-submit.ts
@@ -1,0 +1,44 @@
+import removeUnloadProtection from './remove-unload-protection';
+
+type RequestMethod = 'POST' | 'PUT' | 'DELETE';
+
+interface SubmitOptions {
+  method?: RequestMethod;
+}
+
+/**
+ * Submits a form to the given URL, bypassing any confirmation prompts that may exist to prevent the
+ * user from leaving.
+ *
+ * @param url Destination URL.
+ * @param options.method Request method.
+ */
+function forceSubmit(url: string, { method }: SubmitOptions = {}) {
+  removeUnloadProtection();
+
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = url;
+  document.body.appendChild(form);
+
+  const csrfToken = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content;
+  if (csrfToken) {
+    const csrfInput = document.createElement('input');
+    csrfInput.type = 'hidden';
+    csrfInput.name = 'authenticity_token';
+    csrfInput.value = csrfToken;
+    form.appendChild(csrfInput);
+  }
+
+  if (method) {
+    const methodInput = document.createElement('input');
+    methodInput.type = 'hidden';
+    methodInput.name = '_method';
+    methodInput.value = method;
+    form.appendChild(methodInput);
+  }
+
+  form.submit();
+}
+
+export default forceSubmit;

--- a/app/javascript/packages/url/index.ts
+++ b/app/javascript/packages/url/index.ts
@@ -1,5 +1,6 @@
 export { default as addSearchParams } from './add-search-params';
 export { default as forceRedirect } from './force-redirect';
+export { default as forceSubmit } from './force-submit';
 export { default as removeUnloadProtection } from './remove-unload-protection';
 
 export type { Navigate } from './force-redirect';

--- a/app/views/accounts/_webauthn_platform.html.erb
+++ b/app/views/accounts/_webauthn_platform.html.erb
@@ -2,24 +2,23 @@
   <%= t('account.index.webauthn_platform') %>
 </h2>
 
-<div class="border-bottom border-primary-light">
-  <% MfaContext.new(current_user).webauthn_platform_configurations.each do |cfg| %>
-    <div class="grid-row padding-1 border-top border-left border-right border-primary-light">
-      <div class="grid-col-8 tablet:grid-col-6 truncate">
-        <%= cfg.name %>
-      </div>
-      <% if MfaPolicy.new(current_user).multiple_factors_enabled? %>
-        <div class="grid-col-4 tablet:grid-col-6 text-right">
-          <%= link_to(
-                t('account.index.webauthn_platform_delete'),
-                webauthn_setup_delete_path(id: cfg.id),
-              ) %>
-        </div>
-      <% end %>
-    </div>
-    <div class="clearfix"></div>
+<div role="list">
+  <% MfaContext.new(current_user).webauthn_platform_configurations.each do |configuration| %>
+    <%= render ManageableAuthenticatorComponent.new(
+          configuration:,
+          user_session:,
+          manage_url: edit_webauthn_path(id: configuration.id),
+          manage_api_url: api_internal_two_factor_authentication_webauthn_path(id: configuration.id),
+          custom_strings: {
+            deleted: t('two_factor_authentication.webauthn_platform.deleted'),
+            renamed: t('two_factor_authentication.webauthn_platform.renamed'),
+            manage_accessible_label: t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+          },
+          role: 'list-item',
+        ) %>
   <% end %>
 </div>
+
 <%= render ButtonComponent.new(
       action: ->(**tag_options, &block) do
         link_to(webauthn_setup_path(platform: true), **tag_options, &block)

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -59,7 +59,6 @@ en:
       webauthn_platform: Face or touch unlock
       webauthn_platform_add: Add face or touch unlock
       webauthn_platform_confirm_delete: Yes, remove face or touch unlock
-      webauthn_platform_delete: Remove face or touch unlock
     items:
       delete_your_account: Delete your account
       personal_key: Personal key

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -60,7 +60,6 @@ es:
       webauthn_platform: El desbloqueo facial o táctil
       webauthn_platform_add: Añadir el desbloqueo facial o táctil
       webauthn_platform_confirm_delete: Si, quitar el desbloqueo facial o táctil
-      webauthn_platform_delete: Quitar el desbloqueo facial o táctil
     items:
       delete_your_account: Eliminar su cuenta
       personal_key: Clave personal

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -64,8 +64,6 @@ fr:
       webauthn_platform_add: Ajouter le déverouillage facial ou déverrouillage par empreinte digitale
       webauthn_platform_confirm_delete: Oui, supprimer le déverouillage facial ou
         déverrouillage par empreinte digitale
-      webauthn_platform_delete: Supprimer le déverouillage facial ou déverrouillage
-        par empreinte digitale
     items:
       delete_your_account: Supprimer votre compte
       personal_key: Clé personnelle

--- a/config/locales/components/en.yml
+++ b/config/locales/components/en.yml
@@ -19,6 +19,21 @@ en:
       enabled_alert: You have enabled JavaScript in your browser.
       next_step: Please refresh this page once you have enabled JavaScript in your
         browser.
+    manageable_authenticator:
+      cancel: Cancel
+      created_on: Created on %{date}
+      delete: Delete
+      delete_confirm: Are you sure you want to delete this authentication method?
+      deleted: Successfully deleted an authentication method
+      deleting: Deleting…
+      done: Done
+      manage: Manage
+      manage_accessible_label: Manage authentication method
+      nickname: Nickname
+      rename: Rename
+      renamed: Successfully renamed your authentication method
+      save: Save
+      saving: Saving…
     memorable_date:
       day: Day
       errors:

--- a/config/locales/components/es.yml
+++ b/config/locales/components/es.yml
@@ -19,6 +19,21 @@ es:
       enabled_alert: YHabilitó el JavaScript en su navegador.
       next_step: Recargue esta página una vez que haya habilitado JavaScript en su
         navegador.
+    manageable_authenticator:
+      cancel: Cancelar
+      created_on: Creado el %{date}
+      delete: Borrar
+      delete_confirm: ¿Está seguro que desea eliminar este método de autenticación?
+      deleted: Se ha eliminado correctamente un método de autenticación.
+      deleting: Eliminando…
+      done: Terminado
+      manage: Administrar
+      manage_accessible_label: Gestionar método de autenticación
+      nickname: Apodo
+      rename: Cambiar el nombre
+      renamed: Se ha cambiado correctamente el nombre de su método de autenticación.
+      save: Guardar
+      saving: Guardando…
     memorable_date:
       day: Día
       errors:

--- a/config/locales/components/fr.yml
+++ b/config/locales/components/fr.yml
@@ -19,6 +19,21 @@ fr:
       enabled_alert: Vous avez activé JavaScript dans votre navigateur.
       next_step: Veuillez rafraîchir cette page une fois que vous avez activé
         JavaScript dans votre navigateur.
+    manageable_authenticator:
+      cancel: Annuler
+      created_on: Créé le %{date}
+      delete: Effacer
+      delete_confirm: Êtes-vous sûr de vouloir supprimer cette méthode d’authentification?
+      deleted: Suppression réussie d’une méthode d’authentification
+      deleting: Suppression en cours…
+      done: Terminé
+      manage: Administrer
+      manage_accessible_label: Gérer la méthode d’authentification
+      nickname: Pseudo
+      rename: Renommer
+      renamed: Votre méthode d’authentification a été renommée avec succès
+      save: Sauvegarder
+      saving: Sauvegarde en cours…
     memorable_date:
       day: Jour
       errors:

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -195,6 +195,7 @@ en:
       delete: Delete this device
       deleted: Successfully deleted a face or touch unlock method
       edit_heading: Manage your face or touch unlock settings
+      manage_accessible_label: Manage face or touch unlock
       nickname: Nickname
       renamed: Successfully renamed your face or touch unlock method
     webauthn_platform_header_text: Use face or touch unlock

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -208,6 +208,7 @@ es:
       delete: Eliminar este dispositivo
       deleted: Se ha eliminado correctamente un método de desbloqueo facial o táctil
       edit_heading: Gestione su configuración de desbloqueo facial o táctil
+      manage_accessible_label: Gestionar desbloqueo facial o táctil
       nickname: Apodo
       renamed: Se ha cambiado correctamente el nombre de su método de desbloqueo
         facial o táctil

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -220,6 +220,8 @@ fr:
         faciale ou par empreinte digitale
       edit_heading: Gérez vos paramètres de déverrouillage par reconnaissance faciale
         ou par empreinte digitale
+      manage_accessible_label: Gérer le déverrouillage par reconnaissance faciale ou
+        par empreinte digitale
       nickname: Pseudo
       renamed: Votre méthode de déverrouillage par reconnaissance faciale ou par
         empreinte digitale a été renommée avec succès

--- a/spec/components/manageable_authenticator_component_spec.rb
+++ b/spec/components/manageable_authenticator_component_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe ManageableAuthenticatorComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:configuration_name) { 'Example Configuration' }
+  let(:configuration) { create(:webauthn_configuration, name: configuration_name) }
+  let(:user_session) { {} }
+  let(:reauthenticate_at) { Time.zone.now }
+  let(:manage_api_url) { '/api/manage' }
+  let(:manage_url) { '/manage' }
+  let(:options) { { configuration:, user_session:, manage_api_url:, manage_url: } }
+  let(:component) { ManageableAuthenticatorComponent.new(**options) }
+  subject(:rendered) { render_inline component }
+
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  before do
+    auth_methods_session = instance_double('AuthMethodsSession', reauthenticate_at:)
+    allow(component).to receive(:auth_methods_session).and_return(auth_methods_session)
+  end
+
+  it 'renders with initializing attributes' do
+    rendered
+
+    element = page.find_css('lg-manageable-authenticator').first
+
+    expect(element.attr('api-url')).to eq(manage_api_url)
+    expect(element.attr('configuration-name')).to eq(configuration_name)
+    expect(element.attr('unique-id')).to eq(component.unique_id)
+    expect(element.attr('reauthenticate-at')).to eq(reauthenticate_at.iso8601)
+    expect(element.attr('reauthentication-url')).to eq(component.reauthentication_url)
+  end
+
+  it 'renders with initializing javascript strings' do
+    rendered
+
+    strings_element = page.find_css(
+      'script.manageable-authenticator__strings[type="application/json"]',
+      visible: false,
+    ).first
+
+    expect(JSON.parse(strings_element.text, symbolize_names: true)).to eq(
+      renamed: t('components.manageable_authenticator.renamed'),
+      deleteConfirm: t('components.manageable_authenticator.delete_confirm'),
+      deleted: t('components.manageable_authenticator.deleted'),
+    )
+  end
+
+  it 'renders with focusable edit panel' do
+    rendered
+
+    edit_element = page.find_css('.manageable-authenticator__edit').first
+
+    expect(edit_element.attr('tabindex')).to be_present
+    expect(edit_element).to have_name(
+      format(
+        '%s: %s',
+        t('components.manageable_authenticator.manage_accessible_label'),
+        configuration.name,
+      ),
+    )
+  end
+
+  it 'initializes content with configuration details' do
+    expect(rendered).to have_field(
+      t('components.manageable_authenticator.nickname'),
+      with: configuration_name,
+    )
+    expect(rendered).to have_content(configuration_name)
+    expect(rendered).to have_content(
+      t(
+        'components.manageable_authenticator.created_on',
+        date: l(configuration.created_at, format: :event_date),
+      ),
+    )
+  end
+
+  it 'renders with buttons that have accessibly distinct manage label' do
+    expect(rendered).to have_button(
+      format(
+        '%s: %s',
+        t('components.manageable_authenticator.manage_accessible_label'),
+        configuration.name,
+      ),
+    )
+  end
+
+  describe '#reauthentication_url' do
+    subject(:reauthentication_url) { component.reauthentication_url }
+
+    it 'includes manage_authenticator query parameter for configuration' do
+      rendered
+
+      uri = URI.parse(reauthentication_url)
+      params = CGI.parse(uri.query)
+
+      expect(uri.path).to eq(account_reauthentication_path)
+      expect(params['manage_authenticator']).to eq(["webauthnconfiguration-#{configuration.id}"])
+    end
+  end
+
+  describe '#unique_id' do
+    subject(:unique_id) { component.unique_id }
+
+    it 'derives an id from the configuration class and id' do
+      rendered
+
+      expect(component.unique_id).to eq("webauthnconfiguration-#{configuration.id}")
+    end
+  end
+
+  describe '#strings' do
+    it 'includes default strings' do
+      rendered
+
+      expect(component.strings).to eq(
+        renamed: t('components.manageable_authenticator.renamed'),
+        delete_confirm: t('components.manageable_authenticator.delete_confirm'),
+        deleted: t('components.manageable_authenticator.deleted'),
+        manage_accessible_label: t('components.manageable_authenticator.manage_accessible_label'),
+      )
+    end
+
+    context 'with custom strings' do
+      let(:custom_rename_string) { 'custom rename string' }
+      let(:custom_strings) { { renamed: custom_rename_string } }
+      let(:options) do
+        { configuration:, user_session:, manage_api_url:, manage_url:, custom_strings: }
+      end
+
+      it 'overrides the default strings with provided custom strings' do
+        rendered
+
+        expect(component.strings).to eq(
+          renamed: custom_rename_string,
+          delete_confirm: t('components.manageable_authenticator.delete_confirm'),
+          deleted: t('components.manageable_authenticator.deleted'),
+          manage_accessible_label: t('components.manageable_authenticator.manage_accessible_label'),
+        )
+      end
+
+      context 'with custom manage accessible label' do
+        let(:custom_manage_accessible_label) { 'Manage' }
+        let(:custom_strings) { { manage_accessible_label: custom_manage_accessible_label } }
+
+        it 'overrides button label and affected linked content' do
+          manage_label = format('%s: %s', custom_manage_accessible_label, configuration.name)
+          expect(rendered).to have_button(manage_label)
+          edit_element = page.find_css('.manageable-authenticator__edit').first
+          expect(edit_element).to have_name(manage_label)
+        end
+      end
+    end
+  end
+end

--- a/spec/components/spinner_button_component_spec.rb
+++ b/spec/components/spinner_button_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SpinnerButtonComponent, type: :component do
-  it 'renders a button with the given content and tag options' do
+  it 'renders a button with the given content and button options' do
     render_inline SpinnerButtonComponent.new(
       outline: true,
       data: { foo: 'bar' },
@@ -20,6 +20,16 @@ RSpec.describe SpinnerButtonComponent, type: :component do
   it 'renders without spin-on-click attribute by default' do
     render_inline SpinnerButtonComponent.new.with_content('hi')
     expect(page).to_not have_selector('[spin-on-click]')
+  end
+
+  it 'renders default long-duration-wait-ms attribute' do
+    render_inline SpinnerButtonComponent.new.with_content('')
+
+    element = page.find_css('lg-spinner-button').first
+
+    expect(element['long-wait-duration-ms']).to eq(
+      SpinnerButtonComponent::DEFAULT_LONG_WAIT_DURATION.in_milliseconds.to_s,
+    )
   end
 
   context 'with action message' do
@@ -44,6 +54,38 @@ RSpec.describe SpinnerButtonComponent, type: :component do
     it 'renders spin-on-click attribute' do
       render_inline SpinnerButtonComponent.new(spin_on_click: true).with_content('')
       expect(page).to have_selector('[spin-on-click=true]')
+    end
+  end
+
+  context 'with custom long wait duration' do
+    it 'renders with customized long-duration-wait-ms attribute' do
+      render_inline SpinnerButtonComponent.new(long_wait_duration: 1.second).with_content('')
+
+      element = page.find_css('lg-spinner-button').first
+
+      expect(element['long-wait-duration-ms']).to eq('1000')
+    end
+  end
+
+  context 'with wrapper options' do
+    it 'renders wrapper with given options' do
+      render_inline SpinnerButtonComponent.new(
+        wrapper_options: { data: { foo: 'bar' } },
+        outline: true,
+      ).with_content('')
+
+      expect(page).to have_css('lg-spinner-button[data-foo="bar"]')
+    end
+
+    context 'with outline button' do
+      it 'renders with both customized class and outline class' do
+        rendered = render_inline SpinnerButtonComponent.new(
+          wrapper_options: { class: 'example-class' },
+          outline: true,
+        ).with_content('')
+
+        expect(rendered).to have_css('lg-spinner-button.example-class.spinner-button--outline')
+      end
     end
   end
 end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe AccountsController do
     before(:each) do
       stub_sign_in(user)
     end
+
     it 'redirects to 2FA options' do
       post :reauthentication
 
@@ -194,6 +195,29 @@ RSpec.describe AccountsController do
       post :reauthentication
 
       expect(controller.user_session[:stored_location]).to eq account_url
+    end
+
+    context 'with parameters' do
+      let(:params) { { foo: 'bar' } }
+
+      it 'sets stored location excluding unknown parameters' do
+        post :reauthentication, params: params
+
+        expect(controller.user_session[:stored_location]).to eq account_url
+      end
+
+      context 'with permitted parameters' do
+        let(:manage_authenticator_param) { 'abc-123' }
+        let(:params) { { foo: 'bar', manage_authenticator: manage_authenticator_param } }
+
+        it 'sets stored location including only permitted parameters' do
+          post :reauthentication, params: params
+
+          expect(controller.user_session[:stored_location]).to eq(
+            account_url(manage_authenticator: manage_authenticator_param),
+          )
+        end
+      end
     end
   end
 end

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -94,23 +94,6 @@ RSpec.describe 'webauthn management' do
       expect(user.reload.webauthn_configurations.empty?).to eq(true)
     end
 
-    it 'allows the user to cancel deletion of the security key' do
-      webauthn_config = create(:webauthn_configuration, user: user)
-
-      sign_in_and_2fa_user(user)
-      visit account_two_factor_authentication_path
-
-      expect(page).to have_content webauthn_config.name
-
-      click_link t('account.index.webauthn_delete')
-
-      expect(current_path).to eq webauthn_setup_delete_path
-
-      click_link t('links.cancel')
-
-      expect(page).to have_content webauthn_config.name
-    end
-
     it 'prevents a user from deleting the last key' do
       webauthn_config = create(:webauthn_configuration, user: user)
 
@@ -184,52 +167,145 @@ RSpec.describe 'webauthn management' do
 
     it 'allows user to delete a platform authenticator when another 2FA option is set up' do
       webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+      name = webauthn_config.name
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
 
-      expect(page).to have_content webauthn_config.name
+      expect(page).to have_content(name)
 
-      click_link t('account.index.webauthn_platform_delete')
+      click_link(
+        format(
+          '%s: %s',
+          t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+          name,
+        ),
+      )
 
-      expect(current_path).to eq webauthn_setup_delete_path
+      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
 
-      click_button t('account.index.webauthn_platform_confirm_delete')
+      click_button t('two_factor_authentication.webauthn_platform.delete')
 
-      expect(page).to_not have_content webauthn_config.name
-      expect(page).to have_content t('notices.webauthn_platform_deleted')
+      expect(page).to_not have_content(name)
+      expect(page).to have_content(t('two_factor_authentication.webauthn_platform.deleted'))
       expect(user.reload.webauthn_configurations.empty?).to eq(true)
+    end
+
+    it 'allows user to rename a platform authenticator' do
+      webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+      name = webauthn_config.name
+
+      sign_in_and_2fa_user(user)
+      visit account_two_factor_authentication_path
+
+      expect(page).to have_content(name)
+
+      click_link(
+        format(
+          '%s: %s',
+          t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+          name,
+        ),
+      )
+
+      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_field(
+        t('two_factor_authentication.webauthn_platform.nickname'),
+        with: name,
+      )
+
+      fill_in t('two_factor_authentication.webauthn_platform.nickname'), with: 'new name'
+
+      click_button t('two_factor_authentication.webauthn_platform.change_nickname')
+
+      expect(page).to have_content('new name')
+      expect(page).to have_content(t('two_factor_authentication.webauthn_platform.renamed'))
     end
 
     it 'allows the user to cancel deletion of the platform authenticator' do
       webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+      name = webauthn_config.name
 
       sign_in_and_2fa_user(user)
       visit account_two_factor_authentication_path
 
-      expect(page).to have_content webauthn_config.name
+      expect(page).to have_content(name)
 
-      click_link t('account.index.webauthn_platform_delete')
+      click_link(
+        format(
+          '%s: %s',
+          t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+          name,
+        ),
+      )
 
-      expect(current_path).to eq webauthn_setup_delete_path
+      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
 
       click_link t('links.cancel')
 
-      expect(page).to have_content webauthn_config.name
+      expect(page).to have_content(name)
     end
 
     it 'prevents a user from deleting the last key' do
       webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+      name = webauthn_config.name
 
       sign_in_and_2fa_user(user)
       PhoneConfiguration.first.update(mfa_enabled: false)
       user.backup_code_configurations.destroy_all
 
-      visit account_two_factor_authentication_path
-      expect(current_path).to eq account_two_factor_authentication_path
+      expect(page).to have_content(name)
 
-      expect(page).to have_content webauthn_config.name
-      expect(page).to_not have_link t('account.index.webauthn_platform_delete')
+      click_link(
+        format(
+          '%s: %s',
+          t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+          name,
+        ),
+      )
+
+      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+
+      click_button t('two_factor_authentication.webauthn_platform.delete')
+
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_content(t('errors.manage_authenticator.remove_only_method_error'))
+      expect(user.reload.webauthn_configurations.empty?).to eq(false)
+    end
+
+    it 'requires a user to use a unique name when renaming' do
+      webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+      create(:webauthn_configuration, :platform_authenticator, user:, name: 'existing')
+      name = webauthn_config.name
+
+      sign_in_and_2fa_user(user)
+
+      expect(page).to have_content(name)
+
+      click_link(
+        format(
+          '%s: %s',
+          t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+          name,
+        ),
+      )
+
+      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_field(
+        t('two_factor_authentication.webauthn_platform.nickname'),
+        with: name,
+      )
+
+      fill_in t('two_factor_authentication.webauthn_platform.nickname'), with: 'existing'
+
+      click_button t('two_factor_authentication.webauthn_platform.change_nickname')
+
+      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_field(
+        t('two_factor_authentication.webauthn_platform.nickname'),
+        with: 'existing',
+      )
+      expect(page).to have_content(t('errors.manage_authenticator.unique_name_error'))
     end
 
     it 'gives an error if name is taken and stays on the configuration screen' do
@@ -249,6 +325,124 @@ RSpec.describe 'webauthn management' do
 
       expect(current_path).to eq webauthn_setup_path
       expect(page).to have_content t('errors.webauthn_platform_setup.unique_name')
+    end
+
+    context 'with javascript enabled', :js do
+      it 'allows user to delete a platform authenticator when another 2FA option is set up' do
+        webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+        name = webauthn_config.name
+
+        sign_in_and_2fa_user(user)
+        visit account_two_factor_authentication_path
+
+        expect(page).to have_content(name)
+
+        click_button(
+          format(
+            '%s: %s',
+            t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+            name,
+          ),
+        )
+
+        # Verify user can cancel deletion. There's an implied assertion here that the button becomes
+        # clickable again, since the following confirmation occurs upon successive button click.
+        dismiss_confirm(wait: 5) { click_button t('components.manageable_authenticator.delete') }
+
+        # Verify user confirms deletion
+        accept_confirm(wait: 5) { click_button t('components.manageable_authenticator.delete') }
+
+        expect(page).to have_content(
+          t('two_factor_authentication.webauthn_platform.deleted'),
+          wait: 5,
+        )
+        expect(page).to_not have_content(name)
+        expect(user.reload.webauthn_configurations.empty?).to eq(true)
+      end
+
+      it 'allows user to rename a platform authenticator' do
+        webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+        name = webauthn_config.name
+
+        sign_in_and_2fa_user(user)
+        visit account_two_factor_authentication_path
+
+        expect(page).to have_content(name)
+
+        click_button(
+          format(
+            '%s: %s',
+            t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+            name,
+          ),
+        )
+        click_button t('components.manageable_authenticator.rename')
+
+        expect(page).to have_field(t('components.manageable_authenticator.nickname'), with: name)
+
+        fill_in t('components.manageable_authenticator.nickname'), with: 'new name'
+
+        click_button t('components.manageable_authenticator.save')
+
+        expect(page).to have_content(
+          t('two_factor_authentication.webauthn_platform.renamed'),
+          wait: 5,
+        )
+        expect(page).to have_content('new name')
+      end
+
+      it 'prevents a user from deleting the last key', allow_browser_log: true do
+        webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+        name = webauthn_config.name
+
+        sign_in_and_2fa_user(user)
+        PhoneConfiguration.first.update(mfa_enabled: false)
+        user.backup_code_configurations.destroy_all
+
+        expect(page).to have_content(name)
+
+        click_button(
+          format(
+            '%s: %s',
+            t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+            name,
+          ),
+        )
+        accept_confirm(wait: 5) { click_button t('components.manageable_authenticator.delete') }
+
+        expect(page).to have_content(
+          t('errors.manage_authenticator.remove_only_method_error'),
+          wait: 5,
+        )
+        expect(user.reload.webauthn_configurations.empty?).to eq(false)
+      end
+
+      it 'requires a user to use a unique name when renaming', allow_browser_log: true do
+        webauthn_config = create(:webauthn_configuration, :platform_authenticator, user:)
+        create(:webauthn_configuration, :platform_authenticator, user:, name: 'existing')
+        name = webauthn_config.name
+
+        sign_in_and_2fa_user(user)
+
+        expect(page).to have_content(name)
+
+        click_button(
+          format(
+            '%s: %s',
+            t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
+            name,
+          ),
+        )
+        click_button t('components.manageable_authenticator.rename')
+
+        expect(page).to have_field(t('components.manageable_authenticator.nickname'), with: name)
+
+        fill_in t('components.manageable_authenticator.nickname'), with: 'existing'
+
+        click_button t('components.manageable_authenticator.save')
+
+        expect(page).to have_content(t('errors.manage_authenticator.unique_name_error'), wait: 5)
+      end
     end
   end
 end

--- a/spec/javascript/spec_helper.d.ts
+++ b/spec/javascript/spec_helper.d.ts
@@ -1,5 +1,8 @@
-import { expect as _expect } from 'chai';
+import type { expect as _expect } from 'chai';
+import type { JSDOM } from 'jsdom';
 
 declare global {
   const expect: typeof _expect;
+
+  const jsdom: JSDOM;
 }

--- a/spec/javascript/spec_helper.js
+++ b/spec/javascript/spec_helper.js
@@ -18,6 +18,7 @@ global.expect = chai.expect;
 // Emulate a DOM, since many modules will assume the presence of these globals exist as a side
 // effect of their import.
 const dom = createDOM();
+global.jsdom = dom;
 global.window = dom.window;
 const windowGlobals = Object.fromEntries(
   Object.getOwnPropertyNames(window)

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -130,7 +130,7 @@ RSpec::Matchers.define :have_description do |description|
 end
 
 RSpec::Matchers.define :have_name do |name|
-  match { |element| AccessibleName.new(page:).computed_name(element) == name }
+  match { |element| AccessibleName.new(page:).computed_name(element).strip == name.strip }
 
   failure_message do |element|
     <<-STR.squish

--- a/spec/views/accounts/_webauthn_platform.html.erb_spec.rb
+++ b/spec/views/accounts/_webauthn_platform.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'accounts/_webauthn_platform.html.erb' do
+  let(:user) do
+    create(
+      :user,
+      webauthn_configurations: create_list(:webauthn_configuration, 2, :platform_authenticator),
+    )
+  end
+  let(:user_session) { { auth_events: [] } }
+
+  subject(:rendered) { render partial: 'accounts/webauthn_platform' }
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:user_session).and_return(user_session)
+  end
+
+  it 'renders a list of platform authenticators' do
+    expect(rendered).to have_selector('[role="list"] [role="list-item"]', count: 2)
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11454](https://cm-jira.usa.gov/browse/LG-11454)

## 🛠 Summary of changes

Adds the option for a user to manage (rename or delete) a Face or Touch Unlock authenticator from within the account dashboard, managed inline without the need to navigate to a separate screen.

## 📜 Testing Plan

1. (Prerequisite) Have an account with Face or Touch Unlock
2. Go to http://localhost:3000
3. Sign in
4. On account dashboard, click "Manage" for Face or Touch Unlock
5. Observe that you are able to manage the authenticator inline
6. Disable JavaScript and repeat steps 4 and 5, verifying that there is feature parity in the no-JavaScript experience

## 👀 Screenshots

https://github.com/18F/identity-idp/assets/1779930/d9a47290-589b-413a-8c97-47bbfa40929e
