### PR TITLE
Consolidate SAML/OIDC redirect JavaScript

### DIFF
--- a/app/javascript/packs/click-immediate.ts
+++ b/app/javascript/packs/click-immediate.ts
@@ -1,0 +1,3 @@
+document
+  .querySelectorAll<HTMLElement>('[data-click-immediate]')
+  .forEach((element) => element.click());

--- a/app/javascript/packs/openid-connect-redirect.ts
+++ b/app/javascript/packs/openid-connect-redirect.ts
@@ -1,5 +1,0 @@
-import { forceRedirect } from '@18f/identity-url';
-
-document.body.classList.add('usa-sr-only');
-const link = document.querySelector<HTMLLinkElement>('#openid-connect-redirect')!;
-forceRedirect(link.href);

--- a/app/javascript/packs/saml-post.js
+++ b/app/javascript/packs/saml-post.js
@@ -1,4 +1,0 @@
-document.addEventListener('DOMContentLoaded', function () {
-  document.body.className += ' usa-sr-only';
-  document.getElementById('saml-post-binding').submit();
-});

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -18,7 +18,7 @@
   <title><%= title %> | <%= APP_NAME %></title>
 
   <%= javascript_tag(nonce: true) do %>
-    document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+    document.documentElement.classList.replace('no-js', 'js');
   <% end %>
   <%= preload_link_tag font_url('public-sans/PublicSans-Bold.woff2') %>
   <%= preload_link_tag font_url('public-sans/PublicSans-Regular.woff2') %>

--- a/app/views/openid_connect/shared/redirect_js.html.erb
+++ b/app/views/openid_connect/shared/redirect_js.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title><%= t('headings.redirecting') %> | <%= APP_NAME %></title>
     <%= javascript_tag(nonce: true) do %>
-      document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+      document.documentElement.classList.replace('no-js', 'js');
     <% end %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= render_stylesheet_once_tags %>

--- a/app/views/openid_connect/shared/redirect_js.html.erb
+++ b/app/views/openid_connect/shared/redirect_js.html.erb
@@ -1,13 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html class="no-js">
   <head>
     <meta charset="utf-8" />
     <title><%= t('headings.redirecting') %> | <%= APP_NAME %></title>
+    <%= javascript_tag(nonce: true) do %>
+      document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+    <% end %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= render_stylesheet_once_tags %>
   </head>
   <body class="tablet:bg-primary-lighter">
-    <div class="grid-container tablet:padding-y-6">
+    <div class="grid-container tablet:padding-y-6 no-js">
       <div class="grid-row">
         <div class="tablet:grid-col-6 tablet:grid-offset-3">
           <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
@@ -16,10 +19,10 @@
             <%= t('saml_idp.shared.saml_post_binding.no_js') %>
           </p>
 
-          <%= link_to(t('forms.buttons.continue'), @oidc_redirect_uri, class: 'usa-button usa-button--wide usa-button--big', id: 'openid-connect-redirect') %>
+          <%= link_to(t('forms.buttons.continue'), @oidc_redirect_uri, class: 'usa-button usa-button--wide usa-button--big', data: { click_immediate: '' }) %>
         </div>
       </div>
     </div>
-    <%= render_javascript_pack_once_tags 'openid-connect-redirect' %>
+    <%= render_javascript_pack_once_tags 'click-immediate' %>
   </body>
 </html>

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -26,7 +26,7 @@
             <% if params.key?(:RelayState) %>
               <%= hidden_field_tag('RelayState', params[:RelayState]) %>
             <% end %>
-            <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: true } %>
+            <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: '' } %>
           <% end %>
         </div>
       </div>

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -1,15 +1,17 @@
 <!DOCTYPE html>
-<html>
+<html class="no-js">
   <head>
     <meta charset="utf-8" />
     <title><%= t('headings.redirecting') %> | <%= APP_NAME %></title>
+    <%= javascript_tag(nonce: true) do %>
+      document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+    <% end %>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= render_stylesheet_once_tags %>
-    <%= render_javascript_pack_once_tags 'saml-post' %>
   </head>
   <body>
-    <div class="grid-container tablet:padding-y-6">
+    <div class="grid-container tablet:padding-y-6 no-js">
       <div class="grid-row">
         <div class="tablet:grid-col-6 tablet:grid-offset-3">
           <%= render PageHeadingComponent.new.with_content(t('.heading')) %>
@@ -18,16 +20,17 @@
             <%= t('.no_js') %>
           </p>
 
