### PR TITLE
Deploy RC 340

### DIFF
--- a/app/controllers/api/internal/two_factor_authentication/webauthn_controller.rb
+++ b/app/controllers/api/internal/two_factor_authentication/webauthn_controller.rb
@@ -1,0 +1,52 @@
+module Api
+  module Internal
+    module TwoFactorAuthentication
+      class WebauthnController < ApplicationController
+        include CsrfTokenConcern
+        include ReauthenticationRequiredConcern
+
+        before_action :render_unauthorized, unless: :recently_authenticated_2fa?
+
+        after_action :add_csrf_token_header_to_response
+
+        respond_to :json
+
+        def update
+          result = ::TwoFactorAuthentication::WebauthnUpdateForm.new(
+            user: current_user,
+            configuration_id: params[:id],
+          ).submit(name: params[:name])
+
+          analytics.webauthn_update_name_submitted(**result.to_h)
+
+          if result.success?
+            render json: { success: true }
+          else
+            render json: { success: false, error: result.first_error_message }, status: :bad_request
+          end
+        end
+
+        def destroy
+          result = ::TwoFactorAuthentication::WebauthnDeleteForm.new(
+            user: current_user,
+            configuration_id: params[:id],
+          ).submit
+
+          analytics.webauthn_delete_submitted(**result.to_h)
+
+          if result.success?
+            render json: { success: true }
+          else
+            render json: { success: false, error: result.first_error_message }, status: :bad_request
+          end
+        end
+
+        private
+
+        def render_unauthorized
+          render json: { error: 'Unauthorized' }, status: :unauthorized
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/reauthentication_required_concern.rb
+++ b/app/controllers/concerns/reauthentication_required_concern.rb
@@ -3,7 +3,7 @@ module ReauthenticationRequiredConcern
   include TwoFactorAuthenticatableMethods
 
   def confirm_recently_authenticated_2fa
-    return if !user_fully_authenticated? || auth_methods_session.recently_authenticated_2fa?
+    return if !user_fully_authenticated? || recently_authenticated_2fa?
 
     analytics.user_2fa_reauthentication_required(
       auth_method: auth_methods_session.last_auth_event&.[](:auth_method),
@@ -11,6 +11,10 @@ module ReauthenticationRequiredConcern
     )
 
     prompt_for_second_factor
+  end
+
+  def recently_authenticated_2fa?
+    user_fully_authenticated? && auth_methods_session.recently_authenticated_2fa?
   end
 
   private

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -75,15 +75,8 @@ module OpenidConnect
     def handle_successful_handoff
       track_events
       SpHandoffBounce::AddHandoffTimeToSession.call(sp_session)
-      if IdentityConfig.store.openid_connect_redirect_interstitial_enabled
-        @oidc_redirect_uri = @authorize_form.success_redirect_uri
-        render(
-          'openid_connect/shared/redirect',
-          layout: false,
-        )
-      else
-        redirect_to @authorize_form.success_redirect_uri, allow_other_host: true
-      end
+
+      redirect_user(@authorize_form.success_redirect_uri)
 
       delete_branded_experience
     end
@@ -133,14 +126,8 @@ module OpenidConnect
 
       if redirect_uri.nil?
         render :error
-      elsif IdentityConfig.store.openid_connect_redirect_interstitial_enabled
-        @oidc_redirect_uri = redirect_uri
-        render(
-          'openid_connect/shared/redirect',
-          layout: false,
-        )
       else
-        redirect_to redirect_uri, allow_other_host: true
+        redirect_user(redirect_uri)
       end
     end
 
@@ -197,6 +184,28 @@ module OpenidConnect
         billed_ial: event_ial_context.bill_for_ial_1_or_2,
       )
       track_billing_events
+    end
+
+    def redirect_user(redirect_uri)
+      case IdentityConfig.store.openid_connect_redirect
+      when :client_side
+        @oidc_redirect_uri = redirect_uri
+        render(
+          'openid_connect/shared/redirect',
+          layout: false,
+        )
+      when :client_side_js
+        @oidc_redirect_uri = redirect_uri
+        render(
+          'openid_connect/shared/redirect_js',
+          layout: false,
+        )
+      else # should only be :server_side
+        redirect_to(
+          redirect_uri,
+          allow_other_host: true,
+        )
+      end
     end
   end
 end

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -30,25 +30,36 @@ module OpenidConnect
         analytics.logout_initiated(**result.to_h.except(:redirect_uri))
         irs_attempts_api_tracker.logout_initiated(success: result.success?)
 
+        redirect_user(redirect_uri)
         sign_out
-        if IdentityConfig.store.openid_connect_redirect_interstitial_enabled
-          @oidc_redirect_uri = redirect_uri
-          render(
-            'openid_connect/shared/redirect',
-            layout: false,
-          )
-        else
-          redirect_to(
-            redirect_uri,
-            allow_other_host: true,
-          )
-        end
       else
         render :error
       end
     end
 
     private
+
+    def redirect_user(redirect_uri)
+      case IdentityConfig.store.openid_connect_redirect
+      when :client_side
+        @oidc_redirect_uri = redirect_uri
+        render(
+          'openid_connect/shared/redirect',
+          layout: false,
+        )
+      when :client_side_js
+        @oidc_redirect_uri = redirect_uri
+        render(
+          'openid_connect/shared/redirect_js',
+          layout: false,
+        )
+      else # should only be :server_side
+        redirect_to(
+          redirect_uri,
+          allow_other_host: true,
+        )
+      end
+    end
 
     def apply_logout_secure_headers_override(redirect_uri, service_provider)
       return if service_provider.nil? || redirect_uri.nil?
@@ -94,18 +105,7 @@ module OpenidConnect
 
         sign_out
 
-        if IdentityConfig.store.openid_connect_redirect_interstitial_enabled
-          @oidc_redirect_uri = redirect_uri
-          render(
-            'openid_connect/shared/redirect',
-            layout: false,
-          )
-        else
-          redirect_to(
-            redirect_uri,
-            allow_other_host: true,
-          )
-        end
+        redirect_user(redirect_uri)
       end
     end
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -81,7 +81,7 @@ module SignUp
     end
 
     def analytics_attributes(page_occurence)
