### PR TITLE
Improve effectiveness of spec JSDOM reset

### DIFF
--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -110,16 +110,6 @@ describe('FormSteps', () => {
     },
   ];
 
-  let originalHash;
-
-  beforeEach(() => {
-    originalHash = window.location.hash;
-  });
-
-  afterEach(() => {
-    window.location.hash = originalHash;
-  });
-
   describe('getStepIndexByName', () => {
     it('returns -1 if no step by name', () => {
       const result = getStepIndexByName(STEPS, 'third');

--- a/app/javascript/packages/form-steps/use-history-param.spec.tsx
+++ b/app/javascript/packages/form-steps/use-history-param.spec.tsx
@@ -30,16 +30,6 @@ describe('useHistoryParam', () => {
     );
   }
 
-  let originalHash;
-
-  beforeEach(() => {
-    originalHash = window.location.hash;
-  });
-
-  afterEach(() => {
-    window.location.hash = originalHash;
-  });
-
   it('returns undefined value if absent from initial URL', () => {
     const { getByDisplayValue } = render(<TestComponent />);
 

--- a/spec/javascript/support/dom.js
+++ b/spec/javascript/support/dom.js
@@ -94,13 +94,13 @@ export function createDOM() {
  */
 export function useCleanDOM(dom) {
   beforeEach(() => {
-    while (document.body.firstChild) {
-      document.body.removeChild(document.body.firstChild);
+    for (const element of [document.head, document.body]) {
+      while (element.firstChild) {
+        element.firstChild.remove();
+      }
     }
     document.documentElement.lang = 'en';
-    window.history.replaceState(null, '', TEST_URL);
-    window.location.pathname = '';
-    window.location.hash = '';
+    dom.reconfigure({ url: TEST_URL });
     dom.cookieJar.removeAllCookiesSync();
   });
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Updates JavaScript specs to more effectively reset the simulated DOM between test cases:

- Remove elements appended to `<head>` as well as those in `<body>`
- Reset URL values more universally via the [`reconfigure` helper](https://github.com/jsdom/jsdom#reconfiguring-the-jsdom-with-reconfiguresettings)

This is extracted from #9674 (0ae5baa76e8e4eb08e82d95e1918c0d8fe4ed30b), where it was observed that:

- [`request/index.spec.ts`](https://github.com/18F/identity-idp/blob/main/app/javascript/packages/request/index.spec.ts) was leaking across tests in how it [manipulated `<head>` elements](https://github.com/18F/identity-idp/blob/2debf5dd64c3d2cc8c1d85758b1c5e83342e741c/app/javascript/packages/request/index.spec.ts#L280-L283)
- `reconfigure` can be a handy way to change the current URL in a spec ([example](https://github.com/18F/identity-idp/blob/0c100fdb83a78f9fca8c3376209334d04704ba94/app/javascript/packages/manageable-authenticator/manageable-authenticator-element.spec.ts#L115))

## 📜 Testing Plan

JavaScript tests should pass:

- `yarn test`