### PR TITLE
LG-11454: Improve robustness of WebAuthn controller specs

### DIFF
--- a/spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb
+++ b/spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb
@@ -75,6 +75,30 @@ RSpec.describe Api::Internal::TwoFactorAuthentication::WebauthnController do
         expect(response.status).to eq(401)
       end
     end
+
+    context 'with a configuration that does not exist' do
+      let(:params) { { id: 0 } }
+
+      it 'responds with unsuccessful result' do
+        expect(response_body).to eq(
+          success: false,
+          error: t('errors.manage_authenticator.internal_error'),
+        )
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context 'with a configuration that does not belong to the user' do
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'responds with unsuccessful result' do
+        expect(response_body).to eq(
+          success: false,
+          error: t('errors.manage_authenticator.internal_error'),
+        )
+        expect(response.status).to eq(400)
+      end
+    end
   end
 
   describe '#destroy' do
@@ -143,6 +167,30 @@ RSpec.describe Api::Internal::TwoFactorAuthentication::WebauthnController do
       it 'responds with unauthorized response' do
         expect(response_body).to eq(error: 'Unauthorized')
         expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with a configuration that does not exist' do
+      let(:params) { { id: 0 } }
+
+      it 'responds with unsuccessful result' do
+        expect(response_body).to eq(
+          success: false,
+          error: t('errors.manage_authenticator.internal_error'),
+        )
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context 'with a configuration that does not belong to the user' do
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'responds with unsuccessful result' do
+        expect(response_body).to eq(
+          success: false,
+          error: t('errors.manage_authenticator.internal_error'),
+        )
+        expect(response.status).to eq(400)
       end
     end
   end

--- a/spec/controllers/users/webauthn_controller_spec.rb
+++ b/spec/controllers/users/webauthn_controller_spec.rb
@@ -19,6 +19,41 @@ RSpec.describe Users::WebauthnController do
       expect(assigns(:form)).to be_kind_of(TwoFactorAuthentication::WebauthnUpdateForm)
       expect(assigns(:form).configuration).to eq(configuration)
     end
+
+    context 'signed out' do
+      let(:user) { nil }
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'redirects to sign-in page' do
+        expect(response).to redirect_to(new_user_session_url)
+      end
+    end
+
+    context 'not recently authenticated' do
+      before do
+        allow(controller).to receive(:recently_authenticated_2fa?).and_return(false)
+      end
+
+      it 'redirects to reauthenticate' do
+        expect(response).to redirect_to(login_two_factor_options_path)
+      end
+    end
+
+    context 'editing a configuration that does not exist' do
+      let(:params) { { id: 0 } }
+
+      it 'renders not found' do
+        expect(response).to be_not_found
+      end
+    end
+
+    context 'editing a configuration that does not belong to the user' do
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'renders not found' do
+        expect(response).to be_not_found
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/controllers/users/webauthn_controller_spec.rb
+++ b/spec/controllers/users/webauthn_controller_spec.rb
@@ -122,6 +122,22 @@ RSpec.describe Users::WebauthnController do
         expect(response).to redirect_to(login_two_factor_options_path)
       end
     end
+
+    context 'with a configuration that does not exist' do
+      let(:params) { { id: 0 } }
+
+      it 'renders not found' do
+        expect(response).to be_not_found
+      end
+    end
+
+    context 'with a configuration that does not belong to the user' do
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'renders not found' do
+        expect(response).to be_not_found
+      end
+    end
   end
 
   describe '#destroy' do
@@ -187,6 +203,22 @@ RSpec.describe Users::WebauthnController do
 
       it 'redirects to reauthenticate' do
         expect(response).to redirect_to(login_two_factor_options_path)
+      end
+    end
+
+    context 'with a configuration that does not exist' do
+      let(:params) { { id: 0 } }
+
+      it 'renders not found' do
+        expect(response).to be_not_found
+      end
+    end
+
+    context 'with a configuration that does not belong to the user' do
+      let(:configuration) { create(:webauthn_configuration) }
+
+      it 'renders not found' do
+        expect(response).to be_not_found
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Relates to [LG-11454](https://cm-jira.usa.gov/browse/LG-11454) (originally https://github.com/18F/identity-idp/pull/9674, #9742)

## 🛠 Summary of changes

Adds additional test cases for the WebAuthn controllers implemented in #9742 to verify expected behaviors around checking ownership of the configuration.

Some of this was originally intended to be covered by the associated form's specs, with existing coverage for an "invalid" submission scenario being sufficient coverage for the controller's behaviors. However, there are additional controller-specific behaviors not previously covered (e.g. `WebauthnController#validate_configuration_exists`).

These behaviors worked as intended, but additional test cases could help prevent future regressions.

## 📜 Testing Plan

Verify tests pass:

1. `rspec spec/controllers/users/webauthn_controller_spec.rb spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb`