### PR TITLE
LG-12020 | USPS proofing job handles nil profile

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -363,7 +363,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       reason: 'Successful status update',
       job_name: self.class.name,
     )
-    enrollment.profile.activate_after_passing_in_person
+    enrollment.profile&.activate_after_passing_in_person
     enrollment.update(
       status: :passed,
       proofed_at: proofed_at,

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe GetUspsProofingResultsJob do
               pending_enrollment.update(
                 status_check_attempted_at: Time.zone.now - 1.day,
                 status_updated_at: Time.zone.now - 2.days,
-                )
+              )
 
               expect { job.perform(Time.zone.now) }.not_to(raise_exception)
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe GetUspsProofingResultsJob do
                 status_updated_at: Time.zone.now - 2.days,
               )
 
-              expect { job.perform(Time.zone.now) }.not_to(raise_exception)
+              job.perform(Time.zone.now)
 
               pending_enrollment.reload
               expect(pending_enrollment.status_updated_at).to eq(Time.zone.now)


### PR DESCRIPTION
It is possible, albeit odd, for a user to create an enrollment for IPP, cancel their account, and go to the Post Office to proof.

This commit prevents the job from raising an unhandled exception in this case.

changelog: Internal, IPP, USPS proofing job handles nil profiles


## 🎫 Ticket

[LG-12020](https://cm-jira.usa.gov/browse/LG-12020)

Full disclosure: this was not in the sprint. I was already in this file and realized this would be a trivial fix.


## 🛠 Summary of changes

"Why would someone do this?," you might ask. "Surely, no one actually would?"

But, someone did. 🤷‍♂️ It might be worth thinking about whether we want to consider some UX changes to warn a user with an open enrollment if they try to delete their account, but for now, let's just not trip over ourselves in the job.