### PR TITLE
Jmax/lg 11942 update mock doc auth client to support selfie flag

### DIFF
--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -16,6 +16,7 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.pii = doc_auth_response.pii_from_doc
     session_result.captured_at = Time.zone.now
     session_result.attention_with_barcode = doc_auth_response.attention_with_barcode?
+    session_result.selfie_check_performed = doc_auth_response.selfie_check_performed?
     EncryptedRedisStructStorage.store(
       session_result,
       expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.seconds.to_i,

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -42,7 +42,7 @@ module DocAuth
           LexisNexis::Responses::TrueIdResponse.new(
             http_response,
             config,
-            liveness_checking_required,
+            include_liveness?,
           )
         end
 

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -53,6 +53,7 @@ module DocAuth
             errors: error_messages,
             extra: extra_attributes,
             pii_from_doc: pii_from_doc,
+            selfie_check_performed: liveness_checking_enabled,
           )
         rescue StandardError => e
           NewRelic::Agent.notice_error(e)

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -29,7 +29,12 @@ module DocAuth
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
         instance_id = SecureRandom.uuid
-        Responses::CreateDocumentResponse.new(success: true, errors: {}, instance_id: instance_id)
+        Responses::CreateDocumentResponse.new(
+          success: true,
+          errors: {},
+          instance_id: instance_id,
+          selfie_check_performed: true,
+        )
       end
 
       # rubocop:disable Lint/UnusedMethodArgument
@@ -47,6 +52,14 @@ module DocAuth
         error_response = http_error_response(image, 'back')
         return error_response if error_response
         DocAuth::Response.new(success: true)
