### PR TITLE
LG-11352: Remove Double Address Verification from job arguments

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -19,7 +19,7 @@ class ResolutionProofingJob < ApplicationJob
     encrypted_arguments:,
     trace_id:,
     should_proof_state_id:,
-    ipp_enrollment_in_progress: false,
+    ipp_enrollment_in_progress:,
     user_id: nil,
     threatmetrix_session_id: nil,
     request_ip: nil,

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -19,7 +19,6 @@ class ResolutionProofingJob < ApplicationJob
     encrypted_arguments:,
     trace_id:,
     should_proof_state_id:,
-    double_address_verification: false,
     ipp_enrollment_in_progress: false,
     user_id: nil,
     threatmetrix_session_id: nil,
@@ -46,7 +45,6 @@ class ResolutionProofingJob < ApplicationJob
       threatmetrix_session_id: threatmetrix_session_id,
       request_ip: request_ip,
       should_proof_state_id: should_proof_state_id,
-      double_address_verification: double_address_verification,
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       instant_verify_ab_test_discriminator: instant_verify_ab_test_discriminator,
     )
@@ -75,7 +73,6 @@ class ResolutionProofingJob < ApplicationJob
     threatmetrix_session_id:,
     request_ip:,
     should_proof_state_id:,
-    double_address_verification:,
     ipp_enrollment_in_progress:,
     instant_verify_ab_test_discriminator:
   )
@@ -85,7 +82,6 @@ class ResolutionProofingJob < ApplicationJob
       threatmetrix_session_id: threatmetrix_session_id,
       request_ip: request_ip,
       should_proof_state_id: should_proof_state_id,
-      double_address_verification: double_address_verification,
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       timer: timer,
     )

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -28,7 +28,7 @@ module Idv
         user_id: user_id,
         threatmetrix_session_id: threatmetrix_session_id,
         request_ip: request_ip,
-        double_address_verification: ipp_enrollment_in_progress,
+        ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       }
 
       if IdentityConfig.store.ruby_workers_idv_enabled

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -11,7 +11,7 @@ module Idv
       user_id:,
       threatmetrix_session_id:,
       request_ip:,
-      ipp_enrollment_in_progress: false
+      ipp_enrollment_in_progress:
     )
       document_capture_session.create_proofing_session
 

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -29,7 +29,7 @@ module Proofing
         should_proof_state_id:,
         threatmetrix_session_id:,
         timer:,
-        user_email:,
+        user_email:
       )
         device_profiling_result = proof_with_threatmetrix_if_needed(
           applicant_pii: applicant_pii,
@@ -107,7 +107,7 @@ module Proofing
       def proof_residential_address_if_needed(
         applicant_pii:,
         timer:,
-        ipp_enrollment_in_progress:,
+        ipp_enrollment_in_progress:
       )
         return residential_address_unnecessary_result unless ipp_enrollment_in_progress
 
@@ -130,7 +130,7 @@ module Proofing
 
       def proof_id_address_with_lexis_nexis_if_needed(applicant_pii:, timer:,
                                                       residential_instant_verify_result:,
-                                                      ipp_enrollment_in_progress:,)
+                                                      ipp_enrollment_in_progress:)
         if applicant_pii[:same_address_as_id] == 'true'
           return residential_instant_verify_result
         end
@@ -143,7 +143,7 @@ module Proofing
 
       def should_proof_state_id_with_aamva?(ipp_enrollment_in_progress:, same_address_as_id:,
                                             should_proof_state_id:, instant_verify_result:,
-                                            residential_instant_verify_result:,
+                                            residential_instant_verify_result:
                                             )
         return false unless should_proof_state_id
         # If the user is in double-address-verification and they have changed their address then

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -13,7 +13,7 @@ module Proofing
       end
 
       # @param [Hash] applicant_pii keys are symbols and values are strings, confidential user info
-      # @param [Boolean] ipp_enrollment_in_progress flag is used in place of DAV flag because DAV is 
+      # @param [Boolean] ipp_enrollment_in_progress flag is used in place of DAV flag because DAV is
       #   now always true
       # @param [String] request_ip IP address for request
       # @param [Boolean] should_proof_state_id based on state id jurisdiction, indicates if
