### PR TITLE
LG-11782: Remove create new account from password reset process

### DIFF
--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -23,12 +23,5 @@
   <%= f.input :resend, as: :hidden %>
   <p><%= t('notices.forgot_password.no_email_sent_explanation_start') %>
   <%= f.button :button, t('links.resend'), class: 'usa-button--unstyled margin-left-05' %></p>
-
-  <p>
-    <%= t(
-          'notices.forgot_password.use_diff_email.text_html',
-          link_html: link_to(t('notices.forgot_password.use_diff_email.link'), sign_up_email_path),
-        ) %>
-  </p>
   <p><%= t('instructions.forgot_password.close_window') %></p>
 <% end %>

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -13,9 +13,6 @@ en:
       first_paragraph_start: We sent an email to
       no_email_sent_explanation_start: Didn’t receive an email?
       resend_email_success: We sent another password reset email.
-      use_diff_email:
-        link: create a new account
-        text_html: Or, %{link_html} using a different email address.
     password_changed: You changed your password.
     phone_confirmed: A phone was added to your account.
     piv_cac_configured: A PIV/CAC card was added to your account.

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -13,9 +13,6 @@ es:
       first_paragraph_start: Enviamos un email a
       no_email_sent_explanation_start: '¿No recibió un email?'
       resend_email_success: Enviamos otro email para restablecer la contraseña.
-      use_diff_email:
-        link: crear una cuenta nueva
-        text_html: O, %{link_html} utilizando un email diferente.
     password_changed: Ha cambiado su contraseña.
     phone_confirmed: Un teléfono fue agregado a tu cuenta.
     piv_cac_configured: Una tarjeta PIV/CAC fue agregada a tu cuenta.

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -13,9 +13,6 @@ fr:
       first_paragraph_start: Nous avons envoyé un courriel à
       no_email_sent_explanation_start: Vous n’avez pas reçu de courriel?
       resend_email_success: Nous avons envoyé un autre courriel de réinitialisation de mot de passe.
-      use_diff_email:
-        link: Créer un nouveau compte
-        text_html: Ou, %{link_html} en utilisant une adresse courriel différente.
     password_changed: Vous avez changé votre mot de passe.
     phone_confirmed: Un téléphone a été ajouté à votre compte.
     piv_cac_configured: Une carte PIV / CAC a été ajoutée à votre compte.

--- a/spec/views/forgot_password/show.html.erb_spec.rb
+++ b/spec/views/forgot_password/show.html.erb_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe 'forgot_password/show.html.erb' do
     expect(rendered).to_not have_content t('notices.forgot_password.resend_email_success')
   end
 
-  it 'contains a link to create a new account' do
-    render
-
-    expect(rendered).
-      to have_link(t('notices.forgot_password.use_diff_email.link'), href: sign_up_email_path)
-  end
-
   it 'displays a notice if resend_confirmation is present' do
     @resend = true
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11782](https://cm-jira.usa.gov/browse/LG-11782)


## 🛠 Summary of changes

Removes text from the page `/forgot_password` found during the reset password process.


## 📜 Testing Plan

- Go through the "Forgot your password?" process to reset an account password. Notice the removal of text at the URL `/forgot_password`.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