+      end
+
+      def post_selfie_image(image:, instance_id:)
+        return mocked_response_for_method(__method__) if method_mocked?(__method__)
+        self.class.last_uploaded_selfie_image = image
+        error_response = http_error_response(image, 'selfie')
+        return error_response if error_response
+        DocAuth::Response.new(success: true, selfie_check_performed: true)
       end
 
       def post_images(
@@ -70,6 +83,9 @@ module DocAuth
 
         back_image_response = post_back_image(image: back_image, instance_id: instance_id)
         return back_image_response unless back_image_response.success?
+
+        selfie_image_response = post_selfie_image(image: selfie_image, instance_id: instance_id)
+        return selfie_image_response unless selfie_image_response.success?
 
         get_results(instance_id: instance_id)
       end

--- a/app/services/doc_auth/mock/responses/create_document_response.rb
+++ b/app/services/doc_auth/mock/responses/create_document_response.rb
@@ -4,12 +4,13 @@ module DocAuth
       class CreateDocumentResponse < DocAuth::Response
         attr_reader :instance_id
 
-        def initialize(instance_id:, success: true, errors: [], exception: nil)
+        def initialize(instance_id:, selfie_check_performed:, success: true, errors: [], exception: nil)
           @instance_id = instance_id
           super(
             success: success,
             errors: errors,
             exception: exception,
+            selfie_check_performed: selfie_check_performed,
           )
         end
       end

--- a/app/services/doc_auth/mock/responses/create_document_response.rb
+++ b/app/services/doc_auth/mock/responses/create_document_response.rb
@@ -4,13 +4,12 @@ module DocAuth
       class CreateDocumentResponse < DocAuth::Response
         attr_reader :instance_id
 
-        def initialize(instance_id:, selfie_check_performed:, success: true, errors: [], exception: nil)
+        def initialize(instance_id:, success: true, errors: [], exception: nil)
           @instance_id = instance_id
           super(
             success: success,
             errors: errors,
             exception: exception,
-            selfie_check_performed: selfie_check_performed,
           )
         end
       end

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -6,7 +6,7 @@ module DocAuth
 
       attr_reader :uploaded_file, :config
 
-      def initialize(uploaded_file, config)
+      def initialize(uploaded_file, selfie_check_performed, config)
         @uploaded_file = uploaded_file.to_s
         @config = config
         super(
@@ -14,6 +14,7 @@ module DocAuth
           errors: errors,
           pii_from_doc: pii_from_doc,
           doc_type_supported: id_type_supported?,
+          selfie_check_performed: selfie_check_performed,
           extra: {
             doc_auth_result: doc_auth_result,
             billed: true,

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -15,16 +15,17 @@ module DocAuth
       pii_from_doc: {},
       attention_with_barcode: false,
       doc_type_supported: true,
-      selfie_check_performed: false
+      # This is a stub to get data paths in place. Replace this as soon as possible.
+      selfie_check_performed: IdentityConfig.store.doc_auth_selfie_capture_enabled
     )
       @success = success
-      @selfie_check_performed = selfie_check_performed
       @errors = errors.to_h
       @exception = exception
       @extra = extra
       @pii_from_doc = pii_from_doc
       @attention_with_barcode = attention_with_barcode
       @doc_type_supported = doc_type_supported
+      @selfie_check_performed = selfie_check_performed
     end
 
     def merge(other)
@@ -36,7 +37,6 @@ module DocAuth
         pii_from_doc: pii_from_doc.merge(other.pii_from_doc),
         attention_with_barcode: attention_with_barcode? || other.attention_with_barcode?,
         doc_type_supported: doc_type_supported? || other.doc_type_supported?,
-        selfie_check_performed: selfie_check_performed? || other.selfie_check_performed?,
       )
     end
 

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -1,6 +1,6 @@
 module DocAuth
   class Response
-    attr_reader :errors, :exception, :extra, :pii_from_doc, :doc_type_supported, :selfie_check_performed
+    attr_reader :errors, :exception, :extra, :pii_from_doc, :doc_type_supported
 
     ID_TYPE_SLUGS = {
       'Identification Card' => 'state_id_card',
@@ -18,13 +18,13 @@ module DocAuth
       selfie_check_performed: false
     )
       @success = success
+      @selfie_check_performed = selfie_check_performed
       @errors = errors.to_h
       @exception = exception
       @extra = extra
       @pii_from_doc = pii_from_doc
       @attention_with_barcode = attention_with_barcode
       @doc_type_supported = doc_type_supported
-      @selfie_check_performed = selfie_check_performed
     end
 
     def merge(other)
@@ -36,6 +36,7 @@ module DocAuth
         pii_from_doc: pii_from_doc.merge(other.pii_from_doc),
         attention_with_barcode: attention_with_barcode? || other.attention_with_barcode?,
         doc_type_supported: doc_type_supported? || other.doc_type_supported?,
+        selfie_check_performed: selfie_check_performed? || other.selfie_check_performed?,
       )
     end
 

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -15,7 +15,6 @@ module DocAuth
       pii_from_doc: {},
       attention_with_barcode: false,
       doc_type_supported: true,
-      # This is a stub to get data paths in place. Replace this as soon as possible.
       selfie_check_performed: false
     )
       @success = success

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -15,8 +15,7 @@ module DocAuth
       pii_from_doc: {},
       attention_with_barcode: false,
       doc_type_supported: true,
-      # This is a stub to get data paths in place. Replace this as soon as possible.
-      selfie_check_performed: IdentityConfig.store.doc_auth_selfie_capture_enabled
+      selfie_check_performed: false
     )
       @success = success
       @errors = errors.to_h

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -15,6 +15,7 @@ module DocAuth
       pii_from_doc: {},
       attention_with_barcode: false,
       doc_type_supported: true,
+      # This is a stub to get data paths in place. Replace this as soon as possible.
       selfie_check_performed: false
     )
       @success = success

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -1,6 +1,6 @@
 module DocAuth
   class Response
-    attr_reader :errors, :exception, :extra, :pii_from_doc, :doc_type_supported
+    attr_reader :errors, :exception, :extra, :pii_from_doc, :doc_type_supported, :selfie_check_performed
 
     ID_TYPE_SLUGS = {
       'Identification Card' => 'state_id_card',
@@ -14,7 +14,8 @@ module DocAuth
       extra: {},
       pii_from_doc: {},
       attention_with_barcode: false,
-      doc_type_supported: true
+      doc_type_supported: true,
+      selfie_check_performed: false
     )
       @success = success
       @errors = errors.to_h
@@ -23,6 +24,7 @@ module DocAuth
       @pii_from_doc = pii_from_doc
       @attention_with_barcode = attention_with_barcode
       @doc_type_supported = doc_type_supported
