### PR TITLE
LG-11696: Associate TOTP setup fields with visual label

### DIFF
--- a/app/components/process_list_component.rb
+++ b/app/components/process_list_component.rb
@@ -20,11 +20,12 @@ class ProcessListComponent < BaseComponent
   end
 
   class ProcessListItemComponent < BaseComponent
-    attr_reader :heading_level, :heading
+    attr_reader :heading_level, :heading, :id
 
-    def initialize(heading_level:, heading:)
+    def initialize(heading_level:, heading:, id: nil)
       @heading_level = heading_level
       @heading = heading
+      @id = id
     end
   end
 end

--- a/app/components/process_list_component.rb
+++ b/app/components/process_list_component.rb
@@ -20,12 +20,19 @@ class ProcessListComponent < BaseComponent
   end
 
   class ProcessListItemComponent < BaseComponent
-    attr_reader :heading_level, :heading, :id
+    attr_reader :heading_level, :heading, :heading_id
 
-    def initialize(heading_level:, heading:, id: nil)
+    def initialize(heading_level:, heading:, heading_id: nil)
       @heading_level = heading_level
       @heading = heading
-      @id = id
+      @heading_id = heading_id
+    end
+
+    def heading_options
+      options = { class: 'usa-process-list__heading' }
+
+      options[:id] = heading_id if heading_id.present?
+      options
     end
   end
 end

--- a/app/components/process_list_item_component.html.erb
+++ b/app/components/process_list_item_component.html.erb
@@ -1,4 +1,6 @@
 <li class="usa-process-list__item">
-  <%= content_tag(heading_level, heading, class: 'usa-process-list__heading') %>
+  <% tag_options = { class: 'usa-process-list__heading' } %>
+  <% tag_options[:id] = id if id.present? %>
+  <%= content_tag(heading_level, heading, **tag_options) %>
   <%= content %>
 </li>

--- a/app/components/process_list_item_component.html.erb
+++ b/app/components/process_list_item_component.html.erb
@@ -1,6 +1,4 @@
 <li class="usa-process-list__item">
-  <% tag_options = { class: 'usa-process-list__heading' } %>
-  <% tag_options[:id] = id if id.present? %>
-  <%= content_tag(heading_level, heading, **tag_options) %>
+  <%= content_tag(heading_level, heading, **heading_options) %>
   <%= content %>
 </li>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -19,7 +19,7 @@
 <%= simple_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
   <fieldset aria-labelledby="totp-intro" class="padding-0 border-0 margin-y-4 margin-x-0">
     <%= render ProcessListComponent.new(connected: true) do |c| %>
-      <%= c.with_item(heading: t('forms.totp_setup.totp_step_1')) do %>
+      <%= c.with_item(heading: t('forms.totp_setup.totp_step_1'), id: 'totp-step-1-label') do %>
         <p><%= t('forms.totp_setup.totp_step_1a') %></p>
         <%= render ValidatedFieldComponent.new(
               form: f,
@@ -28,7 +28,7 @@
               label: false,
               wrapper_html: { class: 'margin-bottom-0' },
               input_html: {
-                aria: { label: t('forms.totp_setup.totp_step_1') },
+                aria: { labelledby: 'totp-step-1-label' },
                 maxlength: 20,
               },
             ) %>
@@ -44,7 +44,7 @@
         </code>
         <%= render ClipboardButtonComponent.new(clipboard_text: @code.upcase, outline: true) %>
       <% end %>
-      <%= c.with_item(heading: t('forms.totp_setup.totp_step_4')) do %>
+      <%= c.with_item(heading: t('forms.totp_setup.totp_step_4'), id: 'totp-step-4-label') do %>
         <%= render OneTimeCodeInputComponent.new(
               form: f,
               transport: nil,
@@ -55,7 +55,7 @@
                   class: 'margin-bottom-0',
                 },
                 input_html: {
-                  aria: { label: t('forms.totp_setup.totp_step_4') },
+                  aria: { labelledby: 'totp-step-4-label' },
                 },
               },
             ) %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -19,7 +19,7 @@
 <%= simple_form_for('', method: :patch, html: { class: 'margin-bottom-4' }) do |f| %>
   <fieldset aria-labelledby="totp-intro" class="padding-0 border-0 margin-y-4 margin-x-0">
     <%= render ProcessListComponent.new(connected: true) do |c| %>
