### PR TITLE
LG-12036: capture session props for doc_auth ans selfie

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -454,11 +454,18 @@ module Idv
           failed_back_fingerprint = nil unless errors_hash[:back]&.present?
         end
         document_capture_session.
-          store_failed_auth_image_fingerprint(failed_front_fingerprint, failed_back_fingerprint)
+          store_failed_auth_data(
+            front_image_fingerprint: failed_front_fingerprint,
+            back_image_fingerprint: failed_back_fingerprint,
+            doc_auth_success: client_response.doc_auth_success?,
+            selfie_success: client_response.selfie_success,
+          )
       elsif doc_pii_response && !doc_pii_response.success?
-        document_capture_session.store_failed_auth_image_fingerprint(
-          extra_attributes[:front_image_fingerprint],
-          extra_attributes[:back_image_fingerprint],
+        document_capture_session.store_failed_auth_data(
+          front_image_fingerprint: extra_attributes[:front_image_fingerprint],
+          back_image_fingerprint: extra_attributes[:back_image_fingerprint],
+          doc_auth_success: client_response.doc_auth_success?,
+          selfie_success: client_response.selfie_success,
         )
       end
       # retrieve updated data from session

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -17,6 +17,9 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.captured_at = Time.zone.now
     session_result.attention_with_barcode = doc_auth_response.attention_with_barcode?
     session_result.selfie_check_performed = doc_auth_response.selfie_check_performed?
+    session_result.doc_auth_success = doc_auth_response.doc_auth_success?
+    # nil(selfie not required) or true/false
+    session_result.selfie_success = doc_auth_response.selfie_success
     EncryptedRedisStructStorage.store(
       session_result,
       expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.seconds.to_i,

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -28,12 +28,15 @@ class DocumentCaptureSession < ApplicationRecord
     save!
   end
 
-  def store_failed_auth_image_fingerprint(front_image_fingerprint, back_image_fingerprint)
+  def store_failed_auth_data(front_image_fingerprint:, back_image_fingerprint:, doc_auth_success:,
+                             selfie_success:)
     session_result = load_result || DocumentCaptureSessionResult.new(
       id: generate_result_id,
     )
     session_result.success = false
     session_result.captured_at = Time.zone.now
+    session_result.doc_auth_success = doc_auth_success
+    session_result.selfie_success = selfie_success
     session_result.add_failed_front_image!(front_image_fingerprint) if front_image_fingerprint
     session_result.add_failed_back_image!(back_image_fingerprint) if back_image_fingerprint
     EncryptedRedisStructStorage.store(

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -43,6 +43,10 @@ module DocAuth
           end
         end
 
+        def doc_auth_success?
+          passed_result?
+        end
+
         private
 
         attr_reader :http_response
@@ -67,6 +71,8 @@ module DocAuth
             tamper_result: tamper_result_code&.name,
             classification_info: classification_info,
             address_line2_present: !pii_from_doc[:address2].blank?,
+            doc_auth_success: doc_auth_success?,
+            selfie_success: nil,
           }
         end
 

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -149,6 +149,12 @@ module DocAuth
             doc_auth_result_passed?
         end
 
+        # Returns nil, true, false
+        # * When selfie check is not required, return nil
+        # * Otherwise:
+        #    return false if selfie check result != 'Pass'
+        #    return true if selfie check result == 'Pass'
+        #    return false if selfie check result is missing
         def selfie_success
           return nil unless @liveness_checking_enabled
           selfie_result == 'Pass'

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -315,7 +315,7 @@ module DocAuth
           return @new_alerts if defined?(@new_alerts)
 
           @new_alerts = { passed: [], failed: [] }
-          return @new_alerts unless true_id_product&.dig(:AUTHENTICATION_RESULT)&.present?
+          return @new_alerts unless true_id_product&.dig(:AUTHENTICATION_RESULT).present?
           all_alerts = true_id_product[:AUTHENTICATION_RESULT].select do |key|
             key.start_with?('Alert_')
           end
@@ -356,7 +356,7 @@ module DocAuth
 
         def parse_image_metrics
           image_metrics = {}
-          return image_metrics unless true_id_product&.dig(:ParameterDetails)&.present?
+          return image_metrics unless true_id_product&.dig(:ParameterDetails).present?
           true_id_product[:ParameterDetails].each do |detail|
             next unless detail[:Group] == 'IMAGE_METRICS_RESULT'
 

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -149,12 +149,11 @@ module DocAuth
             doc_auth_result_passed?
         end
 
-        # Returns nil, true, false
-        # * When selfie check is not required, return nil
-        # * Otherwise:
-        #    return false if selfie check result != 'Pass'
-        #    return true if selfie check result == 'Pass'
-        #    return false if selfie check result is missing
+        # @return [Boolean, nil]
+        # When selfie check is not required, return nil
+        # Otherwise:
+        #   return true if selfie check result == 'Pass'
+        #   return false
         def selfie_success
           return nil unless @liveness_checking_enabled
           selfie_result == 'Pass'

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -142,6 +142,18 @@ module DocAuth
           !!doc_auth_result
         end
 
+        def doc_auth_success?
+          transaction_status_passed? &&
+            true_id_product.present? &&
+            product_status_passed? &&
+            doc_auth_result_passed?
+        end
+
+        def selfie_success
+          return nil unless @liveness_checking_enabled
+          selfie_result == 'Pass'
+        end
+
         private
 
         def conversation_id
@@ -230,6 +242,10 @@ module DocAuth
             true_id_product.present? &&
             product_status_passed? &&
             doc_auth_result_passed?
+        end
+
+        def selfie_result
+          response_info[:portrait_match_results]&.dig(:FaceMatchResult)
         end
 
         def product_status_passed?

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -130,6 +130,15 @@ module DocAuth
         )
       end
 
+      def doc_auth_success?
+        doc_auth_result_from_uploaded_file == 'Passed'
+      end
+
+      def selfie_success
+        return nil if parsed_data_from_uploaded_file['liveness_result'].nil?
+        parsed_data_from_uploaded_file['liveness_result'] == 'Pass'
+      end
+
       private
 
       def parsed_alerts
@@ -224,6 +233,8 @@ module DocAuth
           liveness_enabled: liveness_enabled,
           classification_info: classification_info,
           portrait_match_results: @selfie_check_performed ? portrait_match_results : nil,
+          doc_auth_success: doc_auth_success?,
+          selfie_success: selfie_success,
         }.compact
       end
     end

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -131,12 +131,12 @@ module DocAuth
       end
 
       def doc_auth_success?
