### PR TITLE
Remove unimplemented clearfix CSS class from static error pages

### DIFF
--- a/app/views/pages/not_acceptable.html
+++ b/app/views/pages/not_acceptable.html
@@ -9,7 +9,7 @@
 <div class="site-wrapper">
     <div class="site-wrapper-inner">
         <div class="cover-container" role="main">
-            <div class="masthead clearfix">
+            <div class="masthead">
                 <div class="inner"><img width="150" alt="Login.gov" class="masthead-brand"
                                         src="https://login.gov/assets/img/logo-white.svg"/>
                 </div>

--- a/app/views/pages/page_not_found.html
+++ b/app/views/pages/page_not_found.html
@@ -9,7 +9,7 @@
 <div class="site-wrapper">
     <div class="site-wrapper-inner">
         <div class="cover-container" role="main">
-            <div class="masthead clearfix">
+            <div class="masthead">
                 <div class="inner"><img width="150" alt="Login.gov" class="masthead-brand"
                                         src="https://login.gov/assets/img/logo-white.svg"/>
                 </div>

--- a/app/views/pages/page_took_too_long.html.erb
+++ b/app/views/pages/page_took_too_long.html.erb
@@ -13,7 +13,7 @@
     <div class="site-wrapper">
       <div class="site-wrapper-inner">
         <div class="cover-container">
-          <div class="masthead clearfix">
+          <div class="masthead">
             <div class="inner">
                 <%= image_tag(
                       asset_url('logo-white.svg'),

--- a/public/401.html
+++ b/public/401.html
@@ -9,7 +9,7 @@
   <div class="site-wrapper">
     <div class="site-wrapper-inner">
       <div class="cover-container" role="main">
-        <div class="masthead clearfix">
+        <div class="masthead">
           <div class="inner">
             <img width="150" alt="Login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>

--- a/public/406.html
+++ b/public/406.html
@@ -9,7 +9,7 @@
   <div class="site-wrapper">
     <div class="site-wrapper-inner">
       <div class="cover-container" role="main">
-        <div class="masthead clearfix">
+        <div class="masthead">
           <div class="inner">
             <img width="150" alt="Login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>

--- a/public/422.html
+++ b/public/422.html
@@ -9,7 +9,7 @@
   <div class="site-wrapper">
     <div class="site-wrapper-inner">
       <div class="cover-container" role="main">
-        <div class="masthead clearfix">
+        <div class="masthead">
           <div class="inner">
             <img width="150" alt="Login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>

--- a/public/429.html
+++ b/public/429.html
@@ -9,7 +9,7 @@
   <div class="site-wrapper">
     <div class="site-wrapper-inner">
       <div class="cover-container" role="main">
-        <div class="masthead clearfix">
+        <div class="masthead">
           <div class="inner">
             <img width="150" alt="Login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>

--- a/public/500.html
+++ b/public/500.html
@@ -9,7 +9,7 @@
   <div class="site-wrapper">
     <div class="site-wrapper-inner">
       <div class="cover-container" role="main">
-        <div class="masthead clearfix">
+        <div class="masthead">
           <div class="inner">
             <img width="150" alt="Login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>

--- a/public/503.html
+++ b/public/503.html
@@ -9,7 +9,7 @@
   <div class="site-wrapper">
     <div class="site-wrapper-inner">
       <div class="cover-container" role="main">
-        <div class="masthead clearfix">
+        <div class="masthead">
           <div class="inner">
             <img width="150" alt="Login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a reference to a `clearfix` class which does not exist in the context of static error pages.

These error pages load a [reduced, static stylesheet](https://github.com/18F/identity-idp/blob/main/public/css/static.css) which does not implement `.clearfix`.

This is also an incremental step toward removing `clearfix` usage across the application, prompted partly by #9674.

## 📜 Testing Plan

Visit each page and observe no visual regressions, e.g. http://localhost:3000/401.html