### PR TITLE
Include components directory in stylesheet linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "typecheck": "tsc",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "lint:css": "stylelint 'app/assets/stylesheets/**/*.scss' 'app/javascript/**/*.scss'",
+    "lint:css": "stylelint 'app/assets/stylesheets/**/*.scss' 'app/javascript/**/*.scss' 'app/components/*.scss'",
     "test": "mocha 'spec/javascript/**/**spec.+(j|t)s?(x)' 'app/javascript/packages/**/*.spec.+(j|t)s?(x)'",
     "normalize-yaml": "normalize-yaml",
     "generate-browsers-json": "./scripts/generate-browsers-json.js",


### PR DESCRIPTION
## 🛠 Summary of changes

Includes stylesheets located within the `app/components` directory for linting.

This matches build sources:

https://github.com/18F/identity-idp/blob/4c96efb7632de6218ab8c1f273bd0b6be2be3107/package.json#L21

See previous discussion: https://github.com/18F/identity-idp/pull/9840#discussion_r1442374486

## 📜 Testing Plan

Verify `lint:css` passes.

For bonus points, introduce a stylistic error to a `.scss` file within `app/components` and verify the same command fails.

Example:

```diff
diff --git a/app/components/captcha_submit_button_component.scss b/app/components/captcha_submit_button_component.scss
index 545f6b084..83a8d8851 100644
--- a/app/components/captcha_submit_button_component.scss
+++ b/app/components/captcha_submit_button_component.scss
@@ -2,2 +2,3 @@
   visibility: hidden;
+  
 }
```

```
$ yarn lint:css                       
yarn run v1.22.19
$ stylelint 'app/assets/stylesheets/**/*.scss' 'app/javascript/**/*.scss' 'app/components/*.scss'

app/components/captcha_submit_button_component.scss
 3:1  ✖  Delete "··⏎"  prettier/prettier

1 problem (1 error, 0 warnings)

error Command failed with exit code 2.
```