### PR TITLE
LG-11777: Handle logout request as already logged out if concurrent session exists

### DIFF
--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -5,6 +5,7 @@ module OpenidConnect
     include SecureHeadersConcern
     include FullyAuthenticatable
 
+    before_action :set_devise_failure_redirect_for_concurrent_session_logout
     before_action :confirm_two_factor_authenticated, only: [:delete]
 
     def index
@@ -38,6 +39,10 @@ module OpenidConnect
     end
 
     private
+
+    def set_devise_failure_redirect_for_concurrent_session_logout
+      request.env['devise_session_limited_failure_redirect_url'] = request.url
+    end
 
     def redirect_user(redirect_uri, user_uuid)
       redirect_method = IdentityConfig.store.openid_connect_redirect_uuid_override_map.fetch(

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -5,7 +5,7 @@ module OpenidConnect
     include SecureHeadersConcern
     include FullyAuthenticatable
 
-    before_action :set_devise_failure_redirect_for_concurrent_session_logout
+    before_action :set_devise_failure_redirect_for_concurrent_session_logout, only: [:index]
     before_action :confirm_two_factor_authenticated, only: [:delete]
 
     def index

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -17,6 +17,7 @@ class SamlIdpController < ApplicationController
 
   skip_before_action :verify_authenticity_token
   before_action :require_path_year
+  before_action :set_devise_failure_redirect_for_concurrent_session_logout, only: :logout
   before_action :handle_banned_user
   before_action :bump_auth_count, only: :auth
   before_action :redirect_to_sign_in, only: :auth, unless: :user_signed_in?
@@ -103,6 +104,10 @@ class SamlIdpController < ApplicationController
   def prompt_for_password_if_ial2_request_and_pii_locked
     return unless pii_requested_but_locked?
     redirect_to capture_password_url
+  end
+
+  def set_devise_failure_redirect_for_concurrent_session_logout
+    request.env['devise_session_limited_failure_redirect_url'] = request.url
   end
 
   def pii_requested_but_locked?

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -256,6 +256,7 @@ ActiveSupport::Notifications.subscribe(
   'rack.attack',
 ) do |_name, _start, _finish, _request_id, payload|
   req = payload[:request]
+  next if req.env['rack.attack.match_type'] == :safelist
   user = req.env['warden'].user || AnonymousUser.new
   sp = req.env.fetch('rack.session', {}).dig('sp', 'issuer')
   analytics = Analytics.new(user: user, request: req, session: {}, sp: sp)

--- a/lib/custom_devise_failure_app.rb
+++ b/lib/custom_devise_failure_app.rb
@@ -9,6 +9,10 @@ class CustomDeviseFailureApp < Devise::FailureApp
     message.is_a?(Symbol) ? build_message(message) : message.to_s
   end
 
+  def redirect_url
+    request.env["devise_#{warden_message}_failure_redirect_url"] || super
+  end
+
   private
 
   def build_message(message)

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe OpenidConnect::LogoutController do
     ).id_token
   end
 
+  describe '#index' do
+    it 'assigns devise session limited failure redirect url' do
+      get :index
+
+      expect(request.env['devise_session_limited_failure_redirect_url']).to eq(request.url)
+    end
+  end
+
   context 'when accepting id_token_hint and client_id' do
     before do
       allow(IdentityConfig.store).to receive(:reject_id_token_hint_in_logout).

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe SamlIdpController do
   let(:path_year) { SamlAuthHelper::PATH_YEAR }
 
   describe '/api/saml/logout' do
+    it 'assigns devise session limited failure redirect url' do
+      delete :logout, params: { path_year: path_year }
+
+      expect(request.env['devise_session_limited_failure_redirect_url']).to eq(request.url)
+    end
+
     it 'tracks the event when idp initiated' do
       stub_analytics
       stub_attempts_tracker

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -929,10 +929,9 @@ RSpec.describe 'OpenID Connect' do
         id_token_hint: id_token,
       )
 
