### PR TITLE
Improve reliability of WebauthnSetupForm spec

### DIFF
--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -246,6 +246,10 @@ RSpec.describe WebauthnSetupForm do
       end
     end
     context 'webauthn_platform' do
+      let(:params) do
+        super().merge(platform_authenticator: true, transports: 'internal,hybrid')
+      end
+
       context 'with one platform authenticator with the same name' do
         let(:user) do
           user = create(:user)
@@ -257,12 +261,7 @@ RSpec.describe WebauthnSetupForm do
           )
           user
         end
-        let(:params) do
-          super().merge(
-            platform_authenticator: true,
-            transports: 'internal,hybrid',
-          )
-        end
+
         it 'adds a new platform device with the same existing name and appends a (1)' do
           result = subject.submit(protocol, params)
           expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
@@ -276,37 +275,25 @@ RSpec.describe WebauthnSetupForm do
       end
 
       context 'with two existing platform authenticators one with the same name' do
-        let(:user) do
-          user = create(:user)
-          user.webauthn_configurations << create(
-            :webauthn_configuration,
-            name: device_name,
-            platform_authenticator: true,
-            transports: ['internal', 'hybrid'],
-          )
-          user.webauthn_configurations << create(
-            :webauthn_configuration,
-            name: device_name,
-            platform_authenticator: true,
-            transports: ['internal', 'hybrid'],
-          )
-          user
-        end
-        let(:params) do
-          super().merge(
-            platform_authenticator: true,
-            transports: 'internal,hybrid',
+        let!(:user) do
+          create(
+            :user,
+            webauthn_configurations: create_list(
+              :webauthn_configuration,
+              2,
+              name: device_name,
+              platform_authenticator: true,
+            ),
           )
         end
+
         it 'adds a second new platform device with the same existing name and appends a (2)' do
           result = subject.submit(protocol, params)
-          expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
+
+          expect(result.success?).to eq(true)
           expect(user.webauthn_configurations.platform_authenticators.count).to eq(3)
-          expect(
-            user.webauthn_configurations.platform_authenticators[2].name,
-          ).
+          expect(user.webauthn_configurations.platform_authenticators.last.name).
             to eq("#{device_name} (2)")
-          expect(result.to_h[:success]).to eq(true)
         end
       end
     end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe WebauthnSetupForm do
               2,
               name: device_name,
               platform_authenticator: true,
-              transports: 'internal,hybrid',
+              transports: ['internal', 'hybrid'],
             ),
           )
         end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -283,6 +283,7 @@ RSpec.describe WebauthnSetupForm do
               2,
               name: device_name,
               platform_authenticator: true,
+              transports: 'internal,hybrid',
             ),
           )
         end


### PR DESCRIPTION
## 🛠 Summary of changes

Revises `webauthn_setup_form_spec.rb` in hopes of reducing some test flakiness.

Example: https://gsa-tts.slack.com/archives/C0NGESUN5/p1706048041505969

The suspected cause is that `let(:user)` is lazily evaluated _after_ the form is already submitted, which is likely not the intent of the test setup. Eagerly assigning `let!(:user)` with existing authenticators should hopefully produce a more reliable result.

## 📜 Testing Plan

Verify the test passes:

```
rspec spec/forms/webauthn_setup_form_spec.rb
```