### PR TITLE
LG-11743 - Ensure personal key works for GPO users

### DIFF
--- a/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
+++ b/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Password recovery via personal key for a GPO-verified user' do
   include IdvStepHelper
 
-  let(:email) { 'cool_beagle@test.org' }
+  let(:email) { 'cool_beagle@example.org' }
   let(:password) { '!1a Z@6s' * 16 } # default password from user factory
   let(:new_password) { 'some really awesome new password' }
 

--- a/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
+++ b/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Password recovery via personal key for a GPO-verified user' do
+  include IdvStepHelper
+
+  let(:user) { create(:user, :fully_registered) }
+  let(:new_password) { 'some really awesome new password' }
+
+  before do
+    allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
+  end
+
+  scenario 'lets them reactivate their profile with their personal key', email: true, js: true do
+    complete_idv_steps_with_gpo_before_confirmation_step(user)
+    click_on 'Continue'
+
+    click_on t('account.index.verification.reactivate_button')
+    click_on t('idv.gpo.form.submit')
+
+    personal_key = scrape_personal_key
+    check t('forms.personal_key.required_checkbox')
+    click_continue
+
+    click_on 'Sign out'
+
+    trigger_reset_password_and_click_email_link(user.email)
+    reset_password_and_sign_back_in(user, new_password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+
+    click_on t('links.account.reactivate.with_key')
+
+    expect(current_path).to eq verify_personal_key_path
+    fill_in 'personal_key', with: personal_key
+    click_continue
+
+    expect(current_path).to eq verify_password_path
+    fill_in 'Password', with: new_password
+    click_continue
+
+    expect(page).to have_content t('idv.messages.personal_key')
+    expect(page).to have_content t('headings.account.verified_account')
+  end
+end

--- a/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
+++ b/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Password recovery via personal key for a GPO-verified user' do
 
   scenario 'lets them reactivate their profile with their personal key', email: true, js: true do
     complete_idv_steps_with_gpo_before_confirmation_step(user)
-    click_on 'Continue'
+    click_on t('doc_auth.buttons.continue')
 
     click_on t('account.index.verification.reactivate_button')
     click_on t('idv.gpo.form.submit')
@@ -21,7 +21,7 @@ RSpec.feature 'Password recovery via personal key for a GPO-verified user' do
     check t('forms.personal_key.required_checkbox')
     click_continue
 
-    click_on 'Sign out'
+    click_on t('links.sign_out')
 
     trigger_reset_password_and_click_email_link(user.email)
     reset_password_and_sign_back_in(user, new_password)


### PR DESCRIPTION
## 🎫 Ticket

[LG-11743](https://cm-jira.usa.gov/browse/LG-11743)

## 🛠 Summary of changes

Added a spec to check profile reactivation for GPO-verified users.

This is a bug reported by and believed fixed by Matt Hinz (see LG-11549), but we wanted a feature spec to test this exact scenario.

Co-authored by: Matt Hinz <matt.hinz@gsa.gov>

## 📜 Testing Plan

[ ] Run the new feature spec using the command below
[ ] Verify that the system walks through creating a GPO-verified user, resetting their password, and then re-activating their profile with the personal key generated during GPO verification.

`SHOW_BROWSER=true bundle exec rspec spec/features/users/profile_recovery_for_gpo_verified_spec.rb`