### PR TITLE
Deploy RC 342 to Prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'strong_migrations', '>= 0.4.2'
 gem 'subprocess', require: false
 gem 'terminal-table', require: false
 gem 'valid_email', '>= 0.1.3'
-gem 'view_component', '~> 3.0.0'
+gem 'view_component', '~> 3.0'
 gem 'webauthn', '~> 2.5.2'
 gem 'xmldsig', '~> 0.6'
 gem 'xmlenc', '~> 0.7', '>= 0.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     bindata (2.4.15)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
-    brakeman (6.0.1)
+    brakeman (6.1.0)
     browser (5.3.1)
     builder (3.2.4)
     bullet (7.1.4)
@@ -684,7 +684,7 @@ GEM
       activemodel
       mail (>= 2.6.1)
       simpleidn
-    view_component (3.0.0)
+    view_component (3.8.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -842,7 +842,7 @@ DEPENDENCIES
   tableparser
   terminal-table
   valid_email (>= 0.1.3)
-  view_component (~> 3.0.0)
+  view_component (~> 3.0)
   webauthn (~> 2.5.2)
   webmock
   xmldsig (~> 0.6)

--- a/app/assets/stylesheets/components/_password.scss
+++ b/app/assets/stylesheets/components/_password.scss
@@ -1,39 +1,34 @@
 @use 'uswds-core' as *;
 
-$weak: #e80e0e;
-$average: #ffac00;
-$good: #9ac056;
-$great: #00b200;
-
-.pw-bar {
-  background-color: #e9e9e9;
-  border: units(0.5) solid #fff;
-  border-radius: 6px;
-  float: left;
-  height: 16px;
-  width: 25%;
+.password-strength__meter {
+  display: flex;
+  margin-top: units(1);
+  margin-bottom: units(0.5);
 }
 
-.pw-weak {
-  .pw-bar:nth-child(-n + 1) {
-    background-color: $weak;
+.password-strength__meter-bar {
+  flex-basis: 25%;
+  background-color: color('base-lighter');
+  border-radius: 2px;
+  height: units(1);
+
+  & + & {
+    margin-left: units(1);
   }
-}
 
-.pw-average {
-  .pw-bar:nth-child(-n + 2) {
-    background-color: $average;
+  .pw-weak &:nth-child(-n + 1) {
+    background-color: color('error');
   }
-}
 
-.pw-good {
-  .pw-bar:nth-child(-n + 3) {
-    background-color: $good;
+  .pw-average &:nth-child(-n + 2) {
+    background-color: color('warning');
   }
-}
 
-.pw-great {
-  .pw-bar {
-    background-color: $great;
+  .pw-good &:nth-child(-n + 3) {
+    background-color: color('success-light');
+  }
+
+  .pw-great &:nth-child(-n + 4) {
+    background-color: color('success');
   }
 }

--- a/app/controllers/concerns/idv/ab_test_analytics_concern.rb
+++ b/app/controllers/concerns/idv/ab_test_analytics_concern.rb
@@ -1,11 +1,13 @@
 module Idv
   module AbTestAnalyticsConcern
     include AcuantConcern
+    include OptInHelper
 
     def ab_test_analytics_buckets
       buckets = {}
       if defined?(idv_session)
         buckets[:skip_hybrid_handoff] = idv_session&.skip_hybrid_handoff
+        buckets = buckets.merge(opt_in_analytics_properties)
       end
 
       if defined?(document_capture_session_uuid)

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -315,6 +315,10 @@ module Idv
         if stage == :resolution
           # transaction_id comes from ConversationId
           add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
+        elsif stage == :residential_address
+          next if pii[:same_address_as_id] == 'true'
+          next if hash[:vendor_name] == 'ResidentialAddressNotRequired'
+          add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
         elsif stage == :state_id
           next if hash[:exception].present?
           next if hash[:vendor_name] == 'UnsupportedJurisdiction'

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -119,6 +119,10 @@ module IdvStepConcern
   end
 
   def clear_future_steps!
-    flow_policy.undo_future_steps_from_controller!(controller: self.class)
+    clear_future_steps_from!(controller: self.class)
+  end
+
+  def clear_future_steps_from!(controller:)
+    flow_policy.undo_future_steps_from_controller!(controller: controller)
   end
 end

--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -47,6 +47,11 @@ class FrontendLogController < ApplicationController
   # rubocop:enable Layout/LineLength
 
   ALLOWED_EVENTS = %i[
+    idv_sdk_selfie_image_added
+    idv_sdk_selfie_image_capture_closed_without_photo
+    idv_sdk_selfie_image_capture_failed
+    idv_sdk_selfie_image_capture_opened
+    idv_selfie_image_file_uploaded
     phone_input_country_changed
   ].freeze
 

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -5,7 +5,6 @@ module Idv
       include IdvStepConcern
       skip_before_action :confirm_no_pending_gpo_profile
       include Idv::StepIndicatorConcern
-      include OptInHelper
 
       before_action :confirm_mail_not_rate_limited
       before_action :confirm_step_allowed
@@ -81,7 +80,6 @@ module Idv
             gpo_mail_service.hours_since_first_letter(first_letter_requested_at),
           phone_step_attempts: gpo_mail_service.phone_step_attempts,
           **ab_test_analytics_buckets,
-          **opt_in_analytics_properties,
         )
         irs_attempts_api_tracker.idv_gpo_letter_requested(resend: resend_requested?)
         create_user_event(:gpo_mail_sent, current_user)

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -77,7 +77,7 @@ module Idv
         key: :enter_password,
         controller: self,
         action: :new,
-        next_steps: [FlowPolicy::FINAL],
+        next_steps: [:personal_key],
         preconditions: ->(idv_session:, user:) do
           idv_session.phone_or_address_step_complete?
         end,

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -3,7 +3,6 @@ module Idv
     class AddressController < ApplicationController
       include Idv::AvailabilityConcern
       include IdvStepConcern
-      include OptInHelper
 
       before_action :render_404_if_in_person_residential_address_controller_enabled_not_set
       before_action :confirm_in_person_state_id_step_complete
@@ -76,8 +75,7 @@ module Idv
           analytics_id: 'In Person Proofing',
           irs_reproofing: irs_reproofing?,
         }.merge(ab_test_analytics_buckets).
-          merge(extra_analytics_properties).
-          merge(opt_in_analytics_properties)
+          merge(extra_analytics_properties)
       end
 
       def redirect_to_next_page

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -6,6 +6,7 @@ module Idv
 
       before_action :render_404_if_in_person_residential_address_controller_enabled_not_set
       before_action :confirm_in_person_state_id_step_complete
+      ## before_action :confirm_step_allowed # pending FSM removal of state id step
       before_action :confirm_in_person_address_step_needed, only: :show
 
       def show
@@ -15,6 +16,8 @@ module Idv
       end
 
       def update
+        # don't clear the ssn when updating address, clear after SsnController
+        clear_future_steps_from!(controller: Idv::InPerson::SsnController)
         attrs = Idv::InPerson::AddressForm::ATTRIBUTES.difference([:same_address_as_id])
         pii_from_user[:same_address_as_id] = 'false' if updating_address?
         form_result = form.submit(flow_params)
@@ -40,6 +43,24 @@ module Idv
           pii:,
           updating_address: updating_address?,
         }
+      end
+
+      # update Idv::DocumentCaptureController.step_info.next_steps to include
+      # :ipp_address instead of :ipp_ssn in delete PR
+      def self.step_info
+        Idv::StepInfo.new(
+          key: :ipp_address,
+          controller: self,
+          next_steps: [:ipp_ssn],
+          preconditions: ->(idv_session:, user:) { idv_session.ipp_state_id_complete? },
+          undo_step: ->(idv_session:, user:) do
+            flow_session[:pii_from_user][:address1] = nil
+            flow_session[:pii_from_user][:address2] = nil
+            flow_session[:pii_from_user][:city] = nil
+            flow_session[:pii_from_user][:zipcode] = nil
+            flow_session[:pii_from_user][:state] = nil
+          end,
+        )
       end
 
       private

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -6,7 +6,6 @@ module Idv
       include StepIndicatorConcern
       include Steps::ThreatMetrixStepHelper
       include ThreatMetrixConcern
-      include OptInHelper
 
       before_action :confirm_not_rate_limited_after_doc_auth
       before_action :confirm_in_person_address_step_complete
@@ -97,8 +96,7 @@ module Idv
           analytics_id: 'In Person Proofing',
           irs_reproofing: irs_reproofing?,
         }.merge(ab_test_analytics_buckets).
-          merge(**extra_analytics_properties).
-          merge(**opt_in_analytics_properties)
+          merge(**extra_analytics_properties)
       end
 
       def confirm_in_person_address_step_complete

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -6,7 +6,6 @@ module Idv
       include StepIndicatorConcern
       include Steps::ThreatMetrixStepHelper
       include VerifyInfoConcern
-      include OptInHelper
 
       before_action :confirm_not_rate_limited_after_doc_auth, except: [:show]
       before_action :confirm_ssn_step_complete
@@ -88,8 +87,7 @@ module Idv
           analytics_id: 'In Person Proofing',
           irs_reproofing: irs_reproofing?,
         }.merge(ab_test_analytics_buckets).
-          merge(**extra_analytics_properties).
-          merge(**opt_in_analytics_properties)
+          merge(**extra_analytics_properties)
       end
 
       def confirm_ssn_step_complete

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -4,7 +4,6 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
     include PhoneOtpRateLimitable
-    include OptInHelper
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_step_allowed
@@ -20,7 +19,7 @@ module Idv
     def update
       clear_future_steps!
       result = phone_confirmation_otp_verification_form.submit(code: params[:code])
-      analytics.idv_phone_confirmation_otp_submitted(**result.to_h, **opt_in_analytics_properties)
+      analytics.idv_phone_confirmation_otp_submitted(**result.to_h, **ab_test_analytics_buckets)
 
       irs_attempts_api_tracker.idv_phone_otp_submitted(
         success: result.success?,

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -5,7 +5,6 @@ module Idv
     include StepIndicatorConcern
     include PhoneOtpRateLimitable
     include PhoneOtpSendable
-    include OptInHelper
 
     attr_reader :idv_form
 
@@ -33,7 +32,6 @@ module Idv
 
         analytics.idv_phone_of_record_visited(
           **ab_test_analytics_buckets,
-          **opt_in_analytics_properties,
         )
         render :new, locals: { gpo_letter_available: gpo_letter_available }
       elsif async_state.missing?

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -70,6 +70,11 @@ class ServiceProviderSession
     sp.issuer
   end
 
+  def selfie_required?
+    !!(IdentityConfig.store.doc_auth_selfie_capture_enabled &&
+      sp_session[:biometric_comparison_required])
+  end
+
   def cancel_link_url
     view_context.new_user_session_url(request_id: sp_session[:request_id])
   end

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -11,7 +11,13 @@ module Idv
                                   message: proc {
                                              I18n.t('doc_auth.errors.general.no_liveness')
                                            } }
-    validate :zipcode_valid?
+    validates :zipcode, format: {
+      with: /\A[0-9]{5}(?:-[0-9]{4})?\z/,
+      message: proc {
+        I18n.t('doc_auth.errors.general.no_liveness')
+      },
+    }
+
     validates :jurisdiction, inclusion: { in: Idp::Constants::STATE_AND_TERRITORY_CODES,
                                           message: proc {
                                                      I18n.t('doc_auth.errors.general.no_liveness')
@@ -80,12 +86,6 @@ module Idv
       if age < IdentityConfig.store.idv_min_age_years
         errors.add(:dob_min_age, dob_min_age_error, type: :dob)
       end
-    end
-
-    def zipcode_valid?
-      return if zipcode.is_a?(String) && zipcode.present?
-
-      errors.add(:zipcode, generic_error, type: :zipcode)
     end
 
     def generic_error

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -17,7 +17,15 @@ class OpenidConnectAuthorizeForm
     state
   ].freeze
 
-  ATTRS = [:unauthorized_scope, :acr_values, :scope, :verified_within, *SIMPLE_ATTRS].freeze
+  ATTRS = [
+    :unauthorized_scope,
+    :acr_values,
+    :scope,
+    :verified_within,
+    :biometric_comparison_required,
+    *SIMPLE_ATTRS,
+  ].freeze
+
   AALS_BY_PRIORITY = [Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
                       Saml::Idp::Constants::AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF,
                       Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
@@ -55,6 +63,7 @@ class OpenidConnectAuthorizeForm
     @prompt ||= 'select_account'
     @scope = parse_to_values(params[:scope], scopes)
     @unauthorized_scope = check_for_unauthorized_scope(params)
+    @biometric_comparison_required = params[:biometric_comparison_required].to_s == 'true'
 
     if verified_within_allowed?
       @duration_parser = DurationParser.new(params[:verified_within])
@@ -129,6 +138,10 @@ class OpenidConnectAuthorizeForm
   def_delegators :ial_context,
                  :ial2_or_greater?,
                  :ial2_requested?
+
+  def biometric_comparison_required?
+    @biometric_comparison_required
+  end
 
   private
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -409,7 +409,11 @@ function AcuantCapture(
         size: nextValue.size,
         failedImageResubmission: hasFailed,
       });
-      trackEvent(`IdV: ${name} image added`, analyticsPayload);
+
+      trackEvent(
+        name === 'selfie' ? 'idv_selfie_image_file_uploaded' : `IdV: ${name} image added`,
+        analyticsPayload,
+      );
     }
 
     onChangeAndResetError(nextValue, analyticsPayload);
@@ -498,13 +502,32 @@ function AcuantCapture(
     }
   }
 
+  function onSelfieCaptureOpen() {
+    trackEvent('idv_sdk_selfie_image_capture_opened');
+
+    setIsCapturingEnvironment(true);
+  }
+
+  function onSelfieCaptureClosed() {
+    trackEvent('idv_sdk_selfie_image_capture_closed_without_photo');
+
+    setIsCapturingEnvironment(false);
+  }
+
   function onSelfieCaptureSuccess({ image }: { image: string }) {
+    trackEvent('idv_sdk_selfie_image_added', { attempt });
+
     onChangeAndResetError(image);
     onResetFailedCaptureAttempts();
     setIsCapturingEnvironment(false);
   }
 
-  function onSelfieCaptureFailure() {
+  function onSelfieCaptureFailure(error) {
+    trackEvent('idv_sdk_selfie_image_capture_failed', {
+      sdk_error_code: error.code,
+      sdk_error_message: error.message,
+    });
+
     // Internally, Acuant sets a cookie to bail on guided capture if initialization had
     // previously failed for any reason, including declined permission. Since the cookie
     // never expires, and since we want to re-prompt even if the user had previously
@@ -653,8 +676,8 @@ function AcuantCapture(
         <AcuantSelfieCamera
           onImageCaptureSuccess={onSelfieCaptureSuccess}
           onImageCaptureFailure={onSelfieCaptureFailure}
-          onImageCaptureOpen={() => setIsCapturingEnvironment(true)}
-          onImageCaptureClose={() => setIsCapturingEnvironment(false)}
+          onImageCaptureOpen={onSelfieCaptureOpen}
+          onImageCaptureClose={onSelfieCaptureClosed}
         >
           <AcuantSelfieCaptureCanvas
             fullScreenRef={fullScreenRef}

--- a/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
@@ -32,7 +32,7 @@ interface AcuantSelfieCameraContextProps {
   /**
    * Failure callback
    */
-  onImageCaptureFailure: any;
+  onImageCaptureFailure: (error: { code: number; message: string }) => void;
   /**
    * Capture open callback, tells the rest of the page
    * when the fullscreen selfie capture page is open
@@ -100,7 +100,7 @@ function AcuantSelfieCamera({
       onError: (error) => {
         // Error occurred. Camera permission not granted will
         // manifest here with 1 as error code. Unexpected errors will have 2 as error code.
-        onImageCaptureFailure({ error });
+        onImageCaptureFailure(error);
       },
       onPhotoTaken: () => {
         // The photo has been taken and it's showing a preview with a button to accept or retake the image.

--- a/app/models/federated_protocols/oidc.rb
+++ b/app/models/federated_protocols/oidc.rb
@@ -20,6 +20,10 @@ module FederatedProtocols
       OpenidConnectAttributeScoper.new(request.scope).requested_attributes
     end
 
+    def biometric_comparison_required?
+      request.biometric_comparison_required?
+    end
+
     def service_provider
       request.service_provider
     end

--- a/app/models/federated_protocols/saml.rb
+++ b/app/models/federated_protocols/saml.rb
@@ -26,6 +26,10 @@ module FederatedProtocols
       current_service_provider
     end
 
+    def biometric_comparison_required?
+      false
+    end
+
     private
 
     attr_reader :request

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -279,11 +279,6 @@ class Profile < ApplicationRecord
     values.join(':')
   end
 
-  def includes_phone_check?
-    return false if proofing_components.blank?
-    proofing_components['address_check'] == 'lexis_nexis_address'
-  end
-
   def irs_attempts_api_tracker
     @irs_attempts_api_tracker ||= IrsAttemptsApi::Tracker.new
   end

--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -2,7 +2,8 @@ class ServiceProviderRequest
   # WARNING - Modification of these params requires particular care
   # since these objects are serialized to/from Redis and may be present
   # upon deployment
-  attr_accessor :uuid, :issuer, :url, :ial, :aal, :requested_attributes
+  attr_accessor :uuid, :issuer, :url, :ial, :aal, :requested_attributes,
+                :biometric_comparison_required
 
   def initialize(
     uuid: nil,
@@ -11,7 +12,7 @@ class ServiceProviderRequest
     ial: nil,
     aal: nil,
     requested_attributes: [],
-    biometric_comparison_required: false # rubocop:disable Lint/UnusedMethodArgument
+    biometric_comparison_required: false
   )
     @uuid = uuid
     @issuer = issuer
@@ -19,6 +20,7 @@ class ServiceProviderRequest
     @ial = ial
     @aal = aal
     @requested_attributes = requested_attributes&.map(&:to_s)
+    @biometric_comparison_required = biometric_comparison_required
   end
 
   def ==(other)

--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -56,6 +56,7 @@ module Idv
         hybrid_handoff: Idv::HybridHandoffController.step_info,
         link_sent: Idv::LinkSentController.step_info,
         document_capture: Idv::DocumentCaptureController.step_info,
+        ipp_address: Idv::InPerson::AddressController.step_info,
         ssn: Idv::SsnController.step_info,
         ipp_ssn: Idv::InPerson::SsnController.step_info,
         verify_info: Idv::VerifyInfoController.step_info,

--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -66,6 +66,7 @@ module Idv
         otp_verification: Idv::OtpVerificationController.step_info,
         request_letter: Idv::ByMail::RequestLetterController.step_info,
         enter_password: Idv::EnterPasswordController.step_info,
+        personal_key: Idv::PersonalKeyController.step_info,
       }
     end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2729,6 +2729,74 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Integer] attempt number of attempts
+  # User captured and approved of their selfie
+  def idv_sdk_selfie_image_added(attempt:, **extra)
+    track_event(:idv_sdk_selfie_image_added, attempt: attempt, **extra)
+  end
+
+  # User closed the SDK for taking a selfie without submitting a photo
+  def idv_sdk_selfie_image_capture_closed_without_photo(**extra)
+    track_event(:idv_sdk_selfie_image_capture_closed_without_photo, **extra)
+  end
+
+  # @param [Integer] sdk_error_code SDK code for the error encountered
+  # @param [String] sdk_error_message SDK message for the error encountered
+  # User encountered an error with the SDK selfie process
+  # Error code 1: camera permission not granted
+  # Error code 2: unexpected errors
+  def idv_sdk_selfie_image_capture_failed(sdk_error_code:, sdk_error_message:, **extra)
+    track_event(
+      :idv_sdk_selfie_image_capture_failed,
+      sdk_error_code: sdk_error_code,
+      sdk_error_message: sdk_error_message,
+      **extra,
+    )
+  end
+
+  # User opened the SDK to take a selfie
+  def idv_sdk_selfie_image_capture_opened(**extra)
+    track_event(:idv_sdk_selfie_image_capture_opened, **extra)
+  end
+
+  # @param [Integer] attempt number of attempts
+  # @param [Integer] failedImageResubmission
+  # @param [String] fingerprint fingerprint of the image added
+  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param [Integer] height height of image added in pixels
+  # @param [String] mimeType MIME type of image added
+  # @param [Integer] size size of image added in bytes
+  # @param [String] source
+  # @param [Integer] width width of image added in pixels
+  # User uploaded a selfie using the file picker
+  # rubocop:disable Naming/VariableName,Naming/MethodParameterName
+  def idv_selfie_image_file_uploaded(
+    attempt:,
+    failedImageResubmission:,
+    fingerprint:,
+    flow_path:,
+    height:,
+    mimeType:,
+    size:,
+    source:,
+    width:,
+    **_extra
+  )
+    track_event(
+      :idv_selfie_image_file_uploaded,
+      attempt: attempt,
+      failedImageResubmission: failedImageResubmission,
+      fingerprint: fingerprint,
+      flow_path: flow_path,
+      height: height,
+      mimeType: mimeType,
+      size: size,
+      source: source,
+      width: width,
+    )
+  end
+  # rubocop:enable Naming/VariableName,Naming/MethodParameterName
+
   # Tracks when the user visits one of the the session error pages.
   # @param [String] type
   # @param [Integer,nil] attempts_remaining

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -183,7 +183,13 @@ module Idv
     end
 
     def ipp_document_capture_complete?
-      has_pii_from_user_in_flow_session
+      has_pii_from_user_in_flow_session &&
+        user_session['idv/in_person'][:pii_from_user].has_key?(:address1)
+    end
+
+    def ipp_state_id_complete?
+      has_pii_from_user_in_flow_session &&
+        user_session['idv/in_person'][:pii_from_user].has_key?(:identity_doc_address1)
     end
 
     def verify_info_step_complete?

--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -64,7 +64,6 @@ class OutOfBandSessionAccessor
   # @param [#to_s] profile_id
   def put_pii(profile_id:, pii:, expiration: 5.minutes)
     data = {
-      decrypted_pii: pii.to_h.to_json,
       encrypted_profiles: { profile_id.to_s => SessionEncryptor.new.kms_encrypt(pii.to_h.to_json) },
     }
 

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -36,8 +36,6 @@ module Pii
     end
 
     def delete
-      user_session.delete(:decrypted_pii)
-      user_session.delete(:encrypted_pii)
       user_session.delete(:encrypted_profiles)
     end
 

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -64,6 +64,7 @@ class ServiceProviderRequestHandler
       ial: protocol.ial,
       aal: protocol.aal,
       requested_attributes: protocol.requested_attributes,
+      biometric_comparison_required: protocol.biometric_comparison_required?,
       uuid: request_id,
       url: url,
     }

--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -33,7 +33,8 @@ class ServiceProviderRequestProxy
     return obj if obj
     spr = ServiceProviderRequest.new(
       uuid: uuid, issuer: nil, url: nil, ial: nil,
-      aal: nil, requested_attributes: nil
+      aal: nil, requested_attributes: nil,
+      biometric_comparison_required: false
     )
     yield(spr)
     create(
@@ -43,12 +44,15 @@ class ServiceProviderRequestProxy
       ial: spr.ial,
       aal: spr.aal,
       requested_attributes: spr.requested_attributes,
+      biometric_comparison_required: spr.biometric_comparison_required,
     )
   end
 
   def self.create(hash)
     uuid = hash[:uuid]
-    obj = hash.slice(:issuer, :url, :ial, :aal, :requested_attributes)
+    obj = hash.slice(
+      :issuer, :url, :ial, :aal, :requested_attributes, :biometric_comparison_required
+    )
     write(obj, uuid)
     hash_to_spr(obj, uuid)
   end

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -36,6 +36,7 @@ class StoreSpMetadataInSession
       request_url: sp_request.url,
       request_id: sp_request.uuid,
       requested_attributes: sp_request.requested_attributes,
+      biometric_comparison_required: sp_request.biometric_comparison_required,
     }
   end
 

--- a/app/views/accounts/_pii.html.erb
+++ b/app/views/accounts/_pii.html.erb
@@ -68,7 +68,7 @@
     </div>
   </div>
   <% unless locked_for_session %>
-    <div class="grid-row bg-base-lightest padding-x-2 padding-y-1 clearfix fs-12p">
+    <div class="grid-row bg-base-lightest padding-x-2 padding-y-1 fs-12p">
       <div class="grid-col-12">
         <%= image_tag asset_url('lock.svg'), width: 8, height: 10, class: 'margin-right-1' %>
         <%= t('account.security.text') %>

--- a/app/views/accounts/_webauthn_roaming.html.erb
+++ b/app/views/accounts/_webauthn_roaming.html.erb
@@ -17,7 +17,6 @@
         </div>
       <% end %>
     </div>
-    <div class="clearfix"></div>
   <% end %>
 </div>
 

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -1,10 +1,10 @@
 <div id='pw-strength-cntnr' class='display-none' aria-live='polite' aria-atomic='true' data-pw-min-length='<%= Devise.password_length.min %>'>
   <div class="margin-bottom-4">
-    <div class='clearfix margin-x-neg-05 padding-top-05'>
-      <div class='pw-bar'></div>
-      <div class='pw-bar'></div>
-      <div class='pw-bar'></div>
-      <div class='pw-bar'></div>
+    <div class="password-strength__meter">
+      <div class="password-strength__meter-bar"></div>
+      <div class="password-strength__meter-bar"></div>
+      <div class="password-strength__meter-bar"></div>
+      <div class="password-strength__meter-bar"></div>
     </div>
     <div class='h5'>
       <%= t('instructions.password.strength.intro') %>

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -222,14 +222,14 @@ es:
       come_back_later: Carta con una marca de verificación
     legal_statement:
       information_collection: >-
-        Cette collecte d’informations répond aux exigences de l’article 3507 du
-        44 U.S.C., tel que modifié par l’article 2 de la loi de 1995 sur la
-        réduction des tâches administratives. Vous n’avez pas besoin de répondre
-        à ces questions, sauf si nous affichons un numéro de contrôle valide de
-        l’Office of Management and Budget (OMB). Le numéro de contrôle de l’OMB
-        pour cette collecte est 3090-0325. Calculamos que tomará un minuto leer
-        las instrucciones, recopilar los datos y responder las preguntas. Envíe
-        solo comentarios relacionados con nuestro tiempo estimado, incluidas
+        Esta recopilación de información cumple con los requisitos del título 44
+        del U.S.C., § 3507, modificado por la sección 2 de la Ley de Reducción
+        de Trámites de 1995. No es necesario que responda a estas preguntas, a
+        menos que le mostremos un número de control válido de la Oficina de
+        Administración y Presupuesto (OMB). El número de control de la OMB para
+        esta recopilación es 3090-0325. Calculamos que tomará un minuto leer las
+        instrucciones, recopilar los datos y responder las preguntas. Envíe solo
+        comentarios relacionados con nuestro tiempo estimado, incluidas
         sugerencias para reducir esta molestia, o cualquier otro aspecto
         relacionado con esta recopilación de información a: Administración de
         Servicios Generales, División de la Secretaría Reguladora (MVCB), a la

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -230,18 +230,18 @@ fr:
       come_back_later: Lettre avec un crochet
     legal_statement:
       information_collection: >-
-        Esta recopilación de información cumple con los requisitos del título 44
-        del U.S.C., § 3507, modificado por la sección 2 de la Ley de Reducción
-        de Trámites de 1995. No es necesario que responda a estas preguntas, a
-        menos que le mostremos un número de control válido de la Oficina de
-        Administración y Presupuesto (OMB). El número de control de la OMB para
-        esta recopilación es 3090-0325. Nous estimons qu’il faut une minute pour
-        lire les instructions, rassembler les preuves et répondre aux questions.
-        N’envoyez que des commentaires relatifs à notre estimation du temps, y
-        compris des suggestions pour réduire cette charge, ou tout autre aspect
-        de cette collecte d’informations à : General Services Administration,
-        Regulatory Secretariat Division (MVCB), ATTN : Lois Mandell/IC
-        3090-0325, 1800 F Street, NW, Washington, DC 20405.
+        Cette collecte d’informations répond aux exigences de l’article 3507 du
+        44 U.S.C., tel que modifié par l’article 2 de la loi de 1995 sur la
+        réduction des tâches administratives. Vous n’avez pas besoin de répondre
+        à ces questions, sauf si nous affichons un numéro de contrôle valide de
+        l’Office of Management and Budget (OMB). Le numéro de contrôle de l’OMB
+        pour cette collecte est 3090-0325. Nous estimons qu’il faut une minute
+        pour lire les instructions, rassembler les preuves et répondre aux
+        questions. N’envoyez que des commentaires relatifs à notre estimation du
+        temps, y compris des suggestions pour réduire cette charge, ou tout
+        autre aspect de cette collecte d’informations à : General Services
+        Administration, Regulatory Secretariat Division (MVCB), ATTN : Lois
+        Mandell/IC 3090-0325, 1800 F Street, NW, Washington, DC 20405.
     messages:
       activated_html: Votre identité a été vérifiée. Si vous souhaitez modifier votre
         information vérifiée, veuillez %{link_html}.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -66,8 +66,8 @@ workflow to apply formatting automatically on save.
 
 [Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) allow a developer to create and
 organize code which is used just like any other NPM package, but which doesn't require the overhead
-involved in publishing those modules and keeping versions in sync across multiple repositories. The
-IDP uses Yarn workspaces to keep JavaScript code organized, reusable, and to encourage good coding
+involved in publishing those modules and keeping versions in sync across multiple repositories. We
+use Yarn workspaces to keep JavaScript code organized, reusable, and to encourage good coding
 practices in abstractions.
 
 In practice:
@@ -75,21 +75,20 @@ In practice:
 - All folders within `app/javascript/packages` are treated as workspace packages.
 - Each package should have its own `package.json` that includes...
   - ...a `name` starting with `@18f/identity-` and ending with the name of the package folder.
-  - ...a listing of its own dependencies, including to other workspace packages using
-    [`file:` prefix](https://classic.yarnpkg.com/en/docs/cli/add/).
-  - ...[`"private": true`](https://docs.npmjs.com/files/package.json#private) if the workspace
-    package is not intended to be published to NPM.
+  - ...a [`private`](https://docs.npmjs.com/files/package.json#private) value indicating whether the
+    package is intended to be published to NPM.
   - ...a value for the `version` field, since it is required. The value value can be anything, and
     `"1.0.0"` is a good default.
-- Each package should include an `index.js` which serves as the entry-point and public API for the
-  package.
+- The package should be importable by its bare name, either with an `index.ts` or equivalent
+  [package entrypoints](https://nodejs.org/api/packages.html#package-entry-points)
 
-A package might have a corresponding file by the same package name contained within
-`app/javascript/packs` that serves as the integration point between packages and the Rails
-application. This is to encourage packages to be reusable, where the file in `packs` contains any
-logic required to wire the package to the running Rails application. Because Yarn will alias
-workspace packages using symlinks, you can reference a package using the name you assigned using the
-guidelines above for `package.json` `name` field (for example,
+As with any public NPM package, a workspace package should ideally be reusable and avoid direct
+references to page elements. In order to integrate a package within a particular page, you should
+either reference it within [a ViewComponent component's accompanying script](https://github.com/18F/identity-idp/blob/main/app/components/README.md),
+or by creating a new `app/javascript/packs` file to be loaded on a page.
+
+Because Yarn will alias workspace packages using symlinks, you can reference a package using the
+name you assigned using the guidelines above for `package.json` `name` field (for example,
 `import { Button } from '@18f/identity-components';`).
 
 ### Dependencies
@@ -138,9 +137,9 @@ See [`@18f/identity-analytics` package documentation][analytics_package] for cod
 how to track an event in JavaScript.
 
 Any event logged from the frontend must be added to the `ALLOWED_EVENTS` allowlist in [`FrontendLogController`][frontend_log_controller.rb].
-This mapping associates the event name logged from the frontend with the corresponding method from
-[AnalyticsEvents][analytics_events.rb] to be called. All properties will be passed automatically to
-the event from the frontend as long as they are defined in the method argument signature.
+This is an allowlist of events defined in [AnalyticsEvents][analytics_events.rb] which are allowed
+to be logged from the frontend. All properties will be passed automatically to the event from the
+frontend as long as they are defined in the method argument signature.
 
 There may be some situations where you need to append a value known by the server to an event logged
 in the frontend, such as an A/B test bucket descriptor. In these scenarios, you have a few options:

--- a/spec/components/tab_navigation_component_spec.rb
+++ b/spec/components/tab_navigation_component_spec.rb
@@ -35,15 +35,7 @@ RSpec.describe TabNavigationComponent, type: :component do
         post '(:example_param)/second' => 'application#second_create'
       end
 
-      with_request_url(request_path) do
-        vc_test_request.request_method = request_method
-        vc_test_request.path_parameters = Rails.application.routes.recognize_path_with_request(
-          vc_test_request,
-          request_path,
-          {},
-        )
-        example.run
-      end
+      with_request_url(request_path, method: request_method) { example.run }
 
       Rails.application.reload_routes!
     end

--- a/spec/controllers/concerns/idv/ab_test_analytics_concern_spec.rb
+++ b/spec/controllers/concerns/idv/ab_test_analytics_concern_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Idv::AbTestAnalyticsConcern do
     context 'idv_session is available' do
       before do
         sign_in(user)
-        expect(subject).to receive(:idv_session).once.and_return(idv_session)
+        allow(subject).to receive(:idv_session).and_return(idv_session)
       end
 
       it 'includes acuant_sdk_ab_test_analytics_args' do
@@ -46,6 +46,24 @@ RSpec.describe Idv::AbTestAnalyticsConcern do
       it 'includes skip_hybrid_handoff' do
         idv_session.skip_hybrid_handoff = :shh_value
         expect(controller.ab_test_analytics_buckets).to include({ skip_hybrid_handoff: :shh_value })
+      end
+
+      context 'opted_in_to_in_person_proofing value' do
+        before do
+          idv_session.opted_in_to_in_person_proofing = :opt_in_value
+        end
+
+        it 'includes opted_in_to_in_person_proofing when enabled' do
+          allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).
+            and_return(true)
+          expect(controller.ab_test_analytics_buckets).
+            to include({ opted_in_to_in_person_proofing: :opt_in_value })
+        end
+
+        it 'does not include opted_in_to_in_person_proofing when disabled' do
+          expect(controller.ab_test_analytics_buckets).
+            not_to include({ opted_in_to_in_person_proofing: :opt_in_value })
+        end
       end
     end
 

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Idv::AgreementController do
+  include FlowPolicyHelper
+
   let(:user) { create(:user) }
 
   let(:ab_test_args) do
@@ -9,8 +11,8 @@ RSpec.describe Idv::AgreementController do
 
   before do
     stub_sign_in(user)
+    stub_up_to(:welcome, idv_session: subject.idv_session)
     stub_analytics
-    subject.idv_session.welcome_visited = true
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
@@ -79,7 +81,7 @@ RSpec.describe Idv::AgreementController do
 
     context 'agreement already visited' do
       it 'does not redirect to hybrid_handoff' do
-        subject.idv_session.idv_consent_given = true
+        stub_up_to(:agreement, idv_session: subject.idv_session)
 
         get :show
 
@@ -88,10 +90,7 @@ RSpec.describe Idv::AgreementController do
 
       context 'and verify info already completed' do
         before do
-          subject.idv_session.flow_path = 'standard'
-          subject.idv_session.pii_from_doc = { first_name: 'Susan' }
-          subject.idv_session.ssn = '123-45-6789'
-          subject.idv_session.resolution_successful = true
+          stub_up_to(:verify_info, idv_session: subject.idv_session)
         end
 
         it 'renders the show template' do

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Idv::DocumentCaptureController do
+  include FlowPolicyHelper
+
   let(:document_capture_session_requested_at) { Time.zone.now }
 
   let!(:document_capture_session) do
@@ -20,8 +22,8 @@ RSpec.describe Idv::DocumentCaptureController do
 
   before do
     stub_sign_in(user)
+    stub_up_to(:hybrid_handoff, idv_session: subject.idv_session)
     stub_analytics
-    subject.idv_session.flow_path = 'standard'
     subject.idv_session.document_capture_session_uuid = document_capture_session_uuid
 
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
@@ -102,8 +104,6 @@ RSpec.describe Idv::DocumentCaptureController do
 
     context 'hybrid handoff step is not complete' do
       it 'redirects to hybrid handoff' do
-        subject.idv_session.welcome_visited = true
-        subject.idv_session.idv_consent_given = true
         subject.idv_session.flow_path = nil
 
         get :show
@@ -114,12 +114,7 @@ RSpec.describe Idv::DocumentCaptureController do
 
     context 'verify info step is complete' do
       it 'renders show' do
-        subject.idv_session.welcome_visited = true
-        subject.idv_session.idv_consent_given = true
-        subject.idv_session.flow_path = 'standard'
-        subject.idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT
-        subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
-        subject.idv_session.resolution_successful = true
+        stub_up_to(:verify_info, idv_session: subject.idv_session)
 
         get :show
 

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Idv::HybridHandoffController do
+  include FlowPolicyHelper
+
   let(:user) { create(:user) }
 
   let(:ab_test_args) do
@@ -9,9 +11,9 @@ RSpec.describe Idv::HybridHandoffController do
 
   before do
     stub_sign_in(user)
+    stub_up_to(:agreement, idv_session: subject.idv_session)
     stub_analytics
     stub_attempts_tracker
-    subject.idv_session.idv_consent_given = true
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
@@ -71,7 +73,6 @@ RSpec.describe Idv::HybridHandoffController do
 
     context 'agreement step is not complete' do
       before do
-        subject.idv_session.welcome_visited = true
         subject.idv_session.idv_consent_given = nil
       end
 
@@ -138,7 +139,7 @@ RSpec.describe Idv::HybridHandoffController do
 
       context 'user has already completed verify info' do
         before do
-          subject.idv_session.mark_verify_info_step_complete!
+          stub_up_to(:verify_info, idv_session: subject.idv_session)
         end
 
         it 'does set redo_document_capture to true in idv_session' do

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
           threatmetrix_review_status: review_status,
         }
       end
+
       it 'logs proofing results with analytics_id' do
         allow(controller).to receive(:load_async_state).and_return(async_state)
         allow(async_state).to receive(:done?).and_return(true)
@@ -114,6 +115,117 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
           'IdV: doc auth verify proofing results',
           hash_including(**analytics_args, success: true),
         )
+      end
+    end
+
+    context 'tracks costs' do
+      let(:review_status) { 'pass' }
+      let(:async_state) { instance_double(ProofingSessionAsyncResult) }
+      let(:adjudicated_result) do
+        {
+          context: {
+            stages: {
+              threatmetrix: {
+                transaction_id: 1,
+              },
+              resolution: {
+                transaction_id: 'resolution-mock-transaction-id-123',
+                vendor_name: 'ResolutionMock',
+              },
+              residential_address: {
+                transaction_id: 'resolution-mock-transaction-id-123',
+                vendor_name: 'ResolutionMock',
+              },
+              state_id: {
+                transaction_id: 'state-id-mock-transaction-id-456',
+                vendor_name: 'StateIdMock',
+              },
+            },
+          },
+        }
+      end
+
+      before do
+        allow(controller).to receive(:load_async_state).and_return(async_state)
+        allow(async_state).to receive(:done?).and_return(true)
+      end
+
+      context 'when same address as id is true and in aamva jurisdiction' do
+        it 'adds costs to database' do
+          allow(async_state).to receive(:result).and_return(adjudicated_result)
+
+          get :show
+
+          lexis_nexis_costs = SpCost.where(cost_type: 'lexis_nexis_resolution')
+          expect(lexis_nexis_costs.count).to eq(1)
+
+          aamva_costs = SpCost.where(cost_type: 'aamva')
+          expect(aamva_costs.count).to eq(1)
+
+          threatmetrix_costs = SpCost.where(cost_type: 'threatmetrix')
+          expect(threatmetrix_costs.count).to eq(1)
+        end
+      end
+
+      context 'when same address as id is true and not in aamva jurisdiction' do
+        it 'adds costs to database' do
+          adjudicated_result[:context][:stages][:state_id][:vendor_name] = 'UnsupportedJurisdiction'
+          allow(async_state).to receive(:result).and_return(adjudicated_result)
+
+          get :show
+
+          lexis_nexis_costs = SpCost.where(cost_type: 'lexis_nexis_resolution')
+          expect(lexis_nexis_costs.count).to eq(1)
+
+          aamva_costs = SpCost.where(cost_type: 'aamva')
+          expect(aamva_costs.count).to eq(0)
+
+          threatmetrix_costs = SpCost.where(cost_type: 'threatmetrix')
+          expect(threatmetrix_costs.count).to eq(1)
+        end
+      end
+
+      context 'when same address as id is false and in aamva jurisdiction' do
+        let(:pii_from_user) do
+          { same_address_as_id: 'false' }
+        end
+
+        it 'adds costs to database' do
+          allow(async_state).to receive(:result).and_return(adjudicated_result)
+
+          get :show
+
+          lexis_nexis_costs = SpCost.where(cost_type: 'lexis_nexis_resolution')
+          expect(lexis_nexis_costs.count).to eq(2)
+
+          aamva_costs = SpCost.where(cost_type: 'aamva')
+          expect(aamva_costs.count).to eq(1)
+
+          threatmetrix_costs = SpCost.where(cost_type: 'threatmetrix')
+          expect(threatmetrix_costs.count).to eq(1)
+        end
+      end
+
+      context 'when same address as id is false and not in aamva jurisdiction' do
+        let(:pii_from_user) do
+          { same_address_as_id: 'false' }
+        end
+
+        it 'adds costs to database' do
+          adjudicated_result[:context][:stages][:state_id][:vendor_name] = 'UnsupportedJurisdiction'
+          allow(async_state).to receive(:result).and_return(adjudicated_result)
+
+          get :show
+
+          lexis_nexis_costs = SpCost.where(cost_type: 'lexis_nexis_resolution')
+          expect(lexis_nexis_costs.count).to eq(2)
+
+          aamva_costs = SpCost.where(cost_type: 'aamva')
+          expect(aamva_costs.count).to eq(0)
+
+          threatmetrix_costs = SpCost.where(cost_type: 'threatmetrix')
+          expect(threatmetrix_costs.count).to eq(1)
+        end
       end
     end
   end

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -21,11 +21,15 @@ RSpec.describe Idv::OtpVerificationController do
       sent_at: phone_confirmation_otp_sent_at,
     )
   end
+  let(:ab_test_args) do
+    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
+  end
 
   before do
     stub_analytics
     stub_attempts_tracker
     allow(@analytics).to receive(:track_event)
+    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
 
     sign_in(user)
     stub_verify_steps_one_and_two(user)
@@ -177,6 +181,7 @@ RSpec.describe Idv::OtpVerificationController do
         second_factor_attempts_count: 0,
         second_factor_locked_at: nil,
         proofing_components: nil,
+        **ab_test_args,
       }
 
       expect(@analytics).to have_received(:track_event).with(

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Idv::SessionsController do
         expect(controller.user_session['idv/in_person']).to be_blank
       end
 
-      it 'clears the decrypted_pii session' do
+      it 'clears the encrypted_profiles session' do
         expect(controller.user_session[:encrypted_profiles]).to be_blank
       end
     end

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Idv::SsnController do
+  include FlowPolicyHelper
+
   let(:ssn) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn] }
 
   let(:user) { create(:user) }
@@ -11,8 +13,7 @@ RSpec.describe Idv::SsnController do
 
   before do
     stub_sign_in(user)
-    subject.idv_session.flow_path = 'standard'
-    subject.idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT.dup
+    stub_up_to(:document_capture, idv_session: subject.idv_session)
     stub_analytics
     stub_attempts_tracker
     allow(@analytics).to receive(:track_event)
@@ -218,9 +219,6 @@ RSpec.describe Idv::SsnController do
 
     context 'when pii_from_doc is not present' do
       before do
-        subject.idv_session.welcome_visited = true
-        subject.idv_session.idv_consent_given = true
-        subject.idv_session.flow_path = 'standard'
         subject.idv_session.pii_from_doc = nil
       end
 

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Idv::VerifyInfoController do
+  include FlowPolicyHelper
+
   let(:user) { create(:user) }
   let(:analytics_hash) do
     {
@@ -17,13 +19,9 @@ RSpec.describe Idv::VerifyInfoController do
 
   before do
     stub_sign_in(user)
+    stub_up_to(:ssn, idv_session: subject.idv_session)
     stub_analytics
     stub_attempts_tracker
-    subject.idv_session.welcome_visited = true
-    subject.idv_session.idv_consent_given = true
-    subject.idv_session.flow_path = 'standard'
-    subject.idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT.dup
-    subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
@@ -101,10 +99,7 @@ RSpec.describe Idv::VerifyInfoController do
 
     context 'when the user has already verified their info' do
       it 'renders show' do
-        subject.idv_session.resolution_successful = true
-        subject.idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT
-        subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
-        subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN
+        stub_up_to(:verify_info, idv_session: subject.idv_session)
 
         get :show
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -995,7 +995,16 @@ RSpec.describe OpenidConnect::AuthorizationController do
           request_id: sp_request_id,
           request_url: request.original_url,
           requested_attributes: %w[],
+          biometric_comparison_required: false,
         )
+      end
+
+      it 'sets biometric_comparison_required to true if biometric comparison is required' do
+        params[:biometric_comparison_required] = true
+
+        action
+
+        expect(session[:sp][:biometric_comparison_required]).to eq(true)
       end
     end
   end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1127,6 +1127,7 @@ RSpec.describe SamlIdpController do
           request_url: @stored_request_url.gsub('authpost', 'auth'),
           request_id: sp_request_id,
           requested_attributes: ['email'],
+          biometric_comparison_required: false,
         )
       end
 
@@ -1158,6 +1159,7 @@ RSpec.describe SamlIdpController do
           request_url: @saml_request.request.original_url.gsub('authpost', 'auth'),
           request_id: sp_request_id,
           requested_attributes: ['email'],
+          biometric_comparison_required: false,
         )
       end
 

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe ServiceProviderSession do
     ServiceProviderSession.new(
       sp: sp,
       view_context: view_context,
-      sp_session: {},
+      sp_session: sp_session,
       service_provider_request: service_provider_request,
     )
   end
   let(:sp) { build_stubbed(:service_provider) }
+  let(:sp_session) { {} }
   let(:service_provider_request) { ServiceProviderRequest.new }
   let(:sp_name) { subject.sp_name }
   let(:sp_create_link) { '/sign_up/enter_email' }
@@ -174,6 +175,46 @@ RSpec.describe ServiceProviderSession do
         )
 
         expect(subject.sp_logo_url).to be_kind_of(String)
+      end
+    end
+  end
+
+  describe '#selfie_required' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+        and_return(selfie_capture_enabled)
+    end
+
+    context 'doc_auth_selfie_capture_enabled is true' do
+      let(:selfie_capture_enabled) { true }
+
+      it 'returns true when sp biometric_comparison_required is true' do
+        sp_session[:biometric_comparison_required] = true
+        expect(subject.selfie_required?).to eq(true)
+      end
+
+      it 'returns true when sp biometric_comparison_required is truthy' do
+        sp_session[:biometric_comparison_required] = 1
+        expect(subject.selfie_required?).to eq(true)
+      end
+
+      it 'returns false when sp biometric_comparison_required is false' do
+        sp_session[:biometric_comparison_required] = false
+        expect(subject.selfie_required?).to eq(false)
+      end
+
+      it 'returns false when sp biometric_comparison_required is nil' do
+        sp_session[:biometric_comparison_required] = nil
+        expect(subject.selfie_required?).to eq(false)
+      end
+    end
+
+    context 'doc_auth_selfie_capture_enabled is false' do
+      let(:selfie_capture_enabled) { false }
+
+      it 'returns false' do
+        sp_session[:biometric_comparison_required] = true
+        expect(subject.selfie_required?).to eq(false)
       end
     end
   end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: phone confirmation otp submitted' => {
-        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
@@ -221,7 +221,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: phone confirmation otp submitted' => {
-        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
@@ -431,7 +431,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' },
       },
       'IdV: phone confirmation otp submitted' => {
-        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
@@ -542,7 +542,7 @@ RSpec.feature 'Analytics Regression', js: true do
     end
   end
 
-  context 'Happy hybrid path' do
+  context 'Happy hybrid path', allow_browser_log: true do
     before do
       allow(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
         @sms_link = config[:link]
@@ -633,7 +633,7 @@ RSpec.feature 'Analytics Regression', js: true do
       complete_enter_password_step(user)
     end
 
-    it 'records all of the events' do
+    it 'records all of the events', allow_browser_log: true do
       gpo_path_events.each do |event, attributes|
         expect(fake_analytics).to have_logged_event(event, attributes)
       end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -547,7 +547,7 @@ RSpec.feature 'Analytics Regression', js: true do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: phone confirmation otp submitted' => {
-        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -465,6 +465,117 @@ RSpec.feature 'Analytics Regression', js: true do
       'IdV: user clicked sp link on ready to verify page' => {},
     }
   end
+
+  let(:happy_selfie_path_events) do
+    {
+      'IdV: intro visited' => {},
+      'IdV: doc auth welcome visited' => {
+        step: 'welcome', analytics_id: 'Doc Auth', irs_reproofing: false, skip_hybrid_handoff: nil, lexisnexis_instant_verify_workflow_ab_test_bucket: :default
+      },
+      'IdV: doc auth welcome submitted' => {
+        step: 'welcome', analytics_id: 'Doc Auth', irs_reproofing: false, skip_hybrid_handoff: nil, lexisnexis_instant_verify_workflow_ab_test_bucket: :default
+      },
+      'IdV: doc auth agreement visited' => {
+        step: 'agreement', analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default
+      },
+      'IdV: consent checkbox toggled' => {
+        checked: true,
+      },
+      'IdV: doc auth agreement submitted' => {
+        success: true, errors: {}, step: 'agreement', analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default
+      },
+      'IdV: doc auth hybrid handoff visited' => {
+        step: 'hybrid_handoff', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false
+      },
+      'IdV: doc auth hybrid handoff submitted' => {
+        success: true, errors: {}, destination: :document_capture, flow_path: 'standard', step: 'hybrid_handoff', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false
+      },
+      'IdV: doc auth document_capture visited' => {
+        flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, skip_hybrid_handoff: nil, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false
+      },
+      'Frontend: IdV: front image added' => {
+        width: 284, height: 38, mimeType: 'image/png', source: 'upload', size: 3694, attempt: 1, flow_path: 'standard', acuant_sdk_upgrade_a_b_testing_enabled: 'false', use_alternate_sdk: anything, acuant_version: anything, acuantCaptureMode: nil, fingerprint: anything, failedImageResubmission: boolean, documentType: nil, dpi: nil, glare: nil, glareScoreThreshold: nil, isAssessedAsBlurry: nil, isAssessedAsGlare: nil, isAssessedAsUnsupported: nil, moire: nil, sharpness: nil, sharpnessScoreThreshold: nil, assessment: nil
+      },
+      'Frontend: IdV: back image added' => {
+        width: 284, height: 38, mimeType: 'image/png', source: 'upload', size: 3694, attempt: 1, flow_path: 'standard', acuant_sdk_upgrade_a_b_testing_enabled: 'false', use_alternate_sdk: anything, acuant_version: anything, acuantCaptureMode: nil, fingerprint: anything, failedImageResubmission: boolean, documentType: nil, dpi: nil, glare: nil, glareScoreThreshold: nil, isAssessedAsBlurry: nil, isAssessedAsGlare: nil, isAssessedAsUnsupported: nil, moire: nil, sharpness: nil, sharpnessScoreThreshold: nil, assessment: nil
+      },
+      'IdV: doc auth image upload form submitted' => {
+        success: true, errors: {}, attempts: 1, remaining_attempts: 3, user_id: user.uuid, flow_path: 'standard', front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String)
+      },
+      'IdV: doc auth image upload vendor pii validation' => {
+        success: true, errors: {}, user_id: user.uuid, attempts: 1, remaining_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), classification_info: {}
+      },
+      'IdV: doc auth document_capture submitted' => {
+        success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, skip_hybrid_handoff: nil, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false
+      },
+      :idv_selfie_image_file_uploaded => {
+        attempt: 1, failedImageResubmission: nil, fingerprint: 'aIzxkX_iMtoxFOURZr55qkshs53emQKUOr7VfTf6G1Q', flow_path: 'standard', height: 38, mimeType: 'image/png', size: 3694, source: 'upload', width: 284
+      },
+      'IdV: doc auth ssn visited' => {
+        flow_path: 'standard', step: 'ssn', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false
+      },
+      'IdV: doc auth ssn submitted' => {
+        success: true, errors: {}, flow_path: 'standard', step: 'ssn', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false
+      },
+      'IdV: doc auth verify visited' => {
+        flow_path: 'standard', step: 'verify', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false
+      },
+      'IdV: doc auth verify submitted' => {
+        flow_path: 'standard', step: 'verify', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false
+      },
+      'IdV: doc auth verify proofing results' => {
+        success: true, errors: {}, flow_path: 'standard', address_edited: false, address_line2_present: false, analytics_id: 'Doc Auth', ssn_is_unique: true, step: 'verify', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, irs_reproofing: false, skip_hybrid_handoff: nil,
+        proofing_results: { exception: nil, timed_out: false, threatmetrix_review_status: 'pass', context: { device_profiling_adjudication_reason: 'device_profiling_result_pass', resolution_adjudication_reason: 'pass_resolution_and_state_id', should_proof_state_id: true, stages: { resolution: { success: true, errors: {}, exception: nil, timed_out: false, transaction_id: 'resolution-mock-transaction-id-123', reference: 'aaa-bbb-ccc', can_pass_with_additional_verification: false, attributes_requiring_additional_verification: [], vendor_name: 'ResolutionMock', vendor_workflow: nil }, residential_address: { attributes_requiring_additional_verification: [], can_pass_with_additional_verification: false, errors: {}, exception: nil, reference: '', success: true, timed_out: false, transaction_id: '', vendor_name: 'ResidentialAddressNotRequired', vendor_workflow: nil }, state_id: { success: true, errors: {}, exception: nil, mva_exception: nil, timed_out: false, transaction_id: 'state-id-mock-transaction-id-456', vendor_name: 'StateIdMock', verified_attributes: [], state: 'MT', state_id_jurisdiction: 'ND', state_id_number: '#############' }, threatmetrix: threatmetrix_response } } }
+      },
+      'IdV: phone of record visited' => {
+        acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
+      },
+      'IdV: phone confirmation form' => {
+        success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, otp_delivery_preference: 'sms',
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
+      },
+      'IdV: phone confirmation vendor' => {
+        success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, hybrid_handoff_phone_used: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+      },
+      'IdV: phone confirmation otp sent' => {
+        success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202', adapter: :test, errors: {}, phone_fingerprint: anything, rate_limit_exceeded: false, telephony_response: anything,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+      },
+      'IdV: phone confirmation otp visited' => {
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+      },
+      'IdV: phone confirmation otp submitted' => {
+        success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+      },
+      :idv_enter_password_visited => {
+        address_verification_method: 'phone', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+      },
+      :idv_enter_password_submitted => {
+        success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+      },
+      'IdV: final resolution' => {
+        success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+      },
+      'IdV: personal key visited' => {
+        address_verification_method: 'phone', in_person_verification_pending: false,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+      },
+      'IdV: personal key acknowledgment toggled' => {
+        checked: true,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+      },
+      'IdV: personal key submitted' => {
+        address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, in_person_verification_pending: false, deactivation_reason: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+      },
+    }
+  end
   # rubocop:enable Layout/LineLength
   # rubocop:enable Layout/MultilineHashKeyLineBreaks
 
@@ -727,6 +838,63 @@ RSpec.feature 'Analytics Regression', js: true do
         raise err if wait - Time.zone.now < frequency
         sleep frequency
         next
+      end
+    end
+  end
+
+  context 'Happy selfie path' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+
+      mobile_device = Browser.new(mobile_user_agent)
+      allow(BrowserCache).to receive(:parse).and_return(mobile_device)
+
+      perform_in_browser(:mobile) do
+        sign_in_and_2fa_user(user)
+        visit_idp_from_sp_with_ial2(:oidc)
+        complete_doc_auth_steps_before_document_capture_step
+
+        attach_images
+        attach_selfie
+        submit_images
+
+        click_idv_continue
+        visit idv_ssn_url
+        complete_ssn_step
+        complete_verify_step
+        fill_out_phone_form_ok('202-555-1212')
+        verify_phone_otp
+        complete_enter_password_step(user)
+        acknowledge_and_confirm_personal_key
+      end
+    end
+
+    it 'records all of the events' do
+      happy_selfie_path_events.each do |event, attributes|
+        expect(fake_analytics).to have_logged_event(event, attributes)
+      end
+    end
+
+    context 'proofing_device_profiling disabled' do
+      let(:proofing_device_profiling) { :disabled }
+      let(:threatmetrix) { false }
+      let(:threatmetrix_response) do
+        { client: 'tmx_disabled',
+          success: true,
+          errors: {},
+          exception: nil,
+          timed_out: false,
+          transaction_id: nil,
+          review_status: 'pass',
+          response_body: { error: 'TMx response body was empty' } }
+      end
+
+      it 'records all of the events' do
+        aggregate_failures 'analytics events' do
+          happy_selfie_path_events.each do |event, attributes|
+            expect(fake_analytics).to have_logged_event(event, attributes)
+          end
+        end
       end
     end
   end

--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'how to verify step' do
+RSpec.feature 'how to verify step', js: true do
   include IdvHelper
   include DocAuthHelper
 
@@ -14,7 +14,7 @@ RSpec.feature 'how to verify step' do
       complete_agreement_step
     end
 
-    it 'skips when disabled and redirects to hybird handoff)' do
+    it 'skips when disabled and redirects to hybrid handoff' do
       expect(page).to have_current_path(idv_hybrid_handoff_url)
     end
   end
@@ -68,8 +68,149 @@ RSpec.feature 'how to verify step' do
       expect(page).to have_current_path(idv_how_to_verify_path)
       expect(page).to have_content(t('errors.doc_auth.how_to_verify_form'))
 
-      complete_how_to_verify_step
+      complete_how_to_verify_step(remote: true)
       expect(page).to have_current_path(idv_hybrid_handoff_url)
+    end
+  end
+
+  describe 'navigating to How To Verify from Agreement page in 50/50 state' do
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { true }
+      allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) {
+                                       initial_opt_in_enabled
+                                     }
+
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_agreement_step
+      complete_agreement_step
+    end
+
+    context 'opt in false at start but true during navigation' do
+      let(:initial_opt_in_enabled) { false }
+
+      it 'should not be bounced back from Hybrid Handoff to How to Verify' do
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
+        page.refresh
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+      end
+    end
+
+    context 'opt in true at start but false during navigation' do
+      let(:initial_opt_in_enabled) { true }
+
+      it 'should be redirected to Hybrid Handoff page when opt in is false' do
+        expect(page).to have_current_path(idv_how_to_verify_url)
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { false }
+        page.refresh
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+      end
+    end
+
+    context 'Going back from Hybrid Handoff with opt in disabled midstream' do
+      let(:initial_opt_in_enabled) { true }
+      before do
+        complete_how_to_verify_step(remote: true)
+      end
+
+      it 'should not be bounced back to How to Verify with opt in disabled midstream' do
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { false }
+        page.go_back
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+        page.go_back
+        expect(page).to have_current_path(idv_agreement_url)
+      end
+    end
+
+    context 'Going back from Hybrid Handoff with opt in enabled midstream' do
+      let(:initial_opt_in_enabled) { false }
+
+      it 'should go back to the Agreement step from Hybrid Handoff with opt in toggled midstream' do
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
+        page.go_back
+        expect(page).to have_current_path(idv_agreement_url)
+      end
+    end
+
+    context 'Going back from Hybrid Handoff with opt in enabled the whole time' do
+      let(:initial_opt_in_enabled) { true }
+      before do
+        complete_how_to_verify_step(remote: true)
+      end
+
+      it 'should be bounced back to How to Verify' do
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+        page.go_back
+        expect(page).to have_current_path(idv_how_to_verify_url)
+      end
+    end
+
+    context 'Going back from Hybrid Handoff with opt in disabled the whole time' do
+      let(:initial_opt_in_enabled) { false }
+
+      it 'should be not be bounced back to How to Verify' do
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+        page.go_back
+        expect(page).to have_current_path(idv_agreement_url)
+      end
+    end
+
+    context 'Going back from Document Capture with opt in disabled midstream' do
+      let(:initial_opt_in_enabled) { true }
+      before do
+        complete_how_to_verify_step(remote: false)
+      end
+
+      it 'should not be bounced back to How to Verify with opt in disabled midstream' do
+        expect(page).to have_current_path(idv_document_capture_path)
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { false }
+        page.go_back
+        expect(page).to have_current_path(idv_document_capture_path)
+        page.go_back
+        expect(page).to have_current_path(idv_agreement_url)
+      end
+    end
+
+    context 'Going back from Document Capture with opt in enabled midstream' do
+      let(:initial_opt_in_enabled) { false }
+      before do
+        complete_hybrid_handoff_step
+      end
+
+      it 'should go to Hybrid Handoff from Document Capture with opt in toggled midstream' do
+        expect(page).to have_current_path(idv_document_capture_path)
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
+        page.go_back
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+      end
+    end
+
+    context 'Going back from Document Capture with opt in enabled the whole time' do
+      let(:initial_opt_in_enabled) { true }
+      before do
+        complete_how_to_verify_step(remote: false)
+      end
+
+      it 'should be bounced back to How to Verify' do
+        expect(page).to have_current_path(idv_document_capture_path)
+        page.go_back
+        expect(page).to have_current_path(idv_how_to_verify_url)
+      end
+    end
+
+    context 'Going back from Document Capture with opt in disabled the whole time' do
+      let(:initial_opt_in_enabled) { false }
+      before do
+        complete_hybrid_handoff_step
+      end
+
+      it 'should be not be bounced back to how to verify' do
+        expect(page).to have_current_path(idv_document_capture_path)
+        page.go_back
+        expect(page).to have_current_path(idv_hybrid_handoff_url)
+      end
     end
   end
 end

--- a/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
+++ b/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.feature 'Password recovery via personal key for a GPO-verified user' do
+  include IdvStepHelper
+
+  let(:email) { 'cool_beagle@example.org' }
+  let(:password) { '!1a Z@6s' * 16 } # default password from user factory
+  let(:new_password) { 'some really awesome new password' }
+
+  let(:user) { create(:user, :fully_registered, email: email, password: password) }
+
+  before do
+    allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
+  end
+
+  scenario 'lets them reactivate their profile with their personal key', email: true, js: true do
+    complete_idv_steps_with_gpo_before_confirmation_step(user)
+    click_on t('doc_auth.buttons.continue')
+
+    gpo_code = page.get_rack_session_key('last_gpo_confirmation_code')
+    page.go_back # get_rack_session_key navigates away.
+
+    click_on t('links.sign_out')
+
+    fill_in_credentials_and_submit(email, password)
+    fill_in I18n.t('components.one_time_code_input.label'), with: last_phone_otp
+    click_submit_default
+
+    fill_in 'gpo_verify_form_otp', with: gpo_code
+    click_on t('idv.gpo.form.submit')
+
+    personal_key = scrape_personal_key
+    check t('forms.personal_key.required_checkbox')
+    click_continue
+
+    click_on t('links.sign_out')
+
+    trigger_reset_password_and_click_email_link(user.email)
+    reset_password_and_sign_back_in(user, new_password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+
+    click_on t('links.account.reactivate.with_key')
+
+    expect(current_path).to eq verify_personal_key_path
+    fill_in 'personal_key', with: personal_key
+    click_continue
+
+    expect(current_path).to eq verify_password_path
+    fill_in 'Password', with: new_password
+    click_continue
+
+    expect(page).to have_content t('idv.messages.personal_key')
+    expect(page).to have_content t('headings.account.verified_account')
+  end
+end

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe Idv::DocPiiForm do
       state: Faker::Address.state_abbr,
     }
   end
-  let(:non_string_zipcode_pii) do
+  let(:invalid_zipcode_pii) do
     {
       first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
       dob: valid_dob,
       address1: Faker::Address.street_address,
       state: Faker::Address.state_abbr,
-      zipcode: 12345,
+      zipcode: 123456,
       state_id_jurisdiction: 'AL',
     }
   end
@@ -174,7 +174,7 @@ RSpec.describe Idv::DocPiiForm do
     end
 
     context 'when there is a non-string zipcode' do
-      let(:pii) { non_string_zipcode_pii }
+      let(:pii) { invalid_zipcode_pii }
 
       it 'returns a single generic pii error' do
         result = subject.submit

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
       code_challenge: code_challenge,
       code_challenge_method: code_challenge_method,
       verified_within: verified_within,
+      biometric_comparison_required: biometric_comparison_required,
     )
   end
 
@@ -33,6 +34,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
   let(:code_challenge) { nil }
   let(:code_challenge_method) { nil }
   let(:verified_within) { nil }
+  let(:biometric_comparison_required) { nil }
 
   describe '#submit' do
     subject(:result) { form.submit }

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -8,6 +8,15 @@ ALLOWED_INTERPOLATION_MISMATCH_KEYS = [
   'time.formats.event_timestamp_js',
 ]
 
+# A set of patterns which are expected to only occur within specific locales. This is an imperfect
+# solution based on current content, intended to help prevent accidents when adding new translated
+# content. If you are having issues with new content, it would be reasonable to remove or modify
+# the parts of the pattern which are valid for the content you're adding.
+LOCALE_SPECIFIC_CONTENT = {
+  fr: / [nd]’|à/i,
+  es: /¿|ó/,
+}.freeze
+
 module I18n
   module Tasks
     class BaseTask
@@ -155,17 +164,19 @@ RSpec.describe 'I18n' do
       i18n_file = full_path.sub("#{root_dir}/", '')
 
       describe i18n_file do
+        let(:flattened_yaml_data) { flatten_hash(YAML.load_file(full_path)) }
+
         # Transliteration includes special characters by definition, so it could fail checks below
         if !full_path.match?(%(/config/locales/transliterate/))
           it 'has only lower_snake_case keys' do
-            keys = flatten_hash(YAML.load_file(full_path)).keys
+            keys = flattened_yaml_data.keys
 
             bad_keys = keys.reject { |key| key =~ /^[a-z0-9_.]+$/ }
             expect(bad_keys).to be_empty
           end
 
           it 'has only has XML-safe identifiers (keys start with a letter)' do
-            keys = flatten_hash(YAML.load_file(full_path)).keys
+            keys = flattened_yaml_data.keys
 
             bad_keys = keys.select { |key| key.split('.').any? { |part| part =~ /^[0-9]/ } }
 
@@ -174,7 +185,7 @@ RSpec.describe 'I18n' do
         end
 
         it 'has correctly-formatted interpolation values' do
-          bad_keys = flatten_hash(YAML.load_file(full_path)).select do |_key, value|
+          bad_keys = flattened_yaml_data.select do |_key, value|
             next unless value.is_a?(String)
 
             interpolation_names = value.scan(/%\{([^}]+)\}/).flatten
@@ -186,7 +197,7 @@ RSpec.describe 'I18n' do
         end
 
         it 'does not contain any translations expecting legacy fallback behavior' do
-          bad_keys = flatten_hash(YAML.load_file(full_path)).select do |_key, value|
+          bad_keys = flattened_yaml_data.select do |_key, value|
             value.include?('NOT TRANSLATED YET')
           end
 
@@ -194,11 +205,21 @@ RSpec.describe 'I18n' do
         end
 
         it 'does not contain any translations that hardcode APP_NAME' do
-          bad_keys = flatten_hash(YAML.load_file(full_path)).select do |_key, value|
+          bad_keys = flattened_yaml_data.select do |_key, value|
             value.include?(APP_NAME)
           end
 
           expect(bad_keys).to be_empty
+        end
+
+        it 'does not contain content from another language' do
+          flattened_yaml_data.each do |key, value|
+            locale = key.split('.', 2).first.to_sym
+            other_locales = LOCALE_SPECIFIC_CONTENT.keys - [locale]
+            expect(value).not_to match(
+              Regexp.union(*LOCALE_SPECIFIC_CONTENT.slice(*other_locales).values),
+            )
+          end
         end
       end
     end

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -9,7 +9,7 @@ import {
   AnalyticsContext,
   FailedCaptureAttemptsContextProvider,
 } from '@18f/identity-document-capture';
-import { createEvent, waitFor } from '@testing-library/dom';
+import { createEvent, waitFor, screen } from '@testing-library/dom';
 
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import { I18n } from '@18f/identity-i18n';
@@ -1114,21 +1114,116 @@ describe('document-capture/components/acuant-capture', () => {
   });
 
   context('mobile selfie', () => {
-    it('renders the selfie capture loading div in acuant-capture', async () => {
+    const trackEvent = sinon.stub();
+
+    beforeEach(async () => {
+      // Set up the components so that everything is as it would actually be -except- the AcuantSDK
+      // The AcuantSDK isn't possible to run in test, so the initialize({...}) call below mocks it.
+      render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AnalyticsContext.Provider value={{ trackEvent }}>
+            <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+              <AcuantCapture label="Image" name="selfie" isReady />
+            </AcuantContextProvider>
+          </AnalyticsContext.Provider>
+        </DeviceContext.Provider>,
+      );
+
+      // Simulate the user clicking on the box that usually opens full screen selfie capture.
+      // This isn't strictly necessary for the logging tests, but doing this makes the calls to
+      // trackEvent appear in the actual order we'd expect when using the Acuant SDK.
+      await userEvent.click(screen.getByLabelText('Image'));
+    });
+
+    it('renders the selfie capture loading div in acuant-capture', () => {
       // What we want to test is that the selfie version of the FileInput appears
       // when the name="selfie". The only difference between the selfie and document
       // versions is what happens when you click the FileInput, so this test clicks
       // the file input, then checks that the full screen div opened
-      const { getByRole, getByLabelText } = render(
-        <DeviceContext.Provider value={{ isMobile: true }}>
-          <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
-            <AcuantCapture label="Image" name="selfie" isReady />
-          </AcuantContextProvider>
-        </DeviceContext.Provider>,
-      );
+      expect(screen.getByRole('dialog')).to.be.ok();
+    });
 
-      await userEvent.click(getByLabelText('Image'));
-      expect(getByRole('dialog')).to.be.ok();
+    it('calls trackEvent from onSelfieCaptureOpen', () => {
+      // In real use the `start` method opens the Acuant SDK full screen selfie capture window.
+      // Because we can't do that in test (AcuantSDK does not allow), this doesn't attempt to load
+      // the SDK. Instead, it simply calls the callback that happens when a photo is captured.
+      // This allows us to test everything about that callback -except- the Acuant SDK parts.
+      initialize({
+        selfieStart: sinon.stub().callsFake((callbacks) => {
+          callbacks.onOpened();
+        }),
+      });
+
+      expect(trackEvent).to.be.calledWith('IdV: selfie image clicked');
+      expect(trackEvent).to.be.calledWith('IdV: Acuant SDK loaded');
+
+      expect(trackEvent).to.have.been.calledWith('idv_sdk_selfie_image_capture_opened');
+    });
+
+    it('calls trackEvent from onSelfieCaptureClosed', () => {
+      // In real use the `start` method opens the Acuant SDK full screen selfie capture window.
+      // Because we can't do that in test (AcuantSDK does not allow), this doesn't attempt to load
+      // the SDK. Instead, it simply calls the callback that happens when a photo is captured.
+      // This allows us to test everything about that callback -except- the Acuant SDK parts.
+      initialize({
+        selfieStart: sinon.stub().callsFake((callbacks) => {
+          callbacks.onClosed();
+        }),
+      });
+
+      expect(trackEvent).to.be.calledWith('IdV: selfie image clicked');
+      expect(trackEvent).to.be.calledWith('IdV: Acuant SDK loaded');
+
+      expect(trackEvent).to.have.been.calledWith(
+        'idv_sdk_selfie_image_capture_closed_without_photo',
+      );
+    });
+
+    it('calls trackEvent from onSelfieCaptureSuccess', () => {
+      // In real use the `start` method opens the Acuant SDK full screen selfie capture window.
+      // Because we can't do that in test (AcuantSDK does not allow), this doesn't attempt to load
+      // the SDK. Instead, it simply calls the callback that happens when a photo is captured.
+      // This allows us to test everything about that callback -except- the Acuant SDK parts.
+      initialize({
+        selfieStart: sinon.stub().callsFake((callbacks) => {
+          callbacks.onCaptured();
+        }),
+      });
+
+      expect(trackEvent).to.be.calledWith('IdV: selfie image clicked');
+      expect(trackEvent).to.be.calledWith('IdV: Acuant SDK loaded');
+
+      expect(trackEvent).to.have.been.calledWith(
+        'idv_sdk_selfie_image_added',
+        sinon.match({
+          attempt: sinon.match.number,
+        }),
+      );
+    });
+
+    it('calls trackEvent from onSelfieCaptureFailure', () => {
+      const errorHash = { code: 1, message: 'Camera permission not granted' };
+
+      // In real use the `start` method opens the Acuant SDK full screen selfie capture window.
+      // Because we can't do that in test (AcuantSDK does not allow), this doesn't attempt to load
+      // the SDK. Instead, it simply calls the callback that happens when a photo is captured.
+      // This allows us to test everything about that callback -except- the Acuant SDK parts.
+      initialize({
+        selfieStart: sinon.stub().callsFake((callbacks) => {
+          callbacks.onError(errorHash);
+        }),
+      });
+
+      expect(trackEvent).to.be.calledWith('IdV: selfie image clicked');
+      expect(trackEvent).to.be.calledWith('IdV: Acuant SDK loaded');
+
+      expect(trackEvent).to.have.been.calledWith(
+        'idv_sdk_selfie_image_capture_failed',
+        sinon.match({
+          sdk_error_code: sinon.match.number,
+          sdk_error_message: sinon.match.string,
+        }),
+      );
     });
   });
 

--- a/spec/javascript/support/document-capture.jsx
+++ b/spec/javascript/support/document-capture.jsx
@@ -70,6 +70,8 @@ export function useAcuant() {
       isCameraSupported = true,
       start = sinon.stub(),
       end = sinon.stub(),
+      selfieStart = sinon.stub(),
+      selfieEnd = sinon.stub(),
       triggerCapture = sinon.stub(),
     } = {}) {
       window.AcuantJavascriptWebSdk = {
@@ -92,7 +94,7 @@ export function useAcuant() {
         }),
         end,
       };
-      window.AcuantPassiveLiveness = { start: sinon.stub(), end: sinon.stub() };
+      window.AcuantPassiveLiveness = { start: selfieStart, end: selfieEnd };
       window.loadAcuantSdk = () => {};
       const sdkScript = document.querySelector('[data-acuant-sdk]');
       sdkScript.onload();

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -34,19 +34,6 @@ RSpec.describe SessionEncryptor do
       )
     end
 
-    it 'encrypts decrypted_pii bundle without automatically decrypting' do
-      session = { 'warden.user.user.session' => {
-        'decrypted_pii' => { 'ssn' => '666-66-6666' }.to_json,
-      } }
-
-      ciphertext = subject.dump(session)
-
-      result = subject.load(ciphertext)
-
-      expect(result.fetch('warden.user.user.session')['decrypted_pii']).to eq nil
-      expect(result.fetch('warden.user.user.session')['encrypted_pii']).to_not eq nil
-    end
-
     it 'KMS encrypts/decrypts doc auth elements of the session' do
       session = { 'warden.user.user.session' => {
         'idv' => { 'ssn' => '666-66-6666' },

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -46,26 +46,6 @@ RSpec.describe Profile do
     end
   end
 
-  describe '#includes_phone_check?' do
-    it 'returns true if the address_check component is lexis_nexis_address' do
-      profile = create(:profile, proofing_components: { address_check: 'lexis_nexis_address' })
-
-      expect(profile.includes_phone_check?).to eq(true)
-    end
-
-    it 'returns false if the address_check componet is gpo_letter' do
-      profile = create(:profile, proofing_components: { address_check: 'gpo_letter' })
-
-      expect(profile.includes_phone_check?).to eq(false)
-    end
-
-    it 'returns false if proofing_components is blank' do
-      profile = create(:profile, proofing_components: '')
-
-      expect(profile.includes_phone_check?).to eq(false)
-    end
-  end
-
   describe '#in_person_verification_pending?' do
     it 'returns true if the in_person_verification_pending_at is present' do
       profile = create(

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe 'Idv::FlowPolicy' do
 
           expect(subject.info_for_latest_step.key).to eq(:enter_password)
           expect(subject.controller_allowed?(controller: Idv::EnterPasswordController)).to be
-          # expect(subject.controller_allowed?(controller: Idv::PersonalKeyController)).not_to be
+          expect(subject.controller_allowed?(controller: Idv::PersonalKeyController)).not_to be
         end
       end
 
@@ -304,7 +304,31 @@ RSpec.describe 'Idv::FlowPolicy' do
 
           expect(subject.info_for_latest_step.key).to eq(:enter_password)
           expect(subject.controller_allowed?(controller: Idv::EnterPasswordController)).to be
-          # expect(subject.controller_allowed?(controller: Idv::PersonalKeyController)).not_to be
+          expect(subject.controller_allowed?(controller: Idv::PersonalKeyController)).not_to be
+        end
+      end
+    end
+
+    context 'preconditions for personal_key are present' do
+      let(:password) { 'sekrit phrase' }
+      context 'user has a verify by mail pending profile' do
+        it 'returns personal_key' do
+          stub_up_to(:request_letter, idv_session: idv_session)
+          idv_session.gpo_code_verified = true
+          idv_session.create_profile_from_applicant_with_password('password')
+
+          expect(subject.info_for_latest_step.key).to eq(:personal_key)
+          expect(subject.controller_allowed?(controller: Idv::PersonalKeyController)).to be
+        end
+      end
+
+      context 'user has a newly activated profile' do
+        it 'returns personal_key' do
+          stub_up_to(:otp_verification, idv_session: idv_session)
+          idv_session.create_profile_from_applicant_with_password('password')
+
+          expect(subject.info_for_latest_step.key).to eq(:personal_key)
+          expect(subject.controller_allowed?(controller: Idv::PersonalKeyController)).to be
         end
       end
     end

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -222,7 +222,9 @@ RSpec.describe 'Idv::FlowPolicy' do
     context 'preconditions for in_person ssn are present' do
       before do
         stub_up_to(:hybrid_handoff, idv_session: idv_session)
-        idv_session.send(:user_session)['idv/in_person'] = { pii_from_user: { pii: 'value' } }
+        idv_session.send(:user_session)['idv/in_person'] = {
+          pii_from_user: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup,
+        }
       end
 
       it 'returns ipp_ssn' do

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe StoreSpMetadataInSession do
           sp_request.ial = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
           sp_request.url = 'http://issuer.gov'
           sp_request.requested_attributes = %w[email]
+          sp_request.biometric_comparison_required = false
         end
         instance = StoreSpMetadataInSession.new(session: app_session, request_id: request_id)
 
@@ -34,6 +35,7 @@ RSpec.describe StoreSpMetadataInSession do
           request_url: 'http://issuer.gov',
           request_id: request_id,
           requested_attributes: %w[email],
+          biometric_comparison_required: false,
         }
 
         instance.call
@@ -51,6 +53,7 @@ RSpec.describe StoreSpMetadataInSession do
           sp_request.aal = Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
           sp_request.url = 'http://issuer.gov'
           sp_request.requested_attributes = %w[email]
+          sp_request.biometric_comparison_required = false
         end
         instance = StoreSpMetadataInSession.new(session: app_session, request_id: request_id)
 
@@ -65,6 +68,7 @@ RSpec.describe StoreSpMetadataInSession do
           request_url: 'http://issuer.gov',
           request_id: request_id,
           requested_attributes: %w[email],
+          biometric_comparison_required: false,
         }
 
         instance.call
@@ -82,6 +86,7 @@ RSpec.describe StoreSpMetadataInSession do
           sp_request.aal = Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF
           sp_request.url = 'http://issuer.gov'
           sp_request.requested_attributes = %w[email]
+          sp_request.biometric_comparison_required = false
         end
         instance = StoreSpMetadataInSession.new(session: app_session, request_id: request_id)
 
@@ -96,6 +101,40 @@ RSpec.describe StoreSpMetadataInSession do
           request_url: 'http://issuer.gov',
           request_id: request_id,
           requested_attributes: %w[email],
+          biometric_comparison_required: false,
+        }
+
+        instance.call
+        expect(app_session[:sp]).to eq app_session_hash
+      end
+    end
+
+    context 'when biometric comparison is requested' do
+      it 'sets the session[:sp] hash' do
+        app_session = {}
+        request_id = SecureRandom.uuid
+        ServiceProviderRequestProxy.find_or_create_by(uuid: request_id) do |sp_request|
+          sp_request.issuer = 'issuer'
+          sp_request.ial = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+          sp_request.aal = Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
+          sp_request.url = 'http://issuer.gov'
+          sp_request.requested_attributes = %w[email]
+          sp_request.biometric_comparison_required = true
+        end
+        instance = StoreSpMetadataInSession.new(session: app_session, request_id: request_id)
+
+        app_session_hash = {
+          issuer: 'issuer',
+          aal_level_requested: 3,
+          piv_cac_requested: false,
+          phishing_resistant_requested: true,
+          ial: 2,
+          ial2: true,
+          ialmax: false,
+          request_url: 'http://issuer.gov',
+          request_id: request_id,
+          requested_attributes: %w[email],
+          biometric_comparison_required: true,
         }
 
         instance.call

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -35,6 +35,7 @@ module FlowPolicyHelper
       idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.dup
     when :phone
       idv_session.mark_phone_step_started!
+      idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.dup
     when :otp_verification
       idv_session.mark_phone_step_complete!
     when :request_letter


### PR DESCRIPTION
## User-Facing Improvements
- Password Strength: Use consistent colors for password strength feedback ([#9811](https://github.com/18F/identity-idp/pull/9811))

## Bug Fixes
- Identity Verification: Fix incorrect information collection disclosure content for French and Spanish ([#9801](https://github.com/18F/identity-idp/pull/9801))

## Internal
- Code Quality: Simplify to remove unnecessary page markup ([#9812](https://github.com/18F/identity-idp/pull/9812))
- Dependencies: Update brakeman and view_component ([#9813](https://github.com/18F/identity-idp/pull/9813))
- Doc Auth: Fix analytics_spec failures ([#9816](https://github.com/18F/identity-idp/pull/9816))
- Doc Auth: Add front end logging for selfie capture ([#9795](https://github.com/18F/identity-idp/pull/9795))
- Doc Auth: Validate zip code having zip+4 format. ([#9802](https://github.com/18F/identity-idp/pull/9802))
- Documentation: Improve accuracy of frontend architecture documentation ([#9814](https://github.com/18F/identity-idp/pull/9814))
- Feature Specs: Added a feature spec for an issue in LG-11549 ([#9791](https://github.com/18F/identity-idp/pull/9791))
- Identity verification: Integrate PersonalKeyController with FlowPolicy ([#9776](https://github.com/18F/identity-idp/pull/9776))
- In-Person Proofing: Update specs for Opt In IPP to check for navigation issues during 50 50 state ([#9798](https://github.com/18F/identity-idp/pull/9798))
- Verify info concern: Update cost tracking for ipp ([#9753](https://github.com/18F/identity-idp/pull/9753))