### PR TITLE
Rework `review-step` Typing to use Shared Types and Utilities

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -1,13 +1,9 @@
 import { useContext } from 'react';
 import { PageHeading } from '@18f/identity-components';
-import {
-  FormStepError,
-  FormStepsButton,
-  OnErrorCallback,
-  RegisterFieldCallback,
-} from '@18f/identity-form-steps';
+import { FormStepsButton } from '@18f/identity-form-steps';
 import { Cancel } from '@18f/identity-verify-flow';
 import { useI18n } from '@18f/identity-react-i18n';
+import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import UnknownError from './unknown-error';
 import TipList from './tip-list';
 import DocumentSideAcuantCapture from './document-side-acuant-capture';
@@ -15,21 +11,13 @@ import DocumentCaptureNotReady from './document-capture-not-ready';
 import { FeatureFlagContext } from '../context';
 import DocumentCaptureAbandon from './document-capture-abandon';
 import { DocumentCaptureSubheaderOne, SelfieStepWithHeader } from './documents-step';
+import type { ReviewIssuesStepValue } from './review-issues-step';
 
-interface DocumentCaptureReviewIssuesProps {
+interface DocumentCaptureReviewIssuesProps
+  extends Omit<FormStepComponentProps<ReviewIssuesStepValue>, 'toPreviousStep'> {
   isFailedDocType: boolean;
   remainingAttempts: number;
   captureHints: boolean;
-  registerField: RegisterFieldCallback;
-  value: {
-    front?: Blob | string | null | undefined;
-    back?: Blob | string | null | undefined;
-    selfie?: Blob | string | null | undefined;
-  };
-  unknownFieldErrors: FormStepError<any>[];
-  errors: FormStepError<any>[];
-  onChange: (...args: any) => void;
-  onError: OnErrorCallback;
   hasDismissed: boolean;
 }
 

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -9,16 +9,16 @@ import FailedCaptureAttemptsContext from '../context/failed-capture-attempts';
 import DocumentCaptureWarning from './document-capture-warning';
 import DocumentCaptureReviewIssues from './document-capture-review-issues';
 
-interface ReviewIssuesStepValue {
+export interface ReviewIssuesStepValue {
   /**
    * Front image value.
    */
-  front: Blob | string | null | undefined;
+  front?: Blob | string | null | undefined;
 
   /**
    * Back image value.
    */
-  back: Blob | string | null | undefined;
+  back?: Blob | string | null | undefined;
 
   /**
    * Selfie image value.


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-11906

## 🛠 Summary of changes

This PR is a followup to fix some typing oddness we noticed [here](https://github.com/18F/identity-idp/pull/9827#discussion_r1435405386). It ended up changing the typing in one file to use the same `FormStepComponentProps` utility as we use other places.

## 📜 Testing Plan

1. `yarn run tsc`
2. Run the app locally, check the IDV document upload flow for regressions and/or new console warnings.

