### PR TITLE
Jmax/lg 11552 use correct pii on new personal key screen

### DIFF
--- a/app/services/pii/re_encryptor.rb
+++ b/app/services/pii/re_encryptor.rb
@@ -23,7 +23,7 @@ module Pii
     end
 
     def profile
-      user.active_or_pending_profile
+      @profile ||= user.active_or_pending_profile
     end
   end
 end

--- a/app/services/pii/re_encryptor.rb
+++ b/app/services/pii/re_encryptor.rb
@@ -1,9 +1,8 @@
 module Pii
   class ReEncryptor
-    def initialize(user: nil, user_session: nil, pii: nil)
+    def initialize(user: nil, user_session: nil)
       @user = user
       @user_session = user_session
-      @pii_attributes = pii
     end
 
     def perform
@@ -16,7 +15,7 @@ module Pii
     attr_reader :user, :user_session
 
     def pii_attributes
-      @pii_attributes ||= cacher.fetch
+      @pii_attributes ||= cacher.fetch(profile)
     end
 
     def cacher
@@ -24,7 +23,7 @@ module Pii
     end
 
     def profile
-      user.active_profile
+      user.active_or_pending_profile
     end
   end
 end

--- a/app/services/pii/re_encryptor.rb
+++ b/app/services/pii/re_encryptor.rb
@@ -15,7 +15,7 @@ module Pii
     attr_reader :user, :user_session
 
     def pii_attributes
-      @pii_attributes ||= cacher.fetch(profile)
+      @pii_attributes ||= cacher.fetch(profile.id)
     end
 
     def cacher

--- a/app/services/pii/re_encryptor.rb
+++ b/app/services/pii/re_encryptor.rb
@@ -1,10 +1,9 @@
 module Pii
   class ReEncryptor
-    def initialize(user: nil, user_session: nil, pii: nil, profile: nil)
+    def initialize(user: nil, user_session: nil, pii: nil)
       @user = user
       @user_session = user_session
       @pii_attributes = pii
-      @profile = profile
     end
 
     def perform
@@ -25,7 +24,7 @@ module Pii
     end
 
     def profile
-      @profile ||= user.active_profile
+      user.active_profile
     end
   end
 end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -22,7 +22,10 @@ RSpec.describe Pii::ReEncryptor do
 
       it 're-encrypts PII onto the active profile using new code' do
         active_profile = create(:profile, :active, :verified, pii: active_pii, user: user)
-        # creating a pending profile to make sure pending profiles are ignored when an active one is present
+
+        # create a pending profile with different pii, so we're sure
+        # that the ReEncryptor uses the active profile, and not the
+        # pending profile, if both are present.
         create(:profile, :verify_by_mail_pending, pii: pending_pii, user: user)
 
         pii_cacher.save_decrypted_pii(active_pii, active_profile.id)

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -2,45 +2,60 @@ require 'rails_helper'
 
 RSpec.describe Pii::ReEncryptor do
   describe '#perform' do
-    it 're-encrypts PII onto the active profile using new code' do
-      profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
+    let(:active_ssn) { '1234' }
+    let(:active_pii) { { ssn: active_ssn } }
 
-      user = profile.user
+    let(:pending_ssn) { '5678' }
+    let(:pending_pii) { { ssn: pending_ssn } }
 
-      # make sure it doesn't use this
-      create(:profile, :verify_by_mail_pending, user: user, pii: { ssn: '5678' })
+    let(:user) { create(:user) }
+    let(:user_session) { {}.with_indifferent_access }
+    let(:pii_cacher) { Pii::Cacher.new(user, user_session) }
+    let(:re_encryptor) { Pii::ReEncryptor.new(user: user, user_session: user_session) }
 
-      user_session = {}.with_indifferent_access
-      cacher = Pii::Cacher.new(user, user_session)
-      cacher.save_decrypted_pii({ ssn: '1234' }, profile.id)
+    context 'when the user has an active profile and a pending profile' do
+      let(:expected_pii) do
+        expected_pii = Pii::Attributes.new
+        expected_pii[:ssn] = active_ssn
+        expected_pii
+      end
 
