### PR TITLE
Turn off DocumentCapture exit survey in development

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -382,8 +382,8 @@ development:
   database_worker_jobs_username: ''
   database_worker_jobs_host: ''
   database_worker_jobs_password: ''
-  doc_auth_exit_question_section_enabled: true
-  doc_auth_not_ready_section_enabled: true
+  doc_auth_exit_question_section_enabled: false
+  doc_auth_not_ready_section_enabled: false
   doc_auth_selfie_capture_enabled: false
   doc_auth_vendor: 'mock'
   doc_auth_vendor_randomize: false


### PR DESCRIPTION
It has been off in prod for a while, so let's make development match for everyone. If someone needs it on locally, they can turn it on in their application.yml.