### PR TITLE
Add sideEffects directive to all package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ lint_yaml: normalize_yaml ## Lints YAML files
 	(! git diff --name-only | grep "^config/.*\.yml$$") || (echo "Error: Run 'make normalize_yaml' to normalize YAML"; exit 1)
 
 lint_yarn_workspaces: ## Lints Yarn workspace packages
-	scripts/validate-workspaces.js
+	scripts/validate-workspaces.mjs
 
 lint_asset_bundle_size: ## Lints JavaScript and CSS compiled bundle size
 	@# This enforces an asset size budget to ensure that download sizes are reasonable and to protect

--- a/app/javascript/packages/README.md
+++ b/app/javascript/packages/README.md
@@ -2,25 +2,4 @@
 
 Packages are independent JavaScript libraries. As much as possible, their behaviors should be reusable and make no assumptions about particular application pages or configuration. Instead, they should be initialized by a [`pack`](../packs) which provides relevant configuration and page element references.
 
-A package should behave much like any other third-party [NPM package](https://www.npmjs.com/), where each folder in this directory represents a single package. These packages are managed using [Yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/).
-
-Each package should include a `package.json` with at least `name`, `version`, and `private` fields:
-
-- Name should start with `@18f/identity-` and end with the folder name
-- Version should be fixed to `1.0.0`
-- Packages should be private, since they are not published
-- Any `devDependencies` should be defined in the root project directory, not in a package
-- Define `dependencies` for any third-party libraries used in a package
-  - It is not necessary to define `dependencies` for other sibling packages
-
-**Example:**
-
-_packages/analytics/package.json_
-
-```json
-{
-  "name": "@18f/identity-analytics",
-  "version": "1.0.0",
-  "private": true
-}
-```
+A package should behave much like any other third-party [NPM package](https://www.npmjs.com/), where each folder in this directory represents a single package. These packages are managed using [Yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/). Refer to [Front-end Architecture documentation on Yarn Workspaces](https://github.com/18F/identity-idp/blob/main/docs/frontend.md#yarn-workspaces) for more information.

--- a/app/javascript/packages/address-search/package.json
+++ b/app/javascript/packages/address-search/package.json
@@ -32,5 +32,6 @@
     "type": "git",
     "url": "https://github.com/18f/identity-idp.git",
     "directory": "app/javascript/packages/address-search"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/analytics/package.json
+++ b/app/javascript/packages/analytics/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-analytics",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": [
+    "./click-observer-element.ts"
+  ]
 }

--- a/app/javascript/packages/assets/package.json
+++ b/app/javascript/packages/assets/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "peerDependencies": {
     "webpack": ">=5"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/build-sass/package.json
+++ b/app/javascript/packages/build-sass/package.json
@@ -32,5 +32,6 @@
     "chokidar": "^3.5.3",
     "lightningcss": "^1.23.0",
     "sass-embedded": "^1.70.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/captcha-submit-button/package.json
+++ b/app/javascript/packages/captcha-submit-button/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-captcha-submit-button",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "sideEffects": [
+    "./captcha-submit-button-element.ts"
+  ]
 }

--- a/app/javascript/packages/clipboard-button/package.json
+++ b/app/javascript/packages/clipboard-button/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "dependencies": {
     "@18f/identity-design-system": "^8.1.2"
-  }
+  },
+  "sideEffects": [
+    "./clipboard-button-element.ts"
+  ]
 }

--- a/app/javascript/packages/components/package.json
+++ b/app/javascript/packages/components/package.json
@@ -32,5 +32,6 @@
     "type": "git",
     "url": "https://github.com/18f/identity-idp.git",
     "directory": "app/javascript/packages/components"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/compose-components/package.json
+++ b/app/javascript/packages/compose-components/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "dependencies": {
     "react": "^17.0.2"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/config/package.json
+++ b/app/javascript/packages/config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@18f/identity-config",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": false
 }

