### PR TITLE
Narrow TypeScript spec exclusions to spec directory

### DIFF
--- a/app/javascript/packages/build-sass/index.js
+++ b/app/javascript/packages/build-sass/index.js
@@ -26,7 +26,7 @@ const TARGETS = browserslistToTargets(
  * Compiles a given Sass file.
  *
  * @param {string} file File to build.
- * @param {BuildOptions & SyncSassOptions} options Build options.
+ * @param {Partial<BuildOptions> & SyncSassOptions} options Build options.
  *
  * @return {Promise<CompileResult>}
  */

--- a/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/rails-i18n-webpack-plugin.js
@@ -27,7 +27,7 @@ const ExtractKeysWebpackPlugin = require('./extract-keys-webpack-plugin.js');
  * // 'foo'
  * ```
  *
- * @param {Record<string, any>} object
+ * @param {undefined|Record<string, any>} object
  * @param {string[]} keyPath
  *
  * @return {any}
@@ -136,7 +136,7 @@ class RailsI18nWebpackPlugin extends ExtractKeysWebpackPlugin {
    * @param {string} domain
    * @param {string} locale
    *
-   * @return {Promise<Record<string, string>>}
+   * @return {Promise<undefined|Record<string, string>>}
    */
   getLocaleData(domain, locale) {
     if (!(domain in this.localeData)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "./*.js",
     "scripts"
   ],
-  "exclude": ["**/fixtures", "**/*.spec.js"]
+  "exclude": ["**/fixtures", "spec/**/*.spec.js"]
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Limits TypeScript exclusions for spec files to those in the `spec/` directory.

**Why?**

- Moves in the direction of full type-checking coverage
- Recent conventions prefer adding spec files in `app/javascript`, so...
   - ... `spec/` files should be considered "legacy"
   - ... we want to enforce full type checking coverage for new spec files in `app/javascript`
- Helps identify legitimate issues (e.g. see included changes)

## 📜 Testing Plan

Verify that TypeScript type-checking passes:

```
yarn typecheck
```