### PR TITLE
Document disposable email domain analytics parameter

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4570,6 +4570,7 @@ module AnalyticsEvents
   # @param [String] needs_completion_screen_reason
   # @param [Array] sp_request_requested_attributes
   # @param [Array] sp_session_requested_attributes
+  # @param [String, nil] disposable_email_domain Disposable email domain used for registration
   def user_registration_complete(
     ial2:,
     service_provider_name:,
@@ -4578,6 +4579,7 @@ module AnalyticsEvents
     sp_session_requested_attributes:,
     sp_request_requested_attributes: nil,
     ialmax: nil,
+    disposable_email_domain: nil,
     **extra
   )
     track_event(
@@ -4589,6 +4591,7 @@ module AnalyticsEvents
       needs_completion_screen_reason: needs_completion_screen_reason,
       sp_request_requested_attributes: sp_request_requested_attributes,
       sp_session_requested_attributes: sp_session_requested_attributes,
+      disposable_email_domain: disposable_email_domain,
       **extra,
     )
   end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -263,6 +263,7 @@ RSpec.describe SignUp::CompletionsController do
           sp_request_requested_attributes: nil,
           sp_session_requested_attributes: nil,
           in_account_creation_flow: true,
+          disposable_email_domain: nil,
         )
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `user_registration_complete` method signature to include the `disposable_email_domain` argument, which may be passed as a result of this code added in #9747:

https://github.com/18F/identity-idp/blob/43e0c4a5029ce159367ed28a272c670103e90308/app/controllers/sign_up/completions_controller.rb#L104-L106

**Why?**

- So that [Analytics Events documentation](https://handbook.login.gov/articles/analytics-events.html) accurately reflects the  available properties
- To enable discoverability based on searches performed within the `analytics_events.rb` (e.g. this was motivated by my own pursuit to jog my memory about which event this was logged on)

## 📜 Testing Plan

After merged, observe the parameter is visible in [Analytics Events documentation](https://handbook.login.gov/articles/analytics-events.html)

Build should pass