### PR TITLE
Use FeatureManagement method to check whether selfies are allowed

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -30,9 +30,5 @@ module Idv
     def store_encrypted_images?
       IdentityConfig.store.encrypted_document_storage_enabled
     end
-
-    def liveness_checking_enabled?
-      IdentityConfig.store.doc_auth_selfie_capture_enabled
-    end
   end
 end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -48,7 +48,7 @@ module OpenidConnect
 
     def block_biometric_requests_in_production
       if params['biometric_comparison_required'] == 'true' &&
-         FeatureManagement.idv_block_biometrics_requests?
+         !FeatureManagement.idv_allow_selfie_check_in_login_prod?
         render_not_acceptable
       end
     end

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -71,9 +71,7 @@ class ServiceProviderSession
   end
 
   def selfie_required?
-    return false if Identity::Hostdata.env == 'prod'
-
-    !!(IdentityConfig.store.doc_auth_selfie_capture_enabled &&
+    !!(FeatureManagement.idv_allow_selfie_check_in_login_prod? &&
       sp_session[:biometric_comparison_required])
   end
 

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -91,10 +91,8 @@ module DocAuth
         end
 
         def include_liveness?
-          return false if Identity::Hostdata.env == 'prod'
-          return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
-
-          liveness_checking_required
+          FeatureManagement.idv_allow_selfie_check_in_login_prod? &&
+            liveness_checking_required
         end
       end
     end

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -215,7 +215,7 @@ module DocAuthRouter
     end
 
     # if vendor is not set to mock and selfie enabled use lexisnexis
-    if IdentityConfig.store.doc_auth_selfie_capture_enabled &&
+    if FeatureManagement.idv_allow_selfie_check_in_login_prod? &&
        vendor != Idp::Constants::Vendors::MOCK
       vendor = Idp::Constants::Vendors::LEXIS_NEXIS
     end

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -46,7 +46,7 @@ module Idv
     def set_idv_level(in_person_verification_needed:, selfie_check_performed:)
       if in_person_verification_needed
         :legacy_in_person
-      elsif !FeatureManagement.idv_block_biometrics_requests? && selfie_check_performed
+      elsif FeatureManagement.idv_allow_selfie_check_in_login_prod? && selfie_check_performed
         :unsupervised_with_selfie
       else
         :legacy_unsupervised

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: (Identity::Hostdata.env == 'prod' || !IdentityConfig.store.doc_auth_selfie_capture_enabled) ? false : doc_auth_selfie_capture,
+      doc_auth_selfie_capture: FeatureManagement.idv_allow_selfie_check_in_login_prod? && doc_auth_selfie_capture,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_not_ready_section_enabled: IdentityConfig.store.doc_auth_not_ready_section_enabled,

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -163,8 +163,8 @@ class FeatureManagement
       outage_status.phone_finder_outage?
   end
 
-  def self.idv_block_biometrics_requests?
-    (Identity::Hostdata.in_datacenter? && Identity::Hostdata.env == 'prod') ||
-      !IdentityConfig.store.doc_auth_selfie_capture_enabled
+  def self.idv_allow_selfie_check_in_login_prod?
+    !(Identity::Hostdata.in_datacenter? && Identity::Hostdata.env == 'prod') &&
+      IdentityConfig.store.doc_auth_selfie_capture_enabled
   end
 end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -350,9 +350,6 @@ RSpec.describe Idv::ImageUploadsController do
         let(:selfie_img) { DocAuthImageFixtures.selfie_image_multipart }
 
         before do
-          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
-            and_return(true)
-
           allow(controller.decorated_sp_session).to receive(:selfie_required?).and_return(true)
         end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
               let(:selfie_capture_enabled) { true }
               before do
                 params[:biometric_comparison_required] = 'true'
-                allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+                allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
                   and_return(selfie_capture_enabled)
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe SignUp::CompletionsController do
         context 'sp requires selfie' do
           let(:selfie_capture_enabled) { true }
           before do
-            allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+            allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
               and_return(selfie_capture_enabled)
             subject.session[:sp][:biometric_comparison_required] = 'true'
           end

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe ServiceProviderSession do
 
   describe '#selfie_required' do
     before do
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+      allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
         and_return(selfie_capture_enabled)
     end
 
@@ -206,21 +206,6 @@ RSpec.describe ServiceProviderSession do
       it 'returns false when sp biometric_comparison_required is nil' do
         sp_session[:biometric_comparison_required] = nil
         expect(subject.selfie_required?).to eq(false)
-      end
-
-      context 'when environment is prod' do
-        before do
-          allow(Identity::Hostdata).to receive(:env).and_return('prod')
-        end
-        it 'returns false when sp biometric_comparison_required is true' do
-          sp_session[:biometric_comparison_required] = true
-          expect(subject.selfie_required?).to eq(false)
-        end
-
-        it 'returns false when sp biometric_comparison_required is truthy' do
-          sp_session[:biometric_comparison_required] = 1
-          expect(subject.selfie_required?).to eq(false)
-        end
       end
     end
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -844,7 +844,7 @@ RSpec.feature 'Analytics Regression', js: true do
 
   context 'Happy selfie path' do
     before do
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).and_return(true)
       allow_any_instance_of(FederatedProtocols::Oidc).
         to receive(:biometric_comparison_required?).
         and_return({ biometric_comparison_required: true })

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -195,9 +195,11 @@ RSpec.feature 'document capture step', :js do
     end
   end
 
