### PR TITLE
LG-11962 return 406 if biometric selected in production

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -46,8 +46,10 @@ module OpenidConnect
     private
 
     def redirect_to_not_found_if_selfie_requested_in_production
-      return unless params['biometric_comparison_required'] == 'true'
-      redirect_to '/page_not_found'
+      if Rails.env.production? &&
+         params['biometric_comparison_required'] == 'true'
+        redirect_to '/page_not_found'
+      end
     end
 
     def check_sp_active

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -10,7 +10,7 @@ module OpenidConnect
     include BillableEventTrackable
     include ForcedReauthenticationConcern
 
-    before_action :redirect_to_not_found_if_selfie_requested_in_production, only: [:index]
+    before_action :block_biometric_requests_in_production, only: [:index]
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :pre_validate_authorize_form, only: [:index]
     before_action :sign_out_if_prompt_param_is_login_and_user_is_signed_in, only: [:index]
@@ -45,7 +45,7 @@ module OpenidConnect
 
     private
 
-    def redirect_to_not_found_if_selfie_requested_in_production
+    def block_biometric_requests_in_production
       if Rails.env.production? && params['biometric_comparison_required'] == 'true'
         render_not_acceptable
       end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -46,7 +46,8 @@ module OpenidConnect
     private
 
     def block_biometric_requests_in_production
-      if Rails.env.production? && params['biometric_comparison_required'] == 'true'
+      if params['biometric_comparison_required'] == 'true' &&
+         FeatureManagement.idv_block_biometrics_requests?
         render_not_acceptable
       end
     end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -47,8 +47,8 @@ module OpenidConnect
 
     def redirect_to_not_found_if_selfie_requested_in_production
       if Rails.env.production? &&
-         params['biometric_comparison_required'] == 'true'
-        redirect_to '/page_not_found'
+          params['biometric_comparison_required'] == 'true'
+        render_not_acceptable
       end
     end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -46,8 +46,7 @@ module OpenidConnect
     private
 
     def redirect_to_not_found_if_selfie_requested_in_production
-      if Rails.env.production? &&
-          params['biometric_comparison_required'] == 'true'
+      if Rails.env.production? && params['biometric_comparison_required'] == 'true'
         render_not_acceptable
       end
     end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -10,6 +10,7 @@ module OpenidConnect
     include BillableEventTrackable
     include ForcedReauthenticationConcern
 
+    before_action :redirect_to_not_found_if_selfie_requested_in_production, only: [:index]
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :pre_validate_authorize_form, only: [:index]
     before_action :sign_out_if_prompt_param_is_login_and_user_is_signed_in, only: [:index]
@@ -43,6 +44,11 @@ module OpenidConnect
     end
 
     private
+
+    def redirect_to_not_found_if_selfie_requested_in_production
+      return unless params['biometric_comparison_required'] == 'true'
+      redirect_to '/page_not_found'
+    end
 
     def check_sp_active
       return if @authorize_form.service_provider&.active?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -421,6 +421,8 @@ Rails.application.routes.draw do
     root to: 'users/sessions#new'
   end
 
+  match '/page_not_found', via: :all, to: 'pages#page_not_found'
+
   # Make sure any new routes are added above this line!
   # The line below will route all requests that aren't
   # defined route to the 404 page. Therefore, anything you put after this rule

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -421,8 +421,6 @@ Rails.application.routes.draw do
     root to: 'users/sessions#new'
   end
 
-  match '/page_not_found', via: :all, to: 'pages#page_not_found'
-
   # Make sure any new routes are added above this line!
   # The line below will route all requests that aren't
   # defined route to the 404 page. Therefore, anything you put after this rule

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -162,4 +162,9 @@ class FeatureManagement
       outage_status.any_phone_vendor_outage? ||
       outage_status.phone_finder_outage?
   end
