### PR TITLE
Add no-JavaScript tracking for Sign In page

### DIFF
--- a/app/components/javascript_required_component.html.erb
+++ b/app/components/javascript_required_component.html.erb
@@ -16,7 +16,7 @@
 
     <p><strong><%= t('components.javascript_required.next_step') %></strong></p>
   <% end %>
-  <link rel="stylesheet" href="<%= no_js_detect_css_path %>">
+  <link rel="stylesheet" href="<%= no_js_detect_css_path(location:) %>">
 </noscript>
 <div class="js">
   <% if was_no_js? %>

--- a/app/components/javascript_required_component.rb
+++ b/app/components/javascript_required_component.rb
@@ -1,7 +1,7 @@
 class JavascriptRequiredComponent < BaseComponent
   include LinkHelper
 
-  attr_reader :header, :intro
+  attr_reader :header, :location, :intro
 
   BROWSER_RESOURCES = [
     { name: 'Google Chrome', url: 'https://support.google.com' },
@@ -10,8 +10,9 @@ class JavascriptRequiredComponent < BaseComponent
     { name: 'Apple Safari', url: 'https://support.apple.com/safari' },
   ].to_set.freeze
 
-  def initialize(header:, intro: nil)
+  def initialize(header:, location:, intro: nil)
     @header = header
+    @location = location
     @intro = intro
   end
 

--- a/app/controllers/no_js_controller.rb
+++ b/app/controllers/no_js_controller.rb
@@ -3,6 +3,7 @@ class NoJsController < ApplicationController
 
   def index
     session[SESSION_KEY] = true
+    analytics.no_js_detect_stylesheet_loaded(location: params[:location])
     render body: '', content_type: 'text/css'
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3381,6 +3381,12 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String] location Placement location
+  # Logged when a browser with JavaScript disabled loads the detection stylesheet
+  def no_js_detect_stylesheet_loaded(location:, **extra)
+    track_event(:no_js_detect_stylesheet_loaded, location:, **extra)
+  end
+
   # @param [Boolean] success
   # @param [String] client_id
   # @param [Boolean] client_id_parameter_present

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -84,3 +84,5 @@
         ) %>
   </p>
 <% end %>
+
+<noscript><link rel="stylesheet" href="<%= no_js_detect_css_path(location: :sign_in) %>"></noscript>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -12,6 +12,7 @@
   <%= render JavascriptRequiredComponent.new(
         header: t('idv.welcome.no_js_header'),
         intro: t('idv.welcome.no_js_intro', sp_name: decorated_sp_session.sp_name || APP_NAME),
+        location: :idv_welcome,
       ) do %>
 
   <%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.welcome')) %>

--- a/spec/components/javascript_required_component_spec.rb
+++ b/spec/components/javascript_required_component_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe JavascriptRequiredComponent, type: :component do
 
   let(:header) { 'You must enable JavaScript' }
   let(:intro) { nil }
+  let(:location) { 'example' }
   let(:content) { 'JavaScript-required content' }
 
   subject(:rendered) do
-    render_inline described_class.new(header:, intro:).with_content(content)
+    render_inline described_class.new(header:, intro:, location:).with_content(content)
   end
 
   it 'renders instructions to enable JavaScript' do
@@ -25,7 +26,7 @@ RSpec.describe JavascriptRequiredComponent, type: :component do
   end
 
   it 'loads css resource for setting session key in JavaScript-disabled environments' do
-    expect(rendered).to have_css("noscript link[href='#{no_js_detect_css_path}']")
+    expect(rendered).to have_css("noscript link[href='#{no_js_detect_css_path(location:)}']")
   end
 
   context 'with intro' do
@@ -49,7 +50,7 @@ RSpec.describe JavascriptRequiredComponent, type: :component do
     it 'only renders the alert once' do
       rendered
 
-      second_rendered = render_inline described_class.new(header:)
+      second_rendered = render_inline described_class.new(header:, location:)
 
       expect(second_rendered).not_to have_content(t('components.javascript_required.enabled_alert'))
     end

--- a/spec/controllers/no_js_controller_spec.rb
+++ b/spec/controllers/no_js_controller_spec.rb
@@ -2,7 +2,12 @@ require 'rails_helper'
 
 RSpec.describe NoJsController do
   describe '#index' do
-    subject(:response) { get :index }
+    let(:location) { 'example' }
+    subject(:response) { get :index, params: { location: } }
+
+    before do
+      stub_analytics
+    end
 
     it 'returns empty css' do
       expect(response.content_type.split(';').first).to eq('text/css')
@@ -13,6 +18,12 @@ RSpec.describe NoJsController do
       response
 
       expect(session[NoJsController::SESSION_KEY]).to eq(true)
+    end
+
+    it 'logs an event' do
+      response
+
+      expect(@analytics).to have_logged_event(:no_js_detect_stylesheet_loaded, location:)
     end
   end
 end

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe 'devise/sessions/new.html.erb' do
     )
   end
 
+  it 'includes tracking script for no-JavaScript' do
+    render
+
+    expect(rendered).to have_css(
+      "link[rel='stylesheet'][href='#{no_js_detect_css_path(location: :sign_in)}']",
+      visible: false,
+    )
+  end
+
   context 'when SP is present' do
     let(:sp) do
       build_stubbed(


### PR DESCRIPTION
## 🛠 Summary of changes

Adds event logging for the `NoJsController` route, and includes it within the sign-in page.

**Why?**

- So we can better understand use-cases where a user disables JavaScript in their browser

## 📜 Testing Plan

1. Run `make_watch` in a separate terminal process
2. Visit http://localhost:3000
3. Observe `"Sign in page visited"` event is logged, but not `"no_js_detect_stylesheet_loaded"`
4. Disable JavaScript in your browser
5. Visit http://localhost:3000
3. Observe both `"Sign in page visited"` and `"no_js_detect_stylesheet_loaded"` events are logged