### PR TITLE
Revert to using non-rails method for Date

### DIFF
--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -168,7 +168,8 @@ module Reporting
     def overview_table
       [
         ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
-        ['Report Generated', Time.zone.today.to_s],
+        # This needs to be Date.today so it works when run on the command line
+        ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
         ['Issuer', issuers.join(', ')],
         ['Total # of IAL1 Users', sp_redirect_initiated_all],
       ]

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -78,7 +78,8 @@ module Reporting
     def to_csv
       CSV.generate do |csv|
         csv << ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"]
-        csv << ['Report Generated', Time.zone.today.to_s]
+        # This needs to be Date.today so it works when run on the command line
+        csv << ['Report Generated', Date.today.to_s] # rubocop:disable Rails/Date
         csv << ['Issuer', issuers.join(', ')] if issuers.present?
         csv << []
         csv << ['Metric', '# of Users']

--- a/spec/lib/reporting/authentication_report_spec.rb
+++ b/spec/lib/reporting/authentication_report_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Reporting::AuthenticationReport do
     [
       [
         ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
-        ['Report Generated', Time.zone.today.to_s],
+        ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
         ['Issuer', issuer],
         ['Total # of IAL1 Users', strings ? '2' : 2],
       ],

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Reporting::IdentityVerificationReport do
 
       expected_csv = [
         ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
-        ['Report Generated', Time.zone.today.to_s],
+        ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
         ['Issuer', issuer],
         [],
         ['Metric', '# of Users'],


### PR DESCRIPTION
## 🛠 Summary of changes

Reverts a change that was made for consistency, but unfortunately would lead to command-line reports having blank values for the date generated cell.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
