### PR TITLE
LG-11882 (Step 1): Add disposable_email_domains table

### DIFF
--- a/app/models/disposable_email_domain.rb
+++ b/app/models/disposable_email_domain.rb
@@ -1,0 +1,5 @@
+class DisposableEmailDomain < ApplicationRecord
+  def self.disposable?(domain)
+    exists?(name: domain)
+  end
+end

--- a/db/primary_migrate/20240110141229_add_disposable_email_domains_table.rb
+++ b/db/primary_migrate/20240110141229_add_disposable_email_domains_table.rb
@@ -1,0 +1,11 @@
+class AddDisposableEmailDomainsTable < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension "citext"
+
+    create_table :disposable_email_domains do |t|
+      t.citext :name, null: false
+    end
+
+    add_index :disposable_email_domains, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_04_232215) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_10_141229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -98,6 +98,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_04_232215) do
   create_table "disposable_domains", force: :cascade do |t|
     t.citext "name", null: false
     t.index ["name"], name: "index_disposable_domains_on_name", unique: true
+  end
+
+  create_table "disposable_email_domains", force: :cascade do |t|
+    t.citext "name", null: false
+    t.index ["name"], name: "index_disposable_email_domains_on_name", unique: true
   end
 
   create_table "doc_auth_logs", force: :cascade do |t|

--- a/lib/tasks/disposable_domains.rake
+++ b/lib/tasks/disposable_domains.rake
@@ -6,7 +6,7 @@ namespace :disposable_domains do
     ActiveRecord::Base.connection.execute 'SET statement_timeout = 200000'
     file = Identity::Hostdata.secrets_s3.read_file(args[:s3_url])
     names = file.split("\n")
-    DisposableDomain.insert_all(names.map { |name| { name: } })
+    DisposableEmailDomain.insert_all(names.map { |name| { name: } })
   end
 end
 # rake "disposable_domains:load['URL_HERE']"

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SignUp::CompletionsController do
         let(:user) { create(:user, :fully_registered, email: temporary_email) }
 
         before do
-          DisposableDomain.create(name: 'temporary.com')
+          DisposableEmailDomain.create(name: 'temporary.com')
           stub_sign_in(user)
           subject.session[:sp] = {
             issuer: current_sp.issuer,
@@ -302,7 +302,7 @@ RSpec.describe SignUp::CompletionsController do
         let(:user) { create(:user, :fully_registered, email: temporary_email) }
 
         it 'logs disposable domain' do
-          DisposableDomain.create(name: 'temporary.com')
+          DisposableEmailDomain.create(name: 'temporary.com')
           stub_sign_in(user)
           subject.session[:sp] = {
             ial2: false,
@@ -331,7 +331,7 @@ RSpec.describe SignUp::CompletionsController do
 
     context 'IAL2' do
       it 'tracks analytics' do
-        DisposableDomain.create(name: 'temporary.com')
+        DisposableEmailDomain.create(name: 'temporary.com')
         user = create(
           :user,
           :fully_registered,

--- a/spec/models/disposable_email_domain_spec.rb
+++ b/spec/models/disposable_email_domain_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe DisposableEmailDomain do
+  let(:domain) { 'temporary.com' }
+
+  describe '.disposable?' do
+    before do
+      DisposableEmailDomain.create(name: domain)
+    end
+
+    context 'when the domain exists' do
+      it 'returns true' do
+        expect(DisposableEmailDomain.disposable?(domain)).to eq true
+      end
+    end
+
+    context 'when the domain does not exist' do
+      it 'returns false' do
+        expect(DisposableEmailDomain.disposable?('example.com')).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11882](https://cm-jira.usa.gov/browse/LG-11882)

## 🛠 Summary of changes

Adds a new database table `disposable_email_domains`. This is mostly a copy of #9440 and #9747, with the expectation that there will be two follow-up pull requests, split across two subsequent deploys:

1. Update the [code path referencing `DisposableDomain`](https://github.com/18F/identity-idp/blob/dad49d4750398bd1624db26d53ec95311906864b/app/controllers/sign_up/completions_controller.rb#L104) to reference `DisposableEmailDomain` instead
2. Create a migration which drops the old table `disposable_domains`

This does not copy data from the original table, which is expected to be run in deployed environments after the migration is run by using the included Rake script.

## 📜 Testing Plan

Run migration and verify tests pass referencing the new table:

1. `rails db:migrate:primary`
2. `rspec spec/controllers/sign_up/completions_controller_spec.rb spec/models/disposable_email_domain_spec.rb`

Repeat testing plan from #9747 to verify no regressions in current logging.