### PR TITLE
LG-11695 enforce selfie capture performed

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -28,6 +28,7 @@ module OpenidConnect
         return redirect_to reactivate_account_url if user_needs_to_reactivate_account?
         return redirect_to url_for_pending_profile_reason if user_has_pending_profile?
         return redirect_to idv_url if identity_needs_verification?
+        return redirect_to idv_url if selfie_needed?
       end
       return redirect_to sign_up_completed_url if needs_completion_screen_reason
       link_identity_to_service_provider
@@ -97,6 +98,11 @@ module OpenidConnect
         (current_user.identity_not_verified? ||
         decorated_sp_session.requested_more_recent_verification?)) ||
         current_user.reproof_for_irs?(service_provider: current_sp)
+    end
+
+    def selfie_needed?
+      decorated_sp_session.selfie_required? &&
+        !current_user.identity_verified_with_selfie?
     end
 
     def build_authorize_form_from_params

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -4,6 +4,7 @@ module SignUp
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_identity_verified, if: :ial2?
+    before_action :confirm_selfie_captured, if: :selfie_required?
     before_action :apply_secure_headers_override, only: [:show, :update]
     before_action :verify_needs_completions_screen
 
@@ -35,6 +36,10 @@ module SignUp
       redirect_to idv_url if current_user.identity_not_verified?
     end
 
+    def confirm_selfie_captured
+      redirect_to idv_url if !current_user.identity_verified_with_selfie?
+    end
+
     def verify_needs_completions_screen
       return_to_account unless needs_completion_screen_reason
     end
@@ -60,6 +65,10 @@ module SignUp
 
     def ial2_requested?
       !!(ial2? || (ial_max? && current_user.identity_verified?))
+    end
+
+    def selfie_required?
+      decorated_sp_session.selfie_required?
     end
 
     def return_to_account

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -3,7 +3,7 @@ module SignUp
     include SecureHeadersConcern
 
     before_action :confirm_two_factor_authenticated
-    before_action :verify_confirmed, if: :ial2?
+    before_action :confirm_identity_verified, if: :ial2?
     before_action :apply_secure_headers_override, only: [:show, :update]
     before_action :verify_needs_completions_screen
 
@@ -31,7 +31,7 @@ module SignUp
 
     private
 
-    def verify_confirmed
+    def confirm_identity_verified
       redirect_to idv_url if current_user.identity_not_verified?
     end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -33,6 +33,7 @@ class Profile < ApplicationRecord
   enum idv_level: {
     legacy_unsupervised: 1,
     legacy_in_person: 2,
+    unsupervised_with_selfie: 3,
   }
 
   attr_reader :personal_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -346,6 +346,10 @@ class User < ApplicationRecord
     active_profile.present? && !reproof_for_irs?(service_provider: service_provider)
   end
 
+  def identity_verified_with_selfie?
+    active_profile&.idv_level == 'unsupervised_with_selfie'
+  end
+
   def reproof_for_irs?(service_provider:)
     return false unless service_provider&.irs_attempts_api_enabled
     return false unless active_profile.present?

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                   user.active_profile.idv_level = :unsupervised_with_selfie
 
                   action
-    
+
                   expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
                 end
               end
@@ -316,13 +316,13 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
               context 'selfie capture not enabled, selfie check was not performed' do
                 let(:selfie_capture_enabled) { false }
-                  it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
-                    action
+                it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
+                  action
 
-                    expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
-                  end
+                  expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+                end
               end
-            end 
+            end
           end
 
           context 'account is not already verified' do

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -93,6 +93,42 @@ RSpec.describe SignUp::CompletionsController do
         it 'creates a presenter object that is requesting ial2' do
           expect(assigns(:presenter).ial2_requested?).to eq true
         end
+
+        context 'user is not identity verified' do
+          let(:user) { create(:user) }
+          it 'redirects to idv_url' do
+            get :show
+
+            expect(response).to redirect_to(idv_url)
+          end
+        end
+
+        context 'sp requires selfie' do
+          let(:selfie_capture_enabled) { true }
+          before do
+            allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+              and_return(selfie_capture_enabled)
+            subject.session[:sp][:biometric_comparison_required] = 'true'
+          end
+
+          context 'user does not have a selfie' do
+            it 'redirects to idv_url' do
+              get :show
+
+              expect(response).to redirect_to(idv_url)
+            end
+          end
+
+          context 'selfie capture not enabled' do
+            let(:selfie_capture_enabled) { false }
+
+            it 'does not redirect' do
+              get :show
+
+              expect(response).to render_template :show
+            end
+          end
+        end
       end
 
       context 'IALMax' do

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Identity verification', :js do
 
   let(:sp) { :oidc }
 
