### PR TITLE
Replace custom utilities with native JavaScript equivalents

### DIFF
--- a/app/javascript/packages/i18n/index.ts
+++ b/app/javascript/packages/i18n/index.ts
@@ -11,9 +11,6 @@ interface I18nOptions {
   strings?: Entries;
 }
 
-const hasOwn = (object: object, key: string): boolean =>
-  Object.prototype.hasOwnProperty.call(object, key);
-
 /**
  * Returns the pluralization object key corresponding to the given number.
  *
@@ -33,7 +30,7 @@ const getPluralizationKey = (count: number): keyof PluralizedEntry =>
  * @return Entry string or object.
  */
 const getEntry = (strings: Entries, key: string): Entry =>
-  hasOwn(strings, key) ? strings[key] : key;
+  Object.hasOwn(strings, key) ? strings[key] : key;
 
 /**
  * Returns true if the given entry is a pluralization entry, or false otherwise.
@@ -83,7 +80,9 @@ function getString(entry: Entry, count?: number): string | string[] {
  * @return String with variables substituted.
  */
 export const replaceVariables = (string: string, variables: Variables): string =>
-  string.replace(/%{(\w+)}/g, (match, key) => (hasOwn(variables, key) ? variables[key] : match));
+  string.replace(/%{(\w+)}/g, (match, key) =>
+    Object.hasOwn(variables, key) ? variables[key] : match,
+  );
 
 class I18n {
   strings: Entries;

--- a/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.js
@@ -46,18 +46,6 @@ function dig(object, keyPath) {
 }
 
 /**
- * Given an array of key-value tuple pairs, returns the corresponding object form.
- *
- * @template V
- *
- * @param {[key: string, value: V][]} pairs
- *
- * @return {Record<string, V>}
- */
-const fromPairs = (pairs) =>
-  pairs.reduce((result, [key, value]) => ({ ...result, [key]: value }), {});
-
-/**
  * Returns unique values from the given array.
  *
  * @template V
@@ -237,7 +225,7 @@ class RailsI18nWebpackPlugin extends ExtractKeysWebpackPlugin {
 
     const translations = await Promise.all(keys.map(getKeyTranslationPairs));
     if (translations.length) {
-      return fromPairs(translations);
+      return Object.fromEntries(translations);
     }
   }
 
@@ -256,13 +244,12 @@ class RailsI18nWebpackPlugin extends ExtractKeysWebpackPlugin {
     };
 
     const localeAssets = await Promise.all(locales.map(getLocaleAssetsPairs));
-    return fromPairs(compact(localeAssets));
+    return Object.fromEntries(compact(localeAssets));
   }
 }
 
 module.exports = RailsI18nWebpackPlugin;
 module.exports.dig = dig;
-module.exports.fromPairs = fromPairs;
 module.exports.uniq = uniq;
 module.exports.compact = compact;
 module.exports.getKeyPath = getKeyPath;

--- a/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js
@@ -5,8 +5,7 @@ const webpack = require('webpack');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const RailsI18nWebpackPlugin = require('./rails-i18n-webpack-plugin.js');
 
-const { dig, fromPairs, uniq, compact, getKeyPath, getKeyDomain, getKeyDomains } =
-  RailsI18nWebpackPlugin;
+const { dig, uniq, compact, getKeyPath, getKeyDomain, getKeyDomains } = RailsI18nWebpackPlugin;
 
 describe('RailsI18nWebpackPlugin', () => {
   it('generates expected output', (done) => {
@@ -208,18 +207,6 @@ describe('dig', () => {
     const result = dig(object, ['a', 'b']);
 
     expect(result).to.be.equal(1);
-  });
-});
-
-describe('fromPairs', () => {
-  it('returns pairs of key value in object form', () => {
-    const pairs = [
-      ['a', 1],
-      ['b', 2],
-    ];
-    const result = fromPairs(pairs);
-
-    expect(result).to.deep.equal({ a: 1, b: 2 });
   });
 });
 


### PR DESCRIPTION
## 🛠 Summary of changes

Replaces a couple instances of custom utility functions with native language alternatives.

- Replace `hasOwn` with [`Object.hasOwn`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) (relatively new, available since [ES2022](https://262.ecma-international.org/13.0/#:~:text=ECMAScript%202022%2C%20the,prototype.hasOwnProperty.) / [Node.js 16.9.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#browser_compatibility))
- Replace `fromPairs` with [`Object.fromEntries`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries) (no excuse on this one)

**Why?**

- Smaller code size (better maintainability)
- Native implementations is likely more battle-tested than our ad hoc approach
- Possibly more performant since runtime engine may be able to implement optimizations in low-level code (i.e. V8 C++)

## 📜 Testing Plan

Verify tests pass:

```
yarn mocha app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.spec.js app/javascript/packages/i18n/index.spec.ts
```

Review documentation above to confirm that the behavior of the functions would match expectations from previous ad hoc code.