### PR TITLE
Update Rack Attack to reduce Redis calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'premailer-rails', '>= 1.12.0'
 gem 'profanity_filter'
 gem 'propshaft'
 gem 'rack', '>= 3.0'
-gem 'rack-attack', '>= 6.2.1'
+gem 'rack-attack', github: 'rack/rack-attack', ref: 'd9fedfae4f7f6409f33857763391f4e18a6d7467'
 gem 'rack-cors', '>= 1.0.5', require: 'rack/cors'
 gem 'rack-headers_filter'
 gem 'rack-timeout', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,14 @@ GIT
       selenium-webdriver (>= 4.0)
       webrick (>= 1.7)
 
+GIT
+  remote: https://github.com/rack/rack-attack.git
+  revision: d9fedfae4f7f6409f33857763391f4e18a6d7467
+  ref: d9fedfae4f7f6409f33857763391f4e18a6d7467
+  specs:
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -477,8 +485,6 @@ GEM
     raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.8)
-    rack-attack (6.7.0)
-      rack (>= 1.0, < 4)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-headers_filter (0.0.1)
@@ -805,7 +811,7 @@ DEPENDENCIES
   psych
   puma (~> 6.0)
   rack (>= 3.0)
-  rack-attack (>= 6.2.1)
+  rack-attack!
   rack-cors (>= 1.0.5)
   rack-headers_filter
   rack-mini-profiler (>= 1.1.3)


### PR DESCRIPTION
## 🛠 Summary of changes

This PR is mostly for performance reasons. In https://github.com/rack/rack-attack/pull/597, an improvement was made to reduce the number of Redis calls in rack-attack.

For us, the improvement is pretty significant:

```
❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

(0.2698 seconds) "rack attack update"
  FASTER 🚀🚀🚀 by:
    1.0643x [older/newer]
    6.0431% [(older - newer) / older * 100]
(0.2872 seconds) "main"

Iterations per sample: 200
Samples: 200

Test type: Kolmogorov Smirnov
Confidence level: 99.0 %
Is significant? (max > critical): true
D critical: 0.15174271293851463
D max: 0.66
```

I had been planning on waiting for a full release, but it's been a bit over 6 months since the last one. We should revert back to the RubyGems releases once there has been a release that includes this change.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
