### PR TITLE
LG-12085 Returns 400 when blank certificate element is passed through assertion

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -5,7 +5,7 @@ module SamlIdpAuthConcern
 
   included do
     # rubocop:disable Rails/LexicallyScopedActionFilter
-    before_action :create_saml_request_object, only: :auth
+    before_action :validate_and_create_saml_request_object, only: :auth
     before_action :validate_service_provider_and_authn_context, only: :auth
     before_action :check_sp_active, only: :auth
     before_action :log_external_saml_auth_request, only: [:auth]
@@ -62,7 +62,7 @@ module SamlIdpAuthConcern
     )
   end
 
-  def create_saml_request_object
+  def validate_and_create_saml_request_object
     # this saml_idp method creates the saml_request object used for validations
     validate_saml_request
     @saml_request_validator = SamlRequestValidator.new

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -118,7 +118,7 @@ class SamlIdpController < ApplicationController
   end
 
   def capture_analytics
-    analytics_payload = @result.to_h.merge(
+    analytics_payload = result.to_h.merge(
       endpoint: api_saml_auth_path(path_year: params[:path_year]),
       idv: identity_needs_verification?,
       finish_profile: user_has_pending_profile?,

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -1,9 +1,14 @@
 class SamlRequestValidator
   include ActiveModel::Model
 
+  validate :cert_exists
   validate :authorized_service_provider
   validate :authorized_authn_context
   validate :authorized_email_nameid_format
+
+  def initialize(blank_cert: false)
+    @blank_cert = blank_cert
+  end
 
   def call(service_provider:, authn_context:, nameid_format:, authn_context_comparison: nil)
     self.service_provider = service_provider
@@ -43,6 +48,12 @@ class SamlRequestValidator
        (ial_max_requested? &&
         !IdentityConfig.store.allowed_ialmax_providers.include?(service_provider&.issuer))
       errors.add(:authn_context, :unauthorized_authn_context, type: :unauthorized_authn_context)
+    end
+  end
+
+  def cert_exists
+    if @blank_cert
+      errors.add(:service_provider, :blank_cert_element_req, type: :blank_cert_element_req)
     end
   end
 

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -50,6 +50,7 @@ en:
     messages:
       already_confirmed: was already confirmed, please try signing in
       blank: Please fill in this field.
+      blank_cert_element_req: We cannot detect a certificate in your request.
       confirmation_code_incorrect: Incorrect verification code. Did you type it in correctly?
       confirmation_invalid_token: Invalid confirmation link. Either the link expired
         or you already confirmed your account.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -54,6 +54,7 @@ es:
     messages:
       already_confirmed: ya estaba confirmado, por favor intente iniciar una sesión
       blank: Por favor, rellenar este campo.
+      blank_cert_element_req: No podemos detectar un certificado en su solicitud.
       confirmation_code_incorrect: Código de verificación incorrecto. ¿Lo escribió correctamente?
       confirmation_invalid_token: El enlace de confirmación no es válido. El enlace
         expiró o usted ya ha confirmado su cuenta.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -59,6 +59,7 @@ fr:
     messages:
       already_confirmed: a déjà été confirmé, veuillez essayer de vous connecter
       blank: Veuillez remplir ce champ.
+      blank_cert_element_req: Nous ne pouvons pas détecter un certificat sur votre demande.
       confirmation_code_incorrect: Code de vérification incorrect. L’avez-vous saisi correctement ?
       confirmation_invalid_token: Lien de confirmation non valide. Le lien est expiré
         ou vous avez déjà confirmé votre compte.

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2281,9 +2281,9 @@ RSpec.describe SamlIdpController do
     it 'includes the appropriate before_actions' do
       expect(subject).to have_actions(
         :before,
-        :create_saml_request_object,
         :disable_caching,
         :store_saml_request,
+        :validate_and_create_saml_request_object,
         :validate_service_provider_and_authn_context,
       )
     end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1362,6 +1362,23 @@ RSpec.describe SamlIdpController do
     context 'cert element in SAML request is blank' do
       let(:user) { create(:user, :fully_registered) }
       let(:service_provider) { build(:service_provider, issuer: 'http://localhost:3000') }
+      let(:analytics_hash) do
+        {
+          success: false,
+          errors: { service_provider: ['We cannot detect a certificate in your request.'] },
+          error_details: { service_provider: { blank_cert_element_req: true } },
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+          authn_context: [Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF],
+          authn_context_comparison: 'exact',
+          service_provider: 'http://localhost:3000',
+          request_signed: true,
+        }
+      end
+
+      before do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+      end
 
       # the RubySAML library won't let us pass an empty string in as the certificate
       # element, so this test substitutes a SAMLRequest that has that element blank
@@ -1395,7 +1412,6 @@ RSpec.describe SamlIdpController do
             <samlp:NameIDPolicy AllowCreate="true" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"/>
             <samlp:RequestedAuthnContext Comparison="exact">
           <saml:AuthnContextClassRef>urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo</saml:AuthnContextClassRef>
-              <saml:AuthnContextClassRef>http://idmanagement.gov/ns/assurance/ial/1</saml:AuthnContextClassRef>
             </samlp:RequestedAuthnContext>
           </samlp:AuthnRequest>
         XML
@@ -1410,11 +1426,17 @@ RSpec.describe SamlIdpController do
         expect(CGI).to receive(:unescape).and_return deflated_encoded_req
       end
 
-      it 'a ValidationError is raised' do
-        expect { generate_saml_response(user, saml_settings) }.to raise_error(
-          SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-          'Certificate element present in response (ds:X509Certificate) but evaluating to nil',
-        )
+      it 'notes it in the analytics event' do
+        generate_saml_response(user, saml_settings)
+        expect(@analytics).to have_received(:track_event).
+          with('SAML Auth', analytics_hash)
+      end
+
+      it 'returns a 400' do
+        generate_saml_response(user, saml_settings)
+        expect(controller).to render_template('saml_idp/auth/error')
+        expect(response.status).to eq(400)
+        expect(response.body).to include(t('errors.messages.blank_cert_element_req'))
       end
     end
 
@@ -2259,10 +2281,10 @@ RSpec.describe SamlIdpController do
     it 'includes the appropriate before_actions' do
       expect(subject).to have_actions(
         :before,
+        :create_saml_request_object,
         :disable_caching,
-        :validate_saml_request,
-        :validate_service_provider_and_authn_context,
         :store_saml_request,
+        :validate_service_provider_and_authn_context,
       )
     end
   end


### PR DESCRIPTION
## 🎫 Ticket
[LG-12085](https://cm-jira.usa.gov/browse/LG-12085)

## 🛠 Summary of changes
Adds a validation for whether the assertion has a blank certificate element.

There's probably a better way to do this, but creating a new validation in the `SamlRequestValidator` felt the cleanest in terms of being able to create an expected error for the user and return an event that tracks what's happening. Suggestions on other ways to do it welcome! Thanks.