### PR TITLE
FlowPolicy spec helpers for idv_session setup

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -65,8 +65,10 @@ module Idv
         key: :phone,
         controller: self,
         action: :new,
-        next_steps: [:otp_verification, :enter_password],
-        preconditions: ->(idv_session:, user:) { idv_session.verify_info_step_complete? },
+        next_steps: [:otp_verification],
+        preconditions: ->(idv_session:, user:) do
+          idv_session.verify_info_step_complete? && !idv_session.verify_by_mail?
+        end,
         undo_step: ->(idv_session:, user:) do
           idv_session.vendor_phone_confirmation = nil
           idv_session.address_verification_mechanism = nil

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -65,7 +65,7 @@ module Idv
         key: :phone,
         controller: self,
         action: :new,
-        next_steps: [:otp_verification],
+        next_steps: [:otp_verification, :enter_password],
         preconditions: ->(idv_session:, user:) { idv_session.verify_info_step_complete? },
         undo_step: ->(idv_session:, user:) do
           idv_session.vendor_phone_confirmation = nil

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -42,7 +42,7 @@ module Idv
       Idv::StepInfo.new(
         key: :verify_info,
         controller: self,
-        next_steps: [:phone],
+        next_steps: [:phone, :request_letter],
         preconditions: ->(idv_session:, user:) do
           idv_session.ssn && idv_session.remote_document_capture_complete?
         end,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -133,7 +133,7 @@ module Idv
     end
 
     def phone_otp_sent?
-      user_phone_confirmation_session.present? && address_verification_mechanism == 'phone'
+      vendor_phone_confirmation && address_verification_mechanism == 'phone'
     end
 
     def user_phone_confirmation_session

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -133,7 +133,7 @@ module Idv
     end
 
     def phone_otp_sent?
-      user_phone_confirmation_session.present?
+      user_phone_confirmation_session.present? && address_verification_mechanism == 'phone'
     end
 
     def user_phone_confirmation_session
@@ -211,7 +211,7 @@ module Idv
     end
 
     def mark_phone_step_started!
-      session[:address_verification_mechanism] = :phone
+      session[:address_verification_mechanism] = 'phone'
       session[:vendor_phone_confirmation] = true
       session[:user_phone_confirmation] = false
     end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Idv::EnterPasswordController do
     end
 
     it 'redirects to phone step if the user has not completed it' do
-      subject.idv_session.user_phone_confirmation = nil
+      subject.idv_session.vendor_phone_confirmation = nil
 
       get :new
 

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Idv::OtpVerificationController do
   let(:user) { create(:user) }
 
   let(:phone) { '2255555000' }
+  let(:vendor_phone_confirmation) { true }
   let(:user_phone_confirmation) { false }
   let(:phone_confirmation_otp_code) { '777777' }
   let(:phone_confirmation_otp_sent_at) { Time.zone.now }
@@ -35,7 +36,8 @@ RSpec.describe Idv::OtpVerificationController do
     subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn]
     subject.idv_session.resolution_successful = true
     subject.idv_session.applicant[:phone] = phone
-    subject.idv_session.vendor_phone_confirmation = true
+    subject.idv_session.address_verification_mechanism = 'phone'
+    subject.idv_session.vendor_phone_confirmation = vendor_phone_confirmation
     subject.idv_session.user_phone_confirmation = user_phone_confirmation
     subject.idv_session.user_phone_confirmation_session = user_phone_confirmation_session
   end
@@ -55,6 +57,7 @@ RSpec.describe Idv::OtpVerificationController do
   describe '#show' do
     context 'the user has not been sent an otp' do
       let(:user_phone_confirmation_session) { nil }
+      let(:vendor_phone_confirmation) { nil }
 
       it 'redirects to the delivery method path' do
         get :show
@@ -85,6 +88,7 @@ RSpec.describe Idv::OtpVerificationController do
     let(:otp_code_param) { { code: phone_confirmation_otp_code } }
     context 'the user has not been sent an otp' do
       let(:user_phone_confirmation_session) { nil }
+      let(:vendor_phone_confirmation) { nil }
 
       it 'redirects to otp delivery method selection' do
         put :update, params: otp_code_param

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe 'Idv::FlowPolicy' do
     end
 
     context 'preconditions for request_letter are present' do
-      it 'returns enter_password with gpo verification pending' do
+      it 'allows request_letter' do
         stub_up_to_key(key: :verify_info, idv_session: idv_session)
 
         expect(subject.controller_allowed?(controller: Idv::ByMail::RequestLetterController)).to be

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for agreement are present' do
       it 'returns agreement' do
