### PR TITLE
Update query timeout in duplicate SSN report (LG-11963)

### DIFF
--- a/app/jobs/reports/duplicate_ssn_report.rb
+++ b/app/jobs/reports/duplicate_ssn_report.rb
@@ -24,10 +24,13 @@ module Reports
 
     # @return [String]
     def report_body
-      # note, this will table scan until we add an index, for a once-a-day job it may be ok
-      todays_profiles = Profile.
-        select(:id, :ssn_signature).
-        where(active: true, activated_at: start..finish)
+      todays_profiles = transaction_with_timeout do
+        # note, this will table scan until we add an index, for a once-a-day job it may be ok
+        Profile.
+          select(:id, :ssn_signature).
+          where(active: true, activated_at: start..finish).
+          to_a
+      end
 
       todays_profile_ids = todays_profiles.map(&:id).to_set
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11963](https://cm-jira.usa.gov/browse/LG-11963)

## 🛠 Summary of changes

This table scan is timing out in prod [(newrelic link)](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=10800000&state=168040d6-8e74-a6c6-e93c-589858217adf), so this updates the timeout to get around that. The other queries in this file are indexed point queries so I figured it was not worth adding timeout exceptions to those.

## 📜 Testing Plan

- [x] Test in the prod rails console to make sure this works with prod data
