### PR TITLE
LG-11873: doc auth w/ selfie in non-prod hosted envs

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -58,7 +58,7 @@ module Idv
       return false if Identity::Hostdata.env == 'prod'
       return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
 
-      !!sp_session[:biometric_comparison_required]
+      decorated_sp_session.selfie_required?
     end
 
     private

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -55,10 +55,10 @@ module Idv
     end
 
     def liveness_checking_enabled?
-      return false if Identity::Hostdata.env == 'prod'
-      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
+      return { enabled: false } if Identity::Hostdata.env == 'prod'
+      return { enabled: false } unless IdentityConfig.store.doc_auth_selfie_capture_enabled
 
-      return unless sp_session[:biometric_comparison_required]
+      return { enabled: false } unless sp_session[:biometric_comparison_required]
 
       { enabled: true } # until FE updated
     end

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -54,13 +54,6 @@ module Idv
       @stored_result = document_capture_session&.load_result
     end
 
-    def liveness_checking_enabled?
-      return false if Identity::Hostdata.env == 'prod'
-      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
-
-      decorated_sp_session.selfie_required?
-    end
-
     private
 
     def track_document_issuing_state(user, state)

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -58,7 +58,9 @@ module Idv
       return false if Identity::Hostdata.env == 'prod'
       return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
 
-      sp_session[:biometric_camparison_required]
+      return unless sp_session[:biometric_comparison_required]
+
+      { enabled: true } # until FE updated
     end
 
     private

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -55,6 +55,7 @@ module Idv
     end
 
     def liveness_checking_enabled
+      return if Identity::Hostdata.env == 'prod'
       return if params[:selfie] != 'true'
 
       IdentityConfig.store.doc_auth_selfie_capture_enabled

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -54,6 +54,12 @@ module Idv
       @stored_result = document_capture_session&.load_result
     end
 
+    def liveness_checking_enabled
+      return if params[:selfie] != 'true'
+
+      IdentityConfig.store.doc_auth_selfie_capture_enabled
+    end
+
     private
 
     def track_document_issuing_state(user, state)

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -54,11 +54,11 @@ module Idv
       @stored_result = document_capture_session&.load_result
     end
 
-    def liveness_checking_enabled
-      return if Identity::Hostdata.env == 'prod'
-      return if params[:selfie] != 'true'
+    def liveness_checking_enabled?
+      return false if Identity::Hostdata.env == 'prod'
+      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
 
-      IdentityConfig.store.doc_auth_selfie_capture_enabled
+      sp_session[:biometric_camparison_required]
     end
 
     private

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -55,12 +55,10 @@ module Idv
     end
 
     def liveness_checking_enabled?
-      return { enabled: false } if Identity::Hostdata.env == 'prod'
-      return { enabled: false } unless IdentityConfig.store.doc_auth_selfie_capture_enabled
+      return false if Identity::Hostdata.env == 'prod'
+      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
 
-      return { enabled: false } unless sp_session[:biometric_comparison_required]
-
-      { enabled: true } # until FE updated
+      !!sp_session[:biometric_comparison_required]
     end
 
     private

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -48,6 +48,7 @@ module Idv
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         skip_doc_auth: idv_session.skip_doc_auth,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
+        doc_auth_selfie_capture: liveness_checking_enabled,
       }.merge(
         acuant_sdk_upgrade_a_b_testing_variables,
       )

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -48,7 +48,7 @@ module Idv
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         skip_doc_auth: idv_session.skip_doc_auth,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
-        doc_auth_selfie_capture: liveness_checking_enabled?,
+        doc_auth_selfie_capture: decorated_sp_session.selfie_required?,
       }.merge(
         acuant_sdk_upgrade_a_b_testing_variables,
       )

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -48,7 +48,7 @@ module Idv
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         skip_doc_auth: idv_session.skip_doc_auth,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
-        doc_auth_selfie_capture: liveness_checking_enabled,
+        doc_auth_selfie_capture: liveness_checking_enabled?,
       }.merge(
         acuant_sdk_upgrade_a_b_testing_variables,
       )

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -41,7 +41,7 @@ module Idv
           flow_path: 'hybrid',
           document_capture_session_uuid: document_capture_session_uuid,
           failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
-          doc_auth_selfie_capture: liveness_checking_enabled?,
+          doc_auth_selfie_capture: decorated_sp_session.selfie_required?,
         }.merge(
           acuant_sdk_upgrade_a_b_testing_variables,
         )

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -41,6 +41,7 @@ module Idv
           flow_path: 'hybrid',
           document_capture_session_uuid: document_capture_session_uuid,
           failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
+          doc_auth_selfie_capture: liveness_checking_enabled,
         }.merge(
           acuant_sdk_upgrade_a_b_testing_variables,
         )

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -41,7 +41,7 @@ module Idv
           flow_path: 'hybrid',
           document_capture_session_uuid: document_capture_session_uuid,
           failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
-          doc_auth_selfie_capture: liveness_checking_enabled,
+          doc_auth_selfie_capture: liveness_checking_enabled?,
         }.merge(
           acuant_sdk_upgrade_a_b_testing_variables,
         )

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -25,6 +25,7 @@ module Idv
         uuid_prefix: current_sp&.app_id,
         irs_attempts_api_tracker: irs_attempts_api_tracker,
         store_encrypted_images: store_encrypted_images?,
+        liveness_checking_required: liveness_checking_required?,
       )
     end
 
@@ -42,6 +43,10 @@ module Idv
         service_provider: current_sp,
         user: current_user,
       )
+    end
+
+    def liveness_checking_required?
+      sp_session[:biometric_camparison_required]
     end
   end
 end

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -23,7 +23,7 @@ module Idv
         uuid_prefix: current_sp&.app_id,
         irs_attempts_api_tracker: irs_attempts_api_tracker,
         store_encrypted_images: store_encrypted_images?,
-        liveness_checking_required: liveness_checking_required?,
+        liveness_checking_required: decorated_sp_session.selfie_required?,
       )
     end
 
@@ -33,13 +33,6 @@ module Idv
 
     def liveness_checking_enabled?
       IdentityConfig.store.doc_auth_selfie_capture_enabled