-      Pii::ReEncryptor.new(user: user, user_session: user_session).perform
-      personal_key = user.active_profile.personal_key
-      dr_attributes = Profile.find(profile.id).recover_pii(personal_key.gsub(/-/, ' '))
+      it 're-encrypts PII onto the active profile using new code' do
+        active_profile = create(:profile, :active, :verified, pii: active_pii, user: user)
+        # creating a pending profile to make sure pending profiles are ignored when an active one is present
+        create(:profile, :verify_by_mail_pending, pii: pending_pii, user: user)
 
-      pii_attributes = Pii::Attributes.new
-      pii_attributes[:ssn] = '1234'
+        pii_cacher.save_decrypted_pii(active_pii, active_profile.id)
 
-      expect(dr_attributes).to eq(pii_attributes)
+        re_encryptor.perform
+        personal_key = user.active_profile.personal_key
+        recovered_pii = Profile.find(user.active_profile.id).recover_pii(
+          PersonalKeyGenerator.new(user).normalize(personal_key),
+        )
+
+        expect(recovered_pii).to eq(expected_pii)
+      end
     end
 
-    it 're-encrypts PII onto the pending profile using new code' do
-      profile = create(:profile, :verify_by_mail_pending, pii: { ssn: '5678' })
+    context 'when the user has a pending profile, but no active profile' do
+      let(:expected_pii) do
+        expected_pii = Pii::Attributes.new
+        expected_pii[:ssn] = pending_ssn
+        expected_pii
+      end
 
-      user = profile.user
+      it 're-encrypts PII onto the pending profile using new code' do
+        pending_profile = create(:profile, :verify_by_mail_pending, pii: pending_pii, user: user)
+        pii_cacher.save_decrypted_pii(pending_pii, pending_profile.id)
 
-      user_session = {}.with_indifferent_access
-      cacher = Pii::Cacher.new(user, user_session)
-      cacher.save_decrypted_pii({ ssn: '5678' }, profile.id)
+        re_encryptor.perform
+        personal_key = user.pending_profile.personal_key
+o        recovered_pii = Profile.find(pending_profile.id).recover_pii(
+          PersonalKeyGenerator.new(user).normalize(personal_key),
+        )
 
-      Pii::ReEncryptor.new(user: user, user_session: user_session).perform
-      personal_key = user.pending_profile.personal_key
-      dr_attributes = Profile.find(profile.id).recover_pii(personal_key.gsub(/-/, ' '))
-
-      pii_attributes = Pii::Attributes.new
-      pii_attributes[:ssn] = '5678'
-
-      expect(dr_attributes).to eq(pii_attributes)
+        expect(recovered_pii).to eq(expected_pii)
+      end
     end
   end
 end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -2,23 +2,45 @@ require 'rails_helper'
 
 RSpec.describe Pii::ReEncryptor do
   describe '#perform' do
-    it 're-encrypts PII using new code' do
+    it 're-encrypts PII onto the active profile using new code' do
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
 
       user = profile.user
-      user_session = {
-        encrypted_profiles: { profile.id.to_s => SessionEncryptor.new.kms_encrypt({ ssn: '1234' }.to_json) },
-        decrypted_pii: { ssn: '1234' }.to_json,
-      }
+
+      # make sure it doesn't use this
+      create(:profile, :verify_by_mail_pending, user: user, pii: { ssn: '5678' })
+
+      user_session = {}.with_indifferent_access
+      cacher = Pii::Cacher.new(user, user_session)
+      cacher.save_decrypted_pii({ ssn: '1234' }, profile.id)
+
+      Pii::ReEncryptor.new(user: user, user_session: user_session).perform
+      personal_key = user.active_profile.personal_key
+      dr_attributes = Profile.find(profile.id).recover_pii(personal_key.gsub(/-/, ' '))
 
       pii_attributes = Pii::Attributes.new
       pii_attributes[:ssn] = '1234'
 
