### PR TITLE
Add addtional bounce information to email-deliveries script

### DIFF
--- a/bin/oncall/email-deliveries
+++ b/bin/oncall/email-deliveries
@@ -113,10 +113,10 @@ class EmailDeliveries
       email_events = cloudwatch_client('/aws/lambda/SESAllEvents_Lambda').fetch(
         query: <<~EOS,
           fields
-            eventType AS event_type
+            eventType AS event_type, mail.commonHeaders.messageId as ses_message_id,
+            bounce.bounceType as bounce_type, bounce.bounceSubType as bounce_sub_type
           | filter #{message_id_filters}
-          | parse '"messageId": "*"' as ses_message_id
-          | display @timestamp, event_type, ses_message_id
+          | display @timestamp, event_type, ses_message_id, bounce_type, bounce_sub_type
           | limit 10000
         EOS
         from: 1.week.ago,
@@ -131,7 +131,7 @@ class EmailDeliveries
             email_action: events_by_message_id[message_id]['email_action'],
             timestamp: events_by_message_id[message_id]['@timestamp'],
             message_id: message_id,
-            events: events.sort_by { |e| e['@timestamp'] }.map { |e| e['event_type'] },
+            events: events.sort_by { |e| e['@timestamp'] }.map { |e| [e['event_type'], e['bounce_type'], e['bounce_sub_type']].compact.join('-') },
           )
         end
     end

--- a/spec/bin/oncall/email-deliveries_spec.rb
+++ b/spec/bin/oncall/email-deliveries_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe EmailDeliveries do
         { '@timestamp' => '2023-01-01 00:00:01', 'ses_message_id' => 'message-1', 'event_type' => 'Send' },
         { '@timestamp' => '2023-01-01 00:00:02', 'ses_message_id' => 'message-1', 'event_type' => 'Delivery' },
         { '@timestamp' => '2023-01-01 00:00:03', 'ses_message_id' => 'message-2', 'event_type' => 'Send' },
-        { '@timestamp' => '2023-01-01 00:00:04', 'ses_message_id' => 'message-2', 'event_type' => 'Bounce' },
+        { '@timestamp' => '2023-01-01 00:00:04', 'ses_message_id' => 'message-2', 'event_type' => 'Bounce', 'bounce_type' => 'Transient', 'bounce_sub_type' => 'MailboxFull' },
       ]
     end
     # rubocop:enable Layout/LineLength
@@ -82,7 +82,8 @@ RSpec.describe EmailDeliveries do
         [
           ['user_id', 'timestamp', 'message_id', 'email_action', 'events'],
           ['abc123', '2023-01-01 00:00:01', 'message-1', 'forgot_password', 'Send, Delivery'],
-          ['def456', '2023-01-01 00:00:02', 'message-2', 'forgot_password', 'Send, Bounce'],
+          ['def456', '2023-01-01 00:00:02', 'message-2', 'forgot_password',
+           'Send, Bounce-Transient-MailboxFull'],
         ],
       )
     end


### PR DESCRIPTION
## 🛠 Summary of changes

This PR adds a couple additional items from the log to help troubleshoot email issues.

Example of new output:

```
+--------------------------------------+-------------------------+--------------------------------------------------------------+---------------------------------+----------------------------------------------+
| user_id                              | timestamp               | message_id                                                   | email_action                    | events                                       |
+--------------------------------------+-------------------------+--------------------------------------------------------------+---------------------------------+----------------------------------------------+
| 00000000-0000-0000-0000-000000000000 | 2024-01-03 18:00:00.000 | 0000000000000000-00000000-0000-0000-0000-000000000000-000000 | email_confirmation_instructions | Send, Delivery, Bounce-Transient-MailboxFull |
| 00000000-0000-0000-0000-000000000000 | 2024-01-03 18:00:00.000 | 0000000000000000-00000000-0000-0000-0000-000000000000-000000 | new_device_sign_in              | Send, Bounce-Permanent-General               |
| 00000000-0000-0000-0000-000000000000 | 2024-01-03 18:00:00.000 | 0000000000000000-00000000-0000-0000-0000-000000000000-000000 | new_device_sign_in              | Send, Bounce-Transient-ContentRejected       |
+--------------------------------------+-------------------------+--------------------------------------------------------------+---------------------------------+----------------------------------------------+
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
