### PR TITLE
LG-11463 idv_session methods for phone step started, complete, invalid

### DIFF
--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -27,7 +27,7 @@ module Idv
       )
 
       if result.success?
-        idv_session.user_phone_confirmation = true
+        idv_session.mark_phone_step_complete!
         save_in_person_notification_phone
         flash[:success] = t('idv.messages.enter_password.phone_verified')
         redirect_to idv_enter_password_url

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -41,6 +41,7 @@ module Idv
 
     def create
       clear_future_steps!
+      idv_session.invalidate_phone_step!
       result = idv_form.submit(step_params)
       Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
         call(:verify_phone, :update, result.success?)

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -130,10 +130,8 @@ module Idv
     end
 
     def update_idv_session
-      idv_session.address_verification_mechanism = :phone
       idv_session.applicant = applicant
-      idv_session.vendor_phone_confirmation = true
-      idv_session.user_phone_confirmation = false
+      idv_session.mark_phone_step_started!
 
       ProofingComponent.find_or_create_by(user: idv_session.current_user).
         update(address_check: 'lexis_nexis_address')

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -210,11 +210,6 @@ module Idv
       session[:resolution_successful] = nil
     end
 
-    def invalidate_steps_after_verify_info!
-      session[:address_verification_mechanism] = 'phone'
-      invalidate_phone_step!
-    end
-
     def invalidate_phone_step!
       session[:vendor_phone_confirmation] = nil
       session[:user_phone_confirmation] = nil

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -210,7 +210,18 @@ module Idv
       session[:resolution_successful] = nil
     end
 
+    def mark_phone_step_started!
+      session[:address_verification_mechanism] = :phone
+      session[:vendor_phone_confirmation] = true
+      session[:user_phone_confirmation] = false
+    end
+
+    def mark_phone_step_complete!
+      session[:user_phone_confirmation] = true
+    end
+
     def invalidate_phone_step!
+      session[:address_verification_mechanism] = nil
       session[:vendor_phone_confirmation] = nil
       session[:user_phone_confirmation] = nil
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11463](https://cm-jira.usa.gov/browse/LG-11463)
 
## 🛠 Summary of changes

Add idv_session methods to mark phone step started (user passed lexis_nexis in phone_controller), mark it complete (user entered correct code in otp_verification_controller) and mark it invalid (user just submitted request for a code, starting background job to query lexis_nexis).

We mark the phone step invalid at the beginning of create to follow the same pattern as the verify_info_controllers. We clear prior attempts at the beginning, and then the background job marks the step complete when it succeeds.

## 📜 Testing Plan

- [ ] Primarily specs, since this is refactoring
- [ ] Create account, start IdV
- [ ] Try to jump ahead to /verify/phone before submitting verify info, expect to remain on current page
- [ ] Try to jump ahead to /verify/phone_confirmation before submitting verify info, expect to remain on current page
- [ ] Try to jump ahead to /verify/phone_confirmation from phone page before clicking submit, expect to remain on phone page
- [ ] Enter correct code, expect to proceed to enter password
- [ ] Try clicking browser back button, expect to go back
- [ ] Resubmit phone page and enter correct code, expect to proceed to enter password
