### PR TITLE
Fix static usage of error messages that results in them being untranslated

### DIFF
--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -17,12 +17,12 @@ class OpenidConnectLogoutForm
 
   validates :client_id,
             presence: {
-              message: I18n.t('openid_connect.logout.errors.client_id_missing'),
+              message: ->(_, _) { I18n.t('openid_connect.logout.errors.client_id_missing') },
             },
             if: :reject_id_token_hint?
   validates :id_token_hint,
             absence: {
-              message: I18n.t('openid_connect.logout.errors.id_token_hint_present'),
+              message: ->(_, _) { I18n.t('openid_connect.logout.errors.id_token_hint_present') },
             },
             if: :reject_id_token_hint?
   validates :post_logout_redirect_uri, presence: true

--- a/app/validators/idv/form_address_validator.rb
+++ b/app/validators/idv/form_address_validator.rb
@@ -7,7 +7,7 @@ module Idv
 
       validates_format_of :zipcode,
                           with: /\A\d{5}(-?\d{4})?\z/,
-                          message: I18n.t('idv.errors.pattern_mismatch.zipcode'),
+                          message: ->(_, _) { I18n.t('idv.errors.pattern_mismatch.zipcode') },
                           allow_blank: true
 
       validates :city, presence: true, length: { maximum: 255 }

--- a/app/validators/idv/form_ssn_format_validator.rb
+++ b/app/validators/idv/form_ssn_format_validator.rb
@@ -6,7 +6,7 @@ module Idv
       validates :ssn, presence: true
       validates_format_of :ssn,
                           with: /\A\d{3}-?\d{2}-?\d{4}\z/,
-                          message: I18n.t('idv.errors.pattern_mismatch.ssn'),
+                          message: ->(_, _) { I18n.t('idv.errors.pattern_mismatch.ssn') },
                           allow_blank: false
     end
   end

--- a/app/validators/idv/form_state_id_validator.rb
+++ b/app/validators/idv/form_state_id_validator.rb
@@ -37,10 +37,12 @@ module Idv
                      attributes: [:dob], less_than_or_equal_to: ->(_rec) {
                        Time.zone.today - IdentityConfig.store.idv_min_age_years.years
                      },
-                     message: I18n.t(
-                       'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
-                       app_name: APP_NAME,
-                     )
+                     message: ->(_, _) do
+                       I18n.t(
+                         'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
+                         app_name: APP_NAME,
+                       )
+                     end
       # rubocop:enable Layout/LineLength
     end
     # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## 🛠 Summary of changes

I noticed this while doing some testing, but it seems like we only return English error messages for these. I haven't found a good way to detect it comprehensively yet though.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
