### PR TITLE
Fix Lint Problem in `main`

### DIFF
--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -64,8 +64,9 @@ function webauthn() {
         (document.getElementById('client_data_json') as HTMLInputElement).value =
           result.clientDataJSON;
         if (result.authenticatorDataFlagsValue) {
-          (document.getElementById('authenticator_data_value') as HTMLInputElement).value =
-            `${result.authenticatorDataFlagsValue}`;
+          (
+            document.getElementById('authenticator_data_value') as HTMLInputElement
+          ).value = `${result.authenticatorDataFlagsValue}`;
         }
         if (result.transports) {
           (document.getElementById('transports') as HTMLInputElement).value =


### PR DESCRIPTION
## In Progress ##

When we run `make lint` in the CI, the result is different than when I run it locally. For instance, on this PR right now `make lint` fails in CI and succeeds locally. I'm assuming this is a version problem. Here's the CI failure:

```shell
--- eslint ---
yarn run lint
yarn run v1.22.19
$ eslint . --ext .js,.jsx,.ts,.tsx
/builds/lg/identity-idp/app/javascript/packs/webauthn-setup.ts
  67:12  error  Replace `⏎············document.getElementById('authenticator_data_value')·as·HTMLInputElement` with `document.getElementById('authenticator_data_value')·as·HTMLInputElement).value·=`  prettier/prettier
  69:11  error  Replace `).value·=` with `·`                                                                                                                                                            prettier/prettier
✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
error Command failed with exit code 1.
```

## 🎫 Ticket

This is pre-work for the linting exploration that's part of [LG-11654](https://cm-jira.usa.gov/browse/LG-11654).

## 🛠 Summary of changes

When you run `yarn lint` (or `make lint`) on main there's an error in `webauthn-setup.ts` this fixes that error.

## 📜 Testing Plan

- [ ] Check that you see the error on `main` by doing `git checkout main` and `make lint`.
    - [ ] You should get two errors in `webauthn-setup.ts`
- [ ] Check that you don't get those errors on this branch by doing `git checkout charley/fix-codebase-lint-problem` `make lint`
    - [ ] You should get no errors.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
