### PR TITLE
LG-11882 (Step 2): Update code paths referencing DisposableDomain

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -101,7 +101,7 @@ module SignUp
         needs_completion_screen_reason: needs_completion_screen_reason,
       }
 
-      if page_occurence.present? && DisposableDomain.disposable?(email_domain)
+      if page_occurence.present? && DisposableEmailDomain.disposable?(email_domain)
         attributes[:disposable_email_domain] = email_domain
       end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SignUp::CompletionsController do
         let(:user) { create(:user, :fully_registered, email: temporary_email) }
 
         before do
-          DisposableDomain.create(name: 'temporary.com')
+          DisposableEmailDomain.create(name: 'temporary.com')
           stub_sign_in(user)
           subject.session[:sp] = {
             issuer: current_sp.issuer,
@@ -302,7 +302,7 @@ RSpec.describe SignUp::CompletionsController do
         let(:user) { create(:user, :fully_registered, email: temporary_email) }
 
         it 'logs disposable domain' do
-          DisposableDomain.create(name: 'temporary.com')
+          DisposableEmailDomain.create(name: 'temporary.com')
           stub_sign_in(user)
           subject.session[:sp] = {
             ial2: false,
@@ -331,7 +331,7 @@ RSpec.describe SignUp::CompletionsController do
 
     context 'IAL2' do
       it 'tracks analytics' do
-        DisposableDomain.create(name: 'temporary.com')
+        DisposableEmailDomain.create(name: 'temporary.com')
         user = create(
           :user,
           :fully_registered,


### PR DESCRIPTION
## 🎫 Ticket

[LG-11882](https://cm-jira.usa.gov/browse/LG-11882)

## 🛠 Summary of changes

Updates code paths referencing `DisposableDomain` to reference `DisposableEmailDomain` instead, added in #9894.

This will be followed-up with a pull request dropping the old table, to be merged in a separate deployment.

**Do not merge:** This should only be merged after #9894 is live in production.

## 📜 Testing Plan

Verify tests pass referencing the new table:

2. `rspec spec/controllers/sign_up/completions_controller_spec.rb`

Repeat testing plan from #9747 to verify no regressions in current logging.