### PR TITLE
Add support for JavaScript-driven client-side OIDC interstitial redirect

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -187,19 +187,20 @@ module OpenidConnect
     end
 
     def redirect_user(redirect_uri)
-      if IdentityConfig.store.openid_connect_redirect == :client_side
+      case IdentityConfig.store.openid_connect_redirect
+      when :client_side
         @oidc_redirect_uri = redirect_uri
         render(
           'openid_connect/shared/redirect',
           layout: false,
         )
-      elsif IdentityConfig.store.openid_connect_redirect == :client_side_js
+      when :client_side_js
         @oidc_redirect_uri = redirect_uri
         render(
           'openid_connect/shared/redirect_js',
           layout: false,
         )
-      elsif IdentityConfig.store.openid_connect_redirect == :server_side
+      else # should only be :server_side
         redirect_to(
           redirect_uri,
           allow_other_host: true,

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -40,19 +40,20 @@ module OpenidConnect
     private
 
     def redirect_user(redirect_uri)
-      if IdentityConfig.store.openid_connect_redirect == :client_side
+      case IdentityConfig.store.openid_connect_redirect
+      when :client_side
         @oidc_redirect_uri = redirect_uri
         render(
           'openid_connect/shared/redirect',
           layout: false,
         )
-      elsif IdentityConfig.store.openid_connect_redirect == :client_side_js
+      when :client_side_js
         @oidc_redirect_uri = redirect_uri
         render(
           'openid_connect/shared/redirect_js',
           layout: false,
         )
-      elsif IdentityConfig.store.openid_connect_redirect == :server_side
+      else # should only be :server_side
         redirect_to(
           redirect_uri,
           allow_other_host: true,

--- a/app/javascript/packs/openid-connect-redirect.ts
+++ b/app/javascript/packs/openid-connect-redirect.ts
@@ -1,4 +1,5 @@
-import { forceNavigate } from '@18f/identity-url';
+import { forceRedirect } from '@18f/identity-url';
+
 document.body.classList.add('usa-sr-only');
-const link: HTMLLinkElement = document.getElementById('openid-connect-redirect')!;
+const link = document.querySelector<HTMLLinkElement>('#openid-connect-redirect')!;
 forceRedirect(link.href);

--- a/app/javascript/packs/openid-connect-redirect.ts
+++ b/app/javascript/packs/openid-connect-redirect.ts
@@ -1,0 +1,4 @@
+import { forceNavigate } from '@18f/identity-url';
+document.body.classList.add('usa-sr-only');
+const link: HTMLLinkElement = document.getElementById('openid-connect-redirect')!;
+forceRedirect(link.href);

--- a/app/views/openid_connect/shared/redirect_js.html.erb
+++ b/app/views/openid_connect/shared/redirect_js.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title><%= t('headings.redirecting') %> | <%= APP_NAME %></title>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= render_stylesheet_once_tags %>
+  </head>
+  <body class="tablet:bg-primary-lighter">
+    <div class="grid-container tablet:padding-y-6">
+      <div class="grid-row">
+        <div class="tablet:grid-col-6 tablet:grid-offset-3">
+          <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
+
+          <p>
+            <%= t('saml_idp.shared.saml_post_binding.no_js') %>
+          </p>
+
+          <%= link_to(t('forms.buttons.continue'), @oidc_redirect_uri, class: 'usa-button usa-button--wide usa-button--big', id: 'openid-connect-redirect') %>
+        </div>
+      </div>
+    </div>
+    <%= render_javascript_pack_once_tags 'openid-connect-redirect' %>
+  </body>
+</html>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -211,7 +211,7 @@ multi_region_kms_migration_jobs_profile_timeout: 120
 multi_region_kms_migration_jobs_user_count: 1000
 multi_region_kms_migration_jobs_user_timeout: 120
 mx_timeout: 3
-openid_connect_redirect_interstitial_enabled: true
+openid_connect_redirect: client_side_js
 openid_connect_content_security_form_action_enabled: false
 otp_delivery_blocklist_maxretry: 10
 otp_valid_for: 10
@@ -472,7 +472,7 @@ production:
   logins_per_ip_track_only_mode: true
   newrelic_license_key: ''
   nonessential_email_banlist: '[]'
-  openid_connect_redirect_interstitial_enabled: false
+  openid_connect_redirect: server_side
   openid_connect_content_security_form_action_enabled: true
   otp_delivery_blocklist_findtime: 5
   participate_in_dap: true

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -322,7 +322,11 @@ class IdentityConfig
     config.add(:mx_timeout, type: :integer)
     config.add(:newrelic_license_key, type: :string)
     config.add(:nonessential_email_banlist, type: :json)
-    config.add(:openid_connect_redirect, type: :symbol, enum: [:server_side, :client_side, :client_side_js])
+    config.add(
+      :openid_connect_redirect,
+      type: :symbol,
+      enum: [:server_side, :client_side, :client_side_js],
+    )
     config.add(:openid_connect_content_security_form_action_enabled, type: :boolean)
     config.add(:otp_delivery_blocklist_findtime, type: :integer)
     config.add(:otp_delivery_blocklist_maxretry, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -322,7 +322,7 @@ class IdentityConfig
     config.add(:mx_timeout, type: :integer)
     config.add(:newrelic_license_key, type: :string)
     config.add(:nonessential_email_banlist, type: :json)
-    config.add(:openid_connect_redirect_interstitial_enabled, type: :boolean)
+    config.add(:openid_connect_redirect, type: :symbol, enum: [:server_side, :client_side, :client_side_js])
     config.add(:openid_connect_content_security_form_action_enabled, type: :boolean)
     config.add(:otp_delivery_blocklist_findtime, type: :integer)
     config.add(:otp_delivery_blocklist_maxretry, type: :integer)

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
       end
 
       context 'with valid params' do
-        it 'redirects back to the client app with a code if client-side redirect is disabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+        it 'redirects back to the client app with a code if server-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
@@ -64,13 +64,29 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         it 'renders a client-side redirect back to the client app with a code if it is enabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+
+          redirect_params = UriService.params(assigns(:oidc_redirect_uri))
+
+          expect(redirect_params[:code]).to be_present
+          expect(redirect_params[:state]).to eq(params[:state])
+        end
+
+        it 'renders a JS client-side redirect back to the client app with a code if it is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
 
           redirect_params = UriService.params(assigns(:oidc_redirect_uri))
@@ -128,8 +144,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
             end
 
             it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
-              allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                and_return(false)
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:server_side)
               IdentityLinker.new(user, service_provider).link_identity(ial: 3)
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
@@ -141,8 +157,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
             end
 
             it 'renders a client-side redirect back to the client app immediately if it is enabled' do
-              allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                and_return(true)
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:client_side)
               IdentityLinker.new(user, service_provider).link_identity(ial: 3)
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
@@ -151,6 +167,20 @@ RSpec.describe OpenidConnect::AuthorizationController do
               action
 
               expect(controller).to render_template('openid_connect/shared/redirect')
+              expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+            end
+
+            it 'renders a JS client-side redirect back to the client app immediately if it is enabled' do
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:client_side_js)
+              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+              allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+              action
+
+              expect(controller).to render_template('openid_connect/shared/redirect_js')
               expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
             end
 
