### PR TITLE
Remove typo'd country "Berundi", duplicative of Burundi

### DIFF
--- a/config/locales/countries/en.yml
+++ b/config/locales/countries/en.yml
@@ -24,7 +24,6 @@ en:
     bh: Bahrain
     bi: Burundi
     bj: Benin
-    bl: Berundi
     bm: Bermuda
     bn: Brunei
     bo: Bolivia

--- a/config/locales/countries/es.yml
+++ b/config/locales/countries/es.yml
@@ -24,7 +24,6 @@ es:
     bh: Bahrain
     bi: Burundi
     bj: Benin
-    bl: Berundi
     bm: Bermuda
     bn: Brunei
     bo: Bolivia

--- a/config/locales/countries/fr.yml
+++ b/config/locales/countries/fr.yml
@@ -24,7 +24,6 @@ fr:
     bh: Bahrain
     bi: Burundi
     bj: Benin
-    bl: Berundi
     bm: Bermuda
     bn: Brunei
     bo: Bolivie


### PR DESCRIPTION
[Slack thread for context](https://gsa-tts.slack.com/archives/C0NGESUN5/p1705684776537539)

Our translation team identified that "Berundi" is not a recognized country name, nor is the `bl` abbreviation. These seem unused and duplicative of `bi: Burundi`, so we can remove them.

Previous similar cleanup PR: https://github.com/18F/identity-idp/pull/8279