-    end
-
-    def liveness_checking_required?
-      return false if Identity::Hostdata.env == 'prod'
-      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
-
-      decorated_sp_session.selfie_required?
     end
   end
 end

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -20,7 +20,6 @@ module Idv
     def image_upload_form
       @image_upload_form ||= Idv::ApiImageUploadForm.new(
         params,
-        # liveness_checking_enabled: liveness_checking_enabled?,
         service_provider: current_sp,
         analytics: analytics,
         uuid_prefix: current_sp&.app_id,

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -1,7 +1,5 @@
 module Idv
   class ImageUploadsController < ApplicationController
-    include ApplicationHelper # for liveness_checking_enabled? -- can be removed?
-
     respond_to :json
 
     def create
@@ -35,14 +33,6 @@ module Idv
 
     def liveness_checking_enabled?
       IdentityConfig.store.doc_auth_selfie_capture_enabled
-    end
-
-    def ial_context
-      @ial_context ||= IalContext.new(
-        ial: sp_session_ial,
-        service_provider: current_sp,
-        user: current_user,
-      )
     end
 
     def liveness_checking_required?

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -36,7 +36,7 @@ module Idv
     end
 
     def liveness_checking_required?
-      sp_session[:biometric_camparison_required]
+      decorated_sp_session.selfie_required?
     end
   end
 end

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -36,6 +36,9 @@ module Idv
     end
 
     def liveness_checking_required?
+      return false if Identity::Hostdata.env == 'prod'
+      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
+
       decorated_sp_session.selfie_required?
     end
   end

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -1,6 +1,6 @@
 module Idv
   class ImageUploadsController < ApplicationController
-    include ApplicationHelper # for liveness_checking_enabled?
+    include ApplicationHelper # for liveness_checking_enabled? -- can be removed?
 
     respond_to :json
 
@@ -20,7 +20,7 @@ module Idv
     def image_upload_form
       @image_upload_form ||= Idv::ApiImageUploadForm.new(
         params,
-        liveness_checking_enabled: liveness_checking_enabled?,
+        # liveness_checking_enabled: liveness_checking_enabled?,
         service_provider: current_sp,
         analytics: analytics,
         uuid_prefix: current_sp&.app_id,

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -45,6 +45,10 @@ class NullServiceProviderSession
     {}
   end
 
+  def selfie_required?
+    false
+  end
+
   private
 
   attr_reader :view_context

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -71,6 +71,8 @@ class ServiceProviderSession
   end
 
   def selfie_required?
+    return false if Identity::Hostdata.env == 'prod'
+
     !!(IdentityConfig.store.doc_auth_selfie_capture_enabled &&
       sp_session[:biometric_comparison_required])
   end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -5,7 +5,7 @@ module Idv
 
     validates_presence_of :front
     validates_presence_of :back
-    validates_presence_of :selfie, if: :liveness_checking_enabled
+    validates_presence_of :selfie, if: :liveness_checking_enabled?
     validates_presence_of :document_capture_session
 
     validate :validate_images
@@ -13,8 +13,7 @@ module Idv
     validate :limit_if_rate_limited
 
     def initialize(params, service_provider:, analytics: nil,
-                   uuid_prefix: nil, irs_attempts_api_tracker: nil, store_encrypted_images: false,
-                   liveness_checking_enabled: false)
+                   uuid_prefix: nil, irs_attempts_api_tracker: nil, store_encrypted_images: false)
       @params = params
       @service_provider = service_provider
       @analytics = analytics
@@ -22,7 +21,6 @@ module Idv
       @uuid_prefix = uuid_prefix
       @irs_attempts_api_tracker = irs_attempts_api_tracker
       @store_encrypted_images = store_encrypted_images
-      @liveness_checking_enabled = liveness_checking_enabled
     end
 
     def submit
@@ -54,7 +52,7 @@ module Idv
     private
 
     attr_reader :params, :analytics, :service_provider, :form_response, :uuid_prefix,
-                :irs_attempts_api_tracker, :liveness_checking_enabled
+                :irs_attempts_api_tracker
 
     def increment_rate_limiter!
       return unless document_capture_session
@@ -83,11 +81,11 @@ module Idv
         doc_auth_client.post_images(
           front_image: front_image_bytes,
           back_image: back_image_bytes,
-          selfie_image: liveness_checking_enabled ? selfie_image_bytes : nil,
+          selfie_image: liveness_checking_enabled? ? selfie_image_bytes : nil,
           image_source: image_source,
           user_uuid: user_uuid,
           uuid_prefix: uuid_prefix,
-          liveness_checking_enabled: liveness_checking_enabled,
+          liveness_checking_enabled: liveness_checking_enabled?,
         )
       end
 
@@ -370,7 +368,7 @@ module Idv
       Db::AddDocumentVerificationAndSelfieCosts.
         new(user_id: user_id,
             service_provider: service_provider,
-            liveness_checking_enabled: liveness_checking_enabled).
+            liveness_checking_enabled: liveness_checking_enabled?).
         call(response)
     end
 
@@ -471,6 +469,10 @@ module Idv
 
     def image_resubmission_check?
       IdentityConfig.store.doc_auth_check_failed_image_resubmission_enabled
+    end
+
+    def liveness_checking_enabled?
+      params[:liveness_checking_enabled] == 'true'
     end
   end
 end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -472,6 +472,9 @@ module Idv
     end
 
     def liveness_checking_enabled?
+      return false if Identity::Hostdata.env == 'prod'
+      return false unless IdentityConfig.store.doc_auth_selfie_capture[:enabled]
+
       params[:liveness_checking_enabled] == 'true'
     end
   end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -5,7 +5,7 @@ module Idv
 
     validates_presence_of :front
     validates_presence_of :back
-    validates_presence_of :selfie, if: :liveness_checking_required?
+    validates_presence_of :selfie, if: :liveness_checking_required
     validates_presence_of :document_capture_session
 
     validate :validate_images
@@ -83,11 +83,11 @@ module Idv
         doc_auth_client.post_images(
           front_image: front_image_bytes,
           back_image: back_image_bytes,
-          selfie_image: liveness_checking_required? ? selfie_image_bytes : nil,
+          selfie_image: liveness_checking_required ? selfie_image_bytes : nil,
           image_source: image_source,
           user_uuid: user_uuid,
           uuid_prefix: uuid_prefix,
-          liveness_checking_required: liveness_checking_required?,
+          liveness_checking_required: liveness_checking_required,
         )
       end
 
@@ -370,7 +370,7 @@ module Idv
       Db::AddDocumentVerificationAndSelfieCosts.
         new(user_id: user_id,
             service_provider: service_provider,
-            liveness_checking_enabled: liveness_checking_required?).
+            liveness_checking_enabled: liveness_checking_required).
         call(response)
     end
 
@@ -471,10 +471,6 @@ module Idv
 
     def image_resubmission_check?
       IdentityConfig.store.doc_auth_check_failed_image_resubmission_enabled
-    end
-
-    def liveness_checking_required?
-      liveness_checking_required
     end
   end
 end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -474,9 +474,6 @@ module Idv
     end
 
     def liveness_checking_required?
-      return false if Identity::Hostdata.env == 'prod'
-      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
-
       liveness_checking_required
     end
   end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -473,7 +473,7 @@ module Idv
 
     def liveness_checking_enabled?
       return false if Identity::Hostdata.env == 'prod'
-      return false unless IdentityConfig.store.doc_auth_selfie_capture[:enabled]
+      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
 
       params[:liveness_checking_enabled] == 'true'
     end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -5,7 +5,7 @@ module Idv
 
     validates_presence_of :front
     validates_presence_of :back
-    validates_presence_of :selfie, if: :liveness_checking_enabled?
+    validates_presence_of :selfie, if: :liveness_checking_required?
     validates_presence_of :document_capture_session
 
     validate :validate_images
@@ -81,11 +81,11 @@ module Idv
         doc_auth_client.post_images(
           front_image: front_image_bytes,
           back_image: back_image_bytes,
-          selfie_image: liveness_checking_enabled? ? selfie_image_bytes : nil,
+          selfie_image: liveness_checking_required? ? selfie_image_bytes : nil,
           image_source: image_source,
           user_uuid: user_uuid,
           uuid_prefix: uuid_prefix,
-          liveness_checking_enabled: liveness_checking_enabled?,
+          liveness_checking_required: liveness_checking_required?,
         )
       end
 