-      {
+      attributes = {
         ial2: sp_session[:ial2],
         ialmax: sp_session[:ialmax],
         service_provider_name: decorated_sp_session.sp_name,
@@ -91,6 +91,19 @@ module SignUp
         in_account_creation_flow: user_session[:in_account_creation_flow] || false,
         needs_completion_screen_reason: needs_completion_screen_reason,
       }
+
+      if page_occurence.present? && DisposableDomain.disposable?(email_domain)
+        attributes[:disposable_email_domain] = email_domain
+      end
+
+      attributes
+    end
+
+    def email_domain
+      @email_domain ||= begin
+        email_address = current_user.email_addresses.take.email
+        Mail::Address.new(email_address).domain
+      end
     end
 
     def track_completion_event(last_page)

--- a/app/controllers/users/delete_controller.rb
+++ b/app/controllers/users/delete_controller.rb
@@ -13,6 +13,7 @@ module Users
     def delete
       irs_attempts_api_tracker.logged_in_account_purged(success: true)
       send_push_notifications
+      notify_user_via_email_of_deletion
       delete_user
       sign_out
       flash[:success] = t('devise.registrations.destroyed')
@@ -50,5 +51,14 @@ module Users
       event = PushNotification::AccountPurgedEvent.new(user: current_user)
       PushNotification::HttpPush.deliver(event)
     end
+
+    # rubocop:disable IdentityIdp/MailLaterLinter
+    def notify_user_via_email_of_deletion
+      current_user.confirmed_email_addresses.each do |email_address|
+        UserMailer.with(user: current_user, email_address: email_address).
+          account_delete_submitted.deliver_now
+      end
+    end
+    # rubocop:enable IdentityIdp/MailLaterLinter
   end
 end

--- a/app/controllers/users/webauthn_controller.rb
+++ b/app/controllers/users/webauthn_controller.rb
@@ -1,0 +1,61 @@
+module Users
+  class WebauthnController < ApplicationController
+    include ReauthenticationRequiredConcern
+
+    before_action :confirm_two_factor_authenticated
+    before_action :confirm_recently_authenticated_2fa
+    before_action :set_form
+    before_action :validate_configuration_exists
+
+    def edit; end
+
+    def update
+      result = form.submit(name: params.dig(:form, :name))
+
+      analytics.webauthn_update_name_submitted(**result.to_h)
+
+      if result.success?
+        flash[:success] = t('two_factor_authentication.webauthn_platform.renamed')
+        redirect_to account_path
+      else
+        flash.now[:error] = result.first_error_message
+        render :edit
+      end
+    end
+
+    def destroy
+      result = form.submit
+
+      analytics.webauthn_delete_submitted(**result.to_h)
+
+      if result.success?
+        flash[:success] = t('two_factor_authentication.webauthn_platform.deleted')
+        redirect_to account_path
+      else
+        flash[:error] = result.first_error_message
+        redirect_to edit_webauthn_path(id: params[:id])
+      end
+    end
+
+    private
+
+    def form
+      @form ||= form_class.new(user: current_user, configuration_id: params[:id])
+    end
+
+    alias_method :set_form, :form
+
+    def form_class
+      case action_name
+      when 'edit', 'update'
+        TwoFactorAuthentication::WebauthnUpdateForm
+      when 'destroy'
+        TwoFactorAuthentication::WebauthnDeleteForm
+      end
+    end
+
+    def validate_configuration_exists
+      render_not_found if form.configuration.blank?
+    end
+  end
+end

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -163,12 +163,7 @@ module Users
     end
 
     def track_delete(success)
-      counts_hash = MfaContext.new(current_user.reload).enabled_two_factor_configuration_counts_hash
-      analytics.webauthn_deleted(
-        success: success,
-        mfa_method_counts: counts_hash,
-        pii_like_keypaths: [[:mfa_method_counts, :phone]],
-      )
+      analytics.webauthn_delete_submitted(success:, configuration_id: delete_params[:id])
     end
 
     def save_challenge_in_session

--- a/app/forms/two_factor_authentication/webauthn_delete_form.rb
+++ b/app/forms/two_factor_authentication/webauthn_delete_form.rb
@@ -1,0 +1,57 @@
+module TwoFactorAuthentication
+  class WebauthnDeleteForm
+    include ActiveModel::Model
+    include ActionView::Helpers::TranslationHelper
+
+    attr_reader :user, :configuration_id
+
+    validate :validate_configuration_exists
+    validate :validate_has_multiple_mfa
+
+    def initialize(user:, configuration_id:)
+      @user = user
+      @configuration_id = configuration_id
+    end
+
+    def submit
+      success = valid?
+
+      configuration.destroy if success
+
+      FormResponse.new(
+        success:,
+        errors:,
+        extra: extra_analytics_attributes,
+        serialize_error_details_only: true,
+      )
+    end
+
+    def configuration
+      @configuration ||= user.webauthn_configurations.find_by(id: configuration_id)
+    end
+
+    private
+
+    def validate_configuration_exists
+      return if configuration.present?
+      errors.add(
+        :configuration_id,
+        :configuration_not_found,
+        message: t('errors.manage_authenticator.internal_error'),
+      )
+    end
+
+    def validate_has_multiple_mfa
+      return if !configuration || MfaPolicy.new(user).multiple_factors_enabled?
+      errors.add(
+        :configuration_id,
+        :only_method,
+        message: t('errors.manage_authenticator.remove_only_method_error'),
+      )
+    end
+
+    def extra_analytics_attributes
+      { configuration_id: }
+    end
+  end
+end

--- a/app/forms/two_factor_authentication/webauthn_update_form.rb
+++ b/app/forms/two_factor_authentication/webauthn_update_form.rb
@@ -1,0 +1,68 @@
+module TwoFactorAuthentication
+  class WebauthnUpdateForm
+    include ActiveModel::Model
+    include ActionView::Helpers::TranslationHelper
+
+    attr_reader :user, :configuration_id
+
+    validate :validate_configuration_exists
+    validate :validate_unique_name
+
+    def initialize(user:, configuration_id:)
+      @user = user
+      @configuration_id = configuration_id
+    end
+
+    def submit(name:)
+      @name = name
+
+      success = valid?
+      if valid?
+        configuration.name = name
+        success = configuration.valid?
+        errors.merge!(configuration.errors)
+        configuration.save if success
+      end
+
+      FormResponse.new(
+        success:,
+        errors:,
+        extra: extra_analytics_attributes,
+        serialize_error_details_only: true,
+      )
+    end
+
+    def name
+      return @name if defined?(@name)
+      @name = configuration&.name
+    end
+
+    def configuration
+      @configuration ||= user.webauthn_configurations.find_by(id: configuration_id)
+    end
+
+    private
+
+    def validate_configuration_exists
+      return if configuration.present?
+      errors.add(
+        :configuration_id,
+        :configuration_not_found,
+        message: t('errors.manage_authenticator.internal_error'),
+      )
+    end
+
+    def validate_unique_name
+      return unless user.webauthn_configurations.where.not(id: configuration_id).find_by(name:)
+      errors.add(
+        :name,
+        :duplicate,
+        message: t('errors.manage_authenticator.unique_name_error'),
+      )
+    end
+
+    def extra_analytics_attributes
+      { configuration_id: }
+    end
+  end
+end

--- a/app/javascript/packs/openid-connect-redirect.ts
+++ b/app/javascript/packs/openid-connect-redirect.ts
@@ -1,0 +1,5 @@
+import { forceRedirect } from '@18f/identity-url';
+
+document.body.classList.add('usa-sr-only');
+const link = document.querySelector<HTMLLinkElement>('#openid-connect-redirect')!;
+forceRedirect(link.href);

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -174,6 +174,12 @@ class UserMailer < ActionMailer::Base
     end
   end
 
+  def account_delete_submitted
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: t('user_mailer.account_reset_complete.subject'))
+    end
+  end
+
   def account_reset_cancel
     with_user_locale(user) do
       mail(to: email_address.email, subject: t('user_mailer.account_reset_cancel.subject'))

--- a/app/models/disposable_domain.rb
+++ b/app/models/disposable_domain.rb
@@ -1,2 +1,9 @@
 class DisposableDomain < ApplicationRecord
+  class << self
+    def disposable?(domain)
+      return false if !domain.is_a?(String) || domain.empty?
+
+      exists?(name: domain)
+    end
+  end
 end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fingerprinter'
 require 'identity_validations'
 
@@ -27,6 +29,11 @@ class ServiceProvider < ApplicationRecord
     :with_push_notification_urls,
     -> { where.not(push_notification_url: nil).where.not(push_notification_url: '') },
   )
+
+  IAA_INTERNAL = 'LGINTERNAL'
+
+  scope(:internal, -> { where(iaa: IAA_INTERNAL) })
+  scope(:external, -> { where.not(iaa: IAA_INTERNAL).or(where(iaa: nil)) })
 
   def metadata
     attributes.symbolize_keys.merge(certs: ssl_certs)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4718,14 +4718,21 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success
-  # @param [Integer] mfa_method_counts
-  # Tracks when WebAuthn is deleted
-  def webauthn_deleted(success:, mfa_method_counts:, pii_like_keypaths:, **extra)
+  # @param [Hash] error_details
+  # @param [Integer] configuration_id
+  # Tracks when user attempts to delete a WebAuthn configuration
+  # @identity.idp.previous_event_name WebAuthn Deleted
+  def webauthn_delete_submitted(
+    success:,
+    configuration_id:,
+    error_details: nil,
+    **extra
+  )
     track_event(
-      'WebAuthn Deleted',
-      success: success,
-      mfa_method_counts: mfa_method_counts,
-      pii_like_keypaths: pii_like_keypaths,
+      :webauthn_delete_submitted,
+      success:,
+      error_details:,
+      configuration_id:,
       **extra,
     )
   end
@@ -4752,6 +4759,25 @@ module AnalyticsEvents
       'WebAuthn Setup Visited',
       platform_authenticator: platform_authenticator,
       enabled_mfa_methods_count: enabled_mfa_methods_count,
+      **extra,
+    )
+  end
+
+  # @param [Boolean] success
+  # @param [Hash] error_details
+  # @param [Integer] configuration_id
+  # Tracks when user submits a name change for a WebAuthn configuration
+  def webauthn_update_name_submitted(
+    success:,
+    configuration_id:,
+    error_details: nil,
+    **extra
+  )
+    track_event(
+      :webauthn_update_name_submitted,
+      success:,
+      error_details:,
+      configuration_id:,
       **extra,
     )
   end

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -32,8 +32,8 @@ module DocAuth
               Back: encode(back_image),
               Selfie: (encode(selfie_image) if include_liveness?),
               DocumentType: 'DriversLicense',
-            },
-          }.compact
+            }.compact,
+          }
 
           settings.merge(document).to_json
         end

--- a/app/services/reporting/agency_and_sp_report.rb
+++ b/app/services/reporting/agency_and_sp_report.rb
@@ -7,10 +7,9 @@ module Reporting
     end
 
     def agency_and_sp_report
-      idv_sps, auth_sps = ServiceProvider.where('created_at <= ?', report_date).active.
-        partition { |sp| sp.ial.present? && sp.ial >= 2 }
+      idv_sps, auth_sps = service_providers.partition { |sp| sp.ial.present? && sp.ial >= 2 }
       idv_agency_ids = idv_sps.map(&:agency_id).uniq
-      idv_agencies, auth_agencies = agencies_with_sps.partition do |agency|
+      idv_agencies, auth_agencies = active_agencies.partition do |agency|
         idv_agency_ids.include?(agency.id)
       end
 
@@ -30,11 +29,25 @@ module Reporting
       )
     end
 
