### PR TITLE
Add investigation reason to action-account output (LG-12212)

### DIFF
--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -17,6 +17,7 @@ class ActionAccount
       stderr:,
       subtask_class: subtask(argv.shift),
       banner: banner,
+      reason_arg: true,
     )
   end
 
@@ -58,8 +59,8 @@ class ActionAccount
   end
 
   module LogBase
-    def log_message(uuid:, log:, table:, messages:)
-      table << [uuid, log]
+    def log_message(uuid:, log:, reason:, table:, messages:)
+      table << [uuid, log, reason]
       messages << '`' + uuid + '`: ' + log
       [table, messages]
     end
@@ -88,7 +89,7 @@ class ActionAccount
       table = []
       messages = []
       uuids = args
-      table << %w[uuid status]
+      table << %w[uuid status reason]
 
       users = User.where(uuid: uuids).order(:uuid)
       users.each do |user|
@@ -124,6 +125,7 @@ class ActionAccount
           table, messages = log_message(
             uuid: user.uuid,
             log: text,
+            reason: config.reason,
             table:,
             messages:,
           )
@@ -135,6 +137,7 @@ class ActionAccount
           table, messages = log_message(
             uuid: missing_uuid,
             log: log_text[:missing_uuid],
+            reason: config.reason,
             table:,
             messages:,
           )
@@ -164,7 +167,7 @@ class ActionAccount
       users = User.where(uuid: uuids).order(:uuid)
 
       table = []
-      table << %w[uuid status]
+      table << %w[uuid status reason]
 
       messages = []
 
@@ -191,6 +194,7 @@ class ActionAccount
           table, messages = log_message(
             uuid: user.uuid,
             log: text,
+            reason: config.reason,
             table:,
             messages:,
           )
@@ -215,6 +219,7 @@ class ActionAccount
           table, messages = log_message(
             uuid: missing_uuid,
             log: log_text[:missing_uuid],
+            reason: config.reason,
             table:,
             messages:,
           )
@@ -255,7 +260,7 @@ class ActionAccount
       users = User.where(uuid: uuids).order(:uuid)
 
       table = []
-      table << %w[uuid status]
+      table << %w[uuid status reason]
 
       messages = []
       users.each do |user|
@@ -289,6 +294,7 @@ class ActionAccount
           table, messages = log_message(
             uuid: user.uuid,
             log: text,
+            reason: config.reason,
             table:,
             messages:,
           )
@@ -313,6 +319,7 @@ class ActionAccount
           table, messages = log_message(
             uuid: missing_uuid,
             log: log_text[:missing_uuid],
+            reason: config.reason,
             table:,
             messages:,
           )

--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -16,6 +16,7 @@ class DataPull
       stderr:,
       subtask_class: subtask(argv.shift),
       banner: banner,
+      reason_arg: false,
     )
   end
 

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -3,12 +3,17 @@ require 'optparse'
 class ScriptBase
   attr_reader :argv, :stdout, :stderr, :subtask_class, :banner
 
-  def initialize(argv:, stdout:, stderr:, subtask_class:, banner:)
+  def initialize(argv:, stdout:, stderr:, subtask_class:, banner:, reason_arg:)
     @argv = argv
     @stdout = stdout
     @stderr = stderr
     @subtask_class = subtask_class
     @banner = banner
+    @reason_arg = reason_arg
+  end
+
+  def reason_arg?
+    !!@reason_arg
   end
 
   Result = Struct.new(
@@ -26,6 +31,7 @@ class ScriptBase
     :show_help,
     :requesting_issuers,
     :deflate,
+    :reason,
     keyword_init: true,
   ) do
     alias_method :include_missing?, :include_missing
@@ -40,6 +46,7 @@ class ScriptBase
       show_help: false,
       requesting_issuers: [],
       deflate: false,
+      reason: nil,
     )
   end
 
@@ -126,6 +133,12 @@ class ScriptBase
         Whether or not to add rows in the output for missing inputs, defaults to on
       STR
         config.include_missing = include_missing
+      end
+
+      if reason_arg?
+        opts.on('--reason=REASON', 'Reason for command') do |reason|
+          config.reason = reason
+        end
       end
     end
   end

--- a/spec/lib/script_base_spec.rb
+++ b/spec/lib/script_base_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe ScriptBase do
         stderr:,
         subtask_class:,
         banner: '',
+        reason_arg: false,
       )
     end
 


### PR DESCRIPTION
We got a request to include the reason (which is currently logged to Slack) in the output of the command line as well

**Before**

```
+--------------------------------------+--------------------------------------------------+
| uuid                                 | status                                           |
+--------------------------------------+--------------------------------------------------+
| 770059eb-eacb-4738-9e0d-e39091c3372b | Error: User does not have a pending fraud review |
+--------------------------------------+--------------------------------------------------+
```

**After**

```
+--------------------------------------+--------------------------------------------------+---------+
| uuid                                 | status                                           | reason  |
+--------------------------------------+--------------------------------------------------+---------+
| 770059eb-eacb-4738-9e0d-e39091c3372b | Error: User does not have a pending fraud review | INV1234 |
+--------------------------------------+--------------------------------------------------+---------+
```



<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