+      @selfie_check_performed = selfie_check_performed
     end
 
     def merge(other)
@@ -70,6 +72,10 @@ module DocAuth
     def network_error?
       return false unless @errors
       return !!@errors&.with_indifferent_access&.dig(:network)
+    end
+
+    def selfie_check_performed?
+      @selfie_check_performed
     end
   end
 end

--- a/app/services/document_capture_session_result.rb
+++ b/app/services/document_capture_session_result.rb
@@ -9,9 +9,10 @@ DocumentCaptureSessionResult = RedactedStruct.new(
   :failed_front_image_fingerprints,
   :failed_back_image_fingerprints,
   :captured_at,
+  :selfie_check_performed,
   keyword_init: true,
   allowed_members: [:id, :success, :attention_with_barcode, :failed_front_image_fingerprints,
-                    :failed_back_image_fingerprints, :captured_at],
+                    :failed_back_image_fingerprints, :captured_at, :selfie_check_performed],
 ) do
   def self.redis_key_prefix
     'dcs:result'

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -349,12 +349,19 @@ RSpec.describe Idv::ImageUploadsController do
       context 'selfie included' do
         let(:selfie_img) { DocAuthImageFixtures.selfie_image_multipart }
 
+        before do
+          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+            and_return(true)
+
+          allow(controller.decorated_sp_session).to receive(:selfie_required?).and_return(true)
+        end
+
         it 'returns a successful response and modifies the session' do
           expect_any_instance_of(DocAuth::Mock::DocAuthMockClient).
             to receive(:post_images).with(
               front_image: an_instance_of(String),
               back_image: an_instance_of(String),
-              selfie_image: selfie_img,
+              selfie_image: an_instance_of(String),
               image_source: :unknown,
               user_uuid: an_instance_of(String),
               uuid_prefix: nil,
@@ -366,7 +373,7 @@ RSpec.describe Idv::ImageUploadsController do
           expect(response.status).to eq(200)
           expect(json[:success]).to eq(true)
           expect(document_capture_session.reload.load_result.success?).to eq(true)
-          # expect(document_capture_session.reload.load_result.selfie_check_performed).to eq(true)
+          expect(document_capture_session.reload.load_result.selfie_check_performed).to eq(true)
         end
       end
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -343,6 +343,33 @@ RSpec.describe Idv::ImageUploadsController do
     end
 
     context 'when image upload succeeds' do
+      # 50/50 state for selfie_check_performed in redis
+      # fake up a response and verify that selfie_check_performed flows through?
+
+      context 'selfie included' do
+        let(:selfie_img) { DocAuthImageFixtures.selfie_image_multipart }
+
+        it 'returns a successful response and modifies the session' do
+          expect_any_instance_of(DocAuth::Mock::DocAuthMockClient).
+            to receive(:post_images).with(
+              front_image: an_instance_of(String),
+              back_image: an_instance_of(String),
+              selfie_image: selfie_img,
+              image_source: :unknown,
+              user_uuid: an_instance_of(String),
+              uuid_prefix: nil,
+              liveness_checking_required: true,
+            ).and_call_original
+
+          action
+
+          expect(response.status).to eq(200)
+          expect(json[:success]).to eq(true)
+          expect(document_capture_session.reload.load_result.success?).to eq(true)
+          # expect(document_capture_session.reload.load_result.selfie_check_performed).to eq(true)
+        end
+      end
+
       it 'returns a successful response and modifies the session' do
         expect_any_instance_of(DocAuth::Mock::DocAuthMockClient).
           to receive(:post_images).with(
@@ -1063,7 +1090,9 @@ RSpec.describe Idv::ImageUploadsController do
         expect(response.status).to eq(200)
         expect(json[:success]).to eq(true)
         expect(document_capture_session.reload.load_result.success?).to eq(true)
+        expect(document_capture_session.reload.load_result.selfie_check_performed).to eq(true)
       end
+
       it 'sends a selfie' do
         expect_any_instance_of(DocAuth::Mock::DocAuthMockClient).
           to receive(:post_images).with(

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -49,8 +49,10 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       expect(response.exception).to be_nil
       if include_liveness_expected
         expect(request_stub_liveness).to have_been_requested
+        expect(response.selfie_check_performed?).to be(true)
       else
         expect(request_stub).to have_been_requested
+        expect(response.selfie_check_performed?).to be(false)
       end
     end
 
@@ -80,8 +82,10 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
         expect(response.exception).to be_nil
         if include_liveness_expected
           expect(request_stub_liveness).to have_been_requested
+          expect(response.selfie_check_performed?).to be(true)
         else
           expect(request_stub).to have_been_requested
+          expect(response.selfie_check_performed?).to be(false)
         end
       end
     end

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -235,7 +235,10 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
         image: image,
         instance_id: nil,
       )
-      response = client.get_results(instance_id: nil, selfie_check_performed: liveness_checking_required)
+      response = client.get_results(
+        instance_id: nil,
+        selfie_check_performed: liveness_checking_required,
+      )
       expect(response).to be_a(DocAuth::Response)
       expect(response.success?).to eq(false)
       expect(response.errors).to eq(general: ['network'])

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe DocAuth::Mock::DocAuthMockClient do
   subject(:client) { described_class.new }
 
+  let(:liveness_checking_required) { false }
+
   it 'implements all the public methods of the real Acuant client' do
     expect(
       described_class.instance_methods.sort,
@@ -23,7 +25,10 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
       instance_id: instance_id,
       image: DocAuthImageFixtures.document_back_image,
     )
-    get_results_response = client.get_results(instance_id: instance_id)
+    get_results_response = client.get_results(
+      instance_id: instance_id,
+      selfie_check_performed: liveness_checking_required,
+    )
 
     expect(create_document_response.success?).to eq(true)
     expect(create_document_response.instance_id).to_not be_blank
@@ -84,6 +89,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
     )
     get_results_response = client.get_results(
       instance_id: create_document_response.instance_id,
+      selfie_check_performed: liveness_checking_required,
     )
 
     expect(get_results_response.pii_from_doc).to eq(
@@ -124,6 +130,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
     )
     get_results_response = client.get_results(
       instance_id: create_document_response.instance_id,
+      selfie_check_performed: liveness_checking_required,
     )
     expect(get_results_response.attention_with_barcode?).to eq(false)
     errors = get_results_response.errors
@@ -177,6 +184,32 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
     expect(post_images_response).to be_a(DocAuth::Response)
   end
 
+  describe 'selfie check performed flag' do
+    let(:response) do
+      client.post_images(
+        front_image: DocAuthImageFixtures.document_front_image,
+        back_image: DocAuthImageFixtures.document_back_image,
+        liveness_checking_required: liveness_checking_required,
+      )
+    end
+
+    context 'when a liveness check is required' do
+      let(:liveness_checking_required) { true }
+
+      it 'sets selfie_check_performed to true' do
+        expect(response.selfie_check_performed?).to be(true)
+      end
+    end
+
+    context 'when a liveness check is not required' do
+      let(:liveness_checking_required) { false }
+
+      it 'sets selfie_check_performed to false' do
+        expect(response.selfie_check_performed?).to be(false)
+      end
+    end
+  end
+
   describe 'generate response for failure indicating http status' do
     it 'generate network error response for status 500 when post image' do
       image = <<-YAML
@@ -202,7 +235,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
         image: image,
         instance_id: nil,
       )