-    # Agencies have no timestamps, so we need to join to SPs to get something equivalent.
-    def agencies_with_sps
-      Agency.joins(:service_providers).
-        where('service_providers.created_at <= ?', report_date).
-        distinct
+    def active_agencies
+      @active_agencies ||= begin
+        Agreements::PartnerAccountStatus.find_by(name: 'active').
+          partner_accounts.
+          includes(:agency).
+          where('became_partner <= ?', report_date).
+          map(&:agency).
+          uniq
+      end
+    end
+
+    def service_providers
+      @service_providers ||= Reports::BaseReport.transaction_with_timeout do
+        issuers = ServiceProviderIdentity.
+          where('created_at <= ?', report_date).
+          distinct.
+          pluck(:service_provider)
+        ServiceProvider.where(issuer: issuers).active.external
+      end
     end
   end
 end

--- a/app/views/openid_connect/shared/redirect_js.html.erb
+++ b/app/views/openid_connect/shared/redirect_js.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title><%= t('headings.redirecting') %> | <%= APP_NAME %></title>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= render_stylesheet_once_tags %>
+  </head>
+  <body class="tablet:bg-primary-lighter">
+    <div class="grid-container tablet:padding-y-6">
+      <div class="grid-row">
+        <div class="tablet:grid-col-6 tablet:grid-offset-3">
+          <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
+
+          <p>
+            <%= t('saml_idp.shared.saml_post_binding.no_js') %>
+          </p>
+
+          <%= link_to(t('forms.buttons.continue'), @oidc_redirect_uri, class: 'usa-button usa-button--wide usa-button--big', id: 'openid-connect-redirect') %>
+        </div>
+      </div>
+    </div>
+    <%= render_javascript_pack_once_tags 'openid-connect-redirect' %>
+  </body>
+</html>

--- a/app/views/user_mailer/account_delete_submitted.html.erb
+++ b/app/views/user_mailer/account_delete_submitted.html.erb
@@ -1,0 +1,21 @@
+<p class="lead">
+  <%= t('user_mailer.account_reset_complete.intro_html', app_name_html: link_to(APP_NAME, IdentityConfig.store.mailer_domain_name, class: 'gray')) %>
+</p>
+
+<table class="spacer">
+  <tbody>
+    <tr>
+      <td class="s10" height="10px">
+        &nbsp;
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="hr">
+  <tr>
+    <th>
+      &nbsp;
+    </th>
+  </tr>
+</table>

--- a/app/views/users/webauthn/edit.html.erb
+++ b/app/views/users/webauthn/edit.html.erb
@@ -1,0 +1,40 @@
+<% self.title = t('two_factor_authentication.webauthn_platform.edit_heading') %>
+
+<%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.webauthn_platform.edit_heading')) %>
+
+<%= simple_form_for(
+      @form,
+      as: :form,
+      method: :put,
+      html: { autocomplete: 'off' },
+      url: webauthn_path(id: @form.configuration.id),
+    ) do |f| %>
+  <%= render ValidatedFieldComponent.new(
+        form: f,
+        name: :name,
+        label: t('two_factor_authentication.webauthn_platform.nickname'),
+      ) %>
+
+  <%= f.submit(
+        t('two_factor_authentication.webauthn_platform.change_nickname'),
+        class: 'display-block margin-top-5',
+      ) %>
+<% end %>
+
+<%= render ButtonComponent.new(
+      action: ->(**tag_options, &block) do
+        button_to(
+          webauthn_path(id: @form.configuration.id),
+          form: { aria: { label: t('two_factor_authentication.webauthn_platform.delete') } },
+          **tag_options,
+          &block
+        )
+      end,
+      method: :delete,
+      big: true,
+      wide: true,
+      danger: true,
+      class: 'display-block margin-top-2',
+    ).with_content(t('two_factor_authentication.webauthn_platform.delete')) %>
+
+<%= render 'shared/cancel', link: account_path %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -211,7 +211,7 @@ multi_region_kms_migration_jobs_profile_timeout: 120
 multi_region_kms_migration_jobs_user_count: 1000
 multi_region_kms_migration_jobs_user_timeout: 120
 mx_timeout: 3
-openid_connect_redirect_interstitial_enabled: true
+openid_connect_redirect: client_side_js
 openid_connect_content_security_form_action_enabled: false
 otp_delivery_blocklist_maxretry: 10
 otp_valid_for: 10
@@ -472,7 +472,7 @@ production:
   logins_per_ip_track_only_mode: true
   newrelic_license_key: ''
   nonessential_email_banlist: '[]'
-  openid_connect_redirect_interstitial_enabled: false
+  openid_connect_redirect: server_side
   openid_connect_content_security_form_action_enabled: true
   otp_delivery_blocklist_findtime: 5
   participate_in_dap: true

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -41,6 +41,10 @@ en:
         <strong>Try again in %{timeout}.</strong>
     general: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
+    manage_authenticator:
+      internal_error: There was an internal error processing your request. Please try again.
+      remove_only_method_error: You cannot remove your only authentication method.
+      unique_name_error: Name already in use. Please use a different name.
     max_password_attempts_reached: You’ve entered too many incorrect passwords. You
       can reset your password using the “Forgot your password?” link.
     messages:

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -44,6 +44,11 @@ es:
         veces. <strong>Inténtelo de nuevo en %{timeout}.</strong>
     general: '¡Oops! Algo salió mal. Inténtelo de nuevo.'
     invalid_totp: El código es inválido. Vuelva a intentarlo.
+    manage_authenticator:
+      internal_error: Se produjo un error interno al procesar tu solicitud. Por favor,
+        inténtalo de nuevo.
+      remove_only_method_error: No puede eliminar su único método de autenticación.
+      unique_name_error: Nombre ya en uso. Utilice un nombre diferente.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.
       Puede restablecer su contraseña usando el enlace “¿Olvidó su contraseña?”.
     messages:

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -48,6 +48,11 @@ fr:
         reprises. <strong>Réessayez dans %{timeout}.</strong>
     general: Oups, une erreur s’est produite. Veuillez essayer de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.
+    manage_authenticator:
+      internal_error: Une erreur interne s’est produite lors du traitement de votre
+        demande. Veuillez réessayer.
+      remove_only_method_error: Vous ne pouvez pas supprimer votre seule méthode d’authentification.
+      unique_name_error: Ce nom est déjà utilisé. Veuillez utiliser un nom différent.
     max_password_attempts_reached: Vous avez inscrit des mots de passe incorrects un
       trop grand nombre de fois. Vous pouvez réinitialiser votre mot de passe en
       utilisant le lien « Vous avez oublié votre mot de passe? ».

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -190,6 +190,13 @@ en:
       try_again: Face or touch unlock was unsuccessful. Please try again or %{link}.
       use_a_different_method: Use a different authentication method
     webauthn_header_text: Connect your security key
+    webauthn_platform:
+      change_nickname: Change nickname
+      delete: Delete this device
+      deleted: Successfully deleted a face or touch unlock method
+      edit_heading: Manage your face or touch unlock settings
+      nickname: Nickname
+      renamed: Successfully renamed your face or touch unlock method
     webauthn_platform_header_text: Use face or touch unlock
     webauthn_platform_use_key: Use face or touch unlock
     webauthn_use_key: Use security key

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -203,6 +203,14 @@ es:
         nuevo o %{link}.
       use_a_different_method: Utilice otro método de autenticación
     webauthn_header_text: Conecte su llave de seguridad
+    webauthn_platform:
+      change_nickname: Cambiar apodo
+      delete: Eliminar este dispositivo
+      deleted: Se ha eliminado correctamente un método de desbloqueo facial o táctil
+      edit_heading: Gestione su configuración de desbloqueo facial o táctil
+      nickname: Apodo
+      renamed: Se ha cambiado correctamente el nombre de su método de desbloqueo
+        facial o táctil
     webauthn_platform_header_text: Usar desbloqueo facial o táctil
     webauthn_platform_use_key: Usar desbloqueo facial o táctil
     webauthn_use_key: Usar llave de seguridad

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -213,6 +213,16 @@ fr:
         réessayer ou %{link}.
       use_a_different_method: Utilisez un autre moyen d’authentification
     webauthn_header_text: Connectez votre clé de sécurité
+    webauthn_platform:
+      change_nickname: Changer de pseudo
+      delete: Supprimer cet appareil
+      deleted: Suppression réussie d’une méthode de déverrouillage par reconnaissance
+        faciale ou par empreinte digitale
+      edit_heading: Gérez vos paramètres de déverrouillage par reconnaissance faciale
+        ou par empreinte digitale
+      nickname: Pseudo
+      renamed: Votre méthode de déverrouillage par reconnaissance faciale ou par
+        empreinte digitale a été renommée avec succès
     webauthn_platform_header_text: Utilisez le déverrouillage facial ou tactile
     webauthn_platform_use_key: Utilisez le déverrouillage facial ou tactile
     webauthn_use_key: Utiliser la clé de sécurité

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,11 @@ Rails.application.routes.draw do
     namespace :internal do
       get '/sessions' => 'sessions#show'
       put '/sessions' => 'sessions#update'
