### PR TITLE
LG-11882: Rename Rake task for disposable email domains

### DIFF
--- a/lib/tasks/disposable_email_domains.rake
+++ b/lib/tasks/disposable_email_domains.rake
@@ -1,13 +1,13 @@
 # rubocop:disable Rails/SkipsModelValidations
 require 'csv'
-namespace :disposable_domains do
-  task :load, %i[s3_url] => [:environment] do |_task, args|
+namespace :disposable_email_domains do
+  task :load, %i[s3_secrets_path] => [:environment] do |_task, args|
     # Need to increase statement timeout since command takes a long time.
     ActiveRecord::Base.connection.execute 'SET statement_timeout = 200000'
-    file = Identity::Hostdata.secrets_s3.read_file(args[:s3_url])
+    file = Identity::Hostdata.secrets_s3.read_file(args[:s3_secrets_path])
     names = file.split("\n")
     DisposableEmailDomain.insert_all(names.map { |name| { name: } })
   end
 end
-# rake "disposable_domains:load['URL_HERE']"
+# rake "disposable_email_domains:load[S3_SECRETS_PATH]"
 # rubocop:enable Rails/SkipsModelValidations


### PR DESCRIPTION
## 🎫 Ticket

[LG-11882](https://cm-jira.usa.gov/browse/LG-11882)

## 🛠 Summary of changes

Makes a few revisions to the Rake script for populating the disposable email domains table.

1. Per intent of the ticket, rename as "disposable **email** domains"
2. Avoid quotes in usage example which can produce an error when included
3. Reword from "URL" to "path" since the expected parameter is not a fully-qualified URL, it is expected to be a path fragment handled by `Identity::Hostdata.secrets_s3.readfile`

Once merged, I will plan to update the [corresponding rollplan document](https://gsa-tts.slack.com/archives/C0NGESUN5/p1705001993549269?thread_ts=1704997019.166689&cid=C0NGESUN5) accordingly.