@@ -368,7 +368,7 @@ module Idv
       Db::AddDocumentVerificationAndSelfieCosts.
         new(user_id: user_id,
             service_provider: service_provider,
-            liveness_checking_enabled: liveness_checking_enabled?).
+            liveness_checking_enabled: liveness_checking_required?).
         call(response)
     end
 
@@ -471,11 +471,8 @@ module Idv
       IdentityConfig.store.doc_auth_check_failed_image_resubmission_enabled
     end
 
-    def liveness_checking_enabled?
-      return false if Identity::Hostdata.env == 'prod'
-      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
-
-      params[:liveness_checking_enabled] == 'true'
+    def liveness_checking_required?
+      sp_session[:biometric_camparison_required]
     end
   end
 end

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -85,6 +85,7 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
 
 const formData: Record<string, any> = {
   document_capture_session_uuid: appRoot.getAttribute('data-document-capture-session-uuid'),
+  liveness_checking_enabled: getSelfieCaptureEnabled(), // remove once available in idv_session
   locale: document.documentElement.lang,
 };
 

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -85,7 +85,6 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
 
 const formData: Record<string, any> = {
   document_capture_session_uuid: appRoot.getAttribute('data-document-capture-session-uuid'),
-  liveness_checking_enabled: getSelfieCaptureEnabled(), // remove once available in idv_session
   locale: document.documentElement.lang,
 };
 

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -54,8 +54,7 @@ function getServiceProvider() {
 
 function getSelfieCaptureEnabled() {
   const { docAuthSelfieCapture } = appRoot.dataset;
-  const docAuthSelfieCaptureObject = docAuthSelfieCapture ? JSON.parse(docAuthSelfieCapture) : {};
-  return !!docAuthSelfieCaptureObject?.enabled;
+  return docAuthSelfieCapture === 'true';
 }
 
 function getMetaContent(name): string | null {

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -44,7 +44,7 @@ module DocAuth
         user_uuid: nil,
         uuid_prefix: nil,
         selfie_image: nil,
-        liveness_checking_enabled: false
+        liveness_checking_required: false
       )
         document_response = create_document(image_source: image_source)
         return document_response unless document_response.success?

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -19,7 +19,7 @@ module DocAuth
         image_source: nil,
         user_uuid: nil,
         uuid_prefix: nil,
-        liveness_checking_enabled: false
+        liveness_checking_required: false
       )
         Requests::TrueIdRequest.new(
           config: config,
@@ -29,7 +29,7 @@ module DocAuth
           back_image: back_image,
           selfie_image: selfie_image,
           image_source: image_source,
-          liveness_checking_required: liveness_checking_enabled,
+          liveness_checking_required: liveness_checking_required,
         ).fetch
       end
     end

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -91,6 +91,9 @@ module DocAuth
         end
 
         def include_liveness?
+          return false if Identity::Hostdata.env == 'prod'
+          return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
+
           liveness_checking_required
         end
       end

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -56,7 +56,7 @@ module DocAuth
         image_source: nil,
         user_uuid: nil,
         uuid_prefix: nil,
-        liveness_checking_enabled: false
+        liveness_checking_required: false
       )
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 

--- a/app/views/idv/document_capture/show.html.erb
+++ b/app/views/idv/document_capture/show.html.erb
@@ -9,4 +9,5 @@
       acuant_version: acuant_version,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
       skip_doc_auth: skip_doc_auth,
+      doc_auth_selfie_capture: doc_auth_selfie_capture,
     ) %>

--- a/app/views/idv/hybrid_mobile/document_capture/show.html.erb
+++ b/app/views/idv/hybrid_mobile/document_capture/show.html.erb
@@ -9,4 +9,5 @@
       acuant_version: acuant_version,
       opted_in_to_in_person_proofing: false,
       skip_doc_auth: false,
+      doc_auth_selfie_capture: doc_auth_selfie_capture,
     ) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false :  doc_auth_selfie_capture,
+      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false : doc_auth_selfie_capture,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,13 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-<<<<<<< HEAD
-      doc_auth_selfie_capture: {
-        enabled: IdentityConfig.store.doc_auth_selfie_capture_enabled,
-      },
-=======
       doc_auth_selfie_capture: Identity::Hostdata.env == 'prod' ? nil : doc_auth_selfie_capture,
->>>>>>> d9bf596bf1 (rebase main)
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,9 +36,13 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
+<<<<<<< HEAD
       doc_auth_selfie_capture: {
         enabled: IdentityConfig.store.doc_auth_selfie_capture_enabled,
       },
+=======
+      doc_auth_selfie_capture: Identity::Hostdata.env == 'prod' ? nil : doc_auth_selfie_capture,
+>>>>>>> d9bf596bf1 (rebase main)
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false :  doc_auth_selfie_capture,
+      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? { enabled: false } :  doc_auth_selfie_capture,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: doc_auth_selfie_capture, #(Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false :  doc_auth_selfie_capture,
+      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false :  doc_auth_selfie_capture,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? { enabled: false } :  doc_auth_selfie_capture,
+      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false :  doc_auth_selfie_capture,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: Identity::Hostdata.env == 'prod' ? nil : doc_auth_selfie_capture,
+      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false :  doc_auth_selfie_capture,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false :  doc_auth_selfie_capture,
+      doc_auth_selfie_capture: doc_auth_selfie_capture, #(Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false :  doc_auth_selfie_capture,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -84,57 +84,18 @@ RSpec.describe Idv::DocumentCaptureController do
           and_return(double('decorated_session', { selfie_required?: true, sp_name: 'sp' }))
       end
 
-      it 'renders the show template without selfie feature flag' do
+      it 'renders the show template with selfie' do
         expect(subject).to receive(:render).with(
           :show,
           locals: hash_including(
             document_capture_session_uuid: document_capture_session_uuid,
-            doc_auth_selfie_capture: false,
+            doc_auth_selfie_capture: true,
           ),
         ).and_call_original
 
         get :show
 
         expect(response).to render_template :show
-      end
-
-      context 'when selfie is enabled' do
-        before do
-          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
-        end
-
-        it 'renders the show template with selfie feature flag' do
-          expect(subject).to receive(:render).with(
-            :show,
-            locals: hash_including(
-              document_capture_session_uuid: document_capture_session_uuid,
-              doc_auth_selfie_capture: true,
-            ),
-          ).and_call_original
-
-          get :show
-
-          expect(response).to render_template :show
-        end
-
-        context 'when hosted in a prod env' do
-          before do
-            allow(Identity::Hostdata).to receive(:env).and_return('prod')
-          end
-          it 'renders the show template without selfie feature flag' do
-            expect(subject).to receive(:render).with(
-              :show,
-              locals: hash_including(
-                document_capture_session_uuid: document_capture_session_uuid,
-                doc_auth_selfie_capture: false,
-              ),
-            ).and_call_original
-
-            get :show
-
-            expect(response).to render_template :show
-          end
-        end
       end
     end
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -69,12 +69,48 @@ RSpec.describe Idv::DocumentCaptureController do
         :show,
         locals: hash_including(
           document_capture_session_uuid: document_capture_session_uuid,
+          doc_auth_selfie_capture: nil,
         ),
       ).and_call_original
 
       get :show
 
       expect(response).to render_template :show