+
+      namespace :two_factor_authentication do
+        put '/webauthn/:id' => 'webauthn#update', as: :webauthn
+        delete '/webauthn/:id' => 'webauthn#destroy', as: nil
+      end
     end
   end
 
@@ -218,6 +223,8 @@ Rails.application.routes.draw do
 
     get '/webauthn_setup' => 'users/webauthn_setup#new', as: :webauthn_setup
     patch '/webauthn_setup' => 'users/webauthn_setup#confirm'
+
+    # Deprecated routes: Remove once LG-11454 is fully deployed to production.
     delete '/webauthn_setup' => 'users/webauthn_setup#delete'
     get '/webauthn_setup_delete' => 'users/webauthn_setup#show_delete'
 
@@ -245,6 +252,9 @@ Rails.application.routes.draw do
     delete '/manage/phone/:id' => 'users/edit_phone#destroy'
     get '/manage/personal_key' => 'users/personal_keys#show', as: :manage_personal_key
     post '/manage/personal_key' => 'users/personal_keys#update'
+    get '/manage/webauthn/:id' => 'users/webauthn#edit', as: :edit_webauthn
+    put '/manage/webauthn/:id' => 'users/webauthn#update', as: :webauthn
+    delete '/manage/webauthn/:id' => 'users/webauthn#destroy', as: nil
 
     get '/account/personal_key' => 'accounts/personal_keys#new', as: :create_new_personal_key
     post '/account/personal_key' => 'accounts/personal_keys#create'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -322,7 +322,11 @@ class IdentityConfig
     config.add(:mx_timeout, type: :integer)
     config.add(:newrelic_license_key, type: :string)
     config.add(:nonessential_email_banlist, type: :json)
-    config.add(:openid_connect_redirect_interstitial_enabled, type: :boolean)
+    config.add(
+      :openid_connect_redirect,
+      type: :symbol,
+      enum: [:server_side, :client_side, :client_side_js],
+    )
     config.add(:openid_connect_content_security_form_action_enabled, type: :boolean)
     config.add(:otp_delivery_blocklist_findtime, type: :integer)
     config.add(:otp_delivery_blocklist_maxretry, type: :integer)

--- a/spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb
+++ b/spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.describe Api::Internal::TwoFactorAuthentication::WebauthnController do
+  let(:user) { create(:user, :with_phone) }
+  let(:configuration) { create(:webauthn_configuration, user:) }
+
+  before do
+    stub_analytics
+    stub_sign_in(user) if user
+  end
+
+  describe '#update' do
+    let(:name) { 'example' }
+    let(:params) { { id: configuration.id, name: } }
+    let(:response) { put :update, params: params }
+    subject(:response_body) { JSON.parse(response.body, symbolize_names: true) }
+
+    it 'responds with successful result' do
+      expect(response_body).to eq(success: true)
+      expect(response.status).to eq(200)
+    end
+
+    it 'logs the submission attempt' do
+      response
+
+      expect(@analytics).to have_logged_event(
+        :webauthn_update_name_submitted,
+        success: true,
+        configuration_id: configuration.id.to_s,
+        error_details: nil,
+      )
+    end
+
+    it 'includes csrf token in the response headers' do
+      expect(response.headers['X-CSRF-Token']).to be_kind_of(String)
+    end
+
+    context 'signed out' do
+      let(:user) { nil }
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'responds with unauthorized response' do
+        expect(response_body).to eq(error: 'Unauthorized')
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with invalid submission' do
+      let(:name) { '' }
+
+      it 'responds with unsuccessful result' do
+        expect(response_body).to eq(success: false, error: t('errors.messages.blank'))
+        expect(response.status).to eq(400)
+      end
+
+      it 'logs the submission attempt' do
+        response
+
+        expect(@analytics).to have_logged_event(
+          :webauthn_update_name_submitted,
+          success: false,
+          configuration_id: configuration.id.to_s,
+          error_details: { name: { blank: true } },
+        )
+      end
+    end
+
+    context 'not recently authenticated' do
+      before do
+        allow(controller).to receive(:recently_authenticated_2fa?).and_return(false)
+      end
+
+      it 'responds with unauthorized response' do
+        expect(response_body).to eq(error: 'Unauthorized')
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:params) { { id: configuration.id } }
+    let(:response) { delete :destroy, params: params }
+    subject(:response_body) { JSON.parse(response.body, symbolize_names: true) }
+
+    it 'responds with successful result' do
+      expect(response_body).to eq(success: true)
+      expect(response.status).to eq(200)
+    end
+
+    it 'logs the submission attempt' do
+      response
+
+      expect(@analytics).to have_logged_event(
+        :webauthn_delete_submitted,
+        success: true,
+        configuration_id: configuration.id.to_s,
+        error_details: nil,
+      )
+    end
+
+    it 'includes csrf token in the response headers' do
+      expect(response.headers['X-CSRF-Token']).to be_kind_of(String)
+    end
+
+    context 'signed out' do
+      let(:user) { nil }
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'responds with unauthorized response' do
+        expect(response_body).to eq(error: 'Unauthorized')
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with invalid submission' do
+      let(:user) { create(:user) }
+
+      it 'responds with unsuccessful result' do
+        expect(response_body).to eq(
+          success: false,
+          error: t('errors.manage_authenticator.remove_only_method_error'),
+        )
+        expect(response.status).to eq(400)
+      end
+
+      it 'logs the submission attempt' do
+        response
+
+        expect(@analytics).to have_logged_event(
+          :webauthn_delete_submitted,
+          success: false,
+          configuration_id: configuration.id.to_s,
+          error_details: { configuration_id: { only_method: true } },
+        )
+      end
+    end
+
+    context 'not recently authenticated' do
+      before do
+        allow(controller).to receive(:recently_authenticated_2fa?).and_return(false)
+      end
+
+      it 'responds with unauthorized response' do
+        expect(response_body).to eq(error: 'Unauthorized')
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/reauthentication_required_concern_spec.rb
+++ b/spec/controllers/concerns/reauthentication_required_concern_spec.rb
@@ -3,23 +3,33 @@ require 'rails_helper'
 RSpec.describe ReauthenticationRequiredConcern, type: :controller do
   let(:user) { create(:user, :fully_registered, email: 'old_email@example.com') }
 
+  controller ApplicationController do
+    include ReauthenticationRequiredConcern
+
+    before_action :confirm_recently_authenticated_2fa
+
+    def index
+      render plain: 'Hello'
+    end
+  end
+
+  before(:each) do
+    stub_sign_in(user) if user
+  end
+
   describe '#confirm_recently_authenticated_2fa' do
-    controller ApplicationController do
-      include ReauthenticationRequiredConcern
+    context 'recently authenticated' do
+      it 'allows action' do
+        get :index
 
-      before_action :confirm_recently_authenticated_2fa
-
-      def index
-        render plain: 'Hello'
+        expect(response.body).to eq 'Hello'
       end
     end
 
-    before(:each) do
-      stub_sign_in(user)
-    end
+    context 'signed out' do
+      let(:user) { nil }
 
-    context 'recently authenticated' do
-      it 'allows action' do
+      it 'redirects to 2FA options' do
         get :index
 
         expect(response.body).to eq 'Hello'
@@ -59,6 +69,35 @@ RSpec.describe ReauthenticationRequiredConcern, type: :controller do
         )
         get :index
       end
+    end
+  end
+
+  describe '#recently_authenticated_2fa?' do
+    subject(:recently_authenticated_2fa) { controller.recently_authenticated_2fa? }
+
+    context 'recently authenticated' do
+      it { expect(recently_authenticated_2fa).to eq(true) }
+    end
+
+    context 'signed out' do
+      let(:user) { nil }
+
+      it { expect(recently_authenticated_2fa).to eq(false) }
+    end
+
+    context 'authenticated outside the authn window' do
+      let(:travel_time) { (IdentityConfig.store.reauthn_window + 1).seconds }
+
+      before do
+        controller.auth_methods_session.authenticate!(TwoFactorAuthenticatable::AuthMethod::TOTP)
+        travel travel_time
+      end
+
+      around do |example|
+        freeze_time { example.run }
+      end
+
+      it { expect(recently_authenticated_2fa).to eq(false) }
     end
   end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
       end
 
       context 'with valid params' do
-        it 'redirects back to the client app with a code if client-side redirect is disabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+        it 'redirects back to the client app with a code if server-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
@@ -64,13 +64,29 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         it 'renders a client-side redirect back to the client app with a code if it is enabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+
+          redirect_params = UriService.params(assigns(:oidc_redirect_uri))
+
+          expect(redirect_params[:code]).to be_present
+          expect(redirect_params[:state]).to eq(params[:state])
+        end
+
+        it 'renders a JS client-side redirect back to the client app with a code if it is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
 
           redirect_params = UriService.params(assigns(:oidc_redirect_uri))
@@ -128,8 +144,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
             end
 
             it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
