### PR TITLE
LG-11118: zip code format validation

### DIFF
--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -11,7 +11,13 @@ module Idv
                                   message: proc {
                                              I18n.t('doc_auth.errors.general.no_liveness')
                                            } }
-    validate :zipcode_valid?
+    validates :zipcode, format: {
+      with: /\A[0-9]{5}(?:-[0-9]{4})?\z/,
+      message: proc {
+        I18n.t('doc_auth.errors.general.no_liveness')
+      },
+    }
+
     validates :jurisdiction, inclusion: { in: Idp::Constants::STATE_AND_TERRITORY_CODES,
                                           message: proc {
                                                      I18n.t('doc_auth.errors.general.no_liveness')
@@ -80,12 +86,6 @@ module Idv
       if age < IdentityConfig.store.idv_min_age_years
         errors.add(:dob_min_age, dob_min_age_error, type: :dob)
       end
-    end
-
-    def zipcode_valid?
-      return if zipcode.is_a?(String) && zipcode.present?
-
-      errors.add(:zipcode, generic_error, type: :zipcode)
     end
 
     def generic_error

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe Idv::DocPiiForm do
       state: Faker::Address.state_abbr,
     }
   end
-  let(:non_string_zipcode_pii) do
+  let(:invalid_zipcode_pii) do
     {
       first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
       dob: valid_dob,
       address1: Faker::Address.street_address,
       state: Faker::Address.state_abbr,
-      zipcode: 12345,
+      zipcode: 123456,
       state_id_jurisdiction: 'AL',
     }
   end
@@ -174,7 +174,7 @@ RSpec.describe Idv::DocPiiForm do
     end
 
     context 'when there is a non-string zipcode' do
-      let(:pii) { non_string_zipcode_pii }
+      let(:pii) { invalid_zipcode_pii }
 
       it 'returns a single generic pii error' do
         result = subject.submit


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

LG-1118: zip code validation

## 🛠 Summary of changes

Basic zip code validation for [zip+4](https://faq.usps.com/s/article/ZIP-Code-The-Basics#:~:text=Yes%2C%20when%20using%20a%20ZIP,unable%20to%20deliver%20the%20item.) for US and territories postal code format.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Step 1: Start document capturing session
- [x] Step 2: Use following test yml file
   ```yaml
   document:
     type: license
     first_name: Susan
     last_name: Smith
     middle_name: Q
     address1: 1 Microsoft Way
     address2: Apt 3
     city: Bayside
     state: NY
     zipcode: '113642'
     dob: 10/06/1938
     phone: +1 314-555-1212
     state_id_number: '123456789'
     state_id_type: drivers_license
   ```
- [x] Step 3: Warning page should shows and asking to "Take a new picture".


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
