### PR TITLE
Type/Props Change PR: Send 'toPreviousStep' Down as A Prop

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -16,8 +16,7 @@ import {
 } from './documents-step';
 import type { ReviewIssuesStepValue } from './review-issues-step';
 
-interface DocumentCaptureReviewIssuesProps
-  extends Omit<FormStepComponentProps<ReviewIssuesStepValue>, 'toPreviousStep'> {
+interface DocumentCaptureReviewIssuesProps extends FormStepComponentProps<ReviewIssuesStepValue> {
   isFailedDocType: boolean;
   remainingAttempts: number;
   captureHints: boolean;

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -51,6 +51,7 @@ function ReviewIssuesStep({
   unknownFieldErrors = [],
   onError = () => {},
   registerField = () => undefined,
+  toPreviousStep = () => undefined,
   remainingAttempts = Infinity,
   isFailedResult = false,
   isFailedDocType = false,
@@ -136,6 +137,7 @@ function ReviewIssuesStep({
       errors={errors}
       onChange={onChange}
       onError={onError}
+      toPreviousStep={toPreviousStep}
       hasDismissed
     />
   );


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

This is a props change in response to Andrew's [comment here](https://github.com/18F/identity-idp/pull/9836#discussion_r1439469761). We expect the `toPreviousStep` prop to be available to steps even if they're not using it. This PR makes that true, by making `toPreviousStep` available to the review step.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
