### PR TITLE
changelog: Internal, CI, Update Dashboard Image to main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   ECR_REGISTRY: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
   IDP_CI_SHA: 'sha256:26bcd68d39085d0e9dbfe272ec3f95158a272dcc2e25f5152b1d8e4600cf1cac'
   PKI_IMAGE_TAG: 'main'
-  DASHBOARD_IMAGE_TAG: 'ab661426de8de0b4cce094f8c862ad3ce6d97274'
+  DASHBOARD_IMAGE_TAG: 'main'
 
 default:
   image: '${ECR_REGISTRY}/idp/ci@${IDP_CI_SHA}'


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket.
-->

## 🛠 Summary of changes

Currently jobs are failing because of a missing identity-dashboard image, swapping the `DASHBOARD_IMAGE_TAG` to `main` similar to `PKI_IMAGE_TAG` so that we won't have to chase tags moving forward

## 📜 Testing Plan
Validated that we are currently building an identity-dashboard image and the latest is tagged with main.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
