### PR TITLE
LG-11692: Start writing Profile idv_level

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -30,6 +30,11 @@ class Profile < ApplicationRecord
     threatmetrix_reject: 2,
   }
 
+  enum idv_level: {
+    legacy_unsupervised: 1,
+    legacy_in_person: 2,
+  }
+
   attr_reader :personal_key
 
   # Class methods

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -27,11 +27,11 @@ module Idv
       profile.proofing_components = current_proofing_components
       profile.fraud_pending_reason = fraud_pending_reason
 
-      if in_person_verification_needed
-        profile.idv_level = :legacy_in_person
-      else
-        profile.idv_level = :legacy_unsupervised
-      end
+      profile.idv_level = if in_person_verification_needed
+                            :legacy_in_person
+                          else
+                            :legacy_unsupervised
+                          end
 
       profile.save!
       profile.deactivate_for_gpo_verification if gpo_verification_needed

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -26,6 +26,13 @@ module Idv
       profile.encrypt_pii(pii_attributes, user_password)
       profile.proofing_components = current_proofing_components
       profile.fraud_pending_reason = fraud_pending_reason
+
+      if in_person_verification_needed
+        profile.idv_level = :legacy_in_person
+      else
+        profile.idv_level = :legacy_unsupervised
+      end
+
       profile.save!
       profile.deactivate_for_gpo_verification if gpo_verification_needed
       if fraud_pending_reason.present? && !gpo_verification_needed

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
       pii { false }
     end
 
+    idv_level { :legacy_unsupervised }
+
     trait :active do
       active { true }
       activated_at { Time.zone.now }
@@ -35,6 +37,7 @@ FactoryBot.define do
 
     trait :in_person_verification_pending do
       in_person_verification_pending_at { 15.days.ago }
+      idv_level { :legacy_in_person }
     end
 
     trait :fraud_pending_reason do

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -39,14 +39,15 @@ RSpec.describe Idv::ProfileMaker do
     end
 
     context 'with deactivation reason' do
