### PR TITLE
LG-11551 Read the correct PII for resend letter

### DIFF
--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -112,12 +112,17 @@ module Idv
 
       def confirmation_maker_perform
         confirmation_maker = GpoConfirmationMaker.new(
-          pii: Pii::Cacher.new(current_user, user_session).fetch,
+          pii: pii,
           service_provider: current_sp,
           profile: current_user.pending_profile,
         )
         confirmation_maker.perform
         confirmation_maker
+      end
+
+      def pii
+        Pii::Cacher.new(current_user, user_session).
+          fetch(current_user.gpo_verification_pending_profile.id)
       end
 
       def send_reminder

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Idv::ByMail::RequestLetterController do
 
     context 'resending a letter' do
       let(:has_pending_profile) { true }
-      let(:pending_profile) { create(:profile, :verify_by_mail_pending) }
+      let(:pending_profile) { create(:profile, :with_pii, :verify_by_mail_pending) }
 
       before do
         stub_sign_in(user)
@@ -245,9 +245,9 @@ RSpec.describe Idv::ByMail::RequestLetterController do
   end
 
   def expect_resend_letter_to_send_letter_and_redirect(otp:)
-    pii = { first_name: 'Samuel', last_name: 'Sampson' }
+    pii = pending_profile.decrypt_pii(user.password).to_h
     pii_cacher = instance_double(Pii::Cacher)
-    allow(pii_cacher).to receive(:fetch).and_return(pii)
+    allow(pii_cacher).to receive(:fetch).with(pending_profile.id).and_return(pii)
     allow(pii_cacher).to receive(:exists_in_session?).and_return(true)
     allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-11551](https://cm-jira.usa.gov/browse/LG-11551)


<!--
## 🛠 Summary of changes

Changed `Pii::Cacher#fetch` to use a `gpo_verification_pending_profile` when a user wants to resend a letter.
-->


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through Idv with and select verify by mail (changing the address to `1 GPO PENDING PROFILE ST.` helps to identify)
- [ ] Once the pending GPO profile is created go to rails console and create a duplicate profile and set `gpo_verification_pending_at = nil` for visibility purposes you can also change the pii of the address (console commands listed below).
- [ ] On the enter code screen select "Send me another letter" and request another letter.
- [ ] Verify that the address is the same GPO pending address on the enter code screen.

Rails console commands to create duplicate with different address:
```
# rails console
user = User.find_with_email('[EMAIL_USED_FOR_ACCOUNT]')
profile = user.gpo_verification_pending_profile
profile = profile.dup
pii = profile.decrypt_pii('[PASSWORD]')
pii.address1 = 'Non GPO Pending Profile'
pii.address2 = 'Non GPO Pending Profile'
pii.city = 'Pending Profile'
profile.active = false
profile.gpo_verification_pending_at = nil
profile.created_at = Time.zone.now
profile.encrypt_pii(pii, [PASSWORD])
profile.save!
```

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
