### PR TITLE
Spec fix: Expect 406 when selfie flag is off because of production block

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bigdecimal (3.1.4)
+    bigdecimal (3.1.5)
     bindata (2.4.15)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
@@ -684,7 +684,7 @@ GEM
       activemodel
       mail (>= 2.6.1)
       simpleidn
-    view_component (3.8.0)
+    view_component (3.9.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -314,9 +314,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 end
               end
 
-              context 'selfie capture not enabled, selfie check was not performed' do
+              context 'selfie capture not enabled, biometric_comparison_check requested by sp' do
                 let(:selfie_capture_enabled) { false }
-                it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
+                it 'returns status not_acceptable' do
                   action
 
                   expect(response.status).to eq(406)

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
                   action
 
-                  expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+                  expect(response.status).to eq(406)
                 end
               end
             end


### PR DESCRIPTION
When :doc_auth_selfie_capture_enabled is off, we now render the not_acceptable page. Spec now expects that in oidc_connect/authorization_controller_spec.