-      response = client.get_results(instance_id: nil)
+      response = client.get_results(instance_id: nil, selfie_check_performed: liveness_checking_required)
       expect(response).to be_a(DocAuth::Response)
       expect(response.success?).to eq(false)
       expect(response.errors).to eq(general: ['network'])

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DocAuth::Mock::ResultResponse do
   let(:warn_notifier) { instance_double('Proc') }
+  let(:selfie_check_performed) { false }
 
   subject(:response) do
     config = DocAuth::Mock::Config.new(
@@ -10,7 +11,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       glare_threshold: 40,
       warn_notifier: warn_notifier,
     )
-    described_class.new(input, config)
+    described_class.new(input, selfie_check_performed, config)
   end
 
   context 'with an image file' do
@@ -254,7 +255,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
           glare_threshold: 40,
         },
       )
-      described_class.new(input, config)
+      described_class.new(input, selfie_check_performed, config)
     end
 
     let(:input) do
@@ -644,5 +645,19 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         },
       )
     end
+  end
+
+  context 'when a selfie check is performed' do
+    let(:input) { DocAuthImageFixtures.document_front_image }
+    let(:selfie_check_performed) { true }
+
+    it { expect(response.selfie_check_performed?).to eq(true) }
+  end
+
+  context 'when a selfie check is not performed' do
+    let(:input) { DocAuthImageFixtures.document_front_image }
+    let(:selfie_check_performed) { false }
+
+    it { expect(response.selfie_check_performed?).to eq(false) }
   end
 end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DocAuth::Response do
   let(:exception) { nil }
   let(:pii_from_doc) { {} }
   let(:attention_with_barcode) { false }
