### PR TITLE
Remove bind from Puma configuration

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,9 +24,6 @@ if ENV['RAILS_ENV'] == 'production'
   end
 end
 
-app_dir    = File.expand_path('../..', __FILE__)
-shared_dir = "#{app_dir}/shared"
-bind "unix://#{shared_dir}/sockets/puma.sock"
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the `bind` configuration from `config/puma.rb` to resolve an issue where `rails s` currently fails with an error:

```
/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/puma-6.4.2/lib/puma/binder.rb:186:in `realdirpath': No such file or directory @ realpath_rec - /Code/identity-idp/shared (Errno::ENOENT)
```

Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1706044143605219

I'm still not entirely certain if `bind` would be necessary for any reason, but in my testing with both `rails s` and `make run` (Foreman), including with different hostname and port parameterization, it works as expected.

Previously: #9848 

## 📜 Testing Plan

Start the server by whichever method you prefer, e.g.

- `rails s` or `make run`
- `HOST=` or `PORT=` variations
- [HTTPS local development](https://github.com/18F/identity-idp/blob/main/docs/local-development.md#testing-the-application-over-https)
- etc.

Observe that you can access the IdP.

Test that review app for the build works as expected, since this also uses Puma.