### PR TITLE
Update apps/agencies report to exclude internal apps (LG-11800)

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -33,7 +33,7 @@ class ServiceProvider < ApplicationRecord
   IAA_INTERNAL = 'LGINTERNAL'
 
   scope(:internal, -> { where(iaa: IAA_INTERNAL) })
-  scope(:external, -> { where.not(iaa: IAA_INTERNAL) })
+  scope(:external, -> { where.not(iaa: IAA_INTERNAL).or(where(iaa: nil)) })
 
   def metadata
     attributes.symbolize_keys.merge(certs: ssl_certs)

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'fingerprinter'
 require 'identity_validations'
 
@@ -27,6 +28,11 @@ class ServiceProvider < ApplicationRecord
     :with_push_notification_urls,
     -> { where.not(push_notification_url: nil).where.not(push_notification_url: '') },
   )
+
+  IAA_INTERNAL = 'LGINTERNAL'
+
+  scope(:internal, -> { where(iaa: IAA_INTERNAL) })
+  scope(:external, -> { where.not(iaa: IAA_INTERNAL) })
 
   def metadata
     attributes.symbolize_keys.merge(certs: ssl_certs)

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'fingerprinter'
 require 'identity_validations'
 

--- a/app/services/reporting/agency_and_sp_report.rb
+++ b/app/services/reporting/agency_and_sp_report.rb
@@ -7,7 +7,7 @@ module Reporting
     end
 
     def agency_and_sp_report
-      idv_sps, auth_sps = ServiceProvider.where('created_at <= ?', report_date).active.
+      idv_sps, auth_sps = ServiceProvider.where('created_at <= ?', report_date).active.external.
         partition { |sp| sp.ial.present? && sp.ial >= 2 }
       idv_agency_ids = idv_sps.map(&:agency_id).uniq
       idv_agencies, auth_agencies = agencies_with_sps.partition do |agency|

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -51,5 +51,13 @@ FactoryBot.define do
     end
 
     factory :service_provider_without_help_text, traits: [:without_help_text]
+
+    trait :internal do
+      iaa { ServiceProvider::IAA_INTERNAL }
+    end
+
+    trait :external do
+      iaa { 'LG1234' }
+    end
   end
 end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -15,6 +15,29 @@ RSpec.describe ServiceProvider do
     end
   end
 
+  describe 'scopes' do
+    before do
+      clear_agreements_data
+      Agency.destroy_all
+      ServiceProvider.destroy_all
+    end
+
+    let!(:external_sps) { create_list(:service_provider, 2, iaa: 'LG1234') }
+    let!(:internal_sp) { create(:service_provider, :internal) }
+
+    describe '.internal' do
+      it 'includes apps with iaa: LGINTERNAL' do
+        expect(ServiceProvider.internal.to_a).to eq([internal_sp])
+      end
+    end
+
+    describe '.external' do
+      it 'includes apps without iaa: LGINTERNAL' do
+        expect(ServiceProvider.external.to_a).to match_array(external_sps)
+      end
+    end
+  end
+
   describe '#issuer' do
     it 'returns the constructor value' do
       expect(service_provider.issuer).to eq 'http://localhost:3000'

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe ServiceProvider do
       ServiceProvider.destroy_all
     end
 
-    let!(:external_sps) { create_list(:service_provider, 2, :external) }
+    let!(:external_sps) do
+      [
+        create(:service_provider, :external),
+        create(:service_provider, iaa: nil),
+      ]
+    end
     let!(:internal_sp) { create(:service_provider, :internal) }
 
     describe '.internal' do

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ServiceProvider do
       ServiceProvider.destroy_all
     end
 
-    let!(:external_sps) { create_list(:service_provider, 2, iaa: 'LG1234') }
+    let!(:external_sps) { create_list(:service_provider, 2, :external) }
     let!(:internal_sp) { create(:service_provider, :internal) }
 
     describe '.internal' do

--- a/spec/services/reporting/agency_and_sp_report_spec.rb
+++ b/spec/services/reporting/agency_and_sp_report_spec.rb
@@ -14,13 +14,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
 
   # Wipe the pre-seeded data. It's easier to start from a clean slate.
   before do
-    Agreements::IntegrationUsage.destroy_all
-    Agreements::IaaOrder.destroy_all
-    Agreements::Integration.destroy_all
-    Agreements::IntegrationStatus.destroy_all
-    Agreements::IaaGtc.destroy_all
-    Agreements::PartnerAccount.destroy_all
-    Agreements::PartnerAccountStatus.destroy_all
+    clear_agreements_data
     Agency.destroy_all
     ServiceProvider.destroy_all
   end