--- a/app/javascript/packages/countdown/package.json
+++ b/app/javascript/packages/countdown/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@18f/identity-countdown",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": [
+    "./countdown-alert-element.ts",
+    "./countdown-element.ts"
+  ]
 }

--- a/app/javascript/packages/device/package.json
+++ b/app/javascript/packages/device/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@18f/identity-device",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": false
 }

--- a/app/javascript/packages/document-capture-polling/package.json
+++ b/app/javascript/packages/document-capture-polling/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@18f/identity-document-capture-polling",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": false
 }

--- a/app/javascript/packages/document-capture/package.json
+++ b/app/javascript/packages/document-capture/package.json
@@ -6,5 +6,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "swr": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/eslint-plugin/package.json
+++ b/app/javascript/packages/eslint-plugin/package.json
@@ -56,5 +56,6 @@
     "eslint-plugin-react-hooks": {
       "optional": true
     }
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/form-steps/package.json
+++ b/app/javascript/packages/form-steps/package.json
@@ -4,5 +4,6 @@
   "private": true,
   "peerDependencies": {
     "react": "*"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/i18n/package.json
+++ b/app/javascript/packages/i18n/package.json
@@ -24,5 +24,6 @@
     "type": "git",
     "url": "https://github.com/18f/identity-idp.git",
     "directory": "app/javascript/packages/i18n"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/manageable-authenticator/package.json
+++ b/app/javascript/packages/manageable-authenticator/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-manageable-authenticator",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "sideEffects": [
+    "./manageable-authenticator-element.ts"
+  ]
 }

--- a/app/javascript/packages/masked-text-toggle/package.json
+++ b/app/javascript/packages/masked-text-toggle/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@18f/identity-masked-text-toggle",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": false
 }

--- a/app/javascript/packages/memorable-date/package.json
+++ b/app/javascript/packages/memorable-date/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-memorable-date",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": [
+    "./index.ts"
+  ]
 }

--- a/app/javascript/packages/modal/package.json
+++ b/app/javascript/packages/modal/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "dependencies": {
     "focus-trap": "^6.7.1"
-  }
+  },
+  "sideEffects": [
+    "./modal-element.ts"
+  ]
 }

--- a/app/javascript/packages/normalize-yaml/package.json
+++ b/app/javascript/packages/normalize-yaml/package.json
@@ -39,5 +39,6 @@
   },
   "peerDependencies": {
     "prettier": ">=3"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/one-time-code-input/package.json
+++ b/app/javascript/packages/one-time-code-input/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-one-time-code-input",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": [
+    "./one-time-code-input-element.ts"
+  ]
 }

--- a/app/javascript/packages/password-confirmation/package.json
+++ b/app/javascript/packages/password-confirmation/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-password-confirmation",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": [
+    "./password-confirmation-element.ts"
+  ]
 }

--- a/app/javascript/packages/password-strength/package.json
+++ b/app/javascript/packages/password-strength/package.json
@@ -4,5 +4,8 @@
   "version": "1.0.0",
   "dependencies": {
     "zxcvbn": "^4.4.2"
-  }
+  },
+  "sideEffects": [
+    "./password-strength-element.ts"
+  ]
 }

--- a/app/javascript/packages/password-toggle/package.json
+++ b/app/javascript/packages/password-toggle/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-password-toggle",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "sideEffects": [
+    "./password-toggle-element.ts"
+  ]
 }

--- a/app/javascript/packages/phone-input/package.json
+++ b/app/javascript/packages/phone-input/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "intl-tel-input": "^17.0.19",
     "libphonenumber-js": "^1.10.55"
-  }
+  },
+  "sideEffects": [
+    "./index.ts"
+  ]
 }

--- a/app/javascript/packages/print-button/package.json
+++ b/app/javascript/packages/print-button/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-print-button",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "sideEffects": [
+    "./print-button-element.ts"
+  ]
 }

--- a/app/javascript/packages/rails-i18n-webpack-plugin/package.json
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/package.json
@@ -10,5 +10,6 @@
   "peerDependencies": {
     "sinon": "*",
     "webpack": ">=5"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/rails-i18n-webpack-plugin/package.json
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/package.json
@@ -11,5 +11,7 @@
     "sinon": "*",
     "webpack": ">=5"
   },