-              allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                and_return(false)
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:server_side)
               IdentityLinker.new(user, service_provider).link_identity(ial: 3)
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
@@ -141,8 +157,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
             end
 
             it 'renders a client-side redirect back to the client app immediately if it is enabled' do
-              allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                and_return(true)
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:client_side)
               IdentityLinker.new(user, service_provider).link_identity(ial: 3)
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
@@ -151,6 +167,20 @@ RSpec.describe OpenidConnect::AuthorizationController do
               action
 
               expect(controller).to render_template('openid_connect/shared/redirect')
+              expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+            end
+
+            it 'renders a JS client-side redirect back to the client app immediately if it is enabled' do
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:client_side_js)
+              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate verified_at],
+              )
+              allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+              action
+
+              expect(controller).to render_template('openid_connect/shared/redirect_js')
               expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
             end
 
@@ -307,9 +337,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 ).user
               end
 
-              it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(false)
+              it 'redirects to the redirect_uri immediately when pii is unlocked if server-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:server_side)
                 IdentityLinker.new(user, service_provider).link_identity(ial: 3)
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
@@ -321,8 +351,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
               end
 
               it 'renders client-side redirect to the client app immediately if PII is unlocked and it is enabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(true)
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 3)
                 user.identities.last.update!(
@@ -332,6 +362,21 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 action
 
                 expect(controller).to render_template('openid_connect/shared/redirect')
+                expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+              end
+
+              it 'renders JS client-side redirect to the client app immediately if PII is unlocked and it is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side_js)
+
+                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+                allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+                action
+
+                expect(controller).to render_template('openid_connect/shared/redirect_js')
                 expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
               end
 
@@ -388,9 +433,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
             end
 
             context 'account is not already verified' do
-              it 'redirects to the redirect_uri immediately without proofing if client-side redirect is disabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(false)
+              it 'redirects to the redirect_uri immediately without proofing if server-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:server_side)
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
@@ -402,8 +447,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
               end
 
               it 'renders client-side redirect to the client app immediately if client-side redirect is enabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(true)
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -412,6 +457,20 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 action
                 expect(controller).to render_template('openid_connect/shared/redirect')
+                expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+              end
+
+              it 'renders JS client-side redirect to the client app immediately if JS client-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side_js)
+
+                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+
+                action
+                expect(controller).to render_template('openid_connect/shared/redirect_js')
                 expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
               end
 
@@ -458,9 +517,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
             context 'profile is reset' do
               let(:user) { create(:profile, :verified, :password_reset).user }
 
-              it 'redirects to the redirect_uri immediately without proofing if client-side redirect is disabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(false)
+              it 'redirects to the redirect_uri immediately without proofing if server-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:server_side)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -473,8 +532,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
               end
 
               it 'renders client-side redirect to the client app immediately if client-side redirect is enabled' do
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                  and_return(true)
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -483,6 +542,20 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 action
                 expect(controller).to render_template('openid_connect/shared/redirect')
+                expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+              end
+
+              it 'renders JS client-side redirect to the client app immediately if JS client-side redirect is enabled' do
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return(:client_side_js)
+
+                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+
+                action
+                expect(controller).to render_template('openid_connect/shared/redirect_js')
                 expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
               end
 
@@ -548,8 +621,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
           end
 
           it 'redirects back to the client app with a code if client-side redirect is disabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
@@ -561,12 +634,26 @@ RSpec.describe OpenidConnect::AuthorizationController do
           end
 
           it 'renders a client-side redirect back to the client app with a code if it is enabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
 
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+
+            redirect_params = UriService.params(assigns(:oidc_redirect_uri))
+            expect(redirect_params[:code]).to be_present
+            expect(redirect_params[:state]).to eq(params[:state])
+          end
+
+          it 'renders a JS client-side redirect back to the client app with a code if it is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
 
             redirect_params = UriService.params(assigns(:oidc_redirect_uri))
@@ -580,8 +667,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
         before { params[:prompt] = '' }
 
         it 'redirects the user with an invalid request if client-side redirect is disabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           action
 
           expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
@@ -594,11 +681,26 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         it 'renders client-side redirect with an invalid request if client-side redirect is enabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+
+          redirect_params = UriService.params(assigns(:oidc_redirect_uri))
+
+          expect(redirect_params[:error]).to eq('invalid_request')
+          expect(redirect_params[:error_description]).to be_present
+          expect(redirect_params[:state]).to eq(params[:state])
+        end
+
+        it 'renders JS client-side redirect with an invalid request if JS client-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
 
           redirect_params = UriService.params(assigns(:oidc_redirect_uri))
@@ -625,7 +727,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  code_challenge_present: false,
                  service_provider_pkce: nil,
                  scope: 'openid')
-          expect(@analytics).to_not receive(:track_event).with('SP redirect initiated')
+          expect(@analytics).to_not receive(:track_event).with('sp redirect initiated')
 
           action
 
@@ -671,20 +773,29 @@ RSpec.describe OpenidConnect::AuthorizationController do
       context 'without valid acr_values' do
         before { params.delete(:acr_values) }
 
-        it 'handles the error and does not blow up when client-side redirect is disabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+        it 'handles the error and does not blow up when server-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           action
 
           expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
         end
 
         it 'handles the error and does not blow up when client-side redirect is enabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+        end
+
+        it 'handles the error and does not blow up when client-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
         end
       end
@@ -703,9 +814,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
           params[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
         end
 
-        it 'redirects the user if client-side redirect is disabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+        it 'redirects the user if server-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           action
 
           expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
@@ -718,11 +829,26 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         it 'renders a client-side redirect if client-side redirect is enabled' do
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
+
+          redirect_params = UriService.params(assigns(:oidc_redirect_uri))
+
+          expect(redirect_params[:error]).to eq('invalid_request')
+          expect(redirect_params[:error_description]).to be_present
+          expect(redirect_params[:state]).to eq(params[:state])
+        end
+
+        it 'renders a JS client-side redirect if JS client-side redirect is enabled' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(params[:redirect_uri])
 
           redirect_params = UriService.params(assigns(:oidc_redirect_uri))

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -62,20 +62,29 @@ RSpec.describe OpenidConnect::LogoutController do
               action
             end
 
-            it 'redirects back to the client if client-side redirect is disabled' do
-              allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                and_return(false)
+            it 'redirects back to the client if server-side redirect is enabled' do
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:server_side)
               action
 
               expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
             end
 
             it 'renders client-side redirect if client-side redirect is enabled' do
-              allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-                and_return(true)
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:client_side)
               action
 
               expect(controller).to render_template('openid_connect/shared/redirect')
+              expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+            end
+
+            it 'renders JS client-side redirect if client-side JS redirect is enabled' do
+              allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                and_return(:client_side_js)
+              action
+
+              expect(controller).to render_template('openid_connect/shared/redirect_js')
               expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
             end
 
@@ -184,20 +193,29 @@ RSpec.describe OpenidConnect::LogoutController do
         end
 
         context 'user is not signed in' do
-          it 'renders client-side redirect if client-side redirect is enabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+          it 'renders server-side redirect if server-side redirect is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
           end
 
-          it 'redirects back to the client if client-side redirect is disabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+          it 'redirects back to the client if client-side redirect is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'redirects back to the client if JS client-side redirect is enabledj' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
         end
@@ -298,20 +316,29 @@ RSpec.describe OpenidConnect::LogoutController do
         end
 
         context 'user is not signed in' do
-          it 'redirects back to the client if client-side redirect is disabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+          it 'redirects back to the client if server-side redirect is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
           end
 
           it 'renders client-side redirect if client-side redirect is enabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'renders JS client-side redirect if JS client-side redirect is enabled' do
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
         end
@@ -333,10 +360,10 @@ RSpec.describe OpenidConnect::LogoutController do
           let(:user) { create(:user) }
           before { stub_sign_in(user) }
 
-          it 'destroys the session and redirects to client if client-side redirect is disabled' do
+          it 'destroys the session and redirects to client if server-side redirect is enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -344,11 +371,21 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'destroys session and renders client-side redirect if enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'destroys session and renders JS client-side redirect if enabled' do
+            expect(controller).to receive(:sign_out)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
         end
@@ -378,8 +415,8 @@ RSpec.describe OpenidConnect::LogoutController do
           before { stub_sign_in(user) }
           it 'destroys the session and redirects if client-side redirect is disabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -387,11 +424,21 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'destroys the session and renders client-side redirect if enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'destroys the session and renders JS client-side redirect if enabled' do
+            expect(controller).to receive(:sign_out)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
         end
@@ -552,10 +599,10 @@ RSpec.describe OpenidConnect::LogoutController do
       end
 
       context 'user is not signed in' do
-        it 'redirects back to the client if client-side redirect is disabled' do
+        it 'redirects back to the client if server-side redirect is enabled' do
           expect(controller).to receive(:sign_out)
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(false)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:server_side)
           action
 
           expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -563,11 +610,21 @@ RSpec.describe OpenidConnect::LogoutController do
 
         it 'renders client-side redirect if client-side redirect is enabled' do
           expect(controller).to receive(:sign_out)
