### PR TITLE
Allow in person flow to be repeated after resubmitting earlier step

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -168,6 +168,9 @@ module Idv
     def invalidate_in_person_pii_from_user!
       if has_pii_from_user_in_flow_session
         user_session['idv/in_person'][:pii_from_user] = nil
+        # Mark the two FSM steps as incomplete so that they can be re-entered.
+        user_session['idv/in_person'].delete('Idv::Steps::InPerson::StateIdStep')
+        user_session['idv/in_person'].delete('Idv::Steps::InPerson::AddressStep')
       end
     end
 

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe 'Identity verification', :js do
 
       begin_in_person_proofing
       complete_all_in_person_proofing_steps(user)
+      test_restart_in_person_flow(user)
 
       enter_gpo_flow
       test_go_back_from_request_letter
@@ -494,6 +495,12 @@ RSpec.describe 'Identity verification', :js do
     # can't go back further with in person controllers (yet)
 
     3.times { go_forward }
+  end
+
+  def test_restart_in_person_flow(user)
+    visit(idv_welcome_path)
+    begin_in_person_proofing
+    complete_all_in_person_proofing_steps(user)
   end
 
   def try_to_go_back_from_letter_enqueued


### PR DESCRIPTION
## 🛠 Summary of changes

This is a bug-fix followup to back button work. Mark in person FSM steps incomplete when restarting the flow. Without this fix the in person FSM steps are marked complete the first time they are submitted and cannot be reentered.

## 📜 Testing Plan

Try this on main to confirm the bug, and then on this branch.

- [ ] Create account, start Idv
- [ ] Choose in person flow and submit the State Id page (optionally continue and submit Ssn)
- [ ] Click back button back to Agreement step (or enter `/verify/agreement` url)
- [ ] Resubmit Agreement and try to repeat in person flow
- [ ] On main, you will jump to Ssn (or get a redirect loop if you submitted it)
- [ ] On this branch, you will be able to complete the in person flow
