### PR TITLE
LG-11878: Change Use of Compact in True ID Request

### DIFF
--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -32,8 +32,8 @@ module DocAuth
               Back: encode(back_image),
               Selfie: (encode(selfie_image) if include_liveness?),
               DocumentType: 'DriversLicense',
-            },
-          }.compact
+            }.compact,
+          }
 
           settings.merge(document).to_json
         end

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       let(:workflow) { 'test_workflow' }
       let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
       it_behaves_like 'a successful request'
+
+      it 'does not include a nil selfie in the request body sent to TrueID' do
+        body_as_json = subject.send(:body)
+        body_as_hash = JSON.parse(body_as_json)
+        expect(body_as_hash['Document']).not_to have_key('Selfie')
+      end
     end
     context 'with unknown image source' do
       let(:workflow) { 'test_workflow_cropping' }


### PR DESCRIPTION
## 🎫 Ticket
[LG-11878: Fix compact bug in true_id_request.rb](https://cm-jira.usa.gov/browse/LG-11878)


## 🛠 Summary of changes
While investigating a decrease in True ID success rates, Timnit team members pointed out a bug in the use of `compact`.  Here's a [relevant Slack post](https://gsa-tts.slack.com/archives/C056RD1NEHW/p1702408805282139?thread_ts=1702327010.578409&cid=C056RD1NEHW).  Further in the debugging process, team members confirmed that the use of `compact` did not cause this bug.  Here's another [relevant Slack post](https://gsa-tts.slack.com/archives/C056RD1NEHW/p1702413190816059?thread_ts=1702327010.578409&cid=C056RD1NEHW).  I am still sharing this PR for review, but I want to call out that I don't think it addresses the root cause of the change in True ID success rates.


## 📜 Testing Plan
Run automated tests