### PR TITLE
Made `ReactivateAccountSession#decrypted_pii` use the `password_reset_profile` id when fetching Pii

### DIFF
--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -1,6 +1,8 @@
 class ReactivateAccountSession
   SESSION_KEY = :reactivate_account
 
+  attr_reader :user
+
   def initialize(user:, user_session:)
     @user = user
     @session = user_session
@@ -28,7 +30,7 @@ class ReactivateAccountSession
   # @param [Pii::Attributes]
   def store_decrypted_pii(pii)
     reactivate_account_session[:validated_personal_key] = true
-    Pii::Cacher.new(@user, session).save_decrypted_pii(pii, @user.password_reset_profile.id)
+    Pii::Cacher.new(user, session).save_decrypted_pii(pii, user.password_reset_profile.id)
     nil
   end
 
@@ -40,7 +42,7 @@ class ReactivateAccountSession
   # @return [Pii::Attributes, nil]
   def decrypted_pii
     return unless validated_personal_key?
-    Pii::Cacher.new(@user, session).fetch(@user.password_reset_profile.id)
+    Pii::Cacher.new(user, session).fetch(user.password_reset_profile.id)
   end
 
   private

--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -40,7 +40,7 @@ class ReactivateAccountSession
   # @return [Pii::Attributes, nil]
   def decrypted_pii
     return unless validated_personal_key?
-    Pii::Cacher.new(@user, session).fetch
+    Pii::Cacher.new(@user, session).fetch(@user.password_reset_profile.id)
   end
 
   private

--- a/spec/services/reactivate_account_session_spec.rb
+++ b/spec/services/reactivate_account_session_spec.rb
@@ -81,15 +81,23 @@ RSpec.describe ReactivateAccountSession do
   end
 
   describe '#decrypted_pii' do
+    let(:pii_cacher) { Pii::Cacher.new(user, user_session) }
+
+    before do
+      allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
+      allow(pii_cacher).to receive(:fetch).and_call_original
+    end
+
     it 'returns nil as a default' do
       expect(@reactivate_account_session.decrypted_pii).to eq(nil)
     end
 
-    it 'returns the pii stored in the session' do
+    it 'returns the pii stored in the session by way of the password reset profile' do
       pii = Pii::Attributes.new(first_name: 'Test')
       @reactivate_account_session.store_decrypted_pii(pii)
 
       expect(@reactivate_account_session.decrypted_pii).to eq(pii)
+      expect(pii_cacher).to have_received(:fetch).with(user.password_reset_profile.id)
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11548](https://cm-jira.usa.gov/browse/LG-11548)

## 🛠 Summary of changes

- Changed call to `Pii::Cacher#fetch` to use the `password_reset_profile` id.
- Added controller specs to verify that behavior
- Verified via debug logging that the feature spec for recovery with a personal key uses the correct profile id.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify that all specs pass. Inspect the output to verify that the new controller specs ran and passed.
- [ ] Add Rails logging at the top of `Pii::Cacher#fetch` to display its arguments
- [ ] Running locally, create an account and proceed through IdV,  being sure to note your personal key. Log out, click 'forgot my password', change your password, and log back in.
- [ ] Click the 'Reactivate your profile now` link.
- [ ] Using the Rails console, find your user and note their `password_reset_profile`.
- [ ] Switch back to the app, and finish profile recovery using your personal key.
- [ ] Inspect the Rails log output to verify that the correct profile ID was passed in to `Pii::Cacher#fetch`

Code block to be added to `Pii::Cacher#fetch` for testing:
```
# DEBUG CODE
logger.debug "Pii::Cacher#fetch(#{profile_id.inspect})"
```
