### PR TITLE
Remove temporary continuous integration check on content changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,17 +163,6 @@ check_changelog:
         exit 0
       fi
 
-check_content_freeze:
-  stage: test
-  script: |-
-    echo "Content change is not allowed during content freeze"
-    exit 1
-  rules:
-    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH || $CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"'
-      changes:
-        compare_to: 'refs/heads/main'
-        paths:
-          - config/locales/**/en.yml
 specs:
   stage: test
   needs:


### PR DESCRIPTION
## 🛠 Summary of changes

Effectively reverts #9803 now that the content freeze interval has ended

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