-        doc_auth_result_from_uploaded_file == 'Passed'
+        doc_auth_result_from_uploaded_file == 'Passed' || errors.blank?
       end
 
       def selfie_success
-        return nil if parsed_data_from_uploaded_file['liveness_result'].nil?
-        parsed_data_from_uploaded_file['liveness_result'] == 'Pass'
+        return nil if portrait_match_results&.dig(:FaceMatchResult).nil?
+        portrait_match_results[:FaceMatchResult] == 'Pass'
       end
 
       private
@@ -233,8 +233,6 @@ module DocAuth
           liveness_enabled: liveness_enabled,
           classification_info: classification_info,
           portrait_match_results: @selfie_check_performed ? portrait_match_results : nil,
-          doc_auth_success: doc_auth_success?,
-          selfie_success: selfie_success,
         }.compact
       end
     end

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -86,6 +86,7 @@ module DocAuth
 
     def doc_auth_success?
       # to be implemented by concrete subclass
+      false
     end
   end
 end

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -56,6 +56,8 @@ module DocAuth
         exception: exception,
         attention_with_barcode: attention_with_barcode?,
         doc_type_supported: doc_type_supported?,
+        doc_auth_success: doc_auth_success?,
+        selfie_success: selfie_success,
       }.merge(extra)
     end
 
@@ -76,6 +78,14 @@ module DocAuth
 
     def selfie_check_performed?
       @selfie_check_performed
+    end
+
+    def selfie_success
+      # to be implemented by concrete subclass
+    end
+
+    def doc_auth_success?
+      # to be implemented by concrete subclass
     end
   end
 end

--- a/app/services/document_capture_session_result.rb
+++ b/app/services/document_capture_session_result.rb
@@ -10,9 +10,11 @@ DocumentCaptureSessionResult = RedactedStruct.new(
   :failed_back_image_fingerprints,
   :captured_at,
   :selfie_check_performed,
+  :doc_auth_success, :selfie_success,
   keyword_init: true,
   allowed_members: [:id, :success, :attention_with_barcode, :failed_front_image_fingerprints,
-                    :failed_back_image_fingerprints, :captured_at, :selfie_check_performed],
+                    :failed_back_image_fingerprints, :captured_at, :selfie_check_performed,
+                    :doc_auth_success, :selfie_success]
 ) do
   def self.redis_key_prefix
     'dcs:result'

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -434,6 +434,8 @@ RSpec.describe Idv::ImageUploadsController do
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
           doc_type_supported: boolean,
