### PR TITLE
Support symbols in changelog message subcategory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Replace `[Category]`, `[Subcategory]`, and `[Description]` with text relevant fo
    - **Bug Fixes** are corrections to a broken behavior, such as preventing a raised exception.
    - **Internal** are changes which benefit the Login.gov team, such as analytics or code quality.
    - **Upcoming Features** are iterations contributing to a feature which has not yet been enabled for users in production.
-- **Subcategory** does not have any restrictions, but you should try to maintain consistency with changesets affecting similar parts of the application (for example, "In-person proofing").
+- **Subcategory** can be any value, but it cannot contain commas. Try to maintain consistency with changesets affecting similar parts of the application (for example, "In-person proofing").
 - **Description** is a plain language description of the specific changes.
 
 If multiple pull requests iterate on the same feature, it's a good idea to use the same commit message, since identical messages will be combined into a single entry when the release notes are compiled.

--- a/scripts/changelog_check.rb
+++ b/scripts/changelog_check.rb
@@ -3,7 +3,7 @@ require 'open3'
 require 'optparse'
 
 CHANGELOG_REGEX =
-  %r{^(?:\* )?changelog: ?(?<category>[\w -]{2,}), ?(?<subcategory>[\w -]{2,}), ?(?<change>.+)$}i
+  %r{^(?:\* )?changelog: ?(?<category>[\w -]{2,}), ?(?<subcategory>[^,]{2,}), ?(?<change>.+)$}i
 CATEGORIES = [
   'User-Facing Improvements',
   'Bug Fixes',

--- a/spec/fixtures/git_log_changelog.yml
+++ b/spec/fixtures/git_log_changelog.yml
@@ -106,6 +106,18 @@ commit_changelog_capitalized:
   pr_number: '7000'
   commit_messages:
     - 'ChAngElOg: Internal, Changelog, Improve changelog tool flexibility for commit messages'
+commit_changelog_symbols:
+  commit_log: |
+    title: Support symbols in changelog message subcategory (#9697)
+    body:changelog: Internal, Build Tooling (Changelog Script), Support symbols in changelog message subcategory
+    DELIMITER
+  title: Support symbols in changelog message subcategory (#9697)
+  category: Internal
+  subcategory: Build Tooling (Changelog Script)
+  change: Support symbols in changelog message subcategory
+  pr_number: '9697'
+  commit_messages:
+    - 'changelog: Internal, Build Tooling (Changelog Script), Support symbols in changelog message subcategory'
 commit_changelog_whitespace:
   commit_log: |
     title: Improve changelog tool flexibility for commit messages (#7000)

--- a/spec/scripts/changelog_check_spec.rb
+++ b/spec/scripts/changelog_check_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'scripts/changelog_check' do
     it 'builds a git log into structured changelog objects' do
       git_log = git_fixtures.values.pluck('commit_log').join("\n")
       changelog_entries = generate_changelog(git_log)
-      expect(changelog_entries.length).to eq 9
+      expect(changelog_entries.length).to eq 10
       fixture_and_changelog = git_fixtures.values.filter do |x|
         x['category'].present?
       end.zip(changelog_entries)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates changelog script to support use of more symbols in subcategories. Previously, this was limited to `\w -` (most alphanumeric, underscore, dash, and spaces). The current logic allows for everything other than commas.

Related Slack conversation: https://gsa-tts.slack.com/archives/C05MGJ72GU9/p1701709507202099

## 📜 Testing Plan

The commit of this pull request is self-verifying, so observe that build passes.