-          allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-            and_return(true)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side)
           action
 
           expect(controller).to render_template('openid_connect/shared/redirect')
+          expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+        end
+
+        it 'renders JS client-side redirect if JS client-side redirect is enabled' do
+          expect(controller).to receive(:sign_out)
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+            and_return(:client_side_js)
+          action
+
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
           expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
         end
       end
@@ -586,10 +643,10 @@ RSpec.describe OpenidConnect::LogoutController do
 
         context 'user is signed in' do
           before { stub_sign_in(user) }
-          it 'destroys session and redirects to client if client-side redirect is disabled' do
+          it 'destroys session and redirects to client if server-side redirect is enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(false)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:server_side)
             action
 
             expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
@@ -597,11 +654,21 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'destroys the session and renders client-side redirect if enabled' do
             expect(controller).to receive(:sign_out)
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect_interstitial_enabled).
-              and_return(true)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side)
             action
 
             expect(controller).to render_template('openid_connect/shared/redirect')
+            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
+          end
+
+          it 'destroys the session and renders JS client-side redirect if enabled' do
+            expect(controller).to receive(:sign_out)
+            allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+              and_return(:client_side_js)
+            action
+
+            expect(controller).to render_template('openid_connect/shared/redirect_js')
             expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
           end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SignUp::CompletionsController do
+  let(:temporary_email) { 'name@temporary.com' }
+
   describe '#show' do
     let(:current_sp) { create(:service_provider) }
 
@@ -22,8 +24,10 @@ RSpec.describe SignUp::CompletionsController do
       end
 
       context 'IAL1' do
-        let(:user) { create(:user, :fully_registered) }
+        let(:user) { create(:user, :fully_registered, email: temporary_email) }
+
         before do
+          DisposableDomain.create(name: 'temporary.com')
           stub_sign_in(user)
           subject.session[:sp] = {
             issuer: current_sp.issuer,
@@ -255,11 +259,47 @@ RSpec.describe SignUp::CompletionsController do
         patch :update
         expect(response).to redirect_to account_path
       end
+
+      context 'with a disposable email address' do
+        let(:user) { create(:user, :fully_registered, email: temporary_email) }
+
+        it 'logs disposable domain' do
+          DisposableDomain.create(name: 'temporary.com')
+          stub_sign_in(user)
+          subject.session[:sp] = {
+            ial2: false,
+            issuer: 'foo',
+            request_url: 'http://example.com',
+          }
+          subject.user_session[:in_account_creation_flow] = true
+
+          patch :update
+
+          expect(@analytics).to have_received(:track_event).with(
+            'User registration: complete',
+            ial2: false,
+            ialmax: nil,
+            service_provider_name: subject.decorated_sp_session.sp_name,
+            page_occurence: 'agency-page',
+            needs_completion_screen_reason: :new_sp,
+            sp_request_requested_attributes: nil,
+            sp_session_requested_attributes: nil,
+            in_account_creation_flow: true,
+            disposable_email_domain: 'temporary.com',
+          )
+        end
+      end
     end
 
     context 'IAL2' do
       it 'tracks analytics' do
-        user = create(:user, :fully_registered, profiles: [create(:profile, :verified, :active)])
+        DisposableDomain.create(name: 'temporary.com')
+        user = create(
+          :user,
+          :fully_registered,
+          profiles: [create(:profile, :verified, :active)],
+          email: temporary_email,
+        )
         stub_sign_in(user)
         sp = create(:service_provider, issuer: 'https://awesome')
         subject.session[:sp] = {
@@ -282,6 +322,7 @@ RSpec.describe SignUp::CompletionsController do
           sp_request_requested_attributes: nil,
           sp_session_requested_attributes: ['email'],
           in_account_creation_flow: true,
+          disposable_email_domain: 'temporary.com',
         )
       end
 

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe Users::DeleteController do
       expect(User.where(id: user.id).length).to eq(0)
     end
 
+    it 'emails user of account deletion' do
+      allow(UserMailer).to receive(:account_delete_submitted).and_call_original
+      stub_signed_in_user
+      delete
+      expect(UserMailer).not_to have_received(:account_delete_submitted)
+    end
+
     it 'logs a succesful submit' do
       stub_analytics
       stub_attempts_tracker

--- a/spec/controllers/users/webauthn_controller_spec.rb
+++ b/spec/controllers/users/webauthn_controller_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe Users::WebauthnController do
+  let(:user) { create(:user, :with_phone) }
+  let(:configuration) { create(:webauthn_configuration, user:) }
+
+  before do
+    stub_analytics
+    stub_sign_in(user) if user
+  end
+
+  describe '#edit' do
+    let(:params) { { id: configuration.id } }
+    let(:response) { get :edit, params: params }
+
+    it 'assigns the form instance' do
+      response
+
+      expect(assigns(:form)).to be_kind_of(TwoFactorAuthentication::WebauthnUpdateForm)
+      expect(assigns(:form).configuration).to eq(configuration)
+    end
+  end
+
+  describe '#update' do
+    let(:name) { 'example' }
+    let(:params) { { id: configuration.id, form: { name: } } }
+    let(:response) { put :update, params: params }
+
+    it 'redirects to account page with success message' do
+      expect(response).to redirect_to(account_path)
+      expect(flash[:success]).to eq(t('two_factor_authentication.webauthn_platform.renamed'))
+    end
+
+    it 'assigns the form instance' do
+      response
+
+      expect(assigns(:form)).to be_kind_of(TwoFactorAuthentication::WebauthnUpdateForm)
+      expect(assigns(:form).configuration).to eq(configuration)
+    end
+
+    it 'logs the submission attempt' do
+      response
+
+      expect(@analytics).to have_logged_event(
+        :webauthn_update_name_submitted,
+        success: true,
+        configuration_id: configuration.id.to_s,
+        error_details: nil,
+      )
+    end
+
+    context 'signed out' do
+      let(:user) { nil }
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'redirects to sign-in page' do
+        expect(response).to redirect_to(new_user_session_url)
+      end
+    end
+
+    context 'with invalid submission' do
+      let(:name) { '' }
+
+      it 'renders edit template with error' do
+        expect(response).to render_template(:edit)
+        expect(flash.now[:error]).to eq(t('errors.messages.blank'))
+      end
+
+      it 'logs the submission attempt' do
+        response
+
+        expect(@analytics).to have_logged_event(
+          :webauthn_update_name_submitted,
+          success: false,
+          configuration_id: configuration.id.to_s,
+          error_details: { name: { blank: true } },
+        )
+      end
+    end
+
+    context 'not recently authenticated' do
+      before do
+        allow(controller).to receive(:recently_authenticated_2fa?).and_return(false)
+      end
+
+      it 'redirects to reauthenticate' do
+        expect(response).to redirect_to(login_two_factor_options_path)
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:params) { { id: configuration.id } }
+    let(:response) { delete :destroy, params: params }
+
+    it 'responds with successful result' do
+      expect(response).to redirect_to(account_path)
+      expect(flash[:success]).to eq(t('two_factor_authentication.webauthn_platform.deleted'))
+    end
+
+    it 'logs the submission attempt' do
+      response
+
+      expect(@analytics).to have_logged_event(
+        :webauthn_delete_submitted,
+        success: true,
+        configuration_id: configuration.id.to_s,
+        error_details: nil,
+      )
+    end
+
+    it 'assigns the form instance' do
+      response
+
+      expect(assigns(:form)).to be_kind_of(TwoFactorAuthentication::WebauthnDeleteForm)
+      expect(assigns(:form).configuration).to eq(configuration)
+    end
+
+    context 'signed out' do
+      let(:user) { nil }
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'redirects to sign-in page' do
+        expect(response).to redirect_to(new_user_session_url)
+      end
+    end
+
+    context 'with invalid submission' do
+      let(:user) { create(:user) }
+
+      it 'redirects to edit with unsuccessful result' do
+        expect(response).to redirect_to(edit_webauthn_path(id: configuration.id))
+        expect(flash[:error]).to eq(t('errors.manage_authenticator.remove_only_method_error'))
+      end
+
+      it 'logs the submission attempt' do
+        response
+
+        expect(@analytics).to have_logged_event(
+          :webauthn_delete_submitted,
+          success: false,
+          configuration_id: configuration.id.to_s,
+          error_details: { configuration_id: { only_method: true } },
+        )
+      end
+    end
+
+    context 'not recently authenticated' do
+      before do
+        allow(controller).to receive(:recently_authenticated_2fa?).and_return(false)
+      end
+
+      it 'redirects to reauthenticate' do
+        expect(response).to redirect_to(login_two_factor_options_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -149,14 +149,14 @@ RSpec.describe Users::WebauthnSetupController do
       end
 
       it 'tracks the delete in analytics' do
-        result = {
-          success: true,
-          mfa_method_counts: { auth_app: 1, phone: 1 },
-          pii_like_keypaths: [[:mfa_method_counts, :phone]],
-        }
-        expect(@analytics).to receive(:track_event).with('WebAuthn Deleted', result)
-
         delete :delete, params: { id: webauthn_configuration.id }
+
+        expect(@analytics).to have_logged_event(
+          :webauthn_delete_submitted,
+          success: true,
+          error_details: nil,
+          configuration_id: webauthn_configuration.id.to_s,
+        )
       end
 
       it 'sends a recovery information changed event' do

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -51,5 +51,13 @@ FactoryBot.define do
     end
 
     factory :service_provider_without_help_text, traits: [:without_help_text]
+
+    trait :internal do
+      iaa { ServiceProvider::IAA_INTERNAL }
+    end
+
+    trait :external do
+      iaa { 'LG1234' }
+    end
   end
 end

--- a/spec/forms/two_factor_authentication/webauthn_delete_form_spec.rb
+++ b/spec/forms/two_factor_authentication/webauthn_delete_form_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe TwoFactorAuthentication::WebauthnDeleteForm do
+  let(:user) { create(:user) }
+  let(:configuration) { create(:webauthn_configuration, user:) }
+  let(:configuration_id) { configuration&.id }
+  let(:form) { described_class.new(user:, configuration_id:) }
+
+  describe '#submit' do
+    let(:result) { form.submit }
+
+    context 'with having another mfa enabled' do
+      let(:user) { create(:user, :with_phone) }
+
+      it 'returns a successful result' do
+        expect(result.success?).to eq(true)
+        expect(result.to_h).to eq(success: true, configuration_id:)
+      end
+
+      context 'with blank configuration' do
+        let(:configuration) { nil }
+
+        it 'returns an unsuccessful result' do
+          expect(result.success?).to eq(false)
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: {
+              configuration_id: { configuration_not_found: true },
+            },
+            configuration_id:,
+          )
+        end
+      end
+
+      context 'with configuration that does not exist' do
+        let(:configuration_id) { 'does-not-exist' }
+
+        it 'returns an unsuccessful result' do
+          expect(result.success?).to eq(false)
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: {
+              configuration_id: { configuration_not_found: true },
+            },
+            configuration_id:,
+          )
+        end
+      end
+
+      context 'with configuration not belonging to the user' do
+        let(:configuration) { create(:webauthn_configuration) }
+
+        it 'returns an unsuccessful result' do
+          expect(result.success?).to eq(false)
+          expect(result.to_h).to eq(
+            success: false,
+            error_details: {
+              configuration_id: { configuration_not_found: true },
+            },
+            configuration_id:,
+          )
+        end
+      end
+    end
+
+    context 'with user not having another mfa enabled' do
+      let(:user) { create(:user) }
+
+      it 'returns an unsuccessful result' do
+        expect(result.success?).to eq(false)
+        expect(result.to_h).to eq(
+          success: false,
+          error_details: {
+            configuration_id: { only_method: true },
+          },
+          configuration_id:,
+        )
+      end
+    end
+  end
+
+  describe '#configuration' do
+    subject(:form_configuration) { form.configuration }
+
+    it 'returns configuration' do
+      expect(form_configuration).to eq(configuration)
+    end
+  end
+end

