### PR TITLE
LG-11757 - Removed addition of :x509 key from ReactivateAccountSession.

### DIFF
--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -53,7 +53,6 @@ class ReactivateAccountSession
     {
       active: false,
       validated_personal_key: false,
-      x509: nil,
     }
   end
 


### PR DESCRIPTION
Remove dead code from `ReactivateAccountSession`

changelog: internal,dead code removal,Verified that some suspected dead code really was, and removed it.

## 🎫 Ticket
[LG-11757](https://cm-jira.usa.gov/browse/LG-11757)

## 🛠 Summary of changes

We suspected that the the `:x509` value being set up in `ReactivateAccountSession#generate_session` was unused. A search through the code revealed that it was indeed not used anywhere. Removed it.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] All exisiting specs pass without changes
- [ ] All uses of the keyword `:x509` in the codebase have been looked at, and are not uses of it as a session key.
- [ ] All uses of the strings `'509'` and `"x509"` in the codebase have been looked at, and are not uses of it as a session key.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>There were no uses of 'x509' or "x509". The one use of `:x509`, is as part of a test setup, and not as a session key:</summary>
```

    context 'when a piv/cac was used as second factor' do
      let(:x509) do
        {
          subject: x509_subject,
        }
      end

      let(:x509_subject) { 'x509-subject' }

      before do
        OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
      end

```
</details>