### PR TITLE
Add temporary Rake task to backfill Profile idv_level

### DIFF
--- a/lib/tasks/backfill_idv_level.rake
+++ b/lib/tasks/backfill_idv_level.rake
@@ -1,0 +1,48 @@
+namespace :profiles do
+  desc 'Backfill the idv_level column.'
+
+  ##
+  # Usage:
+  #
+  # bundle exec rake profiles:backfill_idv_level
+  #
+  task backfill_idv_level: :environment do |_task, _args|
+    with_statement_timeout do
+      is_in_person = Profile.where(id: InPersonEnrollment.select(:profile_id))
+      is_not_in_person = Profile.where.not(id: InPersonEnrollment.select(:profile_id))
+      needs_idv_level = Profile.where(idv_level: nil)
+
+      # rubocop:disable Rails/SkipsModelValidations
+      count = Profile.and(is_in_person).and(needs_idv_level).
+        update_all(idv_level: :legacy_in_person)
+      warn("set idv_level for #{count} legacy_in_person profile(s)")
+
+      count = Profile.and(is_not_in_person).and(needs_idv_level).
+        update_all(idv_level: :legacy_unsupervised)
+      warn("set idv_level for #{count} legacy_unsupervised profile(s)")
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    with_statement_timeout do
+      warn('Profile counts by idv_level after update:')
+      [:legacy_in_person, :legacy_unsupervised, nil].each do |value|
+        count = Profile.where(idv_level: value).count
+        warn("#{value.inspect}: #{count}")
+      end
+    end
+  end
+
+  def with_statement_timeout(timeout_in_seconds = nil)
+    timeout_in_seconds ||= if ENV['STATEMENT_TIMEOUT_IN_SECONDS']
+                             ENV['STATEMENT_TIMEOUT_IN_SECONDS'].to_i.seconds
+                          else
+                            60.seconds
+                          end
+
+    ActiveRecord::Base.transaction do
+      quoted_timeout = ActiveRecord::Base.connection.quote(timeout_in_seconds.in_milliseconds)
+      ActiveRecord::Base.connection.execute("SET statement_timeout = #{quoted_timeout}")
+      yield
+    end
+  end
+end

--- a/spec/lib/tasks/backfill_idv_level_rake_spec.rb
+++ b/spec/lib/tasks/backfill_idv_level_rake_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'profiles:backfill_idv_level rake task' do
+  let(:task) do
+    Rake.application.rake_require 'tasks/backfill_idv_level'
+    Rake::Task.define_task(:environment)
+    Rake::Task['profiles:backfill_idv_level']
+  end
+
+  subject(:invoke_task) do
+    og_stderr = $stderr
+    fake_stderr = StringIO.new
+    begin
+      $stderr = fake_stderr
+      task.reenable
+      task.invoke
+      fake_stderr.string
+    ensure
+      $stderr = og_stderr
+    end
+  end
+
+  let(:profiles) do
+    {
+      unsupervised: create(:user, :proofed).active_profile,
+      unsupervised_no_level: create(:user, :proofed).active_profile.tap do |profile|
+                               profile.update!(idv_level: nil)
+                             end,
+      in_person: create(
+        :user,
+        :with_pending_in_person_enrollment,
+      ).pending_profile,
+      in_person_no_level: create(
+        :user,
+        :with_pending_in_person_enrollment,
+      ).pending_profile.tap { |profile| profile.update!(idv_level: nil) },
+    }
+  end
+
+  before do
+    expect(profiles[:unsupervised].idv_level).not_to be_nil
+    expect(profiles[:unsupervised_no_level].idv_level).to be_nil
+    expect(profiles[:in_person].idv_level).not_to be_nil
+    expect(profiles[:in_person_no_level].idv_level).to be_nil
+    invoke_task
+  end
+
+  it 'outputs what it did' do
+    expect(invoke_task.to_s).to eql(
+      <<~END,
+        set idv_level for 1 legacy_in_person profile(s)
+        set idv_level for 1 legacy_unsupervised profile(s)
+        Profile counts by idv_level after update:
+        :legacy_in_person: 2
+        :legacy_unsupervised: 2
+        nil: 0
+      END
+    )
+  end
+
+  it 'updates legacy unsupervised user that was missing value' do
+    expect(profiles[:unsupervised_no_level].reload.idv_level).to eql('legacy_unsupervised')
+  end
+
+  it 'does not mess up unsupervised user with value' do
+    expect(profiles[:unsupervised].reload.idv_level).to eql('legacy_unsupervised')
+  end
+
+  it 'updates legacy in person user that was missing value' do
+    expect(profiles[:in_person_no_level].reload.idv_level).to eql('legacy_in_person')
+  end
+
+  it 'does not mess up in person user with value' do
+    expect(profiles[:in_person].reload.idv_level).to eql('legacy_in_person')
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11693](https://cm-jira.usa.gov/browse/LG-11693)


## 🛠 Summary of changes

Adds a temporary Rake task, `profiles:backfill_idv_level`, to support an upcoming roll plan. Will be removed when roll plan is complete.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] `bundle exec rake profiles:backfill_idv_level`
- [ ] Open a rails console and verify all records in your `profiles` table have `idv_level` set: 

```ruby
Profile.where(idv_level: nil).count # should be 0
```

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
