### PR TITLE
Rescue errors in Agencies and SPs report

### DIFF
--- a/app/services/reporting/agency_and_sp_report.rb
+++ b/app/services/reporting/agency_and_sp_report.rb
@@ -19,6 +19,11 @@ module Reporting
         ['IDV', idv_sps.count, idv_agencies.count],
         ['Total', auth_sps.count + idv_sps.count, auth_agencies.count + idv_agencies.count],
       ]
+    rescue ActiveRecord::QueryCanceled => err
+      [
+        ['Error', 'Message'],
+        [err.class.name, err.message],
+      ]
     end
 
     def agency_and_sp_emailable_report

--- a/app/services/reporting/agency_and_sp_report.rb
+++ b/app/services/reporting/agency_and_sp_report.rb
@@ -35,14 +35,12 @@ module Reporting
     end
 
     def active_agencies
-      @active_agencies ||= begin
-        Agreements::PartnerAccountStatus.find_by(name: 'active').
-          partner_accounts.
-          includes(:agency).
-          where('became_partner <= ?', report_date).
-          map(&:agency).
-          uniq
-      end
+      @active_agencies ||= Agreements::PartnerAccountStatus.find_by(name: 'active').
+        partner_accounts.
+        includes(:agency).
+        where('became_partner <= ?', report_date).
+        map(&:agency).
+        uniq
     end
 
     def service_providers

--- a/spec/services/reporting/agency_and_sp_report_spec.rb
+++ b/spec/services/reporting/agency_and_sp_report_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Reporting::AgencyAndSpReport do
   end
 
   describe '#agency_and_sp_report' do
-    subject { report.agency_and_sp_report }
+    subject(:agency_and_sp_report) { report.agency_and_sp_report }
 
     context 'when adding a non-IDV SP' do
       let!(:auth_sp) do
@@ -149,6 +149,22 @@ RSpec.describe Reporting::AgencyAndSpReport do
 
       it 'counts the SP and its Agency as IDV' do
         expect(subject).to match_array(expected_report)
+      end
+    end
+
+    context 'when a query times out' do
+      before do
+        expect(ServiceProvider).to receive(:where).
+          and_raise(ActiveRecord::QueryCanceled, 'query took too long')
+      end
+
+      it 'rescues the error and shows a warning' do
+        expect(agency_and_sp_report).to eq(
+          [
+            ['Error', 'Message'],
+            ['ActiveRecord::QueryCanceled', 'query took too long'],
+          ],
+        )
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Handle query timeouts in Agencies and SPs report
    
- In #9744, we added more correct queries that took much longer. Even though we added the correct `transaction_with_timeout` wrapper, and even though the queries can succeed, the report still failed in prod. [error link](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?duration=86400000&state=d3e9c328-f096-a4f1-58c2-184bb0785564)

- Adding this rescue allows the report to complete and send partial results still



<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
