### PR TITLE
Use design sytem colors for password strength meter

### DIFF
--- a/app/assets/stylesheets/components/_password.scss
+++ b/app/assets/stylesheets/components/_password.scss
@@ -1,39 +1,34 @@
 @use 'uswds-core' as *;
 
-$weak: #e80e0e;
-$average: #ffac00;
-$good: #9ac056;
-$great: #00b200;
-
-.pw-bar {
-  background-color: #e9e9e9;
-  border: units(0.5) solid #fff;
-  border-radius: 6px;
-  float: left;
-  height: 16px;
-  width: 25%;
+.password-strength__meter {
+  display: flex;
+  margin-top: units(1);
+  margin-bottom: units(0.5);
 }
 
-.pw-weak {
-  .pw-bar:nth-child(-n + 1) {
-    background-color: $weak;
+.password-strength__meter-bar {
+  flex-basis: 25%;
+  background-color: color('base-lighter');
+  border-radius: 2px;
+  height: units(1);
+
+  & + & {
+    margin-left: units(1);
   }
-}
 
-.pw-average {
-  .pw-bar:nth-child(-n + 2) {
-    background-color: $average;
+  .pw-weak &:nth-child(-n + 1) {
+    background-color: color('error');
   }
-}
 
-.pw-good {
-  .pw-bar:nth-child(-n + 3) {
-    background-color: $good;
+  .pw-average &:nth-child(-n + 2) {
+    background-color: color('warning');
   }
-}
 
-.pw-great {
-  .pw-bar {
-    background-color: $great;
+  .pw-good &:nth-child(-n + 3) {
+    background-color: color('success-light');
+  }
+
+  .pw-great &:nth-child(-n + 4) {
+    background-color: color('success');
   }
 }

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,10 +1,10 @@
 <div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true' data-pw-min-length='<%= Devise.password_length.min %>'>
   <div class="margin-bottom-4">
-    <div class='clearfix margin-x-neg-05 padding-top-05'>
-      <div class='pw-bar'></div>
-      <div class='pw-bar'></div>
-      <div class='pw-bar'></div>
-      <div class='pw-bar'></div>
+    <div class="password-strength__meter">
+      <div class="password-strength__meter-bar"></div>
+      <div class="password-strength__meter-bar"></div>
+      <div class="password-strength__meter-bar"></div>
+      <div class="password-strength__meter-bar"></div>
     </div>
     <div class='h5'>
       <%= t('instructions.password.strength.intro') %>


### PR DESCRIPTION
## 🛠 Summary of changes

Refactors password strength styling, with the only user-facing visual effect being that it adopts standard design system colors for password feedback.

Originally this started as a continuation of the work in #9799 to eliminate the few remaining usages of `clearfix`. Incrementally, this also works toward a broader refactor of the password strength implementation toward [frontend conventions](https://github.com/18F/identity-idp/blob/main/docs/frontend.md) (ViewComponent, TypeScript, BEM CSS class naming, per-component stylesheet).

## 📜 Testing Plan

Verify no regression in the behavior of password feedback being shown:

1. Go to http://localhost:3000
2. Sign in
3. From account dashboard, click "Edit password"
4. (Reauthenticate if prompted)
5. Enter a "New password" value
6. Observe password strength feedback

## 👀 Screenshots

Strength|Before|After
---|---|---
Very Weak|![before-very-weak](https://github.com/18F/identity-idp/assets/1779930/076db978-434a-4806-b964-f7b65adc76de)|![after-very-weak](https://github.com/18F/identity-idp/assets/1779930/9988d63c-a4fd-46e9-bc34-95ec89d4aaec)
Weak|![before-weak](https://github.com/18F/identity-idp/assets/1779930/22710b45-cf68-4a20-a703-2ce416ce5757)|![after-weak](https://github.com/18F/identity-idp/assets/1779930/b5c62de5-bac5-4b98-aca7-ec687bea13bf)
Average|![before-average](https://github.com/18F/identity-idp/assets/1779930/0a24eed4-f078-4b91-8e83-752a1c3bd5f6)|![after-average](https://github.com/18F/identity-idp/assets/1779930/494d8e8f-7263-4ebb-86e6-a9b31f366bc8)
Good|![before-good](https://github.com/18F/identity-idp/assets/1779930/ad16ca45-8100-4bdb-beb5-399ab740dd97)|![after-good](https://github.com/18F/identity-idp/assets/1779930/a8dae814-e0cf-4ead-a2de-a018dba13ed8)
Great|![before-great](https://github.com/18F/identity-idp/assets/1779930/35a4b705-7547-4121-b6c4-df8dffad581a)|![after-great](https://github.com/18F/identity-idp/assets/1779930/857c155e-004a-4a4f-9542-424c8b3fe1a4)