### PR TITLE
Jmax/LG-12134 Spike use absolute timestamps for rate limiter Redis timeouts.

### DIFF
--- a/app/services/otp_rate_limiter.rb
+++ b/app/services/otp_rate_limiter.rb
@@ -6,40 +6,73 @@ class OtpRateLimiter
   end
 
   def exceeded_otp_send_limit?
+    puts "def exceeded_otp_send_limit?"
+
     if rate_limit_period_expired?
       reset_count_and_otp_last_sent_at
+      puts "  rate limit period expired; exceeded_otp_send_limit?: returning false"
       return false
     end
 
-    max_requests_reached?
+    rv = max_requests_reached?
+    puts "  exceeded_otp_send_limit?: returning #{rv.inspect}"
+    rv
   end
 
   def max_requests_reached?
-    rate_limiter.limited?
+    puts "def max_requests_reached?"
+
+    rv = rate_limiter.limited?
+    puts "  max_requests_reached?: returning #{rv.inspect}"
+    rv
   end
 
   def rate_limit_period_expired?
-    rate_limiter.expired?
+    puts "def rate_limit_period_expired?"
+
+    rv = rate_limiter.expired?
+    puts "  rate_limit_period_expired?: returning #{rv.inspect}"
+    rv
   end
 
   def reset_count_and_otp_last_sent_at
-    rate_limiter.reset!
+    puts "def reset_count_and_otp_last_sent_at"
+
+    rv = rate_limiter.reset!
+    puts "  reset_count_and_otp_last_sent_at: returning #{rv.inspect}"
+    rv
   end
 
   def lock_out_user
-    UpdateUser.new(user: user, attributes: { second_factor_locked_at: Time.zone.now }).call
+    puts "def lock_out_user"
+
+    rv = UpdateUser.new(user: user, attributes: { second_factor_locked_at: Time.zone.now }).call
+    puts "  lock_out_user: returning #{rv.inspect}"
+    rv
   end
 
   def increment
-    rate_limiter.increment!
+    puts "def increment"
+
+    rv = rate_limiter.increment!
+    puts "  increment: returning #{rv.inspect}"
+    rv
   end
 
   def otp_last_sent_at
-    rate_limiter.attempted_at
+    puts "def otp_last_sent_at"
+
+    rv = rate_limiter.attempted_at
+    puts "  otp_last_sent_at: returning: #{rv.inspect}"
+    rv
   end
 
   def rate_limiter
-    @rate_limiter ||= RateLimiter.new(rate_limit_type: :phone_otp, target: rate_limit_key)
+    puts "def rate_limiter"
+
+    rv = (@rate_limiter ||= RateLimiter.new(rate_limit_type: :phone_otp, target: rate_limit_key))
+    puts "  rate_limiter: returning #{rv.inspect}"
+    rv
   end
 
   private
@@ -47,18 +80,34 @@ class OtpRateLimiter
   attr_reader :phone, :user, :phone_confirmed
 
   def otp_findtime
-    IdentityConfig.store.otp_delivery_blocklist_findtime.minutes
+    puts "def otp_findtime"
+
+    rv = IdentityConfig.store.otp_delivery_blocklist_findtime.minutes
+    puts "  otp_findtime: returning #{rv.inspect}"
+    rv
   end
 
   def otp_maxretry_times
-    IdentityConfig.store.otp_delivery_blocklist_maxretry
+    puts "def otp_maxretry_times"
+
+    rv = IdentityConfig.store.otp_delivery_blocklist_maxretry
+    puts "  otp_maxretry_times: returning #{rv.inspect}"
+    rv
   end
 
   def phone_fingerprint
-    @phone_fingerprint ||= Pii::Fingerprinter.fingerprint(PhoneFormatter.format(phone))
+    puts "def phone_fingerprint"
+
+    rv = @phone_fingerprint ||= Pii::Fingerprinter.fingerprint(PhoneFormatter.format(phone))
+    puts "  phone_fingerprint: returning #{rv.inspect}"
+    rv
   end
 
   def rate_limit_key
-    "#{phone_fingerprint}:#{phone_confirmed}"
+    puts "def rate_limit_key"
+
+    rv = "#{phone_fingerprint}:#{phone_confirmed}"
+    puts "  rate_limit_key: returning #{rv.inspect}"
+    rv
   end
 end

--- a/app/services/otp_rate_limiter.rb
+++ b/app/services/otp_rate_limiter.rb
@@ -6,73 +6,40 @@ class OtpRateLimiter
   end
 
   def exceeded_otp_send_limit?
-    puts "def exceeded_otp_send_limit?"
-
     if rate_limit_period_expired?
       reset_count_and_otp_last_sent_at
-      puts "  rate limit period expired; exceeded_otp_send_limit?: returning false"
       return false
     end
 
-    rv = max_requests_reached?
-    puts "  exceeded_otp_send_limit?: returning #{rv.inspect}"
-    rv
+    max_requests_reached?
   end
 
   def max_requests_reached?
-    puts "def max_requests_reached?"
-
-    rv = rate_limiter.limited?
-    puts "  max_requests_reached?: returning #{rv.inspect}"
-    rv
+    rate_limiter.limited?
   end
 
   def rate_limit_period_expired?
-    puts "def rate_limit_period_expired?"
-
-    rv = rate_limiter.expired?
-    puts "  rate_limit_period_expired?: returning #{rv.inspect}"
-    rv
+    rate_limiter.expired?
   end
 
   def reset_count_and_otp_last_sent_at
