### PR TITLE
LG-11986: Modify the Welcome screen if selfie required

### DIFF
--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -25,8 +25,14 @@
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>
 
   <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
-    <%= c.with_item(heading: t('doc_auth.instructions.bullet1')) do %>
-      <p><%= t('doc_auth.instructions.text1') %></p>
+    <% if decorated_sp_session.selfie_required? %>
+      <%= c.with_item(heading: t('doc_auth.instructions.bullet1_with_selfie')) do %>
+        <p><%= t('doc_auth.instructions.text1_with_selfie') %></p>
+      <% end %>
+    <% else %>
+      <%= c.with_item(heading: t('doc_auth.instructions.bullet1')) do %>
+        <p><%= t('doc_auth.instructions.text1') %></p>
+      <% end %>
     <% end %>
     <%= c.with_item(heading: t('doc_auth.instructions.bullet2')) do %>
       <p><%= t('doc_auth.instructions.text2') %></p>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -246,6 +246,7 @@ en:
       you_entered: 'You entered:'
     instructions:
       bullet1: Take photos of your ID
+      bullet1_with_selfie: Take photos of yourself and your ID
       bullet2: Enter your Social Security number
       bullet3: Match to your phone number
       bullet4: Re-enter your %{app_name} password
@@ -260,6 +261,8 @@ en:
         considered valid. Do not enter real PII in this field.
       text1: Use your driver’s license or state ID card. Other forms of ID are not
         accepted.
+      text1_with_selfie: Take a photo of yourself and take photos of your driver’s
+        license or state ID card. Other forms of ID are not accepted.
       text2: You will not need your physical SSN card.
       text3: Your phone number matches you to your personal information. After you
         match, we’ll send you a code.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -288,6 +288,7 @@ es:
       you_entered: 'Ud. entregó:'
     instructions:
       bullet1: Tomar fotos de tu identificación oficial
+      bullet1_with_selfie: Tomar fotos tuyas y de tu identificación oficial
       bullet2: Ingresar tu Número de Seguro Social
       bullet3: Confirmar tu número de teléfono
       bullet4: Ingresar de nuevo tu contraseña de %{app_name}
@@ -303,6 +304,9 @@ es:
         se consideran válidos. No ingrese PII real en este campo.
       text1: Utiliza tu licencia de conducir o identificación oficial estatal. No
         aceptamos ningún otro tipo de identificación.
+      text1_with_selfie: Tómate una foto y toma fotografías de tu licencia de conducir
+        o identificación oficial estatal. No aceptamos ningún otro tipo de
+        identificación.
       text2: No necesitarás tu tarjeta física del seguro social.
       text3: Tu número de teléfono te vincula con tu información personal. Luego de
         confirmar tu información, te enviaremos un código.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -298,6 +298,7 @@ fr:
       you_entered: 'Tu as soumis:'
     instructions:
       bullet1: Prendre des photos de votre pièce d’identité
+      bullet1_with_selfie: Prenez des photos de vous et de vos pièces d’identité
       bullet2: Saisissez votre numéro de sécurité sociale
       bullet3: Faites correspondre votre numéro de téléphone
       bullet4: Saisissez à nouveau votre mot de passe %{app_name}
@@ -313,6 +314,9 @@ fr:
         champ.
       text1: Utilisez votre permis de conduire ou votre carte d’identité nationale.
         Les autres pièces d’identité ne sont pas acceptées.
+      text1_with_selfie: Prenez une photo de vous et une de votre permis de conduire
+        ou carte d’identité nationale. Les autres pièces d’identité ne sont pas
+        acceptées.
       text2: Vous n’aurez pas besoin de votre carte de sécurité sociale.
       text3: Votre numéro de téléphone correspond à vos informations personnelles. Une
         fois la correspondance établie, nous vous enverrons un code.

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 RSpec.describe 'idv/welcome/show.html.erb' do
   let(:user_fully_authenticated) { true }
   let(:sp_name) { nil }
+  let(:selfie_required) { false }
   let(:user) { create(:user) }
 
   before do
     @decorated_sp_session = instance_double(ServiceProviderSession)
     allow(@decorated_sp_session).to receive(:sp_name).and_return(sp_name)
+    allow(@decorated_sp_session).to receive(:selfie_required?).and_return(selfie_required)
     @sp_name = @decorated_sp_session.sp_name || APP_NAME
     @title = t('doc_auth.headings.welcome', sp_name: @sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(@decorated_sp_session)
@@ -33,6 +35,7 @@ RSpec.describe 'idv/welcome/show.html.erb' do
     it 'renders the welcome template' do
       expect(rendered).to have_content(@title)
       expect(rendered).to have_content(t('doc_auth.instructions.getting_started'))
+      expect(rendered).to have_content(t('doc_auth.instructions.bullet1'))
       expect(rendered).to have_link(
         t('doc_auth.info.getting_started_learn_more'),
         href: help_center_redirect_path(
@@ -43,6 +46,14 @@ RSpec.describe 'idv/welcome/show.html.erb' do
           location: 'intro_paragraph',
         ),
       )
+    end
+
+    context 'when the SP requests IAL2 verification' do
+      let(:selfie_required) { true }
+
+      it 'renders a modified welcome template' do
+        expect(rendered).to have_content(t('doc_auth.instructions.bullet1_with_selfie'))
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-11986](https://cm-jira.usa.gov/browse/LG-11986)

## 🛠 Summary of changes

The first bullet on the Welcome page is modified if a selfie check is required.

## 📜 Testing Plan

To see this locally, hard code the method `NullServiceProviderSession#selfie_required?` to return true.

## 👀 Screenshots

<details>
<summary>Without selfie required (current view on `main`):</summary>

| en | es | fr |
|----|----|----|
| <img width="619" alt="LG-11968-orig" src="https://github.com/18F/identity-idp/assets/2583060/f8b96f8a-9379-4241-a908-e614021e4634"> | <img width="619" alt="LG-11968-orig-es" src="https://github.com/18F/identity-idp/assets/2583060/2fdf382f-aebe-4924-acc3-568816ae1888"> | <img width="619" alt="LG-11968-orig-fr" src="https://github.com/18F/identity-idp/assets/2583060/c1fa8580-54be-47a4-a2d2-9d81ed0cdfd9"> |

</details>

<details>
<summary>With selfie required:</summary>

| en | es | fr |
|----|----|----|
| <img width="619" alt="LG-11968-with_selfie" src="https://github.com/18F/identity-idp/assets/2583060/1d2f975c-18be-4c85-9be8-cc2de30f09b0"> | <img width="619" alt="LG-11968-with_selfie-es" src="https://github.com/18F/identity-idp/assets/2583060/46dcff68-63cc-4ab0-a5ce-796c1adae51d"> | <img width="619" alt="LG-11968-with_selfie-fr" src="https://github.com/18F/identity-idp/assets/2583060/be1a7c56-b714-44e1-814c-b570519c15f0"> |

</details>
