### PR TITLE
Silently ignore invalid params for FormSteps 

### DIFF
--- a/app/javascript/packages/form-steps/form-steps.spec.tsx
+++ b/app/javascript/packages/form-steps/form-steps.spec.tsx
@@ -355,12 +355,6 @@ describe('FormSteps', () => {
     expect(window.location.hash).to.equal('#second');
   });
 
-  it('resets hash in URL if there is no matching step', () => {
-    window.location.hash = '#example';
-    render(<FormSteps steps={STEPS} />);
-    expect(window.location.hash).to.equal('');
-  });
-
   it('syncs step by history events', async () => {
     const { getByText, findByText, getByLabelText } = render(<FormSteps steps={STEPS} />);
 

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -231,10 +231,11 @@ function FormSteps({
   promptOnNavigate = true,
   titleFormat,
 }: FormStepsProps) {
+  const stepNames = steps.map((step) => step.name);
   const [values, setValues] = useState(initialValues);
   const [activeErrors, setActiveErrors] = useState(initialActiveErrors);
   const formRef = useRef(null as HTMLFormElement | null);
-  const [stepName, setStepName] = useHistoryParam(initialStep);
+  const [stepName, setStepName] = useHistoryParam(initialStep, stepNames);
   const [stepErrors, setStepErrors] = useState([] as Error[]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [stepCanComplete, setStepCanComplete] = useState<boolean | undefined>(undefined);

--- a/app/javascript/packages/form-steps/use-history-param.ts
+++ b/app/javascript/packages/form-steps/use-history-param.ts
@@ -29,13 +29,17 @@ const subscribers: Array<() => void> = [];
  */
 function useHistoryParam(
   initialValue?: string,
+  validValues?: string[],
 ): [string | undefined, (nextParamValue: ParamValue) => void] {
-  function getCurrentValue(): ParamValue {
+  function getCurrentValue(currentValue?: string): ParamValue {
     const path = window.location.hash.slice(1);
 
     if (path) {
-      return getStepParam(path);
+      const value = getStepParam(path);
+      return !validValues || validValues.includes(value) ? value : currentValue;
     }
+
+    return initialValue;
   }
 
   const [value, setValue] = useState(initialValue ?? getCurrentValue);

--- a/app/javascript/packs/application.ts
+++ b/app/javascript/packs/application.ts
@@ -2,8 +2,3 @@ import { accordion, banner, skipnav } from '@18f/identity-design-system';
 
 const components = [accordion, banner, skipnav];
 components.forEach((component) => component.on());
-const mainContent = document.getElementById('main-content');
-document.querySelector('.usa-skipnav')?.addEventListener('click', (event) => {
-  event.preventDefault();
-  mainContent?.scrollIntoView();
-});


### PR DESCRIPTION
## 🛠 Summary of changes

Updates handling for how FormSteps considers step names from URL parameters, to ensure that URL changes which result in an invalid step (e.g. the skipnav navigation) would not have an effect on what's shown to the user, while avoiding bypassing skipnav URL change altogether.

This is an alternative to #7769. The primary goal of these changes is to avoid potential conflicts with default behavior of U.S. Web Design System by keeping the component implementations closer in sync. This also has a secondary effect of reducing the size of the common `application` JavaScript file that is loaded on every screen of the application.

There's a related USWDS issue at https://github.com/uswds/uswds/issues/5133 which may end up being closed as "working as intended", based on recent findings shared at https://github.com/uswds/uswds/issues/5133#issuecomment-1885437372.

## 📜 Testing Plan

Repeat Testing Plan from #7769

Specifically verify:

- Back and forward buttons behave as expected when traversing "Steps" in document capture, particularly within in-person proofing
- Using the "Skip to main content" link after tabbing from the URL address bar will now update the URL, but it will not affect what's shown on the screen

1. Go to http://localhost:3000
2. Sign in
3. Go to http://localhost:3000/verify
4. Complete identity verification up to document capture step
5. Use an [error file](https://developers.login.gov/testing/#testing-identity-proofing) as front and back image to trigger a failure for document capture
6. Click Submit
7. On failure, click "Try in person"
8. On "Verify your identity in person", click "Continue"
9. Press the back button
10. Observe that you are returned to "Verify your identity in person"
11. Focus the browser URL address bar
12. Press <kbd>Tab</kbd>
13. Observe that the "Skip to main content" link is shown
14. Press <kbd>Enter</kbd>
15. Observe:
   a. Focus shifts to main content
   b. The URL hash fragment changes to `#main-content`
   c. You are still on the "Verify your identity in person" screen (this is the bug that LG-8682 aimed to fix)