-      it 'creates an inactive profile with deactivation reason' do
-        profile = subject.save_profile(
+      let(:profile) do
+        subject.save_profile(
           fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: :encryption_error,
           in_person_verification_needed: false,
         )
-
+      end
+      it 'creates an inactive profile with deactivation reason' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to eq('encryption_error')
@@ -56,17 +57,21 @@ RSpec.describe Idv::ProfileMaker do
         expect(profile.initiating_service_provider).to eq(nil)
         expect(profile.verified_at).to be_nil
       end
+      it 'marks the profile as legacy_unsupervised' do
+        expect(profile.idv_level).to eql('legacy_unsupervised')
+      end
     end
 
     context 'with fraud review needed' do
-      it 'deactivates a profile for fraud review' do
-        profile = subject.save_profile(
+      let(:profile) do
+        subject.save_profile(
           fraud_pending_reason: 'threatmetrix_review',
           gpo_verification_needed: false,
           deactivation_reason: nil,
           in_person_verification_needed: false,
         )
-
+      end
+      it 'deactivates a profile for fraud review' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to be_nil
@@ -76,17 +81,21 @@ RSpec.describe Idv::ProfileMaker do
         expect(profile.initiating_service_provider).to eq(nil)
         expect(profile.verified_at).to be_nil
       end
+      it 'marks the profile as legacy_unsupervised' do
+        expect(profile.idv_level).to eql('legacy_unsupervised')
+      end
     end
 
     context 'with gpo_verification_needed' do
-      it 'deactivates a profile for gpo verification' do
-        profile = subject.save_profile(
+      let(:profile) do
+        subject.save_profile(
           fraud_pending_reason: nil,
           gpo_verification_needed: true,
           deactivation_reason: nil,
           in_person_verification_needed: false,
         )
-
+      end
+      it 'deactivates a profile for gpo verification' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to be_nil
@@ -96,17 +105,21 @@ RSpec.describe Idv::ProfileMaker do
         expect(profile.initiating_service_provider).to eq(nil)
         expect(profile.verified_at).to be_nil
       end
+      it 'marks the profile as legacy_unsupervised' do
+        expect(profile.idv_level).to eql('legacy_unsupervised')
+      end
     end
 
     context 'with in_person_verification_needed' do
-      it 'deactivates a profile for in person verification' do
-        profile = subject.save_profile(
+      let(:profile) do
+        subject.save_profile(
           fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: nil,
           in_person_verification_needed: true,
         )
-
+      end
+      it 'deactivates a profile for in person verification' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to be_nil
@@ -117,17 +130,21 @@ RSpec.describe Idv::ProfileMaker do
         expect(profile.initiating_service_provider).to eq(nil)
         expect(profile.verified_at).to be_nil
       end
+      it 'marks the profile as legacy_in_person' do
+        expect(profile.idv_level).to eql('legacy_in_person')
+      end
     end
 
     context 'as active' do
-      it 'creates an active profile' do
-        profile = subject.save_profile(
+      let(:profile) do
+        subject.save_profile(
           fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: nil,
           in_person_verification_needed: false,
         )
-
+      end
+      it 'creates an active profile' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to be_nil
@@ -137,19 +154,22 @@ RSpec.describe Idv::ProfileMaker do
         expect(profile.initiating_service_provider).to eq(nil)
         expect(profile.verified_at).to be_nil
       end
+      it 'marks the profile as legacy_unsupervised' do
+        expect(profile.idv_level).to eql('legacy_unsupervised')
+      end
     end
 
     context 'with an initiating service provider' do
       let(:initiating_service_provider) { create(:service_provider) }
-
-      it 'creates a profile with the initiating sp recorded' do
-        profile = subject.save_profile(
+      let(:profile) do
+        subject.save_profile(
           fraud_pending_reason: nil,
           gpo_verification_needed: false,
           deactivation_reason: nil,
           in_person_verification_needed: false,
         )
-
+      end
+      it 'creates a profile with the initiating sp recorded' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to be_nil
@@ -158,6 +178,9 @@ RSpec.describe Idv::ProfileMaker do
         expect(profile.gpo_verification_pending_at.present?).to eq(false)
         expect(profile.initiating_service_provider).to eq(initiating_service_provider)
         expect(profile.verified_at).to be_nil
+      end
+      it 'marks the profile as legacy_unsupervised' do
+        expect(profile.idv_level).to eql('legacy_unsupervised')
       end
     end
   end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Idv::ProfileMaker do
           in_person_verification_needed: false,
         )
       end
-      it 'deactivates a profile for gpo verification' do
+      it 'creates a pending profile for gpo verification' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to be_nil

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Idv::ProfileMaker do
           in_person_verification_needed: true,
         )
       end
-      it 'deactivates a profile for in person verification' do
+      it 'creates a pending profile for in person verification' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to be_nil

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Idv::ProfileMaker do
           in_person_verification_needed: false,
         )
       end
-      it 'deactivates a profile for fraud review' do
+      it 'creates a pending profile for fraud review' do
         expect(profile.activated_at).to be_nil
         expect(profile.active).to eq(false)
         expect(profile.deactivation_reason).to be_nil


### PR DESCRIPTION
## 🎫 Ticket

[LG-11692](https://cm-jira.usa.gov/browse/LG-11692)

## 🛠 Summary of changes

* Update `ProfileMaker` to write the `idv_level` column when it mints Profiles
* Update factory_bot Profile factories to write idv_level as well

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through identity verification using the remote unsupervised flow
- [ ] Open up a rails console and verify that `Profile.last.idv_level == "legacy_unsupervised"`
- [ ] Go through identity verification again, but choose in-person proofing
- [ ] Open up a rails console  and verify that `Profile.last.idv_level == "legacy_in_person"