-      expect(user.active_profile).to receive(:encrypt_recovery_pii).
-        with(pii_attributes).and_call_original
-      expect(user.active_profile).to receive(:save!).and_call_original
+      expect(dr_attributes).to eq(pii_attributes)
+    end
+
+    it 're-encrypts PII onto the pending profile using new code' do
+      profile = create(:profile, :verify_by_mail_pending, pii: { ssn: '5678' })
+
+      user = profile.user
+
+      user_session = {}.with_indifferent_access
+      cacher = Pii::Cacher.new(user, user_session)
+      cacher.save_decrypted_pii({ ssn: '5678' }, profile.id)
 
       Pii::ReEncryptor.new(user: user, user_session: user_session).perform
+      personal_key = user.pending_profile.personal_key
+      dr_attributes = Profile.find(profile.id).recover_pii(personal_key.gsub(/-/, ' '))
+
+      pii_attributes = Pii::Attributes.new
+      pii_attributes[:ssn] = '5678'
+
+      expect(dr_attributes).to eq(pii_attributes)
     end
   end
 end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -18,16 +18,5 @@ RSpec.describe Pii::ReEncryptor do
 
       Pii::ReEncryptor.new(user: user, user_session: user_session).perform
     end
-
-    it 're-encrypts PII when supplied with raw PII and explicit profile' do
-      profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
-      pii_attributes = Pii::Attributes.new_from_hash(ssn: '1234')
-
-      expect(profile).to receive(:encrypt_recovery_pii).
-        with(pii_attributes).and_call_original
-      expect(profile).to receive(:save!).and_call_original
-
-      Pii::ReEncryptor.new(profile: profile, pii: pii_attributes).perform
-    end
   end
 end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -2,29 +2,76 @@ require 'rails_helper'
 
 RSpec.describe Pii::ReEncryptor do
   describe '#perform' do
-    let(:active_profile) { create(:profile, :active, :verified, pii: pii) }
-    let(:pii) { { ssn: ssn } }
-    let(:ssn) { ' 1234' }
-    let(:user) { active_profile.user }
-    let(:user_session) { { decrypted_pii: pii.to_json } }
+    context 'when the user has an active profile' do
+      let(:active_profile) { create(:profile, :active, :verified, pii: pii) }
+      let(:pii) { { ssn: ssn } }
+      let(:pii_cacher) { Pii::Cacher.new(user, user_session) }
+      let(:ssn) { ' 1234' }
+      let(:user) { active_profile.user }
+      let(:user_session) { {}.with_indifferent_access }
 
-    let(:expected_pii_attributes) do
-      pii_attributes = Pii::Attributes.new
-      pii_attributes[:ssn] = ssn
-      pii_attributes
+      let(:expected_pii_attributes) do
+        pii_attributes = Pii::Attributes.new
+        pii_attributes[:ssn] = ssn
+        pii_attributes
+      end
+
+      before do
+        Pii::ProfileCacher.new(user, user_session).save_decrypted_pii(pii, active_profile.id)
+
+        allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
+        allow(pii_cacher).to receive(:fetch).and_call_original
+        allow(user.active_profile).to receive(:encrypt_recovery_pii).and_call_original
+        allow(user.active_profile).to receive(:save!).and_call_original
+
+        Pii::ReEncryptor.new(user: user, user_session: user_session).perform
+      end
+
+      it 'fetches the PII from the correct profile' do
+        expect(pii_cacher).to have_received(:fetch).with(active_profile.id)
+      end
+
+      it 're-encrypts PII using new code' do
+        expect(user.active_profile).to have_received(:encrypt_recovery_pii).
+          with(expected_pii_attributes)
+        expect(user.active_profile).to have_received(:save!)
+      end
     end
 
