### PR TITLE
Use a more minimal require pattern for linter specs

### DIFF
--- a/spec/lib/linters/analytics_event_name_linter_spec.rb
+++ b/spec/lib/linters/analytics_event_name_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/analytics_event_name_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::AnalyticsEventNameLinter do

--- a/spec/lib/linters/errors_add_linter_spec.rb
+++ b/spec/lib/linters/errors_add_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/errors_add_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do

--- a/spec/lib/linters/image_size_linter_spec.rb
+++ b/spec/lib/linters/image_size_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/image_size_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::ImageSizeLinter do

--- a/spec/lib/linters/localized_validation_message_linter_spec.rb
+++ b/spec/lib/linters/localized_validation_message_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/localized_validation_message_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::LocalizedValidationMessageLinter do

--- a/spec/lib/linters/mail_later_linter_spec.rb
+++ b/spec/lib/linters/mail_later_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require 'rails_helper'
 require_relative '../../../lib/linters/mail_later_linter'
 

--- a/spec/lib/linters/redirect_back_linter_spec.rb
+++ b/spec/lib/linters/redirect_back_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/redirect_back_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::RedirectBackLinter do

--- a/spec/lib/linters/url_options_linter_spec.rb
+++ b/spec/lib/linters/url_options_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/url_options_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::UrlOptionsLinter do


### PR DESCRIPTION
The rubocop linter specs were requiring the `rubocop/rspec/support`. This file is [defined in the Rubocop gem](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/rspec/support.rb) and adds utilities for testing rubocop linters.

The rubocop support configuration _appears_ to make the assumption that the context in which it is included is a test suite for only testing Cops or at least for primarily testing Cops. The main clue for this is this part of the implementation:

```ruby
RSpec.configure do |config|
  config.include CopHelper
  # ...
end
```

The [`CopHelper` module](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/rspec/cop_helper.rb) defines a number of methods for testing a linter. The support file includes that module for _every single example_. As a result all of our tests have those methods.

I found this problematic when I observed an issue testing a MFA selection presenter. It referenced a `configuration` variable that it expected to be an MFA configuration. This variable was in fact a rubocop configuration thanks to the `configuration` method in the `CopHelper` module (ref: [the failed build where I observed this](https://gitlab.login.gov/lg/identity-idp/-/jobs/915207))

This commit removes the `require` call that included `rubocop/rspec/support`. It replaces that with a simplified set of `require` calls that only bring in the tools we need to test our linters.
