### PR TITLE
LG-11899: Remove unreliable operating system version from device names

### DIFF
--- a/app/services/device_name.rb
+++ b/app/services/device_name.rb
@@ -1,14 +1,28 @@
 class DeviceName
-  def self.from_user_agent(user_agent)
-    browser = BrowserCache.parse(user_agent)
-    os = browser.platform.name
-    os_version = browser.platform.version&.split('.')&.first
-    os = "#{os} #{os_version}" if os_version
+  class << self
+    def from_user_agent(user_agent)
+      browser = BrowserCache.parse(user_agent)
+      os = browser.platform.name
+      os_version = browser.platform.version&.split('.')&.first if reliable_os_version?(browser)
+      os = "#{os} #{os_version}" if os_version
 
-    I18n.t(
-      'account.index.device',
-      browser: "#{browser.name} #{browser.version}",
-      os: os,
-    )
+      I18n.t(
+        'account.index.device',
+        browser: "#{browser.name} #{browser.version}",
+        os: os,
+      )
+    end
+
+    private
+
+    def reliable_os_version?(browser)
+      # Chromium's user agent reduction initiative will produce a unified platform string which may
+      # include an inaccurate operation system version.
+      # See: https://www.chromium.org/updates/ua-reduction/#unified-format
+      #
+      # Consider using Browser#chromium_based? if/when it becomes available
+      # See: https://github.com/fnando/browser/issues/541
+      !browser.chrome? && !browser.edge?
+    end
   end
 end

--- a/app/services/device_name.rb
+++ b/app/services/device_name.rb
@@ -1,28 +1,10 @@
 class DeviceName
-  class << self
-    def from_user_agent(user_agent)
-      browser = BrowserCache.parse(user_agent)
-      os = browser.platform.name
-      os_version = browser.platform.version&.split('.')&.first if reliable_os_version?(browser)
-      os = "#{os} #{os_version}" if os_version
-
-      I18n.t(
-        'account.index.device',
-        browser: "#{browser.name} #{browser.version}",
-        os: os,
-      )
-    end
-
-    private
-
-    def reliable_os_version?(browser)
-      # Chromium's user agent reduction initiative will produce a unified platform string which may
-      # include an inaccurate operation system version.
-      # See: https://www.chromium.org/updates/ua-reduction/#unified-format
-      #
-      # Consider using Browser#chromium_based? if/when it becomes available
-      # See: https://github.com/fnando/browser/issues/541
-      !browser.chrome? && !browser.edge?
-    end
+  def self.from_user_agent(user_agent)
+    browser = BrowserCache.parse(user_agent)
+    I18n.t(
+      'account.index.device',
+      browser: "#{browser.name} #{browser.version}",
+      os: browser.platform.name,
+    )
   end
 end

--- a/spec/decorators/device_decorator_spec.rb
+++ b/spec/decorators/device_decorator_spec.rb
@@ -6,16 +6,7 @@ RSpec.describe DeviceDecorator do
 
   describe '#nice_name' do
     it 'gives a shortened os and browser name' do
-      expect(decorator.nice_name).to eq('Chrome 58 on Windows 10')
-    end
-
-    it 'does not fail if OS version cannot be parsed' do
-      # This user agent currently does not parse the OS version
-      user_agent = 'Mozilla/5.0 (X11; CrOS armv7l 11316.165.0) AppleWebKit/537.36 (KHTML, '\
-                   'like Gecko) Chrome/72.0.3626.122 Safari/537.36'
-      device.user_agent = user_agent
-
-      expect(decorator.nice_name).to eq('Chrome 72 on Chrome OS')
+      expect(decorator.nice_name).to eq('Chrome 58 on Windows')
     end
   end
 end

--- a/spec/features/account/device_spec.rb
+++ b/spec/features/account/device_spec.rb
@@ -18,6 +18,6 @@ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36',
   end
 
   scenario 'viewing devices' do
-    expect(page).to have_content('Chrome 71 on macOS 10')
+    expect(page).to have_content('Chrome 71 on macOS')
   end
 end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe WebauthnSetupForm do
 
   let(:user) { create(:user) }
   let(:user_session) { { webauthn_challenge: webauthn_challenge } }
