### PR TITLE
normalize-yaml: Enhance to collapse spacing

### DIFF
--- a/app/javascript/packages/normalize-yaml/CHANGELOG.md
+++ b/app/javascript/packages/normalize-yaml/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features
 
-- Added new punctuation formatter to enforce single spaces between sentences.
+- Added new punctuation formatter to collapse multiple spaces to a single space.
 
 ## v2.0.0
 

--- a/app/javascript/packages/normalize-yaml/CHANGELOG.md
+++ b/app/javascript/packages/normalize-yaml/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Breaking Changes
+
+- The new punctuation formatter described in "New Features" is enabled by default, which may identify new existing issues in your YAML files.
+
+### New Features
+
+- Added new punctuation formatter to enforce single spaces between sentences.
+
 ## v2.0.0
 
 ### Breaking Changes

--- a/app/javascript/packages/normalize-yaml/README.md
+++ b/app/javascript/packages/normalize-yaml/README.md
@@ -6,6 +6,7 @@ Normalizes YAML files to ensure consistency and typographical quality:
 - Applies improved punctuation.
   - Converts straight quotes `"` and `'` to smart quotes `“`, `”`, and `’`
   - Converts three dots `...` to ellipsis `…`
+  - Reduces multiple spaces between sentences to a single space.
 - Stylizes content using [Prettier](https://prettier.io/), respecting local project Prettier configuration.
 
 ## Installation
@@ -32,6 +33,7 @@ The included `normalize-yaml` binary receives files as an argument, with optiona
 
 - `--disable-sort-keys`: Disable the default behavior to sort keys.
 - `--disable-smart-punctuation`: Disable the default behavior to apply smart punctuation.
+- `--disable-collapse-sentence-spacing`: Disable the default behavior to reduce multiple spaces between sentences to a single space.
 
 **Example:**
 

--- a/app/javascript/packages/normalize-yaml/README.md
+++ b/app/javascript/packages/normalize-yaml/README.md
@@ -6,7 +6,7 @@ Normalizes YAML files to ensure consistency and typographical quality:
 - Applies improved punctuation.
   - Converts straight quotes `"` and `'` to smart quotes `“`, `”`, and `’`
   - Converts three dots `...` to ellipsis `…`
-  - Reduces multiple spaces between sentences to a single space.
+  - Collapse multiple spaces to a single space.
 - Stylizes content using [Prettier](https://prettier.io/), respecting local project Prettier configuration.
 
 ## Installation
@@ -33,7 +33,7 @@ The included `normalize-yaml` binary receives files as an argument, with optiona
 
 - `--disable-sort-keys`: Disable the default behavior to sort keys.
 - `--disable-smart-punctuation`: Disable the default behavior to apply smart punctuation.
-- `--disable-collapse-sentence-spacing`: Disable the default behavior to reduce multiple spaces between sentences to a single space.
+- `--disable-collapse-spacing`: Disable the default behavior to collapse multiple spaces to a single space.
 
 **Example:**
 

--- a/app/javascript/packages/normalize-yaml/cli.js
+++ b/app/javascript/packages/normalize-yaml/cli.js
@@ -23,6 +23,7 @@ const options = {
     [
       flags.includes('--disable-sort-keys') && 'sortKeys',
       flags.includes('--disable-smart-punctuation') && 'smartPunctuation',
+      flags.includes('--disable-collapse-sentence-spacing') && 'collapseSentenceSpacing',
     ].filter(Boolean)
   ),
 };

--- a/app/javascript/packages/normalize-yaml/cli.js
+++ b/app/javascript/packages/normalize-yaml/cli.js
@@ -23,7 +23,7 @@ const options = {
     [
       flags.includes('--disable-sort-keys') && 'sortKeys',
       flags.includes('--disable-smart-punctuation') && 'smartPunctuation',
-      flags.includes('--disable-collapse-sentence-spacing') && 'collapseSentenceSpacing',
+      flags.includes('--disable-collapse-spacing') && 'collapseSpacing',
     ].filter(Boolean)
   ),
 };

--- a/app/javascript/packages/normalize-yaml/index.js
+++ b/app/javascript/packages/normalize-yaml/index.js
@@ -1,8 +1,8 @@
 import YAML from 'yaml';
 import prettier from 'prettier';
-import { getVisitors } from './visitors/index.js';
+import { getUnifiedVisitor } from './visitors/index.js';
 
