### PR TITLE
Enable, document RISC push notifications for local development 

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -404,9 +404,11 @@ development:
   otp_delivery_blocklist_findtime: 5
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
+  push_notifications_enabled: true
   rails_mailer_previews_enabled: true
   rack_timeout_service_timeout_seconds: 9_999_999_999
   raise_on_missing_title: true
+  risc_notifications_local_enabled: true
   s3_report_bucket_prefix: ''
   s3_report_public_bucket_prefix: ''
   saml_endpoint_configs: '[{"suffix":"2023","secret_key_passphrase":"trust-but-verify"}]'

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -164,6 +164,10 @@ stylesheets.
 
   To see outbound SMS messages and phone calls, visit `http://localhost:3000/test/telephony`.
 
+### Viewing RISC push notifications
+
+To view [RISC Security Events](https://developers.login.gov/security-events/) push notifications delivered by the application, visit http://localhost:3000/test/push_notification.
+
 ### Setting up Geolocation
 
 Login.gov uses MaxMind Geolite2 for geolocation. To test geolocation locally, you will need to add a copy of the Geolite2-City database to the IdP.


### PR DESCRIPTION
## 🛠 Summary of changes

Enables RISC event delivery in local development by default, and documents the test route for viewing delivered notifications.

Related Slack thread: https://gsa-tts.slack.com/archives/C0NGESUN5/p1702907459403909

## 📜 Testing Plan

Follow the proposed documentation and verify that you can view RISC events in local development.