-  let(:selfie_check_performed) { false }
+
   subject(:response) do
     described_class.new(
       success: success,
@@ -14,7 +14,6 @@ RSpec.describe DocAuth::Response do
       exception: exception,
       pii_from_doc: pii_from_doc,
       attention_with_barcode: attention_with_barcode,
-      selfie_check_performed: selfie_check_performed,
     )
   end
 
@@ -24,7 +23,7 @@ RSpec.describe DocAuth::Response do
     let(:other_exception) { nil }
     let(:other_pii_from_doc) { {} }
     let(:other_attention_with_barcode) { false }
-    let(:other_selfie_check_performed) { false }
+
     let(:other) do
       described_class.new(
         success: other_success,
@@ -32,7 +31,6 @@ RSpec.describe DocAuth::Response do
         exception: other_exception,
         pii_from_doc: other_pii_from_doc,
         attention_with_barcode: other_attention_with_barcode,
-        selfie_check_performed: other_selfie_check_performed,
       )
     end
     let!(:merged) { response.merge(other) }
@@ -161,9 +159,30 @@ RSpec.describe DocAuth::Response do
     end
   end
 
-  describe 'selfie_check_performed' do
-    it 'returns false by default' do
-      expect(response.selfie_check_performed?).to eq(false)
+  # LG-11942
+  # The following is for the stubbed selfie check value. Replace with
+  # the real tests when selfie implementation gets to that point.
+  describe 'selfie_check_performed?' do
+    before do
+      allow(IdentityConfig.store).
+        to receive(:doc_auth_selfie_capture_enabled).
+        and_return(selfies_enabled)
+    end
+
+    context 'when selfie checks are enabled' do
+      let(:selfies_enabled) { true }
+        
+      it 'returns true by default' do
+        expect(response.selfie_check_performed?).to be(true)
+      end
+    end
+
+    context 'when selfie checks are disabled' do
+      let(:selfies_enabled) { false }
+
+      it 'returns false' do
+        expect(response.selfie_check_performed?).to be(false)
+      end
     end
   end
 end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe DocAuth::Response do
     context 'when selfie checks are disabled' do
       let(:selfies_enabled) { false }
 
-      it 'returns false' do
+      it 'returns false by default' do
         expect(response.selfie_check_performed?).to be(false)
       end
     end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -158,31 +158,4 @@ RSpec.describe DocAuth::Response do
       expect(response.doc_type_supported?).to eq(true)
     end
   end
-
-  # LG-11942
-  # The following is for the stubbed selfie check value. Replace with
-  # the real tests when selfie implementation gets to that point.
-  describe 'selfie_check_performed?' do
-    before do
-      allow(IdentityConfig.store).
-        to receive(:doc_auth_selfie_capture_enabled).
-        and_return(selfies_enabled)
-    end
-
-    context 'when selfie checks are enabled' do
-      let(:selfies_enabled) { true }
-
-      it 'returns true by default' do
-        expect(response.selfie_check_performed?).to be(true)
-      end
-    end
-
-    context 'when selfie checks are disabled' do
-      let(:selfies_enabled) { false }
-
-      it 'returns false by default' do
-        expect(response.selfie_check_performed?).to be(false)
-      end
-    end
-  end
 end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe DocAuth::Response do
         exception: other_exception,
         pii_from_doc: other_pii_from_doc,
         attention_with_barcode: other_attention_with_barcode,
