### PR TITLE
Stop merging things that aren't PII from the document into `pii_from_doc`

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -32,22 +32,15 @@ module Idv
     # @param [DocAuth::Response,
     #   DocumentCaptureSessionResult] response
     def extract_pii_from_doc(user, response, store_in_session: false)
-      pii_from_doc = response.pii_from_doc.merge(
-        uuid: user.uuid,
-        phone: user.phone_configurations.take&.phone,
-        uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
-      )
-
       if defined?(idv_session) # hybrid mobile does not have idv_session
         idv_session.had_barcode_read_failure = response.attention_with_barcode?
         if store_in_session
-          idv_session.pii_from_doc ||= {}
-          idv_session.pii_from_doc.merge!(pii_from_doc)
+          idv_session.pii_from_doc = response.pii_from_doc
           idv_session.selfie_check_performed = response.selfie_check_performed
         end
       end
 
-      track_document_issuing_state(user, pii_from_doc[:state])
+      track_document_issuing_state(user, idv_session.pii_from_doc[:state])
     end
 
     def stored_result

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -40,7 +40,7 @@ module Idv
         end
       end
 
-      track_document_issuing_state(user, idv_session.pii_from_doc[:state])
+      track_document_issuing_state(user, response.pii_from_doc[:state])
     end
 
     def stored_result

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -293,9 +293,12 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
       end
 
       it 'captures state id address fields in the pii' do
-        expect(Idv::Agent).to receive(:new).
-          with(Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS.merge(uuid_prefix: nil)).
-          and_call_original
+        expect(Idv::Agent).to receive(:new).with(
+          Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS.merge(
+            uuid_prefix: nil,
+            uuid: user.uuid,
+          ),
+        ).and_call_original
         put :update
       end
     end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -391,9 +391,14 @@ RSpec.describe Idv::VerifyInfoController do
       sp_session = { issuer: sp.issuer }
       allow(controller).to receive(:sp_session).and_return(sp_session)
 
-      put :update
+      expect(Idv::Agent).to receive(:new).with(
+        hash_including(
+          uuid_prefix: app_id,
+          uuid: user.uuid,
+        ),
+      ).and_call_original
 
-      expect(subject.idv_session.pii_from_doc[:uuid_prefix]).to eq app_id
+      put :update
     end
 
     it 'updates DocAuthLog verify_submit_count' do


### PR DESCRIPTION
The `Idv::Session#pii_from_doc` method has a name that suggests it returns the PII that is read from the document. Prior to this commit this was not the case because we merge data that was not read from the document into the `pii_from_doc` hash. This was done as a convenience so it is available when communicating to vendors in downstream steps.

This commit removes the merge and provides the additional data explicitly in down steam step.