-  context 'with doc_auth_selfie_capture_enabled set to true' do
+  context 'with idv_allow_selfie_check_in_login_prod? set to true' do
+    let(:selfie_check_enabled) { true }
     before do
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
+        and_return(selfie_check_enabled)
     end
 
     context 'when a selfie is not requested by SP' do
@@ -263,9 +265,7 @@ RSpec.feature 'document capture step', :js do
       end
 
       context 'when hosted env is prod' do
-        before do
-          allow(Identity::Hostdata).to receive(:env).and_return('prod')
-        end
+        let(:selfie_check_enabled) { false }
         it 'proceeds to the next page with valid info, excluding a selfie image' do
           perform_in_browser(:mobile) do
             visit_idp_from_oidc_sp_with_ial2

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -243,7 +243,7 @@ RSpec.feature 'doc auth redo document capture', js: true do
   context 'when selfie is enabled' do
     context 'error due to data issue with 2xx status code', allow_browser_log: true do
       before do
-        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+        allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).and_return(true)
         allow_any_instance_of(FederatedProtocols::Oidc).
           to receive(:biometric_comparison_required?).and_return(true)
         start_idv_from_sp

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -264,8 +264,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
 
   context 'barcode read error on desktop, redo document capture on mobile' do
     before do
-      allow(Identity::Hostdata).to receive(:env).and_return('prod')
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).and_return(false)
       allow_any_instance_of(FederatedProtocols::Oidc).
         to receive(:biometric_comparison_required?).and_return(true)
     end
@@ -334,9 +333,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
     end
   end
 
-  it 'prefils the phone number used on the phone step if the user has no MFA phone', :js do
-    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
-      and_return(true)
+  it 'prefills the phone number used on the phone step if the user has no MFA phone', :js do
+    allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).and_return(true)
     allow_any_instance_of(FederatedProtocols::Oidc).
       to receive(:biometric_comparison_required?).and_return(true)
     user = create(:user, :with_authentication_app)

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -541,7 +541,7 @@ RSpec.describe 'FeatureManagement' do
     end
   end
 
-  describe '#idv_block_biometrics_requests?' do
+  describe '#idv_allow_selfie_check_in_login_prod?' do
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
         and_return(selfie_capture_enabled)
@@ -551,15 +551,15 @@ RSpec.describe 'FeatureManagement' do
       let(:selfie_capture_enabled) { false }
 
       it 'says to block biometric requests' do
-        expect(FeatureManagement.idv_block_biometrics_requests?).to eq(true)
+        expect(FeatureManagement.idv_allow_selfie_check_in_login_prod?).to eq(false)
       end
     end
 
     context 'selfies are enabled' do
       let(:selfie_capture_enabled) { true }
 
-      it 'says to not block biometric requests' do
-        expect(FeatureManagement.idv_block_biometrics_requests?).to eq(false)
+      it 'says to allow biometric requests' do
+        expect(FeatureManagement.idv_allow_selfie_check_in_login_prod?).to eq(true)
       end
 
       context 'in production' do
@@ -569,7 +569,7 @@ RSpec.describe 'FeatureManagement' do
         end
 
         it 'says to block biometric requests' do
-          expect(FeatureManagement.idv_block_biometrics_requests?).to eq(true)
+          expect(FeatureManagement.idv_allow_selfie_check_in_login_prod?).to eq(false)
         end
       end
     end

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -91,10 +91,8 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
     end
 
     def include_liveness_expected