+    end
+
+    context 'when a selfie is requested' do
+      context 'when hosted in a prod env' do
+        before do
+          allow(Identity::Hostdata).to receive(:env).and_return('prod')
+        end
+        it 'renders the show template without selfie feature flag' do
+          expect(subject).to receive(:render).with(
+            :show,
+            locals: hash_including(
+              document_capture_session_uuid: document_capture_session_uuid,
+              doc_auth_selfie_capture: nil,
+            ),
+          ).and_call_original
+
+          get :show, params: { selfie: true }
+
+          expect(response).to render_template :show
+        end
+      end
+
+      it 'renders the show template with selfie feature flag' do
+        expect(subject).to receive(:render).with(
+          :show,
+          locals: hash_including(
+            document_capture_session_uuid: document_capture_session_uuid,
+            doc_auth_selfie_capture: { enabled: false },
+          ),
+        ).and_call_original
+
+        get :show, params: { selfie: true }
+
+        expect(response).to render_template :show
+      end
     end
 
     it 'sends analytics_visited event' do

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Idv::DocumentCaptureController do
         :show,
         locals: hash_including(
           document_capture_session_uuid: document_capture_session_uuid,
-          doc_auth_selfie_capture: nil,
+          doc_auth_selfie_capture: false,
         ),
       ).and_call_original
 
@@ -88,7 +88,7 @@ RSpec.describe Idv::DocumentCaptureController do
             :show,
             locals: hash_including(
               document_capture_session_uuid: document_capture_session_uuid,
-              doc_auth_selfie_capture: nil,
+              doc_auth_selfie_capture: false,
             ),
           ).and_call_original
 
@@ -103,7 +103,7 @@ RSpec.describe Idv::DocumentCaptureController do
           :show,
           locals: hash_including(
             document_capture_session_uuid: document_capture_session_uuid,
-            doc_auth_selfie_capture: { enabled: false },
+            doc_auth_selfie_capture: false,
           ),
         ).and_call_original
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Idv::DocumentCaptureController do
             ),
           ).and_call_original
 
-          get :show, params: { selfie: true }
+          get :show
 
           expect(response).to render_template :show
         end
@@ -107,7 +107,7 @@ RSpec.describe Idv::DocumentCaptureController do
           ),
         ).and_call_original
 
-        get :show, params: { selfie: true }
+        get :show
 
         expect(response).to render_template :show
       end

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -79,26 +79,12 @@ RSpec.describe Idv::DocumentCaptureController do
     end
 
     context 'when a selfie is requested' do
-      context 'when hosted in a prod env' do
-        before do
-          allow(Identity::Hostdata).to receive(:env).and_return('prod')
-        end
-        it 'renders the show template without selfie feature flag' do
-          expect(subject).to receive(:render).with(
-            :show,
-            locals: hash_including(
-              document_capture_session_uuid: document_capture_session_uuid,
-              doc_auth_selfie_capture: false,
-            ),
-          ).and_call_original
-
-          get :show
-
-          expect(response).to render_template :show
-        end
+      before do
+        allow(subject).to receive(:decorated_sp_session).
+          and_return(double('decorated_session', { selfie_required?: true, sp_name: 'sp' }))
       end
 
