### PR TITLE
Swap pull policy for external images to Always to prevent staleness

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -484,8 +484,10 @@ review-app:
       --set worker.image.tag="${CI_COMMIT_SHA}"
       --set pivcac.image.repository="${ECR_REGISTRY}/identity-pivcac/review"
       --set pivcac.image.tag="${PKI_IMAGE_TAG}"
+      --set pivcac.image.pullPolicy="Always"
       --set dashboard.image.repository="${ECR_REGISTRY}/identity-dashboard/review"
       --set dashboard.image.tag="${DASHBOARD_IMAGE_TAG}"
+      --set dashboard.image.pullPolicy="Always"
       --set-json dashboard.env="$DASHBOARD_ENV"
       --set-json dashboard.enabled=true
       --set-json idp.env="$IDP_ENV"


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

Swaps from the default pull policy of `IfNotPresent` to `Always` for images that are referencing `main` to prevent stale containers from hanging around and being used.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
