### PR TITLE
LG-11454: Restore successful WebAuthn delete handling user events

### DIFF
--- a/app/controllers/api/internal/two_factor_authentication/webauthn_controller.rb
+++ b/app/controllers/api/internal/two_factor_authentication/webauthn_controller.rb
@@ -35,6 +35,10 @@ module Api
           analytics.webauthn_delete_submitted(**result.to_h)
 
           if result.success?
+            create_user_event(:webauthn_key_removed)
+            revoke_remember_device(current_user)
+            event = PushNotification::RecoveryInformationChangedEvent.new(user: current_user)
+            PushNotification::HttpPush.deliver(event)
             render json: { success: true }
           else
             render json: { success: false, error: result.first_error_message }, status: :bad_request

--- a/app/controllers/users/webauthn_controller.rb
+++ b/app/controllers/users/webauthn_controller.rb
@@ -30,6 +30,10 @@ module Users
 
       if result.success?
         flash[:success] = t('two_factor_authentication.webauthn_platform.deleted')
+        create_user_event(:webauthn_key_removed)
+        revoke_remember_device(current_user)
+        event = PushNotification::RecoveryInformationChangedEvent.new(user: current_user)
+        PushNotification::HttpPush.deliver(event)
         redirect_to account_path
       else
         flash[:error] = result.first_error_message

--- a/spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb
+++ b/spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb
@@ -102,6 +102,26 @@ RSpec.describe Api::Internal::TwoFactorAuthentication::WebauthnController do
       expect(response.headers['X-CSRF-Token']).to be_kind_of(String)
     end
 
+    it 'sends a recovery information changed event' do
+      expect(PushNotification::HttpPush).to receive(:deliver).
+        with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
+
+      response
+    end
+
+    it 'revokes remembered device' do
+      expect(user.remember_device_revoked_at).to eq nil
+
+      freeze_time do
+        response
+        expect(user.reload.remember_device_revoked_at).to eq Time.zone.now
+      end
+    end
+
+    it 'logs a user event for the removed credential' do
+      expect { response }.to change { user.events.webauthn_key_removed.size }.by 1
+    end
+
     context 'signed out' do
       let(:user) { nil }
       let(:configuration) { create(:webauthn_configuration) }


### PR DESCRIPTION
## 🎫 Ticket

Relates to [LG-11454](https://cm-jira.usa.gov/browse/LG-11454) (originally #9674)

## 🛠 Summary of changes

Restores additional behaviors expected to occur after the successful deletion of a WebAuthn credential.

I noticed these after starting to put together the clean-up pull request to remove the old deletion routes, which implement these behaviors:

https://github.com/18F/identity-idp/blob/8558b0bf244082f39f2c1f6bb282973bce1b48ca/app/controllers/users/webauthn_setup_controller.rb#L148-L152

## 📜 Testing Plan

Verify specs pass:

1. `rspec spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb spec/controllers/users/webauthn_controller_spec.rb`

You can also verify that behaviors actually happen when deleting Face or Touch Unlock:

1. (Prerequisite) Have an account with Face or Touch Unlock configured
2. Go to http://localhost:3000
3. Sign in
4. From account dashboard, click "Manage" for your Face or Touch Unlock
5. Click "Delete"
6. Confirm prompt
7. In Rails console, verify user event: `User.find_with_email('email@example.com').events.webauthn_key_removed`
8. TBD how to verify RISC event ([see Slack thread](https://gsa-tts.slack.com/archives/C0NGESUN5/p1702907459403909))
9. Sign out
10. Sign in
11. Observe that you're prompted to MFA