-      it 'renders the show template with selfie feature flag' do
+      it 'renders the show template without selfie feature flag' do
         expect(subject).to receive(:render).with(
           :show,
           locals: hash_including(
@@ -110,6 +96,45 @@ RSpec.describe Idv::DocumentCaptureController do
         get :show
 
         expect(response).to render_template :show
+      end
+
+      context 'when selfie is enabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+        end
+
+        it 'renders the show template with selfie feature flag' do
+          expect(subject).to receive(:render).with(
+            :show,
+            locals: hash_including(
+              document_capture_session_uuid: document_capture_session_uuid,
+              doc_auth_selfie_capture: true,
+            ),
+          ).and_call_original
+
+          get :show
+
+          expect(response).to render_template :show
+        end
+
+        context 'when hosted in a prod env' do
+          before do
+            allow(Identity::Hostdata).to receive(:env).and_return('prod')
+          end
+          it 'renders the show template without selfie feature flag' do
+            expect(subject).to receive(:render).with(
+              :show,
+              locals: hash_including(
+                document_capture_session_uuid: document_capture_session_uuid,
+                doc_auth_selfie_capture: false,
+              ),
+            ).and_call_original
+
+            get :show
+
+            expect(response).to render_template :show
+          end
+        end
       end
     end
 

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -74,6 +74,41 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController do
         expect(response).to render_template :show
       end
 
+      context 'when a selfie is requested' do
+        context 'when hosted in a prod env' do
+          before do
+            allow(Identity::Hostdata).to receive(:env).and_return('prod')
+          end
+          it 'renders the show template without selfie feature flag' do
+            expect(subject).to receive(:render).with(
+              :show,
+              locals: hash_including(
+                document_capture_session_uuid: document_capture_session_uuid,
+                doc_auth_selfie_capture: nil,
+              ),
+            ).and_call_original
+
+            get :show, params: { selfie: true }
+
+            expect(response).to render_template :show
+          end
+        end
+
+        it 'renders the show template with selfie feature flag' do
+          expect(subject).to receive(:render).with(
+            :show,
+            locals: hash_including(
+              document_capture_session_uuid: document_capture_session_uuid,
+              doc_auth_selfie_capture: { enabled: false },
+            ),
+          ).and_call_original
+
+          get :show, params: { selfie: true }
+
+          expect(response).to render_template :show
+        end
+      end
+
       it 'sends analytics_visited event' do
         get :show
 

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -101,7 +101,8 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController do
         context 'renders the show template with selfie feature flag enabled' do
           context 'when selfie is required by sp session' do
             before do
-              allow(subject).to receive(:sp_session).and_return({ biometric_comparison_required: true })
+              allow(subject).to receive(:sp_session).
+                and_return({ biometric_comparison_required: true })
             end
             it 'requests FE to display selfie' do
               expect(subject).to receive(:render).with(

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController do
       context 'when a selfie is requested' do
         before do
           allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
-          allow(subject).to receive(:sp_session).and_return({ biometric_comparison_required: true })
+          allow(subject).to receive(:decorated_sp_session).
+            and_return(double('decorated_session', { selfie_required?: true }))
         end
         context 'when hosted in a prod env' do
           before do
@@ -100,10 +101,6 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController do
 
         context 'renders the show template with selfie feature flag enabled' do
           context 'when selfie is required by sp session' do
-            before do
-              allow(subject).to receive(:sp_session).
-                and_return({ biometric_comparison_required: true })
-            end
             it 'requests FE to display selfie' do
               expect(subject).to receive(:render).with(
                 :show,
@@ -121,7 +118,8 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController do
 
           context 'when selfie is not required by sp session' do
             before do
-              allow(subject).to receive(:sp_session).and_return({})
+              allow(subject).to receive(:decorated_sp_session).
+                and_return(double('decorated_session', { selfie_required?: false }))
             end
             it 'requests FE to display selfie' do
               expect(subject).to receive(:render).with(

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -76,64 +76,22 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController do
 
       context 'when a selfie is requested' do
         before do
-          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
           allow(subject).to receive(:decorated_sp_session).
-            and_return(double('decorated_session', { selfie_required?: true }))
+            and_return(double('decorated_session', { selfie_required?: true, sp_name: 'sp' }))
         end
-        context 'when hosted in a prod env' do
-          before do
-            allow(Identity::Hostdata).to receive(:env).and_return('prod')
-          end
-          it 'renders the show template without selfie feature flag' do
+        context 'when selfie is required by sp session' do
+          it 'requests FE to display selfie' do
             expect(subject).to receive(:render).with(
               :show,
               locals: hash_including(
                 document_capture_session_uuid: document_capture_session_uuid,
-                doc_auth_selfie_capture: false,
+                doc_auth_selfie_capture: true,
               ),
             ).and_call_original
 
             get :show
 
             expect(response).to render_template :show
-          end
-        end
-
-        context 'renders the show template with selfie feature flag enabled' do
-          context 'when selfie is required by sp session' do
-            it 'requests FE to display selfie' do
-              expect(subject).to receive(:render).with(
-                :show,
-                locals: hash_including(
-                  document_capture_session_uuid: document_capture_session_uuid,
-                  doc_auth_selfie_capture: true,
-                ),
-              ).and_call_original
-
-              get :show
-
-              expect(response).to render_template :show
-            end
-          end
-
-          context 'when selfie is not required by sp session' do
-            before do
-              allow(subject).to receive(:decorated_sp_session).
-                and_return(double('decorated_session', { selfie_required?: false }))
-            end
-            it 'requests FE to display selfie' do
-              expect(subject).to receive(:render).with(
-                :show,
-                locals: hash_including(
-                  document_capture_session_uuid: document_capture_session_uuid,
-                  doc_auth_selfie_capture: false,
-                ),
-              ).and_call_original
-
-              get :show
-
-              expect(response).to render_template :show
-            end
           end
         end
       end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Idv::ImageUploadsController do
 
     before do
       allow(controller).to receive(:store_encrypted_images?).and_return(store_encrypted_images)
+      allow(controller).to receive(:liveness_checking_required?).and_return(false)
     end
 
     before do
@@ -353,7 +354,7 @@ RSpec.describe Idv::ImageUploadsController do
             image_source: :unknown,
             user_uuid: an_instance_of(String),
             uuid_prefix: nil,
-            liveness_checking_enabled: false,
+            liveness_checking_required: false,
           ).and_call_original
 
         action
@@ -978,12 +979,8 @@ RSpec.describe Idv::ImageUploadsController do
 
       context 'the frontend requests a selfie' do
         before do
-          params[:liveness_checking_enabled] = true
+          allow(controller).to receive(:liveness_checking_required?).and_return(true)
         end
-        after do
-          params.delete(:liveness_checking_enabled)
-        end
-
         it 'sends a selfie' do
           expect_any_instance_of(DocAuth::Mock::DocAuthMockClient).
             to receive(:post_images).with(
@@ -993,7 +990,7 @@ RSpec.describe Idv::ImageUploadsController do
               image_source: :unknown,
               user_uuid: an_instance_of(String),
               uuid_prefix: nil,
-              liveness_checking_enabled: true,
+              liveness_checking_required: true,
             ).and_call_original
 
           action
@@ -1014,7 +1011,7 @@ RSpec.describe Idv::ImageUploadsController do
                 image_source: :unknown,
                 user_uuid: an_instance_of(String),
                 uuid_prefix: nil,
-                liveness_checking_enabled: false,
+                liveness_checking_required: false,
               ).and_call_original
 
             action

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -31,9 +31,6 @@ RSpec.describe Idv::ImageUploadsController do
 
     before do
       allow(controller).to receive(:store_encrypted_images?).and_return(store_encrypted_images)
-    end
-
-    before do
       Funnel::DocAuth::RegisterStep.new(user.id, '').call('welcome', :view, true)
       allow(IdentityConfig.store).to receive(:idv_acuant_sdk_upgrade_a_b_testing_enabled).
         and_return(false)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Idv::ImageUploadsController do
 
     before do
       allow(controller).to receive(:store_encrypted_images?).and_return(store_encrypted_images)
-      allow(controller).to receive(:liveness_checking_required?).and_return(false)
     end
 
     before do
@@ -979,7 +978,8 @@ RSpec.describe Idv::ImageUploadsController do
 
       context 'the frontend requests a selfie' do
         before do
-          allow(controller).to receive(:liveness_checking_required?).and_return(true)
+          allow(controller).to receive(:decorated_sp_session).
+            and_return(double('decorated_session', { selfie_required?: true }))
         end
         it 'sends a selfie' do
           expect_any_instance_of(DocAuth::Mock::DocAuthMockClient).

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -207,6 +207,21 @@ RSpec.describe ServiceProviderSession do
         sp_session[:biometric_comparison_required] = nil
         expect(subject.selfie_required?).to eq(false)
       end
+
+      context 'when environment is prod' do
+        before do
+          allow(Identity::Hostdata).to receive(:env).and_return('prod')
+        end
+        it 'returns false when sp biometric_comparison_required is true' do
+          sp_session[:biometric_comparison_required] = true
+          expect(subject.selfie_required?).to eq(false)
+        end
+
+        it 'returns false when sp biometric_comparison_required is truthy' do
+          sp_session[:biometric_comparison_required] = 1
+          expect(subject.selfie_required?).to eq(false)
+        end
+      end
     end
 
     context 'doc_auth_selfie_capture_enabled is false' do

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -845,6 +845,9 @@ RSpec.feature 'Analytics Regression', js: true do
   context 'Happy selfie path' do
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      allow_any_instance_of(FederatedProtocols::Oidc).
+        to receive(:biometric_comparison_required?).
+        and_return({ biometric_comparison_required: true })
 
       mobile_device = Browser.new(mobile_user_agent)
       allow(BrowserCache).to receive(:parse).and_return(mobile_device)

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -204,6 +204,10 @@ RSpec.feature 'document capture step', :js do
         complete_doc_auth_steps_before_document_capture_step
 
         expect(page).to have_current_path(idv_document_capture_url)
+        expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+
+        visit(idv_document_capture_path(selfie: true))
+        expect(page).to have_current_path(idv_document_capture_url(selfie: true))
         expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
         expect_doc_capture_page_header(t('doc_auth.headings.document_capture_with_selfie'))
         expect_doc_capture_id_subheader
@@ -221,6 +225,40 @@ RSpec.feature 'document capture step', :js do
         click_idv_continue
         complete_verify_step
         expect(page).to have_current_path(idv_phone_url)
+      end
+    end
+
+    context 'when hosted env is prod' do
+      before do
+        allow(Identity::Hostdata).to receive(:env).and_return('prod')
+      end
+      it 'proceeds to the next page with valid info, including a selfie image' do
+        perform_in_browser(:mobile) do
+          visit_idp_from_oidc_sp_with_ial2
+          sign_in_and_2fa_user(user)
+          complete_doc_auth_steps_before_document_capture_step
+
+          expect(page).to have_current_path(idv_document_capture_url)
+          expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+
+          visit(idv_document_capture_path(selfie: true))
+          expect(page).to have_current_path(idv_document_capture_url(selfie: true))
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+          expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+          attach_images
+          submit_images
+
+          expect(page).to have_current_path(idv_ssn_url)
+          expect_costing_for_document
+          expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
+
+          expect(page).to have_current_path(idv_ssn_url)
+          fill_out_ssn_form_ok
+          click_idv_continue
+          complete_verify_step
+          expect(page).to have_current_path(idv_phone_url)
+        end
       end
     end
   end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -109,6 +109,8 @@ RSpec.feature 'document capture step', :js do
         end
 
         it 'proceeds to the next page with valid info' do
+          expect(page).to have_current_path(idv_document_capture_url)
+          expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
           attach_and_submit_images
           expect(page).to have_current_path(idv_ssn_url)
 
@@ -176,6 +178,7 @@ RSpec.feature 'document capture step', :js do
 
         expect(page).to have_current_path(idv_document_capture_url)
         expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+        expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
 
         attach_and_submit_images
 

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -210,11 +210,8 @@ RSpec.feature 'document capture step', :js do
           expect(page).to have_current_path(idv_document_capture_url)
           expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
 
-          visit(idv_document_capture_path(selfie: true))
-          expect(page).to have_current_path(idv_document_capture_url(selfie: true))
           expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
 
-          expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
           attach_images
           submit_images
 
@@ -278,8 +275,6 @@ RSpec.feature 'document capture step', :js do
             expect(page).to have_current_path(idv_document_capture_url)
             expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
 
-            visit(idv_document_capture_path(selfie: true))
-            expect(page).to have_current_path(idv_document_capture_url(selfie: true))
             expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
 
             expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -233,7 +233,9 @@ RSpec.feature 'document capture step', :js do
 
     context 'when a selfie is required by the SP' do
       before do
-        allow_any_instance_of(FederatedProtocols::Oidc).to receive(:biometric_comparison_required?).and_return({ biometric_comparison_required: true })
+        allow_any_instance_of(FederatedProtocols::Oidc).
+          to receive(:biometric_comparison_required?).
+          and_return({ biometric_comparison_required: true })
       end
 
       it 'proceeds to the next page with valid info, including a selfie image' do

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -200,42 +200,8 @@ RSpec.feature 'document capture step', :js do
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
     end
 
-    it 'proceeds to the next page with valid info, including a selfie image' do
-      perform_in_browser(:mobile) do
-        visit_idp_from_oidc_sp_with_ial2
-        sign_in_and_2fa_user(user)
-        complete_doc_auth_steps_before_document_capture_step
-
-        expect(page).to have_current_path(idv_document_capture_url)
-        expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
-
-        visit(idv_document_capture_path(selfie: true))
-        expect(page).to have_current_path(idv_document_capture_url(selfie: true))
-        expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
-        expect_doc_capture_page_header(t('doc_auth.headings.document_capture_with_selfie'))
-        expect_doc_capture_id_subheader
-        expect_doc_capture_selfie_subheader
-        attach_images
-        attach_selfie
-        submit_images
-
-        expect(page).to have_current_path(idv_ssn_url)
-        expect_costing_for_document
-        expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
-
-        expect(page).to have_current_path(idv_ssn_url)
-        fill_out_ssn_form_ok
-        click_idv_continue
-        complete_verify_step
-        expect(page).to have_current_path(idv_phone_url)
-      end
-    end
-
-    context 'when hosted env is prod' do
-      before do
-        allow(Identity::Hostdata).to receive(:env).and_return('prod')
-      end
-      it 'proceeds to the next page with valid info, including a selfie image' do
+    context 'when a selfie is not requested by SP' do
+      it 'proceeds to the next page with valid info, excluding a selfie image' do
         perform_in_browser(:mobile) do
           visit_idp_from_oidc_sp_with_ial2
           sign_in_and_2fa_user(user)
@@ -261,6 +227,73 @@ RSpec.feature 'document capture step', :js do
           click_idv_continue
           complete_verify_step
           expect(page).to have_current_path(idv_phone_url)
+        end
+      end
+    end
+
+    context 'when a selfie is required by the SP' do
+      before do
+        allow_any_instance_of(FederatedProtocols::Oidc).to receive(:biometric_comparison_required?).and_return({ biometric_comparison_required: true })
+      end
+
+      it 'proceeds to the next page with valid info, including a selfie image' do
+        perform_in_browser(:mobile) do
+          visit_idp_from_oidc_sp_with_ial2
+          sign_in_and_2fa_user(user)
+          complete_doc_auth_steps_before_document_capture_step
+
+          expect(page).to have_current_path(idv_document_capture_url)
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+          expect_doc_capture_page_header(t('doc_auth.headings.document_capture_with_selfie'))
+          expect_doc_capture_id_subheader
+          expect_doc_capture_selfie_subheader
+          attach_images
+          attach_selfie
+          submit_images
+
+          expect(page).to have_current_path(idv_ssn_url)
+          expect_costing_for_document
+          expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
+
+          expect(page).to have_current_path(idv_ssn_url)
+          fill_out_ssn_form_ok
+          click_idv_continue
+          complete_verify_step
+          expect(page).to have_current_path(idv_phone_url)
+        end
+      end
+
+      context 'when hosted env is prod' do
+        before do
+          allow(Identity::Hostdata).to receive(:env).and_return('prod')
+        end
+        it 'proceeds to the next page with valid info, excluding a selfie image' do
+          perform_in_browser(:mobile) do
+            visit_idp_from_oidc_sp_with_ial2
+            sign_in_and_2fa_user(user)
+            complete_doc_auth_steps_before_document_capture_step
+
+            expect(page).to have_current_path(idv_document_capture_url)
+            expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+
+            visit(idv_document_capture_path(selfie: true))
+            expect(page).to have_current_path(idv_document_capture_url(selfie: true))
+            expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+            expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+            attach_images
+            submit_images
+
+            expect(page).to have_current_path(idv_ssn_url)
+            expect_costing_for_document
+            expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
+
+            expect(page).to have_current_path(idv_ssn_url)
+            fill_out_ssn_form_ok
+            click_idv_continue
+            complete_verify_step
+            expect(page).to have_current_path(idv_phone_url)
+          end
         end
       end
     end

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -244,6 +244,9 @@ RSpec.feature 'doc auth redo document capture', js: true do
     context 'error due to data issue with 2xx status code', allow_browser_log: true do
       before do
         allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+        allow_any_instance_of(FederatedProtocols::Oidc).
+          to receive(:biometric_comparison_required?).and_return(true)
+        start_idv_from_sp
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_acuant_error_unknown

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -266,7 +266,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
     before do
       allow(Identity::Hostdata).to receive(:env).and_return('prod')
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
-      allow_any_instance_of(FederatedProtocols::Oidc).to receive(:biometric_comparison_required?).and_return(true)
+      allow_any_instance_of(FederatedProtocols::Oidc).
+        to receive(:biometric_comparison_required?).and_return(true)
     end
     it 'continues to ssn on desktop when user selects Continue', js: true do
       user = nil
@@ -334,8 +335,10 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
   end
 
   it 'prefils the phone number used on the phone step if the user has no MFA phone', :js do
-    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
-    allow_any_instance_of(FederatedProtocols::Oidc).to receive(:biometric_comparison_required?).and_return(true)
+    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+      and_return(true)
+    allow_any_instance_of(FederatedProtocols::Oidc).
+      to receive(:biometric_comparison_required?).and_return(true)
     user = create(:user, :with_authentication_app)
 
     perform_in_browser(:desktop) do

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -265,7 +265,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
   context 'barcode read error on desktop, redo document capture on mobile' do
     before do
       allow(Identity::Hostdata).to receive(:env).and_return('prod')
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).and_return({ enabled: true })
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      allow_any_instance_of(FederatedProtocols::Oidc).to receive(:biometric_comparison_required?).and_return(true)
     end
     it 'continues to ssn on desktop when user selects Continue', js: true do
       user = nil
@@ -333,8 +334,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
   end
 
   it 'prefils the phone number used on the phone step if the user has no MFA phone', :js do
-    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).and_return({ enabled: true })
-
+    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+    allow_any_instance_of(FederatedProtocols::Oidc).to receive(:biometric_comparison_required?).and_return(true)
     user = create(:user, :with_authentication_app)
 
     perform_in_browser(:desktop) do
@@ -352,10 +353,6 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       visit @sms_link
 
       expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
-      expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
-
-      visit(idv_hybrid_mobile_document_capture_url(selfie: true))
-      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url(selfie: true))
 
       attach_images
       attach_selfie

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       expect(page).to have_current_path(root_url)
       visit idv_hybrid_mobile_document_capture_url
 