@@ -47,12 +47,11 @@ module Proofing
 
         applicant_pii_transformed = applicant_pii.clone
         applicant_pii_transformed = with_state_id_address(applicant_pii_transformed)
-      
+
         instant_verify_result = proof_id_address_with_lexis_nexis_if_needed(
           applicant_pii: applicant_pii_transformed,
           timer: timer,
           residential_instant_verify_result: residential_instant_verify_result,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
         )
 
         state_id_result = proof_id_with_aamva_if_needed(
@@ -129,8 +128,7 @@ module Proofing
       end
 
       def proof_id_address_with_lexis_nexis_if_needed(applicant_pii:, timer:,
-                                                      residential_instant_verify_result:,
-                                                      ipp_enrollment_in_progress:)
+                                                      residential_instant_verify_result:)
         if applicant_pii[:same_address_as_id] == 'true'
           return residential_instant_verify_result
         end
@@ -143,8 +141,7 @@ module Proofing
 
       def should_proof_state_id_with_aamva?(ipp_enrollment_in_progress:, same_address_as_id:,
                                             should_proof_state_id:, instant_verify_result:,
-                                            residential_instant_verify_result:
-                                            )
+                                            residential_instant_verify_result:)
         return false unless should_proof_state_id
         # If the user is in double-address-verification and they have changed their address then
         # they are not eligible for get-to-yes

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -13,7 +13,7 @@ module Proofing
       end
 
       # @param [Hash] applicant_pii keys are symbols and values are strings, confidential user info
-      # @param [Boolean] ipp_enrollment_in_progress flag remains true and is used in place of DAV flag because DAV is 
+      # @param [Boolean] ipp_enrollment_in_progress flag is used in place of DAV flag because DAV is 
       #   now always true
       # @param [String] request_ip IP address for request
       # @param [Boolean] should_proof_state_id based on state id jurisdiction, indicates if
@@ -130,7 +130,7 @@ module Proofing
 
       def proof_id_address_with_lexis_nexis_if_needed(applicant_pii:, timer:,
                                                       residential_instant_verify_result:,
-                                                      ipp_enrollment_in_progress:)
+                                                      ipp_enrollment_in_progress:,)
         if applicant_pii[:same_address_as_id] == 'true'
           return residential_instant_verify_result
         end

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -2,8 +2,8 @@ module Proofing
   module Resolution
     class ResultAdjudicator
       attr_reader :resolution_result, :state_id_result, :device_profiling_result,
-                  :double_address_verification, :ipp_enrollment_in_progress,
-                  :residential_resolution_result, :same_address_as_id
+                  :ipp_enrollment_in_progress, :residential_resolution_result, 
+                  :same_address_as_id
 
       def initialize(
         resolution_result:, # InstantVerify
@@ -13,13 +13,11 @@ module Proofing
         ipp_enrollment_in_progress:,
         device_profiling_result:,
         same_address_as_id:,
-        double_address_verification: false
       )
         @resolution_result = resolution_result
         @state_id_result = state_id_result
         @should_proof_state_id = should_proof_state_id
         @ipp_enrollment_in_progress = ipp_enrollment_in_progress
-        @double_address_verification = double_address_verification
         @device_profiling_result = device_profiling_result
         @residential_resolution_result = residential_resolution_result
         @same_address_as_id = same_address_as_id # this is a string, "true" or "false"
@@ -90,7 +88,7 @@ module Proofing
 
       def resolution_result_and_reason
         if !residential_resolution_result.success? && same_address_as_id == 'false' &&
-           (ipp_enrollment_in_progress || double_address_verification)
+           ipp_enrollment_in_progress
           [false, :fail_resolution_skip_state_id]
         elsif resolution_result.success? && state_id_result.success?
           [true, :pass_resolution_and_state_id]

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -2,7 +2,7 @@ module Proofing
   module Resolution
     class ResultAdjudicator
       attr_reader :resolution_result, :state_id_result, :device_profiling_result,
