### PR TITLE
LG-12101 Add active to with_push_notification_urls scope

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -27,7 +27,11 @@ class ServiceProvider < ApplicationRecord
   scope(:active, -> { where(active: true) })
   scope(
     :with_push_notification_urls,
-    -> { where.not(push_notification_url: nil).where.not(push_notification_url: '') },
+    -> {
+      where.not(push_notification_url: nil).
+        where.not(push_notification_url: '').
+        where(active: true)
+    },
   )
 
   IAA_INTERNAL = 'LGINTERNAL'


### PR DESCRIPTION
## 🎫 Ticket
[LG-12101](https://cm-jira.usa.gov/browse/LG-12101)

## 🛠 Summary of changes
Adds a clause to the `with_push_notification_urls` scope to only allow RISC push notifications to active integrations. 
