### PR TITLE
Sync default reauthn_window with production value

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -254,7 +254,7 @@ rack_mini_profiler: false
 rack_timeout_service_timeout_seconds: 15
 rails_mailer_previews_enabled: false
 raise_on_missing_title: false
-reauthn_window: 120
+reauthn_window: 1200
 recaptcha_enterprise_api_key: ''
 recaptcha_enterprise_project_id: ''
 recaptcha_site_key_v2: ''

--- a/spec/features/openid_connect/phishing_resistant_required_spec.rb
+++ b/spec/features/openid_connect/phishing_resistant_required_spec.rb
@@ -19,32 +19,31 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
 
       # Regression (LG-11110): Ensure the user can reauthenticate with any existing configuration,
       # not limited based on phishing-resistant requirement.
-      travel (IdentityConfig.store.reauthn_window + 1).seconds do
-        check t('two_factor_authentication.two_factor_choice_options.webauthn')
-        click_continue
+      expire_reauthn_window
+      check t('two_factor_authentication.two_factor_choice_options.webauthn')
+      click_continue
 
-        expect(page).to have_content(t('two_factor_authentication.login_options.sms'))
-        expect(page).to have_content(t('two_factor_authentication.login_options.voice'))
+      expect(page).to have_content(t('two_factor_authentication.login_options.sms'))
+      expect(page).to have_content(t('two_factor_authentication.login_options.voice'))
 
-        choose t('two_factor_authentication.login_options.sms')
-        click_continue
+      choose t('two_factor_authentication.login_options.sms')
+      click_continue
 
-        fill_in_code_with_last_phone_otp
-        click_submit_default
+      fill_in_code_with_last_phone_otp
+      click_submit_default
 
-        # LG-11193: Currently the user is redirected back to the MFA setup selection after
-        # reauthenticating. This should be improved to remember their original selection.
-        expect(page).to have_current_path(authentication_methods_setup_path)
-        expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
-        mock_webauthn_setup_challenge
-        check t('two_factor_authentication.two_factor_choice_options.webauthn')
-        click_continue
+      # LG-11193: Currently the user is redirected back to the MFA setup selection after
+      # reauthenticating. This should be improved to remember their original selection.
+      expect(page).to have_current_path(authentication_methods_setup_path)
+      expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
+      mock_webauthn_setup_challenge
+      check t('two_factor_authentication.two_factor_choice_options.webauthn')
+      click_continue
 
-        fill_in_nickname_and_click_continue
-        mock_press_button_on_hardware_key_on_setup
+      fill_in_nickname_and_click_continue
+      mock_press_button_on_hardware_key_on_setup
 
-        expect(page).to have_current_path(sign_up_completed_path)
-      end
+      expect(page).to have_current_path(sign_up_completed_path)
     end
   end
 

--- a/spec/features/saml/phishing_resistant_required_spec.rb
+++ b/spec/features/saml/phishing_resistant_required_spec.rb
@@ -17,32 +17,31 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
 
       # Regression (LG-11110): Ensure the user can reauthenticate with any existing configuration,
       # not limited based on phishing-resistant requirement.
-      travel (IdentityConfig.store.reauthn_window + 1).seconds do
-        check t('two_factor_authentication.two_factor_choice_options.webauthn')
-        click_continue
+      expire_reauthn_window
+      check t('two_factor_authentication.two_factor_choice_options.webauthn')
+      click_continue
 
-        expect(page).to have_content(t('two_factor_authentication.login_options.sms'))
-        expect(page).to have_content(t('two_factor_authentication.login_options.voice'))
+      expect(page).to have_content(t('two_factor_authentication.login_options.sms'))
+      expect(page).to have_content(t('two_factor_authentication.login_options.voice'))
 
-        choose t('two_factor_authentication.login_options.sms')
-        click_continue
+      choose t('two_factor_authentication.login_options.sms')
+      click_continue
 
-        fill_in_code_with_last_phone_otp
-        click_submit_default
+      fill_in_code_with_last_phone_otp
+      click_submit_default
 
