### PR TITLE
Remove empty option in Login Button component preview

### DIFF
--- a/spec/components/previews/login_button_component_preview.rb
+++ b/spec/components/previews/login_button_component_preview.rb
@@ -6,7 +6,7 @@ class LoginButtonComponentPreview < ButtonComponentPreview
 
   # @!endgroup
   # @param big toggle "Change button size"
-  # @param color select [~,primary,primary-darker,primary-lighter] "Select button color"
+  # @param color select [primary,primary-darker,primary-lighter] "Select button color"
   def workbench(
     big: false,
     color: 'primary'


### PR DESCRIPTION

## 🎫 Ticket

Related to #9840 - minor update to the component 


## 🛠 Summary of changes

Quick 1 line change. 

Since this component is embedded in the dev doc user guide, we don't want anything that could create an error - but when selecting the empty option in the color params it created a stack trace so I removed it ( caught during acceptance ) 