+
+  def self.idv_block_biometrics_requests?
+    (Identity::Hostdata.in_datacenter? && Identity::Hostdata.env == 'prod') ||
+      !IdentityConfig.store.doc_auth_selfie_capture_enabled
+  end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -999,12 +999,66 @@ RSpec.describe OpenidConnect::AuthorizationController do
         )
       end
 
-      it 'sets biometric_comparison_required to true if biometric comparison is required' do
-        params[:biometric_comparison_required] = true
+      context 'the session :biometric_comparison_required value' do
+        before do
+          allow(Rails.env).to receive(:production?).and_return(production)
+        end
 
-        action
+        context 'when the param value :biometric_comparison_required is "true"' do
+          before do
+            params[:biometric_comparison_required] = 'true'
 
-        expect(session[:sp][:biometric_comparison_required]).to eq(true)
+            action
+          end
+
+          # Temporary barrier to public presentation. Remove when we
+          # are ready to accept :biometric_comparison_required for
+          # real in production.
+          context 'in production' do
+            let(:production) { true }
+
+            it 'does not set the :sp value' do
+              expect(session).not_to include(:sp)
+            end
+
+            it 'redirects to /page_not_found' do
+              expect(response).to redirect_to('/page_not_found')
+            end
+          end
+
+          context 'not in production' do
+            let(:production) { false }
+
+            it 'sets the session :biometric_comparison_required value to true' do
+              expect(session[:sp][:biometric_comparison_required]).to eq(true)
+            end
+          end
+        end
+
+        context 'when the param value :biometric_comparison_required is not set' do
+          before do
+            # Should be a no-op, but let's be paranoid.
+            params.delete(:biometric_comparison_required)
+
+            action
+          end
+
+          context 'in production' do
+            let(:production) { true }
+
+            it 'sets the session :biometric_comparison_required value to false' do
+              expect(session[:sp][:biometric_comparison_required]).to eq(false)
+            end
+          end
+
+          context 'not in production' do
+            let(:production) { false }
+
+            it 'sets the session :biometric_comparison_required value to false' do
+              expect(session[:sp][:biometric_comparison_required]).to eq(false)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -999,11 +999,11 @@ RSpec.describe OpenidConnect::AuthorizationController do
         )
       end
 
-      context 'the session :biometric_comparison_required value' do
+      describe 'handling the :biometric_comparison_required parameter' do
         before do
           allow(Rails.env).to receive(:production?).and_return(production)
           if require_biometric_comparison
-            params[:biometric_comparison_required] = true
+            params[:biometric_comparison_required] = 'true'
           else
             # Should be a no-op, but let's be paranoid.
             params.delete(:biometric_comparison_required)
@@ -1015,9 +1015,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
         context 'when the param value :biometric_comparison_required is "true"' do
           let(:require_biometric_comparison) { true }
 
-          # Temporary barrier to public presentation. Remove when we
-          # are ready to accept :biometric_comparison_required in
-          # production.
+          # Temporary barrier to public presentation. Update or remove
+          # when we are ready to accept :biometric_comparison_required
+          # in production. See LG-11962.
           context 'in production' do
             let(:production) { true }
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1025,8 +1025,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
               expect(session).not_to include(:sp)
             end
 
-            it 'redirects to /page_not_found' do
-              expect(response).to redirect_to(page_not_found_path)
+            it 'renders the unacceptable page' do
+              expect(controller).to render_template('pages/not_acceptable')
             end
           end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1002,14 +1002,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
       context 'the session :biometric_comparison_required value' do
         before do
           allow(Rails.env).to receive(:production?).and_return(production)
+          if require_biometric_comparison
+            params[:biometric_comparison_required] = true
+          else
+            # Should be a no-op, but let's be paranoid.
+            params.delete(:biometric_comparison_required)
+          end
+
+          action
         end
 
         context 'when the param value :biometric_comparison_required is "true"' do
