### PR TITLE
LG-10480 Remove in person address_controller 404 action

### DIFF
--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -4,7 +4,6 @@ module Idv
       include Idv::AvailabilityConcern
       include IdvStepConcern
 
-      before_action :render_404_if_in_person_residential_address_controller_enabled_not_set
       before_action :confirm_in_person_state_id_step_complete
       ## before_action :confirm_step_allowed # pending FSM removal of state id step
       before_action :confirm_in_person_address_step_needed, only: :show
@@ -105,11 +104,6 @@ module Idv
         else
           redirect_to idv_in_person_ssn_url
         end
-      end
-
-      def render_404_if_in_person_residential_address_controller_enabled_not_set
-        render_not_found unless
-            IdentityConfig.store.in_person_residential_address_controller_enabled
       end
 
       def confirm_in_person_state_id_step_complete

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -28,32 +28,6 @@ RSpec.describe Idv::InPerson::AddressController do
   end
 
   describe 'before_actions' do
-    context '#render_404_if_in_person_residential_address_controller_enabled not set' do
-      context 'flag not set' do
-        before do
-          allow(IdentityConfig.store).to receive(:in_person_residential_address_controller_enabled).
-            and_return(nil)
-        end
-        it 'renders a 404' do
-          get :show
-
-          expect(response).to be_not_found
-        end
-      end
-
-      context 'flag not enabled' do
-        before do
-          allow(IdentityConfig.store).to receive(:in_person_residential_address_controller_enabled).
-            and_return(false)
-        end
-        it 'renders a 404' do
-          get :show
-
-          expect(response).to be_not_found
-        end
-      end
-    end
-
     context '#confirm_in_person_state_id_step_complete' do
       it 'redirects to state id page if not complete' do
         subject.user_session['idv/in_person'][:pii_from_user].delete(:identity_doc_address1)


### PR DESCRIPTION
## 🎫 Ticket

[LG-10480](https://cm-jira.usa.gov/browse/LG-10480)

## 🛠 Summary of changes

Remove 404 action from post-FSM in person address controller to enable testing and eventually turning the feature flag on.

## 📜 Testing Plan

- [ ] In application.yml, make sure `render_404_if_in_person_residential_address_controller_enabled_not_set: false` (or not there)
- [ ] Create account, start IdV, choose in person proofing
- [ ] On state id page, choose different residential address and submit
- [ ] Change the url to `/verify/in_person_proofing/address`
- [ ] Expect to see the address page from the controller (not a 404)
