### PR TITLE
LG-12143 Create a vector of trust parser

### DIFF
--- a/app/services/vot_parser.rb
+++ b/app/services/vot_parser.rb
@@ -9,13 +9,13 @@ class VotParser
     '0' => :no_identity_proofing,
     '1' => :identity_proofing_no_biometric,
     '2' => :identity_proofing_biometric_required,
-  }
+  }.freeze
   CREDENTIAL_USAGE_VECTOR_VALUES = {
     '0' => :default,
     '1' => :no_remember_device,
     '2' => :unphishable_mfa,
     '3' => :piv_cac_required,
-  }
+  }.freeze
 
   attr_reader :vector_of_trust
 
@@ -23,7 +23,7 @@ class VotParser
     @vector_of_trust = vector_of_trust
   end
 
-  def parse_vot
+  def parse
     result = { identity_proofing: :no_identity_proofing, credential_usage: :default }
     vector_component_map.each do |component, value|
       if component == 'P'

--- a/app/services/vot_parser.rb
+++ b/app/services/vot_parser.rb
@@ -1,0 +1,68 @@
+class VotParser
+  class VotParseException < StandardError; end
+
+  VotParserResult = Data.define(:identity_proofing, :credential_usage)
+
+  VECTOR_COMPONENT_REGEXP = /\A(?<component>[A-Z])(?<value>[0-9a-z])\z/
+
+  IDENTITY_PROOFING_VECTOR_VALUES = {
+    '0' => :no_identity_proofing,
+    '1' => :identity_proofing_no_biometric,
+    '2' => :identity_proofing_biometric_required,
+  }
+  CREDENTIAL_USAGE_VECTOR_VALUES = {
+    '0' => :default,
+    '1' => :no_remember_device,
+    '2' => :unphishable_mfa,
+    '3' => :piv_cac_required,
+  }
+
+  attr_reader :vector_of_trust
+
+  def initialize(vector_of_trust)
+    @vector_of_trust = vector_of_trust
+  end
+
+  def parse_vot
+    result = { identity_proofing: :no_identity_proofing, credential_usage: :default }
+    vector_component_map.each do |component, value|
+      if component == 'P'
+        result[:identity_proofing] = read_vector_value_from_map(
+          component: 'P',
+          value: value,
+          map: IDENTITY_PROOFING_VECTOR_VALUES,
+        )
+      elsif component == 'C'
+        result[:credential_usage] = read_vector_value_from_map(
+          component: 'C',
+          value: value,
+          map: CREDENTIAL_USAGE_VECTOR_VALUES,
+        )
+      else
+        raise VotParseException, "#{vector_of_trust} contains unsupported component #{component}"
+      end
+    end
+    VotParserResult.new(**result)
+  end
+
+  private
+
+  def vector_component_map
+    @vector_component_map ||= begin
+      vector_components = vector_of_trust.split('.')
+      vector_components.map do |component|
+        match_data = component.match(VECTOR_COMPONENT_REGEXP)
+        raise VotParseException, "#{vector_of_trust} is not a valid VoT" if match_data.nil?
+        [match_data[:component], match_data[:value]]
+      end.to_h
+    end
+  end
+
+  def read_vector_value_from_map(component:, value:, map:)
+    result = map[value]
+    if result.nil?
+      raise VotParseException, "#{vector_of_trust} contains unsupported #{component} value #{value}"
+    end
+    result
+  end
+end

--- a/spec/services/vot_parser_spec.rb
+++ b/spec/services/vot_parser_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe VotParser do
+  context 'with a VoT with both components' do
+    it 'returns a properly mapped result' do
+      result = VotParser.new('P1.C2').parse_vot
+
+      expect(result.identity_proofing).to eq(:identity_proofing_no_biometric)
+      expect(result.credential_usage).to eq(:unphishable_mfa)
+    end
+
+    it 'raises an exception if a component value is not supported' do
+      expect { VotParser.new('P1.C2.D3').parse_vot }.to raise_exception(
+        VotParser::VotParseException,
+        'P1.C2.D3 contains unsupported component D',
+      )
+    end
+  end
+
+  context 'with a VoT with only a P component' do
+    it 'returns a properly mapped result' do
+      result = VotParser.new('P2').parse_vot
+
+      expect(result.identity_proofing).to eq(:identity_proofing_biometric_required)
+      expect(result.credential_usage).to eq(:default)
+    end
+
+    it 'raises an exception if the P component value is not supported' do
+      expect { VotParser.new('Px').parse_vot }.to raise_exception(
+        VotParser::VotParseException,
+        'Px contains unsupported P value x',
+      )
+    end
+  end
+
+  context 'with a VoT with only a C component' do
+    it 'returns a properly mapped result' do
+      result = VotParser.new('C1').parse_vot
+
+      expect(result.identity_proofing).to eq(:no_identity_proofing)
+      expect(result.credential_usage).to eq(:no_remember_device)
+    end
+
+    it 'raises an exception if the C component value is not supported'  do
+      expect { VotParser.new('Cx').parse_vot }.to raise_exception(
+        VotParser::VotParseException,
+        'Cx contains unsupported C value x',
+      )
+    end
+  end
+
+  context 'with an empty VoT' do
+    it 'returns a result mapped to both default values' do
+      result = VotParser.new('').parse_vot
+
+      expect(result.identity_proofing).to eq(:no_identity_proofing)
+      expect(result.credential_usage).to eq(:default)
+    end
+  end
+
+  context 'with an improperly formatted VoT' do
+    it 'raises an exception' do
+      expect { VotParser.new('this_is_not_valid').parse_vot }.to raise_exception(
+        VotParser::VotParseException,
+        'this_is_not_valid is not a valid VoT',
+      )
+    end
+  end
+end

