### PR TITLE
Fixes a bug in the Verify By Mail reminder logic.

### DIFF
--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -2,13 +2,12 @@ class GpoReminderSender
   LOCAL_DATABASE_TIMEOUT = 60_000
 
   def send_emails(for_letters_sent_before)
-    letter_eligible_range =
+    reminder_eligible_range =
       IdentityConfig.store.usps_confirmation_max_days.days.ago..for_letters_sent_before
-
-    profiles_due_for_reminder(letter_eligible_range).each do |profile|
+    profiles_due_for_reminder(for_letters_sent_before).each do |profile|
       profile.gpo_confirmation_codes.all.each do |gpo_code|
         next if gpo_code.reminder_sent_at
-        next unless letter_eligible_range.cover?(gpo_code.created_at)
+        next unless reminder_eligible_range.cover?(gpo_code.created_at)
 
         # Only email the user if we have an eligible code.
         # Unlikely to have multiple codes since we only allow one letter/day
@@ -22,17 +21,21 @@ class GpoReminderSender
 
   private
 
-  def profiles_due_for_reminder(letter_eligible_range)
+  def profiles_due_for_reminder(for_letters_sent_before)
     ActiveRecord::Base.transaction do
       ActiveRecord::Base.connection.execute(
         "SET LOCAL statement_timeout = #{LOCAL_DATABASE_TIMEOUT}",
       )
 
+      profile_eligible_range =
+        (IdentityConfig.store.usps_confirmation_max_days +
+          IdentityConfig.store.gpo_max_profile_age_to_send_letter_in_days).
+          days.ago..for_letters_sent_before
       Profile.joins(:gpo_confirmation_codes).
         where(
-          gpo_verification_pending_at: letter_eligible_range,
+          gpo_verification_pending_at: profile_eligible_range,
           gpo_confirmation_codes: { reminder_sent_at: nil },
-          deactivation_reason: [nil, :in_person_verification_pending],
+          deactivation_reason: nil,
         )
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-12100](https://cm-jira.usa.gov/browse/LG-12100)

## 🛠 Summary of changes

If a user had an expired gpo code and requested a new letter more than the reminder timeframe ago, the user would not have been sent a reminder for the second letter.

## 📜 Testing Plan

You can run the newly added spec on main, then again on this branch.