-        stub_up_to_key(key: :welcome, idv_session: idv_session)
+        stub_up_to(:welcome, idv_session: idv_session)
 
         expect(subject.info_for_latest_step.key).to eq(:agreement)
         expect(subject.controller_allowed?(controller: Idv::AgreementController)).to be
@@ -171,7 +171,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for hybrid_handoff are present' do
       it 'returns hybrid_handoff' do
-        stub_up_to_key(key: :agreement, idv_session: idv_session)
+        stub_up_to(:agreement, idv_session: idv_session)
 
         expect(subject.info_for_latest_step.key).to eq(:hybrid_handoff)
         expect(subject.controller_allowed?(controller: Idv::HybridHandoffController)).to be
@@ -181,7 +181,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for document_capture are present' do
       it 'returns document_capture' do
-        stub_up_to_key(key: :hybrid_handoff, idv_session: idv_session)
+        stub_up_to(:hybrid_handoff, idv_session: idv_session)
 
         expect(subject.info_for_latest_step.key).to eq(:document_capture)
         expect(subject.controller_allowed?(controller: Idv::DocumentCaptureController)).to be
@@ -191,7 +191,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for link_sent are present' do
       it 'returns link_sent' do
-        stub_up_to_key(key: :hybrid_handoff, idv_session: idv_session)
+        stub_up_to(:hybrid_handoff, idv_session: idv_session)
         idv_session.flow_path = 'hybrid'
 
         expect(subject.info_for_latest_step.key).to eq(:link_sent)
@@ -202,7 +202,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for ssn are present' do
       before do
-        stub_up_to_key(key: :document_capture, idv_session: idv_session)
+        stub_up_to(:document_capture, idv_session: idv_session)
       end
 
       it 'returns ssn for standard flow' do
@@ -221,7 +221,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for in_person ssn are present' do
       before do
-        stub_up_to_key(key: :hybrid_handoff, idv_session: idv_session)
+        stub_up_to(:hybrid_handoff, idv_session: idv_session)
         idv_session.send(:user_session)['idv/in_person'] = { pii_from_user: { pii: 'value' } }
       end
 
@@ -235,7 +235,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for verify_info are present' do
       it 'returns verify_info' do
-        stub_up_to_key(key: :ssn, idv_session: idv_session)
+        stub_up_to(:ssn, idv_session: idv_session)
         expect(subject.info_for_latest_step.key).to eq(:verify_info)
         expect(subject.controller_allowed?(controller: Idv::VerifyInfoController)).to be
         expect(subject.controller_allowed?(controller: Idv::PhoneController)).not_to be
@@ -244,7 +244,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for in_person verify_info are present' do
       it 'returns ipp_verify_info' do
-        stub_up_to_key(key: :ipp_ssn, idv_session: idv_session)
+        stub_up_to(:ipp_ssn, idv_session: idv_session)
 
         expect(subject.info_for_latest_step.key).to eq(:ipp_verify_info)
         expect(subject.controller_allowed?(controller: Idv::InPerson::VerifyInfoController)).to be
@@ -254,7 +254,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for phone are present' do
       it 'returns phone' do
-        stub_up_to_key(key: :verify_info, idv_session: idv_session)
+        stub_up_to(:verify_info, idv_session: idv_session)
 
         expect(subject.info_for_latest_step.key).to eq(:phone)
         expect(subject.controller_allowed?(controller: Idv::PhoneController)).to be
@@ -266,7 +266,7 @@ RSpec.describe 'Idv::FlowPolicy' do
       let(:user_phone_confirmation_session) { { code: 'abcde' } }
 
       it 'returns otp_verification' do
-        stub_up_to_key(key: :phone, idv_session: idv_session)
+        stub_up_to(:phone, idv_session: idv_session)
 
         idv_session.user_phone_confirmation_session = user_phone_confirmation_session
 
@@ -278,7 +278,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for request_letter are present' do
       it 'allows request_letter' do
-        stub_up_to_key(key: :verify_info, idv_session: idv_session)
+        stub_up_to(:verify_info, idv_session: idv_session)
 
         expect(subject.controller_allowed?(controller: Idv::ByMail::RequestLetterController)).to be
         expect(subject.controller_allowed?(controller: Idv::EnterPasswordController)).not_to be
@@ -290,7 +290,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
       context 'user has a gpo address_verification_mechanism' do
         it 'returns enter_password with gpo verification pending' do
