### PR TITLE
Add missing spec assertion for password change user event

### DIFF
--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -69,10 +69,16 @@ RSpec.describe Users::PasswordsController do
       end
 
       it 'creates a user Event for the password change' do
-        stub_sign_in(create(:user))
+        user = stub_sign_in
 
-        params = { password: 'salty new password' }
-        patch :update, params: { update_user_password_form: params }
+        params = {
+          password: 'salty new password',
+          password_confirmation: 'salty new password',
+        }
+
+        expect do
+          patch :update, params: { update_user_password_form: params }
+        end.to change { user.events.password_changed.size }.by 1
       end
 
       it 'sends a security event' do


### PR DESCRIPTION
## 🛠 Summary of changes

Adds an assertion to a test case intended to verify that a user event is created upon successful password change.

Previously, this spec would only do the set up to invoke the password change, but didn't include any assertions.

This was noticed in putting together #9780 and looking for examples of other user event spec verifications.

## 📜 Testing Plan

```
rspec spec/controllers/users/passwords_controller_spec.rb
```