-    puts "def reset_count_and_otp_last_sent_at"
-
-    rv = rate_limiter.reset!
-    puts "  reset_count_and_otp_last_sent_at: returning #{rv.inspect}"
-    rv
+    rate_limiter.reset!
   end
 
   def lock_out_user
-    puts "def lock_out_user"
-
-    rv = UpdateUser.new(user: user, attributes: { second_factor_locked_at: Time.zone.now }).call
-    puts "  lock_out_user: returning #{rv.inspect}"
-    rv
+    UpdateUser.new(user: user, attributes: { second_factor_locked_at: Time.zone.now }).call
   end
 
   def increment
-    puts "def increment"
-
-    rv = rate_limiter.increment!
-    puts "  increment: returning #{rv.inspect}"
-    rv
+    rate_limiter.increment!
   end
 
   def otp_last_sent_at
-    puts "def otp_last_sent_at"
-
-    rv = rate_limiter.attempted_at
-    puts "  otp_last_sent_at: returning: #{rv.inspect}"
-    rv
+    rate_limiter.attempted_at
   end
 
   def rate_limiter
-    puts "def rate_limiter"
-
-    rv = (@rate_limiter ||= RateLimiter.new(rate_limit_type: :phone_otp, target: rate_limit_key))
-    puts "  rate_limiter: returning #{rv.inspect}"
-    rv
+    @rate_limiter ||= RateLimiter.new(rate_limit_type: :phone_otp, target: rate_limit_key)
   end
 
   private
@@ -80,34 +47,18 @@ class OtpRateLimiter
   attr_reader :phone, :user, :phone_confirmed
 
   def otp_findtime
-    puts "def otp_findtime"
-
-    rv = IdentityConfig.store.otp_delivery_blocklist_findtime.minutes
-    puts "  otp_findtime: returning #{rv.inspect}"
-    rv
+    IdentityConfig.store.otp_delivery_blocklist_findtime.minutes
   end
 
   def otp_maxretry_times
-    puts "def otp_maxretry_times"
-
-    rv = IdentityConfig.store.otp_delivery_blocklist_maxretry
-    puts "  otp_maxretry_times: returning #{rv.inspect}"
-    rv
+    IdentityConfig.store.otp_delivery_blocklist_maxretry
   end
 
   def phone_fingerprint
-    puts "def phone_fingerprint"
-
-    rv = @phone_fingerprint ||= Pii::Fingerprinter.fingerprint(PhoneFormatter.format(phone))
-    puts "  phone_fingerprint: returning #{rv.inspect}"
-    rv
+    @phone_fingerprint ||= Pii::Fingerprinter.fingerprint(PhoneFormatter.format(phone))
   end
 
   def rate_limit_key
-    puts "def rate_limit_key"
-
-    rv = "#{phone_fingerprint}:#{phone_confirmed}"
-    puts "  rate_limit_key: returning #{rv.inspect}"
-    rv
+    "#{phone_fingerprint}:#{phone_confirmed}"
   end
 end

--- a/app/services/rate_limiter.rb
+++ b/app/services/rate_limiter.rb
@@ -71,18 +71,19 @@ class RateLimiter
     return if limited?
     value = nil
 
+    now = Time.zone.now
     REDIS_THROTTLE_POOL.with do |client|
       value, _success = client.multi do |multi|
         multi.incr(key)
-        multi.expire(
+        multi.expireat(
           key,
-          RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.seconds.to_i,
+          now + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.seconds.to_i,
         )
       end
     end
 
     @redis_attempts = value.to_i
-    @redis_attempted_at = Time.zone.now
+    @redis_attempted_at = now
 
     attempts
   end

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -32,6 +32,12 @@ RSpec.feature 'idv request letter step', allowed_extra_analytics: [:*] do
   context 'the user has sent a letter but not verified an OTP' do
     let(:user) { user_with_2fa }
 
+    before do
+      # Without this, the check for GPO expiration leaves an expired
+      # OTP rate limiter laying around.
+      allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(3)
+    end
+
     it 'if not rate limited, allow user to resend letter & redirect to letter enqueued step', :js do
       complete_idv_by_mail_and_sign_out
 

--- a/spec/services/rate_limiter_spec.rb
+++ b/spec/services/rate_limiter_spec.rb
@@ -155,6 +155,16 @@ RSpec.describe RateLimiter do
             of(rate_limiter.attempted_at + attempt_window.minutes)
         end
       end
+
+      context 'when we are out of sync with Redis' do
+        it 'returns the correct expiration time' do
+          fake_attempt_time = 1.year.ago
+          travel_to(fake_attempt_time) { rate_limiter.increment! }
+
+          expect(rate_limiter.expires_at).to be_within(1.second).
+            of(fake_attempt_time + attempt_window.minutes)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12134](https://cm-jira.usa.gov/browse/LG-12134)

## 🛠 Summary of changes

Changed Redis calls in RateLimiter to always use absolute time values, instead of relative ones.

This change is internal to the timestamp class, and not visible outside it.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify that all existing specs pass.
- [ ] For each of the rate limiters in [Handbook Rate Limiters Page ](https://handbook.login.gov/articles/identity-proofing-rate-limiting.html#hybrid-handoff-rate-limiter), verify that the documented procedure for triggering each rate limiter still works as described.