### PR TITLE
Bust caches in User::active_profile and User::pending_profile

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ApplicationRecord
 
   def active_profile
     if defined?(@active_profile)
-      if !@active_profile&.active
+      if @active_profile && !@active_profile.active
         remove_instance_variable(:@active_profile)
       else
         return @active_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,7 +95,15 @@ class User < ApplicationRecord
   end
 
   def active_profile
-    @active_profile ||= profiles.verified.find(&:active?)
+    if defined?(@active_profile)
+      if !@active_profile&.active
+        remove_instance_variable(:@active_profile)
+      else
+        return @active_profile
+      end
+    end
+
+    @active_profile = profiles.verified.find(&:active?)
   end
 
   def pending_profile?
@@ -149,7 +157,13 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    return @pending_profile if defined?(@pending_profile)
+    if defined?(@pending_profile)
+      if @pending_profile&.active
+        remove_instance_variable(:@pending_profile)
+      else
+        return @pending_profile
+      end
+    end
 
     @pending_profile = begin
       pending = profiles.in_person_verification_pending.or(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -481,7 +481,6 @@ class User < ApplicationRecord
   end
 
   def reload(...)
-    remove_instance_variable(:@active_profile) if defined?(@active_profile)
     remove_instance_variable(:@pending_profile) if defined?(@pending_profile)
     super(...)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,9 +95,7 @@ class User < ApplicationRecord
   end
 
   def active_profile
-    return @active_profile if defined?(@active_profile) &&
-                              (@active_profile.nil? || @active_profile.active)
-
+    return @active_profile if defined?(@active_profile) && @active_profile&.active
     @active_profile = profiles.verified.find(&:active?)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,13 +95,8 @@ class User < ApplicationRecord
   end
 
   def active_profile
-    if defined?(@active_profile)
-      if @active_profile && !@active_profile.active
-        remove_instance_variable(:@active_profile)
-      else
-        return @active_profile
-      end
-    end
+    return @active_profile if defined?(@active_profile) &&
+                              (@active_profile.nil? || @active_profile.active)
 
     @active_profile = profiles.verified.find(&:active?)
   end
@@ -157,13 +152,7 @@ class User < ApplicationRecord
   end
 
   def pending_profile
-    if defined?(@pending_profile)
-      if @pending_profile&.active
-        remove_instance_variable(:@pending_profile)
-      else
-        return @pending_profile
-      end
-    end
+    return @pending_profile if defined?(@pending_profile) && !@pending_profile&.active
 
     @pending_profile = begin
       pending = profiles.in_person_verification_pending.or(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -493,6 +493,12 @@ class User < ApplicationRecord
     end
   end
 
+  def reload(...)
+    remove_instance_variable(:@active_profile) if defined?(@active_profile)
+    remove_instance_variable(:@pending_profile) if defined?(@pending_profile)
+    super(...)
+  end
+
   private
 
   def lockout_period

--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
       end
 
       let(:user) { create(:user, :with_pending_gpo_profile, created_at: 2.days.ago) }
-      let(:pending_profile) { user.gpo_verification_pending_profile }
+      let!(:pending_profile) { user.gpo_verification_pending_profile }
       let(:success) { true }
 
       it 'uses the PII from the pending profile' do
@@ -189,7 +189,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
           errors: {},
           pending_in_person_enrollment: false,
           fraud_check_failed: false,
-          enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
+          enqueued_at: pending_profile.gpo_confirmation_codes.last.code_sent_at,
           which_letter: 1,
           letter_count: 1,
           attempts: 1,
@@ -234,7 +234,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
             errors: {},
             pending_in_person_enrollment: true,
             fraud_check_failed: false,
-            enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
+            enqueued_at: pending_profile.gpo_confirmation_codes.last.code_sent_at,
             which_letter: 1,
             letter_count: 1,
             attempts: 1,
@@ -265,7 +265,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
               errors: {},
               pending_in_person_enrollment: false,
               fraud_check_failed: true,
-              enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
+              enqueued_at: pending_profile.gpo_confirmation_codes.last.code_sent_at,
               which_letter: 1,
               letter_count: 1,
               attempts: 1,

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'dev rake tasks' do
       expect(User.count).to eq 10
       verified_user.reload
       expect(verified_user.updated_at).to eq(verified_user_updated_at)
-      expect(verified_user.active_profile).to be(verified_user_profile)
+      expect(verified_user.active_profile).to eq(verified_user_profile)
 
       unverified_user = User.last
       expect(unverified_user.active_profile).to be_nil
@@ -99,7 +99,7 @@ RSpec.describe 'dev rake tasks' do
 
       verified_user.reload
       expect(verified_user.updated_at).to eq(verified_user_updated_at)
-      expect(verified_user.active_profile).to be(verified_user_profile)
+      expect(verified_user.active_profile).to eq(verified_user_profile)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe User do
       end
 
       context 'when there is no active profile' do
-        it 'caches the nil value until .reload is called' do
+        it 'does not cache the nil value' do
           user = create(:user, :fully_registered)
           profile = create(
             :profile,
@@ -213,9 +213,6 @@ RSpec.describe User do
           profile.remove_gpo_deactivation_reason
           profile.activate
 
-          expect(user.active_profile).to be_nil
-
-          user.reload
           expect(user.active_profile).to eql(profile)
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -197,6 +197,28 @@ RSpec.describe User do
           expect(user.active_profile).to be_nil
         end
       end
+
+      context 'when there is no active profile' do
+        it 'caches the nil value until .reload is called' do
+          user = create(:user, :fully_registered)
+          profile = create(
+            :profile,
+            gpo_verification_pending_at: 2.days.ago,
+            created_at: 2.days.ago,
+            user: user,
+          )
+
+          expect(user.active_profile).to be_nil
+
+          profile.remove_gpo_deactivation_reason
+          profile.activate
+
+          expect(user.active_profile).to be_nil
+
+          user.reload
+          expect(user.active_profile).to eql(profile)
+        end
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -640,8 +640,9 @@ RSpec.describe User do
   end
 
   describe '#pending_profile' do
+    let(:user) { User.new }
+
     context 'when a pending profile exists' do
-      let(:user) { User.new }
       let!(:pending) do
         create(
           :profile,
@@ -676,7 +677,6 @@ RSpec.describe User do
 
     context 'when pending profile does not exist' do
       it 'returns nil' do
-        user = User.new
         create(
           :profile,
           deactivation_reason: :encryption_error,
@@ -684,6 +684,19 @@ RSpec.describe User do
         )
 
         expect(user.pending_profile).to be_nil
+      end
+
+      it 'caches nil until reload' do
+        expect(user.pending_profile).to be_nil
+        pending_profile = create(
+          :profile,
+          gpo_verification_pending_at: 2.days.ago,
+          created_at: 2.days.ago,
+          user: user,
+        )
+        expect(user.pending_profile).to be_nil
+        user.reload
+        expect(user.pending_profile).to eql(pending_profile)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -186,6 +186,17 @@ RSpec.describe User do
 
         expect(user.active_profile).to eq profile1
       end
+
+      context 'when the active profile is deactivated' do
+        it 'is no longer returned' do
+          user = create(:user, :fully_registered)
+          create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })
+
+          expect(user.active_profile).not_to be_nil
+          user.active_profile.deactivate(:password_reset)
+          expect(user.active_profile).to be_nil
+        end
+      end
     end
   end
 
@@ -628,6 +639,16 @@ RSpec.describe User do
         allow(user).to receive(:active_profile).and_return(Profile.new(activated_at: 3.days.ago))
 
         expect(user.pending_profile).to eq pending
+      end
+
+      it 'returns nil after the pending profile is activated' do
+        pending_profile = user.pending_profile
+        expect(pending_profile).not_to be_nil
+
+        pending_profile.remove_gpo_deactivation_reason
+        pending_profile.activate
+
+        expect(user.pending_profile).to be_nil
       end
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

`User::active_profile` and `User::pending_profile` both cache their results in instance variables. This is fine, but sometimes, especially in tests, those caches get stale, and there's not a straightforward way to bust them without creating a new User instance (for example, `User::reload` does not clear those cached instance variables).

This PR updates `active_profile` and `pending_profile` to check whether the cached Profile they're about to return are still active or pending, and busts the cache if something has changed.

