### PR TITLE
Fix missing require for OTP deliveries script

### DIFF
--- a/bin/oncall/email-deliveries
+++ b/bin/oncall/email-deliveries
@@ -4,7 +4,6 @@
 Dir.chdir(__dir__) { require 'bundler/setup' }
 
 require 'active_support'
-require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/enumerable' # index_by
 require 'active_support/core_ext/integer/time'
 require 'optparse'

--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk-cloudwatchlogs'
 require 'ruby-progressbar'
 require 'identity/hostdata'
+require 'active_support/core_ext/object/blank'
 
 module Reporting
   class CloudwatchClient


### PR DESCRIPTION
## Before

```bash
> aws-vault exec prod-power -- ./bin/oncall/otp-deliveries asdasd
[ Querying logs ] =---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=--- Time: 00:00:00
/identity-idp/lib/reporting/cloudwatch_client.rb:245:in `slice_time_range': undefined method `present?' for nil:NilClass (NoMethodError)

      if time_slices.present?
                    ^^^^^^^^^
	from identity-idp/lib/reporting/cloudwatch_client.rb:65:in `fetch'
	from ./bin/oncall/otp-deliveries:108:in `block in query_data'
	from identity-idp/lib/reporting/unknown_progress_bar.rb:24:in `wrap'
	from ./bin/oncall/otp-deliveries:107:in `query_data'
	from ./bin/oncall/otp-deliveries:79:in `run'
	from ./bin/oncall/otp-deliveries:148:in `<main>'
```

## After

```
> aws-vault exec prod-power -- ./bin/oncall/otp-deliveries asdasd
[ Querying logs ] =---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=--- Time: 00:00:09
+---------+-----------+------------+---------------------+--------------+
| user_id | timestamp | message_id | delivery_preference | country_code |
+---------+-----------+------------+---------------------+--------------+
+-----------------------------------------------------------------------+
```
