### PR TITLE
Update idv_level backfill to handle cases where profile_id is NULL

### DIFF
--- a/lib/tasks/backfill_idv_level.rake
+++ b/lib/tasks/backfill_idv_level.rake
@@ -8,8 +8,10 @@ namespace :profiles do
   #
   task backfill_idv_level: :environment do |_task, _args|
     with_statement_timeout do
-      is_in_person = Profile.where(id: InPersonEnrollment.select(:profile_id))
-      is_not_in_person = Profile.where.not(id: InPersonEnrollment.select(:profile_id))
+      in_person_enrollment_profile_ids = InPersonEnrollment.
+        where.not(profile_id: nil).select(:profile_id)
+      is_in_person = Profile.where(id: in_person_enrollment_profile_ids)
+      is_not_in_person = Profile.where.not(id: in_person_enrollment_profile_ids)
       needs_idv_level = Profile.where(idv_level: nil)
 
       in_person_and_needs_idv_level = Profile.and(is_in_person).and(needs_idv_level)

--- a/spec/lib/tasks/backfill_idv_level_rake_spec.rb
+++ b/spec/lib/tasks/backfill_idv_level_rake_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'profiles:backfill_idv_level rake task' do
     expect(profiles[:in_person].idv_level).not_to be_nil
     expect(profiles[:in_person_no_level].idv_level).to be_nil
 
-    # NULL values can blow up postgres WHERE NOT IN() conditions if you're
+    # NULL values can blow up postgres WHERE NOT IN () conditions if you're
     # not careful...
     create(:in_person_enrollment, profile: nil)
 

--- a/spec/lib/tasks/backfill_idv_level_rake_spec.rb
+++ b/spec/lib/tasks/backfill_idv_level_rake_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe 'profiles:backfill_idv_level rake task' do
     expect(profiles[:unsupervised_no_level].idv_level).to be_nil
     expect(profiles[:in_person].idv_level).not_to be_nil
     expect(profiles[:in_person_no_level].idv_level).to be_nil
+
+    # NULL values can blow up postgres WHERE NOT IN() conditions if you're
+    # not careful...
+    create(:in_person_enrollment, profile: nil)
+
     invoke_task
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11693](https://cm-jira.usa.gov/browse/LG-11693)

## 🛠 Summary of changes

This rake task is meant to backfill the `profiles.idv_level` column, but it was missing some records.

To determine whether a Profile should be tagged as `legacy_in_person`, the task checks whether an `InPersonEnrollment` record exists for the profile.

To determine whether a Profile should be tagged as `legacy_unsupervised`, the task checks whether an `InPersonEnrollment` record **does not** exist for the profile. It was doing this using, essentially:

```sql
SELECT * FROM profiles WHERE id NOT IN (SELECT profile_id FROM in_person_enrollments)
```
However this query will return no records when any `in_person_enrollments.profile_id IS NULL`. The fix is to limit the subquery to exclude null values:

```sql
SELECT * FROM profiles WHERE id NOT IN (SELECT profile_id FROM in_person_enrollments WHERE profile_id IS NOT NULL)
```