-  "sideEffects": false
+  "sideEffects": [
+    "./spec/**"
+  ]
 }

--- a/app/javascript/packages/react-hooks/package.json
+++ b/app/javascript/packages/react-hooks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "peerDependencies": {
     "react": ">=16.8.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/react-i18n/package.json
+++ b/app/javascript/packages/react-i18n/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "dependencies": {
     "react": "^17.0.2"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/request/package.json
+++ b/app/javascript/packages/request/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@18f/identity-request",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "sideEffects": false
 }

--- a/app/javascript/packages/session/package.json
+++ b/app/javascript/packages/session/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@18f/identity-session",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "sideEffects": false
 }

--- a/app/javascript/packages/spinner-button/package.json
+++ b/app/javascript/packages/spinner-button/package.json
@@ -9,5 +9,8 @@
     "react": {
       "optional": true
     }
-  }
+  },
+  "sideEffects": [
+    "./spinner-button-element.ts"
+  ]
 }

--- a/app/javascript/packages/step-indicator/package.json
+++ b/app/javascript/packages/step-indicator/package.json
@@ -9,5 +9,8 @@
     "react": {
       "optional": true
     }
-  }
+  },
+  "sideEffects": [
+    "./step-indicator-element.ts"
+  ]
 }

--- a/app/javascript/packages/stylelint-config/package.json
+++ b/app/javascript/packages/stylelint-config/package.json
@@ -23,5 +23,6 @@
   "peerDependencies": {
     "prettier": ">=3.0.0",
     "stylelint": ">=15.10.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/submit-button/package.json
+++ b/app/javascript/packages/submit-button/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@18f/identity-submit-button",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "sideEffects": [
+    "./submit-button-element.ts"
+  ]
 }

--- a/app/javascript/packages/test-helpers/package.json
+++ b/app/javascript/packages/test-helpers/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "peerDependencies": {
     "sinon": "*"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/time-element/package.json
+++ b/app/javascript/packages/time-element/package.json
@@ -2,5 +2,8 @@
   "name": "@18f/identity-time-element",
   "private": true,
   "version": "1.0.0",
-  "type": "module"
+  "type": "module",
+  "sideEffects": [
+    "./time-element.ts"
+  ]
 }

--- a/app/javascript/packages/unpolyfill-webpack-plugin/package.json
+++ b/app/javascript/packages/unpolyfill-webpack-plugin/package.json
@@ -11,5 +11,6 @@
   },
   "peerDependencies": {
     "webpack": ">=5"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/url/package.json
+++ b/app/javascript/packages/url/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@18f/identity-url",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "sideEffects": false
 }

--- a/app/javascript/packages/validated-field/package.json
+++ b/app/javascript/packages/validated-field/package.json
@@ -9,5 +9,8 @@
     "react": {
       "optional": true
     }
-  }
+  },
+  "sideEffects": [
+    "./validated-field-element.ts"
+  ]
 }

--- a/app/javascript/packages/verify-flow/package.json
+++ b/app/javascript/packages/verify-flow/package.json
@@ -4,5 +4,6 @@
   "private": true,
   "dependencies": {
     "react": "^17.0.2"
-  }
+  },
+  "sideEffects": false
 }

--- a/app/javascript/packages/webauthn/package.json
+++ b/app/javascript/packages/webauthn/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@18f/identity-webauthn",
   "version": "1.0.0",
-  "private": true
+  "private": true,
+  "sideEffects": [
+    "./webauthn-input-element.ts",
+    "./webauthn-verify-button-element.ts"
+  ]
 }

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -79,6 +79,7 @@ In practice:
     package is intended to be published to NPM.
   - ...a value for the `version` field, since it is required. The value value can be anything, and
     `"1.0.0"` is a good default.
