### PR TITLE
Fix and test for mismatched locale content

### DIFF
--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -222,14 +222,14 @@ es:
       come_back_later: Carta con una marca de verificación
     legal_statement:
       information_collection: >-
-        Cette collecte d’informations répond aux exigences de l’article 3507 du
-        44 U.S.C., tel que modifié par l’article 2 de la loi de 1995 sur la
-        réduction des tâches administratives. Vous n’avez pas besoin de répondre
-        à ces questions, sauf si nous affichons un numéro de contrôle valide de
-        l’Office of Management and Budget (OMB). Le numéro de contrôle de l’OMB
-        pour cette collecte est 3090-0325. Calculamos que tomará un minuto leer
-        las instrucciones, recopilar los datos y responder las preguntas. Envíe
-        solo comentarios relacionados con nuestro tiempo estimado, incluidas
+        Esta recopilación de información cumple con los requisitos del título 44
+        del U.S.C., § 3507, modificado por la sección 2 de la Ley de Reducción
+        de Trámites de 1995. No es necesario que responda a estas preguntas, a
+        menos que le mostremos un número de control válido de la Oficina de
+        Administración y Presupuesto (OMB). El número de control de la OMB para
+        esta recopilación es 3090-0325. Calculamos que tomará un minuto leer las
+        instrucciones, recopilar los datos y responder las preguntas. Envíe solo
+        comentarios relacionados con nuestro tiempo estimado, incluidas
         sugerencias para reducir esta molestia, o cualquier otro aspecto
         relacionado con esta recopilación de información a: Administración de
         Servicios Generales, División de la Secretaría Reguladora (MVCB), a la

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -230,18 +230,18 @@ fr:
       come_back_later: Lettre avec un crochet
     legal_statement:
       information_collection: >-
-        Esta recopilación de información cumple con los requisitos del título 44
-        del U.S.C., § 3507, modificado por la sección 2 de la Ley de Reducción
-        de Trámites de 1995. No es necesario que responda a estas preguntas, a
-        menos que le mostremos un número de control válido de la Oficina de
-        Administración y Presupuesto (OMB). El número de control de la OMB para
-        esta recopilación es 3090-0325. Nous estimons qu’il faut une minute pour
-        lire les instructions, rassembler les preuves et répondre aux questions.
-        N’envoyez que des commentaires relatifs à notre estimation du temps, y
-        compris des suggestions pour réduire cette charge, ou tout autre aspect
-        de cette collecte d’informations à : General Services Administration,
-        Regulatory Secretariat Division (MVCB), ATTN : Lois Mandell/IC
-        3090-0325, 1800 F Street, NW, Washington, DC 20405.
+        Cette collecte d’informations répond aux exigences de l’article 3507 du
+        44 U.S.C., tel que modifié par l’article 2 de la loi de 1995 sur la
+        réduction des tâches administratives. Vous n’avez pas besoin de répondre
+        à ces questions, sauf si nous affichons un numéro de contrôle valide de
+        l’Office of Management and Budget (OMB). Le numéro de contrôle de l’OMB
+        pour cette collecte est 3090-0325. Nous estimons qu’il faut une minute
+        pour lire les instructions, rassembler les preuves et répondre aux
+        questions. N’envoyez que des commentaires relatifs à notre estimation du
+        temps, y compris des suggestions pour réduire cette charge, ou tout
+        autre aspect de cette collecte d’informations à : General Services
+        Administration, Regulatory Secretariat Division (MVCB), ATTN : Lois
+        Mandell/IC 3090-0325, 1800 F Street, NW, Washington, DC 20405.
     messages:
       activated_html: Votre identité a été vérifiée. Si vous souhaitez modifier votre
         information vérifiée, veuillez %{link_html}.

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -8,6 +8,15 @@ ALLOWED_INTERPOLATION_MISMATCH_KEYS = [
   'time.formats.event_timestamp_js',
 ]
 
+# A set of patterns which are expected to only occur within specific locales. This is an imperfect
+# solution based on current content, intended to help prevent accidents when adding new translated
+# content. If you are having issues with new content, it would be reasonable to remove or modify
+# the parts of the pattern which are valid for the content you're adding.
+LOCALE_SPECIFIC_CONTENT = {
+  fr: / [nd]’|à/i,
+  es: /¿|ó/,
+}.freeze
+
 module I18n
   module Tasks
     class BaseTask
@@ -155,17 +164,19 @@ RSpec.describe 'I18n' do
       i18n_file = full_path.sub("#{root_dir}/", '')
 
       describe i18n_file do
+        let(:flattened_yaml_data) { flatten_hash(YAML.load_file(full_path)) }
+
         # Transliteration includes special characters by definition, so it could fail checks below
         if !full_path.match?(%(/config/locales/transliterate/))
           it 'has only lower_snake_case keys' do
-            keys = flatten_hash(YAML.load_file(full_path)).keys
+            keys = flattened_yaml_data.keys
 
             bad_keys = keys.reject { |key| key =~ /^[a-z0-9_.]+$/ }
             expect(bad_keys).to be_empty
           end
 
           it 'has only has XML-safe identifiers (keys start with a letter)' do
-            keys = flatten_hash(YAML.load_file(full_path)).keys
+            keys = flattened_yaml_data.keys
 
             bad_keys = keys.select { |key| key.split('.').any? { |part| part =~ /^[0-9]/ } }
 
@@ -174,7 +185,7 @@ RSpec.describe 'I18n' do
         end
 
         it 'has correctly-formatted interpolation values' do
-          bad_keys = flatten_hash(YAML.load_file(full_path)).select do |_key, value|
+          bad_keys = flattened_yaml_data.select do |_key, value|
             next unless value.is_a?(String)
 
             interpolation_names = value.scan(/%\{([^}]+)\}/).flatten
@@ -186,7 +197,7 @@ RSpec.describe 'I18n' do
         end
 
         it 'does not contain any translations expecting legacy fallback behavior' do
-          bad_keys = flatten_hash(YAML.load_file(full_path)).select do |_key, value|
+          bad_keys = flattened_yaml_data.select do |_key, value|
             value.include?('NOT TRANSLATED YET')
           end
 
@@ -194,11 +205,21 @@ RSpec.describe 'I18n' do
         end
 
         it 'does not contain any translations that hardcode APP_NAME' do
-          bad_keys = flatten_hash(YAML.load_file(full_path)).select do |_key, value|
+          bad_keys = flattened_yaml_data.select do |_key, value|
             value.include?(APP_NAME)
           end
 
           expect(bad_keys).to be_empty
+        end
+
+        it 'does not contain content from another language' do
+          flattened_yaml_data.each do |key, value|
+            locale = key.split('.', 2).first.to_sym
+            other_locales = LOCALE_SPECIFIC_CONTENT.keys - [locale]
+            expect(value).not_to match(
+              Regexp.union(*LOCALE_SPECIFIC_CONTENT.slice(*other_locales).values),
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where French and Spanish content are mismatched, contained within the others' locale data for identity verification information disclosure.

Also adds a new regression spec intended to try to catch these sorts of issues by checking for content patterns which are expected to only exist within specific locales.

See: https://github.com/18F/identity-idp/pull/9392/files#r1431752474

## 📜 Testing Plan

Repeat Testing Plan from #9392 

Verify new tests pass:

```
rspec spec/i18n_spec.rb
```

Also observe that the tests would fail without the included content updates:

```
git checkout main -- config/locales/idv/es.yml config/locales/idv/fr.yml
rspec spec/i18n_spec.rb
```