### PR TITLE
Fix Accessibility Violation - Header level

### DIFF
--- a/app/assets/stylesheets/components/_radio-button.scss
+++ b/app/assets/stylesheets/components/_radio-button.scss
@@ -21,7 +21,7 @@
   }
 
   .usa-radio__label--text {
-    h3 {
+    h2, h3 {
       @include u-text('gray-70');
     }
   }

--- a/app/assets/stylesheets/components/_radio-button.scss
+++ b/app/assets/stylesheets/components/_radio-button.scss
@@ -21,7 +21,8 @@
   }
 
   .usa-radio__label--text {
-    h2, h3 {
+    h2,
+    h3 {
       @include u-text('gray-70');
     }
   }

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -30,7 +30,7 @@
             <span class="usa-tag usa-tag--informative">
               <%= t('doc_auth.tips.most_common') %>
             </span>
-            <h3><%= t('doc_auth.headings.verify_online') %></h3>
+            <h2 class="h3"><%= t('doc_auth.headings.verify_online') %></h2>
             <span class="usa-radio__label-description">
               <p><%= t('doc_auth.info.verify_online_instruction') %></p>
               <p><%= t('doc_auth.info.verify_online_description') %></p>

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -13,6 +13,19 @@ RSpec.feature 'Accessibility on IDV pages', :js do
       expect_page_to_have_no_accessibility_violations(page)
     end
 
+    scenario 'how to verify page' do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+      sign_in_and_2fa_user
+
+      visit idv_welcome_url
+      complete_welcome_step
+      complete_agreement_step
+
+      expect(current_path).to eq idv_how_to_verify_path
+      expect_page_to_have_no_accessibility_violations(page)
+    end
+
     scenario 'cancel idv' do
       sign_in_and_2fa_user
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-12109](https://cm-jira.usa.gov/browse/LG-12109) Fix Accessibility Violation on How to Verify View

## 🛠 Summary of changes

- Update h2 to so that is has a h3 class to fix accessibility violation on the How To Verify page


## 📜 Testing Plan

- [ ] Step 1  Spec with this [commit](https://github.com/18F/identity-idp/pull/9898/commits/da7c919626efaec22b2e41a75d15369901751b2b) was failing when we were testing flags on for Opt-in IPP.   - spec/features/accessibility/idv_pages_spec.rb - test: `doc auth steps accessibility on mobile`

Gina Confirmed:
- [x] Double check that mfa selection (color) is not affected -- it is nested too deep - no other hits on global search
- [x] Find the spec that broke and add path below in testing plan-  spec/features/accessibility/idv_pages_spec.rb:65
- [x] Add new regression spec


👀 Screenshots

![Screenshot 2024-01-12 at 1 26 14 PM](https://github.com/18F/identity-idp/assets/125507397/e8894df3-2427-4041-8a54-30482913b580)
