### PR TITLE
LG-12183: selfie image metadata

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -373,7 +373,9 @@ module Idv
     def acuant_sdk_capture?
       image_metadata.dig(:front, :source) == Idp::Constants::Vendors::ACUANT &&
         image_metadata.dig(:back, :source) == Idp::Constants::Vendors::ACUANT &&
-        image_metadata.dig(:selfie, :source) == Idp::Constants::Vendors::ACUANT
+        (liveness_checking_required ?
+          image_metadata.dig(:selfie, :source) == Idp::Constants::Vendors::ACUANT :
+           true)
     end
 
     def image_metadata

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -372,12 +372,13 @@ module Idv
 
     def acuant_sdk_capture?
       image_metadata.dig(:front, :source) == Idp::Constants::Vendors::ACUANT &&
-        image_metadata.dig(:back, :source) == Idp::Constants::Vendors::ACUANT
+        image_metadata.dig(:back, :source) == Idp::Constants::Vendors::ACUANT &&
+        image_metadata.dig(:selfie, :source) == Idp::Constants::Vendors::ACUANT
     end
 
     def image_metadata
-      @image_metadata ||= params.permit(:front_image_metadata, :back_image_metadata).
-        to_h.
+      @image_metadata ||= params.
+        permit(:front_image_metadata, :back_image_metadata, :selfie_image_metadata).to_h.
         transform_values do |str|
           JSON.parse(str)
         rescue JSON::ParserError

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -6,13 +6,15 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
   subject(:form) do
     Idv::ApiImageUploadForm.new(
       ActionController::Parameters.new(
-        front: front_image,
-        front_image_metadata: front_image_metadata,
-        back: back_image,
-        back_image_metadata: back_image_metadata,
-        selfie: selfie_image,
-        selfie_image_metadata: selfie_image_metadata,
-        document_capture_session_uuid: document_capture_session_uuid,
+        {
+          front: front_image,
+          front_image_metadata: front_image_metadata,
+          back: back_image,
+          back_image_metadata: back_image_metadata,
+          selfie: selfie_image,
+          selfie_image_metadata: selfie_image_metadata,
+          document_capture_session_uuid: document_capture_session_uuid,
+        }.compact,
       ),
       service_provider: build(:service_provider, issuer: 'test_issuer'),
       analytics: fake_analytics,
@@ -310,7 +312,6 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
           expect(response.selfie_status).to eq(:success)
           expect(response.errors).to eq({})
           expect(response.attention_with_barcode?).to eq(false)
-          expect(response.pii_from_doc).to eq(Idp::Constants::MOCK_IDV_APPLICANT)
         end
       end
     end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
         back: back_image,
         back_image_metadata: back_image_metadata,
         selfie: selfie_image,
+        selfie_image_metadata: selfie_image_metadata,
         document_capture_session_uuid: document_capture_session_uuid,
       ),
       service_provider: build(:service_provider, issuer: 'test_issuer'),
@@ -31,6 +32,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
   let(:back_image_metadata) do
     { width: 20, height: 20, mimeType: 'image/png', source: 'upload' }.to_json
   end
+  let(:selfie_image_metadata) { nil }
   let!(:document_capture_session) { DocumentCaptureSession.create!(user: create(:user)) }
   let(:document_capture_session_uuid) { document_capture_session.uuid }
   let(:fake_analytics) { FakeAnalytics.new }
@@ -199,6 +201,10 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
         let(:liveness_checking_required) { true }
         let(:back_image) { DocAuthImageFixtures.portrait_match_success_yaml }
         let(:selfie_image) { DocAuthImageFixtures.selfie_image_multipart }
+        let(:selfie_image_metadata) do
+          { width: 10, height: 10, mimeType: 'image/png', source: 'upload' }.to_json
+        end
+
         it 'logs analytics' do
           expect(irs_attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
             {
@@ -254,6 +260,12 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
                 source: 'upload',
                 width: 40,
               },
+              selfie: {
+                height: 10,
+                mimeType: 'image/png',
+                source: 'upload',
+                width: 10,
+              },
             },
             conversation_id: nil,
             decision_product_status: nil,
@@ -298,7 +310,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
           expect(response.selfie_status).to eq(:success)
           expect(response.errors).to eq({})
           expect(response.attention_with_barcode?).to eq(false)
-          # expect(response.pii_from_doc).to eq(Idp::Constants::MOCK_IDV_APPLICANT)
+          expect(response.pii_from_doc).to eq(Idp::Constants::MOCK_IDV_APPLICANT)
         end
       end
     end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -697,6 +697,31 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
         it 'sets image source to acuant sdk' do
           form.submit
         end
+
+        context 'selfie is submitted' do
+          let(:liveness_checking_required) { true }
+          let(:selfie_image) { DocAuthImageFixtures.selfie_image_multipart }
+          context 'captured with acuant sdk' do
+            let(:selfie_image_metadata) do
+              { width: 10, height: 10, mimeType: 'image/png', source: source }.to_json
+            end
+
+            it 'sets image source to acuant sdk' do
+              form.submit
+            end
+          end
+
+          context 'add using file upload' do
+            let(:selfie_image_metadata) do
+              { width: 10, height: 10, mimeType: 'image/png', source: 'upload' }.to_json
+            end
+            let(:image_source) { DocAuth::ImageSources::UNKNOWN }
+
+            it 'sets image source to acuant sdk' do
+              form.submit
+            end
+          end
+        end
       end
 
       context 'malformed image metadata' do

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -718,7 +718,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
             end
             let(:image_source) { DocAuth::ImageSources::UNKNOWN }
 
-            it 'sets image source to acuant sdk' do
+            it 'sets image source to unknown' do
               form.submit
             end
           end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-12183](https://cm-jira.usa.gov/browse/LG-12183)

## 🛠 Summary of changes
During liveness selfie image metadata needs to be captured, logged and used to determine doc auth vendor workflow.

## 📜 Testing Plan
1. Complete doc auth with selfie on Desktop:
in logs, verify that _IdV: doc auth image upload vendor submitted_ analytics event is logged with selfie source: _upload_

2. Complete doc auth with selfie using autocapture on mobile device:
in logs, verify that _IdV: doc auth image upload vendor submitted_ analytics event is logged with selfie source: _acuant_

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