--- a/spec/services/vot_parser_spec.rb
+++ b/spec/services/vot_parser_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe VotParser do
   context 'with a VoT with both components' do
     it 'returns a properly mapped result' do
-      result = VotParser.new('P1.C2').parse_vot
+      result = VotParser.new('P1.C2').parse
 
       expect(result.identity_proofing).to eq(:identity_proofing_no_biometric)
       expect(result.credential_usage).to eq(:unphishable_mfa)
     end
 
     it 'raises an exception if a component value is not supported' do
-      expect { VotParser.new('P1.C2.D3').parse_vot }.to raise_exception(
+      expect { VotParser.new('P1.C2.D3').parse }.to raise_exception(
         VotParser::VotParseException,
         'P1.C2.D3 contains unsupported component D',
       )
@@ -19,14 +19,14 @@ RSpec.describe VotParser do
 
   context 'with a VoT with only a P component' do
     it 'returns a properly mapped result' do
-      result = VotParser.new('P2').parse_vot
+      result = VotParser.new('P2').parse
 
       expect(result.identity_proofing).to eq(:identity_proofing_biometric_required)
       expect(result.credential_usage).to eq(:default)
     end
 
     it 'raises an exception if the P component value is not supported' do
-      expect { VotParser.new('Px').parse_vot }.to raise_exception(
+      expect { VotParser.new('Px').parse }.to raise_exception(
         VotParser::VotParseException,
         'Px contains unsupported P value x',
       )
@@ -35,14 +35,14 @@ RSpec.describe VotParser do
 
   context 'with a VoT with only a C component' do
     it 'returns a properly mapped result' do
-      result = VotParser.new('C1').parse_vot
+      result = VotParser.new('C1').parse
 
       expect(result.identity_proofing).to eq(:no_identity_proofing)
       expect(result.credential_usage).to eq(:no_remember_device)
     end
 
-    it 'raises an exception if the C component value is not supported'  do
-      expect { VotParser.new('Cx').parse_vot }.to raise_exception(
+    it 'raises an exception if the C component value is not supported' do
+      expect { VotParser.new('Cx').parse }.to raise_exception(
         VotParser::VotParseException,
         'Cx contains unsupported C value x',
       )
@@ -51,7 +51,7 @@ RSpec.describe VotParser do
 
   context 'with an empty VoT' do
     it 'returns a result mapped to both default values' do
-      result = VotParser.new('').parse_vot
+      result = VotParser.new('').parse
 
       expect(result.identity_proofing).to eq(:no_identity_proofing)
       expect(result.credential_usage).to eq(:default)
@@ -60,7 +60,7 @@ RSpec.describe VotParser do
 
   context 'with an improperly formatted VoT' do
     it 'raises an exception' do
-      expect { VotParser.new('this_is_not_valid').parse_vot }.to raise_exception(
+      expect { VotParser.new('this_is_not_valid').parse }.to raise_exception(
         VotParser::VotParseException,
         'this_is_not_valid is not a valid VoT',
       )


### PR DESCRIPTION
This commit introduces a service that can take a string representing a vector of trust and parse it into its components and values.

Vectors of trust are described in [RFC 8485](https://www.rfc-editor.org/rfc/rfc8485.html).

We are planning to use vectors of trust in our OIDC interface to allow service providers to describe the authentication and identity proofing feature set they need in place for their use case. This will be an alternative to ACR values. To that end this commit includes VoT 2 components with their own unique values.

The `P` component represents identity proofing. It contains the following values:

- `0`: No identity proofing
- `1`: Identity proofing without a biometric comparison (this is the current offering)
- `2`: Identity proofing with a biometric comparison (this is a future offering)

The `C` component represents credential usage. This essentially describes authentication features. It contains the following values:

- `0`: Default option. This maps to what occurs when AAL is set to "1".
- `1`: "No remember device". This maps to what occurs when AAL is set to "2".
- `2`: Phishing resistant auth methods
- `3`: PIV/CAC required

The construction of this mapping satisfies LG-12151.

As an example for how this new tool behaves, consider the vector "C2.P1". This would be parsed into `unphishable_mfa` for credential usage and `identity_proofing_no_biometric` for identity proofing.
