### PR TITLE
LG-11893: Prep by Continuing Unifying `document-capture` and `review-issues` Steps

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -12,7 +12,7 @@ import DocumentCaptureAbandon from './document-capture-abandon';
 import {
   DocumentCaptureSubheaderOne,
   SelfieCaptureWithHeader,
-  DocumentFrontAndBackCapture
+  DocumentFrontAndBackCapture,
 } from './documents-step';
 import type { ReviewIssuesStepValue } from './review-issues-step';
 
@@ -45,7 +45,7 @@ function DocumentCaptureReviewIssues({
     onChange,
     errors,
     onError,
-  }
+  };
 
   return (
     <>
@@ -72,7 +72,7 @@ function DocumentCaptureReviewIssues({
       )}
       <DocumentFrontAndBackCapture defaultSideProps={defaultSideProps} value={value} />
       {selfieCaptureEnabled && (
-        <SelfieCaptureWithHeader defaultSideProps={defaultSideProps} selfieValue={value.selfie}/>
+        <SelfieCaptureWithHeader defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
       )}
       <FormStepsButton.Submit />
       {notReadySectionEnabled && <DocumentCaptureNotReady />}

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -10,7 +10,7 @@ import DocumentSideAcuantCapture from './document-side-acuant-capture';
 import DocumentCaptureNotReady from './document-capture-not-ready';
 import { FeatureFlagContext } from '../context';
 import DocumentCaptureAbandon from './document-capture-abandon';
-import { DocumentCaptureSubheaderOne, SelfieStepWithHeader } from './documents-step';
+import { DocumentCaptureSubheaderOne, SelfieCaptureWithHeader } from './documents-step';
 import type { ReviewIssuesStepValue } from './review-issues-step';
 
 interface DocumentCaptureReviewIssuesProps
@@ -78,7 +78,7 @@ function DocumentCaptureReviewIssues({
         />
       ))}
       {selfieCaptureEnabled && (
-        <SelfieStepWithHeader
+        <SelfieCaptureWithHeader
           defaultSideProps={{
             registerField,
             onChange,

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -6,11 +6,14 @@ import { useI18n } from '@18f/identity-react-i18n';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import UnknownError from './unknown-error';
 import TipList from './tip-list';
-import DocumentSideAcuantCapture from './document-side-acuant-capture';
 import DocumentCaptureNotReady from './document-capture-not-ready';
 import { FeatureFlagContext } from '../context';
 import DocumentCaptureAbandon from './document-capture-abandon';
-import { DocumentCaptureSubheaderOne, SelfieCaptureWithHeader } from './documents-step';
+import {
+  DocumentCaptureSubheaderOne,
+  SelfieCaptureWithHeader,
+  DocumentFrontAndBackCapture
+} from './documents-step';
 import type { ReviewIssuesStepValue } from './review-issues-step';
 
 interface DocumentCaptureReviewIssuesProps
@@ -20,8 +23,6 @@ interface DocumentCaptureReviewIssuesProps
   captureHints: boolean;
   hasDismissed: boolean;
 }
-
-type DocumentSide = 'front' | 'back';
 
 function DocumentCaptureReviewIssues({
   isFailedDocType,
@@ -39,8 +40,12 @@ function DocumentCaptureReviewIssues({
   const { notReadySectionEnabled, exitQuestionSectionEnabled, selfieCaptureEnabled } =
     useContext(FeatureFlagContext);
 
-  // Sides of document to present as file input.
-  const documentSides: DocumentSide[] = ['front', 'back'];
+  const defaultSideProps = {
+    registerField,
+    onChange,
+    errors,
+    onError,
+  }
 
   return (
     <>
@@ -65,28 +70,9 @@ function DocumentCaptureReviewIssues({
           ]}
         />
       )}
-      {documentSides.map((side) => (
-        <DocumentSideAcuantCapture
-          key={side}
-          side={side}
-          registerField={registerField}
-          value={value[side]}
-          onChange={onChange}
-          errors={errors}
-          onError={onError}
-          className="document-capture-review-issues-step__input"
-        />
-      ))}
+      <DocumentFrontAndBackCapture defaultSideProps={defaultSideProps} value={value} />
       {selfieCaptureEnabled && (
-        <SelfieCaptureWithHeader
-          defaultSideProps={{
-            registerField,
-            onChange,
-            errors,
-            onError,
-          }}
-          selfieValue={value.selfie}
-        />
+        <SelfieCaptureWithHeader defaultSideProps={defaultSideProps} selfieValue={value.selfie}/>
       )}
       <FormStepsButton.Submit />
       {notReadySectionEnabled && <DocumentCaptureNotReady />}

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -22,7 +22,7 @@ export function DocumentCaptureSubheaderOne({ selfieCaptureEnabled }) {
   );
 }
 
-export function SelfieStepWithHeader({ defaultSideProps, selfieValue }) {
+export function SelfieCaptureWithHeader({ defaultSideProps, selfieValue }) {
   const { t } = useI18n();
   return (
     <>
@@ -47,9 +47,28 @@ export function SelfieStepWithHeader({ defaultSideProps, selfieValue }) {
   );
 }
 
-/**
- * @typedef {'front'|'back'} DocumentSide
- */
+export function DocumentFrontAndBackCapture({ defaultSideProps, value }) {
+  /**
+   * Sides of the ID document to present as file input.
+   *
+   *
+   * @typedef {'front'|'back'} DocumentSide
+   * @type {DocumentSide[]}
+   */
+  const documentsSides = ['front', 'back'];
+  return (
+    <>
+      {documentsSides.map((side) => (
+        <DocumentSideAcuantCapture
+          {...defaultSideProps}
+          key={side}
+          side={side}
+          value={value[side]}
+        />
+      ))}
+    </>
+  );
+}
 
 /**
  * @typedef DocumentsStepValue
@@ -71,13 +90,6 @@ function DocumentsStep({
   onError = () => {},
   registerField = () => undefined,
 }) {
-  /**
-   * Sides of the ID document to present as file input.
-   *
-   * @type {DocumentSide[]}
-   */
-  const documentsSides = ['front', 'back'];
-
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
   const { isLastStep } = useContext(FormStepsContext);
@@ -109,16 +121,9 @@ function DocumentsStep({
           t('doc_auth.tips.document_capture_id_text3'),
         ].concat(!isMobile ? [t('doc_auth.tips.document_capture_id_text4')] : [])}
       />
-      {documentsSides.map((side) => (
-        <DocumentSideAcuantCapture
-          {...defaultSideProps}
-          key={side}
-          side={side}
-          value={value[side]}
-        />
-      ))}
+      <DocumentFrontAndBackCapture defaultSideProps={defaultSideProps} value={value} />
       {selfieCaptureEnabled && (
-        <SelfieStepWithHeader defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
+        <SelfieCaptureWithHeader defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
       )}
       {isLastStep ? <FormStepsButton.Submit /> : <FormStepsButton.Continue />}
       {notReadySectionEnabled && <DocumentCaptureNotReady />}

--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -34,8 +34,8 @@ export function SelfieCaptureWithHeader({
   defaultSideProps,
   selfieValue,
 }: {
-  defaultSideProps: any;
-  selfieValue: any;
+  defaultSideProps: DefaultSideProps;
+  selfieValue: ImageValue;
 }) {
   const { t } = useI18n();
   return (
@@ -65,8 +65,8 @@ export function DocumentFrontAndBackCapture({
   defaultSideProps,
   value,
 }: {
-  defaultSideProps: any;
-  value: any;
+  defaultSideProps: DefaultSideProps;
+  value: Record<string, ImageValue>;
 }) {
   type DocumentSide = 'front' | 'back';
   const documentsSides: DocumentSide[] = ['front', 'back'];
@@ -84,13 +84,20 @@ export function DocumentFrontAndBackCapture({
   );
 }
 
+type ImageValue = Blob | string | null | undefined;
+
 interface DocumentsStepValue {
-  front: Blob | string | null | undefined;
-  back: Blob | string | null | undefined;
-  selfie: Blob | string | null | undefined;
+  front: ImageValue;
+  back: ImageValue;
+  selfie: ImageValue;
   front_image_metadata?: string;
   back_image_metadata?: string;
 }
+
+type DefaultSideProps = Pick<
+  FormStepComponentProps<DocumentsStepValue>,
+  'registerField' | 'onChange' | 'errors' | 'onError'
+>;
 
 function DocumentsStep({
   value = {},
@@ -110,7 +117,7 @@ function DocumentsStep({
     ? t('doc_auth.headings.document_capture_with_selfie')
     : t('doc_auth.headings.document_capture');
 
-  const defaultSideProps = {
+  const defaultSideProps: DefaultSideProps = {
     registerField,
     onChange,
     errors,

--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -1,6 +1,10 @@
 import { useContext } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
-import { FormStepComponentProps, FormStepsButton, FormStepsContext } from '@18f/identity-form-steps';
+import {
+  FormStepComponentProps,
+  FormStepsButton,
+  FormStepsContext,
+} from '@18f/identity-form-steps';
 import { PageHeading } from '@18f/identity-components';
 import { Cancel } from '@18f/identity-verify-flow';
 import HybridDocCaptureWarning from './hybrid-doc-capture-warning';
@@ -12,7 +16,11 @@ import DocumentCaptureNotReady from './document-capture-not-ready';
 import { FeatureFlagContext } from '../context';
 import DocumentCaptureAbandon from './document-capture-abandon';
 
-export function DocumentCaptureSubheaderOne({ selfieCaptureEnabled }) {
+export function DocumentCaptureSubheaderOne({
+  selfieCaptureEnabled,
+}: {
+  selfieCaptureEnabled: boolean;
+}) {
   const { t } = useI18n();
   return (
     <h2>
@@ -22,7 +30,13 @@ export function DocumentCaptureSubheaderOne({ selfieCaptureEnabled }) {
   );
 }
 
-export function SelfieCaptureWithHeader({ defaultSideProps, selfieValue }) {
+export function SelfieCaptureWithHeader({
+  defaultSideProps,
+  selfieValue,
+}: {
+  defaultSideProps: any;
+  selfieValue: any;
+}) {
   const { t } = useI18n();
   return (
     <>
@@ -47,7 +61,13 @@ export function SelfieCaptureWithHeader({ defaultSideProps, selfieValue }) {
   );
 }
 
-export function DocumentFrontAndBackCapture({ defaultSideProps, value }) {
+export function DocumentFrontAndBackCapture({
+  defaultSideProps,
+  value,
+}: {
+  defaultSideProps: any;
+  value: any;
+}) {
   type DocumentSide = 'front' | 'back';
   const documentsSides: DocumentSide[] = ['front', 'back'];
   return (

--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
-import { FormStepsButton, FormStepsContext } from '@18f/identity-form-steps';
+import { FormStepComponentProps, FormStepsButton, FormStepsContext } from '@18f/identity-form-steps';
 import { PageHeading } from '@18f/identity-components';
 import { Cancel } from '@18f/identity-verify-flow';
 import HybridDocCaptureWarning from './hybrid-doc-capture-warning';
@@ -48,14 +48,8 @@ export function SelfieCaptureWithHeader({ defaultSideProps, selfieValue }) {
 }
 
 export function DocumentFrontAndBackCapture({ defaultSideProps, value }) {
-  /**
-   * Sides of the ID document to present as file input.
-   *
-   *
-   * @typedef {'front'|'back'} DocumentSide
-   * @type {DocumentSide[]}
-   */
-  const documentsSides = ['front', 'back'];
+  type DocumentSide = 'front' | 'back';
+  const documentsSides: DocumentSide[] = ['front', 'back'];
   return (
     <>
       {documentsSides.map((side) => (
@@ -70,26 +64,21 @@ export function DocumentFrontAndBackCapture({ defaultSideProps, value }) {
   );
 }
 
-/**
- * @typedef DocumentsStepValue
- *
- * @prop {Blob|string|null|undefined} front Front image value.
- * @prop {Blob|string|null|undefined} back Back image value.
- * @prop {Blob|string|null|undefined} selfie Selfie image value.
- * @prop {string=} front_image_metadata Front image metadata.
- * @prop {string=} back_image_metadata Back image metadata.
- */
+interface DocumentsStepValue {
+  front: Blob | string | null | undefined;
+  back: Blob | string | null | undefined;
+  selfie: Blob | string | null | undefined;
+  front_image_metadata?: string;
+  back_image_metadata?: string;
+}
 
-/**
- * @param {import('@18f/identity-form-steps').FormStepComponentProps<DocumentsStepValue>} props Props object.
- */
 function DocumentsStep({
   value = {},
   onChange = () => {},
   errors = [],
   onError = () => {},
   registerField = () => undefined,
-}) {
+}: FormStepComponentProps<DocumentsStepValue>) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
   const { isLastStep } = useContext(FormStepsContext);

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -37,15 +37,10 @@ export interface ReviewIssuesStepValue {
 
 interface ReviewIssuesStepProps extends FormStepComponentProps<ReviewIssuesStepValue> {
   remainingAttempts?: number;
-
   isFailedResult?: boolean;
-
   isFailedDocType?: boolean;
-
   captureHints?: boolean;
-
   pii?: PII;
-
   failedImageFingerprints?: { front: string[] | null; back: string[] | null };
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-11893

## 🛠 Summary of changes

These changes extract and reuse a component for both the `document-capture` and `review-issues` step rather than doing it twice in two different places. This is not directly related to the ticket, but this cleanup is in the same file, so doing this first should make the work in coming PRs easier.

## 📜 Testing Plan

Log in to the app, enter the IDV flow on a phone and check that the front/back upload boxes still look and behave as expected.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