@@ -307,9 +337,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 ).user
               end
 
-              it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(false)
+              it 'redirects to the redirect_uri immediately when pii is unlocked if server-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:server_side)
                 IdentityLinker.new(user, service_provider).link_identity(ial: 3)
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
@@ -321,8 +351,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
               end
 
               it 'renders client-side redirect to the client app immediately if PII is unlocked and it is enabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(true)
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 3)
                 user.identities.last.update!(
@@ -332,6 +362,21 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 action
 
                 expect(controller).to render_template('openid_connect/shared/redirect')
+                expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+              end
+
+              it 'renders JS client-side redirect to the client app immediately if PII is unlocked and it is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side_js)
+
+                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+                allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+                action
+
+                expect(controller).to render_template('openid_connect/shared/redirect_js')
                 expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
               end
 
@@ -388,9 +433,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
             end
 
             context 'account is not already verified' do
-              it 'redirects to the redirect_uri immediately without proofing if client-side redirect is disabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(false)
+              it 'redirects to the redirect_uri immediately without proofing if server-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:server_side)
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
@@ -402,8 +447,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
               end
 
               it 'renders client-side redirect to the client app immediately if client-side redirect is enabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(true)
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -412,6 +457,20 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 action
                 expect(controller).to render_template('openid_connect/shared/redirect')
+                expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+              end
+
+              it 'renders JS client-side redirect to the client app immediately if JS client-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side_js)
+
+                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+
+                action
+                expect(controller).to render_template('openid_connect/shared/redirect_js')
                 expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
               end
 
@@ -458,9 +517,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
             context 'profile is reset' do
               let(:user) { create(:profile, :verified, :password_reset).user }
 
-              it 'redirects to the redirect_uri immediately without proofing if client-side redirect is disabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(false)
+              it 'redirects to the redirect_uri immediately without proofing if server-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:server_side)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -473,8 +532,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
               end
 
               it 'renders client-side redirect to the client app immediately if client-side redirect is enabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(true)
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -483,6 +542,20 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 action
                 expect(controller).to render_template('openid_connect/shared/redirect')
+                expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+              end
+
+              it 'renders JS client-side redirect to the client app immediately if JS client-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side_js)
+
+                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+
+                action
+                expect(controller).to render_template('openid_connect/shared/redirect_js')
                 expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
               end
 
@@ -548,8 +621,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
           end
 
           it 'redirects back to the client app with a code if client-side redirect is disabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
@@ -561,12 +634,26 @@ RSpec.describe OpenidConnect::AuthorizationController do
           end
 
           it 'renders a client-side redirect back to the client app with a code if it is enabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
 
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+
+            redirect_params = UriService.params(assigns(:oidc_redirect_uri))
+            expect(redirect_params[:code]).to be_present
+            expect(redirect_params[:state]).to eq(params[:state])
+          end
+
+          it 'renders a JS client-side redirect back to the client app with a code if it is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
 
             redirect_params = UriService.params(assigns(:oidc_redirect_uri))
@@ -580,8 +667,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
         before { params[:prompt] = '' }
 
         it 'redirects the user with an invalid request if client-side redirect is disabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           action
 
           expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
@@ -594,11 +681,26 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         it 'renders client-side redirect with an invalid request if client-side redirect is enabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+
+          redirect_params = UriService.params(assigns(:oidc_redirect_uri))
+
+          expect(redirect_params[:error]).to eq('invalid_request')
+          expect(redirect_params[:error_description]).to be_present
+          expect(redirect_params[:state]).to eq(params[:state])
+        end
+
+        it 'renders JS client-side redirect with an invalid request if JS client-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
 
           redirect_params = UriService.params(assigns(:oidc_redirect_uri))
@@ -625,7 +727,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  code_challenge_present: false,
                  service_provider_pkce: nil,
                  scope: 'openid')
