### PR TITLE
LG-10525: Refactor AcuantContext

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -82,10 +82,10 @@ interface AcuantImageAnalyticsPayload extends ImageAnalyticsPayload {
   dpi: number;
   moire: number;
   glare: number;
-  glareScoreThreshold: number;
+  glareScoreThreshold: number | null;
   isAssessedAsGlare: boolean;
   sharpness: number;
-  sharpnessScoreThreshold: number;
+  sharpnessScoreThreshold: number | null;
   isAssessedAsBlurry: boolean;
   assessment: AcuantImageAssessment;
   isAssessedAsUnsupported: boolean;
@@ -551,8 +551,8 @@ function AcuantCapture(
     const { image, dpi, moire, glare, sharpness } = nextCapture;
     const cardType = 'cardType' in nextCapture ? nextCapture.cardType : nextCapture.cardtype;
 
-    const isAssessedAsGlare = glare < glareThreshold;
-    const isAssessedAsBlurry = sharpness < sharpnessThreshold;
+    const isAssessedAsGlare = glare < glareThreshold!;
+    const isAssessedAsBlurry = sharpness < sharpnessThreshold!;
     const isAssessedAsUnsupported = cardType !== AcuantDocumentType.ID;
     const { width, height, data } = image;
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -551,8 +551,8 @@ function AcuantCapture(
     const { image, dpi, moire, glare, sharpness } = nextCapture;
     const cardType = 'cardType' in nextCapture ? nextCapture.cardType : nextCapture.cardtype;
 
-    const isAssessedAsGlare = glare < glareThreshold!;
-    const isAssessedAsBlurry = sharpness < sharpnessThreshold!;
+    const isAssessedAsGlare = !!glareThreshold && glare < glareThreshold;
+    const isAssessedAsBlurry = !!sharpnessThreshold && sharpness < sharpnessThreshold;
     const isAssessedAsUnsupported = cardType !== AcuantDocumentType.ID;
     const { width, height, data } = image;
 

--- a/app/javascript/packages/document-capture/context/acuant.tsx
+++ b/app/javascript/packages/document-capture/context/acuant.tsx
@@ -125,12 +125,11 @@ export type AcuantCaptureMode = 'AUTO' | 'TAP';
 /**
  * The minimum glare score value to be considered acceptable.
  */
-export const DEFAULT_ACCEPTABLE_GLARE_SCORE = 30;
-
+export const DEFAULT_ACCEPTABLE_GLARE_SCORE = 50;
 /**
  * The minimum sharpness score value to be considered acceptable.
  */
-export const DEFAULT_ACCEPTABLE_SHARPNESS_SCORE = 30;
+export const DEFAULT_ACCEPTABLE_SHARPNESS_SCORE = 50;
 
 /**
  * Returns the containing directory of the given file, including a trailing slash.

--- a/app/javascript/packages/document-capture/context/acuant.tsx
+++ b/app/javascript/packages/document-capture/context/acuant.tsx
@@ -109,11 +109,11 @@ interface AcuantContextProviderProps {
   /**
    * Minimum acceptable glare score for images.
    */
-  glareThreshold: number;
+  glareThreshold: number | null;
   /**
    * Minimum acceptable sharpness score for images.
    */
-  sharpnessThreshold: number;
+  sharpnessThreshold: number | null;
   /**
    * Child element
    */
@@ -121,15 +121,6 @@ interface AcuantContextProviderProps {
 }
 
 export type AcuantCaptureMode = 'AUTO' | 'TAP';
-
-/**
- * The minimum glare score value to be considered acceptable.
- */
-export const DEFAULT_ACCEPTABLE_GLARE_SCORE = 50;
-/**
- * The minimum sharpness score value to be considered acceptable.
- */
-export const DEFAULT_ACCEPTABLE_SHARPNESS_SCORE = 50;
 
 /**
  * Returns the containing directory of the given file, including a trailing slash.
@@ -146,8 +137,8 @@ interface AcuantContextInterface {
   acuantCaptureMode: AcuantCaptureMode;
   setAcuantCaptureMode: (type: AcuantCaptureMode) => void;
   credentials: string | null;
-  glareThreshold: number;
-  sharpnessThreshold: number;
+  glareThreshold: number | null;
+  sharpnessThreshold: number | null;
   endpoint: string | null;
 }
 
@@ -161,8 +152,8 @@ const AcuantContext = createContext<AcuantContextInterface>({
   acuantCaptureMode: 'AUTO',
   setAcuantCaptureMode: () => {},
   credentials: null,
-  glareThreshold: DEFAULT_ACCEPTABLE_GLARE_SCORE,
-  sharpnessThreshold: DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
+  glareThreshold: null,
+  sharpnessThreshold: null,
   endpoint: null as string | null,
 });
 
@@ -224,8 +215,8 @@ function AcuantContextProvider({
   passiveLivenessSrc,
   credentials = null,
   endpoint = null,
-  glareThreshold = DEFAULT_ACCEPTABLE_GLARE_SCORE,
-  sharpnessThreshold = DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
+  glareThreshold,
+  sharpnessThreshold,
   children,
 }: AcuantContextProviderProps) {
   const { isMobile } = useContext(DeviceContext);

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -596,7 +596,12 @@ describe('document-capture/components/acuant-capture', () => {
       const onChange = sinon.mock();
       const { getByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
-          <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank" sharpnessThreshold={50} glareThreshold={50}>
+          <AcuantContextProvider
+            sdkSrc="about:blank"
+            cameraSrc="about:blank"
+            sharpnessThreshold={50}
+            glareThreshold={50}
+          >
             <AcuantCapture label="Image" onChange={onChange} />
           </AcuantContextProvider>
         </DeviceContext.Provider>,
@@ -756,7 +761,12 @@ describe('document-capture/components/acuant-capture', () => {
       const { getByText, findByText } = render(
         <AnalyticsContext.Provider value={{ trackEvent }}>
           <DeviceContext.Provider value={{ isMobile: true }}>
-            <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank" glareThreshold={50} sharpnessThreshold={50}>
+            <AcuantContextProvider
+              sdkSrc="about:blank"
+              cameraSrc="about:blank"
+              glareThreshold={50}
+              sharpnessThreshold={50}
+            >
               <AcuantCapture label="Image" name="test" />
             </AcuantContextProvider>
           </DeviceContext.Provider>

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -596,7 +596,7 @@ describe('document-capture/components/acuant-capture', () => {
       const onChange = sinon.mock();
       const { getByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
-          <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
+          <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank" sharpnessThreshold={50} glareThreshold={50}>
             <AcuantCapture label="Image" onChange={onChange} />
           </AcuantContextProvider>
         </DeviceContext.Provider>,
@@ -756,7 +756,7 @@ describe('document-capture/components/acuant-capture', () => {
       const { getByText, findByText } = render(
         <AnalyticsContext.Provider value={{ trackEvent }}>
           <DeviceContext.Provider value={{ isMobile: true }}>
-            <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank" glareThreshold={50}>
+            <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank" glareThreshold={50} sharpnessThreshold={50}>
               <AcuantCapture label="Image" name="test" />
             </AcuantContextProvider>
           </DeviceContext.Provider>
@@ -814,6 +814,7 @@ describe('document-capture/components/acuant-capture', () => {
               sdkSrc="about:blank"
               cameraSrc="about:blank"
               sharpnessThreshold={50}
+              glareThreshold={50}
             >
               <AcuantCapture label="Image" name="test" />
             </AcuantContextProvider>
@@ -912,6 +913,7 @@ describe('document-capture/components/acuant-capture', () => {
               sdkSrc="about:blank"
               cameraSrc="about:blank"
               sharpnessThreshold={50}
+              glareThreshold={50}
             >
               <AcuantCapture label="Image" name="test" />
             </AcuantContextProvider>

--- a/spec/javascript/packages/document-capture/context/acuant-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/acuant-spec.jsx
@@ -1,7 +1,5 @@
 import AcuantContext, {
   Provider as AcuantContextProvider,
-  DEFAULT_ACCEPTABLE_GLARE_SCORE,
-  DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
   dirname,
 } from '@18f/identity-document-capture/context/acuant';
 import { AnalyticsContext, DeviceContext } from '@18f/identity-document-capture';
@@ -47,8 +45,6 @@ describe('document-capture/context/acuant', () => {
     expect(result.current.setIsActive).to.be.a('function');
     expect(result.current.credentials).to.be.null();
     expect(result.current.endpoint).to.be.null();
-    expect(result.current.glareThreshold).to.equal(DEFAULT_ACCEPTABLE_GLARE_SCORE);
-    expect(result.current.sharpnessThreshold).to.equal(DEFAULT_ACCEPTABLE_SHARPNESS_SCORE);
   });
 
   it('allows configurable acceptable scores', () => {


### PR DESCRIPTION


## 🎫 Ticket

Link to the relevant ticket:
[LG-10525](https://cm-jira.usa.gov/browse/LG-10525)



## 🛠 Summary of changes
My goal was to reduce the confusing discrepancy between the threshold of `50`, which we get from the backend, and the front-end constants of `DEFAULT_ACCEPTABLE_GLARE_SCORE` and `DEFAULT_ACCEPTABLE_SHARPNESS_SCORE`, which were set to 30.  I wanted to remove those constants, but I am now thinking it may be better to leave them and just change them to 50.  Slack context [here](https://gsa-tts.slack.com/archives/C05HSH9RQ57/p1704834031072889).


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
