### PR TITLE
LG 11479 relabel form field to Backup code

### DIFF
--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -120,7 +120,7 @@ en:
       totp_step_3: Scan this QR barcode with your app
       totp_step_4: Enter the temporary code from your app
     two_factor:
-      backup_code: Security code
+      backup_code: Backup code
       personal_key: Personal key
       try_again: Use another phone number
     validation:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -127,7 +127,7 @@ es:
       totp_step_3: Escanee este código de barras QR con su aplicación
       totp_step_4: Ingrese el código temporal de su aplicación
     two_factor:
-      backup_code: Código de seguridad
+      backup_code: Código de respaldo
       personal_key: Clave personal
       try_again: Use otro número de teléfono.
     validation:

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -129,7 +129,7 @@ fr:
       totp_step_3: Scannez ce code-barres QR avec votre application
       totp_step_4: Entrez le code temporaire de votre application
     two_factor:
-      backup_code: Code de sécurité
+      backup_code: Code de sauvegarde
       personal_key: Clé personnelle
       try_again: Utilisez un autre numéro de téléphone
     validation:


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-11479](https://cm-jira.usa.gov/browse/LG-11479)


## 🛠 Summary of changes

Revision to translated text for Backup code label. From 'Security code' to 'Backup code'


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Sign in to account on http://localhost:3000 with Backup codes as MFA method
- [ ] Observe the label above the backup codes field now reads "Backup code" instead of "Security code"

## 👀 Screenshots

Before:
![Screenshot 2023-11-29 at 10 26 45 AM (2)](https://github.com/18F/identity-idp/assets/135744319/1c909b2c-d01d-4273-ae7e-260772a8b861)

After:
![Screenshot 2023-11-29 at 10 24 24 AM (2)](https://github.com/18F/identity-idp/assets/135744319/c76b57be-398c-498b-bffa-0a8ade2d5171)