--- a/spec/forms/two_factor_authentication/webauthn_update_form_spec.rb
+++ b/spec/forms/two_factor_authentication/webauthn_update_form_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+RSpec.describe TwoFactorAuthentication::WebauthnUpdateForm do
+  let(:user) { create(:user) }
+  let(:original_name) { 'original-name' }
+  let(:configuration) { create(:webauthn_configuration, user:, name: original_name) }
+  let(:configuration_id) { configuration&.id }
+  let(:form) { described_class.new(user:, configuration_id:) }
+
+  describe '#submit' do
+    let(:name) { 'new-namae' }
+    let(:result) { form.submit(name:) }
+
+    it 'returns a successful result' do
+      expect(result.success?).to eq(true)
+      expect(result.to_h).to eq(success: true, configuration_id:)
+    end
+
+    it 'saves the new name' do
+      result
+
+      expect(configuration.reload.name).to eq(name)
+    end
+
+    context 'with blank configuration' do
+      let(:configuration) { nil }
+
+      it 'returns an unsuccessful result' do
+        expect(result.success?).to eq(false)
+        expect(result.to_h).to eq(
+          success: false,
+          error_details: {
+            configuration_id: { configuration_not_found: true },
+          },
+          configuration_id:,
+        )
+      end
+    end
+
+    context 'with configuration that does not exist' do
+      let(:configuration_id) { 'does-not-exist' }
+
+      it 'returns an unsuccessful result' do
+        expect(result.success?).to eq(false)
+        expect(result.to_h).to eq(
+          success: false,
+          error_details: {
+            configuration_id: { configuration_not_found: true },
+          },
+          configuration_id:,
+        )
+      end
+    end
+
+    context 'with configuration not belonging to the user' do
+      let(:configuration) { create(:webauthn_configuration, name: original_name) }
+
+      it 'returns an unsuccessful result' do
+        expect(result.success?).to eq(false)
+        expect(result.to_h).to eq(
+          success: false,
+          error_details: {
+            configuration_id: { configuration_not_found: true },
+          },
+          configuration_id:,
+        )
+      end
+
+      it 'does not save the new name' do
+        expect(configuration).not_to receive(:save)
+
+        result
+
+        expect(configuration.reload.name).to eq(original_name)
+      end
+    end
+
+    context 'with blank name' do
+      let(:name) { '' }
+
+      it 'returns an unsuccessful result' do
+        expect(result.success?).to eq(false)
+        expect(result.to_h).to eq(
+          success: false,
+          error_details: {
+            name: { blank: true },
+          },
+          configuration_id:,
+        )
+      end
+
+      it 'does not save the new name' do
+        expect(configuration).not_to receive(:save)
+
+        result
+
+        expect(configuration.reload.name).to eq(original_name)
+      end
+    end
+
+    context 'with duplicate name' do
+      before do
+        create(:webauthn_configuration, user:, name:)
+      end
+
+      it 'returns an unsuccessful result' do
+        expect(result.success?).to eq(false)
+        expect(result.to_h).to eq(
+          success: false,
+          error_details: {
+            name: { duplicate: true },
+          },
+          configuration_id:,
+        )
+      end
+
+      it 'does not save the new name' do
+        expect(configuration).not_to receive(:save)
+
+        result
+
+        expect(configuration.reload.name).to eq(original_name)
+      end
+    end
+  end
+
+  describe '#name' do
+    subject(:name) { form.name }
+
+    it 'returns configuration name' do
+      expect(name).to eq(configuration.name)
+    end
+  end
+
+  describe '#configuration' do
+    subject(:form_configuration) { form.configuration }
+
+    it 'returns configuration' do
+      expect(form_configuration).to eq(configuration)
+    end
+  end
+end

--- a/spec/lib/linters/analytics_event_name_linter_spec.rb
+++ b/spec/lib/linters/analytics_event_name_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/analytics_event_name_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::AnalyticsEventNameLinter do

--- a/spec/lib/linters/errors_add_linter_spec.rb
+++ b/spec/lib/linters/errors_add_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/errors_add_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::ErrorsAddLinter do

--- a/spec/lib/linters/image_size_linter_spec.rb
+++ b/spec/lib/linters/image_size_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/image_size_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::ImageSizeLinter do

--- a/spec/lib/linters/localized_validation_message_linter_spec.rb
+++ b/spec/lib/linters/localized_validation_message_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/localized_validation_message_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::LocalizedValidationMessageLinter do

--- a/spec/lib/linters/mail_later_linter_spec.rb
+++ b/spec/lib/linters/mail_later_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require 'rails_helper'
 require_relative '../../../lib/linters/mail_later_linter'
 

--- a/spec/lib/linters/redirect_back_linter_spec.rb
+++ b/spec/lib/linters/redirect_back_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/redirect_back_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::RedirectBackLinter do

--- a/spec/lib/linters/url_options_linter_spec.rb
+++ b/spec/lib/linters/url_options_linter_spec.rb
@@ -1,5 +1,7 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
 require_relative '../../../lib/linters/url_options_linter'
 
 RSpec.describe RuboCop::Cop::IdentityIdp::UrlOptionsLinter do

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -84,6 +84,10 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.with(user: user, email_address: email_address_record).account_reset_complete
   end
 
+  def account_delete_submitted
+    UserMailer.with(user: user, email_address: email_address_record).account_delete_submitted
+  end
+
   def account_reset_cancel
     UserMailer.with(user: user, email_address: email_address_record).account_reset_cancel
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -426,6 +426,31 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
+  describe '#account_delete_submitted' do
+    let(:mail) do
+      UserMailer.with(user: user, email_address: email_address).
+        account_delete_submitted
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+
+    it 'sends to the current email' do
+      expect(mail.to).to eq [email_address.email]
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('user_mailer.account_reset_complete.subject')
+    end
+
+    it 'renders the body' do
+      expect(mail.html_part.body).
+        to have_content(
+          strip_tags(t('user_mailer.account_reset_complete.intro_html', app_name_html: APP_NAME)),
+        )
+    end
+  end
+
   describe '#account_reset_cancel' do
     let(:mail) do
       UserMailer.with(user: user, email_address: email_address).

