### PR TITLE
Remove browser_log: true from analytics_spec

### DIFF
--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -653,7 +653,7 @@ RSpec.feature 'Analytics Regression', js: true do
     end
   end
 
-  context 'Happy hybrid path', allow_browser_log: true do
+  context 'Happy hybrid path' do
     before do
       allow(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
         @sms_link = config[:link]
@@ -744,7 +744,7 @@ RSpec.feature 'Analytics Regression', js: true do
       complete_enter_password_step(user)
     end
 
-    it 'records all of the events', allow_browser_log: true do
+    it 'records all of the events' do
       gpo_path_events.each do |event, attributes|
         expect(fake_analytics).to have_logged_event(event, attributes)
       end


### PR DESCRIPTION
## 🛠 Summary of changes

I was getting a local chromedriver error that went away when I added `allow_browser_log: true` to specs. Now fixed locally, and should not have been checked in, so removing that.

For some reason feature specs for the in person flow do need `allow_browser_log: true` to pass. Do we know why that is?

## 📜 Testing Plan

Specs pass on CI.