+          doc_auth_success: boolean,
+          selfie_success: nil,
         )
 
         expect(@analytics).to receive(:track_event).with(
@@ -610,6 +612,8 @@ RSpec.describe Idv::ImageUploadsController do
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
               doc_type_supported: boolean,
+              doc_auth_success: boolean,
+              selfie_success: nil,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -699,6 +703,8 @@ RSpec.describe Idv::ImageUploadsController do
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
               doc_type_supported: boolean,
+              doc_auth_success: boolean,
+              selfie_success: nil,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -788,6 +794,8 @@ RSpec.describe Idv::ImageUploadsController do
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
               doc_type_supported: boolean,
+              doc_auth_success: boolean,
+              selfie_success: nil,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -874,6 +882,8 @@ RSpec.describe Idv::ImageUploadsController do
               front_image_fingerprint: an_instance_of(String),
               back_image_fingerprint: an_instance_of(String),
               doc_type_supported: boolean,
+              doc_auth_success: boolean,
+              selfie_success: nil,
             )
 
             expect(@analytics).to receive(:track_event).with(
@@ -985,6 +995,8 @@ RSpec.describe Idv::ImageUploadsController do
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
           doc_type_supported: boolean,
+          doc_auth_success: boolean,
+          selfie_success: nil,
         )
 
         action
@@ -1055,6 +1067,8 @@ RSpec.describe Idv::ImageUploadsController do
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
           doc_type_supported: boolean,
