### PR TITLE
LG-10976: Delete Account from Dashboard triggers Account deleted email

### DIFF
--- a/app/controllers/users/delete_controller.rb
+++ b/app/controllers/users/delete_controller.rb
@@ -56,7 +56,7 @@ module Users
     def notify_user_via_email_of_deletion
       current_user.confirmed_email_addresses.each do |email_address|
         UserMailer.with(user: current_user, email_address: email_address).
-          account_reset_complete.deliver_now
+          account_delete_submitted.deliver_now
       end
     end
     # rubocop:enable IdentityIdp/MailLaterLinter

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -174,6 +174,12 @@ class UserMailer < ActionMailer::Base
     end
   end
 
+  def account_delete_submitted
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: t('user_mailer.account_reset_complete.subject'))
+    end
+  end
+
   def account_reset_cancel
     with_user_locale(user) do
       mail(to: email_address.email, subject: t('user_mailer.account_reset_cancel.subject'))

--- a/app/views/user_mailer/account_delete_submitted.html.erb
+++ b/app/views/user_mailer/account_delete_submitted.html.erb
@@ -1,0 +1,21 @@
+<p class="lead">
+  <%= t('user_mailer.account_reset_complete.intro_html', app_name_html: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
+</p>
+
+<table class="spacer">
+  <tbody>
+    <tr>
+      <td class="s10" height="10px">
+        &nbsp;
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="hr">
+  <tr>
+    <th>
+      &nbsp;
+    </th>
+  </tr>
+</table>

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe Users::DeleteController do
       expect(User.where(id: user.id).length).to eq(0)
     end
 
+    it 'emails user of account deletion' do
+      stub_signed_in_user
+      delete
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+    end
+
     it 'logs a succesful submit' do
       stub_analytics
       stub_attempts_tracker

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -71,9 +71,10 @@ RSpec.describe Users::DeleteController do
     end
 
     it 'emails user of account deletion' do
+      allow(UserMailer).to receive(:account_delete_submitted).and_call_original
       stub_signed_in_user
       delete
-      expect(ActionMailer::Base.deliveries.count).to eq 1
+      expect(UserMailer).not_to have_received(:account_delete_submitted)
     end
 
     it 'logs a succesful submit' do

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -84,6 +84,10 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.with(user: user, email_address: email_address_record).account_reset_complete
   end
 
+  def account_delete_submitted
+    UserMailer.with(user: user, email_address: email_address_record).account_delete_submitted
+  end
+
   def account_reset_cancel
     UserMailer.with(user: user, email_address: email_address_record).account_reset_cancel
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -426,6 +426,31 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
+  describe '#account_delete_submitted' do
+    let(:mail) do
+      UserMailer.with(user: user, email_address: email_address).
+        account_delete_submitted
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+
+    it 'sends to the current email' do
+      expect(mail.to).to eq [email_address.email]
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('user_mailer.account_reset_complete.subject')
+    end
+
+    it 'renders the body' do
+      expect(mail.html_part.body).
+        to have_content(
+          strip_tags(t('user_mailer.account_reset_complete.intro_html', app_name_html: APP_NAME)),
+        )
+    end
+  end
+
   describe '#account_reset_cancel' do
     let(:mail) do
       UserMailer.with(user: user, email_address: email_address).


### PR DESCRIPTION

## 🎫 Ticket
[LG-10976: Delete Account triggers delete email](https://cm-jira.usa.gov/browse/LG-10976)


## 🛠 Summary of changes
Account deletion triggers an email to user email when deleting through Account dashboard

## 📜 Testing Plan

- Create an account
- Go to Account Dashboard
- Delete account
- Ensure that email is sent to user email when account is deleted


## 👀 Screenshots

![Screenshot 2023-12-07 at 9 13 17 AM](https://github.com/18F/identity-idp/assets/23225522/f5c92cc4-a6fe-4d25-b59d-136fb61efa47)
![Screenshot 2023-12-07 at 9 13 23 AM](https://github.com/18F/identity-idp/assets/23225522/4bfb38a7-7d62-4888-92d9-b4c74d986dbc)

