### PR TITLE
LG-12015: stop spamming users who requested letters

### DIFF
--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -6,14 +6,17 @@ class GpoReminderSender
       IdentityConfig.store.usps_confirmation_max_days.days.ago..for_letters_sent_before
 
     profiles_due_for_reminder(letter_eligible_range).each do |profile|
-      profile.user.send_email_to_all_addresses(:gpo_reminder)
       profile.gpo_confirmation_codes.all.each do |gpo_code|
         next if gpo_code.reminder_sent_at
         next unless letter_eligible_range.cover?(gpo_code.created_at)
 
+        # Only email the user if we have an eligible code.
+        # Unlikely to have multiple codes since we only allow one letter/day
+        # due to config setting: minimum_wait_before_another_usps_letter_in_hours
+        profile.user.send_email_to_all_addresses(:gpo_reminder)
+        analytics.idv_gpo_reminder_email_sent(user_id: profile.user.uuid)
         gpo_code.update(reminder_sent_at: Time.zone.now)
       end
-      analytics.idv_gpo_reminder_email_sent(user_id: profile.user.uuid)
     end
   end
 

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe GpoReminderJob do
     let(:due_for_reminder_user) { create(:user, :with_pending_gpo_profile) }
     let(:not_yet_due_for_reminder_user) { create(:user, :with_pending_gpo_profile) }
     let(:user_with_invalid_profile) { create(:user, :with_pending_gpo_profile) }
+    let(:user_with_new_gpo_code) { create(:user, :with_pending_gpo_profile) }
 
     let(:job_analytics) { FakeAnalytics.new }
 
@@ -21,22 +22,28 @@ RSpec.describe GpoReminderJob do
         and_return(max_days_ago_to_send_letter)
       allow(Analytics).to receive(:new).and_return(job_analytics)
 
