### PR TITLE
Revert "Try configuring Dependabot for security updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,19 +7,9 @@ updates:
     allow:
       - dependency-name: '@18f/identity-design-system'
       - dependency-name: libphonenumber-js
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 0
   - package-ecosystem: bundler
     directory: /
     schedule:
       interval: daily
     allow:
       - dependency-name: phonelib
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 0


### PR DESCRIPTION
Reverts 18F/identity-idp#9877

After merging to main, this started failing due to invalid configuration:

>Your .github/dependabot.yml contained invalid details
>
>Dependabot encountered the following error when parsing your `.github/dependabot.yml`:
>
>```
>The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
>The property '#/updates/3' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
>```
>
>Please update the config file to conform with Dependabot's specification.

https://github.com/18F/identity-idp/runs/20273670820
