### PR TITLE
Remove unnecessary clearfix from account page widgets

### DIFF
--- a/app/views/accounts/_pii.html.erb
+++ b/app/views/accounts/_pii.html.erb
@@ -68,7 +68,7 @@
     </div>
   </div>
   <% unless locked_for_session %>
-    <div class="grid-row bg-base-lightest padding-x-2 padding-y-1 clearfix fs-12p">
+    <div class="grid-row bg-base-lightest padding-x-2 padding-y-1 fs-12p">
       <div class="grid-col-12">
         <%= image_tag asset_url('lock.svg'), width: 8, height: 10, class: 'margin-right-1' %>
         <%= t('account.security.text') %>

--- a/app/views/accounts/_webauthn_roaming.html.erb
+++ b/app/views/accounts/_webauthn_roaming.html.erb
@@ -17,7 +17,6 @@
         </div>
       <% end %>
     </div>
-    <div class="clearfix"></div>
   <% end %>
 </div>
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes two instances of unnecessary `clearfix`, within the account page Security Key listing and Verified Information security disclosure text.

Historically, these were implemented using [BassCSS grid](https://basscss.com/#basscss-grid), which uses `float` on individual columns. As documented, it's required to define `clearfix` on the column container when using BassCSS grid. In #4169, we migrated from BassCSS to USWDS for these grid layouts. The design system uses flexbox for grids and does not require a `clearfix`.

This is a continuation of the work in https://github.com/18F/identity-idp/pull/9799 to eliminate the few remaining usages of `clearfix`.

## 📜 Testing Plan

Verify no visual regressions in display of Security Key and Verified Information widgets on account dashboard:

1. (Prerequisite: Have an account with security key and is identity-verified)
2. Go to http://localhost:3000
3. Sign in
4. Observe no collapsing content in "Security Key" listing or "Verified Information"