### PR TITLE
LG-11209: Log event when new registered account uses disposable email domain

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -93,7 +93,7 @@ module SignUp
       }
 
       if page_occurence.present? && DisposableDomain.is_disposable?(email_domain)
-        attributes.merge!({ disposable_email_domain: email_domain })
+        attributes[:disposable_email_domain] = email_domain
       end
 
       attributes

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -81,7 +81,7 @@ module SignUp
     end
 
     def analytics_attributes(page_occurence)
-      {
+      attributes = {
         ial2: sp_session[:ial2],
         ialmax: sp_session[:ialmax],
         service_provider_name: decorated_sp_session.sp_name,
@@ -91,6 +91,19 @@ module SignUp
         in_account_creation_flow: user_session[:in_account_creation_flow] || false,
         needs_completion_screen_reason: needs_completion_screen_reason,
       }
+
+      if page_occurence.present? && DisposableDomain.is_disposable?(email_domain)
+        attributes.merge!({ disposable_email_domain: email_domain })
+      end
+
+      attributes
+    end
+
+    def email_domain
+      @email_domain ||= begin
+        email_address = current_user.email_addresses.take.email
+        Mail::Address.new(email_address).domain
+      end
     end
 
     def track_completion_event(last_page)

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -92,7 +92,7 @@ module SignUp
         needs_completion_screen_reason: needs_completion_screen_reason,
       }
 
-      if page_occurence.present? && DisposableDomain.is_disposable?(email_domain)
+      if page_occurence.present? && DisposableDomain.disposable?(email_domain)
         attributes[:disposable_email_domain] = email_domain
       end
 

--- a/app/models/disposable_domain.rb
+++ b/app/models/disposable_domain.rb
@@ -1,2 +1,9 @@
 class DisposableDomain < ApplicationRecord
+  class << self
+    def is_disposable?(domain)
+      return false if !domain.is_a?(String) || domain.empty?
+
+      exists?(name: domain)
+    end
+  end
 end

--- a/app/models/disposable_domain.rb
+++ b/app/models/disposable_domain.rb
@@ -1,6 +1,6 @@
 class DisposableDomain < ApplicationRecord
   class << self
-    def is_disposable?(domain)
+    def disposable?(domain)
       return false if !domain.is_a?(String) || domain.empty?
 
       exists?(name: domain)

--- a/spec/models/disposable_domain_spec.rb
+++ b/spec/models/disposable_domain_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe DisposableDomain do
+  let(:domain) { 'temporary.com' }
+
+  describe '.is_disposable?' do
+    before do
+      DisposableDomain.create(name: domain)
+    end
+
+    context 'when the domain exists' do
+      it 'returns true' do
+        expect(DisposableDomain.is_disposable?(domain)).to eq true
+      end
+    end
+
+    context 'when the domain does not exist' do
+      it 'returns false' do
+        expect(DisposableDomain.is_disposable?('example.com')).to eq false
+      end
+    end
+
+    context 'with bad data' do
+      it 'returns false' do
+        expect(DisposableDomain.is_disposable?('')).to eq false
+        expect(DisposableDomain.is_disposable?(nil)).to eq false
+        expect(DisposableDomain.is_disposable?({})).to eq false
+      end
+    end
+  end
+end

--- a/spec/models/disposable_domain_spec.rb
+++ b/spec/models/disposable_domain_spec.rb
@@ -3,28 +3,28 @@ require 'rails_helper'
 RSpec.describe DisposableDomain do
   let(:domain) { 'temporary.com' }
 
-  describe '.is_disposable?' do
+  describe '.disposable?' do
     before do
       DisposableDomain.create(name: domain)
     end
 
     context 'when the domain exists' do
       it 'returns true' do
-        expect(DisposableDomain.is_disposable?(domain)).to eq true
+        expect(DisposableDomain.disposable?(domain)).to eq true
       end
     end
 
     context 'when the domain does not exist' do
       it 'returns false' do
-        expect(DisposableDomain.is_disposable?('example.com')).to eq false
+        expect(DisposableDomain.disposable?('example.com')).to eq false
       end
     end
 
     context 'with bad data' do
       it 'returns false' do
-        expect(DisposableDomain.is_disposable?('')).to eq false
-        expect(DisposableDomain.is_disposable?(nil)).to eq false
-        expect(DisposableDomain.is_disposable?({})).to eq false
+        expect(DisposableDomain.disposable?('')).to eq false
+        expect(DisposableDomain.disposable?(nil)).to eq false
+        expect(DisposableDomain.disposable?({})).to eq false
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11209](https://cm-jira.usa.gov/browse/LG-11209)

## 🛠 Summary of changes

Adds the property named `disposable_email_domain` to the event `User registration: complete` when the user registers with a known temporary email domain.

## 📜 Testing Plan

- Create a new account with a domain populated in the model DisposableDomain
- Check for the property `disposable_email_domain` on the event `User registration: complete`

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