--- a/spec/models/disposable_domain_spec.rb
+++ b/spec/models/disposable_domain_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe DisposableDomain do
+  let(:domain) { 'temporary.com' }
+
+  describe '.disposable?' do
+    before do
+      DisposableDomain.create(name: domain)
+    end
+
+    context 'when the domain exists' do
+      it 'returns true' do
+        expect(DisposableDomain.disposable?(domain)).to eq true
+      end
+    end
+
+    context 'when the domain does not exist' do
+      it 'returns false' do
+        expect(DisposableDomain.disposable?('example.com')).to eq false
+      end
+    end
+
+    context 'with bad data' do
+      it 'returns false' do
+        expect(DisposableDomain.disposable?('')).to eq false
+        expect(DisposableDomain.disposable?(nil)).to eq false
+        expect(DisposableDomain.disposable?({})).to eq false
+      end
+    end
+  end
+end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -15,6 +15,34 @@ RSpec.describe ServiceProvider do
     end
   end
 
+  describe 'scopes' do
+    before do
+      clear_agreements_data
+      Agency.destroy_all
+      ServiceProvider.destroy_all
+    end
+
+    let!(:external_sps) do
+      [
+        create(:service_provider, :external),
+        create(:service_provider, iaa: nil),
+      ]
+    end
+    let!(:internal_sp) { create(:service_provider, :internal) }
+
+    describe '.internal' do
+      it 'includes apps with iaa: LGINTERNAL' do
+        expect(ServiceProvider.internal.to_a).to eq([internal_sp])
+      end
+    end
+
+    describe '.external' do
+      it 'includes apps without iaa: LGINTERNAL' do
+        expect(ServiceProvider.external.to_a).to match_array(external_sps)
+      end
+    end
+  end
+
   describe '#issuer' do
     it 'returns the constructor value' do
       expect(service_provider.issuer).to eq 'http://localhost:3000'

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       let(:workflow) { 'test_workflow' }
       let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
       it_behaves_like 'a successful request'
+
+      it 'does not include a nil selfie in the request body sent to TrueID' do
+        body_as_json = subject.send(:body)
+        body_as_hash = JSON.parse(body_as_json)
+        expect(body_as_hash['Document']).not_to have_key('Selfie')
+      end
     end
     context 'with unknown image source' do
       let(:workflow) { 'test_workflow_cropping' }

--- a/spec/services/reporting/agency_and_sp_report_spec.rb
+++ b/spec/services/reporting/agency_and_sp_report_spec.rb
@@ -14,24 +14,41 @@ RSpec.describe Reporting::AgencyAndSpReport do
 
   # Wipe the pre-seeded data. It's easier to start from a clean slate.
   before do
-    Agreements::IntegrationUsage.destroy_all
-    Agreements::IaaOrder.destroy_all
-    Agreements::Integration.destroy_all
-    Agreements::IntegrationStatus.destroy_all
-    Agreements::IaaGtc.destroy_all
-    Agreements::PartnerAccount.destroy_all
-    Agreements::PartnerAccountStatus.destroy_all
+    clear_agreements_data
     Agency.destroy_all
     ServiceProvider.destroy_all
   end
 
   subject(:report) { described_class.new(report_date) }
 
+  let(:agency) do
+    create(
+      :agency,
+      partner_accounts: [
+        build(
+          :partner_account,
+          became_partner: report_date - 10.days,
+          partner_account_status: build(
+            :partner_account_status, name: 'active'
+          ),
+        ),
+      ],
+    )
+  end
+
   describe '#agency_and_sp_report' do
     subject { report.agency_and_sp_report }
 
     context 'when adding a non-IDV SP' do
-      let!(:auth_sp) { create(:service_provider, :active) }
+      let!(:auth_sp) do
+        create(
+          :service_provider,
+          :external,
+          :active,
+          agency:,
+          identities: [build(:service_provider_identity)],
+        )
+      end
       let(:expected_report) do
         [
           header_row,
@@ -47,7 +64,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
     end
 
     context 'when adding an inactive SP' do
-      let!(:inactive_sp) { create(:service_provider) }
+      let!(:inactive_sp) { create(:service_provider, :external, agency:, identities: []) }
       let(:expected_report) do
         [
           header_row,
@@ -57,15 +74,21 @@ RSpec.describe Reporting::AgencyAndSpReport do
         ]
       end
 
-      # Agencies don't have a sense of 'active' and are included.
       it 'includes the agency but not the inactive SP' do
         expect(subject).to match_array(expected_report)
       end
     end
 
     context 'when adding an IDV SP to a non-IDV Agency' do
-      let!(:initial_sp) { create(:service_provider, :active) }
-      let!(:agency) { initial_sp.agency }
+      let!(:initial_sp) do
+        create(
+          :service_provider,
+          :external,
+          :active,
+          agency:,
+          identities: [build(:service_provider_identity)],
+        )
+      end
 
       let(:initial_report) do
         [
@@ -88,7 +111,14 @@ RSpec.describe Reporting::AgencyAndSpReport do
       it 'becomes an IDV agency' do
         expect(subject).to match_array(initial_report)
 
-        create(:service_provider, :active, :idv, agency: agency)
+        create(
+          :service_provider,
+          :external,
+          :active,
+          :idv,
+          agency:,
+          identities: [build(:service_provider_identity)],
+        )
 
         # The report gets memoized, so we need to reconstruct it here:
         new_report = described_class.new(report_date)
@@ -97,7 +127,16 @@ RSpec.describe Reporting::AgencyAndSpReport do
     end
 
     context 'when adding an IDV SP' do
-      let!(:idv_sp) { create(:service_provider, :idv, :active) }
+      let!(:idv_sp) do
+        create(
+          :service_provider,
+          :external,
+          :idv,
+          :active,
+          agency:,
+          identities: [build(:service_provider_identity)],
+        )
+      end
 
       let(:expected_report) do
         [

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -115,10 +115,18 @@ module OidcAuthHelper
     url
   end
 
+  def extract_redirect_url
+    content = page.find('a#openid-connect-redirect')
+    content[:href]
+  end
+
   def oidc_redirect_url
-    if IdentityConfig.store.openid_connect_redirect_interstitial_enabled
+    case IdentityConfig.store.openid_connect_redirect
+    when :client_side
       extract_meta_refresh_url
-    else
+    when :client_side_js
+      extract_redirect_url
+    else # should only be :server_side
       current_url
     end
   end

--- a/spec/views/users/webauthn/edit.html.erb_spec.rb
+++ b/spec/views/users/webauthn/edit.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'users/webauthn/edit.html.erb' do
+  include Devise::Test::ControllerHelpers
+
+  let(:nickname) { 'Example' }
+  let(:configuration) { create(:webauthn_configuration, :platform_authenticator, name: nickname) }
+  let(:user) { create(:user, webauthn_configurations: [configuration]) }
+  let(:form) do
+    TwoFactorAuthentication::WebauthnUpdateForm.new(
+      user:,
+      configuration_id: configuration.id,
+    )
+  end
+
+  subject(:rendered) { render }
+
+  before do
+    @form = form
+  end
+
+  it 'renders form to update configuration' do
+    expect(rendered).to have_selector(
+      "form[action='#{webauthn_path(id: configuration.id)}'] input[name='_method'][value='put']",
+      visible: false,
+    )
+  end
+
+  it 'initializes form with configuration values' do
+    expect(rendered).to have_field(
+      t('two_factor_authentication.webauthn_platform.nickname'),
+      with: nickname,
+    )
+  end
+
+  it 'has labelled form with button to delete configuration' do
+    expect(rendered).to have_button_to_with_accessibility(
+      t('two_factor_authentication.webauthn_platform.delete'),
+      webauthn_path(id: configuration.id),
+    )
+  end
+end


### PR DESCRIPTION
## User-Facing Improvements
- Authentication: Send email to user when they delete an account ([#9724](https://github.com/18F/identity-idp/pull/9724))

## Internal
- Analytics: Add tracking for disposable email domains ([#9747](https://github.com/18F/identity-idp/pull/9747))
- DocAuth: Tweak true id request body ([#9751](https://github.com/18F/identity-idp/pull/9751))
- OpenID Connect: Add support for client-side OIDC redirect ([#9755](https://github.com/18F/identity-idp/pull/9755))
- Reporting: Update monthly reporting on apps & agencies to exclude internal apps ([#9744](https://github.com/18F/identity-idp/pull/9744))

## Upcoming Features
- Face or Touch Unlock: Add new renaming interface for face or touch unlock ([#9742](https://github.com/18F/identity-idp/pull/9742))