### PR TITLE
Fix a 50/50 issue in the progress proofer

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -20,7 +20,7 @@ class ResolutionProofingJob < ApplicationJob
     trace_id:,
     should_proof_state_id:,
     double_address_verification: nil,
-    ipp_enrollment_in_progress: true,
+    ipp_enrollment_in_progress: false,
     user_id: nil,
     threatmetrix_session_id: nil,
     request_ip: nil,

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -11,7 +11,7 @@ module Idv
       user_id:,
       threatmetrix_session_id:,
       request_ip:,
-      ipp_enrollment_in_progress: true
+      ipp_enrollment_in_progress: false
     )
       document_capture_session.create_proofing_session
 
@@ -28,6 +28,7 @@ module Idv
         user_id: user_id,
         threatmetrix_session_id: threatmetrix_session_id,
         request_ip: request_ip,
+        double_address_verification: ipp_enrollment_in_progress,
         ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       }
 

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -30,7 +30,7 @@ module Proofing
         timer:,
         user_email:,
         double_address_verification: nil,
-        ipp_enrollment_in_progress: true
+        ipp_enrollment_in_progress: false
       )
         device_profiling_result = proof_with_threatmetrix_if_needed(
           applicant_pii: applicant_pii,

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe Idv::VerifyInfoController do
             verified_attributes: [],
           ),
           device_profiling_result: Proofing::DdpResult.new(success: true),
-          ipp_enrollment_in_progress: true,
+          ipp_enrollment_in_progress: false,
           residential_resolution_result: Proofing::Resolution::Result.new(success: true),
           resolution_result: Proofing::Resolution::Result.new(success: true),
           same_address_as_id: true,


### PR DESCRIPTION
A previous commit (https://github.com/18F/identity-idp/commit/e138a4904af3d7f4ed598d609a502fd8a8c1ae2a) changed the default values for `ipp_enrollment_in_progress` through stack for the vendor calls on the verify info step. This caused a number of `NoMethodError`s when the deploy happened. These errors results from the applicants address being nil when it was transformed for the LexisNexis API.

After some investigation it was discovered that the applicants address was being transformed for in-person proofing outside of in-person contexts. Since the user does not have the `identity_*` prefixed address values outside of in-person proofing this resulted in nil values for the address properties.

The cause of this is that `ipp_enrollment_in_progress` was introduced as a job argument with a default value of `true` which inverted it's previous value. As a result old web hosts were scheduling jobs without a `ipp_enrollment_in_progress` argument. New workers were picking up those jobs and erroneously assuming the default of `false.

This commit fixes all of the above.

[skip changelog]
