### PR TITLE
Add temporary continuous integration check to fail on content changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,17 @@ check_changelog:
         exit 0
       fi
 
+check_content_freeze:
+  stage: test
+  script: |-
+    echo "Content change is not allowed during content freeze"
+    exit 1
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH || $CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"'
+      changes:
+        compare_to: 'refs/heads/main'
+        paths:
+          - config/locales/**/en.yml
 specs:
   stage: test
   needs:


### PR DESCRIPTION
## 🛠 Summary of changes

As part of the internationalization process changes, we are in a content freeze. To assist in preventing those changes, this PR intends to add a simple CI check that will fail when there is a change in a content file. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