-/** @typedef {'smartPunctuation'|'sortKeys'} Formatter */
+/** @typedef {'smartPunctuation'|'sortKeys'|'collapseSentenceSpacing'} Formatter */
 
 /**
  * @typedef NormalizeOptions
@@ -21,7 +21,7 @@ import { getVisitors } from './visitors/index.js';
  */
 function normalize(content, { prettierConfig, exclude } = {}) {
   const document = YAML.parseDocument(content);
-  YAML.visit(document, getVisitors({ exclude }));
+  YAML.visit(document, getUnifiedVisitor({ exclude }));
   return prettier.format(document.toString(), { ...prettierConfig, parser: 'yaml' });
 }
 

--- a/app/javascript/packages/normalize-yaml/index.js
+++ b/app/javascript/packages/normalize-yaml/index.js
@@ -2,7 +2,7 @@ import YAML from 'yaml';
 import prettier from 'prettier';
 import { getUnifiedVisitor } from './visitors/index.js';
 
-/** @typedef {'smartPunctuation'|'sortKeys'|'collapseSentenceSpacing'} Formatter */
+/** @typedef {'smartPunctuation'|'sortKeys'|'collapseSpacing'} Formatter */
 
 /**
  * @typedef NormalizeOptions

--- a/app/javascript/packages/normalize-yaml/index.spec.js
+++ b/app/javascript/packages/normalize-yaml/index.spec.js
@@ -22,8 +22,8 @@ describe('normalize', () => {
     expect(await normalize(original)).to.equal(expected);
   });
 
-  it('collapses multiple spaces between sentences', async () => {
-    const original = '---\nparagraph: Lorem ipsum.  Dolor sit amet.';
+  it('collapses multiple spaces', async () => {
+    const original = '---\nparagraph: Lorem ipsum.  Dolor sit  amet.';
     const expected = '---\nparagraph: Lorem ipsum. Dolor sit amet.\n';
 
     expect(await normalize(original)).to.equal(expected);

--- a/app/javascript/packages/normalize-yaml/index.spec.js
+++ b/app/javascript/packages/normalize-yaml/index.spec.js
@@ -22,6 +22,13 @@ describe('normalize', () => {
     expect(await normalize(original)).to.equal(expected);
   });
 
+  it('collapses multiple spaces between sentences', async () => {
+    const original = '---\nparagraph: Lorem ipsum.  Dolor sit amet.';
+    const expected = '---\nparagraph: Lorem ipsum. Dolor sit amet.\n';
+
+    expect(await normalize(original)).to.equal(expected);
+  });
+
   it('formats using prettier', async () => {
     const original = "---\nfoo:  'bar' ";
     const expected = '---\nfoo: "bar"\n';

--- a/app/javascript/packages/normalize-yaml/package.json
+++ b/app/javascript/packages/normalize-yaml/package.json
@@ -18,7 +18,7 @@
     "cli.js",
     "index.js",
     "visitors/index.js",
-    "visitors/colllapse-sentence-spacing.js",
+    "visitors/colllapse-spacing.js",
     "visitors/smart-punctuation.js",
     "visitors/sort-keys.js",
     "types"

--- a/app/javascript/packages/normalize-yaml/package.json
+++ b/app/javascript/packages/normalize-yaml/package.json
@@ -18,6 +18,7 @@
     "cli.js",
     "index.js",
     "visitors/index.js",
+    "visitors/single-spaces.js",
     "visitors/smart-punctuation.js",
     "visitors/sort-keys.js",
     "types"

--- a/app/javascript/packages/normalize-yaml/package.json
+++ b/app/javascript/packages/normalize-yaml/package.json
@@ -18,7 +18,7 @@
     "cli.js",
     "index.js",
     "visitors/index.js",
-    "visitors/single-spaces.js",
+    "visitors/colllapse-sentence-spacing.js",
     "visitors/smart-punctuation.js",
     "visitors/sort-keys.js",
     "types"

--- a/app/javascript/packages/normalize-yaml/visitors/collapse-sentence-spacing.js
+++ b/app/javascript/packages/normalize-yaml/visitors/collapse-sentence-spacing.js
@@ -1,0 +1,7 @@
+export default /** @type {import('yaml').visitor} */ ({
+  Scalar(_key, node) {
+    if (typeof node.value === 'string') {
+      node.value = node.value.replace(/(\w)\. {2,}/g, '$1. ');
+    }
+  },
+});

--- a/app/javascript/packages/normalize-yaml/visitors/collapse-spacing.js
+++ b/app/javascript/packages/normalize-yaml/visitors/collapse-spacing.js
@@ -1,7 +1,7 @@
 export default /** @type {import('yaml').visitor} */ ({
   Scalar(_key, node) {
     if (typeof node.value === 'string') {
-      node.value = node.value.replace(/(\w)\. {2,}/g, '$1. ');
+      node.value = node.value.replace(/ {2,}/g, ' ');
     }
   },
 });