-      <%= c.with_item(heading: t('forms.totp_setup.totp_step_1'), id: 'totp-step-1-label') do %>
+      <%= c.with_item(heading: t('forms.totp_setup.totp_step_1'), heading_id: 'totp-step-1-label') do %>
         <p><%= t('forms.totp_setup.totp_step_1a') %></p>
         <%= render ValidatedFieldComponent.new(
               form: f,
@@ -44,7 +44,7 @@
         </code>
         <%= render ClipboardButtonComponent.new(clipboard_text: @code.upcase, outline: true) %>
       <% end %>
-      <%= c.with_item(heading: t('forms.totp_setup.totp_step_4'), id: 'totp-step-4-label') do %>
+      <%= c.with_item(heading: t('forms.totp_setup.totp_step_4'), heading_id: 'totp-step-4-label') do %>
         <%= render OneTimeCodeInputComponent.new(
               form: f,
               transport: nil,

--- a/spec/components/process_list_component_spec.rb
+++ b/spec/components/process_list_component_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe ProcessListComponent, type: :component do
     end
   end
 
+  context 'with specified id' do
+    it 'renders with css class' do
+      rendered = render_inline ProcessListComponent.new(id: 'my-custom-id')
+
+      expect(rendered).to have_selector('#my-custom-id')
+    end
+  end
+
   context 'tag options' do
     it 'applies tag options to wrapper element' do
       rendered = render_inline ProcessListComponent.new(data: { foo: 'bar' })

--- a/spec/components/process_list_component_spec.rb
+++ b/spec/components/process_list_component_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe ProcessListComponent, type: :component do
     expect(rendered).to have_css('.usa-process-list__item', text: 'Item 2 Content')
   end
 
+  it 'renders items with custom heading id' do
+    rendered = render_inline ProcessListComponent.new do |c|
+      c.with_item(heading: 'Item 1', heading_id: 'heading-id-1')
+      c.with_item(heading: 'Item 2', heading_id: 'heading-id-2')
+    end
+
+    expect(rendered).to have_selector('#heading-id-1', text: 'Item 1')
+    expect(rendered).to have_selector('#heading-id-2', text: 'Item 2')
+  end
+
   context 'custom heading level' do
     it 'renders items slot content at custom heading level' do
       rendered = render_inline ProcessListComponent.new(heading_level: :h3) do |c|

--- a/spec/components/process_list_component_spec.rb
+++ b/spec/components/process_list_component_spec.rb
@@ -53,14 +53,6 @@ RSpec.describe ProcessListComponent, type: :component do
     end
   end
 
-  context 'with specified id' do
-    it 'renders with css class' do
-      rendered = render_inline ProcessListComponent.new(id: 'my-custom-id')
-
-      expect(rendered).to have_selector('#my-custom-id')
-    end
-  end
-
   context 'tag options' do
     it 'applies tag options to wrapper element' do
       rendered = render_inline ProcessListComponent.new(data: { foo: 'bar' })

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -26,10 +26,7 @@ RSpec.describe 'Remembering a TOTP device' do
       user.password = Features::SessionHelper::VALID_PASSWORD
 
       select_2fa_option('auth_app')
-
-      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
-      nickname_field.set('App')
-
+      fill_in_totp_name
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default
@@ -50,8 +47,7 @@ RSpec.describe 'Remembering a TOTP device' do
       click_on t('account.index.totp_confirm_delete')
       travel_to(10.seconds.from_now) # Travel past the revoked at date from disabling the device
       click_link t('account.index.auth_app_add'), href: authenticator_setup_url
-      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
-      nickname_field.set('App')
+      fill_in_totp_name
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -26,7 +26,10 @@ RSpec.describe 'Remembering a TOTP device' do
       user.password = Features::SessionHelper::VALID_PASSWORD
 
       select_2fa_option('auth_app')
-      fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
+
+      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
+      nickname_field.set('App')
+
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default
@@ -47,7 +50,8 @@ RSpec.describe 'Remembering a TOTP device' do
       click_on t('account.index.totp_confirm_delete')
       travel_to(10.seconds.from_now) # Travel past the revoked at date from disabling the device
       click_link t('account.index.auth_app_add'), href: authenticator_setup_url
-      fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
+      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
+      nickname_field.set('App')
       fill_in :code, with: totp_secret_from_page
       check t('forms.messages.remember_device')
       click_submit_default

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'Unchecking remember device' do
         select_2fa_option('auth_app')
 
         secret = find('#qr-code').text
-        fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
+        nickname_field = find('[aria-labelledby="totp-step-1-label"]')
+        nickname_field.set('App')
         fill_in 'code', with: generate_totp_code(secret)
         uncheck 'remember_device'
 

--- a/spec/features/remember_device/user_opted_preference_spec.rb
+++ b/spec/features/remember_device/user_opted_preference_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'Unchecking remember device' do
         select_2fa_option('auth_app')
 
         secret = find('#qr-code').text
-        nickname_field = find('[aria-labelledby="totp-step-1-label"]')
-        nickname_field.set('App')
+
+        fill_in_totp_name
         fill_in 'code', with: generate_totp_code(secret)
         uncheck 'remember_device'
 

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -72,7 +72,9 @@ RSpec.feature 'Multi Two Factor Authentication' do
       expect(page).to have_current_path(authentication_methods_setup_path)
 
       select_2fa_option('auth_app')
-      fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
+
+      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
+      nickname_field.set('App')
 
       secret = find('#qr-code').text
       totp = generate_totp_code(secret)
@@ -97,7 +99,9 @@ RSpec.feature 'Multi Two Factor Authentication' do
       click_continue
 
       expect(current_path).to eq authenticator_setup_path
-      fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
+
+      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
+      nickname_field.set('App')
 
       secret = find('#qr-code').text
       totp = generate_totp_code(secret)

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -73,8 +73,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
 
       select_2fa_option('auth_app')
 
-      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
-      nickname_field.set('App')
+      fill_in_totp_name
 
       secret = find('#qr-code').text
       totp = generate_totp_code(secret)
@@ -100,8 +99,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
 
       expect(current_path).to eq authenticator_setup_path
 
-      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
-      nickname_field.set('App')
+      fill_in_totp_name
 
       secret = find('#qr-code').text
       totp = generate_totp_code(secret)

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe 'totp management' do
 
       expect(
         [
-          page.find_field(t('forms.totp_setup.totp_step_1')),
-          page.find_field(t('forms.totp_setup.totp_step_4')),
+          page.find('[aria-labelledby="totp-step-1-label"]'),
+          page.find('[aria-labelledby="totp-step-4-label"]'),
         ],
       ).to be_logically_grouped(t('forms.totp_setup.totp_intro'))
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -567,10 +567,15 @@ module Features
 
       expect(page).to have_current_path authenticator_setup_path
 
-      fill_in t('forms.totp_setup.totp_step_1'), with: 'App'
+      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
+      nickname_field.set('App')
 
       secret = find('#qr-code').text
-      fill_in 'code', with: generate_totp_code(secret)
+
+      nickname_field = find('[aria-labelledby="totp-step-4-label"]')
+      totp_code = generate_totp_code(secret)
+      nickname_field.set(totp_code)
+
       click_button 'Submit'
     end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -114,6 +114,10 @@ module Features
       click_button t('links.sign_in')
     end
 
+    def fill_in_totp_name(nickname = 'App')
+      fill_in 'name', with: nickname
+    end
+
     def continue_as(email = nil, password = VALID_PASSWORD)
       return unless current_url.include?(user_authorization_confirmation_path)
 
@@ -286,7 +290,7 @@ module Features
 
     def fill_in_code_with_last_totp(user)
       accept_rules_of_use_and_continue_if_displayed
-      fill_in I18n.t('components.one_time_code_input.label'), with: last_totp(user)
+      fill_in 'code', with: last_totp(user)
     end
 
     def accept_rules_of_use_and_continue_if_displayed
@@ -567,14 +571,12 @@ module Features
 
       expect(page).to have_current_path authenticator_setup_path
 
-      nickname_field = find('[aria-labelledby="totp-step-1-label"]')
-      nickname_field.set('App')
+      fill_in_totp_name
 
       secret = find('#qr-code').text
-
-      nickname_field = find('[aria-labelledby="totp-step-4-label"]')
+      code_field = find('[aria-labelledby="totp-step-4-label"]')
       totp_code = generate_totp_code(secret)
-      nickname_field.set(totp_code)
+      code_field.set(totp_code)
 
       click_button 'Submit'
     end

--- a/spec/views/users/totp_setup/new.html.erb_spec.rb
+++ b/spec/views/users/totp_setup/new.html.erb_spec.rb
@@ -49,8 +49,14 @@ RSpec.describe 'users/totp_setup/new.html.erb' do
     it 'has labelled fields' do
       render
 
-      expect(rendered).to have_field(t('forms.totp_setup.totp_step_1'))
-      expect(rendered).to have_field(t('forms.totp_setup.totp_step_4'))
+      expect(rendered).to have_selector(
+        'h2#totp-step-1-label',
+        text: t('forms.totp_setup.totp_step_1'),
+      )
+      expect(rendered).to have_selector(
+        'h2#totp-step-4-label',
+        text: t('forms.totp_setup.totp_step_4'),
+      )
     end
   end
 

--- a/spec/views/users/totp_setup/new.html.erb_spec.rb
+++ b/spec/views/users/totp_setup/new.html.erb_spec.rb
@@ -58,6 +58,13 @@ RSpec.describe 'users/totp_setup/new.html.erb' do
         text: t('forms.totp_setup.totp_step_4'),
       )
     end
+
+    it 'has aria labels for TOTP' do
+      render
+
+      expect(rendered).to have_selector('[aria-labelledby="totp-step-1-label"]')
+      expect(rendered).to have_selector('[aria-labelledby="totp-step-4-label"]')
+    end
   end
 
   context 'user is setting up 2FA' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG11696](https://cm-jira.usa.gov/browse/LG-11696)


## 🛠 Summary of changes

Adds `aria-labelledby` to input fields on the page  `/authenticator_setup`.


## 📜 Testing Plan

- See aria attributes added to inputs on /authenticator_setup

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
