### PR TITLE
LG-12027: Normalize whitespace in PII

### DIFF
--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -23,7 +23,7 @@ module Pii
       attrs = new
       hash.with_indifferent_access.
         slice(*members).
-        each { |key, val| attrs[key] = val }
+        each { |key, val| attrs[key] = val&.squish }
       attrs
     end
 

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -23,7 +23,7 @@ module Pii
       attrs = new
       hash.with_indifferent_access.
         slice(*members).
-        each { |key, val| attrs[key] = val.is_a?(String) ? val&.squish : val }
+        each { |key, val| attrs[key] = val.is_a?(String) ? val.squish : val }
       attrs
     end
 

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -23,7 +23,7 @@ module Pii
       attrs = new
       hash.with_indifferent_access.
         slice(*members).
-        each { |key, val| attrs[key] = val&.squish }
+        each { |key, val| attrs[key] = val.is_a?(String) ? val&.squish : val }
       attrs
     end
 

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe Pii::Attributes do
       expect(pii.identity_doc_zipcode).to eq('20005')
       expect(pii.identity_doc_address_state).to eq('NY')
     end
+
+    it 'normalizes whitespace in values' do
+      pii = described_class.new_from_hash(
+        identity_doc_address1: "  1600\r\r Pennsylvania Avenue\t",
+        identity_doc_address2: ' Apt 2 ',
+        identity_doc_city: ' Washington ',
+        state_id_jurisdiction: ' DC  ',
+        identity_doc_zipcode: ' 20005 ',
+        identity_doc_address_state: ' NY ',
+      )
+      expect(pii.identity_doc_address1).to eq('1600 Pennsylvania Avenue')
+      expect(pii.identity_doc_address2).to eq('Apt 2')
+      expect(pii.identity_doc_city).to eq('Washington')
+      expect(pii.state_id_jurisdiction).to eq('DC')
+      expect(pii.identity_doc_zipcode).to eq('20005')
+      expect(pii.identity_doc_address_state).to eq('NY')
+    end
   end
 
   describe '#new_from_json' do

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe Pii::Attributes do
       expect(pii.identity_doc_zipcode).to eq('20005')
       expect(pii.identity_doc_address_state).to eq('NY')
     end
+
+    it 'accepts Date values' do
+      pii = described_class.new_from_hash(dob: Date.new(2000, 1, 2))
+      expect(pii.dob).to eql(Date.new(2000, 1, 2))
+    end
   end
 
   describe '#new_from_json' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12027](https://cm-jira.usa.gov/browse/LG-12027)

## 🛠 Summary of changes

This PR updates `Pii::Attributes` to normalize whitespace (via [squish](https://api.rubyonrails.org/classes/String.html#method-i-squish)).

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV, using a YAML file for your identity document. Make sure the PII in the .yml file includes some weird whitespace in it.
- [ ] After you've proofed, check the PII written for your profile and verify it does not include the whitespace

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