-        # LG-11193: Currently the user is redirected back to the MFA setup selection after
-        # reauthenticating. This should be improved to remember their original selection.
-        expect(page).to have_current_path(authentication_methods_setup_path)
-        expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
-        mock_webauthn_setup_challenge
-        check t('two_factor_authentication.two_factor_choice_options.webauthn')
-        click_continue
+      # LG-11193: Currently the user is redirected back to the MFA setup selection after
+      # reauthenticating. This should be improved to remember their original selection.
+      expect(page).to have_current_path(authentication_methods_setup_path)
+      expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
+      mock_webauthn_setup_challenge
+      check t('two_factor_authentication.two_factor_choice_options.webauthn')
+      click_continue
 
-        fill_in_nickname_and_click_continue
-        mock_press_button_on_hardware_key_on_setup
+      fill_in_nickname_and_click_continue
+      mock_press_button_on_hardware_key_on_setup
 
-        expect(page).to have_current_path(sign_up_completed_path)
-      end
+      expect(page).to have_current_path(sign_up_completed_path)
     end
   end
 

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -6,8 +6,7 @@ RSpec.feature 'Changing authentication factor' do
 
     before do
       user # Sign up the user
-      reauthn_date = (IdentityConfig.store.reauthn_window + 1).seconds.from_now
-      travel_to(reauthn_date)
+      expire_reauthn_window
     end
 
     scenario 'editing password' do
@@ -29,7 +28,7 @@ RSpec.feature 'Changing authentication factor' do
         old_phone = phone_configuration.phone
         parsed_phone = Phonelib.parse(old_phone)
 
-        travel(IdentityConfig.store.reauthn_window + 1)
+        expire_reauthn_window
         visit manage_phone_path(id: phone_configuration)
         complete_2fa_confirmation_without_entering_otp
         click_link t('links.two_factor_authentication.send_another_code')
@@ -57,7 +56,7 @@ RSpec.feature 'Changing authentication factor' do
     context 'changing authentication methods' do
       it 'returns user to account page if they choose to cancel' do
         sign_in_and_2fa_user
-        travel(IdentityConfig.store.reauthn_window + 1)
+        expire_reauthn_window
         visit manage_password_path
         complete_2fa_confirmation_without_entering_otp
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'View personal key' do
         first(:link, t('forms.buttons.edit')).click
         click_on(t('links.cancel'))
 
-        travel(IdentityConfig.store.reauthn_window + 1)
+        expire_reauthn_window
 
         visit account_two_factor_authentication_path
         click_on(t('account.links.regenerate_personal_key'), match: :prefer_exact)

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe 'webauthn management' do
       expect(page).to have_current_path webauthn_setup_path(platform: true)
 
       # Regression: LG-9860: Ensure that the platform URL parameter is maintained through reauthn
-      travel_to (IdentityConfig.store.reauthn_window + 1).seconds.from_now
+      expire_reauthn_window
       mock_press_button_on_hardware_key_on_setup
 
       expect(page).to have_current_path login_two_factor_options_path

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -220,6 +220,13 @@ module Features
       user
     end
 
+    def expire_reauthn_window
+      Warden.on_next_request do |proxy|
+        proxy.env['rack.session']['warden.user.user.session']['auth_events'].last[:at] =
+          IdentityConfig.store.reauthn_window.seconds.ago
+      end
+    end
+
     def user_with_2fa
       create(:user, :fully_registered, with: { phone: IAL1_USER_PHONE }, password: VALID_PASSWORD)
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the default configuration for `reauthn_window` to match production.

In testing in review apps and sandbox environments, we'll frequently encounter 2 minute reauthentications, which are overly aggressive and I'll have to explain behaves differently in production ([example 1 from 2 days ago](https://docs.google.com/document/d/1yvxk6ncQ451plF-kMWjMM9n8db7QHLAIhdwi9r37qB8/edit#bookmark=id.hbsyre5jb07e), [example 2 from yesterday](https://gsa-tts.slack.com/archives/C0595QABDS7/p1702580379988289?thread_ts=1702575969.564879&cid=C0595QABDS7)).

## 📜 Testing Plan

Test that this changes reauthentication timeout in default environments:

1. Ensure that you're not overriding `reauthn_window` in your local `config/application.yml`
2. Go to http://localhost:3000
3. Sign in
4. On account dashboard, wait 3 minutes
5. Click to add, edit, or delete an MFA method
6. Observe that you are not prompted to reauthenticate

Test that this matches the production value:

1. Refer to ["Secrets and Configuration" handbook article](https://handbook.login.gov/articles/appdev-secrets-configuration.html) for retrieving value for `reauthn_window`
2. Confirm that the value matches the proposed revision