### PR TITLE
Reveal GPO codes on identitysandbox.gov

### DIFF
--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -1,10 +1,4 @@
 class FeatureManagement
-  ENVS_WHERE_PREFILLING_GPO_CODE_ALLOWED = %w[
-    idp.dev.login.gov idp.int.login.gov idp.qa.login.gov idp.pt.login.gov
-    idp.dev.identitysandbox.gov idp.qa.identitysandbox.gov idp.int.identitysandbox.gov
-    idp.pt.identitysandbox.gov
-  ].freeze
-
   def self.telephony_test_adapter?
     IdentityConfig.store.telephony_adapter == 'test'
   end
@@ -63,7 +57,7 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    ENVS_WHERE_PREFILLING_GPO_CODE_ALLOWED.include?(IdentityConfig.store.domain_name)
+    Identity::Hostdata.domain == 'identitysandbox.gov'
   end
 
   def self.show_demo_banner?

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -104,30 +104,41 @@ RSpec.describe 'FeatureManagement' do
   end
 
   describe '#reveal_gpo_code?' do
-    context 'server domain name is dev, qa, or int' do
-      it 'returns true' do
-        %w[idp.dev.login.gov idp.int.login.gov idp.qa.login.gov].each do |domain|
-          allow(IdentityConfig.store).to receive(:domain_name).and_return(domain)
+    context 'domain is set to identitysandbox.gov' do
+      before do
+        allow(Identity::Hostdata).to receive(:domain).and_return('identitysandbox.gov')
+      end
 
+      context 'Rails env is development' do
+        before do
+          allow(Rails.env).to receive(:development?).and_return(true)
+          allow(Rails.env).to receive(:production?).and_return(false)
+        end
+        it 'returns true' do
+          expect(FeatureManagement.reveal_gpo_code?).to eq(true)
+        end
+      end
+
+      context 'Rails env is production' do
+        before do
+          allow(Rails.env).to receive(:development?).and_return(false)
+          allow(Rails.env).to receive(:production?).and_return(true)
+        end
+        it 'returns true' do
           expect(FeatureManagement.reveal_gpo_code?).to eq(true)
         end
       end
     end
 
-    context 'Rails env is development' do
-      it 'returns true' do
-        allow(Rails.env).to receive(:development?).and_return(true)
-
-        expect(FeatureManagement.reveal_gpo_code?).to eq(true)
-      end
-    end
-
-    context 'Rails env is not development and server is not dev, qa, or int' do
-      it 'returns false' do
-        allow(Rails.env).to receive(:development?).and_return(false)
-        allow(IdentityConfig.store).to receive(:domain_name).and_return('foo.login.gov')
-
-        expect(FeatureManagement.reveal_gpo_code?).to eq(false)
+    context 'domain is set to login.gov' do
+      context 'Rails env is production' do
+        before do
+          allow(Rails.env).to receive(:development?).and_return(false)
+          allow(Rails.env).to receive(:production?).and_return(true)
+        end
+        it 'returns false' do
+          expect(FeatureManagement.reveal_gpo_code?).to eq(false)
+        end
       end
     end
   end


### PR DESCRIPTION
Previously, we used an allowlist for specific subdomains on identitysandbox.gov. This means that Gitlab review apps are not able to reveal GPO codes for users testing GPO functionality.

This update makes it so all apps running on identitysandbox.gov reveal their GPO code.