### PR TITLE
Update deprecated action_dispatch test option

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :memory_store
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
   config.action_controller.allow_forgery_protection = false
   config.active_support.test_order = :random
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes the following deprecation:

```
DEPRECATION WARNING: Setting action_dispatch.show_exceptions to false is deprecated. Set to :none instead. (called from call_with_excludes at /builds/lg/identity-idp/config/initializers/rack_timeout.rb:22)
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
