### PR TITLE
LG-11979 remove aamva banlist config

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -27,7 +27,7 @@ module Idv
       pii[:ssn] = idv_session.ssn
       Idv::Agent.new(pii).proof_resolution(
         document_capture_session,
-        should_proof_state_id: should_use_aamva?(pii),
+        should_proof_state_id: aamva_state?(pii),
         trace_id: amzn_trace_id,
         user_id: current_user.id,
         threatmetrix_session_id: idv_session.threatmetrix_session_id,
@@ -44,20 +44,10 @@ module Idv
       current_user.has_in_person_enrollment?
     end
 
-    def should_use_aamva?(pii)
-      aamva_state?(pii) && !aamva_disallowed_for_service_provider?
-    end
-
     def aamva_state?(pii)
       IdentityConfig.store.aamva_supported_jurisdictions.include?(
         pii['state_id_jurisdiction'],
       )
-    end
-
-    def aamva_disallowed_for_service_provider?
-      return false if sp_session.nil?
-      banlist = IdentityConfig.store.aamva_sp_banlist_issuers
-      banlist.include?(sp_session[:issuer])
     end
 
     def resolution_rate_limiter

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -17,7 +17,6 @@
 aamva_auth_request_timeout: 5.0
 aamva_auth_url: 'https://example.org:12345/auth/url'
 aamva_cert_enabled: true
-aamva_sp_banlist_issuers: '[]'
 aamva_supported_jurisdictions: '["AL","AR","AZ","CO","CT","DC","DE","FL","GA","HI","IA","ID","IL","IN","KS","KY","MA","MD","ME","MI","MO","MS","MT","NC","ND","NE","NJ","NM","NV","OH","OR","PA","RI","SC","SD","TN","TX","VA","VT","WA","WI","WV","WY"]'
 aamva_verification_request_timeout: 5.0
 aamva_verification_url: https://example.org:12345/verification/url

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -103,7 +103,6 @@ class IdentityConfig
     config.add(:aamva_cert_enabled, type: :boolean)
     config.add(:aamva_private_key, type: :string)
     config.add(:aamva_public_key, type: :string)
-    config.add(:aamva_sp_banlist_issuers, type: :json)
     config.add(:aamva_supported_jurisdictions, type: :json)
     config.add(:aamva_verification_request_timeout, type: :float)
     config.add(:aamva_verification_url)

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -321,29 +321,6 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
         expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
       end
     end
-
-    context 'when the SP is in the AAMVA banlist' do
-      it 'does not perform the state ID check' do
-        allow(IdentityConfig.store).to receive(:aamva_sp_banlist_issuers).
-          and_return("[\"#{OidcAuthHelper::OIDC_IAL1_ISSUER}\"]")
-        expect_any_instance_of(Idv::Agent).
-          to receive(:proof_resolution).
-          with(
-            anything,
-            should_proof_state_id: false,
-            user_id: user.id,
-            **proof_resolution_args,
-          ).
-          and_call_original
-
-        visit_idp_from_sp_with_ial1(:oidc)
-        sign_in_and_2fa_user(user)
-        complete_doc_auth_steps_before_verify_step
-        complete_verify_step
-
-        expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
-      end
-    end
   end
 
   context 'async missing' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11979](https://cm-jira.usa.gov/browse/LG-11979)

## 🛠 Summary of changes

Remove `aamva_sp_banlist_issuers` unused config value.

It was empty in application.yml.default, and it doesn't appear in the s3 buckets for any env.

## 📜 Testing Plan

- [ ] Run specs. This config was unused.
- [ ] To make really sure, create account, start IdV, continue up to submitting VerifyInfo step.