-    before do
-      allow(user.active_profile).to receive(:encrypt_recovery_pii).and_call_original
-      allow(user.active_profile).to receive(:save!).and_call_original
+    context 'when the user has a pending profile' do
+      let(:pending_profile) { create(:profile, :verify_by_mail_pending, pii: pii) }
+      let(:pii) { { ssn: ssn } }
+      let(:pii_cacher) { Pii::Cacher.new(user, user_session) }
+      let(:ssn) { ' 1234' }
+      let(:user) { pending_profile.user }
+      let(:user_session) { {}.with_indifferent_access }
 
-      Pii::ReEncryptor.new(user: user, user_session: user_session).perform
-    end
+      let(:expected_pii_attributes) do
+        pii_attributes = Pii::Attributes.new
+        pii_attributes[:ssn] = ssn
+        pii_attributes
+      end
 
-    it 're-encrypts PII using new code' do
-      expect(user.active_profile).to have_received(:encrypt_recovery_pii).
-        with(expected_pii_attributes)
-      expect(user.active_profile).to have_received(:save!)
+      before do
+        Pii::ProfileCacher.new(user, user_session).save_decrypted_pii(pii, pending_profile.id)
+
+        allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
+        allow(pii_cacher).to receive(:fetch).and_call_original
+        allow(user.pending_profile).to receive(:encrypt_recovery_pii).and_call_original
+        allow(user.pending_profile).to receive(:save!).and_call_original
+
+        Pii::ReEncryptor.new(user: user, user_session: user_session).perform
+      end
+
+      it 'fetches the PII from the correct profile' do
+        expect(pii_cacher).to have_received(:fetch).with(pending_profile.id)
+      end
+
+      it 're-encrypts PII using new code' do
+        expect(user.pending_profile).to have_received(:encrypt_recovery_pii).
+          with(expected_pii_attributes)
+        expect(user.pending_profile).to have_received(:save!)
+      end
     end
   end
 end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe Pii::ReEncryptor do
   before do
     allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
     allow(pii_cacher).to receive(:fetch).and_call_original
+
+    if user.active_profile
+      allow(user.active_profile).to receive(:encrypt_recovery_pii).and_call_original
+      allow(user.active_profile).to receive(:save!).and_call_original
+    end
+
+    if user.pending_profile
+      allow(user.pending_profile).to receive(:encrypt_recovery_pii).and_call_original
+      allow(user.pending_profile).to receive(:save!).and_call_original
+    end
+
     Pii::ProfileCacher.new(user, user_session).save_decrypted_pii(pii, profile.id)
   end
 
@@ -24,9 +35,6 @@ RSpec.describe Pii::ReEncryptor do
       let(:profile) { create(:profile, :active, :verified, pii: pii) }
 
       before do
-        allow(user.active_profile).to receive(:encrypt_recovery_pii).and_call_original
-        allow(user.active_profile).to receive(:save!).and_call_original
-
         Pii::ReEncryptor.new(user: user, user_session: user_session).perform
       end
 
@@ -45,9 +53,6 @@ RSpec.describe Pii::ReEncryptor do
       let(:profile) { create(:profile, :verify_by_mail_pending, pii: pii) }
 
       before do
-        allow(user.pending_profile).to receive(:encrypt_recovery_pii).and_call_original
-        allow(user.pending_profile).to receive(:save!).and_call_original
-
         Pii::ReEncryptor.new(user: user, user_session: user_session).perform
       end
 

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe Pii::ReEncryptor do
     let(:re_encryptor) { Pii::ReEncryptor.new(user: user, user_session: user_session) }
 
     context 'when the user has an active profile and a pending profile' do
-      let(:expected_pii) do
-        expected_pii = Pii::Attributes.new
-        expected_pii[:ssn] = active_ssn
-        expected_pii
-      end
-
       it 're-encrypts PII onto the active profile using new code' do
         active_profile = create(:profile, :active, :verified, pii: active_pii, user: user)
 
@@ -36,26 +30,26 @@ RSpec.describe Pii::ReEncryptor do
           PersonalKeyGenerator.new(user).normalize(personal_key),
         )
 