+      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+      expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
       attach_and_submit_images
 
       expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
@@ -119,6 +121,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
 
     perform_in_browser(:mobile) do
       visit @sms_link
+      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+      expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
       click_on t('links.cancel')
       click_on t('forms.buttons.cancel') # Yes, cancel
     end
@@ -259,6 +263,10 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
   end
 
   context 'barcode read error on desktop, redo document capture on mobile' do
+    before do
+      allow(Identity::Hostdata).to receive(:env).and_return('prod')
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).and_return({ enabled: true })
+    end
     it 'continues to ssn on desktop when user selects Continue', js: true do
       user = nil
 
@@ -292,6 +300,14 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         visit @sms_link
 
         DocAuth::Mock::DocAuthMockClient.reset!
+
+        expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+        expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+
+        visit(idv_hybrid_mobile_document_capture_url(selfie: true))
+        expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url(selfie: true))
+        expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+
         attach_and_submit_images
 
         expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
@@ -317,6 +333,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
   end
 
   it 'prefils the phone number used on the phone step if the user has no MFA phone', :js do
+    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).and_return({ enabled: true })
+
     user = create(:user, :with_authentication_app)
 
     perform_in_browser(:desktop) do
@@ -332,7 +350,16 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
 
     perform_in_browser(:mobile) do
       visit @sms_link
