### PR TITLE
Jmax/lg 11942 add a selfie check performed prop to the doc auth response

### DIFF
--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -15,16 +15,17 @@ module DocAuth
       pii_from_doc: {},
       attention_with_barcode: false,
       doc_type_supported: true,
-      selfie_check_performed: false
+      # This is a stub to get data paths in place. Replace this as soon as possible.
+      selfie_check_performed: IdentityConfig.store.doc_auth_selfie_capture_enabled
     )
       @success = success
-      @selfie_check_performed = selfie_check_performed
       @errors = errors.to_h
       @exception = exception
       @extra = extra
       @pii_from_doc = pii_from_doc
       @attention_with_barcode = attention_with_barcode
       @doc_type_supported = doc_type_supported
+      @selfie_check_performed = selfie_check_performed
     end
 
     def merge(other)
@@ -36,7 +37,6 @@ module DocAuth
         pii_from_doc: pii_from_doc.merge(other.pii_from_doc),
         attention_with_barcode: attention_with_barcode? || other.attention_with_barcode?,
         doc_type_supported: doc_type_supported? || other.doc_type_supported?,
-        selfie_check_performed: selfie_check_performed? || other.selfie_check_performed?,
       )
     end
 

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -1,6 +1,6 @@
 module DocAuth
   class Response
-    attr_reader :errors, :exception, :extra, :pii_from_doc, :doc_type_supported, :selfie_check_performed
+    attr_reader :errors, :exception, :extra, :pii_from_doc, :doc_type_supported
 
     ID_TYPE_SLUGS = {
       'Identification Card' => 'state_id_card',
@@ -18,13 +18,13 @@ module DocAuth
       selfie_check_performed: false
     )
       @success = success
+      @selfie_check_performed = selfie_check_performed
       @errors = errors.to_h
       @exception = exception
       @extra = extra
       @pii_from_doc = pii_from_doc
       @attention_with_barcode = attention_with_barcode
       @doc_type_supported = doc_type_supported
-      @selfie_check_performed = selfie_check_performed
     end
 
     def merge(other)
@@ -36,6 +36,7 @@ module DocAuth
         pii_from_doc: pii_from_doc.merge(other.pii_from_doc),
         attention_with_barcode: attention_with_barcode? || other.attention_with_barcode?,
         doc_type_supported: doc_type_supported? || other.doc_type_supported?,
+        selfie_check_performed: selfie_check_performed? || other.selfie_check_performed?,
       )
     end
 

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -15,8 +15,7 @@ module DocAuth
       pii_from_doc: {},
       attention_with_barcode: false,
       doc_type_supported: true,
-      # This is a stub to get data paths in place. Replace this as soon as possible.
-      selfie_check_performed: IdentityConfig.store.doc_auth_selfie_capture_enabled
+      selfie_check_performed: false
     )
       @success = success
       @errors = errors.to_h

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -15,6 +15,7 @@ module DocAuth
       pii_from_doc: {},
       attention_with_barcode: false,
       doc_type_supported: true,
+      # This is a stub to get data paths in place. Replace this as soon as possible.
       selfie_check_performed: false
     )
       @success = success

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -1,6 +1,6 @@
 module DocAuth
   class Response
-    attr_reader :errors, :exception, :extra, :pii_from_doc, :doc_type_supported
+    attr_reader :errors, :exception, :extra, :pii_from_doc, :doc_type_supported, :selfie_check_performed
 
     ID_TYPE_SLUGS = {
       'Identification Card' => 'state_id_card',
@@ -14,7 +14,8 @@ module DocAuth
       extra: {},
       pii_from_doc: {},
       attention_with_barcode: false,
-      doc_type_supported: true
+      doc_type_supported: true,
+      selfie_check_performed: false
     )
       @success = success
       @errors = errors.to_h
@@ -23,6 +24,7 @@ module DocAuth
       @pii_from_doc = pii_from_doc
       @attention_with_barcode = attention_with_barcode
       @doc_type_supported = doc_type_supported
+      @selfie_check_performed = selfie_check_performed
     end
 
     def merge(other)
@@ -70,6 +72,10 @@ module DocAuth
     def network_error?
       return false unless @errors
       return !!@errors&.with_indifferent_access&.dig(:network)
+    end
+
+    def selfie_check_performed?
+      @selfie_check_performed
     end
   end
 end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DocAuth::Response do
   let(:exception) { nil }
   let(:pii_from_doc) { {} }
   let(:attention_with_barcode) { false }
-  let(:selfie_check_performed) { false }
+
   subject(:response) do
     described_class.new(
       success: success,
@@ -14,7 +14,6 @@ RSpec.describe DocAuth::Response do
       exception: exception,
       pii_from_doc: pii_from_doc,
       attention_with_barcode: attention_with_barcode,
-      selfie_check_performed: selfie_check_performed,
     )
   end
 
@@ -24,7 +23,7 @@ RSpec.describe DocAuth::Response do
     let(:other_exception) { nil }
     let(:other_pii_from_doc) { {} }
     let(:other_attention_with_barcode) { false }
-    let(:other_selfie_check_performed) { false }
+
     let(:other) do
       described_class.new(
         success: other_success,
@@ -32,7 +31,6 @@ RSpec.describe DocAuth::Response do
         exception: other_exception,
         pii_from_doc: other_pii_from_doc,
         attention_with_barcode: other_attention_with_barcode,
-        selfie_check_performed: other_selfie_check_performed,
       )
     end
     let!(:merged) { response.merge(other) }