-                  :ipp_enrollment_in_progress, :residential_resolution_result, 
+                  :ipp_enrollment_in_progress, :residential_resolution_result,
                   :same_address_as_id
 
       def initialize(

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -12,7 +12,7 @@ module Proofing
         should_proof_state_id:,
         ipp_enrollment_in_progress:,
         device_profiling_result:,
-        same_address_as_id:,
+        same_address_as_id:
       )
         @resolution_result = resolution_result
         @state_id_result = state_id_result

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:threatmetrix_session_id) { SecureRandom.uuid }
   let(:proofing_device_profiling) { :enabled }
   let(:lexisnexis_threatmetrix_mock_enabled) { false }
+  let(:ipp_enrollment_in_progress) { true }
 
   before do
     allow(IdentityConfig.store).to receive(:proofing_device_profiling).
@@ -40,6 +41,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
         user_id: user.id,
         threatmetrix_session_id: threatmetrix_session_id,
         request_ip: request_ip,
+        ipp_enrollment_in_progress: ipp_enrollment_in_progress
       )
     end
 
@@ -118,6 +120,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
           user_id: user.id,
           threatmetrix_session_id: threatmetrix_session_id,
           request_ip: request_ip,
+          ipp_enrollment_in_progress: ipp_enrollment_in_progress
         )
       end
       it 'stores a successful result' do
@@ -411,7 +414,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
           user_id: user.id,
           threatmetrix_session_id: threatmetrix_session_id,
           request_ip: request_ip,
-          ipp_enrollment_in_progress: true,
+          ipp_enrollment_in_progress: ipp_enrollment_in_progress
         )
       end
 

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
         user_id: user.id,
         threatmetrix_session_id: threatmetrix_session_id,
         request_ip: request_ip,
-        ipp_enrollment_in_progress: ipp_enrollment_in_progress
+        ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       )
     end
 
@@ -120,7 +120,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
           user_id: user.id,
           threatmetrix_session_id: threatmetrix_session_id,
           request_ip: request_ip,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress
+          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
         )
       end
       it 'stores a successful result' do
@@ -414,7 +414,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
           user_id: user.id,
           threatmetrix_session_id: threatmetrix_session_id,
           request_ip: request_ip,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress
+          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
         )
       end
 

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Idv::Agent do
     let(:issuer) { 'fake-issuer' }
     let(:friendly_name) { 'fake-name' }
     let(:app_id) { 'fake-app-id' }
+    let(:ipp_enrollment_in_progress) { true }
 
     let(:agent) { Idv::Agent.new(applicant) }
 
@@ -41,6 +42,7 @@ RSpec.describe Idv::Agent do
             user_id: user.id,
             threatmetrix_session_id: nil,
             request_ip: request_ip,
+            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
           )
 
           result = document_capture_session.load_proofing_result.result
@@ -57,6 +59,7 @@ RSpec.describe Idv::Agent do
             user_id: user.id,
             threatmetrix_session_id: nil,
             request_ip: request_ip,
+            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
           )
           result = document_capture_session.load_proofing_result.result
           expect(result[:context][:stages][:state_id]).to include(
@@ -82,6 +85,7 @@ RSpec.describe Idv::Agent do
             user_id: user.id,
             threatmetrix_session_id: nil,
             request_ip: request_ip,
+            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
           )
           result = document_capture_session.load_proofing_result.result
           expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
@@ -97,6 +101,7 @@ RSpec.describe Idv::Agent do
             user_id: user.id,
             threatmetrix_session_id: nil,
             request_ip: request_ip,
+            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
           )
 
           result = document_capture_session.load_proofing_result.result
@@ -118,6 +123,7 @@ RSpec.describe Idv::Agent do
             user_id: user.id,
             threatmetrix_session_id: nil,
             request_ip: request_ip,
+            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
           )
           result = document_capture_session.load_proofing_result.result
 
@@ -142,6 +148,7 @@ RSpec.describe Idv::Agent do
           user_id: user.id,
           threatmetrix_session_id: nil,
           request_ip: request_ip,