-      return false if Identity::Hostdata.env == 'prod'
-      return false unless IdentityConfig.store.doc_auth_selfie_capture_enabled
-
-      liveness_checking_required
+      FeatureManagement.idv_allow_selfie_check_in_login_prod? &&
+        liveness_checking_required
     end
   end
 
@@ -138,7 +136,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
 
   context 'with liveness_checking_enabled as true' do
     before do
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).and_return(true)
     end
 
     context 'when liveness checking is NOT required' do
@@ -173,7 +171,8 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
 
       context 'when hosted env is prod' do
         before do
-          allow(Identity::Hostdata).to receive(:env).and_return('prod')
+          allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
+            and_return(false)
         end
         context 'with acuant image source' do
           let(:workflow) { 'test_workflow' }

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe DocAuthRouter do
 
       context 'when selfie is enabled' do
         before do
-          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+          allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
+            and_return(true)
         end
         context 'when vendor is not set to mock' do
           it 'chose lexisnexis' do
@@ -122,7 +123,8 @@ RSpec.describe DocAuthRouter do
 
       context 'with selfie enabled' do
         before do
-          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+          allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
+            and_return(true)
         end
         it 'is the lexisnexis vendor' do
           expect(DocAuthRouter.doc_auth_vendor(discriminator: discriminator)).

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -172,8 +172,8 @@ RSpec.describe Idv::ProfileMaker do
         let(:selfie_check_performed) { true }
 
         before do
-          allow(FeatureManagement).to receive(:idv_block_biometrics_requests?).
-            and_return(false)
+          allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
+            and_return(true)
         end
 
         it 'creates an active profile' do

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
   let(:in_person_proofing_enabled_issuer) { nil }
   let(:acuant_sdk_upgrade_a_b_testing_enabled) { false }
   let(:use_alternate_sdk) { false }
-  let(:doc_auth_selfie_capture_enabled) { true }
+  let(:selfie_capture_enabled) { true }
 
   let(:acuant_version) { '1.3.3.7' }
   let(:skip_doc_auth) { false }
@@ -45,7 +45,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
-      doc_auth_selfie_capture: doc_auth_selfie_capture_enabled,
+      doc_auth_selfie_capture: selfie_capture_enabled,
       skip_doc_auth: skip_doc_auth,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
     }
@@ -98,7 +98,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
     end
   end
   describe 'view variables sent correctly' do
-    it 'sends doc_auth_selfie_capture_enabled to the FE' do
+    it 'sends selfie_capture_enabled to the FE' do
       render_partial
       expect(rendered).to have_css(
         "#document-capture-form[data-doc-auth-selfie-capture='false']",
@@ -107,7 +107,8 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
 
     context 'when selfie FF enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+        allow(FeatureManagement).to receive(:idv_allow_selfie_check_in_login_prod?).
+          and_return(selfie_capture_enabled)
       end
       it 'does send doc_auth_selfie_capture to the FE' do
         render_partial
@@ -116,9 +117,8 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
         )
       end
       context 'when hosted in prod env' do
+        let(:selfie_capture_enabled) { false }
         it 'does not send doc_auth_selfie_capture to the FE' do
-          allow(Identity::Hostdata).to receive(:env).and_return('prod')
-
           render_partial
           expect(rendered).to have_css(
             "#document-capture-form[data-doc-auth-selfie-capture='false']",


### PR DESCRIPTION
# 🎫 Ticket

Link to the relevant ticket:
[LG-11695](https://cm-jira.usa.gov/browse/LG-11695)

## 🛠 Summary of changes

Rename `FeatureManagement. idv_block_biometrics_requests?` to `FeatureManagement.idv_allow_selfie_check_in_login_prod?` and invert true/false value.

Update specs and code to check this method rather than the feature flag and Hostdata values.

## 📜 Testing Plan

- [ ] In application.yml, set `doc_auth_selfie_capture_enabled: true`
- [ ] From oidc sample app, request biometrics_comparison.
- [ ] Create account, start idv
- [ ] Confirm that selfie capture is included in DocumentCapture
- [ ] In application.yml, change to `doc_auth_selfie_capture_enabled: false`
- [ ] From oidc sample app, request biometrics_comparison.
- [ ] Create account, start idv
- [ ] Confirm that selfie capture is NOT included in DocumentCapture
