### PR TITLE
Read `vtr` property while reading and writing `ServiceProviderRequest`

### DIFF
--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -3,7 +3,7 @@ class ServiceProviderRequest
   # since these objects are serialized to/from Redis and may be present
   # upon deployment
   attr_accessor :uuid, :issuer, :url, :ial, :aal, :requested_attributes,
-                :biometric_comparison_required
+                :biometric_comparison_required, :acr_values, :vtr
 
   def initialize(
     uuid: nil,
@@ -13,8 +13,8 @@ class ServiceProviderRequest
     aal: nil,
     requested_attributes: [],
     biometric_comparison_required: false,
-    acr_values: nil, # rubocop:disable Lint/UnusedMethodArgument
-    vtr: nil # rubocop:disable Lint/UnusedMethodArgument
+    acr_values: nil,
+    vtr: nil
   )
     @uuid = uuid
     @issuer = issuer
@@ -23,6 +23,8 @@ class ServiceProviderRequest
     @aal = aal
     @requested_attributes = requested_attributes&.map(&:to_s)
     @biometric_comparison_required = biometric_comparison_required
+    @acr_values = acr_values
+    @vtr = vtr
   end
 
   def ==(other)

--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -34,7 +34,7 @@ class ServiceProviderRequestProxy
     spr = ServiceProviderRequest.new(
       uuid: uuid, issuer: nil, url: nil, ial: nil,
       aal: nil, requested_attributes: nil,
-      biometric_comparison_required: false
+      biometric_comparison_required: false, acr_values: nil, vtr: nil
     )
     yield(spr)
     create(
@@ -45,13 +45,22 @@ class ServiceProviderRequestProxy
       aal: spr.aal,
       requested_attributes: spr.requested_attributes,
       biometric_comparison_required: spr.biometric_comparison_required,
+      acr_values: spr.acr_values,
+      vtr: spr.vtr,
     )
   end
 
   def self.create(hash)
     uuid = hash[:uuid]
     obj = hash.slice(
-      :issuer, :url, :ial, :aal, :requested_attributes, :biometric_comparison_required
+      :issuer,
+      :url,
+      :ial,
+      :aal,
+      :requested_attributes,
+      :biometric_comparison_required,
+      :acr_values,
+      :vtr,
     )
     write(obj, uuid)
     hash_to_spr(obj, uuid)


### PR DESCRIPTION
In #9991 the `vtr` property is added to the `ServiceProviderRequest`. Since the `vtr` property is introduced there it is unsafe to create a `ServiceProviderRequest` record with `vtr` during a deploy since some instances may have code that is unaware of the `vtr` property and will result in an `ArgumentError` when creating a `ServiceProviderRequest`

Once the changes in #9991 are deployed it should be safe to create records with the `vtr` property. This commit does that in the `ServiceProviderRequestProxy`.

This should not be merged until the changes in #9991 are merged and deployed all the way through production.
