### PR TITLE
Add and document environment flag for skipping asset build in local testing

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -110,6 +110,22 @@ different options of the authentication request, such as AAL or IAL.
   $ SHOW_BROWSER=true bundle exec rspec spec/features/
   ```
 
+#### Skipping asset compilation in feature tests
+
+To ensure that tests are run using the latest source code, JavaScript-enabled feature specs will
+compile all JavaScript and stylesheets in local development. This can be time-consuming if you're
+repeatedly running the same tests, so you can choose to skip the build by passing the
+`SKIP_BUILD=true` environment variable:
+
+```
+$ SKIP_BUILD=true bundle exec rspec spec/features
+```
+
+Since the automatic build is meant to act as a safeguard to prevent stale assets from being used,
+disabling it will mean you're responsible for running the build any time JavaScript or Sass source
+files are changed. You can do this by running `yarn build` for JavaScript, or `yarn build:css` for
+stylesheets.
+
 ### Viewing email messages
 
   In local development, the application does not deliver real email messages. Instead, we use a tool

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,7 +70,7 @@ RSpec.configure do |config|
     end
   end
 
-  if !ENV['CI']
+  if !ENV['CI'] && !ENV['SKIP_BUILD']
     config.before(js: true) do
       # rubocop:disable Style/GlobalVars
       next if defined?($ran_asset_build)


### PR DESCRIPTION
## 🛠 Summary of changes

Adds support for a new `SKIP_BUILD` environment variable which can be used in local development to skip asset compilation for JavaScript-enabled feature tests.

It also includes new documentation which explains the use-case and how to use it.

Previously, I could use `CI=true` for this, but (a) it's not very obvious that this would be an effect, (b) `ENV['CI']` can have many different effects which are intended for continuous integration (CI) environments, and (c) such changes as in #9734 may have adverse effects on the ability to continue using this locally.

Related: #9734

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1702322045401739?thread_ts=1702068737.905679&cid=C0NGESUN5

## 📜 Testing Plan

Observe that compilation happens without the flag, and doesn't happen with the flag. You can tell by seeing "Bundling JavaScript and stylesheets..." in the terminal output.

```
bundle exec rspec spec/features/accessibility/idv_pages_spec.rb:9
```

vs.

```
SKIP_BUILD=true bundle exec rspec spec/features/accessibility/idv_pages_spec.rb:9
```