### PR TITLE
LG-11667: Add FE Tests for Selfie Feature

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -8,6 +8,7 @@ function FullScreenLoadingSpinner({ fullScreenRef, onRequestClose, fullScreenLab
     <FullScreen ref={fullScreenRef} label={fullScreenLabel} onRequestClose={onRequestClose}>
       <img
         src={getAssetPath('loading-badge.gif')}
+        aria-label="loading spinner"
         alt=""
         width="144"
         height="144"

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -1113,6 +1113,25 @@ describe('document-capture/components/acuant-capture', () => {
     });
   });
 
+  context('mobile selfie', () => {
+    it('renders the selfie capture loading div in acuant-capture', async () => {
+      // What we want to test is that the selfie version of the FileInput appears
+      // when the name="selfie". The only difference between the selfie and document
+      // versions is what happens when you click the FileInput, so this test clicks
+      // the file input, then checks the id of the resulting full screen div
+      const { queryByRole, getByLabelText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+            <AcuantCapture label="Image" name="selfie" isReady />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      await userEvent.click(getByLabelText('Image'));
+      expect(queryByRole('img', { name: 'loading spinner' })).to.be.ok();
+    });
+  });
+
   it('optionally disallows upload', () => {
     const { getByText } = render(
       <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">

--- a/spec/javascript/packages/document-capture/components/acuant-selfie-camera-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-selfie-camera-spec.jsx
@@ -1,0 +1,68 @@
+import { AcuantContextProvider, DeviceContext } from '@18f/identity-document-capture';
+import AcuantSelfieCamera from '@18f/identity-document-capture/components/acuant-selfie-camera';
+import AcuantSelfieCaptureCanvas from '@18f/identity-document-capture/components/acuant-selfie-capture-canvas';
+import { render, useAcuant } from '../../../support/document-capture';
+
+describe('document-capture/components/acuant-selfie-camera', () => {
+  const { initialize } = useAcuant();
+
+  it('waits for initialization', () => {
+    render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+          <AcuantSelfieCamera>
+            <AcuantSelfieCaptureCanvas />
+          </AcuantSelfieCamera>
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
+    );
+
+    // At this point, it's assumed `window.AcuantPassivelivenss.start` has not been called. This can't be
+    // asserted, since the global is only assigned as part of `initialize` itself. But we can rely
+    // on the fact that if it was called, an error would be thrown, and the test would fail.
+
+    initialize();
+
+    expect(window.AcuantPassiveLiveness.start.calledOnce).to.be.true();
+
+    const callbacks = window.AcuantPassiveLiveness.start.getCall(0).args[0];
+    const callbackNames = Object.keys(callbacks).sort;
+    const expectedCallbackNames = [
+      'onDetectorInitialized',
+      'onDetection',
+      'onOpened',
+      'onClosed',
+      'onError',
+      'onPhotoTaken',
+      'onPhotoRetake',
+      'onCaptured',
+    ].sort;
+    expect(callbackNames).to.equal(expectedCallbackNames);
+
+    expect(window.AcuantPassiveLiveness.start.getCall(0).args[1]).to.deep.equal({
+      FACE_NOT_FOUND: 'FACE NOT FOUND',
+      TOO_MANY_FACES: 'TOO MANY FACES',
+      FACE_ANGLE_TOO_LARGE: 'FACE ANGLE TOO LARGE',
+      PROBABILITY_TOO_SMALL: 'PROBABILITY TOO SMALL',
+      FACE_TOO_SMALL: 'FACE TOO SMALL',
+      FACE_CLOSE_TO_BORDER: 'TOO CLOSE TO THE FRAME'
+    });
+  });
+
+  it('ends on unmount', () => {
+    const { unmount } = render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+          <AcuantSelfieCamera>
+            <AcuantSelfieCaptureCanvas />
+          </AcuantSelfieCamera>
+        </AcuantContextProvider>
+      </DeviceContext.Provider>,
+    );
+
+    initialize();
+    unmount();
+
+    expect(window.AcuantPassiveLiveness.end.calledOnce).to.be.true();
+  });
+});

--- a/spec/javascript/packages/document-capture/components/acuant-selfie-capture-canvas-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-selfie-capture-canvas-spec.jsx
@@ -1,0 +1,30 @@
+import AcuantSelfieCaptureCanvas from '@18f/identity-document-capture/components/acuant-selfie-capture-canvas';
+import { AcuantContext, DeviceContext } from '@18f/identity-document-capture';
+import { render } from '../../../support/document-capture';
+
+// It shows the loading spinner when the script hasn't loaded
+it('shows the loading spinner when the script hasnt loaded', () => {
+  const { queryByRole, container } = render(
+    <DeviceContext.Provider value={{ isMobile: true }}>
+      <AcuantContext.Provider value={{ isReady: false }}>
+        <AcuantSelfieCaptureCanvas />
+      </AcuantContext.Provider>
+    </DeviceContext.Provider>,
+  );
+
+  expect(queryByRole('img', { name: 'loading spinner' })).to.be.ok();
+  expect(container.querySelector('#acuant-face-capture-container')).to.not.exist();
+});
+
+it('shows the acunt div when the script has loaded', () => {
+  const { queryByRole, container } = render(
+    <DeviceContext.Provider value={{ isMobile: true }}>
+      <AcuantContext.Provider value={{ isReady: true }}>
+        <AcuantSelfieCaptureCanvas />
+      </AcuantContext.Provider>
+    </DeviceContext.Provider>,
+  );
+
+  expect(queryByRole('img', { name: 'loading spinner' })).to.not.exist();
+  expect(container.querySelector('#acuant-face-capture-container')).to.exist();
+});

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.jsx
@@ -15,14 +15,16 @@ import { render } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
 
 describe('document-capture/components/documents-step', () => {
-  it('renders with front and back inputs', () => {
-    const { getByLabelText } = render(<DocumentsStep />);
+  it('renders with only front and back inputs by default', () => {
+    const { getByLabelText, queryByLabelText } = render(<DocumentsStep />);
 
     const front = getByLabelText('doc_auth.headings.document_capture_front');
     const back = getByLabelText('doc_auth.headings.document_capture_back');
+    const selfie = queryByLabelText('doc_auth.headings.document_capture_selfie');
 
     expect(front).to.be.ok();
     expect(back).to.be.ok();
+    expect(selfie).to.not.exist();
   });
 
   it('calls onChange callback with uploaded image', async () => {
@@ -146,6 +148,31 @@ describe('document-capture/components/documents-step', () => {
       );
       const { queryByRole } = render(<App />);
       expect(queryByRole('heading', { name: 'doc_auth.not_ready.header', level: 2 })).to.be.null();
+    });
+  });
+
+  context('selfie capture', () => {
+    it('renders with front, back, and selfie inputs when featureflag is on', () => {
+      const App = composeComponents(
+        [
+          FeatureFlagContext.Provider,
+          {
+            value: {
+              selfieCaptureEnabled: true,
+            },
+          },
+        ],
+        [DocumentsStep],
+      );
+      const { getByLabelText, queryByLabelText } = render(<App />);
+
+      const front = getByLabelText('doc_auth.headings.document_capture_front');
+      const back = getByLabelText('doc_auth.headings.document_capture_back');
+      const selfie = queryByLabelText('doc_auth.headings.document_capture_selfie');
+
+      expect(front).to.be.ok();
+      expect(back).to.be.ok();
+      expect(selfie).to.be.ok();
     });
   });
 });

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -166,13 +166,37 @@ describe('document-capture/components/review-issues-step', () => {
     expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
   });
 
-  it('renders with front and back inputs', async () => {
-    const { getByLabelText, getByRole } = render(<ReviewIssuesStep {...DEFAULT_PROPS} />);
+  it('renders with only front and back inputs only by default', async () => {
+    const { getByLabelText, queryByLabelText, getByRole } = render(
+      <ReviewIssuesStep {...DEFAULT_PROPS} />,
+    );
 
     await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
 
     expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
     expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
+    expect(queryByLabelText('doc_auth.headings.document_capture_selfie')).to.not.exist();
+  });
+
+  it('renders with front, back, and selfie inputs when featureflag', async () => {
+    const App = composeComponents(
+      [
+        FeatureFlagContext.Provider,
+        {
+          value: {
+            selfieCaptureEnabled: true,
+          },
+        },
+      ],
+      [ReviewIssuesStep, DEFAULT_PROPS],
+    );
+    const { getByLabelText, queryByLabelText, getByRole } = render(<App />);
+
+    await userEvent.click(getByRole('button', { name: 'idv.failure.button.warning' }));
+
+    expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
+    expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
+    expect(queryByLabelText('doc_auth.headings.document_capture_selfie')).to.be.ok();
   });
 
   it('calls onChange callback with uploaded image', async () => {

--- a/spec/javascript/support/document-capture.jsx
+++ b/spec/javascript/support/document-capture.jsx
@@ -60,6 +60,7 @@ export function useAcuant() {
     delete window.AcuantJavascriptWebSdk;
     delete window.AcuantCamera;
     delete window.AcuantCameraUI;
+    delete window.AcuantPassiveLiveness;
     delete window.loadAcuantSdk;
   });
 
@@ -91,6 +92,7 @@ export function useAcuant() {
         }),
         end,
       };
+      window.AcuantPassiveLiveness = { start: sinon.stub(), end: sinon.stub() };
       window.loadAcuantSdk = () => {};
       const sdkScript = document.querySelector('[data-acuant-sdk]');
       sdkScript.onload();


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-11667

## 🛠 Summary of changes

This PR adds tests for the selfie feature added in LG-11377 ([PR #9580](https://github.com/18F/identity-idp/pull/9580))

## 📜 Testing Plan

This PR only adds automated tests on the FE so the testing plan is `yarn test` and make sure everything passes. However, I'm more interested in whether these tests provide us with good coverage. Specifically around the `document-capture` component.