-  let(:device_name) { 'Chrome 119 on macOS 10' }
+  let(:device_name) { 'Chrome 119 on macOS' }
   let(:domain_name) { 'localhost:3000' }
   let(:params) do
     {

--- a/spec/services/device_name_spec.rb
+++ b/spec/services/device_name_spec.rb
@@ -2,10 +2,30 @@ require 'rails_helper'
 
 RSpec.describe DeviceName do
   describe '.device_name' do
-    let(:device) { create(:device) }
-    it 'gives a shortened os and browser name' do
-      name = DeviceName.from_user_agent(device.user_agent)
-      expect(name).to eq('Chrome 58 on Windows 10')
+    let(:user_agent) {}
+    let(:device) { create(:device, user_agent:) }
+    subject(:name) { DeviceName.from_user_agent(device.user_agent) }
+
+    context 'with a user agent producing a reliable OS version' do
+      let(:user_agent) do
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2_1) AppleWebKit/605.1.15 (KHTML, like Gecko) ' \
+          'Version/17.2 Safari/605.1.15'
+      end
+
+      it 'gives a shortened browser name with operating system version' do
+        expect(name).to eq('Safari 17 on macOS 14')
+      end
+    end
+
+    context 'with a user agent not producing a reliable OS version' do
+      let(:user_agent) do
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' \
+          'Chrome/120.0.0.0 Safari/537.36 Edg/120.0.2210.121'
+      end
+
+      it 'gives a shortened browser name with unversioned operating system' do
+        expect(name).to eq('Microsoft Edge 120 on Windows')
+      end
     end
   end
 end

--- a/spec/services/device_name_spec.rb
+++ b/spec/services/device_name_spec.rb
@@ -2,30 +2,10 @@ require 'rails_helper'
 
 RSpec.describe DeviceName do
   describe '.device_name' do
-    let(:user_agent) {}
-    let(:device) { create(:device, user_agent:) }
-    subject(:name) { DeviceName.from_user_agent(device.user_agent) }
-
-    context 'with a user agent producing a reliable OS version' do
-      let(:user_agent) do
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2_1) AppleWebKit/605.1.15 (KHTML, like Gecko) ' \
-          'Version/17.2 Safari/605.1.15'
-      end
-
-      it 'gives a shortened browser name with operating system version' do
-        expect(name).to eq('Safari 17 on macOS 14')
-      end
-    end
-
-    context 'with a user agent not producing a reliable OS version' do
-      let(:user_agent) do
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' \
-          'Chrome/120.0.0.0 Safari/537.36 Edg/120.0.2210.121'
-      end
-
-      it 'gives a shortened browser name with unversioned operating system' do
-        expect(name).to eq('Microsoft Edge 120 on Windows')
-      end
+    let(:device) { create(:device) }
+    it 'gives a shortened os and browser name' do
+      name = DeviceName.from_user_agent(device.user_agent)
+      expect(name).to eq('Chrome 58 on Windows')
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-11899](https://cm-jira.usa.gov/browse/LG-11899)

## 🛠 Summary of changes

Updates `DeviceName.from_user_agent` to exclude the version number from the operating system ~for user agents which do not produce reliable version numbers~. **Edit:** See conversation stemming from https://github.com/18F/identity-idp/pull/9904#issuecomment-1887349723 and [related Slack thread](https://gsa-tts.slack.com/archives/C01710KMYUB/p1704985300785019), the version number is being removed for all devices.

In recent versions, Chromium has started to use a unified platform identifier in its user agent strings, as part of its user agent reduction effort. This means that we shouldn't rely on the version number being accurate. Since we include device names in user notifications for security alerts ([LG-1147](https://cm-jira.usa.gov/browse/LG-11474), #9668), showing an inaccurate operating system may cause unnecessary alarm to a user.

Reference: https://www.chromium.org/updates/ua-reduction/#unified-format

**Edit:** The following tickets also demonstrate a similar behavior in Safari & Firefox on macOS, via https://github.com/18F/identity-idp/pull/9904#issuecomment-1887349723:

> * https://bugs.webkit.org/show_bug.cgi?id=216593#c8
>    * >The long term goal is to limit the disclosure of the underlying macOS via user agent string and other means since it can be used for finger printing purposes.
> * https://bugzilla.mozilla.org/show_bug.cgi?id=1679929

## 📜 Testing Plan

1. In a Chrome private browsing window, go to http://localhost:3000
2. Sign in
3. (At this point, a new tab should be opened with the email preview contents for "New sign-in with your Login.gov account"
4. Note that the sign-in notification includes a device name excluding the OS version, e.g. "Chrome 120 on macOS"
5. ~Repeat Steps 1-3 in a different browser, such as Firefox or Safari~
6. ~Note that the sign-in notification still includes the OS version~

## 👀 Screenshots

<img src="https://github.com/18F/identity-idp/assets/1779930/024e7619-c01e-4b78-8a1f-fdae5d5d88aa" alt="Chrome screenshot">

<details><summary>Click to see screenshots from original changes</summary>
<table><thead><tr><th>Chrome</th><th>Safari</th></tr></thead>
<tbody><tr><td><img src="https://github.com/18F/identity-idp/assets/1779930/024e7619-c01e-4b78-8a1f-fdae5d5d88aa" alt="Chrome screenshot"></td><td><img src="https://github.com/18F/identity-idp/assets/1779930/966508de-ef9e-4a8d-8b83-33a3abfc27ad" alt="Safari screenshot"></td></tr></tbody></table></details>