-  scenario 'Unsupervised proofing happy path desktop', allow_browser_log: true do
+  scenario 'Unsupervised proofing happy path desktop' do
     try_to_skip_ahead_before_signing_in
     visit_idp_from_sp_with_ial2(sp)
     user = sign_up_and_2fa_ial1_user
@@ -52,7 +52,7 @@ RSpec.describe 'Identity verification', :js do
     validate_return_to_sp
   end
 
-  scenario 'Unsupervised proofing back button', allow_browser_log: true do
+  scenario 'Unsupervised proofing back button' do
     visit_idp_from_sp_with_ial2(sp)
     user = sign_up_and_2fa_ial1_user
 

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Identity verification', :js do
 
   let(:sp) { :oidc }
 
-  scenario 'Unsupervised proofing happy path desktop' do
+  scenario 'Unsupervised proofing happy path desktop', allow_browser_log: true do
     try_to_skip_ahead_before_signing_in
     visit_idp_from_sp_with_ial2(sp)
     user = sign_up_and_2fa_ial1_user
@@ -52,7 +52,7 @@ RSpec.describe 'Identity verification', :js do
     validate_return_to_sp
   end
 
-  scenario 'Unsupervised proofing back button' do
+  scenario 'Unsupervised proofing back button', allow_browser_log: true do
     visit_idp_from_sp_with_ial2(sp)
     user = sign_up_and_2fa_ial1_user
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1404,6 +1404,34 @@ RSpec.describe User do
     end
   end
 
+  describe '#identity_verified_with_selfie?' do
+    let(:user) { create(:user) }
+    let(:active_profile) do
+      create(
+        :profile, :active, :verified,
+        activated_at: 1.day.ago, pii: { first_name: 'Jane' },
+        user: user
+      )
+    end
+
+    it 'returns true if user has an active profile with selfie' do
+      active_profile.idv_level = :unsupervised_with_selfie
+      active_profile.save
+      expect(user.identity_verified_with_selfie?).to eq true
+    end
+
+    it 'returns false if user has an active profile without selfie' do
+      expect(user.identity_verified_with_selfie?).to eq false
+    end
+
+    context 'user does not have active profile' do
+      let(:active_profile) { nil }
+      it 'returns false' do
+        expect(user.identity_verified_with_selfie?).to eq false
+      end
+    end
+  end
+
   describe '#locked_out?' do
     let(:locked_at) { nil }
     let(:user) { User.new }


### PR DESCRIPTION
## 🎫 Ticket

[LG-11695](https://cm-jira.usa.gov/browse/LG-11695)

## 🛠 Summary of changes

This is Part 1 of several PRs for this ticket, and addresses AC1: If an SP requests a selfie check and the user has not performed a selfie check, we send the user back to the start of proofing before re-directing to the SP (edge case)

- Add :unsupervised_with_selfie value to Profile idv_level enum
- Add User#identity_verified_with_selfie? which checks the active profile idv_level
- In completions_controller, add before_action that checks whether the user was verified with selfie if the SP requires it and doc_auth_selfie_capture_enabled is true.
- In OpenidConnect::AuthorizationController#index, redirect to idv_url if a selfie is required and user did not verify at that level.
- Leaving out SamlIdpController#auth for now because it's not wired up for biometric_comparison_needed.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] In application.yml, set `doc_auth_selfie_capture_enabled: true`
- [ ] Starting from sample SP, sign in with biometric_comparison_required
- [ ] Complete IdV
- [ ] Expect to be redirected to idv_url (and then Welcome step) before being redirected to SP, because idv_level is not yet being updated during proofing
- [ ] Starting from sample SP, sign in with identity_verification required
- [ ] Complete IdV
- [ ] Expect to be redirected to SP
- [ ] In application.yml, set `doc_auth_selfie_capture_enabled: false`
- [ ] Starting from sample SP, sign in with biometric_comparison_required
- [ ] Complete IdV
- [ ] Expect to be redirected to SP