+        expected_pii = Pii::Attributes.new
+        expected_pii[:ssn] = active_ssn
+
         expect(recovered_pii).to eq(expected_pii)
       end
     end
 
     context 'when the user has a pending profile, but no active profile' do
-      let(:expected_pii) do
-        expected_pii = Pii::Attributes.new
-        expected_pii[:ssn] = pending_ssn
-        expected_pii
-      end
-
       it 're-encrypts PII onto the pending profile using new code' do
         pending_profile = create(:profile, :verify_by_mail_pending, pii: pending_pii, user: user)
         pii_cacher.save_decrypted_pii(pending_pii, pending_profile.id)
 
         re_encryptor.perform
         personal_key = user.pending_profile.personal_key
-o        recovered_pii = Profile.find(pending_profile.id).recover_pii(
+        recovered_pii = Profile.find(pending_profile.id).recover_pii(
           PersonalKeyGenerator.new(user).normalize(personal_key),
         )
+
+        expected_pii = Pii::Attributes.new
+        expected_pii[:ssn] = pending_ssn
 
         expect(recovered_pii).to eq(expected_pii)
       end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -1,70 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Pii::ReEncryptor do
-  let(:expected_pii_attributes) do
-    pii_attributes = Pii::Attributes.new
-    pii_attributes[:ssn] = ssn
-    pii_attributes
-  end
-
-  let(:pii) { { ssn: ssn } }
-  let(:pii_cacher) { Pii::Cacher.new(user, user_session) }
-  let(:ssn) { '1234' }
-  let(:user) { profile.user }
-  let(:user_session) { {}.with_indifferent_access }
-
-  before do
-    allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
-    allow(pii_cacher).to receive(:fetch).and_call_original
-
-    if user.active_profile
-      allow(user.active_profile).to receive(:encrypt_recovery_pii).and_call_original
-      allow(user.active_profile).to receive(:save!).and_call_original
-    end
-
-    if user.pending_profile
-      allow(user.pending_profile).to receive(:encrypt_recovery_pii).and_call_original
-      allow(user.pending_profile).to receive(:save!).and_call_original
-    end
-
-    Pii::ProfileCacher.new(user, user_session).save_decrypted_pii(pii, profile.id)
-  end
-
   describe '#perform' do
-    context 'when the user has an active profile' do
-      let(:profile) { create(:profile, :active, :verified, pii: pii) }
+    it 're-encrypts PII using new code' do
+      profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
 
-      before do
-        Pii::ReEncryptor.new(user: user, user_session: user_session).perform
-      end
+      user = profile.user
+      user_session = {
+        encrypted_profiles: { profile.id.to_s => SessionEncryptor.new.kms_encrypt({ ssn: '1234' }.to_json) },
+        decrypted_pii: { ssn: '1234' }.to_json,
+      }
 
-      it 'fetches the PII from the correct profile' do
-        expect(pii_cacher).to have_received(:fetch).with(profile.id)
-      end
+      pii_attributes = Pii::Attributes.new
+      pii_attributes[:ssn] = '1234'
 
-      it 're-encrypts PII using new code' do
-        expect(user.active_profile).to have_received(:encrypt_recovery_pii).
-          with(expected_pii_attributes)
-        expect(user.active_profile).to have_received(:save!)
-      end
-    end
+      expect(user.active_profile).to receive(:encrypt_recovery_pii).
+        with(pii_attributes).and_call_original
+      expect(user.active_profile).to receive(:save!).and_call_original
 
-    context 'when the user has a pending profile' do
-      let(:profile) { create(:profile, :verify_by_mail_pending, pii: pii) }
-
-      before do
-        Pii::ReEncryptor.new(user: user, user_session: user_session).perform
-      end
-
-      it 'fetches the PII from the correct profile' do
-        expect(pii_cacher).to have_received(:fetch).with(profile.id)
-      end
-
-      it 're-encrypts PII using new code' do
-        expect(user.pending_profile).to have_received(:encrypt_recovery_pii).
-          with(expected_pii_attributes)
-        expect(user.pending_profile).to have_received(:save!)
-      end
+      Pii::ReEncryptor.new(user: user, user_session: user_session).perform
     end
   end
 end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -2,21 +2,29 @@ require 'rails_helper'
 
 RSpec.describe Pii::ReEncryptor do
   describe '#perform' do
-    it 're-encrypts PII using new code' do
-      profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
-      user = profile.user
-      user_session = {
-        decrypted_pii: { ssn: '1234' }.to_json,
-      }
+    let(:active_profile) { create(:profile, :active, :verified, pii: pii) }
+    let(:pii) { { ssn: ssn } }
+    let(:ssn) { ' 1234' }
+    let(:user) { active_profile.user }
+    let(:user_session) { { decrypted_pii: pii.to_json } }
 
+    let(:expected_pii_attributes) do
       pii_attributes = Pii::Attributes.new
-      pii_attributes[:ssn] = '1234'
+      pii_attributes[:ssn] = ssn
+      pii_attributes
+    end
 
-      expect(user.active_profile).to receive(:encrypt_recovery_pii).
-        with(pii_attributes).and_call_original
-      expect(user.active_profile).to receive(:save!).and_call_original
+    before do
+      allow(user.active_profile).to receive(:encrypt_recovery_pii).and_call_original
+      allow(user.active_profile).to receive(:save!).and_call_original
 
       Pii::ReEncryptor.new(user: user, user_session: user_session).perform
+    end
+
+    it 're-encrypts PII using new code' do
+      expect(user.active_profile).to have_received(:encrypt_recovery_pii).
+        with(expected_pii_attributes)
+      expect(user.active_profile).to have_received(:save!)
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket
[LG-11552](https://cm-jira.usa.gov/browse/LG-11552)

## 🛠 Summary of changes

Modified concern for new personal key controller (`PersonalKeyConcern#create_new_code`) to use the Pii from the user's active profile if present, or from the user's pending profile if present and there is no active profile.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
- [ ] Add the debug print below to `Pii::Cacher#fetch`
- [ ] Create a user and proceed through IdV. Return to your account page.
- [ ] Click `Reset Personal Key` in the left column, and generate a new personal key.
- [ ] Verify by inspecting the Rails output and the Rails console that `Pii::Cacher#fetch` was called with the correct profile id.

```
      # DEBUG
      puts "fetch(#{profile_id.inspect})"
```

Console output showing the id for the user's active profile:
```
[7] pry(main)> Profile.all
  Profile Load (5.0ms)  SELECT "profiles"."id", "profiles"."user_id", "profiles"."active", "profiles"."verified_at", "profiles"."activated_at", "profiles"."created_at", "profiles"."updated_at", "profiles"."encrypted_pii", "profiles"."ssn_signature", "profiles"."encrypted_pii_recovery", "profiles"."deactivation_reason", "profiles"."proofing_components", "profiles"."name_zip_birth_year_signature", "profiles"."initiating_service_provider_issuer", "profiles"."fraud_review_pending_at", "profiles"."fraud_rejection_at", "profiles"."gpo_verification_pending_at", "profiles"."fraud_pending_reason", "profiles"."in_person_verification_pending_at", "profiles"."encrypted_pii_multi_region", "profiles"."encrypted_pii_recovery_multi_region", "profiles"."gpo_verification_expired_at", "profiles"."idv_level" FROM "profiles" /* loading for pp */ LIMIT $1  [["LIMIT", 11]]
=> [#<Profile:0x000000011ee751e8
  id: 1,
  user_id: 1,
  active: true,

*snip*

  gpo_verification_expired_at: nil,
  idv_level: nil>]
[8] pry(main)> 
```

Rails output showing the id passed to `#fetch`:
```
11:26:22 web.1    | ::1 - - [06/Dec/2023:11:26:22 -0500] "GET /account/personal_key HTTP/1.1" 200 12268 0.0511
11:26:24 web.1    | fetch(1)
```