-      gpo_expired_user.gpo_verification_pending_profile.update(
-        gpo_verification_pending_at: (max_days_ago_to_send_letter + 1).days.ago,
+      set_gpo_verification_pending_at(gpo_expired_user, (max_days_ago_to_send_letter + 1).days.ago)
+
+      set_gpo_verification_pending_at(due_for_reminder_user, days_before_sending_reminder.days.ago)
+
+      set_gpo_verification_pending_at(
+        not_yet_due_for_reminder_user,
+        (days_before_sending_reminder - 1).days.ago,
       )
 
-      due_for_reminder_user.gpo_verification_pending_profile.update(
-        gpo_verification_pending_at: days_before_sending_reminder.days.ago,
-      )
-
-      not_yet_due_for_reminder_user.gpo_verification_pending_profile.update(
-        gpo_verification_pending_at: (days_before_sending_reminder - 1).days.ago,
-      )
-
-      user_with_invalid_profile.gpo_verification_pending_profile.update(
-        gpo_verification_pending_at: days_before_sending_reminder.days.ago,
+      set_gpo_verification_pending_at(
+        user_with_invalid_profile,
+        days_before_sending_reminder.days.ago,
       )
       user_with_invalid_profile.gpo_verification_pending_profile.deactivate(:password_reset)
+
+      set_gpo_verification_pending_at(
+        user_with_new_gpo_code,
+        (max_days_ago_to_send_letter + 1).days.ago,
+      )
+      new_confirmation_code = create(:gpo_confirmation_code, created_at: 1.day.ago)
+      user_with_new_gpo_code.gpo_verification_pending_profile.gpo_confirmation_codes <<
+        new_confirmation_code
     end
 
     it 'sends only one reminder email, to the correct user' do
@@ -47,5 +54,17 @@ RSpec.describe GpoReminderJob do
         user_id: due_for_reminder_user.uuid,
       )
     end
+  end
+
+  def set_gpo_verification_pending_at(user, to_time)
+    user.
+      gpo_verification_pending_profile.
+      update(gpo_verification_pending_at: to_time)
+
+    user.
+      gpo_verification_pending_profile.
+      gpo_confirmation_codes.each do |code|
+        code.update(code_sent_at: to_time, created_at: to_time, updated_at: to_time)
+      end
   end
 end

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -9,16 +9,36 @@ RSpec.describe GpoReminderJob do
 
     let(:job) { GpoReminderJob.new }
 
-    let!(:gpo_expired_user) { create(:user, :with_pending_gpo_profile,
-      code_sent_at: (max_days_ago_to_send_letter + 1).days.ago) }
-    let!(:due_for_reminder_user) { create(:user, :with_pending_gpo_profile,
-      code_sent_at: days_before_sending_reminder.days.ago) }
-    let!(:not_yet_due_for_reminder_user) { create(:user, :with_pending_gpo_profile,
-      code_sent_at: (days_before_sending_reminder - 1).days.ago) }
-    let!(:user_with_invalid_profile) { create(:user, :with_pending_gpo_profile,
-      code_sent_at: days_before_sending_reminder.days.ago) }
-    let!(:user_with_new_gpo_code) { create(:user, :with_pending_gpo_profile,
-      code_sent_at: (max_days_ago_to_send_letter + 1).days.ago) }
+    let!(:gpo_expired_user) do
+      create(
+        :user, :with_pending_gpo_profile,
+        code_sent_at: (max_days_ago_to_send_letter + 1).days.ago
+      )
+    end
+    let!(:due_for_reminder_user) do
+      create(
+        :user, :with_pending_gpo_profile,
+        code_sent_at: days_before_sending_reminder.days.ago
+      )
+    end
+    let!(:not_yet_due_for_reminder_user) do
+      create(
+        :user, :with_pending_gpo_profile,
+        code_sent_at: (days_before_sending_reminder - 1).days.ago
+      )
+    end
+    let!(:user_with_invalid_profile) do
+      create(
+        :user, :with_pending_gpo_profile,
+        code_sent_at: days_before_sending_reminder.days.ago
+      )
+    end
+    let!(:user_with_new_gpo_code) do
+      create(
+        :user, :with_pending_gpo_profile,
+        code_sent_at: (max_days_ago_to_send_letter + 1).days.ago
+      )
+    end
 
     let(:job_analytics) { FakeAnalytics.new }
 

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -113,8 +113,12 @@ RSpec.describe GpoReminderSender do
 
       context 'and the user has multiple emails' do
         let(:code_sent_at) { time_due_for_reminder - 2.days }
-        let!(:user) { create(:user, :with_pending_gpo_profile, :with_multiple_emails,
-          code_sent_at: code_sent_at) }
+        let!(:user) do
+          create(
+            :user, :with_pending_gpo_profile, :with_multiple_emails,
+            code_sent_at: code_sent_at
+          )
+        end
 
         include_examples 'sends emails',
                          expected_number_of_emails: 2,

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -78,6 +78,21 @@ RSpec.describe GpoReminderSender do
       include_examples 'sends no emails'
     end
 
+    context 'when a user has old reminded code and new code' do
+      before do
+        old_timestamp = time_due_for_reminder - 2.days
+        reminder_timestamp = 1.day.ago
+        set_gpo_verification_pending_at(user, old_timestamp)
+        set_reminder_sent_at(reminder_timestamp)
+
+        # user received reminder email and requests new letter
+        new_confirmation_code = create(:gpo_confirmation_code, created_at: reminder_timestamp)
+        user.gpo_verification_pending_profile.gpo_confirmation_codes << new_confirmation_code
+      end
+
+      include_examples 'sends no emails'
+    end
+
     context 'when a user has requested two letters' do
       before do
         timestamp = time_due_for_reminder - 2.days
@@ -185,9 +200,10 @@ RSpec.describe GpoReminderSender do
       let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
       before do
-        gpo_code = create(:gpo_confirmation_code)
+        timestamp = time_due_for_reminder
+        gpo_code = create(:gpo_confirmation_code, created_at: timestamp)
         user.pending_profile.gpo_confirmation_codes << gpo_code
-        user.pending_profile.gpo_verification_pending_at = time_due_for_reminder
+        user.pending_profile.gpo_verification_pending_at = timestamp
         user.pending_profile.save
       end
 

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe GpoReminderSender do
   describe '#send_emails' do
     subject(:sender) { GpoReminderSender.new }
 
-    let(:user) { create(:user, :with_pending_gpo_profile) }
+    let!(:user) { create(:user, :with_pending_gpo_profile, code_sent_at: code_sent_at) }
     let(:gpo_confirmation_code) do
       user.
         gpo_verification_pending_profile.
@@ -50,18 +50,6 @@ RSpec.describe GpoReminderSender do
     let(:time_not_yet_due) { time_due_for_reminder + 1.day }
     let(:time_yesterday) { Time.zone.now - 1.day }
 
-    def set_gpo_verification_pending_at(user, to_time)
-      user.
-        gpo_verification_pending_profile.
-        update(gpo_verification_pending_at: to_time)
-
-      user.
-        gpo_verification_pending_profile.
-        gpo_confirmation_codes.each do |code|
-          code.update(code_sent_at: to_time, created_at: to_time, updated_at: to_time)
-        end
-    end
-
     def set_reminder_sent_at(to_time)
       gpo_confirmation_code.update(
         reminder_sent_at: to_time,
@@ -72,16 +60,15 @@ RSpec.describe GpoReminderSender do
     before { allow(Analytics).to receive(:new).and_return(fake_analytics) }
 
     context 'when no users need a reminder' do
-      before { set_gpo_verification_pending_at(user, time_not_yet_due) }
+      let(:code_sent_at) { time_not_yet_due }
 
       include_examples 'sends no emails'
     end
 
     context 'when a user has old reminded code and new code' do
+      let(:code_sent_at) { time_due_for_reminder - 2.days }
       before do
-        old_timestamp = time_due_for_reminder - 2.days
         reminder_timestamp = 1.day.ago
-        set_gpo_verification_pending_at(user, old_timestamp)
         set_reminder_sent_at(reminder_timestamp)
 
         # user received reminder email and requests new letter
@@ -93,10 +80,9 @@ RSpec.describe GpoReminderSender do
     end
 
     context 'when a user has requested two letters' do
+      let(:code_sent_at) { time_due_for_reminder - 2.days }
       before do
-        timestamp = time_due_for_reminder - 2.days
-        set_gpo_verification_pending_at(user, timestamp)
-        new_confirmation_code = create(:gpo_confirmation_code, created_at: timestamp)
+        new_confirmation_code = create(:gpo_confirmation_code, created_at: code_sent_at)
         user.gpo_verification_pending_profile.gpo_confirmation_codes << new_confirmation_code
       end
 
@@ -114,7 +100,7 @@ RSpec.describe GpoReminderSender do
     end
 
     context 'when a user is due for a reminder' do
-      before { set_gpo_verification_pending_at(user, time_due_for_reminder) }
+      let(:code_sent_at) { time_due_for_reminder }
 
       include_examples 'sends emails', expected_number_of_emails: 1
 
@@ -126,7 +112,9 @@ RSpec.describe GpoReminderSender do
       end
 
       context 'and the user has multiple emails' do
-        let(:user) { create(:user, :with_pending_gpo_profile, :with_multiple_emails) }
+        let(:code_sent_at) { time_due_for_reminder - 2.days }
+        let!(:user) { create(:user, :with_pending_gpo_profile, :with_multiple_emails,
+          code_sent_at: code_sent_at) }
 
         include_examples 'sends emails',
                          expected_number_of_emails: 2,
@@ -185,9 +173,9 @@ RSpec.describe GpoReminderSender do
 
     context 'when a user is due for a reminder from too long ago' do
       let(:max_age_to_send_letter_in_days) { 42 }
+      let(:code_sent_at) { (max_age_to_send_letter_in_days + 1).days.ago }
 
       before do
-        set_gpo_verification_pending_at(user, (max_age_to_send_letter_in_days + 1).days.ago)
         allow(IdentityConfig.store).to receive(:usps_confirmation_max_days).
           and_return(max_age_to_send_letter_in_days)
       end

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe GpoReminderSender do
     def set_reminder_sent_at(to_time)
       gpo_confirmation_code.update(
         reminder_sent_at: to_time,
-        created_at: to_time,
         updated_at: to_time,
       )
     end


### PR DESCRIPTION
## 🎫 Ticket

[LG-12015](https://cm-jira.usa.gov/browse/LG-12015)

## 🛠 Summary of changes

If a user has an old GPO code that has received a reminder and a new code that is not yet eligible for a reminder, we were sending them an email every day. /o\ This was due to the join where a gpo code had a nil reminder_sent_at and a gpo code created in the reminder window.

Now we only send an email if we find a gpo code that meets all requirements.

## 📜 Testing Plan

Note that the new spec fails on `main` but passes on the branch.