### PR TITLE
LG-11655: Added the ability to email IdV reports

### DIFF
--- a/app/jobs/reports/identity_verification_report.rb
+++ b/app/jobs/reports/identity_verification_report.rb
@@ -10,10 +10,11 @@ module Reports
       return unless IdentityConfig.store.s3_reports_enabled
       self.report_date = report_date
 
-      emails = IdentityConfig.store.team_ada_email
       csv = report_maker.to_csv
 
       save_report(REPORT_NAME, csv, extension: 'csv')
+
+      emails = IdentityConfig.store.team_ada_emails
 
       emails.each do |email|
         ReportMailer.tables_report(

--- a/app/jobs/reports/identity_verification_report.rb
+++ b/app/jobs/reports/identity_verification_report.rb
@@ -2,7 +2,7 @@ require 'reporting/identity_verification_report'
 
 module Reports
   class IdentityVerificationReport < BaseReport
-    REPORT_NAME = 'identity-verification-report'
+    REPORT_NAME = 'identity-verification-report'.freeze
 
     attr_accessor :report_date
 
@@ -10,9 +10,35 @@ module Reports
       return unless IdentityConfig.store.s3_reports_enabled
       self.report_date = report_date
 
+      emails = IdentityConfig.store.team_ada_email
       csv = report_maker.to_csv
 
       save_report(REPORT_NAME, csv, extension: 'csv')
+
+      emails.each do |email|
+        ReportMailer.tables_report(
+          email: email,
+          subject: "Daily Identity Verification Report - #{report_date.to_date}",
+          reports: reports,
+          message: preamble,
+          attachment_format: :csv,
+        ).deliver_now
+      end
+    end
+
+    def preamble
+      ERB.new(<<~ERB).result(binding).html_safe # rubocop:disable Rails/OutputSafety
+        <h2>
+          Identity Verification Report
+        </h2>
+        <p>
+          Disclaimer: This Report is In Progress: Not Production Ready
+        </p>
+      ERB
+    end
+
+    def reports
+      [report_maker.identity_verification_emailable_report]
     end
 
     def report_maker

--- a/app/jobs/reports/identity_verification_report.rb
+++ b/app/jobs/reports/identity_verification_report.rb
@@ -27,14 +27,14 @@ module Reports
     end
 
     def preamble
-      ERB.new(<<~ERB).result(binding).html_safe # rubocop:disable Rails/OutputSafety
+      <<~HTML.html_safe # rubocop:disable Rails/OutputSafety
         <h2>
           Identity Verification Report
         </h2>
         <p>
           Disclaimer: This Report is In Progress: Not Production Ready
         </p>
-      ERB
+      HTML
     end
 
     def reports

--- a/app/jobs/reports/identity_verification_report.rb
+++ b/app/jobs/reports/identity_verification_report.rb
@@ -14,7 +14,10 @@ module Reports
 
       save_report(REPORT_NAME, csv, extension: 'csv')
 
-      emails = IdentityConfig.store.team_ada_emails
+      if emails.empty?
+        Rails.logger.warn 'No email addresses received - Identity Verification Report NOT SENT'
+        return false
+      end
 
       emails.each do |email|
         ReportMailer.tables_report(
@@ -36,6 +39,10 @@ module Reports
           Disclaimer: This Report is In Progress: Not Production Ready
         </p>
       HTML
+    end
+
+    def emails
+      [IdentityConfig.store.team_ada_email]
     end
 
     def reports

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -578,7 +578,7 @@ test:
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   skip_encryption_allowed_list: '[]'
   state_tracking_enabled: true
-  team_ada_emails: '[ada@example.com]'
+  team_ada_emails: '["ada@example.com"]'
   team_agnes_email: 'a@example.com'
   team_all_contractors_email: 'c@example.com'
   team_all_feds_email: 'f@example.com'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -316,7 +316,7 @@ show_user_attribute_deprecation_warnings: false
 otp_min_attempts_remaining_warning_count: 3
 system_demand_report_email: 'foo@bar.com'
 sp_issuer_user_counts_report_configs: '[]'
-team_ada_emails: '[]'
+team_ada_email: ''
 team_agnes_email: ''
 team_all_contractors_email: ''
 team_all_feds_email: ''
@@ -578,7 +578,7 @@ test:
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   skip_encryption_allowed_list: '[]'
   state_tracking_enabled: true
-  team_ada_emails: '["ada@example.com"]'
+  team_ada_email: 'ada@example.com'
   team_agnes_email: 'a@example.com'
   team_all_contractors_email: 'c@example.com'
   team_all_feds_email: 'f@example.com'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -316,6 +316,7 @@ show_user_attribute_deprecation_warnings: false
 otp_min_attempts_remaining_warning_count: 3
 system_demand_report_email: 'foo@bar.com'
 sp_issuer_user_counts_report_configs: '[]'
+team_ada_email: ''
 team_agnes_email: ''
 team_all_contractors_email: ''
 team_all_feds_email: ''
@@ -577,6 +578,7 @@ test:
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   skip_encryption_allowed_list: '[]'
   state_tracking_enabled: true
+  team_ada_email: 'ada@example.com'
   team_agnes_email: 'a@example.com'
   team_all_contractors_email: 'c@example.com'
   team_all_feds_email: 'f@example.com'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -316,7 +316,7 @@ show_user_attribute_deprecation_warnings: false
 otp_min_attempts_remaining_warning_count: 3
 system_demand_report_email: 'foo@bar.com'
 sp_issuer_user_counts_report_configs: '[]'
-team_ada_email: ''
+team_ada_emails: '[]'
 team_agnes_email: ''
 team_all_contractors_email: ''
 team_all_feds_email: ''
@@ -578,7 +578,7 @@ test:
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   skip_encryption_allowed_list: '[]'
   state_tracking_enabled: true
-  team_ada_email: 'ada@example.com'
+  team_ada_emails: '[ada@example.com]'
   team_agnes_email: 'a@example.com'
   team_all_contractors_email: 'c@example.com'
   team_all_feds_email: 'f@example.com'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -446,6 +446,7 @@ class IdentityConfig
     config.add(:sp_issuer_user_counts_report_configs, type: :json)
     config.add(:state_tracking_enabled, type: :boolean)
     config.add(:system_demand_report_email, type: :string)
+    config.add(:team_ada_email, type: :string)
     config.add(:team_agnes_email, type: :string)
     config.add(:team_all_contractors_email, type: :string)
     config.add(:team_all_feds_email, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -446,7 +446,7 @@ class IdentityConfig
     config.add(:sp_issuer_user_counts_report_configs, type: :json)
     config.add(:state_tracking_enabled, type: :boolean)
     config.add(:system_demand_report_email, type: :string)
-    config.add(:team_ada_email, type: :string)
+    config.add(:team_ada_emails, type: :json)
     config.add(:team_agnes_email, type: :string)
     config.add(:team_all_contractors_email, type: :string)
     config.add(:team_all_feds_email, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -446,7 +446,7 @@ class IdentityConfig
     config.add(:sp_issuer_user_counts_report_configs, type: :json)
     config.add(:state_tracking_enabled, type: :boolean)
     config.add(:system_demand_report_email, type: :string)
-    config.add(:team_ada_emails, type: :json)
+    config.add(:team_ada_email, type: :string)
     config.add(:team_agnes_email, type: :string)
     config.add(:team_all_contractors_email, type: :string)
     config.add(:team_all_feds_email, type: :string)

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -80,36 +80,44 @@ module Reporting
     def identity_verification_emailable_report
       EmailableReport.new(
         title: 'Identiy Verification Metrics',
-        table: to_csv,
+        table: as_csv,
         filename: 'identity_verification_metrics',
       )
     end
 
+    def as_csv
+      csv = []
+
+      csv << ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"]
+      # This needs to be Date.today so it works when run on the command line
+      csv << ['Report Generated', Date.today.to_s] # rubocop:disable Rails/Date
+      csv << ['Issuer', issuers.join(', ')] if issuers.present?
+      csv << []
+      csv << ['Metric', '# of Users']
+      csv << []
+      csv << ['Started IdV Verification', idv_started]
+      csv << ['Submitted welcome page', idv_doc_auth_welcome_submitted]
+      csv << ['Images uploaded', idv_doc_auth_image_vendor_submitted]
+      csv << []
+      csv << ['Workflow completed', idv_final_resolution]
+      csv << ['Workflow completed - Verified', idv_final_resolution_verified]
+      csv << ['Workflow completed - Total Pending', idv_final_resolution_total_pending]
+      csv << ['Workflow completed - GPO Pending', idv_final_resolution_gpo]
+      csv << ['Workflow completed - In-Person Pending', idv_final_resolution_in_person]
+      csv << ['Workflow completed - Fraud Review Pending', idv_final_resolution_fraud_review]
+      csv << []
+      csv << ['Successfully verified', successfully_verified_users]
+      csv << ['Successfully verified - Inline', idv_final_resolution_verified]
+      csv << ['Successfully verified - GPO Code Entry', gpo_verification_submitted]
+      csv << ['Successfully verified - In Person', usps_enrollment_status_updated]
+      csv << ['Successfully verified - Passed Fraud Review', fraud_review_passed]
+    end
+
     def to_csv
       CSV.generate do |csv|
-        csv << ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"]
-        # This needs to be Date.today so it works when run on the command line
-        csv << ['Report Generated', Date.today.to_s] # rubocop:disable Rails/Date
-        csv << ['Issuer', issuers.join(', ')] if issuers.present?
-        csv << []
-        csv << ['Metric', '# of Users']
-        csv << []
-        csv << ['Started IdV Verification', idv_started]
-        csv << ['Submitted welcome page', idv_doc_auth_welcome_submitted]
-        csv << ['Images uploaded', idv_doc_auth_image_vendor_submitted]
-        csv << []
-        csv << ['Workflow completed', idv_final_resolution]
-        csv << ['Workflow completed - Verified', idv_final_resolution_verified]
-        csv << ['Workflow completed - Total Pending', idv_final_resolution_total_pending]
-        csv << ['Workflow completed - GPO Pending', idv_final_resolution_gpo]
-        csv << ['Workflow completed - In-Person Pending', idv_final_resolution_in_person]
-        csv << ['Workflow completed - Fraud Review Pending', idv_final_resolution_fraud_review]
-        csv << []
-        csv << ['Successfully verified', successfully_verified_users]
-        csv << ['Successfully verified - Inline', idv_final_resolution_verified]
-        csv << ['Successfully verified - GPO Code Entry', gpo_verification_submitted]
-        csv << ['Successfully verified - In Person', usps_enrollment_status_updated]
-        csv << ['Successfully verified - Passed Fraud Review', fraud_review_passed]
+        as_csv.each do |row|
+          csv << row
+        end
       end
     end
 

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -77,6 +77,14 @@ module Reporting
       @progress
     end
 
+    def identity_verification_emailable_report
+      EmailableReport.new(
+        title: 'Identiy Verification Metrics',
+        table: to_csv,
+        filename: 'identity_verification_metrics',
+      )
+    end
+
     def to_csv
       CSV.generate do |csv|
         csv << ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"]

--- a/spec/jobs/reports/identity_verification_report_spec.rb
+++ b/spec/jobs/reports/identity_verification_report_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Reports::IdentityVerificationReport do
   let(:report_date) { Date.new(2023, 12, 12).in_time_zone('UTC') }
-  let(:team_ada_emails) { ['ada@example.com'] }
+  let(:team_ada_email) { 'ada@example.com' }
 
   before do
     allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
-    allow(IdentityConfig.store).to receive(:team_ada_emails).and_return(team_ada_emails)
+    allow(IdentityConfig.store).to receive(:team_ada_email).and_return(team_ada_email)
   end
 
   describe '#perform' do
@@ -53,7 +53,7 @@ RSpec.describe Reports::IdentityVerificationReport do
       )
 
       expect(ReportMailer).to receive(:tables_report).once.with(
-        email: IdentityConfig.store.team_ada_emails[0],
+        email: IdentityConfig.store.team_ada_email,
         subject: 'Daily Identity Verification Report - 2023-12-12',
         reports: anything,
         message: anything,

--- a/spec/jobs/reports/identity_verification_report_spec.rb
+++ b/spec/jobs/reports/identity_verification_report_spec.rb
@@ -1,13 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe Reports::IdentityVerificationReport do
+  let(:report_date) { Date.new(2023, 12, 12).in_time_zone('UTC') }
+  let(:team_ada_email) { ['ada@example.com'] }
+
   before do
     allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:team_ada_email).and_return(team_ada_email)
   end
 
   describe '#perform' do
-    it 'gets a CSV from the report maker and saves it to S3' do
-      report_maker = double(Reporting::IdentityVerificationReport, to_csv: 'I am a CSV, see')
+    it 'gets a CSV from the report maker, saves it to S3, and sends email to team' do
+      reports =
+        Reporting::EmailableReport.new(
+          title: 'Identity Verification Metrics',
+          table: [
+            ['Report Timeframe', '2023-12-10 00:00:00 UTC to 2023-12-10 23:59:59 UTC'],
+            ['Report Generated', '2023-12-11'],
+            ['Issuer', 'some:issuer'],
+            ['Metric', '# of Users'],
+            [],
+            ['Started IdV Verification', '78'],
+            ['Submitted welcome page', '75'],
+            ['Images uploaded', '73'],
+            [],
+            ['Workflow completed', '72'],
+            ['Workflow completed - Verified', '71'],
+            ['Workflow completed - Total Pending', '33'],
+            ['Workflow completed - GPO Pending', '23'],
+            ['Workflow completed - In-Person Pending', '55'],
+            ['Workflow completed - Fraud Review Pending', '34'],
+            [],
+            ['Successfully verified', '56'],
+            ['Successfully verified - Inline', '55'],
+            ['Successfully verified - GPO Code Entry', '25'],
+            ['Successfully verified - In Person', '25'],
+            ['Successfully verified - Passed Fraud Review', '15'],
+          ],
+          filename: 'identity_verification_metrics',
+        )
+
+      report_maker = double(
+        Reporting::IdentityVerificationReport,
+        to_csv: 'I am a CSV, see',
+        identity_verification_emailable_report: reports,
+      )
       allow(subject).to receive(:report_maker).and_return(report_maker)
       expect(subject).to receive(:save_report).with(
         'identity-verification-report',
@@ -15,7 +52,15 @@ RSpec.describe Reports::IdentityVerificationReport do
         extension: 'csv',
       )
 
-      subject.perform(Date.new(2023, 12, 25))
+      expect(ReportMailer).to receive(:tables_report).once.with(
+        email: IdentityConfig.store.team_ada_email[0],
+        subject: 'Daily Identity Verification Report - 2023-12-12',
+        reports: anything,
+        message: anything,
+        attachment_format: :csv,
+      ).and_call_original
+
+      subject.perform(report_date)
     end
   end
 

--- a/spec/jobs/reports/identity_verification_report_spec.rb
+++ b/spec/jobs/reports/identity_verification_report_spec.rb
@@ -2,11 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Reports::IdentityVerificationReport do
   let(:report_date) { Date.new(2023, 12, 12).in_time_zone('UTC') }
-  let(:team_ada_email) { 'ada@example.com' }
 
   before do
     allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
-    allow(IdentityConfig.store).to receive(:team_ada_email).and_return(team_ada_email)
+    allow(IdentityConfig.store).to receive(:team_ada_email).and_return('ada@example.com')
   end
 
   describe '#perform' do

--- a/spec/jobs/reports/identity_verification_report_spec.rb
+++ b/spec/jobs/reports/identity_verification_report_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Reports::IdentityVerificationReport do
   let(:report_date) { Date.new(2023, 12, 12).in_time_zone('UTC') }
-  let(:team_ada_email) { ['ada@example.com'] }
+  let(:team_ada_emails) { ['ada@example.com'] }
 
   before do
     allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
-    allow(IdentityConfig.store).to receive(:team_ada_email).and_return(team_ada_email)
+    allow(IdentityConfig.store).to receive(:team_ada_emails).and_return(team_ada_emails)
   end
 
   describe '#perform' do
@@ -53,7 +53,7 @@ RSpec.describe Reports::IdentityVerificationReport do
       )
 
       expect(ReportMailer).to receive(:tables_report).once.with(
-        email: IdentityConfig.store.team_ada_email[0],
+        email: IdentityConfig.store.team_ada_emails[0],
         subject: 'Daily Identity Verification Report - 2023-12-12',
         reports: anything,
         message: anything,

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -58,6 +58,40 @@ RSpec.describe Reporting::IdentityVerificationReport do
     allow(report).to receive(:cloudwatch_client).and_return(cloudwatch_client)
   end
   # rubocop:enable Layout/LineLength
+  describe '#as_csv' do
+    it 'renders a csv report' do
+      expected_csv = [
+        ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
+        ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
+        ['Issuer', issuer],
+        [],
+        ['Metric', '# of Users'],
+        [],
+        ['Started IdV Verification', 5],
+        ['Submitted welcome page', 5],
+        ['Images uploaded', 5],
+        [],
+        ['Workflow completed', 4],
+        ['Workflow completed - Verified', 1],
+        ['Workflow completed - Total Pending', 3],
+        ['Workflow completed - GPO Pending', 1],
+        ['Workflow completed - In-Person Pending', 1],
+        ['Workflow completed - Fraud Review Pending', 1],
+        [],
+        ['Successfully verified', 4],
+        ['Successfully verified - Inline', 1],
+        ['Successfully verified - GPO Code Entry', 1],
+        ['Successfully verified - In Person', 1],
+        ['Successfully verified - Passed Fraud Review', 1],
+      ]
+
+      aggregate_failures do
+        report.as_csv.zip(expected_csv).each do |actual, expected|
+          expect(actual).to eq(expected)
+        end
+      end
+    end
+  end
 
   describe '#to_csv' do
     it 'generates a csv' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11655](https://cm-jira.usa.gov/browse/LG-11655)


## 🛠 Summary of changes

Added the ability to email the IdentityVerificationReport to team Ada members. Added `team_ada_email` config value.
Out of scope for this PR: Add a team Ada mailing list.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
Since this job requires cloudwatch wait until this is merged.
- [ ] Test in staging if possible, otherwise in prod
- [ ] Update `team_ada_email` config to a test email
- [ ] Open rails console and type `Reports::IdentityVerificationReport.new(Time.zone.now).perform_now`
- [ ] Verify that you have received an IdV report email
