### PR TITLE
Move opt in analytics to ab_test_analytics_buckets

### DIFF
--- a/app/controllers/concerns/idv/ab_test_analytics_concern.rb
+++ b/app/controllers/concerns/idv/ab_test_analytics_concern.rb
@@ -1,11 +1,13 @@
 module Idv
   module AbTestAnalyticsConcern
     include AcuantConcern
+    include OptInHelper
 
     def ab_test_analytics_buckets
       buckets = {}
       if defined?(idv_session)
         buckets[:skip_hybrid_handoff] = idv_session&.skip_hybrid_handoff
+        buckets = buckets.merge(opt_in_analytics_properties)
       end
 
       if defined?(document_capture_session_uuid)

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -5,7 +5,6 @@ module Idv
       include IdvStepConcern
       skip_before_action :confirm_no_pending_gpo_profile
       include Idv::StepIndicatorConcern
-      include OptInHelper
 
       before_action :confirm_mail_not_rate_limited
       before_action :confirm_step_allowed
@@ -81,7 +80,6 @@ module Idv
             gpo_mail_service.hours_since_first_letter(first_letter_requested_at),
           phone_step_attempts: gpo_mail_service.phone_step_attempts,
           **ab_test_analytics_buckets,
-          **opt_in_analytics_properties,
         )
         irs_attempts_api_tracker.idv_gpo_letter_requested(resend: resend_requested?)
         create_user_event(:gpo_mail_sent, current_user)

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -3,7 +3,6 @@ module Idv
     class AddressController < ApplicationController
       include Idv::AvailabilityConcern
       include IdvStepConcern
-      include OptInHelper
 
       before_action :render_404_if_in_person_residential_address_controller_enabled_not_set
       before_action :confirm_in_person_state_id_step_complete
@@ -76,8 +75,7 @@ module Idv
           analytics_id: 'In Person Proofing',
           irs_reproofing: irs_reproofing?,
         }.merge(ab_test_analytics_buckets).
-          merge(extra_analytics_properties).
-          merge(opt_in_analytics_properties)
+          merge(extra_analytics_properties)
       end
 
       def redirect_to_next_page

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -6,7 +6,6 @@ module Idv
       include StepIndicatorConcern
       include Steps::ThreatMetrixStepHelper
       include ThreatMetrixConcern
-      include OptInHelper
 
       before_action :confirm_not_rate_limited_after_doc_auth
       before_action :confirm_in_person_address_step_complete
@@ -97,8 +96,7 @@ module Idv
           analytics_id: 'In Person Proofing',
           irs_reproofing: irs_reproofing?,
         }.merge(ab_test_analytics_buckets).
-          merge(**extra_analytics_properties).
-          merge(**opt_in_analytics_properties)
+          merge(**extra_analytics_properties)
       end
 
       def confirm_in_person_address_step_complete

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -6,7 +6,6 @@ module Idv
       include StepIndicatorConcern
       include Steps::ThreatMetrixStepHelper
       include VerifyInfoConcern
-      include OptInHelper
 
       before_action :confirm_not_rate_limited_after_doc_auth, except: [:show]
       before_action :confirm_ssn_step_complete
@@ -88,8 +87,7 @@ module Idv
           analytics_id: 'In Person Proofing',
           irs_reproofing: irs_reproofing?,
         }.merge(ab_test_analytics_buckets).
-          merge(**extra_analytics_properties).
-          merge(**opt_in_analytics_properties)
+          merge(**extra_analytics_properties)
       end
 
       def confirm_ssn_step_complete

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -4,7 +4,6 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
     include PhoneOtpRateLimitable
-    include OptInHelper
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_step_allowed
@@ -20,7 +19,7 @@ module Idv
     def update
       clear_future_steps!
       result = phone_confirmation_otp_verification_form.submit(code: params[:code])
