### PR TITLE
LG-11984: document capture selfie hint text

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -48,7 +48,7 @@ module Idv
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         skip_doc_auth: idv_session.skip_doc_auth,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
-        doc_auth_selfie_capture: true, #decorated_sp_session.selfie_required?,
+        doc_auth_selfie_capture: decorated_sp_session.selfie_required?,
       }.merge(
         acuant_sdk_upgrade_a_b_testing_variables,
       )

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -48,7 +48,7 @@ module Idv
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         skip_doc_auth: idv_session.skip_doc_auth,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
-        doc_auth_selfie_capture: decorated_sp_session.selfie_required?,
+        doc_auth_selfie_capture: true, #decorated_sp_session.selfie_required?,
       }.merge(
         acuant_sdk_upgrade_a_b_testing_variables,
       )

--- a/app/javascript/packages/document-capture/components/acuant-capture.scss
+++ b/app/javascript/packages/document-capture/components/acuant-capture.scss
@@ -37,7 +37,7 @@
   .document-capture-file-image--loading {
     @extend %pad-common-id-card;
   }
-// Styles for the text that appears over the selfie capture screen to help users position their face for a good photo
+  // Styles for the text that appears over the selfie capture screen to help users position their face for a good photo
   .document-capture-selfie-feedback {
     left: 50%;
     top: 10%;

--- a/app/javascript/packages/document-capture/components/acuant-capture.scss
+++ b/app/javascript/packages/document-capture/components/acuant-capture.scss
@@ -40,7 +40,8 @@
 
   .document-capture-selfie-feedback {
     left: 50%;
-    position: absolute;
+    top: 10%;
+    position: fixed;
     transform: translateX(-50%);
     z-index: 11;
   }

--- a/app/javascript/packages/document-capture/components/acuant-capture.scss
+++ b/app/javascript/packages/document-capture/components/acuant-capture.scss
@@ -37,4 +37,11 @@
   .document-capture-file-image--loading {
     @extend %pad-common-id-card;
   }
+
+  .document-capture-selfie-feedback {
+    left: 50%;
+    position: absolute;
+    transform: translateX(-50%);
+    z-index: 10;
+  }
 }

--- a/app/javascript/packages/document-capture/components/acuant-capture.scss
+++ b/app/javascript/packages/document-capture/components/acuant-capture.scss
@@ -42,6 +42,6 @@
     left: 50%;
     position: absolute;
     transform: translateX(-50%);
-    z-index: 10;
+    z-index: 11;
   }
 }

--- a/app/javascript/packages/document-capture/components/acuant-capture.scss
+++ b/app/javascript/packages/document-capture/components/acuant-capture.scss
@@ -37,7 +37,7 @@
   .document-capture-file-image--loading {
     @extend %pad-common-id-card;
   }
-
+// Styles for the text that appears over the selfie capture screen to help users position their face for a good photo
   .document-capture-selfie-feedback {
     left: 50%;
     top: 10%;

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -654,7 +654,7 @@ function AcuantCapture(
     });
   }
 
-  function onImageCaptureFeedback(text){
+  function onImageCaptureFeedback(text: string){
     setImageCaptureText(text);
   }
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -337,6 +337,7 @@ function AcuantCapture(
   const [attempt, incrementAttempt] = useCounter(1);
   const [acuantFailureCookie, setAcuantFailureCookie, refreshAcuantFailureCookie] =
     useCookie('AcuantCameraHasFailed');
+  const [imageCaptureText, setImageCaptureText] = useState('');
   // There's some pretty significant changes to this component when it's used for
   // selfie capture vs document image capture. This controls those changes.
   const selfieCapture = name === 'selfie';
@@ -678,11 +679,13 @@ function AcuantCapture(
           onImageCaptureFailure={onSelfieCaptureFailure}
           onImageCaptureOpen={onSelfieCaptureOpen}
           onImageCaptureClose={onSelfieCaptureClosed}
+          onImageCaptureFeedback={onImageCaptureFeedback}
         >
           <AcuantSelfieCaptureCanvas
             fullScreenRef={fullScreenRef}
             fullScreenLabel={t('doc_auth.accessible_labels.document_capture_dialog')}
             onRequestClose={() => setIsCapturingEnvironment(false)}
+            imageCaptureText={imageCaptureText}
           />
         </AcuantSelfieCamera>
       )}

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -337,7 +337,7 @@ function AcuantCapture(
   const [attempt, incrementAttempt] = useCounter(1);
   const [acuantFailureCookie, setAcuantFailureCookie, refreshAcuantFailureCookie] =
     useCookie('AcuantCameraHasFailed');
-  const [imageCaptureText, setImageCaptureText] = useState('test');
+  const [imageCaptureText, setImageCaptureText] = useState('');
   // There's some pretty significant changes to this component when it's used for
   // selfie capture vs document image capture. This controls those changes.
   const selfieCapture = name === 'selfie';

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -337,7 +337,7 @@ function AcuantCapture(
   const [attempt, incrementAttempt] = useCounter(1);
   const [acuantFailureCookie, setAcuantFailureCookie, refreshAcuantFailureCookie] =
     useCookie('AcuantCameraHasFailed');
-  const [imageCaptureText, setImageCaptureText] = useState('');
+  const [imageCaptureText, setImageCaptureText] = useState('test');
   // There's some pretty significant changes to this component when it's used for
   // selfie capture vs document image capture. This controls those changes.
   const selfieCapture = name === 'selfie';
@@ -652,6 +652,10 @@ function AcuantCapture(
       acuantCaptureMode,
       error: getNormalizedAcuantCaptureFailureMessage(error, code),
     });
+  }
+
+  function onImageCaptureFeedback(text){
+    setImageCaptureText(text);
   }
 
   return (

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -654,7 +654,7 @@ function AcuantCapture(
     });
   }
 