-          <%= form_tag action_url, id: 'saml-post-binding' do %>
+          <%= simple_form_for('', url: action_url) do |f| %>
             <%= hidden_field_tag('csp_uris', csp_uris) if Rails.env.test? %>
             <%= hidden_field_tag(type, message) %>
             <% if params.key?(:RelayState) %>
               <%= hidden_field_tag('RelayState', params[:RelayState]) %>
             <% end %>
-            <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--wide usa-button--big' %>
+            <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: true } %>
           <% end %>
         </div>
       </div>
     </div>
+    <%= render_javascript_pack_once_tags 'click-immediate' %>
   </body>
 </html>

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -21,7 +21,6 @@
           </p>
 
           <%= simple_form_for('', url: action_url) do |f| %>
-            <%= hidden_field_tag('csp_uris', csp_uris) if Rails.env.test? %>
             <%= hidden_field_tag(type, message) %>
             <% if params.key?(:RelayState) %>
               <%= hidden_field_tag('RelayState', params[:RelayState]) %>

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title><%= t('headings.redirecting') %> | <%= APP_NAME %></title>
     <%= javascript_tag(nonce: true) do %>
-      document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+      document.documentElement.classList.replace('no-js', 'js');
     <% end %>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>

--- a/app/views/shared/saml_post_form.html.erb
+++ b/app/views/shared/saml_post_form.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <%= javascript_tag(nonce: true) do %>
-      document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+      document.documentElement.classList.replace('no-js', 'js');
     <% end %>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>

--- a/app/views/shared/saml_post_form.html.erb
+++ b/app/views/shared/saml_post_form.html.erb
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html class="no-js">
   <head>
     <meta charset="utf-8" />
+    <%= javascript_tag(nonce: true) do %>
+      document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+    <% end %>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= render_stylesheet_once_tags %>
-    <%= render_javascript_pack_once_tags 'saml-post' %>
   </head>
   <body>
-    <div class="grid-container tablet:padding-y-6">
+    <div class="grid-container tablet:padding-y-6 no-js">
       <div class="grid-row">
         <div class="tablet:grid-col-6 tablet:grid-offset-3">
           <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
@@ -17,14 +19,15 @@
             <%= t('saml_idp.shared.saml_post_binding.no_js') %>
           </p>
 
-          <%= form_tag action_url, id: 'saml-post-binding' do %>
+          <%= simple_form_for('', url: action_url) do |f| %>
             <% form_params.each do |key, val| %>
               <%= hidden_field_tag(key, val) %>
             <% end %>
-            <%= submit_tag t('forms.buttons.submit.default'), class: 'usa-button usa-button--wide usa-button--big' %>
+            <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: true } %>
           <% end %>
         </div>
       </div>
     </div>
+    <%= render_javascript_pack_once_tags 'click-immediate' %>
   </body>
 </html>

--- a/app/views/shared/saml_post_form.html.erb
+++ b/app/views/shared/saml_post_form.html.erb
@@ -23,7 +23,7 @@
             <% form_params.each do |key, val| %>
               <%= hidden_field_tag(key, val) %>
             <% end %>
-            <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: true } %>
+            <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: '' } %>
           <% end %>
         </div>
       </div>

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -120,8 +120,7 @@ module OidcAuthHelper
   end
 
   def extract_redirect_url
-    content = page.find('a#openid-connect-redirect')
-    content[:href]
+    page.find_link(t('forms.buttons.continue'))[:href]
   end
 
   def oidc_redirect_url

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -33,7 +33,7 @@ class SamlResponseDoc
   def raw_xml_response
     if @test_type == 'feature'
       xml_response
-    elsif @response.body.include?('<html>')
+    elsif @response.body.include?('<html')
       html_response
     else
       @response.body

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "./*.js",
     "scripts"
   ],
-  "exclude": ["**/fixtures", "**/*.spec.js", "app/javascript/packs/saml-post.js"]
+  "exclude": ["**/fixtures", "**/*.spec.js"]
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Consolidates `openid-connect-redirect.ts` and `saml-post.js` packs to a single `click-immediate.ts` which immediately clicks any elements annotated with a `data-click-immediate` attribute.

**Why?**

- The intended behavior of these scripts is essentially the same
- Remove legacy, non-typechecked JavaScript code
- Smaller file size
- Avoid announcing screen reader text for text which would not be visible for a JavaScript-enabled device

## 📜 Testing Plan

Using SAML & OIDC sample applications, verify there are no regressions in signing-in and redirecting back to the partner application.

Repeat testing instructions from #9790 to verify behavior of client-side OIDC redirect.