+        selfie_check_performed: other_selfie_check_performed,
       )
     end
     let!(:merged) { response.merge(other) }

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe DocAuth::Response do
   let(:exception) { nil }
   let(:pii_from_doc) { {} }
   let(:attention_with_barcode) { false }
+  let(:selfie_check_performed) { false }
   subject(:response) do
     described_class.new(
       success: success,
@@ -13,6 +14,7 @@ RSpec.describe DocAuth::Response do
       exception: exception,
       pii_from_doc: pii_from_doc,
       attention_with_barcode: attention_with_barcode,
+      selfie_check_performed: selfie_check_performed,
     )
   end
 
@@ -22,6 +24,7 @@ RSpec.describe DocAuth::Response do
     let(:other_exception) { nil }
     let(:other_pii_from_doc) { {} }
     let(:other_attention_with_barcode) { false }
+    let(:other_selfie_check_performed) { false }
     let(:other) do
       described_class.new(
         success: other_success,
@@ -154,6 +157,12 @@ RSpec.describe DocAuth::Response do
   describe 'doc_type_supported?' do
     it 'returns true by default' do
       expect(response.doc_type_supported?).to eq(true)
+    end
+  end
+
+  describe 'selfie_check_performed' do
+    it 'returns false by default' do
+      expect(response.selfie_check_performed?).to eq(false)
     end
   end
 end

--- a/spec/services/doc_auth/response_spec.rb
+++ b/spec/services/doc_auth/response_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe DocAuth::Response do
 
     context 'when selfie checks are enabled' do
       let(:selfies_enabled) { true }
-        
+
       it 'returns true by default' do
         expect(response.selfie_check_performed?).to be(true)
       end

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe DocAuthRouter do
         ),
       )
 
-      response = proxy.get_results(instance_id: 'abcdef')
+      response = proxy.get_results(instance_id: 'abcdef', selfie_check_performed: false)
 
       expect(response.errors[:network]).to eq(I18n.t('doc_auth.errors.general.network_error'))
     end

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe DocAuthRouter do
       )
 
       response = I18n.with_locale(:es) do
-        proxy.get_results(instance_id: 'abcdef')
+        proxy.get_results(instance_id: 'abcdef', selfie_check_performed: false)
       end
 
       expect(response.errors[:some_other_key]).to eq(['will not be translated'])


### PR DESCRIPTION
## 🎫 Ticket

[LG-11942](https://cm-jira.usa.gov/browse/LG-11942)

## 🛠 Summary of changes

Added the minimal changes necessary to allow team Ada to proceed with our side of the selfie work. Incorporated team Timnit's current work.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify that the new controller specs for this (`spec/controllers/idv/image_uploads_controller.rb:349`) runs and passes.
- [ ] Verify that all existing specs still pass

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>New spec run:</summary>

```
RSpec Compilation started at Wed Dec 27 13:42:19

bundle exec rspec --format documentation /Users/johnamaxwell/projects/identity-idp/spec/controllers/idv/image_uploads_controller_spec.rb:346
Run options: include {:locations=>{"./spec/controllers/idv/image_uploads_controller_spec.rb"=>[346]}}

Randomized with seed 30508

Idv::ImageUploadsController
  #create
    when image upload succeeds
      returns a successful response and modifies the session
      tracks events
      selfie included
        returns a successful response and modifies the session
      encrypted document storage is enabled
        includes image fields in attempts api event
      but doc_pii validation fails
        due to invalid State
          tracks state validation errors in analytics
        encrypted document storage is enabled
          includes image references in attempts api
        due to invalid Name
          tracks name validation errors in analytics
        but doc_pii validation fails due to invalid DOB
          tracks dob validation errors in analytics
        but doc_pii validation fails due to missing state_id_number
          tracks state_id_number validation errors in analytics

Top 0 slowest examples (0 seconds, 0.0% of total time):

Finished in 0.84071 seconds (files took 1.84 seconds to load)
9 examples, 0 failures

Randomized with seed 30508


RSpec Compilation finished at Wed Dec 27 13:42:22
```

</details>