-          stub_up_to_key(key: :request_letter, idv_session: idv_session)
+          stub_up_to(:request_letter, idv_session: idv_session)
 
           expect(subject.info_for_latest_step.key).to eq(:enter_password)
           expect(subject.controller_allowed?(controller: Idv::EnterPasswordController)).to be
@@ -300,7 +300,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
       context 'user passed phone step' do
         it 'returns enter_password' do
-          stub_up_to_key(key: :otp_verification, idv_session: idv_session)
+          stub_up_to(:otp_verification, idv_session: idv_session)
 
           expect(subject.info_for_latest_step.key).to eq(:enter_password)
           expect(subject.controller_allowed?(controller: Idv::EnterPasswordController)).to be

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -221,7 +221,8 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for in_person ssn are present' do
       before do
-        stub_up_to_key(key: :ipp_address, idv_session: idv_session)
+        stub_up_to_key(key: :hybrid_handoff, idv_session: idv_session)
+        idv_session.send(:user_session)['idv/in_person'] = { pii_from_user: { pii: 'value' } }
       end
 
       it 'returns ipp_ssn' do

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -1,13 +1,13 @@
 module FlowPolicyHelper
-  def stub_up_to_key(key:, idv_session:, user_session: {})
+  def stub_up_to_key(key:, idv_session:)
     keys = keys_up_to(key: key)
 
     keys.each do |key|
-      stub_step(key: key, idv_session: idv_session, user_session: user_session)
+      stub_step(key: key, idv_session: idv_session)
     end
   end
 
-  def stub_step(key:, idv_session:, user_session: {})
+  def stub_step(key:, idv_session:)
     case key
     when :welcome
       idv_session.welcome_visited = true
@@ -22,11 +22,12 @@ module FlowPolicyHelper
       idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT.dup
     when :ssn
       idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
-    when :ipp_ssn
+    when :ipp_address
       idv_session.pii_from_doc = nil
