### PR TITLE
Capitalization: Rename LexisnexisInstantVerify to LexisNexisInstantVerify

### DIFF
--- a/app/controllers/concerns/idv/ab_test_analytics_concern.rb
+++ b/app/controllers/concerns/idv/ab_test_analytics_concern.rb
@@ -9,7 +9,7 @@ module Idv
       end
 
       if defined?(document_capture_session_uuid)
-        lniv_args = LexisnexisInstantVerify.new(document_capture_session_uuid).
+        lniv_args = LexisNexisInstantVerify.new(document_capture_session_uuid).
           workflow_ab_test_analytics_args
         buckets = buckets.merge(lniv_args)
       end

--- a/app/services/idv/lexis_nexis_instant_verify.rb
+++ b/app/services/idv/lexis_nexis_instant_verify.rb
@@ -1,5 +1,5 @@
 module Idv
-  class LexisnexisInstantVerify
+  class LexisNexisInstantVerify
     attr_reader :document_capture_session_uuid
 
     def initialize(document_capture_session_uuid)

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -259,7 +259,7 @@ module Proofing
       end
 
       def lexisnexis_instant_verify_workflow
-        ab_test_variables = Idv::LexisnexisInstantVerify.new(instant_verify_ab_test_discriminator).
+        ab_test_variables = Idv::LexisNexisInstantVerify.new(instant_verify_ab_test_discriminator).
           workflow_ab_testing_variables
         ab_test_variables[:instant_verify_workflow]
       end

--- a/spec/controllers/concerns/idv/ab_test_analytics_concern_spec.rb
+++ b/spec/controllers/concerns/idv/ab_test_analytics_concern_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Idv::AbTestAnalyticsConcern do
 
     let(:acuant_sdk_args) { { as_bucket: :as_value } }
     let(:instant_verify_sdk_args) { { iv_bucket: :iv_value } }
-    let(:lniv) { Idv::LexisnexisInstantVerify.new(controller.document_capture_session_uuid) }
+    let(:lniv) { Idv::LexisNexisInstantVerify.new(controller.document_capture_session_uuid) }
 
     before do
       allow(subject).to receive(:current_user).and_return(user)
       expect(subject).to receive(:acuant_sdk_ab_test_analytics_args).
         and_return(acuant_sdk_args)
-      allow(Idv::LexisnexisInstantVerify).to receive(:new).
+      allow(Idv::LexisNexisInstantVerify).to receive(:new).
         and_return(lniv)
       expect(lniv).to receive(:workflow_ab_test_analytics_args).
         and_return(instant_verify_sdk_args)

--- a/spec/services/idv/lexis_nexis_instant_verify_spec.rb
+++ b/spec/services/idv/lexis_nexis_instant_verify_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe Idv::LexisnexisInstantVerify do
+RSpec.describe Idv::LexisNexisInstantVerify do
   let(:session_uuid) { SecureRandom.uuid }
   let(:default_workflow) { 'legacy_workflow' }
   let(:alternate_workflow) { 'equitable_workflow' }
   let(:ab_testing_enabled) { false }
 
-  subject { Idv::LexisnexisInstantVerify.new(session_uuid) }
+  subject { Idv::LexisNexisInstantVerify.new(session_uuid) }
 
   before do
     allow(IdentityConfig.store).

--- a/spec/services/proofing/resolution/progressive_proofer_spec.rb
+++ b/spec/services/proofing/resolution/progressive_proofer_spec.rb
@@ -139,10 +139,10 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
       end
 
       it 'uses the selected workflow' do
-        lniv = Idv::LexisnexisInstantVerify.new(dcs_uuid)
+        lniv = Idv::LexisNexisInstantVerify.new(dcs_uuid)
         expect(lniv).to receive(:workflow_ab_testing_variables).
           and_return(ab_test_variables)
-        expect(Idv::LexisnexisInstantVerify).to receive(:new).
+        expect(Idv::LexisNexisInstantVerify).to receive(:new).
           and_return(lniv)
         expect(Proofing::LexisNexis::InstantVerify::Proofer).to receive(:new).
           with(hash_including(instant_verify_workflow: instant_verify_workflow)).


### PR DESCRIPTION
Capitalization: Rename LexisnexisInstantVerify to LexisNexisInstantVerify

Followup to [comment](https://github.com/18F/identity-idp/pull/9761#discussion_r1427124472) on service name spelling in #9743 