-      expected_redirect_uri = URI('gov.gsa.openidconnect.test://result/signout').
-        tap { |uri| uri.query = URI.encode_www_form(state:) }.
-        to_s
-      expect(oidc_redirect_url).to eq(expected_redirect_uri)
+      expect(oidc_redirect_url).to eq(
+        UriService.add_params('gov.gsa.openidconnect.test://result/signout', state:),
+      )
 
       visit account_path
       expect(page).to_not have_content(t('headings.account.login_info'))

--- a/spec/lib/custom_devise_failure_app_spec.rb
+++ b/spec/lib/custom_devise_failure_app_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+require 'custom_devise_failure_app'
+
+RSpec.describe CustomDeviseFailureApp do
+  subject(:failure_app) { CustomDeviseFailureApp.new }
+
+  let(:message) { :invalid }
+  let(:env) { { 'warden' => OpenStruct.new(message:) } }
+  let(:request) { ActionDispatch::Request.new(env) }
+
+  before do
+    failure_app.set_request!(request)
+  end
+
+  describe '#redirect_url' do
+    it 'defers to to the default implementation' do
+      expect_any_instance_of(Devise::FailureApp).to receive(:redirect_url)
+
+      failure_app.redirect_url
+    end
+
+    context 'with custom redirect url assigned in request env' do
+      let(:custom_redirect_url) { '/redirect' }
+      let(:env) { super().merge({ 'devise_invalid_failure_redirect_url' => custom_redirect_url }) }
+
+      it 'returns the custom redirect url' do
+        expect(failure_app.redirect_url).to eq(custom_redirect_url)
+      end
+    end
+  end
+end

--- a/spec/lib/custom_devise_failure_app_spec.rb
+++ b/spec/lib/custom_devise_failure_app_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CustomDeviseFailureApp do
 
     context 'with custom redirect url assigned in request env' do
       let(:custom_redirect_url) { '/redirect' }
-      let(:env) { super().merge({ 'devise_invalid_failure_redirect_url' => custom_redirect_url }) }
+      let(:env) { super().merge('devise_invalid_failure_redirect_url' => custom_redirect_url) }
 
       it 'returns the custom redirect url' do
         expect(failure_app.redirect_url).to eq(custom_redirect_url)

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe 'throttling requests' do
 
       expect(request.env['rack.attack.throttle_data']).to be_nil
     end
+
+    it 'does not log an event' do
+      analytics = FakeAnalytics.new
+      allow(Analytics).to receive(:new).and_return(analytics)
+
+      get '/'
+
+      expect(analytics).not_to have_logged_event('Rate Limit Triggered')
+    end
   end
 
   describe 'high requests per ip' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11777](https://cm-jira.usa.gov/browse/LG-11777)

Related issue: #9407

## 🛠 Summary of changes

Updates the behavior of the OIDC and SAML logout actions to prevent a user from being sent to the sign-in page if their session is terminated by [the `session_limitable` logic (concurrent browser session)](https://github.com/18F/identity-idp/blob/main/config/initializers/session_limitable.rb), treating them as if they had already been logged-out, and inheriting the existing expected behavior[[1]](https://github.com/18F/identity-idp/blob/61c5e6685f87ee383941d4924ecabd1fab823513/spec/features/saml/saml_logout_spec.rb#L91-L107)[[2]](https://github.com/18F/identity-idp/blob/61c5e6685f87ee383941d4924ecabd1fab823513/spec/controllers/openid_connect/logout_controller_spec.rb#L227-L253) for redirecting a logged-out user.

## 📜 Testing Plan

1. Run the [OIDC](https://github.com/18F/identity-oidc-sinatra) or [SAML](https://github.com/18F/identity-saml-sinatra) sample application in a separate terminal process
2. Go to http://localhost:9292 (OIDC) or http://localhost:4567 (SAML) 
3. Click "Sign in"
4. Complete sign in or account creation until returned to the partner. Keep this tab open.
5. In a separate browser or private browsing window, repeat Steps 2-4
6. Return to your original tab from Step 4
7. Click "Sign out"

Observe that you are redirected back to the sample application as a completed logout.