-          before do
-            params[:biometric_comparison_required] = 'true'
-
-            action
-          end
+          let(:require_biometric_comparison) { true }
 
           # Temporary barrier to public presentation. Remove when we
           # are ready to accept :biometric_comparison_required in
@@ -1036,12 +1040,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         context 'when the param value :biometric_comparison_required is not set' do
-          before do
-            # Should be a no-op, but let's be paranoid.
-            params.delete(:biometric_comparison_required)
-
-            action
-          end
+          let(:require_biometric_comparison) { false }
 
           context 'in production' do
             let(:production) { true }

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1060,7 +1060,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
           context 'in production' do
             let(:in_datacenter) { true }
             let(:env) { 'prod' }
-              
+
             it 'sets the session :biometric_comparison_required value to false' do
               expect(session[:sp][:biometric_comparison_required]).to eq(false)
             end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1012,8 +1012,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
           end
 
           # Temporary barrier to public presentation. Remove when we
-          # are ready to accept :biometric_comparison_required for
-          # real in production.
+          # are ready to accept :biometric_comparison_required in
+          # production.
           context 'in production' do
             let(:production) { true }
 
@@ -1022,7 +1022,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             end
 
             it 'redirects to /page_not_found' do
-              expect(response).to redirect_to('/page_not_found')
+              expect(response).to redirect_to(page_not_found_path)
             end
           end
 

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -112,9 +112,8 @@ RSpec.feature 'OIDC Authorization Confirmation' do
       visit visit_idp_from_ial2_oidc_sp(biometric_comparison_required: true)
     end
 
-    it 'redirects to the 404 page' do
-      expect(current_path).to eq(page_not_found_path)
-      expect(page.status_code).to eq(404)
+    it 'redirects to the 406 (unacceptable) page' do
+      expect(page.status_code).to eq(406)
     end
   end
 end

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -107,8 +107,13 @@ RSpec.feature 'OIDC Authorization Confirmation' do
   end
 
   context 'when asked for selfie verification in production' do
-    it 'redirects to the 404 page' do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
       visit visit_idp_from_ial2_oidc_sp(biometric_comparison_required: true)
+    end
+
+    it 'redirects to the 404 page' do
+      expect(page.path).to eq(page_not_found_path)
       expect(page.status_code).to eq(404)
     end
   end

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -105,4 +105,11 @@ RSpec.feature 'OIDC Authorization Confirmation' do
       end
     end
   end
+
+  context 'when asked for selfie verification in production' do
+    it 'redirects to the 404 page' do
+      visit visit_idp_from_ial2_oidc_sp(biometric_comparison_required: true)
+      expect(page.status_code).to eq(404)
+    end
+  end
 end

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'OIDC Authorization Confirmation' do
     end
 
     it 'redirects to the 404 page' do
-      expect(page.path).to eq(page_not_found_path)
+      expect(current_path).to eq(page_not_found_path)
       expect(page.status_code).to eq(404)
     end
   end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -540,4 +540,38 @@ RSpec.describe 'FeatureManagement' do
       end
     end
   end