-      attach_and_submit_images
+
+      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+      expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+
+      visit(idv_hybrid_mobile_document_capture_url(selfie: true))
+      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url(selfie: true))
+
+      attach_images
+      attach_selfie
+      submit_images
 
       expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
       expect(page).to have_text(t('doc_auth.instructions.switch_back'))

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
     end
 
-    context 'when liveness check is enabled' do
+    context 'when liveness check is required' do
       let(:liveness_checking_required) { 'true' }
       it 'is not valid without selfie' do
         expect(form.valid?).to eq(false)

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Idv::ApiImageUploadForm do
     end
 
     context 'when liveness check is required' do
-      let(:liveness_checking_required) { 'true' }
+      let(:liveness_checking_required) { true }
       it 'is not valid without selfie' do
         expect(form.valid?).to eq(false)
       end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Idv::ApiImageUploadForm do
     context 'when liveness check is enabled' do
       let(:liveness_checking_enabled) { 'true' }
       before do
-        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).and_return({ enabled: true })
+        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
       end
       it 'is not valid without selfie' do
         expect(form.valid?).to eq(false)

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -80,9 +80,6 @@ RSpec.describe Idv::ApiImageUploadForm do
 
     context 'when liveness check is enabled' do
       let(:liveness_checking_required) { 'true' }
-      before do
-        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
-      end
       it 'is not valid without selfie' do
         expect(form.valid?).to eq(false)
       end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -12,19 +12,19 @@ RSpec.describe Idv::ApiImageUploadForm do
         back_image_metadata: back_image_metadata,
         selfie: selfie_image,
         document_capture_session_uuid: document_capture_session_uuid,
-        liveness_checking_enabled: liveness_checking_enabled,
       ),
       service_provider: build(:service_provider, issuer: 'test_issuer'),
       analytics: fake_analytics,
       irs_attempts_api_tracker: irs_attempts_api_tracker,
       store_encrypted_images: store_encrypted_images,
+      liveness_checking_required: liveness_checking_required,
     )
   end
 
   let(:front_image) { DocAuthImageFixtures.document_front_image_multipart }
   let(:back_image) { DocAuthImageFixtures.document_back_image_multipart }
   let(:selfie_image) { nil }
-  let(:liveness_checking_enabled) { false }
+  let(:liveness_checking_required) { false }
   let(:front_image_metadata) do
     { width: 40, height: 40, mimeType: 'image/png', source: 'upload' }.to_json
   end
@@ -79,7 +79,7 @@ RSpec.describe Idv::ApiImageUploadForm do
     end
 
     context 'when liveness check is enabled' do
-      let(:liveness_checking_enabled) { 'true' }
+      let(:liveness_checking_required) { 'true' }
       before do
         allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
       end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Idv::ApiImageUploadForm do
         back_image_metadata: back_image_metadata,
         selfie: selfie_image,
         document_capture_session_uuid: document_capture_session_uuid,
+        liveness_checking_enabled: liveness_checking_enabled,
       ),
       service_provider: build(:service_provider, issuer: 'test_issuer'),
       analytics: fake_analytics,
       irs_attempts_api_tracker: irs_attempts_api_tracker,
       store_encrypted_images: store_encrypted_images,
-      liveness_checking_enabled: liveness_checking_enabled,
     )
   end
 
@@ -79,7 +79,10 @@ RSpec.describe Idv::ApiImageUploadForm do
     end
 
     context 'when liveness check is enabled' do
-      let(:liveness_checking_enabled) { true }
+      let(:liveness_checking_enabled) { 'true' }
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).and_return({ enabled: true })
+      end
       it 'is not valid without selfie' do
         expect(form.valid?).to eq(false)
       end

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
 
   context 'with liveness_checking_enabled as true' do
     before do
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).and_return({ enabled: true })
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
     end
 
     context 'when liveness checking is NOT required' do

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
 
     def include_liveness
       return false if Identity::Hostdata.env == 'prod'
-      return false unless IdentityConfig.store.doc_auth_selfie_capture[:enabled]
+      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
 
       liveness_checking_required
     end

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -58,10 +58,16 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       it 'fails response with errors' do
         request_stub_liveness = stub_request(:post, full_url).with do |request|
           JSON.parse(request.body, symbolize_names: true)[:Document][:Selfie].present?
