### PR TITLE
Fix flakey JavaScript spec for async navigate

### DIFF
--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { i18n } from '@18f/identity-i18n';
 import { setupServer } from 'msw/node';
@@ -336,6 +337,6 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
     );
 
     expect(queryByText('simple_form.required.text')).to.be.null();
-    expect(window.location.hash).to.equal(inPersonURL);
+    await waitFor(() => expect(window.location.hash).to.equal(inPersonURL));
   });
 });

--- a/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { i18n } from '@18f/identity-i18n';
 import { usePropertyValue } from '@18f/identity-test-helpers';
@@ -395,7 +396,7 @@ describe('InPersonLocationPostOfficeSearchStep', () => {
       );
 
       expect(queryByText('in_person_proofing.body.location.inline_error')).to.be.null();
-      expect(window.location.hash).to.equal(inPersonURL);
+      await waitFor(() => expect(window.location.hash).to.equal(inPersonURL));
     });
   });
 });


### PR DESCRIPTION
## 🛠 Summary of changes

Improves reliability of JavaScript tests where a user is navigated after selecting a post office in the in-person proofing flow.

Example failure: https://gitlab.login.gov/lg/identity-idp/-/jobs/985447 (via #9972)

The behavior for redirecting after making a selection occurs only after a network request has finished, which may not be instantaneous.

https://github.com/18F/identity-idp/blob/a68df9295ea5f78d9bd4b100fde8a333dcb96514/app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx#L58-L61

## 📜 Testing Plan

```
yarn mocha app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
```