### PR TITLE
LG-11839 Don't delete proofing_component on password reset for profiles not yet activated

### DIFF
--- a/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
+++ b/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
@@ -31,6 +31,8 @@ module EventDisavowal
     end
 
     def mark_profile_inactive
+      return if user.active_profile.blank?
+
       user.active_profile&.deactivate(:password_reset)
       Funnel::DocAuth::ResetSteps.call(@user.id)
       user.proofing_component&.destroy

--- a/spec/forms/event_disavowal/password_reset_from_disavowal_form_spec.rb
+++ b/spec/forms/event_disavowal/password_reset_from_disavowal_form_spec.rb
@@ -26,4 +26,26 @@ RSpec.describe EventDisavowal::PasswordResetFromDisavowalForm, type: :model do
       expect(user.reload.valid_password?(new_password)).to eq(false)
     end
   end
+
+  context 'user has an active profile' do
+    let(:user) { create(:user, :proofed) }
+
+    it 'destroys the proofing component' do
+      ProofingComponent.create(user_id: user.id, document_check: 'acuant')
+
+      subject.submit(password: new_password)
+
+      expect(user.reload.proofing_component).to be_nil
+    end
+  end
+
+  context 'user does not have an active profile' do
+    it 'does not destroy the proofing component' do
+      ProofingComponent.create(user_id: user.id, document_check: 'acuant')
+
+      subject.submit(password: new_password)
+
+      expect(user.reload.proofing_component).to_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-11839](https://cm-jira.usa.gov/browse/LG-11839)



## 🛠 Summary of changes

If a user goes through IdV and choses to reset their password at the enter password step and then disavow that password reset, their proofing components gets deleted. We want to keep those proofing components until a user completed IdV so that they get minted with the profile. This PR fixes that. This should not matter because if a user resets their password they have to go through IdV again, but this eliminates an edge case.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV until the enter code step.
- [ ] At the enter password step, reset your password.
- [ ] Once you reset your password disavow that reset. (Click the email link in the email that says If you did not make this change reset your password)
- [ ] Open rails console and confirm that user still has proofing components.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
