### PR TITLE
Active_support blank requirement for bin/query-cloudwatch

### DIFF
--- a/bin/query-cloudwatch
+++ b/bin/query-cloudwatch
@@ -3,6 +3,7 @@ Dir.chdir(__dir__) { require 'bundler/setup' }
 
 require 'active_support'
 require 'active_support/core_ext/integer/time'
+require 'active_support/core_ext/object/blank'
 require 'active_support/time'
 require 'aws-sdk-cloudwatchlogs'
 require 'concurrent-ruby'


### PR DESCRIPTION
## 🛠 Summary of changes

This PR adds a new require statement for `bin/query-cloudwatch` to satisfy dependencies. 

## 👀 Behavior

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
Example Query:

`bin/query-cloudwatch --from 7d --env henrydrich --app idp --log events.log --query "fields @timestamp | limit 20"`

Error Message:
```
bin/query-cloudwatch:260:in `parse!': undefined method `blank?' for "events.log":String (NoMethodError)

    if (app = config.app) && (env = config.env) && !(log = config.log).blank?
                                                                      ^^^^^^^
	from bin/query-cloudwatch:315:in `<main>'
```
</details>

<details>
<summary>After:</summary>
Example Query:

`bin/query-cloudwatch --from 7d --env henrydrich --app idp --log events.log --query "fields @timestamp | limit 20"`

Output:
```
Querying log slices 100% [1/1] |=========================================| Time: 00:00:03
2023-12-05 17:00:07.783
```
</details>
