### PR TITLE
Rename `doc_auth_selfie_capture` config to `doc_auth_selfie_capture_enabled`

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -34,7 +34,7 @@ module Idv
     end
 
     def liveness_checking_enabled?
-      IdentityConfig.store.doc_auth_selfie_capture[:enabled]
+      IdentityConfig.store.doc_auth_selfie_capture_enabled
     end
 
     def ial_context

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -215,7 +215,7 @@ module DocAuthRouter
     end
 
     # if vendor is not set to mock and selfie enabled use lexisnexis
-    if IdentityConfig.store.doc_auth_selfie_capture[:enabled] &&
+    if IdentityConfig.store.doc_auth_selfie_capture_enabled &&
        vendor != Idp::Constants::Vendors::MOCK
       vendor = Idp::Constants::Vendors::LEXIS_NEXIS
     end

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,9 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: IdentityConfig.store.doc_auth_selfie_capture,
+      doc_auth_selfie_capture: {
+        enabled: IdentityConfig.store.doc_auth_selfie_capture_enabled,
+      },
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -87,7 +87,7 @@ doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_not_ready_section_enabled: false
-doc_auth_selfie_capture: '{"enabled":false}'
+doc_auth_selfie_capture_enabled: false
 doc_auth_sdk_capture_orientation: '{"horizontal": 100, "vertical": 0}'
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
 doc_capture_request_valid_for_minutes: 15
@@ -382,7 +382,7 @@ development:
   database_worker_jobs_password: ''
   doc_auth_exit_question_section_enabled: true
   doc_auth_not_ready_section_enabled: true
-  doc_auth_selfie_capture: '{"enabled": false}'
+  doc_auth_selfie_capture_enabled: false
   doc_auth_vendor: 'mock'
   doc_auth_vendor_randomize: false
   doc_auth_vendor_randomize_percent: 0
@@ -521,7 +521,7 @@ test:
   database_worker_jobs_host: ''
   database_worker_jobs_password: ''
   doc_auth_max_attempts: 4
-  doc_auth_selfie_capture: '{"enabled":false}'
+  doc_auth_selfie_capture_enabled: false
   doc_auth_vendor: 'mock'
   doc_auth_vendor_randomize: false
   doc_auth_vendor_randomize_percent: 0

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -186,7 +186,7 @@ class IdentityConfig
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_s3_request_timeout, type: :integer)
-    config.add(:doc_auth_selfie_capture, type: :json, options: { symbolize_names: true })
+    config.add(:doc_auth_selfie_capture_enabled, type: :boolean)
     config.add(:doc_auth_sdk_capture_orientation, type: :json, options: { symbolize_names: true })
     config.add(:doc_auth_supported_country_codes, type: :json)
     config.add(:doc_auth_vendor, type: :string)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -955,8 +955,7 @@ RSpec.describe Idv::ImageUploadsController do
 
     context 'when liveness checking enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).
-          and_return({ enabled: true })
+        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
       end
       let(:selfie_img) { DocAuthImageFixtures.selfie_image_multipart }
       it 'returns a successful response' do

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -192,9 +192,9 @@ RSpec.feature 'document capture step', :js do
     end
   end
 
-  context 'with doc_auth_selfie_capture set to true' do
+  context 'with doc_auth_selfie_capture_enabled set to true' do
     before do
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).and_return({ enabled: true })
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
     end
 
     it 'proceeds to the next page with valid info, including a selfie image' do

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -243,8 +243,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
   context 'when selfie is enabled' do
     context 'error due to data issue with 2xx status code', allow_browser_log: true do
       before do
-        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).
-          and_return({ enabled: true })
+        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_acuant_error_unknown

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -84,8 +84,7 @@ RSpec.describe DocAuthRouter do
 
       context 'when selfie is enabled' do
         before do
-          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).
-            and_return({ enabled: true })
+          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
         end
         context 'when vendor is not set to mock' do
           it 'chose lexisnexis' do
@@ -123,8 +122,7 @@ RSpec.describe DocAuthRouter do
 
       context 'with selfie enabled' do
         before do
-          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture).
-            and_return({ enabled: true })
+          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
         end
         it 'is the lexisnexis vendor' do
           expect(DocAuthRouter.doc_auth_vendor(discriminator: discriminator)).

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
   let(:in_person_proofing_enabled_issuer) { nil }
   let(:acuant_sdk_upgrade_a_b_testing_enabled) { false }
   let(:use_alternate_sdk) { false }
-  let(:doc_auth_selfie_capture) { { enabled: false } }
+  let(:doc_auth_selfie_capture_enabled) { false }
   let(:acuant_version) { '1.3.3.7' }
   let(:skip_doc_auth) { false }
   let(:opted_in_to_in_person_proofing) { false }
@@ -44,7 +44,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
-      doc_auth_selfie_capture: doc_auth_selfie_capture,
+      doc_auth_selfie_capture: { enabled: doc_auth_selfie_capture_enabled },
       skip_doc_auth: skip_doc_auth,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
     }
@@ -97,7 +97,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
     end
   end
   describe 'view variables sent correctly' do
-    it 'sends doc_auth_selfie_capture to the FE' do
+    it 'sends doc_auth_selfie_capture_enabled to the FE' do
       render_partial
       expect(rendered).to have_css(
         "#document-capture-form[data-doc-auth-selfie-capture='{\"enabled\":false}']",


### PR DESCRIPTION
The `doc_auth_selfie_capture` is a JSON hash that was intended to manage multiple configs for document selfie capture. Prior to this commit it contains a single value: `enabled`.

Using an unstructured hash this way means we do not get many of the benefits of using IdentityConfig e.g. type validation for configs and warnings/errors when configs are missing.

This commit moves the enabled config from `doc_auth_selfie_capture` to `doc_auth_selfie_capture_enabled` and deletes the `doc_auth_selfie_capture` config. Future configs for selfie capture can use the `doc_auth_selfie_capture` prefix.
