### PR TITLE
Fix headless mode used by Selenium locally 

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,7 +7,7 @@ require 'selenium/webdriver'
 
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument('--headless') if !ENV['SHOW_BROWSER']
+  options.add_argument("--headless#{ENV['CI'] ? '' : '=new'}") if !ENV['SHOW_BROWSER']
   options.add_argument('--disable-gpu') if !ENV['SHOW_BROWSER']
   options.add_argument('--window-size=1200x700')
   options.add_argument('--no-sandbox')
@@ -26,7 +26,7 @@ Capybara.register_driver(:headless_chrome_mobile) do |app|
                       'HeadlessChrome/88.0.4324.150 Safari/602.1'
 
   options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument('--headless') if !ENV['SHOW_BROWSER']
+  options.add_argument("--headless#{ENV['CI'] ? '' : '=new'}") if !ENV['SHOW_BROWSER']
   options.add_argument('--disable-gpu') if !ENV['SHOW_BROWSER']
   options.add_argument('--no-sandbox')
   options.add_argument('--disable-dev-shm-usage')


### PR DESCRIPTION
## 🛠 Summary of changes

This fixes local dev for Chromedriver v120. We found that upgrading Chromedriver to v120 in Docker for CI caused all sorts of issues, so for the time being we are not upgrading CI.

This is a workaround from the failures in https://github.com/18F/identity-idp/pull/9734.

[See this documentation for details on the change](https://www.selenium.dev/blog/2023/headless-is-going-away/), [this conversation in Slack for discussion](https://gsa-tts.slack.com/archives/C0NGESUN5/p1702068737905679), and [this issue on Chromedriver](https://bugs.chromium.org/p/chromedriver/issues/detail?id=4440).