### PR TITLE
Try configuring Dependabot for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,19 @@ updates:
     allow:
       - dependency-name: '@18f/identity-design-system'
       - dependency-name: libphonenumber-js
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
   - package-ecosystem: bundler
     directory: /
     schedule:
       interval: daily
     allow:
       - dependency-name: phonelib
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## 🛠 Summary of changes

Revises the Dependabot configuration to restore the behavior of automatic update pull requests for security advisories. 

Based on Dependabot logs bailing with "all versions were ignored" messaging, it's suspected that customizations to Dependabot implemented in #9055 and #5462 are taking precedence over the default Dependabot configuration for security advisories, which was not the intent. Our `bundler-audit` and `yarn audit`-based dependency auditing has worked as a fallback option, but it would be nice to configure Dependabot to automatically update dependencies on our behalf when a new version is available.

While GitHub does not provide specific example configurations for our setup, this is based partly on documentation that ["If you only require security updates and want to exclude version updates, you can set `open-pull-requests-limit` to `0` in order to prevent version updates for a given `package-ecosystem`"](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates)

## 📜 Testing Plan

This may not be possible to test until merged. After merged, it's expected that we'd receive Dependabot pull requests for both security advisories, as well as the package-specific version updates currently configured.