### PR TITLE
Fix concatenation for accessibility matcher error message

### DIFF
--- a/spec/support/matchers/aria_view_matchers.rb
+++ b/spec/support/matchers/aria_view_matchers.rb
@@ -38,8 +38,8 @@ class HaveButtonToWithAccessibilityMatcher
     return 'expected button to be in a (Rails) "button_to" form tag' unless enclosing_form
 
     messages = []
-    messages += aria_label_failure_message unless aria_label_ok?
-    messages += action_failure_message unless action_ok?
+    messages << aria_label_failure_message unless aria_label_ok?
+    messages << action_failure_message unless action_ok?
     messages.join("\n")
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where the code to create an error message for an invalid button raises an error due to an invalid operator.

The intent is to push to an array, which should use `<<` instead of `+=`.

Previously: #9508
Extracted from: #9674

## 📜 Testing Plan

This code is only run when there is an accessibility issue present. You can simulate by temporarily removing the fixes introduced with #9508:

```diff
diff --git a/app/views/idv/cancellations/new.html.erb b/app/views/idv/cancellations/new.html.erb
index 492cc9ead..f11b76219 100644
--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -34,7 +34,6 @@
             method: :delete,
             big: true,
             wide: true,
-            form: { 'aria-label': t('idv.cancel.actions.start_over') },
           ).with_content(t('idv.cancel.actions.start_over'))
       %>
       <div class="margin-top-2">
```

Before:

```
     TypeError:
       no implicit conversion of String into Array
     # ./spec/support/matchers/aria_view_matchers.rb:41:in `+'
     # ./spec/support/matchers/aria_view_matchers.rb:41:in `failure_message'
     # ./spec/support/matchers/aria_view_matchers.rb:88:in `block (2 levels) in <main>'
     # ./spec/views/idv/cancellations/new.html.erb_spec.rb:25:in `block (2 levels) in <top (required)>'
```

After:

```
       expected enclosing form to have an 'aria-label' attribute with value 'Start over'
     # ./spec/views/idv/cancellations/new.html.erb_spec.rb:25:in `block (2 levels) in <top (required)>'
```