-      user_session['idv/in_person'] = {
+      idv_session.send(:user_session)['idv/in_person'] = {
         pii_from_user: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup,
       }
+    when :ipp_ssn
       idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
     when :verify_info
       idv_session.mark_verify_info_step_complete!
@@ -62,11 +63,11 @@ module FlowPolicyHelper
     when :ssn
       %i[welcome agreement hybrid_handoff document_capture ssn]
     when :ipp_ssn
-      %i[welcome agreement hybrid_handoff document_capture ipp_ssn]
+      %i[welcome agreement hybrid_handoff document_capture ipp_address ipp_ssn]
     when :verify_info
       %i[welcome agreement hybrid_handoff document_capture ssn verify_info]
     when :ipp_verify_info
-      %i[welcome agreement hybrid_handoff document_capture ipp_ssn ipp_verify_info]
+      %i[welcome agreement hybrid_handoff document_capture ipp_address ipp_ssn ipp_verify_info]
     when :phone
       %i[welcome agreement hybrid_handoff document_capture ssn verify_info phone]
     when :otp_verification

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -35,6 +35,7 @@ module FlowPolicyHelper
       idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup
     when :phone
       idv_session.mark_phone_step_started!
+      idv_session.user_phone_confirmation_session = { code: 'abcde' }
     when :otp_verification
       idv_session.mark_phone_step_complete!
     when :request_letter

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -35,7 +35,6 @@ module FlowPolicyHelper
       idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup
     when :phone
       idv_session.mark_phone_step_started!
-      idv_session.user_phone_confirmation_session = { code: 'abcde' }
     when :otp_verification
       idv_session.mark_phone_step_complete!
     when :request_letter

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -22,12 +22,10 @@ module FlowPolicyHelper
       idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT.dup
     when :ssn
       idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
-    when :ipp_address
-      idv_session.pii_from_doc = nil
+    when :ipp_ssn
       idv_session.send(:user_session)['idv/in_person'] = {
         pii_from_user: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup,
       }
-    when :ipp_ssn
       idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
     when :verify_info
       idv_session.mark_verify_info_step_complete!
@@ -63,11 +61,11 @@ module FlowPolicyHelper
     when :ssn
       %i[welcome agreement hybrid_handoff document_capture ssn]
     when :ipp_ssn
-      %i[welcome agreement hybrid_handoff document_capture ipp_address ipp_ssn]
+      %i[welcome agreement hybrid_handoff ipp_ssn]
     when :verify_info
       %i[welcome agreement hybrid_handoff document_capture ssn verify_info]
     when :ipp_verify_info
-      %i[welcome agreement hybrid_handoff document_capture ipp_address ipp_ssn ipp_verify_info]
+      %i[welcome agreement hybrid_handoff ipp_ssn ipp_verify_info]
     when :phone
       %i[welcome agreement hybrid_handoff document_capture ssn verify_info phone]
     when :otp_verification

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -1,5 +1,5 @@
 module FlowPolicyHelper
-  def stub_up_to_key(key:, idv_session:)
+  def stub_up_to(key, idv_session:)
     keys = keys_up_to(key: key)
 
     keys.each do |key|

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -1,0 +1,83 @@
+module FlowPolicyHelper
+  def stub_up_to_key(key:, idv_session:, user_session: {})
+    keys = keys_up_to(key: key)
+
+    keys.each do |key|
+      stub_step(key: key, idv_session: idv_session, user_session: user_session)
+    end
+  end
+
+  def stub_step(key:, idv_session:, user_session: {})
+    case key
+    when :welcome
+      idv_session.welcome_visited = true
+    when :agreement
+      idv_session.idv_consent_given = true
+    when :hybrid_handoff
+      idv_session.flow_path = 'standard'
+    when :link_sent
+      idv_session.flow_path = 'hybrid'
+      idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT.dup
+    when :document_capture
+      idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT.dup
+    when :ssn
+      idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
+    when :ipp_ssn
+      idv_session.pii_from_doc = nil
+      user_session['idv/in_person'] = {
+        pii_from_user: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup,
+      }
+      idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
+    when :verify_info
+      idv_session.mark_verify_info_step_complete!
+      idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup
+    when :ipp_verify_info
+      idv_session.mark_verify_info_step_complete!
+      idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup
+    when :phone
+      idv_session.mark_phone_step_started!
+    when :otp_verification
+      idv_session.mark_phone_step_complete!
+    when :request_letter
+      idv_session.address_verification_mechanism = 'gpo'
+      idv_session.vendor_phone_confirmation = false
+      idv_session.user_phone_confirmation = false
+    when :enter_password
+      # FINAL!
+    end
+  end
+
+  def keys_up_to(key:)
+    case key
+    when :welcome
+      %i[welcome]
+    when :agreement
+      %i[welcome agreement]
+    when :hybrid_handoff
+      %i[welcome agreement hybrid_handoff]
+    when :link_sent
+      %i[welcome agreement hybrid_handoff link_sent]
+    when :document_capture
+      %i[welcome agreement hybrid_handoff document_capture]
+    when :ssn
+      %i[welcome agreement hybrid_handoff document_capture ssn]
+    when :ipp_ssn
+      %i[welcome agreement hybrid_handoff document_capture ipp_ssn]
+    when :verify_info
+      %i[welcome agreement hybrid_handoff document_capture ssn verify_info]
+    when :ipp_verify_info
+      %i[welcome agreement hybrid_handoff document_capture ipp_ssn ipp_verify_info]
+    when :phone
+      %i[welcome agreement hybrid_handoff document_capture ssn verify_info phone]
+    when :otp_verification
+      %i[welcome agreement hybrid_handoff document_capture ssn verify_info phone otp_verification]
+    when :request_letter
+      %i[welcome agreement hybrid_handoff document_capture ssn verify_info request_letter]
+    when :enter_password
+      %i[welcome agreement hybrid_handoff document_capture ssn verify_info phone otp_verification
+         enter_password]
+    else
+      []
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Introduces helpers in FlowPolicyHelper to set up the preconditions for idv steps in our specs. Note how much cleaner the flow_policy_spec setup is for all the individual step specs. We plan to use `stub_up_to_key` in the controller specs once this is merged.

Along the way, improved preconditions for PhoneStep and VerifyByMail.

## 📜 Testing Plan

- [ ] Primarily spec change, so run specs
- [ ] Create account, start IdV
- [ ] At VerifyInfo step, try to jump to urls: `/verify/phone`, `/verify/phone_confirmation`, `/verify/by_mail/request_letter`, `/verify/enter_password`, `/verify/personal_key`
- [ ] Expect to stay on VerifyInfo
- [ ] Submit VerifyInfo, choose verify by mail, click RequestLetter
- [ ] Use browser back and forward buttons to move in the flow
- [ ] Resubmit VerifyInfo
- [ ] Try to jump to urls:`/verify/phone_confirmation`, `/verify/enter_password`, `/verify/personal_key`
- [ ] Expect to stay on Phone step
- [ ] Submit Phone step
- [ ] Try to jump to urls: `/verify/enter_password`, `/verify/personal_key`
- [ ] Expect to stay on phone confirmation step
- [ ] Submit phone confirmation step
- [ ] Expect to be able to use arrow keys to move around the flow

