### PR TITLE
Remove unused Profile::includes_phone_check? method

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -279,11 +279,6 @@ class Profile < ApplicationRecord
     values.join(':')
   end
 
-  def includes_phone_check?
-    return false if proofing_components.blank?
-    proofing_components['address_check'] == 'lexis_nexis_address'
-  end
-
   def irs_attempts_api_tracker
     @irs_attempts_api_tracker ||= IrsAttemptsApi::Tracker.new
   end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -46,26 +46,6 @@ RSpec.describe Profile do
     end
   end
 
-  describe '#includes_phone_check?' do
-    it 'returns true if the address_check component is lexis_nexis_address' do
-      profile = create(:profile, proofing_components: { address_check: 'lexis_nexis_address' })
-
-      expect(profile.includes_phone_check?).to eq(true)
-    end
-
-    it 'returns false if the address_check componet is gpo_letter' do
-      profile = create(:profile, proofing_components: { address_check: 'gpo_letter' })
-
-      expect(profile.includes_phone_check?).to eq(false)
-    end
-
-    it 'returns false if proofing_components is blank' do
-      profile = create(:profile, proofing_components: '')
-
-      expect(profile.includes_phone_check?).to eq(false)
-    end
-  end
-
   describe '#in_person_verification_pending?' do
     it 'returns true if the in_person_verification_pending_at is present' do
       profile = create(


### PR DESCRIPTION
## 🛠 Summary of changes

Remove `Profile::includes_phone_check?`, which does not appear to be referenced anywhere in the code base.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