@@ -161,9 +159,30 @@ RSpec.describe DocAuth::Response do
     end
   end
 
-  describe 'selfie_check_performed' do
-    it 'returns false by default' do
-      expect(response.selfie_check_performed?).to eq(false)
+  # LG-11942
+  # The following is for the stubbed selfie check value. Replace with
+  # the real tests when selfie implementation gets to that point.
+  describe 'selfie_check_performed?' do
+    before do
+      allow(IdentityConfig.store).
+        to receive(:doc_auth_selfie_capture_enabled).
+        and_return(selfies_enabled)
+    end
+
+    context 'when selfie checks are enabled' do
+      let(:selfies_enabled) { true }
+        
+      it 'returns true by default' do
+        expect(response.selfie_check_performed?).to be(true)
+      end
+    end
+
+    context 'when selfie checks are disabled' do
+      let(:selfies_enabled) { false }
+
+      it 'returns false' do
+        expect(response.selfie_check_performed?).to be(false)
+      end
     end
   end
 end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe DocAuth::Response do
     context 'when selfie checks are disabled' do
       let(:selfies_enabled) { false }
 
-      it 'returns false' do
+      it 'returns false by default' do
         expect(response.selfie_check_performed?).to be(false)
       end
     end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe DocAuth::Response do
         exception: other_exception,
         pii_from_doc: other_pii_from_doc,
         attention_with_barcode: other_attention_with_barcode,
+        selfie_check_performed: other_selfie_check_performed,
       )
     end
     let!(:merged) { response.merge(other) }

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe DocAuth::Response do
   let(:exception) { nil }
   let(:pii_from_doc) { {} }
   let(:attention_with_barcode) { false }
+  let(:selfie_check_performed) { false }
   subject(:response) do
     described_class.new(
       success: success,
@@ -13,6 +14,7 @@ RSpec.describe DocAuth::Response do
       exception: exception,
       pii_from_doc: pii_from_doc,
       attention_with_barcode: attention_with_barcode,
+      selfie_check_performed: selfie_check_performed,
     )
   end
 
@@ -22,6 +24,7 @@ RSpec.describe DocAuth::Response do
     let(:other_exception) { nil }
     let(:other_pii_from_doc) { {} }
     let(:other_attention_with_barcode) { false }
+    let(:other_selfie_check_performed) { false }
     let(:other) do
       described_class.new(
         success: other_success,
@@ -154,6 +157,12 @@ RSpec.describe DocAuth::Response do
   describe 'doc_type_supported?' do
     it 'returns true by default' do
       expect(response.doc_type_supported?).to eq(true)
+    end
+  end
+
+  describe 'selfie_check_performed' do
+    it 'returns false by default' do
+      expect(response.selfie_check_performed?).to eq(false)
     end
   end
 end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe DocAuth::Response do
 
     context 'when selfie checks are enabled' do
       let(:selfies_enabled) { true }
-        
+
       it 'returns true by default' do
         expect(response.selfie_check_performed?).to be(true)
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11942](https://cm-jira.usa.gov/browse/LG-11942)

## 🛠 Summary of changes

Added `selfie_check_performed?` method and property to `DocAuth::Response` object.

As a temporary measure, we default this value to `true` if selfie checks are enabled, and `false` if they are not. 

This is stub code, and needs to be replaced with real values from the IdV vendors, with the specs updated accordingly, before selfies are enabled in production.

## 📜 Testing Plan

- [ ] In your `application.yml`, set `doc_auth_selfie_capture_enabled` to `true`
- [ ] Start a Rails console, and create a `DocAuth::Response` object. Do not specify a value for the `selfie_check_performed` parameter.
- [ ] Verify that your new response object returns `true` from `selfie_check_performed?`
- [ ] Exit the console and set `doc_auth_selfie_capture_enabled` to `false`
- [ ] Start a new console, and create a `DocAuth::Response` object. Do not specify a value for the `selfie_check_performed` parameter.
- [ ] Verify that your new response object returns `false` from `selfie_check_performed?`

## 👀 Screenshots

<details>
<summary>Selfie check disabled:</summary>

```
Loading development environment (Rails 7.1.2)
[1] pry(main)> response = DocAuth::Response.new(success: true)
=> #<DocAuth::Response:0x000000010d738fd0
 @attention_with_barcode=false,
 @doc_type_supported=true,
 @errors={},
 @exception=nil,
 @extra={},
 @pii_from_doc={},
 @selfie_check_performed=false,
 @success=true>
[9] pry(main)> response.selfie_check_performed?
=> false
[16] pry(main)> quit

Process rails finished

```

</details>

<details>
<summary>Selfie check enabled:</summary>

```
Loading development environment (Rails 7.1.2)
[1] pry(main)> response = DocAuth::Response.new(success: true)
=> #<DocAuth::Response:0x0000000111626198
 @attention_with_barcode=false,
 @doc_type_supported=true,
 @errors={},
 @exception=nil,
 @extra={},
 @pii_from_doc={},
 @selfie_check_performed=true,
 @success=true>
[17] pry(main)> response.selfie_check_performed?
=> true
[21] pry(main)> quit

Process rails finished
```

</details>