--- a/app/javascript/packages/normalize-yaml/visitors/index.js
+++ b/app/javascript/packages/normalize-yaml/visitors/index.js
@@ -1,12 +1,12 @@
 import smartPunctuation from './smart-punctuation.js';
 import sortKeys from './sort-keys.js';
-import collapseSentenceSpacing from './collapse-sentence-spacing.js';
+import collapseSpacing from './collapse-spacing.js';
 
 /** @typedef {import('yaml').visitor} Visitor */
 /** @typedef {import('../').Formatter} Formatter */
 
 /** @type {Record<Formatter, Visitor>} */
-const DEFAULT_VISITORS = { smartPunctuation, sortKeys, collapseSentenceSpacing };
+const DEFAULT_VISITORS = { smartPunctuation, sortKeys, collapseSpacing };
 
 /** @type {(...callbacks: Array<(...args: any[]) => any>) => (...args: any[]) => void} */
 const over =

--- a/app/javascript/packages/normalize-yaml/visitors/index.js
+++ b/app/javascript/packages/normalize-yaml/visitors/index.js
@@ -1,18 +1,32 @@
 import smartPunctuation from './smart-punctuation.js';
 import sortKeys from './sort-keys.js';
+import collapseSentenceSpacing from './collapse-sentence-spacing.js';
 
 /** @typedef {import('yaml').visitor} Visitor */
 /** @typedef {import('../').Formatter} Formatter */
 
 /** @type {Record<Formatter, Visitor>} */
-const DEFAULT_VISITORS = { smartPunctuation, sortKeys };
+const DEFAULT_VISITORS = { smartPunctuation, sortKeys, collapseSentenceSpacing };
+
+/** @type {(...callbacks: Array<(...args: any[]) => any>) => (...args: any[]) => void} */
+const over =
+  (...callbacks) =>
+  (...args) =>
+    callbacks.forEach((callback) => callback(...args));
 
 /**
  * @param {{ exclude?: Formatter[] }} exclude
  *
  * @return {Visitor}
  */
-export const getVisitors = ({ exclude = [] }) =>
+export const getUnifiedVisitor = ({ exclude = [] }) =>
   Object.entries(DEFAULT_VISITORS)
     .filter(([formatter]) => !exclude.includes(/** @type {Formatter} */ (formatter)))
-    .reduce((result, [, visitor]) => Object.assign(result, visitor), /* @type {Visitor} */ {});
+    .map(([_formatter, visitor]) => visitor)
+    .reduce((result, visitor) => {
+      Object.entries(visitor).forEach(([key, callback]) => {
+        result[key] = result[key] ? over(result[key], callback) : callback;
+      });
+
+      return result;
+    }, /** @type {Visitor} */ ({}));

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -59,7 +59,7 @@ en:
           to use the same email address and set up new authentication methods.
           However, deleting will remove any agency applications you have linked
           to your account and you will need to restore each connection.
-        - If you continue, you will first receive an email confirmation.  As a
+        - If you continue, you will first receive an email confirmation. As a
           security measure, you will receive another email with the link to
           continue deleting your account 24 hours after the initial confirmation
           email arrives.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -18,7 +18,7 @@ en:
           one: Password must be at least one character long
           other: Password must be at least %{count} characters long
     capture_doc:
-      invalid_link: This link is expired or not valid.  Please request another link to
+      invalid_link: This link is expired or not valid. Please request another link to
         verify your identity on a mobile phone.
     confirm_password_incorrect: Incorrect password.
     doc_auth:

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -39,13 +39,13 @@ en:
         invalid_phone_number: The phone number entered is not valid.
         opt_out: The phone number entered has opted out of text messages.
         permanent_failure: The phone number entered is not valid.
-        rate_limited: That number is experiencing high message volume.  Please try again
+        rate_limited: That number is experiencing high message volume. Please try again
           later.
         sms_unsupported: The phone number entered doesn’t support text messaging. Try
           the Phone call option.
-        temporary_failure: We are experiencing technical difficulties.  Please try again later.
+        temporary_failure: We are experiencing technical difficulties. Please try again later.
         timeout: The server took too long to respond. Please try again.
-        unknown_failure: We are experiencing technical difficulties.  Please try again later.
+        unknown_failure: We are experiencing technical difficulties. Please try again later.
         voice_unsupported: Invalid phone number. Check that you’ve entered the correct
           country code or area code.
     format_type:

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -45,7 +45,7 @@ fr:
     mfa_setup:
       face_touch_unlock_confirmation: Déverrouillage facial ou tactile ajouté
       suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification !
-        Ajoutez-en une deuxième  en guise de sauvegarde.
+        Ajoutez-en une deuxième en guise de sauvegarde.
     no_auth_option: Aucun message de connexion trouvé
     openid_connect:
       authorization: Autorisation OpenID Connect

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -12,7 +12,7 @@ es:
       link: eliminando su cuenta
       pending: Actualmente tiene una solicitud pendiente para eliminar su cuenta. Se
         necesitan 24 horas desde el momento en que realizó la solicitud para
-        completar el proceso.  Por favor, vuelva más tarde.
+        completar el proceso. Por favor, vuelva más tarde.
       successful_cancel: Gracias. Su solicitud para eliminar su cuenta de %{app_name}
         ha sido cancelada.
       text_html: Si no puede usar ninguna de estas opciones de seguridad anteriores,

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -13,8 +13,8 @@ fr:
       cancel_link: Annuler votre demande
       link: supprimer votre compte
       pending: Vous avez actuellement une demande en attente pour supprimer votre
-        compte.  Il faut compter 24 heures à partir du moment où vous avez fait
-        la demande pour terminer le processus.  Veuillez vérifier plus tard.
+        compte. Il faut compter 24 heures à partir du moment où vous avez fait
+        la demande pour terminer le processus. Veuillez vérifier plus tard.
       successful_cancel: Je vous remercie. Votre demande de suppression de votre
         compte %{app_name} a été annulée.
       text_html: Si vous ne pouvez pas utiliser l’une de ces options de sécurité

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -283,7 +283,7 @@ en:
         your letter will no longer work and you’ll have to verify your identity
         again.
       gpo_letter_header: Your letter is on the way
-      header: To finish resetting your password, please click the link below  or copy
+      header: To finish resetting your password, please click the link below or copy
         and paste the entire link into your browser.
       link_text: Reset your password
       subject: Reset your password

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -292,7 +292,7 @@ en:
         visit the %{app_name_html} %{help_link_html} or %{contact_link_html}.
       intro_html: This email address is already associated with a %{app_name_html}
         account, so we can’t use it to create a new account. To sign in with
-        your existing account, follow the link below.  If you are not trying to
+        your existing account, follow the link below. If you are not trying to
         sign in with this email address, you can ignore this message.
       link_text: Go to %{app_name}
       reset_password_html: If you can’t remember your password, go to %{app_name_html} to reset it.

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -274,7 +274,7 @@ es:
     phone_added:
       disavowal_link: restablezca su contraseña
       help_html: Si no realizó este cambio, inicie sesión en su perfil y administre
-        sus números de teléfono.  También le recomendamos que
+        sus números de teléfono. También le recomendamos que
         %{disavowal_link_html}.
       intro: Se agregó un nuevo número de teléfono a su perfil de %{app_name}.
       subject: Nuevo número de teléfono añadido

--- a/config/locales/zxcvbn/fr.yml
+++ b/config/locales/zxcvbn/fr.yml
@@ -26,7 +26,7 @@ fr:
       repeats_like_aaa_are_easy_to_guess: Les répétitions comme « aaa » sont faciles à deviner
       repeats_like_abcabcabc_are_only_slightly_harder_to_guess_than_abc: |-
         Les répétitions comme « abcabcabc » sont à peine
-                 plus difficiles à deviner que « abc »
+         plus difficiles à deviner que « abc »
       reversed_words_arent_much_harder_to_guess: Les mots inversés ne sont pas très difficiles à deviner
       sequences_like_abc_or_6543_are_easy_to_guess: Les séquences comme abc ou 6543 sont faciles à deviner
       short_keyboard_patterns_are_easy_to_guess: Les motifs de clavier courts sont faciles à deviner


### PR DESCRIPTION
## 🛠 Summary of changes

Adds new behavior to the YAML normalization package to collapse spacing ~between sentences~ in YAML content.

Related discussion: https://gsa-tts.slack.com/archives/CEUQ9FXNJ/p1706111249614589

## 📜 Testing Plan

Verify that `make lint_yaml` is produces a successful exit code.

1. `make lint_yaml`
2. `echo $?`
3. Observe: `0`

Verify that reverting included normalizations and running normalization applies the changes to collapse spaces

1. `git checkout main -- config/locales`
2. `make normalize_yaml`
3. `git add config/locales`
4. `git status`
5. Observe "nothing to commit, working tree clean"

Verify that included specs pass:

1. `yarn mocha app/javascript/packages/normalize-yaml/index.spec.js`