### PR TITLE
LG-12126 address buttons for inline MFA editing on mobile devices

### DIFF
--- a/app/components/manageable_authenticator_component.scss
+++ b/app/components/manageable_authenticator_component.scss
@@ -75,3 +75,37 @@
 .manageable-authenticator__actions {
   @include grid-col('auto');
 }
+
+.manageable-authenticator__done-button,
+.manageable-authenticator__rename-button,
+.manageable-authenticator__delete-button .usa-button,
+.manageable-authenticator__save-rename-button .usa-button,
+.manageable-authenticator__cancel-rename-button {
+  @include at-media-max('tablet') {
+    color: color('primary');
+    box-shadow: none;
+    text-align: left;
+    background-color: color('white');
+    border: 0;
+    border-radius: 0;
+    margin: 0;
+    padding: 0;
+    font-weight: normal;
+    text-decoration: underline;
+    width: auto;
+  }
+}
+
+.manageable-authenticator__rename-button,
+.manageable-authenticator__save-rename-button {
+  @include at-media-max('tablet') {
+    margin-right: 1rem;
+  }
+}
+
+.manageable-authenticator__delete-button
+  .usa-button.usa-button--danger.usa-button--outline:not(:disabled, [aria-disabled='true']) {
+  @include at-media-max('tablet') {
+    box-shadow: none;
+  }
+}

--- a/app/components/manageable_authenticator_component.scss
+++ b/app/components/manageable_authenticator_component.scss
@@ -82,16 +82,7 @@
 .manageable-authenticator__save-rename-button .usa-button,
 .manageable-authenticator__cancel-rename-button {
   @include at-media-max('tablet') {
-    color: color('primary');
-    box-shadow: none;
-    text-align: left;
-    background-color: color('white');
-    border: 0;
-    border-radius: 0;
-    margin: 0;
-    padding: 0;
-    font-weight: normal;
-    text-decoration: underline;
+    @include button-unstyled;
     width: auto;
   }
 }


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-12126](https://cm-jira.usa.gov/browse/LG-12126)


## 🛠 Summary of changes

Adds appropriate media-based override to scss file pertaining to manageable authenticator component. 
Rename, Delete, Done, Save, and Cancel buttons remove default button component styling.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->


## 👀 Screenshots

<details>
<summary>Before:</summary>

![Screenshot 2024-01-24 at 3 12 36 PM (2)](https://github.com/18F/identity-idp/assets/135744319/20ba614d-f6d3-47b4-901b-dc1125e6c1f8)

![Screenshot 2024-01-24 at 3 12 22 PM (2)](https://github.com/18F/identity-idp/assets/135744319/df4b4bc3-1929-41d5-888f-f9884b51f165)

</details>

<details>
<summary>After:</summary>

![Screenshot 2024-01-24 at 3 10 14 PM (2)](https://github.com/18F/identity-idp/assets/135744319/b93ea064-9dc2-4401-ae4a-22453d82cc94)

![Screenshot 2024-01-24 at 3 22 27 PM (2)](https://github.com/18F/identity-idp/assets/135744319/945fa9a1-74dd-49eb-8138-49e1d4d9ee25)

</details>