+
+  describe '#idv_block_biometrics_requests?' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+        and_return(selfie_capture_enabled)
+    end
+
+    context 'selfies are disabled' do
+      let(:selfie_capture_enabled) { false }
+
+      it 'says to block biometric requests' do
+        expect(FeatureManagement.idv_block_biometrics_requests?).to eq(true)
+      end
+    end
+
+    context 'selfies are enabled' do
+      let(:selfie_capture_enabled) { true }
+
+      it 'says to not block biometric requests' do
+        expect(FeatureManagement.idv_block_biometrics_requests?).to eq(false)
+      end
+
+      context 'in production' do
+        before do
+          allow(Identity::Hostdata).to receive(:in_datacenter?).and_return(true)
+          allow(Identity::Hostdata).to receive(:env).and_return('prod')
+        end
+
+        it 'says to block biometric requests' do
+          expect(FeatureManagement.idv_block_biometrics_requests?).to eq(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -93,7 +93,7 @@ module OidcAuthHelper
     ial2_params[:tid] = tid if tid
     ial2_params[:prompt] = prompt if prompt
     if biometric_comparison_required
-      ial2_params[:biometric_comparison_required] = biometric_comparison_required
+      ial2_params[:biometric_comparison_required] = 'true'
     end
     ial2_params
   end

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -79,8 +79,8 @@ module OidcAuthHelper
                   nonce: SecureRandom.hex,
                   client_id: OIDC_ISSUER,
                   acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-                  biometric_comparison_required:,
-                  tid: nil)
+                  tid: nil,
+                  biometric_comparison_required: false)
     ial2_params = {
       client_id: client_id,
       response_type: 'code',

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -79,6 +79,7 @@ module OidcAuthHelper
                   nonce: SecureRandom.hex,
                   client_id: OIDC_ISSUER,
                   acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                  biometric_comparison_required:,
                   tid: nil)
     ial2_params = {
       client_id: client_id,
@@ -91,6 +92,9 @@ module OidcAuthHelper
     }
     ial2_params[:tid] = tid if tid
     ial2_params[:prompt] = prompt if prompt
+    if biometric_comparison_required
+      ial2_params[:biometric_comparison_required] = biometric_comparison_required
+    end
     ial2_params
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11962](https://cm-jira.usa.gov/browse/LG-11962)

## 🛠 Summary of changes

Added a check to ensure that SP requests for selfies are not permitted in production. This is a temporary measure, until  we are actually ready to handle them properly.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Start the Sinatra sample SP and the IDP server.
- [ ] From the Sinatra sample SP, request authentication with biometrics. Verify that you end up on the login.gov start page.
- [ ] Edit `feature_management` to simulate a production environment (see below).
- [ ] From the Sinatra sample SP, request authentication without biometrics. Verify that you end up on the login.gov start page.
- [ ] From the Sinatra sample SP, request authentication with biometrics. Verify that you end up on the 406 page.


Simulating a production environment on a dev box turned out to be a time sink. After spending Friday afternoon shaving yaks, re-assessed and simulated a production environment via a code change. If desired, we could spin up a sandbox for closer simulation of production. I don't feel that's necessary for code review, but perhaps for acceptance.

The code change is in `lib/feature_management.rb`, lines 167-168:

```
  def self.idv_block_biometrics_requests?
    # (Identity::Hostdata.in_datacenter? && Identity::Hostdata.env == 'prod') ||
    #   !IdentityConfig.store.doc_auth_selfie_capture_enabled
    true
  end
```

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Development request for biometrics:</summary>

![Screenshot 2024-01-03 at 10 47 56 AM](https://github.com/18F/identity-idp/assets/101212334/3926344b-e9cd-4ec6-a78d-bd5934fdee65)

![Screenshot 2024-01-03 at 10 49 16 AM](https://github.com/18F/identity-idp/assets/101212334/61a28a93-3ce3-4847-bb3c-cd040925ff4f)

</details>

<details>

<summary>Production: no request for biometrics</summary>

![Screenshot 2024-01-03 at 10 51 20 AM](https://github.com/18F/identity-idp/assets/101212334/0b2853ca-6bde-4ad6-9c15-011eed03cca0)

![Screenshot 2024-01-03 at 10 55 57 AM](https://github.com/18F/identity-idp/assets/101212334/935467fb-0bc7-4c22-81c2-4ec9ad44f11f)

</details>

<details>

<summary>Production: request for biometrics</summary>

![Screenshot 2024-01-03 at 10 56 49 AM](https://github.com/18F/identity-idp/assets/101212334/44133b5a-af6b-4432-902d-4bc388cc3af7)

![Screenshot 2024-01-03 at 10 57 45 AM](https://github.com/18F/identity-idp/assets/101212334/0860170f-8bba-4570-8f17-bd9aa4860508)

<details>
