### PR TITLE
Add the requested vectors of trust to `ServiceProviderRequest`

### DIFF
--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -12,7 +12,8 @@ class ServiceProviderRequest
     ial: nil,
     aal: nil,
     requested_attributes: [],
-    biometric_comparison_required: false
+    biometric_comparison_required: false,
+    vtr: nil # rubocop:disable Lint/UnusedMethodArgument
   )
     @uuid = uuid
     @issuer = issuer

--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -14,7 +14,7 @@ class ServiceProviderRequest
     requested_attributes: [],
     biometric_comparison_required: false,
     acr_values: nil, # rubocop:disable Lint/UnusedMethodArgument
-    vtr: nil, # rubocop:disable Lint/UnusedMethodArgument
+    vtr: nil # rubocop:disable Lint/UnusedMethodArgument
   )
     @uuid = uuid
     @issuer = issuer

--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -13,7 +13,8 @@ class ServiceProviderRequest
     aal: nil,
     requested_attributes: [],
     biometric_comparison_required: false,
-    vtr: nil # rubocop:disable Lint/UnusedMethodArgument
+    acr_values: nil, # rubocop:disable Lint/UnusedMethodArgument
+    vtr: nil, # rubocop:disable Lint/UnusedMethodArgument
   )
     @uuid = uuid
     @issuer = issuer


### PR DESCRIPTION
We are working on imlementing a feature for partners to request identity proofing and authentication features using vectors of trust. This will involve sending param describing the vector of trust in the original SAML or OIDC request. Within the context of OIDC this param is named `vtr`.

This commit adds a `vtr` property to `ServiceProviderRequest`. This property is unused and unset in the persisted service provider request. This will allow us to write to it in the future and initialize `ServiceProviderRequest`s with the value without resulting in an `ArgumentError` (thus avoiding a dreaded 50/50 state bug)

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
