### PR TITLE
Undo idv_session.selfie_check_performed in undo step for DocumentCapture and LinkSent

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -65,6 +65,7 @@ module Idv
           idv_session.invalidate_in_person_pii_from_user!
           idv_session.had_barcode_attention_error = nil
           idv_session.had_barcode_read_failure = nil
+          idv_session.selfie_check_performed = nil
         end,
       )
     end

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -47,6 +47,7 @@ module Idv
           idv_session.invalidate_in_person_pii_from_user!
           idv_session.had_barcode_attention_error = nil
           idv_session.had_barcode_read_failure = nil
+          idv_session.selfie_check_performed = nil
         end,
       )
     end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -184,10 +184,6 @@ module Idv
       end
     end
 
-    def document_capture_complete?
-      pii_from_doc || has_pii_from_user_in_flow_session
-    end
-
     def remote_document_capture_complete?
       pii_from_doc
     end


### PR DESCRIPTION
## 🎫 Ticket

This is an addendum for [LG-11698](https://cm-jira.usa.gov/browse/LG-11698)

## 🛠 Summary of changes

Since we update `idv_session.selfie_check_performed` in DocumentCaptureController and LinkSentController, set it to nil in the respective StepInfo.undo_step so that it's cleared if someone resubmits an earlier step.

Specs deferred to make a more general solution for undo_step.

## 📜 Testing Plan

- [ ] In application.yml, set `doc_auth_selfie_capture_enabled: true`
- [ ] Starting from sample OIDC sinatra SP, request biometric_comparison
- [ ] Proceed up to Ssn step
- [ ] Add breakpoint, inspect idv_session.selfie_check_performed, confirm it is true
- [ ] Click back button to Agreement step, submit
- [ ] Add breakpoint, inspect idv_session.selfie_check_performed, confirm it is nil