+  - ...a `sideEffects` value listing files containing any side effects, used for [Webpack's Tree Shaking optimization](https://webpack.js.org/guides/tree-shaking/).
 - The package should be importable by its bare name, either with an `index.ts` or equivalent
   [package entrypoints](https://nodejs.org/api/packages.html#package-entry-points)
 

--- a/scripts/validate-workspaces.mjs
+++ b/scripts/validate-workspaces.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { readFile, stat } from 'node:fs/promises';
-import { dirname, basename, join, resolve } from 'node:path';
+import { dirname, basename, join, resolve, relative } from 'node:path';
 import glob from 'fast-glob';
 
 /** @typedef {[path: string, manifest: Record<string, any>]} ManifestPair */
@@ -137,9 +137,10 @@ function checkPackageSideEffectsIncludesCustomElements(manifests) {
       const hasExpected = expectedPaths.every((path) => actualPaths.includes(path));
       if (!hasExpected) {
         throw new Error(
-          `Missing expected custom elements in ${manifestPath} sideEffects: ${customElementPaths.map(
-            (path) => resolve(manifestDirectory, path),
-          )}`,
+          [
+            `Missing expected custom elements in ${manifestPath} sideEffects:`,
+            customElementPaths.map((path) => `./${relative(manifestDirectory, path)}`).join(', '),
+          ].join(' '),
         );
       }
     }),

--- a/scripts/validate-workspaces.mjs
+++ b/scripts/validate-workspaces.mjs
@@ -43,9 +43,16 @@ function checkHaveCommonDependencyVersions(manifests) {
  */
 function checkHaveRequiredFields(manifests) {
   for (const [path, manifest] of manifests) {
-    ['name', 'version', 'private', 'sideEffects'].forEach((field) => {
+    Object.entries({
+      name: `Expected "@18f/identity-${basename(dirname(path))}".`,
+      version: '"1.0.0" is recommended for private packages.',
+      private: '`true` is recommended unless the package is intended to be published to NPM.',
+      sideEffects:
+        'This is usually `false`, unless there are files which include side effects, ' +
+        'such as custom elements registering to the custom element registry.',
+    }).forEach(([field, guidance]) => {
       if (!(field in manifest)) {
-        throw new Error(`Missing required field ${field} in ${path}`);
+        throw new Error([`Missing required field ${field} in ${path}`, guidance].join(' '));
       }
     });
   }


### PR DESCRIPTION
## 🛠 Summary of changes

Adds (and enforces) the presence of a `sideEffects` directive within each package's `package.json`.

**Why?**

By default, Webpack and other common bundlers assume that any imported code may include side effects, and as such will not aggressively try to perform dead code elimination. Explicitly defining side effects (or the absence of them) allows Webpack to perform this optimization.

See also: 

- https://webpack.js.org/guides/tree-shaking/
- https://esbuild.github.io/api/#ignore-annotations

In practice, I noticed this by looking at the `platform-authenticator-avaiable-*.js` file loaded on https://secure.login.gov/ , which includes the snippet of code `new Set(["NotAllowedError", "TimeoutError", "InvalidStateError"]);` irrelevant for that bundle.

### Performance Impact

```
yarn build:js
```

Total JavaScript size:

`du -s public/packs/js`

**Before:** 12240kb
**After:** 12176kb
**Diff:** -64kb (-0.5%)

Critical path (http://localhost:3000), with gzip enabled:

**Before:** 6.4kb
**After:** 6.3kb
**Diff:** -0.1kb (-1.6%)

**Observation:** The benefit here isn't as substantial as I might have hoped, and may not warrant the effort involved in maintaining an accurate configuration for every package. I could be open to pushback here. I still think targeting a lack of side effects is ideal, with custom elements being the main point of complication. The savings here could be more substantial in the future depending on future package code revisions.

## 📜 Testing Plan

1. `rm -rf public/packs/js`
2. `NODE_ENV=production yarn build:js`
3. `cat public/packs/js/platform-authenticator-available-*.digested.js | grep NotAllowedError`
4. `echo $?`
5. Observe: "1"