+          doc_auth_success: boolean,
+          selfie_success: nil,
         )
 
         action

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_with_liveness.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_with_liveness.json
@@ -1,0 +1,1100 @@
+{
+  "Status": {
+    "ConversationId": "70000300394121",
+    "RequestId": "614507871",
+    "TransactionStatus": "passed",
+    "TransactionReasonCode": {
+      "Code": "trueid_pass",
+      "Description": "TRUEID PASS"
+    },
+    "Reference": "ca6e36c4-8a55-4831-aa8a-38d78b7c80e3"
+  },
+  "Products": [
+    {
+      "ProductType": "TrueID",
+      "ExecutedStepName": "True_ID_Step",
+      "ProductConfigurationName": "GSA2.V3.TrueID.CROP.PT.test",
+      "ProductStatus": "pass",
+      "ParameterDetails": [
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocumentName",
+          "Values": [{ "Value": "Maryland (MD) Driver's License - STAR" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocAuthResult",
+          "Values": [{ "Value": "Passed" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocAuthTamperResult",
+          "Values": [{ "Value": "Passed" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocAuthTamperSensitivity",
+          "Values": [{ "Value": "Normal" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerCode",
+          "Values": [{ "Value": "MD" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerName",
+          "Values": [{ "Value": "Maryland" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerType",
+          "Values": [{ "Value": "StateProvince" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClassCode",
+          "Values": [{ "Value": "DriversLicense" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClass",
+          "Values": [{ "Value": "DriversLicense" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClassName",
+          "Values": [{ "Value": "Drivers License" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIsGeneric",
+          "Values": [{ "Value": "false" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssue",
+          "Values": [{ "Value": "2016" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssueType",
+          "Values": [{ "Value": "Driver's License - STAR" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocSize",
+          "Values": [{ "Value": "ID1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ClassificationMode",
+          "Values": [{ "Value": "Automatic" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "OrientationChanged",
+          "Values": [{ "Value": "true" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "PresentationChanged",
+          "Values": [{ "Value": "false" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "Side",
+          "Values": [{ "Value": "Front" }, { "Value": "Back" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "GlareMetric",
+          "Values": [{ "Value": "100" }, { "Value": "100" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "SharpnessMetric",
+          "Values": [{ "Value": "65" }, { "Value": "65" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "IsTampered",
+          "Values": [{ "Value": "0" }, { "Value": "0" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "IsCropped",
+          "Values": [{ "Value": "1" }, { "Value": "1" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "HorizontalResolution",
+          "Values": [{ "Value": "600" }, { "Value": "600" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "VerticalResolution",
+          "Values": [{ "Value": "600" }, { "Value": "600" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "Light",
+          "Values": [{ "Value": "White" }, { "Value": "White" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "MimeType",
+          "Values": [
+            { "Value": "image/vnd.ms-photo" },
+            { "Value": "image/vnd.ms-photo" }
+          ]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "ImageMetrics_Id",
+          "Values": [
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "FullName",
+          "Values": [{ "Value": "DAVID LICENSE SAMPLE" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Sex",
+          "Values": [{ "Value": "Male" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Age",
+          "Values": [{ "Value": "33" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Year",
+          "Values": [{ "Value": "1985" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Month",
+          "Values": [{ "Value": "7" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Day",
+          "Values": [{ "Value": "1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Year",
+          "Values": [{ "Value": "2099" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_AlertName",
+          "Values": [{ "Value": "Document Expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_AlertName",
+          "Values": [{ "Value": "2D Barcode Content" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_AlertName",
+          "Values": [{ "Value": "2D Barcode Read" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_AlertName",
+          "Values": [{ "Value": "Barcode Encoding" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_AlertName",
+          "Values": [{ "Value": "Birth Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_AlertName",
+          "Values": [{ "Value": "Birth Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_AlertName",
+          "Values": [{ "Value": "Document Classification" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_AlertName",
+          "Values": [{ "Value": "Document Crosscheck Aggregation" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_AlertName",
+          "Values": [{ "Value": "Document Number Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_AlertName",
+          "Values": [{ "Value": "Expiration Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_AlertName",
+          "Values": [{ "Value": "Expiration Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_AlertName",
+          "Values": [{ "Value": "Full Name Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_AlertName",
+          "Values": [{ "Value": "Issue Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_AlertName",
+          "Values": [{ "Value": "Issue Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_AlertName",
+          "Values": [{ "Value": "Series Expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_AlertName",
+          "Values": [{ "Value": "Sex Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Model",
+          "Values": [{ "Value": "Text Tampering Detection V1.3.1 (Beta)" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Model",
+          "Values": [{ "Value": "Photo Tampering Detection V2.4" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Model",
+          "Values": [{ "Value": "Text Tampering Detection V1.2.1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_Model",
+          "Values": [{ "Value": "Physical Document Presence V2.5" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Checked if the document is expired."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Checked the contents of the two-dimensional barcode on the document."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Attention",
+              "Detail": "Verified that the two-dimensional barcode on the document was read successfully."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the format of the barcode."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable birth date field to the human-readable birth date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the birth date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the type of document is supported and is able to be fully authenticated."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compared the machine-readable fields to the human-readable fields."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable document number field to the human-readable document number field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable expiration date field to the human-readable expiration date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the expiration date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable full name field to the human-readable full name field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable issue date field to the human-readable issue date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the issue date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified whether the document type is still in circulation."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable sex field to the human-readable sex field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_Disposition",
+          "Values": [{ "Value": "The document has expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Disposition",
+          "Values": [{ "Value": "A visible pattern was not found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Disposition",
+          "Values": [
+            {
+              "Value": "Evidence suggests that the document may have been tampered with."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_Disposition",
+          "Values": [{ "Value": "The 2D barcode is formatted correctly" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_Disposition",
+          "Values": [{ "Value": "The 2D barcode was read successfully" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_Disposition",
+          "Values": [
+            {
+              "Value": "The barcode encoding is consistent with the expected encoding for the type"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_Disposition",
+          "Values": [{ "Value": "The birth dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_Disposition",
+          "Values": [{ "Value": "The birth date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_Disposition",
+          "Values": [{ "Value": "The document type is supported" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_Disposition",
+          "Values": [
+            {
+              "Value": "There are not a large number of differences between electronic and human-readable data sources"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_Disposition",
+          "Values": [{ "Value": "The document numbers match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Disposition",
+          "Values": [
+            { "Value": "No evidence of document tampering was detected." }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Disposition",
+          "Values": [
+            { "Value": "No evidence of document tampering was detected." }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_Disposition",
+          "Values": [
+            { "Value": "No evidence of document tampering was detected." }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_Disposition",
+          "Values": [{ "Value": "The expiration dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_Disposition",
+          "Values": [{ "Value": "The expiration date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_Disposition",
+          "Values": [{ "Value": "The full names match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_Disposition",
+          "Values": [{ "Value": "The issue dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_Disposition",
+          "Values": [{ "Value": "The issue date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_Disposition",
+          "Values": [{ "Value": "The series has not expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_Disposition",
+          "Values": [{ "Value": "The sexes match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Regions",
+          "Values": [{ "Value": "Background" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Regions",
+          "Values": [
+            { "Value": "Address" },
+            { "Value": "Birth Date" },
+            { "Value": "Document Number" },
+            { "Value": "Expiration Date" },
+            { "Value": "Full Name" },
+            { "Value": "Issue Date" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Regions",
+          "Values": [{ "Value": "Photo" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Regions",
+          "Values": [
+            { "Value": "Address" },
+            { "Value": "Birth Date" },
+            { "Value": "Document Number" },
+            { "Value": "Expiration Date" },
+            { "Value": "Full Name" },
+            { "Value": "Issue Date" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Regions",
+          "Values": [{ "Value": "Expires Label" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Regions",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Regions",
+          "Values": [{ "Value": "Background Upper" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Regions_Reference",
+          "Values": [{ "Value": "faacfb79-d0a1-4a8e-b868-20c604988e84" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Regions_Reference",
+          "Values": [
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Regions_Reference",
+          "Values": [{ "Value": "f29b1fe5-6482-4b39-8b4a-d91caf4ecb57" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Regions_Reference",
+          "Values": [
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Regions_Reference",
+          "Values": [{ "Value": "d55f2c66-f84f-4213-a660-4ff9e5d0fde5" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Regions_Reference",
+          "Values": [{ "Value": "bbf6ba02-ee3f-4b5c-a5d0-2fdb39ac79f7" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Regions_Reference",
+          "Values": [{ "Value": "20203cb8-f8a4-4a5b-999f-3700f73fe4fe" }]
+        },
+        {
+          "Group": "PORTRAIT_MATCH_RESULT",
+          "Name": "FaceMatchResult",
+          "Values": [{"Value": "Pass"}]
+        },
+        {
+          "Group": "PORTRAIT_MATCH_RESULT",
+          "Name": "FaceMatchScore",
+          "Values": [{"Value": "96"}]
+        },
+        {
+          "Group": "PORTRAIT_MATCH_RESULT",
+          "Name": "FaceStatusCode",
+          "Values": [{"Value": "1"}]
+        },
+        {
+          "Group": "PORTRAIT_MATCH_RESULT",
+          "Name": "FaceErrorMessage",
+          "Values": [{"Value": "Successful. Liveness: Live"}]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_FullName",
+          "Values": [{ "Value": "DAVID LICENSE SAMPLE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_Surname",
+          "Values": [{ "Value": "SAMPLE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_GivenName",
+          "Values": [{ "Value": "DAVID LICENSE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_FirstName",
+          "Values": [{ "Value": "DAVID" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_MiddleName",
+          "Values": [{ "Value": "LICENSE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Year",
+          "Values": [{ "Value": "1986" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Month",
+          "Values": [{ "Value": "7" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Day",
+          "Values": [{ "Value": "1" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DocumentClassName",
+          "Values": [{ "Value": "Drivers License" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DocumentNumber",
+          "Values": [{ "Value": "M555555555555" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_ExpirationDate_Year",
+          "Values": [{ "Value": "2099" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_ExpirationDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_xpirationDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssuingStateCode",
+          "Values": [{ "Value": "MD" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssuingStateName",
+          "Values": [{ "Value": "Maryland" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_CountryCode",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_Address",
+          "Values": [
+            {
+              "Value": "123 ABC AVExE2x80xA8ANYTOWN, MD 12345"
+            }
+          ]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_AddressLine1",
+          "Values": [{ "Value": "123 ABC AVE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_AddressLine2",
+          "Values": [{ "Value": "APT 3E" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_City",
+          "Values": [{ "Value": "ANYTOWN" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_State",
+          "Values": [{ "Value": "MD" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_PostalCode",
+          "Values": [{ "Value": "12345" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_Height",
+          "Values": [{ "Value": "5' 9\"" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Year",
+          "Values": [{ "Value": "2016" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_LicenseClass",
+          "Values": [{ "Value": "C" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_LicenseRestrictions",
+          "Values": [{ "Value": "B" }]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_Id",
+          "Values": [
+            { "Value": "ce2cf0e2-5373-4ec2-84e8-7fe44a01642b" },
+            { "Value": "0b4f4f2b-cbd6-43e9-ac67-55bf2bdd9df5" },
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a0fdf00c-071c-4d8e-81af-8af0fc7688b8" },
+            { "Value": "faacfb79-d0a1-4a8e-b868-20c604988e84" },
+            { "Value": "3362ad4b-a36b-487e-826c-c748c7b04e8d" },
+            { "Value": "20203cb8-f8a4-4a5b-999f-3700f73fe4fe" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "a3e3a625-8b0e-4deb-a91e-86afc55d036b" },
+            { "Value": "cda4092d-9208-4871-bbc1-1b732c299d26" },
+            { "Value": "42770baf-3a4a-4477-9e5f-4400237273fe" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "b36594f2-d19c-48aa-98c2-2b4f8429744f" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "d55f2c66-f84f-4213-a660-4ff9e5d0fde5" },
+            { "Value": "26ca0c85-01ab-4311-bfd5-d27d2ee975eb" },
+            { "Value": "0af79f76-1542-4391-ad17-a5d6169be57f" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "64e8ee97-2b24-452d-a5af-1627951aa737" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" },
+            { "Value": "f29b1fe5-6482-4b39-8b4a-d91caf4ecb57" },
+            { "Value": "35442fb1-c3bb-4f2f-ad9e-537a8f0e7e0f" },
+            { "Value": "29964031-e072-4204-a9ae-b2b7122bfdc1" },
+            { "Value": "a3bbdf8b-62f5-438f-bf72-091bb2f6f0ff" },
+            { "Value": "42d0c49e-fc7a-45da-8f6d-8896c4b5267f" },
+            { "Value": "5430efcb-523b-4c62-a190-e9aa7eea4ebd" },
+            { "Value": "bbf6ba02-ee3f-4b5c-a5d0-2fdb39ac79f7" },
+            { "Value": "0686341c-0b3f-4544-840e-58822120ef06" }
+          ]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_Key",
+          "Values": [
+            { "Value": "1D Barcode" },
+            { "Value": "2D Barcode" },
+            { "Value": "Address" },
+            { "Value": "Alaska Validator" },
+            { "Value": "Background" },
+            { "Value": "Background Lower" },
+            { "Value": "Background Upper" },
+            { "Value": "Birth Date" },
+            { "Value": "Birth Date" },
+            { "Value": "DOB Label" },
+            { "Value": "DOB Label Text" },
+            { "Value": "Document Number" },
+            { "Value": "Document Type" },
+            { "Value": "Expiration Date" },
+            { "Value": "Expires Label" },
+            { "Value": "Expires Label Position" },
+            { "Value": "Eye Color" },
+            { "Value": "Full Name" },
+            { "Value": "Height" },
+            { "Value": "Issue Date" },
+            { "Value": "Photo" },
+            { "Value": "Photo Printing" },
+            { "Value": "Secondary Photo" },
+            { "Value": "Sex" },
+            { "Value": "Sex Height Labels" },
+            { "Value": "Signature" },
+            { "Value": "USA" },
+            { "Value": "Weight" }
+          ]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_ImageReference",
+          "Values": [
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" }
+          ]
+        }
+      ]
+    },
+    {
+      "ProductType": "TrueID_Decision",
+      "ExecutedStepName": "Decision",
+      "ProductConfigurationName": "TRUEID_PASS",
+      "ProductStatus": "pass",
+      "ProductReason": {
+        "Code": "trueid_pass",
+        "Description": "TRUEID PASS"
+      }
+    }
+  ]
+}

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -484,6 +484,8 @@ RSpec.describe Idv::ApiImageUploadForm do
           allow(client_response).to receive(:success?).and_return(false)
           allow(client_response).to receive(:network_error?).and_return(false)
           allow(client_response).to receive(:errors).and_return(errors)
+          allow(client_response).to receive(:doc_auth_success?).and_return(false)
+          allow(client_response).to receive(:selfie_success).and_return(nil)
           form.send(:validate_form)
           capture_result = form.send(:store_failed_images, client_response, doc_pii_response)
           expect(capture_result[:front]).not_to be_empty
@@ -496,6 +498,8 @@ RSpec.describe Idv::ApiImageUploadForm do
           allow(client_response).to receive(:success?).and_return(false)
           allow(client_response).to receive(:network_error?).and_return(false)
           allow(client_response).to receive(:errors).and_return(errors)
+          allow(client_response).to receive(:doc_auth_success?).and_return(false)
+          allow(client_response).to receive(:selfie_success).and_return(nil)
           form.send(:validate_form)
           capture_result = form.send(:store_failed_images, client_response, doc_pii_response)
           expect(capture_result[:front]).not_to be_empty
@@ -508,6 +512,8 @@ RSpec.describe Idv::ApiImageUploadForm do
           allow(client_response).to receive(:success?).and_return(false)
           allow(client_response).to receive(:network_error?).and_return(false)
           allow(client_response).to receive(:errors).and_return(errors)
+          allow(client_response).to receive(:doc_auth_success?).and_return(false)
+          allow(client_response).to receive(:selfie_success).and_return(nil)
           form.send(:validate_form)
           capture_result = form.send(:store_failed_images, client_response, doc_pii_response)
           expect(capture_result[:front]).not_to be_empty
@@ -535,6 +541,8 @@ RSpec.describe Idv::ApiImageUploadForm do
           allow(client_response).to receive(:success?).and_return(false)
           allow(client_response).to receive(:network_error?).and_return(true)
           allow(client_response).to receive(:errors).and_return(errors)
+          allow(client_response).to receive(:doc_auth_success?).and_return(false)
+          allow(client_response).to receive(:selfie_success).and_return(nil)
           allow(doc_pii_response).to receive(:success?).and_return(false)
           form.send(:validate_form)
           capture_result = form.send(:store_failed_images, client_response, doc_pii_response)

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -159,6 +159,8 @@ RSpec.describe Idv::ApiImageUploadForm do
           front_image_fingerprint: an_instance_of(String),
           back_image_fingerprint: an_instance_of(String),
           doc_type_supported: boolean,
+          doc_auth_success: boolean,
+          selfie_success: anything,
         )
       end
 

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
         },
         address_line2_present: true,
         doc_type_supported: true,
+        doc_auth_success: true,
+        selfie_success: nil,
       }
 
       processed_alerts = response_hash[:processed_alerts]
@@ -418,6 +420,8 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
           },
           address_line2_present: true,
           doc_type_supported: false,
+          doc_auth_success: true,
+          selfie_success: nil,
         }
 
         processed_alerts = response_hash[:processed_alerts]
@@ -499,6 +503,8 @@ RSpec.describe DocAuth::Acuant::Responses::GetResultsResponse do
             },
             address_line2_present: true,
             doc_type_supported: false,
+            doc_auth_success: true,
+            selfie_success: nil,
           }
 
           expect(response_hash).to match(expected_hash)

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -2,8 +2,14 @@ require 'rails_helper'
 
 RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
   let(:success_response_body) { LexisNexisFixtures.true_id_response_success_3 }
+  let(:success_with_liveness_response_body) do
+    LexisNexisFixtures.true_id_response_success_with_liveness
+  end
   let(:success_response) do
     instance_double(Faraday::Response, status: 200, body: success_response_body)
+  end
+  let(:success_with_liveness_response) do
+    instance_double(Faraday::Response, status: 200, body: success_with_liveness_response_body)
   end
   let(:failure_body_no_liveness) { LexisNexisFixtures.true_id_response_failure_no_liveness }
   let(:failure_body_with_liveness) { LexisNexisFixtures.true_id_response_failure_with_liveness }
@@ -320,8 +326,11 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     end
 
     it 'returns Failed for liveness failure' do
-      output = described_class.new(failure_response_with_liveness, config).to_h
+      response = described_class.new(failure_response_with_liveness, config)
+      output = response.to_h
       expect(output[:success]).to eq(false)
+      expect(response.doc_auth_success?).to eq(false)
+      expect(response.selfie_success).to eq(nil)
     end
 
     it 'produces expected hash output' do
@@ -632,6 +641,50 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       it 'mark doc type as not supported' do
         response = described_class.new(error_response, config)
         expect(response.doc_type_supported?).to eq(false)
+      end
+    end
+  end
+  describe '#doc_auth_success?' do
+    context 'when document validation is successful' do
+      let(:response) { described_class.new(success_response, config) }
+      it 'returns true' do
+        expect(response.doc_auth_success?).to eq(true)
+      end
+    end
+    context 'when document validation failed' do
+      let(:response) { described_class.new(failure_response_tampering, config) }
+      it 'returns false' do
+        expect(response.doc_auth_success?).to eq(false)
+      end
+    end
+  end
+
+  describe '#selfie_success' do
+    context 'when selfie check is disabled' do
+      let(:response) { described_class.new(success_response, config, false) }
+      it 'returns nil' do
+        expect(response.selfie_success).to eq(nil)
+      end
+    end
+
+    context 'when selfie check is enabled' do
+      context 'whe missing selfie result in response' do
+        let(:response) { described_class.new(success_response, config, true) }
+        it 'returns false when missing selfie in response' do
+          expect(response.selfie_success).to eq(false)
+        end
+      end
+      context 'when selfie passed' do
+        let(:response) { described_class.new(success_with_liveness_response, config, true) }
+        it 'returns true' do
+          expect(response.selfie_success).to eq(true)
+        end
+      end
+      context 'when selfie failed' do
+        let(:response) { described_class.new(failure_response_with_liveness, config, true) }
+        it 'returns false' do
+          expect(response.selfie_success).to eq(false)
+        end
       end
     end
   end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -146,6 +146,8 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
           Front: a_hash_including(:ClassName, :CountryCode, :IssuerType),
           Back: a_hash_including(:ClassName, :CountryCode, :IssuerType),
         },
+        doc_auth_success: true,
+        selfie_success: nil,
       )
       passed_alerts = response_hash.dig(:processed_alerts, :passed)
       passed_alerts.each do |alert|
@@ -385,6 +387,8 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
           Front: a_hash_including(:ClassName, :CountryCode, :IssuerType),
           Back: a_hash_including(:ClassName, :CountryCode, :IssuerType),
         },
+        doc_auth_success: false,
+        selfie_success: nil,
       )
     end
     it 'produces appropriate errors with document tampering' do

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       output = response.to_h
       expect(output[:success]).to eq(false)
       expect(response.doc_auth_success?).to eq(false)
-      expect(response.selfie_success).to eq(nil)
+      expect(response.selfie_success).to eq(false)
     end
 
     it 'produces expected hash output' do
@@ -388,7 +388,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
           Back: a_hash_including(:ClassName, :CountryCode, :IssuerType),
         },
         doc_auth_success: false,
-        selfie_success: nil,
+        selfie_success: false,
       )
     end
     it 'produces appropriate errors with document tampering' do
@@ -674,8 +674,8 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     context 'when selfie check is enabled' do
       context 'whe missing selfie result in response' do
         let(:response) { described_class.new(success_response, config, true) }
-        it 'returns false when missing selfie in response' do
-          expect(response.selfie_success).to eq(false)
+        it 'returns nil when missing selfie in response' do
+          expect(response.selfie_success).to eq(nil)
         end
       end
       context 'when selfie passed' do

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -304,6 +304,8 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         billed: true,
         classification_info: {},
       )
+      expect(response.doc_auth_success?).to eq(true)
+      expect(response.selfie_success).to be_nil
     end
   end
 
@@ -669,6 +671,8 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         expect(response.selfie_check_performed?).to eq(true)
         expect(response.success?).to eq(true)
         expect(response.extra[:portrait_match_results]).to eq(selfie_results)
+        expect(response.doc_auth_success?).to eq(true)
+        expect(response.selfie_success).to eq(true)
       end
     end
 
@@ -693,6 +697,8 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         expect(response.selfie_check_performed?).to eq(true)
         expect(response.success?).to eq(false)
         expect(response.extra[:portrait_match_results]).to eq(selfie_results)
+        expect(response.doc_auth_success?).to eq(true)
+        expect(response.selfie_success).to eq(false)
       end
     end
   end
@@ -704,6 +710,8 @@ RSpec.describe DocAuth::Mock::ResultResponse do
     it 'returns the expected values' do
       expect(response.selfie_check_performed?).to eq(false)
       expect(response.extra).not_to have_key(:portrait_match_results)
+      expect(response.doc_auth_success?).to eq(true)
+      expect(response.selfie_success).to be_nil
     end
   end
 end

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -160,6 +160,10 @@ module LexisNexisFixtures
       read_fixture_file_at_path('true_id/true_id_response_success_3.json')
     end
 
+    def true_id_response_success_with_liveness
+      read_fixture_file_at_path('true_id/true_id_response_success_with_liveness.json')
+    end
+
     def true_id_response_failure_no_liveness
       read_fixture_file_at_path('true_id/true_id_response_failure_no_liveness.json')
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12036](https://cm-jira.usa.gov/browse/LG-12036)


## 🛠 Summary of changes
Add _doc_auth_success_ and _selfie_success_ to _DocumentCaptureSessionResult_ as part of selfie feature. Also, added the two properties to response hash.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