+          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
         )
         result = document_capture_session.load_proofing_result.result
 

--- a/spec/services/proofing/resolution/progressive_proofer_spec.rb
+++ b/spec/services/proofing/resolution/progressive_proofer_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
   let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS }
   let(:should_proof_state_id) { true }
   let(:ipp_enrollment_in_progress) { true }
-  let(:double_address_verification) { true }
   let(:request_ip) { Faker::Internet.ip_v4_address }
   let(:threatmetrix_session_id) { SecureRandom.uuid }
   let(:timer) { JobHelpers::Timer.new }
@@ -42,7 +41,6 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
       instance.proof(
         applicant_pii: applicant_pii,
         ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-        double_address_verification: double_address_verification,
         request_ip: request_ip,
         should_proof_state_id: should_proof_state_id,
         threatmetrix_session_id: threatmetrix_session_id,
@@ -180,7 +178,6 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
 
         expect(result.same_address_as_id).to eq('true')
         expect(result.ipp_enrollment_in_progress).to eq(true)
-        expect(result.double_address_verification).to eq(true)
         expect(result.resolution_result).to eq(result.residential_resolution_result)
       end
 
@@ -299,7 +296,6 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
         instance_double(Proofing::Resolution::Result)
       end
       let(:ipp_enrollment_in_progress) { true }
-      let(:double_address_verification) { true }
       let(:applicant_pii) do
         JSON.parse(<<-STR, symbolize_names: true)
             {

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
   end
 
   let(:should_proof_state_id) { true }
-  let(:double_address_verification) { true }
   let(:ipp_enrollment_in_progress) { true }
   let(:same_address_as_id) { 'false' }
 
@@ -52,7 +51,6 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
       state_id_result: state_id_result,
       should_proof_state_id: should_proof_state_id,
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-      double_address_verification: double_address_verification,
       device_profiling_result: device_profiling_result,
       same_address_as_id: same_address_as_id,
     )
@@ -91,33 +89,6 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
           expect(result.success?).to eq(false)
           resolution_adjudication_reason = result.extra[:context][:resolution_adjudication_reason]
           expect(resolution_adjudication_reason).to eq(:fail_state_id)
-        end
-      end
-
-      # rubocop:disable Layout/LineLength
-      context 'Confirm adjudication works for either double_address_verification or ipp_enrollment_in_progress' do
-        context 'Adjudication passes if double_address_verification is false and ipp_enrollment_in_progress is true' do
-          # rubocop:enable Layout/LineLength
-          let(:double_address_verification) { false }
-          let(:ipp_enrollment_in_progress) { true }
-
-          it 'returns a successful response' do
-            result = subject.adjudicated_result
-
-            expect(result.success?).to eq(true)
-          end
-        end
-        # rubocop:disable Layout/LineLength
-        context 'Adjudication passes if ipp_enrollment_in_progress is false and double_address_verification is true' do
-          # rubocop:enable Layout/LineLength
-          let(:double_address_verification) { true }
-          let(:ipp_enrollment_in_progress) { false }
-
-          it 'returns a successful response' do
-            result = subject.adjudicated_result
-
-            expect(result.success?).to eq(true)
-          end
         end
       end
     end


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-11352)

##  Open Question

We are removing the double_address_verification variable and replacing it with `ipp_enrollment_in_progress`. DAV used to be a configuration value, but since we're doing `ipp_enrollment_in_progress` that will always be true if a user's enrollment is either pending, or establishing. Which as they are moving through the flow, is always true. 

1. Do we need to check in the proofer, adjudicator and resolution job for cases where this could be false? Could ipp_enrollment_in_progress ever be false when this code is being run?

If not, then I could cut out a few things to have them always or never happen. 

## 🛠 Summary of changes

Removed the `double_address_verification` variable.

## 📜 Testing Plan

Nothing should change. All specs should continue to pass. 
As a test, run through the IPP flow, and on the address step first select:
1. No my address is different from the one on my ID
3. Proofing Job should not fail

Create a new enrollment.
1. Yes my address is the same as the one on my ID
2. Proofing Job should not fail