-      analytics.idv_phone_confirmation_otp_submitted(**result.to_h, **opt_in_analytics_properties)
+      analytics.idv_phone_confirmation_otp_submitted(**result.to_h, **ab_test_analytics_buckets)
 
       irs_attempts_api_tracker.idv_phone_otp_submitted(
         success: result.success?,

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -5,7 +5,6 @@ module Idv
     include StepIndicatorConcern
     include PhoneOtpRateLimitable
     include PhoneOtpSendable
-    include OptInHelper
 
     attr_reader :idv_form
 
@@ -33,7 +32,6 @@ module Idv
 
         analytics.idv_phone_of_record_visited(
           **ab_test_analytics_buckets,
-          **opt_in_analytics_properties,
         )
         render :new, locals: { gpo_letter_available: gpo_letter_available }
       elsif async_state.missing?

--- a/spec/controllers/concerns/idv/ab_test_analytics_concern_spec.rb
+++ b/spec/controllers/concerns/idv/ab_test_analytics_concern_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Idv::AbTestAnalyticsConcern do
     context 'idv_session is available' do
       before do
         sign_in(user)
-        expect(subject).to receive(:idv_session).once.and_return(idv_session)
+        allow(subject).to receive(:idv_session).and_return(idv_session)
       end
 
       it 'includes acuant_sdk_ab_test_analytics_args' do
@@ -46,6 +46,24 @@ RSpec.describe Idv::AbTestAnalyticsConcern do
       it 'includes skip_hybrid_handoff' do
         idv_session.skip_hybrid_handoff = :shh_value
         expect(controller.ab_test_analytics_buckets).to include({ skip_hybrid_handoff: :shh_value })
+      end
+
+      context 'opted_in_to_in_person_proofing value' do
+        before do
+          idv_session.opted_in_to_in_person_proofing = :opt_in_value
+        end
+
+        it 'includes opted_in_to_in_person_proofing when enabled' do
+          allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).
+            and_return(true)
+          expect(controller.ab_test_analytics_buckets).
+            to include({ opted_in_to_in_person_proofing: :opt_in_value })
+        end
+
+        it 'does not include opted_in_to_in_person_proofing when disabled' do
+          expect(controller.ab_test_analytics_buckets).
+            not_to include({ opted_in_to_in_person_proofing: :opt_in_value })
+        end
       end
     end
 

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -21,11 +21,15 @@ RSpec.describe Idv::OtpVerificationController do
       sent_at: phone_confirmation_otp_sent_at,
     )
   end
+  let(:ab_test_args) do
+    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
+  end
 
   before do
     stub_analytics
     stub_attempts_tracker
     allow(@analytics).to receive(:track_event)
+    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
 
     sign_in(user)
     stub_verify_steps_one_and_two(user)
@@ -177,6 +181,7 @@ RSpec.describe Idv::OtpVerificationController do
         second_factor_attempts_count: 0,
         second_factor_locked_at: nil,
         proofing_components: nil,
+        **ab_test_args,
       }
 
       expect(@analytics).to have_received(:track_event).with(

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: phone confirmation otp submitted' => {
-        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
@@ -221,7 +221,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: phone confirmation otp submitted' => {
-        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
@@ -431,7 +431,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' },
       },
       'IdV: phone confirmation otp submitted' => {
-        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
@@ -542,7 +542,7 @@ RSpec.feature 'Analytics Regression', js: true do
     end
   end
 
-  context 'Happy hybrid path' do
+  context 'Happy hybrid path', allow_browser_log: true do
     before do
       allow(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
         @sms_link = config[:link]
@@ -633,7 +633,7 @@ RSpec.feature 'Analytics Regression', js: true do
       complete_enter_password_step(user)
     end
 
-    it 'records all of the events' do
+    it 'records all of the events', allow_browser_log: true do
       gpo_path_events.each do |event, attributes|
         expect(fake_analytics).to have_logged_event(event, attributes)
       end


### PR DESCRIPTION
## 🛠 Summary of changes

This is a followup to #9646 which added :opt_in_analytics_buckets to some IdV controller analytics. Move the addition to ab_test_analytics_buckets so that it gets added to all the IdV controllers, and tested in ab_test_analytics_concern_spec.rb.

OtpVerificationController didn't have ab_test_analytics_buckets, so add it in.

PersonalKeyController didn't have it either, but it also didn't have IdvStepConcern, which is being added in #9776, so leaving it alone for now to avoid unnecessary conflicts.

## 📜 Testing Plan

- [ ] In application.yml, set `in_person_proofing_opt_in_enabled: true`
- [ ] Create account, start IdV
- [ ] On How to Verify screen, choose in person proofing
- [ ] Go up to Enter Password step, do not enter password
- [ ] Check events.log, confirm that opted_in_to_in_person_proofing: is present and true
- [ ] Go back to How to Verify screen
- [ ] Choose remote proofing
- [ ] Go up to Enter Password step, do not enter password
- [ ] Check events.log, confirm that opted_in_to_in_person_proofing: is present and false
- [ ] In application.yml, set `in_person_proofing_opt_in_enabled: false`
- [ ] Restart server
- [ ] Go back to Agreement step
- [ ] Go forward via remote proofing to Enter Password step
- [ ] Check events.log, confirm that opted_in_to_in_person_proofing: is not present for the most recent events