-  function onImageCaptureFeedback(text: string){
+  function onImageCaptureFeedback(text: string) {
     setImageCaptureText(text);
   }
 

--- a/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import AcuantContext from '../context/acuant';
+import { t } from '@18f/identity-i18n';
 
 declare global {
   interface Window {
@@ -63,8 +64,6 @@ interface FaceCaptureCallback {
 interface FaceDetectionStates {
   FACE_NOT_FOUND: string;
   TOO_MANY_FACES: string;
-  FACE_ANGLE_TOO_LARGE: string;
-  PROBABILITY_TOO_SMALL: string;
   FACE_TOO_SMALL: string;
   FACE_CLOSE_TO_BORDER: string;
 }
@@ -119,12 +118,10 @@ function AcuantSelfieCamera({
     };
 
     const faceDetectionStates = {
-      FACE_NOT_FOUND: 'FACE NOT FOUND',
-      TOO_MANY_FACES: 'TOO MANY FACES',
-      FACE_ANGLE_TOO_LARGE: 'FACE ANGLE TOO LARGE',
-      PROBABILITY_TOO_SMALL: 'PROBABILITY TOO SMALL',
-      FACE_TOO_SMALL: 'FACE TOO SMALL',
-      FACE_CLOSE_TO_BORDER: 'TOO CLOSE TO THE FRAME',
+      FACE_NOT_FOUND: t('doc_auth.info.selfie_capture_status.face_not_found'),
+      TOO_MANY_FACES: t('doc_auth.info.selfie_capture_status.too_many_faces'),
+      FACE_TOO_SMALL: t('doc_auth.info.selfie_capture_status.face_too_small'),
+      FACE_CLOSE_TO_BORDER: t('doc_auth.info.selfie_capture_status.face_close_to_border'),
     };
     const cleanupSelfieCamera = () => {
       window.AcuantPassiveLiveness.end();
@@ -143,7 +140,7 @@ function AcuantSelfieCamera({
     return () => (isReady ? cleanupSelfieCamera() : undefined);
   }, [isReady]);
 
-  return <>{children}<div id='document-capture-selfie-feedback'>{feedback}</div></>;
+  return <>{children}<div className='document-capture-selfie-feedback'>{feedback}</div></>;
 }
 
 export default AcuantSelfieCamera;

--- a/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import AcuantContext from '../context/acuant';
 
@@ -77,6 +77,7 @@ function AcuantSelfieCamera({
   children,
 }: AcuantSelfieCameraContextProps) {
   const { isReady, setIsActive } = useContext(AcuantContext);
+  const [feedback, setFeedback] = useState('');
 
   useEffect(() => {
     const faceCaptureCallback: FaceCaptureCallback = {
@@ -85,7 +86,9 @@ function AcuantSelfieCamera({
         // Until then, no actions are executed and the user sees only the camera stream.
         // You can opt to display an alert before the callback is triggered.
       },
-      onDetection: () => {
+      onDetection: (text) => {
+        // console.log(text);
+        setFeedback(text);
         // Triggered when the face does not pass the scan. The UI element
         // should be updated here to provide guidence to the user
       },
@@ -104,6 +107,7 @@ function AcuantSelfieCamera({
       },
       onPhotoTaken: () => {
         // The photo has been taken and it's showing a preview with a button to accept or retake the image.
+        setFeedback('');
       },
       onPhotoRetake: () => {
         // Triggered when retake button is tapped
@@ -139,7 +143,7 @@ function AcuantSelfieCamera({
     return () => (isReady ? cleanupSelfieCamera() : undefined);
   }, [isReady]);
 
-  return <>{children}</>;
+  return <>{children}<div id='document-capture-selfie-feedback'>{feedback}</div></>;
 }
 
 export default AcuantSelfieCamera;

--- a/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
@@ -1,7 +1,7 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect } from 'react';
 import type { ReactNode } from 'react';
-import AcuantContext from '../context/acuant';
 import { t } from '@18f/identity-i18n';
+import AcuantContext from '../context/acuant';
 
 declare global {
   interface Window {

--- a/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
@@ -143,7 +143,7 @@ function AcuantSelfieCamera({
     // Cleanup when the AcuantSelfieCamera component is unmounted
     return () => (isReady ? cleanupSelfieCamera() : undefined);
   }, [isReady]);
-  // <div className='document-capture-selfie-feedback'>{feedback}</div>
+
   return <>{children}</>;
 }
 

--- a/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
@@ -75,8 +75,7 @@ function AcuantSelfieCamera({
   onImageCaptureClose = () => {},
   children,
 }: AcuantSelfieCameraContextProps) {
-  const { isReady, setIsActive } = useContext(AcuantContext);
-  const [feedback, setFeedback] = useState('');
+  const { isReady, setIsActive, setFeedback } = useContext(AcuantContext);
 
   useEffect(() => {
     const faceCaptureCallback: FaceCaptureCallback = {
@@ -86,7 +85,6 @@ function AcuantSelfieCamera({
         // You can opt to display an alert before the callback is triggered.
       },
       onDetection: (text) => {
-        // console.log(text);
         setFeedback(text);
         // Triggered when the face does not pass the scan. The UI element
         // should be updated here to provide guidence to the user
@@ -139,8 +137,8 @@ function AcuantSelfieCamera({
     // Cleanup when the AcuantSelfieCamera component is unmounted
     return () => (isReady ? cleanupSelfieCamera() : undefined);
   }, [isReady]);
-
-  return <>{children}<div className='document-capture-selfie-feedback'>{feedback}</div></>;
+  // <div className='document-capture-selfie-feedback'>{feedback}</div>
+  return <>{children}</>;
 }
 
 export default AcuantSelfieCamera;

--- a/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
@@ -45,6 +45,11 @@ interface AcuantSelfieCameraContextProps {
    */
   onImageCaptureClose: () => void;
   /**
+   * Capture hint text from onDetection callback, tells the user
+   * why the acuant sdk cannot capture a selfie.
+   */
+  onImageCaptureFeedback: (text: string) => void;
+  /**
    * React children node
    */
   children: ReactNode;
@@ -73,9 +78,10 @@ function AcuantSelfieCamera({
   onImageCaptureFailure = () => {},
   onImageCaptureOpen = () => {},
   onImageCaptureClose = () => {},
+  onImageCaptureFeedback = () => {},
   children,
 }: AcuantSelfieCameraContextProps) {
-  const { isReady, setIsActive, setFeedback } = useContext(AcuantContext);
+  const { isReady, setIsActive } = useContext(AcuantContext);
 
   useEffect(() => {
     const faceCaptureCallback: FaceCaptureCallback = {
@@ -85,7 +91,7 @@ function AcuantSelfieCamera({
         // You can opt to display an alert before the callback is triggered.
       },
       onDetection: (text) => {
-        setFeedback(text);
+        onImageCaptureFeedback(text);
         // Triggered when the face does not pass the scan. The UI element
         // should be updated here to provide guidence to the user
       },
@@ -104,7 +110,7 @@ function AcuantSelfieCamera({
       },
       onPhotoTaken: () => {
         // The photo has been taken and it's showing a preview with a button to accept or retake the image.
-        setFeedback('');
+        onImageCaptureFeedback('');
       },
       onPhotoRetake: () => {
         // Triggered when retake button is tapped

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -17,14 +17,19 @@ function FullScreenLoadingSpinner({ fullScreenRef, onRequestClose, fullScreenLab
   );
 }
 
-function AcuantSelfieCaptureCanvas({ fullScreenRef, onRequestClose, fullScreenLabel, imageCaptureText }) {
+function AcuantSelfieCaptureCanvas({
+  fullScreenRef,
+  onRequestClose,
+  fullScreenLabel,
+  imageCaptureText,
+}) {
   const { isReady } = useContext(AcuantContext);
   // The Acuant SDK script AcuantPassiveLiveness attaches to whatever element has
   // this id. It then uses that element as the root for the full screen selfie capture
   const acuantCaptureContainerId = 'acuant-face-capture-container';
   return isReady ? (
     <div id={acuantCaptureContainerId}>
-      <p className='document-capture-selfie-feedback'>{imageCaptureText}</p>
+      <p className="document-capture-selfie-feedback">{imageCaptureText}</p>
     </div>
   ) : (
     <FullScreenLoadingSpinner

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -17,13 +17,15 @@ function FullScreenLoadingSpinner({ fullScreenRef, onRequestClose, fullScreenLab
   );
 }
 
-function AcuantSelfieCaptureCanvas({ fullScreenRef, onRequestClose, fullScreenLabel }) {
+function AcuantSelfieCaptureCanvas({ fullScreenRef, onRequestClose, fullScreenLabel, imageCaptureText }) {
   const { isReady } = useContext(AcuantContext);
   // The Acuant SDK script AcuantPassiveLiveness attaches to whatever element has
   // this id. It then uses that element as the root for the full screen selfie capture
   const acuantCaptureContainerId = 'acuant-face-capture-container';
   return isReady ? (
-    <div id={acuantCaptureContainerId} />
+    <div id={acuantCaptureContainerId}>
+      <p className='document-capture-selfie-feedback'>{imageCaptureText}</p>
+    </div>
   ) : (
     <FullScreenLoadingSpinner
       fullScreenRef={fullScreenRef}

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -220,6 +220,11 @@ en:
       secure_account: We’ll encrypt your account with your password. Encryption means
         your data is protected and only you will be able to access or change
         your information.
+      selfie_capture_status:
+        face_close_to_border: 'TOO CLOSE TO THE FRAME'
+        face_not_found: 'FACE NOT FOUND'
+        face_too_small: 'FACE TOO SMALL'
+        too_many_faces: 'TOO MANY FACES'
       ssn: We need your Social Security number to verify your name, date of birth and
         address.
       tag: Recommended

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -221,10 +221,10 @@ en:
         your data is protected and only you will be able to access or change
         your information.
       selfie_capture_status:
-        face_close_to_border: 'TOO CLOSE TO THE FRAME'
-        face_not_found: 'FACE NOT FOUND'
-        face_too_small: 'FACE TOO SMALL'
-        too_many_faces: 'TOO MANY FACES'
+        face_close_to_border: TOO CLOSE TO THE FRAME
+        face_not_found: FACE NOT FOUND
+        face_too_small: FACE TOO SMALL
+        too_many_faces: TOO MANY FACES
       ssn: We need your Social Security number to verify your name, date of birth and
         address.
       tag: Recommended

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -258,6 +258,11 @@ es:
       secure_account: Vamos a encriptar su cuenta con su contraseña. La encriptación
         significa que sus datos están protegidos y solo usted podrá acceder o
         modificar su información.
+      selfie_capture_status:
+        face_close_to_border: 'DEMASIADO CERCA DEL MARCO'
+        face_not_found: 'NO SE ENCONTRÓ LA CARA'
+        face_too_small: 'LA CARA ES DEMASIADO CHICA'
+        too_many_faces: 'HAY DEMASIADAS CARAS'
       ssn: Necesitamos su número de Seguro Social para validar su nombre, fecha de
         nacimiento y dirección.
       tag: Recomendado

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -259,10 +259,10 @@ es:
         significa que sus datos están protegidos y solo usted podrá acceder o
         modificar su información.
       selfie_capture_status:
-        face_close_to_border: 'DEMASIADO CERCA DEL MARCO'
-        face_not_found: 'NO SE ENCONTRÓ LA CARA'
-        face_too_small: 'LA CARA ES DEMASIADO CHICA'
-        too_many_faces: 'HAY DEMASIADAS CARAS'
+        face_close_to_border: DEMASIADO CERCA DEL MARCO
+        face_not_found: NO SE ENCONTRÓ LA CARA
+        face_too_small: LA CARA ES DEMASIADO CHICA
+        too_many_faces: HAY DEMASIADAS CARAS
       ssn: Necesitamos su número de Seguro Social para validar su nombre, fecha de
         nacimiento y dirección.
       tag: Recomendado

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -268,10 +268,10 @@ fr:
         chiffrage signifie que vos données sont protégées et que vous êtes le/la
         seul(e) à pouvoir accéder à vos informations ou les modifier.
       selfie_capture_status:
-        face_close_to_border: 'TROP PRÈS DU CADRE'
-        face_not_found: 'VISAGE NON TROUVÉ'
-        face_too_small: 'VISAGE TROP PETIT'
-        too_many_faces: 'TROP DE VISAGES'
+        face_close_to_border: TROP PRÈS DU CADRE
+        face_not_found: VISAGE NON TROUVÉ
+        face_too_small: VISAGE TROP PETIT
+        too_many_faces: TROP DE VISAGES
       ssn: Nous avons besoin de votre numéro de sécurité sociale pour vérifier votre
         nom, date de naissance et adresse.
       tag: Recommandation

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -267,6 +267,11 @@ fr:
       secure_account: Nous chiffrerons votre compte avec votre mot de passe. Le
         chiffrage signifie que vos données sont protégées et que vous êtes le/la
         seul(e) à pouvoir accéder à vos informations ou les modifier.
+      selfie_capture_status:
+        face_close_to_border: 'TROP PRÈS DU CADRE'
+        face_not_found: 'VISAGE NON TROUVÉ'
+        face_too_small: 'VISAGE TROP PETIT'
+        too_many_faces: 'TROP DE VISAGES'
       ssn: Nous avons besoin de votre numéro de sécurité sociale pour vérifier votre
         nom, date de naissance et adresse.
       tag: Recommandation

--- a/spec/javascript/packages/document-capture/components/acuant-selfie-camera-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-selfie-camera-spec.jsx
@@ -2,6 +2,7 @@ import { AcuantContextProvider, DeviceContext } from '@18f/identity-document-cap
 import AcuantSelfieCamera from '@18f/identity-document-capture/components/acuant-selfie-camera';
 import AcuantSelfieCaptureCanvas from '@18f/identity-document-capture/components/acuant-selfie-capture-canvas';
 import { render, useAcuant } from '../../../support/document-capture';
+import { t } from '@18f/identity-i18n';
 
 describe('document-capture/components/acuant-selfie-camera', () => {
   const { initialize } = useAcuant();
@@ -40,12 +41,10 @@ describe('document-capture/components/acuant-selfie-camera', () => {
     expect(callbackNames).to.equal(expectedCallbackNames);
 
     expect(window.AcuantPassiveLiveness.start.getCall(0).args[1]).to.deep.equal({
-      FACE_NOT_FOUND: 'FACE NOT FOUND',
-      TOO_MANY_FACES: 'TOO MANY FACES',
-      FACE_ANGLE_TOO_LARGE: 'FACE ANGLE TOO LARGE',
-      PROBABILITY_TOO_SMALL: 'PROBABILITY TOO SMALL',
-      FACE_TOO_SMALL: 'FACE TOO SMALL',
-      FACE_CLOSE_TO_BORDER: 'TOO CLOSE TO THE FRAME',
+      FACE_NOT_FOUND: t('doc_auth.info.selfie_capture_status.face_not_found'),
+      TOO_MANY_FACES: t('doc_auth.info.selfie_capture_status.too_many_faces'),
+      FACE_TOO_SMALL: t('doc_auth.info.selfie_capture_status.face_too_small'),
+      FACE_CLOSE_TO_BORDER: t('doc_auth.info.selfie_capture_status.face_close_to_border'),
     });
   });
 

--- a/spec/javascript/packages/document-capture/components/acuant-selfie-camera-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-selfie-camera-spec.jsx
@@ -1,8 +1,8 @@
 import { AcuantContextProvider, DeviceContext } from '@18f/identity-document-capture';
 import AcuantSelfieCamera from '@18f/identity-document-capture/components/acuant-selfie-camera';
 import AcuantSelfieCaptureCanvas from '@18f/identity-document-capture/components/acuant-selfie-capture-canvas';
-import { render, useAcuant } from '../../../support/document-capture';
 import { t } from '@18f/identity-i18n';
+import { render, useAcuant } from '../../../support/document-capture';
 
 describe('document-capture/components/acuant-selfie-camera', () => {
   const { initialize } = useAcuant();


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-11984](https://cm-jira.usa.gov/browse/LG-11984)

## 🛠 Summary of changes
Display the selfie capture hint text to the user on the acuant capture canvas.

## 📜 Testing Plan
- [ ] in the Idv (using hybrid or mobile standard flow), launch the acuant sdk by attempting to upoad a selfie photo
- [ ] move your face around the frame and verify the hint text at the top of the screen

## 👀 Screenshots
<img width="380" alt="selfie_face_not_found" src="https://github.com/18F/identity-idp/assets/1261794/6a9a4d90-6bae-4cc8-bb29-b6fd86dd4507">

<!--
If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
