### PR TITLE
build-sass: Use new Shared Resources API

### DIFF
--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improvements
 
 - `--out-dir` is now optional. If omitted, files will be output in the same directory as their source files.
+- The command-line tool now uses [Sass Shared Resources API](https://github.com/sass/sass/blob/main/accepted/shared-resources.d.ts.md), improving performance when compiling multiple files that share common resources.
 
 ## 2.0.0
 

--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `--out-dir` is now optional. If omitted, files will be output in the same directory as their source files.
 - The command-line tool now uses [Sass Shared Resources API](https://github.com/sass/sass/blob/main/accepted/shared-resources.d.ts.md), improving performance when compiling multiple files that share common resources.
+  - In Login.gov's identity provider application, this reduced compilation times by an average of 66%!
 
 ## 2.0.0
 

--- a/app/javascript/packages/build-sass/README.md
+++ b/app/javascript/packages/build-sass/README.md
@@ -44,7 +44,7 @@ function buildFile(
   options: {
     outDir: string,
     optimize: boolean,
-    sassCompiler: SassCompiler,
+    sassCompiler: SassAsyncCompiler,
     ...sassOptions: SassOptions<'sync'>,
   },
 ): Promise<SassCompileResult>;

--- a/app/javascript/packages/build-sass/README.md
+++ b/app/javascript/packages/build-sass/README.md
@@ -44,6 +44,7 @@ function buildFile(
   options: {
     outDir: string,
     optimize: boolean,
+    sassCompiler: SassCompiler,
     ...sassOptions: SassOptions<'sync'>,
   },
 ): Promise<SassCompileResult>;

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -4,8 +4,9 @@
 
 import { mkdir } from 'node:fs/promises';
 import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
 import { watch } from 'chokidar';
-import { fileURLToPath } from 'url';
+import { initCompiler as initSassCompiler } from 'sass-embedded';
 import { buildFile } from './index.js';
 import getDefaultLoadPaths from './get-default-load-paths.js';
 import getErrorSassStackPaths from './get-error-sass-stack-paths.js';
@@ -29,8 +30,10 @@ const { values: flags, positionals: fileArgs } = parseArgs({
 const { watch: isWatching, 'out-dir': outDir, 'load-path': loadPaths = [] } = flags;
 loadPaths.push(...getDefaultLoadPaths());
 
+const sassCompiler = initSassCompiler();
+
 /** @type {BuildOptions & SyncSassOptions} */
-const options = { outDir, loadPaths, optimize: isProduction };
+const options = { outDir, loadPaths, sassCompiler, optimize: isProduction };
 
 /**
  * Watches given file path(s), triggering the callback on the first change.
@@ -89,4 +92,8 @@ try {
 } catch (error) {
   console.error(error);
   process.exitCode = 1;
+} finally {
+  if (!isWatching) {
+    sassCompiler.dispose();
+  }
 }

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -6,7 +6,7 @@ import { mkdir } from 'node:fs/promises';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { watch } from 'chokidar';
-import { initCompiler as initSassCompiler } from 'sass-embedded';
+import { initAsyncCompiler as initAsyncSassCompiler } from 'sass-embedded';
 import { buildFile } from './index.js';
 import getDefaultLoadPaths from './get-default-load-paths.js';
 import getErrorSassStackPaths from './get-error-sass-stack-paths.js';
@@ -30,7 +30,7 @@ const { values: flags, positionals: fileArgs } = parseArgs({
 const { watch: isWatching, 'out-dir': outDir, 'load-path': loadPaths = [] } = flags;
 loadPaths.push(...getDefaultLoadPaths());
 
-const sassCompiler = initSassCompiler();
+const sassCompiler = await initAsyncSassCompiler();
 
 /** @type {BuildOptions & SyncSassOptions} */
 const options = { outDir, loadPaths, sassCompiler, optimize: isProduction };
@@ -94,6 +94,6 @@ try {
   process.exitCode = 1;
 } finally {
   if (!isWatching) {
-    sassCompiler.dispose();
+    await sassCompiler.dispose();
   }
 }

--- a/app/javascript/packages/build-sass/index.js
+++ b/app/javascript/packages/build-sass/index.js
@@ -2,10 +2,11 @@ import { basename, join, dirname } from 'node:path';
 import { createWriteStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { compile as sassCompile } from 'sass-embedded';
+import { compile as baseSassCompile } from 'sass-embedded';
 import { transform as lightningTransform, browserslistToTargets } from 'lightningcss';
 import browserslist from 'browserslist';
 
+/** @typedef {import('sass-embedded').Compiler} Compiler */
 /** @typedef {import('sass-embedded').CompileResult} CompileResult */
 /** @typedef {import('sass-embedded').Options<'sync'>} SyncSassOptions */
 
@@ -14,6 +15,7 @@ import browserslist from 'browserslist';
  *
  * @prop {string=} outDir Output directory.
  * @prop {boolean} optimize Whether to optimize output for production.
+ * @prop {Compiler=} sassCompiler Sass compiler to use, particularly useful with initCompiler
  */
 
 const TARGETS = browserslistToTargets(
@@ -29,7 +31,14 @@ const TARGETS = browserslistToTargets(
  * @return {Promise<CompileResult>}
  */
 export async function buildFile(file, options) {
-  const { outDir = dirname(file), optimize, loadPaths = [], ...sassOptions } = options;
+  const {
+    outDir = dirname(file),
+    optimize,
+    loadPaths = [],
+    sassCompiler,
+    ...sassOptions
+  } = options;
+  const sassCompile = sassCompiler ? sassCompiler.compile.bind(sassCompiler) : baseSassCompile;
   const sassResult = sassCompile(file, {
     style: optimize ? 'compressed' : 'expanded',
     ...sassOptions,

--- a/app/javascript/packages/build-sass/index.js
+++ b/app/javascript/packages/build-sass/index.js
@@ -2,11 +2,11 @@ import { basename, join, dirname } from 'node:path';
 import { createWriteStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { compile as baseSassCompile } from 'sass-embedded';
+import { compileAsync as baseSassCompileAsync } from 'sass-embedded';
 import { transform as lightningTransform, browserslistToTargets } from 'lightningcss';
 import browserslist from 'browserslist';
 
-/** @typedef {import('sass-embedded').Compiler} Compiler */
+/** @typedef {import('sass-embedded').AsyncCompiler} AsyncCompiler */
 /** @typedef {import('sass-embedded').CompileResult} CompileResult */
 /** @typedef {import('sass-embedded').Options<'sync'>} SyncSassOptions */
 
@@ -15,7 +15,7 @@ import browserslist from 'browserslist';
  *
  * @prop {string=} outDir Output directory.
  * @prop {boolean} optimize Whether to optimize output for production.
- * @prop {Compiler=} sassCompiler Sass compiler to use, particularly useful with initCompiler
+ * @prop {AsyncCompiler=} sassCompiler Sass compiler to use, particularly useful with initCompiler
  */
 
 const TARGETS = browserslistToTargets(
@@ -38,8 +38,11 @@ export async function buildFile(file, options) {
     sassCompiler,
     ...sassOptions
   } = options;
-  const sassCompile = sassCompiler ? sassCompiler.compile.bind(sassCompiler) : baseSassCompile;
-  const sassResult = sassCompile(file, {
+  const sassCompile = sassCompiler
+    ? sassCompiler.compileAsync.bind(sassCompiler)
+    : baseSassCompileAsync;
+
+  const sassResult = await sassCompile(file, {
     style: optimize ? 'compressed' : 'expanded',
     ...sassOptions,
     loadPaths: [...loadPaths, 'node_modules'],

--- a/app/javascript/packages/build-sass/package.json
+++ b/app/javascript/packages/build-sass/package.json
@@ -31,6 +31,6 @@
     "browserslist": "^4.22.1",
     "chokidar": "^3.5.3",
     "lightningcss": "^1.22.0",
-    "sass-embedded": "^1.69.2"
+    "sass-embedded": "^1.70.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5980,50 +5980,90 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-embedded-darwin-arm64@1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.69.2.tgz#43acf549b5ca753a0fc32dc504e8c2b007c5a503"
-  integrity sha512-3e/tRdLTMlmJ45g0vKRDgJJi5P3DO6eS/L7mS89QQcGSTWI5hIS4Yk3K2KkxGwH8QqjkUHAqrVuaD//eBjkGdA==
+sass-embedded-android-arm64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.70.0.tgz#3bdc0591239a0c4c45313e949883a87bb37e07a2"
+  integrity sha512-vMr7fruLUv/VvF7CPVF1z7Bc28a8K9Ps5nyN3UatOj+irxN1LbZIbeQua6neX2eFUsXvcg7hLZwvV3+T96Fhrw==
 
-sass-embedded-darwin-x64@1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.69.2.tgz#703e59cae6511f9b8f9ed5fbaf625dc708ebbab2"
-  integrity sha512-kJAqg/0fzJMlJY6lzUaWdkzw7P7HJpIXPgxZ8JTCcYM2Xnkt0/kOMMk3a6xwh5m9uNmCNyd18xaau7BnItiVLw==
+sass-embedded-android-arm@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-arm/-/sass-embedded-android-arm-1.70.0.tgz#e003444e41e1ac2f85cbaa662a7e39df510286e6"
+  integrity sha512-Vog4Z+tsDYGv7m9sZisr/P6KvqDioCMu0cinexdnXhHXReo+X6CFe79yv/zA/Xfq5HtAAmFjGD6CO/nTjoydtw==
 
-sass-embedded-linux-arm64@1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.69.2.tgz#91756876417e1b1637226dc3f006f05f1aa8dcd4"
-  integrity sha512-WoNDh/nJ3XNayzSDV7GLOEnW1X6x1zgOBqiXTRQDtQ/Vlf8ydvASUsdcQ4xYDnGlPPkpNgG7XhQjsk1oPSi3Kg==
+sass-embedded-android-ia32@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.70.0.tgz#3051a973b902be3ec66a2b24549273e23484b08f"
+  integrity sha512-RWEJ7sBGBCd101oSBPuePPU8yXb1iB/ME4sRhgI5xjjyIsldiuvX48saW25u1ZqCo2AVA0BTXfWpNJnhKB3b4Q==
 
-sass-embedded-linux-arm@1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.69.2.tgz#93156cb92797351e4f3a2386df040ceca17a7600"
-  integrity sha512-U/n1qL516VfCkMZ4nuNhbORkyvmoyirloSWECuG07L5/irNr0OlAJZ1gmAoLFaZvTLNC5jepLSh18E5N2yvcOQ==
+sass-embedded-android-x64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-x64/-/sass-embedded-android-x64-1.70.0.tgz#86f4e7d1c91d35443cb9c06566e9a61efb4cf6e1"
+  integrity sha512-u+ijV6AQR/84kjjGb3mp0aibPiXkFKqfmHxqYBMN7h2xV7EM70Yz054nVifaBr8nfC0E8aT/DurSI4nkkQ6Uvg==
 
-sass-embedded-linux-ia32@1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.69.2.tgz#990976b81846493e7948b18131687c1b83bcfabb"
-  integrity sha512-94/3sR1xuIWBX/UqnYLBhxS7Xx6mn0iuVuxQBHv3emdFKCLLrUhUBPT3CaBJPcRtzpeRf9docBBNEbJbk92hyQ==
+sass-embedded-darwin-arm64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.70.0.tgz#6fca5c9925e70b85ae2008b5cb9d5359c7f0b80d"
+  integrity sha512-qMs08h0nwRA1B/Ieakcg/Y6lcCEnuBnPTNEkFkBlnfj3PFVPTb50wQvDr9JLpcjXWznlBxyFrz1nZM+pXDix7Q==
 
-sass-embedded-linux-x64@1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.69.2.tgz#2baf19761d28bc1c9fea680c3375e00ea18c5e13"
-  integrity sha512-0rgdwkVBCNKnmlxHHs5DSp8WzicYXAdFGy5KkpCUngRuDZt8P3bwXD7j0fwLOZx83nbaAI54PmZVUDQBODkvMg==
+sass-embedded-darwin-x64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.70.0.tgz#c618be025ddc47515f4cb7e25c71ac1cb21551c2"
+  integrity sha512-Vf8UQY3IBmsaz9L5DeJDjn19N//1n3rTquH69x29zPCd3zF2gnay38atxIZ+6h7VsZT3C6evm0y58JUJDWN1CA==
 
-sass-embedded-win32-ia32@1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.69.2.tgz#a24ae3f696efef6418ae44a6af2e8fd2eb0ec658"
-  integrity sha512-dBV8Gb9EvqZ4R7VgpYGXaPcqsDDHWznvnY7Cenp6Ub9ookq9X+wXp86JGifQSeisC/sYQPiJafvPrbLZKz4lLQ==
+sass-embedded-linux-arm64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.70.0.tgz#24ca8d8ed74611cb9f9efbf76ecd65908387a99e"
+  integrity sha512-PzhBg5xlyXcZ8FgyjqAcVtfaq462l3KeEid2OxrsOzBQgdgJb0La1tAEOpP9jz7YOOTr9A96vm609W9fRLI2Iw==
 
-sass-embedded-win32-x64@1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.69.2.tgz#281906403c3ee87d63909542220eda864318c313"
-  integrity sha512-TqsJajpboz/qY96R38KF/XSWlt/sdZ+O5Nnkm0os5rbBw3Rv8j/80C8eQ30T4BNinLPrsyBWfH5xJw+Cl9mpWA==
+sass-embedded-linux-arm@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.70.0.tgz#017085c42a2060e36f629c22f9daaa5491dd866f"
+  integrity sha512-U9e+k0XHwubeSIwsBYTNrTVH+0zF/ErSfuHfgTfuvlcKlhoGtFgAb7W8Qfe9FDF6TYTt0fJAJhSV2MdoExsgRA==
 
-sass-embedded@^1.69.2:
-  version "1.69.2"
-  resolved "https://registry.yarnpkg.com/sass-embedded/-/sass-embedded-1.69.2.tgz#3d68cf30da4c14b5b2c009d8cb47f9a245c65c6d"
-  integrity sha512-B6vRMgpKkWagflo57FXvrpWxizQDJwCB7vquV3WVXzGsEWxRIX4CUWNR/Mq6lMohnkzuUb3ctW54Zrt/716l9Q==
+sass-embedded-linux-ia32@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.70.0.tgz#cf6bc32beda3c8fc8c6886fb1b796de925c5f201"
+  integrity sha512-UOxTJywQRC/HzFQthlyNWJ07MX8EzKuTgH0N5T3XyXQTNuGeJQ8EPWY9fv1weLCjydVOEwm853F3djtUNmkCtg==
+
+sass-embedded-linux-musl-arm64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.70.0.tgz#cc81f56d2e14cdf412133a5ae2ed9d62f5b1dcac"
+  integrity sha512-DJl1AV9W7T3SHzXFqAtyjPZy4O2g4AC6QctY5/aM42DTY/xpWOmwUBgsDzDoRbNqP7qDl+GtHLlggrLWCBP9fg==
+
+sass-embedded-linux-musl-arm@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.70.0.tgz#4e22f7dc127b6920a784b0acb9a59efb465f1d1f"
+  integrity sha512-8zudDFpAoNrQDujNYBKkq8nwl4i0jMmXcysO9Ou0llrzdY7Keok2z1aS3IbZy7AvUXtGaeYSHUi5lXdOalJ/QQ==
+
+sass-embedded-linux-musl-ia32@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.70.0.tgz#c0a7278d542870a8114134b9bd1829d6fd16828e"
+  integrity sha512-CcAvT3KPc7cCJfTu1E0HzsAjE/dPQsKaXQD/nsBXNZo081R+lLR2u22wpXM2pnzMNJETRV/pDwozHoYEcPkPqQ==
+
+sass-embedded-linux-musl-x64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.70.0.tgz#5c0710733cf98b309e72f82b6b17bf53f3c9b230"
+  integrity sha512-g3i9PKmqTxuyrM1Yeju1s4Fj6fzAGyyfzw/LiZZtq0ZZGhJXJMVvEDog/OxQ37eYxWqq9XHFTW2PphMvukVK0g==
+
+sass-embedded-linux-x64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.70.0.tgz#1ceae4677f7dc9052727d08aa6f54dee2cf6c0b2"
+  integrity sha512-F9F2CA7C6z/ROfF0U/jtYWknbDe9S/TJoCJ5TlHafwS+SrZE1A+Czf2MWJ+8mc2NFiRjYzYxt4Ad29cuc6rrhw==
+
+sass-embedded-win32-ia32@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.70.0.tgz#b67e4a66548deca91eb75a9c467d40b1ad080e95"
+  integrity sha512-TITx2QwJouhMwA0CAjCmnTNeCDL9g2fkLe9z+5rf39OdmcX9CEBrY4CNaO5REnMpgoa+o82u272ZR3oWrsUs8Q==
+
+sass-embedded-win32-x64@1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.70.0.tgz#5a07423cf1370c302e6d44105358f6591b675b1e"
+  integrity sha512-rPe8WUdARhlfgIhGcCTGbTNgd6OppcmjtBrxUNoGs3AENSREQCpaNv5d+HBOMhGUfYgXIHUSiipilFUhLWpsrQ==
+
+sass-embedded@^1.70.0:
+  version "1.70.0"
+  resolved "https://registry.yarnpkg.com/sass-embedded/-/sass-embedded-1.70.0.tgz#558f5e9776c6e4b91d9859a4dd325ac7c2b91391"
+  integrity sha512-1sVSh5MlSdktkwC2zG9WuaVR6j7AlDxadPmZBN0wP4GhznMQTvpwNIAFhAqgjwJYhwdWFOKEdIHSQK4V8K434Q==
   dependencies:
     "@bufbuild/protobuf" "^1.0.0"
     buffer-builder "^0.2.0"
@@ -6032,14 +6072,22 @@ sass-embedded@^1.69.2:
     supports-color "^8.1.1"
     varint "^6.0.0"
   optionalDependencies:
-    sass-embedded-darwin-arm64 "1.69.2"
-    sass-embedded-darwin-x64 "1.69.2"
-    sass-embedded-linux-arm "1.69.2"
-    sass-embedded-linux-arm64 "1.69.2"
-    sass-embedded-linux-ia32 "1.69.2"
-    sass-embedded-linux-x64 "1.69.2"
-    sass-embedded-win32-ia32 "1.69.2"
-    sass-embedded-win32-x64 "1.69.2"
+    sass-embedded-android-arm "1.70.0"
+    sass-embedded-android-arm64 "1.70.0"
+    sass-embedded-android-ia32 "1.70.0"
+    sass-embedded-android-x64 "1.70.0"
+    sass-embedded-darwin-arm64 "1.70.0"
+    sass-embedded-darwin-x64 "1.70.0"
+    sass-embedded-linux-arm "1.70.0"
+    sass-embedded-linux-arm64 "1.70.0"
+    sass-embedded-linux-ia32 "1.70.0"
+    sass-embedded-linux-musl-arm "1.70.0"
+    sass-embedded-linux-musl-arm64 "1.70.0"
+    sass-embedded-linux-musl-ia32 "1.70.0"
+    sass-embedded-linux-musl-x64 "1.70.0"
+    sass-embedded-linux-x64 "1.70.0"
+    sass-embedded-win32-ia32 "1.70.0"
+    sass-embedded-win32-x64 "1.70.0"
 
 saxes@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## 🛠 Summary of changes

Enhances the `@18f/identity-build-sass` Sass compilation tool to use the new [Shared Resources API](https://github.com/sass/sass/blob/main/accepted/shared-resources.d.ts.md) added to Sass in a recent version. This feature is well-suited for our use-case, where we compile many different stylesheets, and each stylesheet shares a number of common resources (USWDS, etc.).

### Performance:

Average of `yarn build:css` on a set of 10 runs:

**Before:** 8.75s
**After:** ~6.71s~ 2.98s after 3fe4d75
**Diff:** ~-2.04s (-23.3%)~ -5.77s (-65.9%) after 3fe4d75

## 📜 Testing Plan

Verify that `yarn build:css` successfully outputs to `app/assets/build`
