### PR TITLE
LG-11893: Selfie Liveness Errors on the FE

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -17,6 +17,7 @@ import type { ReviewIssuesStepValue } from './review-issues-step';
 
 interface DocumentCaptureReviewIssuesProps extends FormStepComponentProps<ReviewIssuesStepValue> {
   isFailedDocType: boolean;
+  isFailedSelfieLivenessOrQuality: boolean;
   remainingAttempts: number;
   captureHints: boolean;
   hasDismissed: boolean;
@@ -24,6 +25,7 @@ interface DocumentCaptureReviewIssuesProps extends FormStepComponentProps<Review
 
 function DocumentCaptureReviewIssues({
   isFailedDocType,
+  isFailedSelfieLivenessOrQuality,
   remainingAttempts = Infinity,
   captureHints,
   registerField = () => undefined,
@@ -52,6 +54,7 @@ function DocumentCaptureReviewIssues({
         unknownFieldErrors={unknownFieldErrors}
         remainingAttempts={remainingAttempts}
         isFailedDocType={isFailedDocType}
+        isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
         altFailedDocTypeMsg={isFailedDocType ? t('doc_auth.errors.doc.wrong_id_type_html') : null}
         hasDismissed={hasDismissed}
       />

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -55,8 +55,8 @@ function DocumentCaptureReviewIssues({
         remainingAttempts={remainingAttempts}
         isFailedDocType={isFailedDocType}
         isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
+        altIsFailedSelfieDontIncludeAttempts
         altFailedDocTypeMsg={isFailedDocType ? t('doc_auth.errors.doc.wrong_id_type_html') : null}
-        altIsFailedSelfieLivenessOrQualityMessage
         hasDismissed={hasDismissed}
       />
       {!isFailedDocType && captureHints && (

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -56,6 +56,7 @@ function DocumentCaptureReviewIssues({
         isFailedDocType={isFailedDocType}
         isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
         altFailedDocTypeMsg={isFailedDocType ? t('doc_auth.errors.doc.wrong_id_type_html') : null}
+        altIsFailedSelfieLivenessOrQualityMessage
         hasDismissed={hasDismissed}
       />
       {!isFailedDocType && captureHints && (

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -20,14 +20,14 @@ interface DocumentCaptureWarningProps {
 
 const DISPLAY_ATTEMPTS = 3;
 
-function getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality }) {
+function getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality, t }) {
   if (isFailedDocType) {
-    return 'errors.doc_auth.doc_type_not_supported_heading';
+    return t('errors.doc_auth.doc_type_not_supported_heading');
   }
   if (isFailedSelfieLivenessOrQuality) {
-    return 'errors.doc_auth.selfie_not_live_or_poor_quality_heading';
+    return t('errors.doc_auth.selfie_not_live_or_poor_quality_heading');
   }
-  return 'errors.doc_auth.rate_limited_heading';
+  return t('errors.doc_auth.rate_limited_heading');
 }
 
 function DocumentCaptureWarning({
@@ -44,7 +44,7 @@ function DocumentCaptureWarning({
   const { trackEvent } = useContext(AnalyticsContext);
 
   const nonIppOrFailedResult = !inPersonURL || isFailedResult;
-  const heading = t(getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality }));
+  const heading = t(getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality, t }));
   const actionText = nonIppOrFailedResult
     ? t('idv.failure.button.warning')
     : t('idv.failure.button.try_online');

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -2,6 +2,7 @@ import { Cancel } from '@18f/identity-verify-flow';
 import { useI18n, HtmlTextWithStrongNoWrap } from '@18f/identity-react-i18n';
 import { useContext, useEffect, useRef } from 'react';
 import { FormStepError } from '@18f/identity-form-steps';
+import type { I18n } from '@18f/identity-i18n';
 import Warning from './warning';
 import DocumentCaptureTroubleshootingOptions from './document-capture-troubleshooting-options';
 import UnknownError from './unknown-error';
@@ -23,7 +24,7 @@ const DISPLAY_ATTEMPTS = 3;
 type GetHeadingArguments = {
   isFailedDocType: boolean;
   isFailedSelfieLivenessOrQuality: boolean;
-  t: { (key: string): string };
+  t: typeof I18n.prototype.t;
 };
 function getHeading({ isFailedDocType, isFailedSelfieLivenessOrQuality, t }: GetHeadingArguments) {
   if (isFailedDocType) {

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -20,7 +20,7 @@ interface DocumentCaptureWarningProps {
 
 const DISPLAY_ATTEMPTS = 3;
 
-function getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality, t }) {
+function getHeading({ isFailedDocType, isFailedSelfieLivenessOrQuality, t }) {
   if (isFailedDocType) {
     return t('errors.doc_auth.doc_type_not_supported_heading');
   }
@@ -44,7 +44,7 @@ function DocumentCaptureWarning({
   const { trackEvent } = useContext(AnalyticsContext);
 
   const nonIppOrFailedResult = !inPersonURL || isFailedResult;
-  const heading = getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality, t });
+  const heading = getHeading({ isFailedDocType, isFailedSelfieLivenessOrQuality, t });
   const actionText = nonIppOrFailedResult
     ? t('idv.failure.button.warning')
     : t('idv.failure.button.try_online');

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -11,6 +11,7 @@ import AnalyticsContext from '../context/analytics';
 interface DocumentCaptureWarningProps {
   isFailedDocType: boolean;
   isFailedResult: boolean;
+  isFailedSelfieLivenessOrQuality: boolean;
   remainingAttempts: number;
   actionOnClick?: () => void;
   unknownFieldErrors: FormStepError<{ front: string; back: string }>[];
@@ -19,9 +20,20 @@ interface DocumentCaptureWarningProps {
 
 const DISPLAY_ATTEMPTS = 3;
 
+function getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality }) {
+  if (isFailedDocType) {
+    return 'errors.doc_auth.doc_type_not_supported_heading';
+  }
+  if (isFailedSelfieLivenessOrQuality) {
+    return 'SELFIE FAILED HEADING';
+  }
+  return 'errors.doc_auth.rate_limited_heading';
+}
+
 function DocumentCaptureWarning({
   isFailedDocType,
   isFailedResult,
+  isFailedSelfieLivenessOrQuality,
   remainingAttempts,
   actionOnClick,
   unknownFieldErrors = [],
@@ -32,9 +44,7 @@ function DocumentCaptureWarning({
   const { trackEvent } = useContext(AnalyticsContext);
 
   const nonIppOrFailedResult = !inPersonURL || isFailedResult;
-  const heading = isFailedDocType
-    ? t('errors.doc_auth.doc_type_not_supported_heading')
-    : t('errors.doc_auth.rate_limited_heading');
+  const heading = t(getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality }));
   const actionText = nonIppOrFailedResult
     ? t('idv.failure.button.warning')
     : t('idv.failure.button.try_online');
@@ -79,6 +89,7 @@ function DocumentCaptureWarning({
             unknownFieldErrors={unknownFieldErrors}
             remainingAttempts={remainingAttempts}
             isFailedDocType={isFailedDocType}
+            isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
             hasDismissed={hasDismissed}
           />
         </div>

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -48,9 +48,9 @@ function DocumentCaptureWarning({
   const actionText = nonIppOrFailedResult
     ? t('idv.failure.button.warning')
     : t('idv.failure.button.try_online');
-  const subheading = !nonIppOrFailedResult && !isFailedDocType && (
-    <h2>{t('errors.doc_auth.rate_limited_subheading')}</h2>
-  );
+  const subheading = !nonIppOrFailedResult &&
+    !isFailedDocType &&
+    !isFailedSelfieLivenessOrQuality && <h2>{t('errors.doc_auth.rate_limited_subheading')}</h2>;
   const subheadingRef = useRef<HTMLDivElement>(null);
   const errorMessageDisplayedRef = useRef<HTMLDivElement>(null);
 

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -44,7 +44,7 @@ function DocumentCaptureWarning({
   const { trackEvent } = useContext(AnalyticsContext);
 
   const nonIppOrFailedResult = !inPersonURL || isFailedResult;
-  const heading = t(getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality, t }));
+  const heading = getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality, t });
   const actionText = nonIppOrFailedResult
     ? t('idv.failure.button.warning')
     : t('idv.failure.button.try_online');

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -25,7 +25,7 @@ function getHeadingI8nKey({ isFailedDocType, isFailedSelfieLivenessOrQuality }) 
     return 'errors.doc_auth.doc_type_not_supported_heading';
   }
   if (isFailedSelfieLivenessOrQuality) {
-    return 'SELFIE FAILED HEADING';
+    return 'errors.doc_auth.selfie_not_live_or_poor_quality_heading';
   }
   return 'errors.doc_auth.rate_limited_heading';
 }

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -20,7 +20,12 @@ interface DocumentCaptureWarningProps {
 
 const DISPLAY_ATTEMPTS = 3;
 
-function getHeading({ isFailedDocType, isFailedSelfieLivenessOrQuality, t }) {
+type GetHeadingArguments = {
+  isFailedDocType: boolean;
+  isFailedSelfieLivenessOrQuality: boolean;
+  t: { (key: string): string };
+};
+function getHeading({ isFailedDocType, isFailedSelfieLivenessOrQuality, t }: GetHeadingArguments) {
   if (isFailedDocType) {
     return t('errors.doc_auth.doc_type_not_supported_heading');
   }

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -115,7 +115,8 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
                     remainingAttempts: submissionError.remainingAttempts,
                     isFailedResult: submissionError.isFailedResult,
                     isFailedDocType: submissionError.isFailedDocType,
-                    isFailedSelfieLivenessOrQuality: true,
+                    isFailedSelfieLivenessOrQuality:
+                      submissionError.selfieNotLive || submissionError.selfieNotGoodQuality,
                     captureHints: submissionError.hints,
                     pii: submissionError.pii,
                     failedImageFingerprints: submissionError.failed_image_fingerprints,

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -115,6 +115,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
                     remainingAttempts: submissionError.remainingAttempts,
                     isFailedResult: submissionError.isFailedResult,
                     isFailedDocType: submissionError.isFailedDocType,
+                    isFailedSelfieLivenessOrQuality: true,
                     captureHints: submissionError.hints,
                     pii: submissionError.pii,
                     failedImageFingerprints: submissionError.failed_image_fingerprints,

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -39,6 +39,7 @@ interface ReviewIssuesStepProps extends FormStepComponentProps<ReviewIssuesStepV
   remainingAttempts?: number;
   isFailedResult?: boolean;
   isFailedDocType?: boolean;
+  isFailedSelfieLivenessOrQuality?: boolean;
   captureHints?: boolean;
   pii?: PII;
   failedImageFingerprints?: { front: string[] | null; back: string[] | null };
@@ -55,6 +56,7 @@ function ReviewIssuesStep({
   remainingAttempts = Infinity,
   isFailedResult = false,
   isFailedDocType = false,
+  isFailedSelfieLivenessOrQuality = false,
   pii,
   captureHints = false,
   failedImageFingerprints = { front: [], back: [] },
@@ -118,6 +120,7 @@ function ReviewIssuesStep({
       <DocumentCaptureWarning
         isFailedDocType={isFailedDocType}
         isFailedResult={isFailedResult}
+        isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
         remainingAttempts={remainingAttempts}
         unknownFieldErrors={unknownFieldErrors}
         actionOnClick={onWarningPageDismissed}
@@ -129,6 +132,7 @@ function ReviewIssuesStep({
   return (
     <DocumentCaptureReviewIssues
       isFailedDocType={isFailedDocType}
+      isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
       remainingAttempts={remainingAttempts}
       captureHints={captureHints}
       value={value}

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -12,7 +12,7 @@ interface UnknownErrorProps extends ComponentProps<'p'> {
   isFailedSelfieLivenessOrQuality: boolean;
   remainingAttempts: number;
   altFailedDocTypeMsg?: string | null;
-  altIsFailedSelfieLivenessOrQualityMessage?: boolean;
+  altIsFailedSelfieDontIncludeAttempts?: boolean;
   hasDismissed: boolean;
 }
 
@@ -43,7 +43,7 @@ function UnknownError({
   isFailedSelfieLivenessOrQuality = false,
   remainingAttempts,
   altFailedDocTypeMsg = null,
-  altIsFailedSelfieLivenessOrQualityMessage = false,
+  altIsFailedSelfieDontIncludeAttempts = false,
   hasDismissed,
 }: UnknownErrorProps) {
   const { t } = useI18n();
@@ -82,7 +82,7 @@ function UnknownError({
       <>
         <p>{err.message}</p>
         <p>
-          {!altIsFailedSelfieLivenessOrQualityMessage && (
+          {!altIsFailedSelfieDontIncludeAttempts && (
             <HtmlTextWithStrongNoWrap
               text={t('idv.warning.attempts_html', { count: remainingAttempts })}
             />

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -9,6 +9,7 @@ import MarketingSiteContext from '../context/marketing-site';
 interface UnknownErrorProps extends ComponentProps<'p'> {
   unknownFieldErrors: FormStepError<{ front: string; back: string }>[];
   isFailedDocType: boolean;
+  isFailedSelfieLivenessOrQuality: boolean;
   remainingAttempts: number;
   altFailedDocTypeMsg?: string | null;
   hasDismissed: boolean;
@@ -27,6 +28,7 @@ function formatIdTypeMsg({ altFailedDocTypeMsg, acceptedIdUrl }) {
 function UnknownError({
   unknownFieldErrors = [],
   isFailedDocType = false,
+  isFailedSelfieLivenessOrQuality = false,
   remainingAttempts,
   altFailedDocTypeMsg = null,
   hasDismissed,
@@ -58,6 +60,16 @@ function UnknownError({
     return (
       <p key={`${err.message}-${remainingAttempts}`}>
         {err.message}{' '}
+        <HtmlTextWithStrongNoWrap
+          text={t('idv.warning.attempts_html', { count: remainingAttempts })}
+        />
+      </p>
+    );
+  }
+  if (isFailedSelfieLivenessOrQuality && err) {
+    return (
+      <p>
+        UNKNOWN ERROR FAIL TEXT
         <HtmlTextWithStrongNoWrap
           text={t('idv.warning.attempts_html', { count: remainingAttempts })}
         />

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -26,7 +26,10 @@ function formatIdTypeMsg({ altFailedDocTypeMsg, acceptedIdUrl }) {
   });
 }
 
-function getError({ unknownFieldErrors }) {
+type GetErrorArguments = {
+  unknownFieldErrors: FormStepError<{ front: string; back: string }>[];
+};
+function getError({ unknownFieldErrors }: GetErrorArguments) {
   const errs =
     !!unknownFieldErrors &&
     // Errors where the field than is not 'front' or 'back'. In practice this means the field

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -30,7 +30,7 @@ function getError({ unknownFieldErrors }) {
   const errs =
     !!unknownFieldErrors &&
     // Errors where the field than is not 'front' or 'back'. In practice this means the field
-    // should either be 'general' or 'selfie'
+    // should be from the 'general' field in the "IdV: doc auth image upload vendor submitted" event
     unknownFieldErrors.filter((error) => !['front', 'back'].includes(error.field!));
   const err = errs.length !== 0 ? errs[0].error : null;
 

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -26,6 +26,17 @@ function formatIdTypeMsg({ altFailedDocTypeMsg, acceptedIdUrl }) {
   });
 }
 
+function getError({ unknownFieldErrors }) {
+  const errs =
+    !!unknownFieldErrors &&
+    // Errors where the field than is not 'front' or 'back'. In practice this means the field
+    // should either be 'general' or 'selfie'
+    unknownFieldErrors.filter((error) => !['front', 'back'].includes(error.field!));
+  const err = errs.length !== 0 ? errs[0].error : null;
+
+  return err;
+}
+
 function UnknownError({
   unknownFieldErrors = [],
   isFailedDocType = false,
@@ -49,10 +60,8 @@ function UnknownError({
     location: 'document_capture_review_issues',
   });
 
-  const errs =
-    !!unknownFieldErrors &&
-    unknownFieldErrors.filter((error) => !['front', 'back'].includes(error.field!));
-  const err = errs.length !== 0 ? errs[0].error : null;
+  const err = getError({ unknownFieldErrors });
+
   if (isFailedDocType && !!altFailedDocTypeMsg) {
     return (
       <p key={altFailedDocTypeMsg}>{formatIdTypeMsg({ altFailedDocTypeMsg, acceptedIdUrl })}</p>

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -12,6 +12,7 @@ interface UnknownErrorProps extends ComponentProps<'p'> {
   isFailedSelfieLivenessOrQuality: boolean;
   remainingAttempts: number;
   altFailedDocTypeMsg?: string | null;
+  altIsFailedSelfieLivenessOrQualityMessage?: boolean;
   hasDismissed: boolean;
 }
 
@@ -31,6 +32,7 @@ function UnknownError({
   isFailedSelfieLivenessOrQuality = false,
   remainingAttempts,
   altFailedDocTypeMsg = null,
+  altIsFailedSelfieLivenessOrQualityMessage = false,
   hasDismissed,
 }: UnknownErrorProps) {
   const { t } = useI18n();
@@ -65,6 +67,9 @@ function UnknownError({
         />
       </p>
     );
+  }
+  if (isFailedSelfieLivenessOrQuality && !!altIsFailedSelfieLivenessOrQualityMessage) {
+    return <p>THIS IS THE REVIEW PAGE TEXT</p>;
   }
   if (isFailedSelfieLivenessOrQuality && err) {
     return (

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -68,17 +68,18 @@ function UnknownError({
       </p>
     );
   }
-  if (isFailedSelfieLivenessOrQuality && !!altIsFailedSelfieLivenessOrQualityMessage) {
-    return <p>THIS IS THE REVIEW PAGE TEXT</p>;
-  }
   if (isFailedSelfieLivenessOrQuality && err) {
     return (
-      <p>
-        UNKNOWN ERROR FAIL TEXT
-        <HtmlTextWithStrongNoWrap
-          text={t('idv.warning.attempts_html', { count: remainingAttempts })}
-        />
-      </p>
+      <>
+        <p>{err.message}</p>
+        <p>
+          {!altIsFailedSelfieLivenessOrQualityMessage && (
+            <HtmlTextWithStrongNoWrap
+              text={t('idv.warning.attempts_html', { count: remainingAttempts })}
+            />
+          )}
+        </p>
+      </>
     );
   }
   if (err && !hasDismissed) {

--- a/app/javascript/packages/document-capture/context/upload.tsx
+++ b/app/javascript/packages/document-capture/context/upload.tsx
@@ -103,12 +103,12 @@ export interface UploadErrorResponse {
   /*
    * Whether the selfie passed the liveness check from trueid
    */
-  selfie_live: boolean;
+  selfie_live?: boolean;
 
   /*
    * Whether the selfie passed the quality check from trueid.
    */
-  selfie_quality_good: boolean;
+  selfie_quality_good?: boolean;
 
   /**
    * Record of failed image fingerprints

--- a/app/javascript/packages/document-capture/context/upload.tsx
+++ b/app/javascript/packages/document-capture/context/upload.tsx
@@ -100,6 +100,16 @@ export interface UploadErrorResponse {
    */
   doc_type_supported: boolean;
 
+  /*
+   * Whether the selfie passed the liveness check from trueid
+   */
+  selfie_live: boolean;
+
+  /*
+   * Whether the selfie passed the quality check from trueid.
+   */
+  selfie_quality_good: boolean;
+
   /**
    * Record of failed image fingerprints
    */

--- a/app/javascript/packages/document-capture/services/upload.ts
+++ b/app/javascript/packages/document-capture/services/upload.ts
@@ -126,6 +126,8 @@ const upload: UploadImplementation = async function (payload, { method = 'POST',
 
     error.isFailedResult = !!result.result_failed;
 
+    error.isFailedDocType = !result.doc_type_supported;
+
     error.selfieNotLive = result.selfie_live === undefined ? false : !result.selfie_live;
 
     error.selfieNotGoodQuality =

--- a/app/javascript/packages/document-capture/services/upload.ts
+++ b/app/javascript/packages/document-capture/services/upload.ts
@@ -126,9 +126,10 @@ const upload: UploadImplementation = async function (payload, { method = 'POST',
 
     error.isFailedResult = !!result.result_failed;
 
-    error.selfieNotLive = !result.selfie_live;
+    error.selfieNotLive = result.selfie_live === undefined ? false : !result.selfie_live;
 
-    error.selfieNotGoodQuality = !result.selfie_quality_good;
+    error.selfieNotGoodQuality =
+      result.selfie_quality_good === undefined ? false : !result.selfie_quality_good;
 
     error.failed_image_fingerprints = result.failed_image_fingerprints ?? { front: [], back: [] };
 

--- a/app/javascript/packages/document-capture/services/upload.ts
+++ b/app/javascript/packages/document-capture/services/upload.ts
@@ -42,6 +42,10 @@ export class UploadFormEntriesError extends FormError {
 
   isFailedDocType = false;
 
+  selfieNotLive = false;
+
+  selfieNotGoodQuality = false;
+
   pii?: PII;
 
   hints = false;
@@ -122,7 +126,9 @@ const upload: UploadImplementation = async function (payload, { method = 'POST',
 
     error.isFailedResult = !!result.result_failed;
 
-    error.isFailedDocType = !result.doc_type_supported;
+    error.selfieNotLive = !result.selfie_live;
+
+    error.selfieNotGoodQuality = !result.selfie_quality_good;
 
     error.failed_image_fingerprints = result.failed_image_fingerprints ?? { front: [], back: [] };
 

--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -120,8 +120,8 @@ module DocAuth
       # TODO, theses messages need modifying
       # Liveness, use general error for now
       SELFIE_FAILURE => { long_msg: GENERAL_ERROR, field_msg: FALLBACK_FIELD_LEVEL, hints: false },
-      SELFIE_NOT_LIVE => { long_msg: GENERAL_ERROR, field_msg: FALLBACK_FIELD_LEVEL, hints: false },
-      SELFIE_POOR_QUALITY => { long_msg: GENERAL_ERROR, field_msg: FALLBACK_FIELD_LEVEL, hints: false },
+      SELFIE_NOT_LIVE => { long_msg: 'SELFIE NOT LIVE MESSAGE', field_msg: 'SELFIE NOT LIVE FIELD', hints: false },
+      SELFIE_POOR_QUALITY => { long_msg: 'SELFIE POOR QUALITY MESSAGE', field_msg: 'SELFIE POOR QUALITY FIELD', hints: false },
     }
     # rubocop:enable Layout/LineLength
   end

--- a/app/services/doc_auth/errors.rb
+++ b/app/services/doc_auth/errors.rb
@@ -29,6 +29,7 @@ module DocAuth
     SELFIE_FAILURE = 'selfie_failure'
     SELFIE_NOT_LIVE = 'selfie_not_live'
     SELFIE_POOR_QUALITY = 'selfie_poor_quality'
+    SELFIE_NOT_LIVE_POOR_QUALITY_FIELD = 'selfie_not_live_poor_quality'
     SEX_CHECK = 'sex_check'
     VISIBLE_COLOR_CHECK = 'visible_color_check'
     VISIBLE_PHOTO_CHECK = 'visible_photo_check'
@@ -120,8 +121,8 @@ module DocAuth
       # TODO, theses messages need modifying
       # Liveness, use general error for now
       SELFIE_FAILURE => { long_msg: GENERAL_ERROR, field_msg: FALLBACK_FIELD_LEVEL, hints: false },
-      SELFIE_NOT_LIVE => { long_msg: 'SELFIE NOT LIVE MESSAGE', field_msg: 'SELFIE NOT LIVE FIELD', hints: false },
-      SELFIE_POOR_QUALITY => { long_msg: 'SELFIE POOR QUALITY MESSAGE', field_msg: 'SELFIE POOR QUALITY FIELD', hints: false },
+      SELFIE_NOT_LIVE => { long_msg: SELFIE_NOT_LIVE, field_msg: SELFIE_NOT_LIVE_POOR_QUALITY_FIELD, hints: false },
+      SELFIE_POOR_QUALITY => { long_msg: SELFIE_POOR_QUALITY, field_msg: SELFIE_NOT_LIVE_POOR_QUALITY_FIELD, hints: false },
     }
     # rubocop:enable Layout/LineLength
   end

--- a/app/services/doc_auth/selfie_concern.rb
+++ b/app/services/doc_auth/selfie_concern.rb
@@ -4,25 +4,25 @@ module DocAuth
     def selfie_live?
       portait_error = get_portrait_error(portrait_match_results)
       return true if portait_error.nil? || portait_error.blank?
-      return error_is_not_live(portait_error)
+      return !error_is_not_live(portait_error)
     end
 
     def selfie_quality_good?
       portait_error = get_portrait_error(portrait_match_results)
       return true if portait_error.nil? || portait_error.blank?
-      return error_is_poor_quality(portait_error)
+      return !error_is_poor_quality(portait_error)
     end
 
     def error_is_success(error_message)
-      return error_message != ERROR_TEXTS[:success]
+      error_message == ERROR_TEXTS[:success]
     end
 
     def error_is_not_live(error_message)
-      return error_message != ERROR_TEXTS[:not_live]
+      return error_message == ERROR_TEXTS[:not_live]
     end
 
     def error_is_poor_quality(error_message)
-      return error_message != ERROR_TEXTS[:poor_quality]
+      error_message == ERROR_TEXTS[:poor_quality]
     end
 
   private

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -54,6 +54,13 @@ module DocAuthRouter
     # i18n-tasks-use t('doc_auth.errors.alerts.ref_control_number_check')
     DocAuth::Errors::REF_CONTROL_NUMBER_CHECK =>
       'doc_auth.errors.alerts.ref_control_number_check',
+    # i18n-tasks-use t('doc_auth.errors.alerts.selfie_not_live')
+    DocAuth::Errors::SELFIE_NOT_LIVE => 'doc_auth.errors.alerts.selfie_not_live',
+    # i18n-tasks-use t('doc_auth.errors.alerts.selfie_poor_quality')
+    DocAuth::Errors::SELFIE_POOR_QUALITY => 'doc_auth.errors.alerts.selfie_poor_quality',
+    # i18n-tasks-use t('doc_auth.errors.alerts.selfie_not_live_poor_quality')
+    DocAuth::Errors::SELFIE_NOT_LIVE_POOR_QUALITY_FIELD =>
+      'doc_auth.errors.alerts.selfie_not_live_poor_quality',
     # i18n-tasks-use t('doc_auth.errors.alerts.sex_check')
     DocAuth::Errors::SEX_CHECK => 'doc_auth.errors.alerts.sex_check',
     # i18n-tasks-use t('doc_auth.errors.alerts.visible_color_check')

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -38,12 +38,11 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
-        selfie_not_live: 'Try taking a photo of yourself again. Make sure your whole face
-          is clear and visible in the photo.'
-        selfie_poor_quality: 'Try taking a photo of yourself again. Make sure your whole face
-          is clear and visible in the photo.'
-        selfie_not_live_poor_quality: 'We couldn’t verify the photo of yourself.
-          Try taking a new picture.'
+        selfie_not_live: 'Try taking a photo of yourself again. Make sure your whole
+          face is clear and visible in the photo.'
+        selfie_not_live_poor_quality: 'We couldn’t verify the photo of yourself. Try taking a new picture.'
+        selfie_poor_quality: 'Try taking a photo of yourself again. Make sure your whole
+          face is clear and visible in the photo.'
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
         visible_color_check: We couldn’t verify your ID. It might have moved when you
           took the picture, or the picture is too dark. Try taking new pictures

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -38,9 +38,12 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
-        selfie_not_live: 'Selfie not live'
-        selfie_poor_quality: 'Selfie poor quality'
-        selfie_not_live_poor_quality: 'Field message: notlive/poorquality'
+        selfie_not_live: 'Try taking a photo of yourself again. Make sure your whole face
+          is clear and visible in the photo.'
+        selfie_poor_quality: 'Try taking a photo of yourself again. Make sure your whole face
+          is clear and visible in the photo.'
+        selfie_not_live_poor_quality: 'We couldn’t verify the photo of yourself.
+          Try taking a new picture.'
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
         visible_color_check: We couldn’t verify your ID. It might have moved when you
           took the picture, or the picture is too dark. Try taking new pictures

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -38,6 +38,9 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
+        selfie_not_live: 'Selfie not live'
+        selfie_poor_quality: 'Selfie poor quality'
+        selfie_not_live_poor_quality: 'Field message: notlive/poorquality'
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
         visible_color_check: We couldn’t verify your ID. It might have moved when you
           took the picture, or the picture is too dark. Try taking new pictures

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -48,6 +48,11 @@ es:
           identidad. Intente tomar nuevas fotos.
         ref_control_number_check: No pudimos leer el código de barras del número de
           control. Intente tomar nuevas fotografías.
+        selfie_not_live: 'Intenta volver a tomarte una foto. Asegúrate de que tu
+          rostro completo esté claro y visible en la foto.'
+        selfie_poor_quality: 'Intenta volver a tomarte una foto. Asegúrate de que tu
+          rostro completo esté claro y visible en la foto.'
+        selfie_not_live_poor_quality: 'No pudimos verificar su foto. Trate de tomarse otra foto.'
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar
           nuevas fotos.
         visible_color_check: No pudimos verificar su documento de identidad. Puede que

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -48,11 +48,11 @@ es:
           identidad. Intente tomar nuevas fotos.
         ref_control_number_check: No pudimos leer el código de barras del número de
           control. Intente tomar nuevas fotografías.
-        selfie_not_live: 'Intenta volver a tomarte una foto. Asegúrate de que tu
-          rostro completo esté claro y visible en la foto.'
+        selfie_not_live: 'Intenta volver a tomarte una foto. Asegúrate de que tu rostro
+          completo esté claro y visible en la foto.'
+        selfie_not_live_poor_quality: 'No pudimos verificar su foto. Trate de tomarse otra foto.'
         selfie_poor_quality: 'Intenta volver a tomarte una foto. Asegúrate de que tu
           rostro completo esté claro y visible en la foto.'
-        selfie_not_live_poor_quality: 'No pudimos verificar su foto. Trate de tomarse otra foto.'
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar
           nuevas fotos.
         visible_color_check: No pudimos verificar su documento de identidad. Puede que

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -51,12 +51,12 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
         ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro de
           contrôle. Essayez de prendre de nouvelles photos.
-        selfie_not_live: 'Rééssayez de vous prendre en photo. Assurez-vous que
-          lensemble de votre visage est clair et visible sur la photo.'
-        selfie_poor_quality: 'Rééssayez de vous prendre en photo. Assurez-vous que
-          l’ensemble de votre visage est clair et visible sur la photo.'
+        selfie_not_live: 'Rééssayez de vous prendre en photo. Assurez-vous que lensemble
+          de votre visage est clair et visible sur la photo.'
         selfie_not_live_poor_quality: 'Nous n’avons pas réussi à vérifier votre photo.
           Essayez à nouveau avec une nouvelle photo.'
+        selfie_poor_quality: 'Rééssayez de vous prendre en photo. Assurez-vous que
+          l’ensemble de votre visage est clair et visible sur la photo.'
         sex_check: Nous n’avons pas pu lire le sexe sur votre pièce d’identité. Essayez
           de prendre de nouvelles photos.
         visible_color_check: Nous n’avons pas pu vérifier votre pièce d’identité. Elle a

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -51,6 +51,12 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
         ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro de
           contrôle. Essayez de prendre de nouvelles photos.
+        selfie_not_live: 'Rééssayez de vous prendre en photo. Assurez-vous que
+          lensemble de votre visage est clair et visible sur la photo.'
+        selfie_poor_quality: 'Rééssayez de vous prendre en photo. Assurez-vous que
+          l’ensemble de votre visage est clair et visible sur la photo.'
+        selfie_not_live_poor_quality: 'Nous n’avons pas réussi à vérifier votre photo.
+          Essayez à nouveau avec une nouvelle photo.'
         sex_check: Nous n’avons pas pu lire le sexe sur votre pièce d’identité. Essayez
           de prendre de nouvelles photos.
         visible_color_check: Nous n’avons pas pu vérifier votre pièce d’identité. Elle a

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -36,6 +36,7 @@ en:
         %{timeout}.</strong>'
       send_link_limited: You tried too many times, please try again in %{timeout}. You
         can also go back and choose to use your computer instead.
+      selfie_not_live_or_poor_quality_heading: We could not verify the photo of yourself
     enter_code:
       rate_limited_html: You entered an incorrect verification code too many times.
         <strong>Try again in %{timeout}.</strong>

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -34,9 +34,9 @@ en:
       rate_limited_text_html: 'For your security, we limit the number of times you can
         attempt to verify a document online. <strong>Try again in
         %{timeout}.</strong>'
+      selfie_not_live_or_poor_quality_heading: We could not verify the photo of yourself
       send_link_limited: You tried too many times, please try again in %{timeout}. You
         can also go back and choose to use your computer instead.
-      selfie_not_live_or_poor_quality_heading: We could not verify the photo of yourself
     enter_code:
       rate_limited_html: You entered an incorrect verification code too many times.
         <strong>Try again in %{timeout}.</strong>

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -36,10 +36,10 @@ es:
       rate_limited_text_html: 'Por su seguridad, limitamos el número de veces que
         puede intentar verificar un documento en línea. <strong>Inténtelo de
         nuevo en %{timeout}.</strong>'
+      selfie_not_live_or_poor_quality_heading: No pudimos verificar tu foto
       send_link_limited: Ha intentado demasiadas veces, por favor, inténtelo de nuevo
         en %{timeout}. También puede retroceder y elegir utilizar su computadora
         como alternativa.
-      selfie_not_live_or_poor_quality_heading: No pudimos verificar tu foto
     enter_code:
       rate_limited_html: Ingresó un código de verificación incorrecto demasiadas
         veces. <strong>Inténtelo de nuevo en %{timeout}.</strong>

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -39,6 +39,7 @@ es:
       send_link_limited: Ha intentado demasiadas veces, por favor, inténtelo de nuevo
         en %{timeout}. También puede retroceder y elegir utilizar su computadora
         como alternativa.
+      selfie_not_live_or_poor_quality_heading: No pudimos verificar tu foto
     enter_code:
       rate_limited_html: Ingresó un código de verificación incorrecto demasiadas
         veces. <strong>Inténtelo de nuevo en %{timeout}.</strong>

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -40,10 +40,10 @@ fr:
       rate_limited_text_html: 'Pour votre sécurité, nous limitons le nombre de fois où
         vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
         réessayer dans %{timeout}.</strong>'
+      selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
       send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans
         %{timeout}. Vous pouvez également revenir en arrière et choisir
         d’utiliser votre ordinateur à la place.
-      selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
     enter_code:
       rate_limited_html: Vous avez saisi un code de vérification inexact à trop de
         reprises. <strong>Réessayez dans %{timeout}.</strong>

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -43,6 +43,7 @@ fr:
       send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans
         %{timeout}. Vous pouvez également revenir en arrière et choisir
         d’utiliser votre ordinateur à la place.
+      selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
     enter_code:
       rate_limited_html: Vous avez saisi un code de vérification inexact à trop de
         reprises. <strong>Réessayez dans %{timeout}.</strong>

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -250,6 +250,73 @@ RSpec.feature 'document capture step', :js do
         end
       end
 
+      context 'selfie with no liveness or poor quality is uploaded', allow_browser_log: true do
+        it 'try again and page show no liveness inline error message' do
+          visit_idp_from_oidc_sp_with_ial2
+          sign_in_and_2fa_user(user)
+          complete_doc_auth_steps_before_document_capture_step
+          attach_images(Rails.root.join(
+            'spec', 'fixtures',
+            'ial2_test_credential_no_liveness.yml'
+          ))
+          attach_selfie(Rails.root.join(
+            'spec', 'fixtures',
+            'ial2_test_credential_no_liveness.yml'
+          ))
+          submit_images
+          message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+          expect(page).to have_content(message)
+          detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live'))
+          security_message = strip_tags(
+            t(
+              'idv.warning.attempts_html',
+              count: IdentityConfig.store.doc_auth_max_attempts - 1,
+            ),
+          )
+          expect(page).to have_content(detail_message << "\n" << security_message)
+          review_issues_header = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+          expect(page).to have_content(review_issues_header)
+          expect(page).to have_current_path(idv_document_capture_path)
+          click_try_again
+          expect(page).to have_current_path(idv_document_capture_path)
+          inline_error = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_poor_quality'))
+          expect(page).to have_content(inline_error)
+        end
+
+
+        it 'try again and page show poor quality inline error message' do
+          visit_idp_from_oidc_sp_with_ial2
+          sign_in_and_2fa_user(user)
+          complete_doc_auth_steps_before_document_capture_step
+          attach_images(Rails.root.join(
+            'spec', 'fixtures',
+            'ial2_test_credential_poor_quality.yml'
+          ))
+          attach_selfie(Rails.root.join(
+            'spec', 'fixtures',
+            'ial2_test_credential_poor_quality.yml'
+          ))
+          submit_images
+          message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+          expect(page).to have_content(message)
+          detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_poor_quality'))
+          security_message = strip_tags(
+            t(
+              'idv.warning.attempts_html',
+              count: IdentityConfig.store.doc_auth_max_attempts - 1,
+            ),
+          )
+          expect(page).to have_content(detail_message << "\n" << security_message)
+          review_issues_header = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+          expect(page).to have_content(review_issues_header)
+          expect(page).to have_current_path(idv_document_capture_path)
+          click_try_again
+          expect(page).to have_current_path(idv_document_capture_path)
+          inline_error = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_poor_quality'))
+          expect(page).to have_content(inline_error)
+        end
+      end
+
       context 'when selfie check is not enabled (flag off, and/or in production)' do
         let(:selfie_check_enabled) { false }
         it 'proceeds to the next page with valid info, excluding a selfie image' do

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -255,14 +255,18 @@ RSpec.feature 'document capture step', :js do
           visit_idp_from_oidc_sp_with_ial2
           sign_in_and_2fa_user(user)
           complete_doc_auth_steps_before_document_capture_step
-          attach_images(Rails.root.join(
-            'spec', 'fixtures',
-            'ial2_test_credential_no_liveness.yml'
-          ))
-          attach_selfie(Rails.root.join(
-            'spec', 'fixtures',
-            'ial2_test_credential_no_liveness.yml'
-          ))
+          attach_images(
+            Rails.root.join(
+              'spec', 'fixtures',
+              'ial2_test_credential_no_liveness.yml'
+            ),
+          )
+          attach_selfie(
+            Rails.root.join(
+              'spec', 'fixtures',
+              'ial2_test_credential_no_liveness.yml'
+            ),
+          )
           submit_images
           message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
           expect(page).to have_content(message)
@@ -274,7 +278,9 @@ RSpec.feature 'document capture step', :js do
             ),
           )
           expect(page).to have_content(detail_message << "\n" << security_message)
-          review_issues_header = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+          review_issues_header = strip_tags(
+            t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+          )
           expect(page).to have_content(review_issues_header)
           expect(page).to have_current_path(idv_document_capture_path)
           click_try_again
@@ -283,19 +289,22 @@ RSpec.feature 'document capture step', :js do
           expect(page).to have_content(inline_error)
         end
 
-
         it 'try again and page show poor quality inline error message' do
           visit_idp_from_oidc_sp_with_ial2
           sign_in_and_2fa_user(user)
           complete_doc_auth_steps_before_document_capture_step
-          attach_images(Rails.root.join(
-            'spec', 'fixtures',
-            'ial2_test_credential_poor_quality.yml'
-          ))
-          attach_selfie(Rails.root.join(
-            'spec', 'fixtures',
-            'ial2_test_credential_poor_quality.yml'
-          ))
+          attach_images(
+            Rails.root.join(
+              'spec', 'fixtures',
+              'ial2_test_credential_poor_quality.yml'
+            ),
+          )
+          attach_selfie(
+            Rails.root.join(
+              'spec', 'fixtures',
+              'ial2_test_credential_poor_quality.yml'
+            ),
+          )
           submit_images
           message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
           expect(page).to have_content(message)
@@ -307,7 +316,9 @@ RSpec.feature 'document capture step', :js do
             ),
           )
           expect(page).to have_content(detail_message << "\n" << security_message)
-          review_issues_header = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+          review_issues_header = strip_tags(
+            t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+          )
           expect(page).to have_content(review_issues_header)
           expect(page).to have_current_path(idv_document_capture_path)
           click_try_again

--- a/spec/fixtures/ial2_test_credential_no_liveness.yml
+++ b/spec/fixtures/ial2_test_credential_no_liveness.yml
@@ -1,0 +1,20 @@
+portrait_match_results:
+  # returns the portrait match result
+  FaceMatchResult: Fail
+  # returns the liveness result
+  FaceErrorMessage: 'Liveness: PoorQuality'
+doc_auth_result: Passed
+document:
+  first_name: Jane
+  last_name: Doe
+  middle_name: Q
+  address1: 1800 F Street
+  address2: Apt 3
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  dob: 10/06/1938
+  phone: +1 314-555-1212
+  state_id_jurisdiction: 'ND'
+  state_id_number: 'S59397998'
+  state_id_type: drivers_license

--- a/spec/fixtures/ial2_test_credential_no_liveness.yml
+++ b/spec/fixtures/ial2_test_credential_no_liveness.yml
@@ -2,7 +2,7 @@ portrait_match_results:
   # returns the portrait match result
   FaceMatchResult: Fail
   # returns the liveness result
-  FaceErrorMessage: 'Liveness: PoorQuality'
+  FaceErrorMessage: 'Liveness: NotLive'
 doc_auth_result: Passed
 document:
   first_name: Jane

--- a/spec/fixtures/ial2_test_credential_poor_quality.yml
+++ b/spec/fixtures/ial2_test_credential_poor_quality.yml
@@ -1,0 +1,20 @@
+portrait_match_results:
+  # returns the portrait match result
+  FaceMatchResult: Fail
+  # returns the liveness result
+  FaceErrorMessage: 'Liveness: PoorQuality'
+doc_auth_result: Passed
+document:
+  first_name: Jane
+  last_name: Doe
+  middle_name: Q
+  address1: 1800 F Street
+  address2: Apt 3
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  dob: 10/06/1938
+  phone: +1 314-555-1212
+  state_id_jurisdiction: 'ND'
+  state_id_number: 'S59397998'
+  state_id_type: drivers_license

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -343,7 +343,9 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
 
           errors = post_images_response.errors
           expect(errors.keys).to contain_exactly(:general, :hints, :selfie)
-          expect(errors[:selfie]).to contain_exactly(DocAuth::Errors::SELFIE_NOT_LIVE_POOR_QUALITY_FIELD)
+          expect(errors[:selfie]).to contain_exactly(
+            DocAuth::Errors::SELFIE_NOT_LIVE_POOR_QUALITY_FIELD,
+          )
         end
       end
 
@@ -373,7 +375,9 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
 
           errors = post_images_response.errors
           expect(errors.keys).to contain_exactly(:general, :hints, :selfie)
-          expect(errors[:selfie]).to contain_exactly(DocAuth::Errors::SELFIE_NOT_LIVE_POOR_QUALITY_FIELD)
+          expect(errors[:selfie]).to contain_exactly(
+            DocAuth::Errors::SELFIE_NOT_LIVE_POOR_QUALITY_FIELD,
+          )
         end
       end
 

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
 
           errors = post_images_response.errors
           expect(errors.keys).to contain_exactly(:general, :hints, :selfie)
-          expect(errors[:selfie]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+          expect(errors[:selfie]).to contain_exactly(DocAuth::Errors::SELFIE_NOT_LIVE_POOR_QUALITY_FIELD)
         end
       end
 
@@ -373,7 +373,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
 
           errors = post_images_response.errors
           expect(errors.keys).to contain_exactly(:general, :hints, :selfie)
-          expect(errors[:selfie]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
+          expect(errors[:selfie]).to contain_exactly(DocAuth::Errors::SELFIE_NOT_LIVE_POOR_QUALITY_FIELD)
         end
       end
 


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-11893

- This ticket changes the `<h1>` title of the screen you see after uploading a failing selfie.
- It changes the inline error message on the selfie field when you click `Try again online` and go back to the upload page.
- It also fixes the error handling for selfie errors in `selfie_concern.rb` which is currently broken in `main`.

Here's the related [figma](https://www.figma.com/file/YejFLjUrlzZNjjM8McoudH/MVP%3A-Selfie-UX?type=design&node-id=0-1&mode=design&t=Z8yla5PuEFGLB5Cm-0). And here are screenshots of the result.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Click a magic link like [this one](https://192.168.1.60:3000/openid_connect/authorize?acr_values=http://idmanagement.gov/ns/assurance/ial/2&biometric_comparison_required=true&client_id=urn:gov:gsa:openidconnect:sp:sinatra&nonce=123456789012345678901345678&redirect_uri=http://localhost:9292/auth/result&response_type=code&scope=openid&state=1234567890123456789012) to get to the IDP app with selfie enabled. Alternately, use the SAML/OIDC test apps.
- [ ] Create an account, and get to the front/back/selfie upload page.
- [ ] Upload the `test_selfie_liveness_poor_quality.yml` file in all three (front/back/selfie) fields.
- [ ] "Submit" the page and look at the next page. It should match the figma (linked above) and screenshots (below).
- [ ] Click "Try again online" and note that the next screen matches the figma and screenshots.
- [ ] Repeat these steps with the `test_selfie_with_no_liveness.yml`, you should get the same results.
- [ ] Repeat these steps with the `document_classification_error.yml` file. You should see different results, but they should be the same on `main` and this branch.

Another set of interesting tests: Look at the logs specifically the "IdV: doc auth image upload vendor submitted" event
In that event, you should see for the failing selfie
- `selfie_live` and `selfie_quality_good` should appear as keys.
- One of the values in those fields should be `false` and the other `true`. Which one is which depends on which yaml file you use.
- In that event, you should see for the successful selfie
`selfie_live` and `selfie_quality_good` do not appear as keys.
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>After:</summary>

![IMG_3082](https://github.com/18F/identity-idp/assets/6818839/33497e4e-617b-49a6-8f96-22ee54875469)

![IMG_3080](https://github.com/18F/identity-idp/assets/6818839/073d054d-ddbb-4510-8864-bb565533952b)

</details>