-          expect(@analytics).to_not receive(:track_event).with('SP redirect initiated')
+          expect(@analytics).to_not receive(:track_event).with('sp redirect initiated')
 
           action
 
@@ -671,20 +773,29 @@ RSpec.describe OpenidConnect::AuthorizationController do
       context 'without valid acr_values' do
         before { params.delete(:acr_values) }
 
-        it 'handles the error and does not blow up when client-side redirect is disabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+        it 'handles the error and does not blow up when server-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           action
 
           expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
         end
 
         it 'handles the error and does not blow up when client-side redirect is enabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+        end
+
+        it 'handles the error and does not blow up when client-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
         end
       end
@@ -703,9 +814,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
           params[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
         end
 
-        it 'redirects the user if client-side redirect is disabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+        it 'redirects the user if server-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           action
 
           expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
@@ -718,11 +829,26 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         it 'renders a client-side redirect if client-side redirect is enabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+
+          redirect_params = UriService.params(assigns(:oidc_redirect_uri))
+
+          expect(redirect_params[:error]).to eq('invalid_request')
+          expect(redirect_params[:error_description]).to be_present
+          expect(redirect_params[:state]).to eq(params[:state])
+        end
+
+        it 'renders a JS client-side redirect if JS client-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
 
           redirect_params = UriService.params(assigns(:oidc_redirect_uri))

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -62,20 +62,29 @@ RSpec.describe OpenidConnect::LogoutController do
               action
             end
 
-            it 'redirects back to the client if client-side redirect is disabled' do
-              allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                and_return(false)
+            it 'redirects back to the client if server-side redirect is enabled' do
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:server_side)
               action
 
               expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
             end
 
             it 'renders client-side redirect if client-side redirect is enabled' do
-              allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                and_return(true)
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:client_side)
               action
 
               expect(controller).to render_template('openid_connect/shared/redirect')
+              expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+            end
+
+            it 'renders JS client-side redirect if client-side JS redirect is enabled' do
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:client_side_js)
+              action
+
+              expect(controller).to render_template('openid_connect/shared/redirect_js')
               expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
             end
 
