### PR TITLE
Remove the passive encryption of encrypted PII in the session

### DIFF
--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -64,7 +64,6 @@ class OutOfBandSessionAccessor
   # @param [#to_s] profile_id
   def put_pii(profile_id:, pii:, expiration: 5.minutes)
     data = {
-      decrypted_pii: pii.to_h.to_json,
       encrypted_profiles: { profile_id.to_s => SessionEncryptor.new.kms_encrypt(pii.to_h.to_json) },
     }
 

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -36,8 +36,6 @@ module Pii
     end
 
     def delete
-      user_session.delete(:decrypted_pii)
-      user_session.delete(:encrypted_pii)
       user_session.delete(:encrypted_profiles)
     end
 

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Idv::SessionsController do
         expect(controller.user_session['idv/in_person']).to be_blank
       end
 
-      it 'clears the decrypted_pii session' do
+      it 'clears the encrypted_profiles session' do
         expect(controller.user_session[:encrypted_profiles]).to be_blank
       end
     end

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -34,19 +34,6 @@ RSpec.describe SessionEncryptor do
       )
     end
 
-    it 'encrypts decrypted_pii bundle without automatically decrypting' do
-      session = { 'warden.user.user.session' => {
-        'decrypted_pii' => { 'ssn' => '666-66-6666' }.to_json,
-      } }
-
-      ciphertext = subject.dump(session)
-
-      result = subject.load(ciphertext)
-
-      expect(result.fetch('warden.user.user.session')['decrypted_pii']).to eq nil
-      expect(result.fetch('warden.user.user.session')['encrypted_pii']).to_not eq nil
-    end
-
     it 'KMS encrypts/decrypts doc auth elements of the session' do
       session = { 'warden.user.user.session' => {
         'idv' => { 'ssn' => '666-66-6666' },


### PR DESCRIPTION
In #9754 the code that depended on the passive encryption of `decrypted_pii` in the session was removed. Some of the code removed here was left behind to ensure that PII remained encrypted.

Once the code in #9754 is deployed to production this should be safe to merge.