@@ -31,7 +25,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
     subject { report.agency_and_sp_report }
 
     context 'when adding a non-IDV SP' do
-      let!(:auth_sp) { create(:service_provider, :active) }
+      let!(:auth_sp) { create(:service_provider, :external, :active) }
       let(:expected_report) do
         [
           header_row,
@@ -47,7 +41,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
     end
 
     context 'when adding an inactive SP' do
-      let!(:inactive_sp) { create(:service_provider) }
+      let!(:inactive_sp) { create(:service_provider, :external) }
       let(:expected_report) do
         [
           header_row,
@@ -64,7 +58,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
     end
 
     context 'when adding an IDV SP to a non-IDV Agency' do
-      let!(:initial_sp) { create(:service_provider, :active) }
+      let!(:initial_sp) { create(:service_provider, :external, :active) }
       let!(:agency) { initial_sp.agency }
 
       let(:initial_report) do
@@ -88,7 +82,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
       it 'becomes an IDV agency' do
         expect(subject).to match_array(initial_report)
 
-        create(:service_provider, :active, :idv, agency: agency)
+        create(:service_provider, :external, :active, :idv, agency: agency)
 
         # The report gets memoized, so we need to reconstruct it here:
         new_report = described_class.new(report_date)
@@ -97,7 +91,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
     end
 
     context 'when adding an IDV SP' do
-      let!(:idv_sp) { create(:service_provider, :idv, :active) }
+      let!(:idv_sp) { create(:service_provider, :external, :idv, :active) }
 
       let(:expected_report) do
         [

--- a/spec/services/reporting/agency_and_sp_report_spec.rb
+++ b/spec/services/reporting/agency_and_sp_report_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe Reporting::AgencyAndSpReport do
         create(
           :service_provider,
           :external,
-          :active, identities: [build(:service_provider_identity)],
+          :active,
+          identities: [build(:service_provider_identity)],
         )
       end
       let(:expected_report) do
@@ -99,7 +100,8 @@ RSpec.describe Reporting::AgencyAndSpReport do
           :external,
           :active,
           :idv,
-          agency: agency, identities: [build(:service_provider_identity)],
+          agency: agency,
+          identities: [build(:service_provider_identity)],
         )
 
         # The report gets memoized, so we need to reconstruct it here:

--- a/spec/services/reporting/agency_and_sp_report_spec.rb
+++ b/spec/services/reporting/agency_and_sp_report_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe Reporting::AgencyAndSpReport do
 
   subject(:report) { described_class.new(report_date) }
 
+  let(:agency) do
+    create(
+      :agency,
+      partner_accounts: [
+        build(
+          :partner_account,
+          became_partner: report_date - 10.days,
+          partner_account_status: build(
+            :partner_account_status, name: 'active'
+          ),
+        ),
+      ],
+    )
+  end
+
   describe '#agency_and_sp_report' do
     subject { report.agency_and_sp_report }
 
@@ -30,6 +45,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
           :service_provider,
           :external,
           :active,
+          agency:,
           identities: [build(:service_provider_identity)],
         )
       end
@@ -48,13 +64,13 @@ RSpec.describe Reporting::AgencyAndSpReport do
     end
 
     context 'when adding an inactive SP' do
-      let!(:inactive_sp) { create(:service_provider, :external, identities: []) }
+      let!(:inactive_sp) { create(:service_provider, :external, agency:, identities: []) }
       let(:expected_report) do
         [
           header_row,
-          ['Auth', 0, 0],
+          ['Auth', 0, 1],
           ['IDV', 0, 0],
-          ['Total', 0, 0],
+          ['Total', 0, 1],
         ]
       end
 
@@ -69,10 +85,10 @@ RSpec.describe Reporting::AgencyAndSpReport do
           :service_provider,
           :external,
           :active,
+          agency:,
           identities: [build(:service_provider_identity)],
         )
       end
-      let!(:agency) { initial_sp.agency }
 
       let(:initial_report) do
         [
@@ -100,7 +116,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
           :external,
           :active,
           :idv,
-          agency: agency,
+          agency:,
           identities: [build(:service_provider_identity)],
         )
 
@@ -117,6 +133,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
           :external,
           :idv,
           :active,
+          agency:,
           identities: [build(:service_provider_identity)],
         )
       end


### PR DESCRIPTION
## 🎫 Ticket


[LG-11800](https://cm-jira.usa.gov/browse/LG-11800)

## 🛠 Summary of changes

We were reporting on 5 apps that are internal (OIDC example, etc), but we should be excluding those for reporting. Major kudos to @Sgtpluck for finding that all the apps we needed to exclude conveniently had `iaa: 'LGINTERNAL'` on them.