-        end.to_return(body: response_body_with_doc_auth_errors(include_liveness_expected), status: 201)
+        end.to_return(
+          body: response_body_with_doc_auth_errors(include_liveness_expected),
+          status: 201,
+        )
         request_stub = stub_request(:post, full_url).with do |request|
           !JSON.parse(request.body, symbolize_names: true)[:Document][:Selfie].present?
-        end.to_return(body: response_body_with_doc_auth_errors(include_liveness_expected), status: 201)
+        end.to_return(
+          body: response_body_with_doc_auth_errors(include_liveness_expected),
+          status: 201,
+        )
 
         response = subject.fetch
 

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -37,17 +37,17 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
     it 'uploads the image and returns a successful result' do
       request_stub_liveness = stub_request(:post, full_url).with do |request|
         JSON.parse(request.body, symbolize_names: true)[:Document][:Selfie].present?
-      end.to_return(body: response_body(include_liveness), status: 201)
+      end.to_return(body: response_body(include_liveness_expected), status: 201)
       request_stub = stub_request(:post, full_url).with do |request|
         !JSON.parse(request.body, symbolize_names: true)[:Document][:Selfie].present?
-      end.to_return(body: response_body(include_liveness), status: 201)
+      end.to_return(body: response_body(include_liveness_expected), status: 201)
 
       response = subject.fetch
 
       expect(response.success?).to eq(true)
       expect(response.errors).to eq({})
       expect(response.exception).to be_nil
-      if include_liveness
+      if include_liveness_expected
         expect(request_stub_liveness).to have_been_requested
       else
         expect(request_stub).to have_been_requested
@@ -58,10 +58,10 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       it 'fails response with errors' do
         request_stub_liveness = stub_request(:post, full_url).with do |request|
           JSON.parse(request.body, symbolize_names: true)[:Document][:Selfie].present?
-        end.to_return(body: response_body_with_doc_auth_errors(include_liveness), status: 201)
+        end.to_return(body: response_body_with_doc_auth_errors(include_liveness_expected), status: 201)
         request_stub = stub_request(:post, full_url).with do |request|
           !JSON.parse(request.body, symbolize_names: true)[:Document][:Selfie].present?
-        end.to_return(body: response_body_with_doc_auth_errors(include_liveness), status: 201)
+        end.to_return(body: response_body_with_doc_auth_errors(include_liveness_expected), status: 201)
 
         response = subject.fetch
 
@@ -72,7 +72,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
         expect(response.errors[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
         expect(response.errors[:hints]).to eq(true)
         expect(response.exception).to be_nil
-        if include_liveness
+        if include_liveness_expected
           expect(request_stub_liveness).to have_been_requested
         else
           expect(request_stub).to have_been_requested
@@ -80,7 +80,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       end
     end
 
-    def include_liveness
+    def include_liveness_expected
       return false if Identity::Hostdata.env == 'prod'
       return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
 

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
-      doc_auth_selfie_capture: { enabled: doc_auth_selfie_capture_enabled },
+      doc_auth_selfie_capture: doc_auth_selfie_capture_enabled,
       skip_doc_auth: skip_doc_auth,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
     }
@@ -101,7 +101,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
     it 'sends doc_auth_selfie_capture_enabled to the FE' do
       render_partial
       expect(rendered).to have_css(
-        "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":false}']",
+        "#document-capture-form[data-doc-auth-selfie-capture='false']",
       )
     end
 
@@ -112,7 +112,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       it 'does send doc_auth_selfie_capture to the FE' do
         render_partial
         expect(rendered).to have_css(
-          "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":true}']",
+          "#document-capture-form[data-doc-auth-selfie-capture='true']",
         )
       end
       context 'when hosted in prod env' do
@@ -121,7 +121,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
 
           render_partial
           expect(rendered).to have_css(
-            "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":false}']",
+            "#document-capture-form[data-doc-auth-selfie-capture='false']",
           )
         end
       end

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
   let(:in_person_proofing_enabled_issuer) { nil }
   let(:acuant_sdk_upgrade_a_b_testing_enabled) { false }
   let(:use_alternate_sdk) { false }
-  let(:doc_auth_selfie_capture_enabled) { false }
+  let(:doc_auth_selfie_capture_enabled) { true }
+
   let(:acuant_version) { '1.3.3.7' }
   let(:skip_doc_auth) { false }
   let(:opted_in_to_in_person_proofing) { false }
@@ -100,8 +101,19 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
     it 'sends doc_auth_selfie_capture_enabled to the FE' do
       render_partial
       expect(rendered).to have_css(
-        "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":false}']",
+        "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":true}']",
       )
+    end
+
+    context 'when hosted in prod env' do
+      it 'does not send doc_auth_selfie_capture to the FE' do
+        allow(Identity::Hostdata).to receive(:env).and_return('prod')
+
+        render_partial
+        expect(rendered).not_to have_css(
+          "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":true}']",
+        )
+      end
     end
   end
 end

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -101,18 +101,29 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
     it 'sends doc_auth_selfie_capture_enabled to the FE' do
       render_partial
       expect(rendered).to have_css(
-        "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":true}']",
+        "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":false}']",
       )
     end
 
-    context 'when hosted in prod env' do
-      it 'does not send doc_auth_selfie_capture to the FE' do
-        allow(Identity::Hostdata).to receive(:env).and_return('prod')
-
+    context 'when selfie FF enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      end
+      it 'does send doc_auth_selfie_capture to the FE' do
         render_partial
-        expect(rendered).not_to have_css(
+        expect(rendered).to have_css(
           "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":true}']",
         )
+      end
+      context 'when hosted in prod env' do
+        it 'does not send doc_auth_selfie_capture to the FE' do
+          allow(Identity::Hostdata).to receive(:env).and_return('prod')
+
+          render_partial
+          expect(rendered).to have_css(
+            "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":false}']",
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-11873](https://cm-jira.usa.gov/browse/LG-11873)

## 🛠 Summary of changes
- determine if doc auth with selfie is required based on the SP Session
- only allow selfie to be sent to doc auth vendor if selfie FF is enabled
- do not allow selfie to be sent to doc auth vendor  if host env is production
- indicate to the FE to display selfie field if hosted env is not production, selfie FF is enabled and requested by SP

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
- [x] Enable selfie feature flag
  - [x] Using the OIDC Sample App, attempt to login with Level of Service _Biometric Comparison_
  - [x] Verify selfie field is displayed on standard document capture form and complete document capture
  - [x] Redo document capture and verify selfie field is displayed on standard document capture form and complete document capture
  - [x] Complete IdV

- [x] Disable selfie feature flag
  - [x] Using the OIDC Sample App, attempt to login with Level of Service _Biometric Comparison_
  - [x] Verify selfie field is  NOT displayed on standard document capture form and complete document capture
  - [x] Redo document capture and verify selfie field is NOT displayed on standard document capture form and complete document capture
  - [x] Complete IdV

- [x] Enable selfie feature flag
  - [x] Using the OIDC Sample App, attempt to login with Level of Service _Identity-verified_
  - [x] Verify selfie field is NOT displayed on standard document capture form and complete document capture
  - [x] Redo document capture and verify selfie field is NOT displayed on standard document capture form and complete document capture
  - [x] Complete IdV


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