@@ -184,20 +193,29 @@ RSpec.describe OpenidConnect::LogoutController do
         end
 
         context 'user is not signed in' do
-          it 'renders client-side redirect if client-side redirect is enabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+          it 'renders server-side redirect if server-side redirect is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
           end
 
-          it 'redirects back to the client if client-side redirect is disabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+          it 'redirects back to the client if client-side redirect is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'redirects back to the client if JS client-side redirect is enabledj' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
         end
@@ -298,20 +316,29 @@ RSpec.describe OpenidConnect::LogoutController do
         end
 
         context 'user is not signed in' do
-          it 'redirects back to the client if client-side redirect is disabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+          it 'redirects back to the client if server-side redirect is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
           end
 
           it 'renders client-side redirect if client-side redirect is enabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'renders JS client-side redirect if JS client-side redirect is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
         end
@@ -333,10 +360,10 @@ RSpec.describe OpenidConnect::LogoutController do
           let(:user) { create(:user) }
           before { stub_sign_in(user) }
 
-          it 'destroys the session and redirects to client if client-side redirect is disabled' do
+          it 'destroys the session and redirects to client if server-side redirect is enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -344,11 +371,21 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'destroys session and renders client-side redirect if enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'destroys session and renders JS client-side redirect if enabled' do
+            expect(controller).to receive(:sign_out)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
         end
@@ -378,8 +415,8 @@ RSpec.describe OpenidConnect::LogoutController do
           before { stub_sign_in(user) }
           it 'destroys the session and redirects if client-side redirect is disabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -387,11 +424,21 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'destroys the session and renders client-side redirect if enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'destroys the session and renders JS client-side redirect if enabled' do
+            expect(controller).to receive(:sign_out)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
         end
@@ -552,10 +599,10 @@ RSpec.describe OpenidConnect::LogoutController do
       end
 
       context 'user is not signed in' do
-        it 'redirects back to the client if client-side redirect is disabled' do
+        it 'redirects back to the client if server-side redirect is enabled' do
           expect(controller).to receive(:sign_out)
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           action
 
           expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -563,11 +610,21 @@ RSpec.describe OpenidConnect::LogoutController do
 
         it 'renders client-side redirect if client-side redirect is enabled' do
           expect(controller).to receive(:sign_out)
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+        end
+
+        it 'renders JS client-side redirect if JS client-side redirect is enabled' do
+          expect(controller).to receive(:sign_out)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
         end
       end
@@ -586,10 +643,10 @@ RSpec.describe OpenidConnect::LogoutController do
 
         context 'user is signed in' do
           before { stub_sign_in(user) }
-          it 'destroys session and redirects to client if client-side redirect is disabled' do
+          it 'destroys session and redirects to client if server-side redirect is enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -597,11 +654,21 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'destroys the session and renders client-side redirect if enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'destroys the session and renders JS client-side redirect if enabled' do
+            expect(controller).to receive(:sign_out)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
 

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -115,11 +115,18 @@ module OidcAuthHelper
     url
   end
 
+  def extract_redirect_url
+    content = page.find('a#openid-connect-redirect')
+    content[:href]
+  end
+
   def oidc_redirect_url
-    if IdentityConfig.store.openid_connect_redirect_interstitial_enabled
-      extract_meta_refresh_url
-    else
+    if IdentityConfig.store.openid_connect_redirect == :client_side
       current_url
+    elsif IdentityConfig.store.openid_connect_redirect == :client_side
+      extract_meta_refresh_url
+    elsif IdentityConfig.store.openid_connect_redirect == :client_side_js
+      extract_redirect_url
     end
   end
 end

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -121,12 +121,13 @@ module OidcAuthHelper
   end
 
   def oidc_redirect_url
-    if IdentityConfig.store.openid_connect_redirect == :client_side
-      current_url
-    elsif IdentityConfig.store.openid_connect_redirect == :client_side
+    case IdentityConfig.store.openid_connect_redirect
+    when :client_side
       extract_meta_refresh_url
-    elsif IdentityConfig.store.openid_connect_redirect == :client_side_js
+    when :client_side_js
       extract_redirect_url
+    else # should only be :server_side
+      current_url
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

This is a follow-up to #9669 to add a different option for client-side redirect by using JavaScript rather than the HTTP `meta` tag.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
