### PR TITLE
LG-11699/LG-11700: Allow verified user to repeat idv if they need biometric

### DIFF
--- a/app/controllers/concerns/idv_session_concern.rb
+++ b/app/controllers/concerns/idv_session_concern.rb
@@ -7,6 +7,8 @@ module IdvSessionConcern
   end
 
   def confirm_idv_needed
+    return if user_needs_selfie?
+
     return if idv_session_user.active_profile.blank? ||
               decorated_sp_session.requested_more_recent_verification? ||
               idv_session_user.reproof_for_irs?(service_provider: current_sp)
@@ -65,5 +67,9 @@ module IdvSessionConcern
     return User.find_by(id: session[:doc_capture_user_id]) if !current_user && hybrid_session?
 
     current_user
+  end
+
+  def user_needs_selfie?
+    decorated_sp_session.selfie_required? && !current_user.identity_verified_with_selfie?
   end
 end

--- a/app/controllers/concerns/idv_session_concern.rb
+++ b/app/controllers/concerns/idv_session_concern.rb
@@ -7,17 +7,18 @@ module IdvSessionConcern
   end
 
   def confirm_idv_needed
-    return if user_needs_selfie?
-
-    return if idv_session_user.active_profile.blank? ||
-              decorated_sp_session.requested_more_recent_verification? ||
-              idv_session_user.reproof_for_irs?(service_provider: current_sp)
-
-    redirect_to idv_activated_url
+    redirect_to idv_activated_url unless idv_needed?
   end
 
   def hybrid_session?
     session[:doc_capture_user_id].present?
+  end
+
+  def idv_needed?
+    user_needs_selfie? ||
+      idv_session_user.active_profile.blank? ||
+      decorated_sp_session.requested_more_recent_verification? ||
+      idv_session_user.reproof_for_irs?(service_provider: current_sp)
   end
 
   def idv_session

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -10,10 +10,7 @@ class IdvController < ApplicationController
   before_action :confirm_not_rate_limited
 
   def index
-    if decorated_sp_session.requested_more_recent_verification? ||
-       current_user.reproof_for_irs?(service_provider: current_sp)
-      verify_identity
-    elsif active_profile?
+    if already_verified?
       redirect_to idv_activated_url
     else
       verify_identity
@@ -31,6 +28,14 @@ class IdvController < ApplicationController
   end
 
   private
+
+  def already_verified?
+    if decorated_sp_session.selfie_required?
+      return current_user.identity_verified_with_selfie?
+    end
+
+    return current_user.active_profile.present?
+  end
 
   def verify_identity
     analytics.idv_intro_visit

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -47,6 +47,31 @@ RSpec.describe IdvController, allowed_extra_analytics: [:*] do
       expect(response).to redirect_to(idv_not_verified_url)
     end
 
+    context 'user has active profile' do
+      let(:user) { create(:user, :proofed) }
+      before do
+        stub_sign_in(user)
+      end
+      it 'redirects to activated' do
+        get :index
+        expect(response).to redirect_to idv_activated_url
+      end
+
+      context 'but user needs to redo idv with biometric' do
+        let(:current_sp) { create(:service_provider) }
+        before do
+          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+          session[:sp] =
+            { issuer: current_sp.issuer, biometric_comparison_required: true }
+        end
+
+        it 'redirects to welcome' do
+          get :index
+          expect(response).to redirect_to idv_welcome_url
+        end
+      end
+    end
+
     context 'if number of verify_info attempts has been exceeded' do
       before do
         user = create(:user)

--- a/spec/features/idv/step_up_spec.rb
+++ b/spec/features/idv/step_up_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'IdV step up flow', allowed_extra_analytics: [:*] do
+  include IdvStepHelper
+  include InPersonHelper
+
+  let(:sp) { :oidc }
+  let(:sp_name) { 'Test SP' }
+
+  let(:user) do
+    create(:user, :proofed)
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+  end
+
+  scenario 'User with active profile can redo idv when selfie required' do
+    visit_idp_from_sp_with_ial2(sp, biometric_comparison_required: true)
+    sign_in_live_with_2fa(user)
+
+    expect(page).to have_current_path(idv_welcome_path)
+
+    click_continue
+
+    expect(page).to have_current_path(idv_agreement_path)
+  end
+
+  scenario 'User with active profile cannot redo idv when selfie not required' do
+    visit_idp_from_sp_with_ial2(sp)
+    sign_in_live_with_2fa(user)
+
+    expect(page).to have_current_path(sign_up_completed_path)
+  end
+end

--- a/spec/features/idv/step_up_spec.rb
+++ b/spec/features/idv/step_up_spec.rb
@@ -15,21 +15,29 @@ RSpec.describe 'IdV step up flow', allowed_extra_analytics: [:*] do
     allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
   end
 
-  scenario 'User with active profile can redo idv when selfie required' do
+  scenario 'User with active profile can redo idv when selfie required', js: true do
     visit_idp_from_sp_with_ial2(sp, biometric_comparison_required: true)
     sign_in_live_with_2fa(user)
 
     expect(page).to have_current_path(idv_welcome_path)
 
-    click_continue
+    complete_doc_auth_steps_before_document_capture_step
 
-    expect(page).to have_current_path(idv_agreement_path)
+    # TODO: Refactor this
+    attach_images
+    attach_selfie
+    submit_images
+
+    complete_ssn_step
+    complete_verify_step
+    complete_phone_step(user)
+    complete_enter_password_step(user)
+    acknowledge_and_confirm_personal_key
   end
 
   scenario 'User with active profile cannot redo idv when selfie not required' do
     visit_idp_from_sp_with_ial2(sp)
     sign_in_live_with_2fa(user)
-
     expect(page).to have_current_path(sign_up_completed_path)
   end
 end

--- a/spec/features/idv/step_up_spec.rb
+++ b/spec/features/idv/step_up_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'IdV step up flow', allowed_extra_analytics: [:*] do
   let(:sp_name) { 'Test SP' }
 
   let(:user) do
-    create(:user, :proofed)
+    create(:user, :proofed, password: RequestHelper::VALID_PASSWORD)
   end
 
   before do
@@ -21,18 +21,7 @@ RSpec.describe 'IdV step up flow', allowed_extra_analytics: [:*] do
 
     expect(page).to have_current_path(idv_welcome_path)
 
-    complete_doc_auth_steps_before_document_capture_step
-
-    # TODO: Refactor this
-    attach_images
-    attach_selfie
-    submit_images
-
-    complete_ssn_step
-    complete_verify_step
-    complete_phone_step(user)
-    complete_enter_password_step(user)
-    acknowledge_and_confirm_personal_key
+    complete_proofing_steps(with_selfie: true)
   end
 
   scenario 'User with active profile cannot redo idv when selfie not required' do

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -116,8 +116,10 @@ module DocAuthHelper
     complete_how_to_verify_step(remote: remote)
   end
 
-  def complete_document_capture_step
-    attach_and_submit_images
+  def complete_document_capture_step(with_selfie: false)
+    attach_images
+    attach_selfie if with_selfie
+    submit_images
   end
 
   # yml_file example: 'spec/fixtures/puerto_rico_resident.yml'
@@ -128,8 +130,11 @@ module DocAuthHelper
     expect(page).to have_current_path(expected_path, wait: 10)
   end
 
-  def complete_doc_auth_steps_before_phone_otp_step(expect_accessible: false)
-    complete_doc_auth_steps_before_verify_step(expect_accessible: expect_accessible)
+  def complete_doc_auth_steps_before_phone_otp_step(expect_accessible: false, with_selfie: false)
+    complete_doc_auth_steps_before_verify_step(
+      expect_accessible: expect_accessible,
+      with_selfie: with_selfie,
+    )
     click_idv_continue
     expect_page_to_have_no_accessibility_violations(page) if expect_accessible
     click_idv_continue
@@ -139,9 +144,9 @@ module DocAuthHelper
     Browser.new(mobile_user_agent)
   end
 
-  def complete_doc_auth_steps_before_ssn_step(expect_accessible: false)
+  def complete_doc_auth_steps_before_ssn_step(expect_accessible: false, with_selfie: false)
     complete_doc_auth_steps_before_document_capture_step(expect_accessible: expect_accessible)
-    complete_document_capture_step
+    complete_document_capture_step(with_selfie: with_selfie)
     expect_page_to_have_no_accessibility_violations(page) if expect_accessible
   end
 
@@ -150,8 +155,11 @@ module DocAuthHelper
     click_idv_continue
   end
 
-  def complete_doc_auth_steps_before_verify_step(expect_accessible: false)
-    complete_doc_auth_steps_before_ssn_step(expect_accessible: expect_accessible)
+  def complete_doc_auth_steps_before_verify_step(expect_accessible: false, with_selfie: false)
+    complete_doc_auth_steps_before_ssn_step(
+      expect_accessible: expect_accessible,
+      with_selfie: with_selfie,
+    )
     complete_ssn_step
     expect_page_to_have_no_accessibility_violations(page) if expect_accessible
   end
@@ -160,8 +168,8 @@ module DocAuthHelper
     click_idv_submit_default
   end
 
-  def complete_doc_auth_steps_before_address_step(expect_accessible: false)
-    complete_doc_auth_steps_before_verify_step
+  def complete_doc_auth_steps_before_address_step(expect_accessible: false, with_selfie: false)
+    complete_doc_auth_steps_before_verify_step(with_selfie: with_selfie)
     expect_page_to_have_no_accessibility_violations(page) if expect_accessible
     click_link t('idv.buttons.change_address_label')
   end
@@ -187,14 +195,17 @@ module DocAuthHelper
     click_on t('idv.cancel.actions.exit', app_name: APP_NAME)
   end
 
-  def complete_all_doc_auth_steps(expect_accessible: false)
-    complete_doc_auth_steps_before_verify_step(expect_accessible: expect_accessible)
+  def complete_all_doc_auth_steps(expect_accessible: false, with_selfie: false)
+    complete_doc_auth_steps_before_verify_step(
+      expect_accessible: expect_accessible,
+      with_selfie: with_selfie,
+    )
     complete_verify_step
     expect_page_to_have_no_accessibility_violations(page) if expect_accessible
   end
 
-  def complete_all_doc_auth_steps_before_password_step(expect_accessible: false)
-    complete_all_doc_auth_steps(expect_accessible: expect_accessible)
+  def complete_all_doc_auth_steps_before_password_step(expect_accessible: false, with_selfie: false)
+    complete_all_doc_auth_steps(expect_accessible: expect_accessible, with_selfie: with_selfie)
     fill_out_phone_form_ok if find('#idv_phone_form_phone').value.blank?
     click_continue
     verify_phone_otp
@@ -202,8 +213,8 @@ module DocAuthHelper
     expect_page_to_have_no_accessibility_violations(page) if expect_accessible
   end
 
-  def complete_proofing_steps
-    complete_all_doc_auth_steps_before_password_step
+  def complete_proofing_steps(with_selfie: false)
+    complete_all_doc_auth_steps_before_password_step(with_selfie: with_selfie)
     fill_in 'Password', with: RequestHelper::VALID_PASSWORD
     click_continue
     acknowledge_and_confirm_personal_key

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -141,7 +141,8 @@ module IdvHelper
     client_id: sp_oidc_issuer,
     state: SecureRandom.hex,
     nonce: SecureRandom.hex,
-    verified_within: nil
+    verified_within: nil,
+    biometric_comparison_required: nil
   )
     visit openid_connect_authorize_path(
       client_id: client_id,
@@ -153,6 +154,7 @@ module IdvHelper
       prompt: 'select_account',
       nonce: nonce,
       verified_within: verified_within,
+      biometric_comparison_required: biometric_comparison_required,
     )
   end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant tickets:
* [LG-11699](https://cm-jira.usa.gov/browse/LG-11699)
* [LG-11700](https://cm-jira.usa.gov/browse/LG-11700)

## 🛠 Summary of changes

Refines "does this user need idv?" checks to take into account when users need to step up from verified to verified with biometric.

## 📜 Testing Plan

1. Make sure you have `doc_auth_selfie_capture_enabled: true` in your application.yml
2. Go through IdV and verify without a biometric
3. Make a request from an SP with biometric comparison enabled
4. Go back through IdV, this time verifying with a selfie
5. Ensure you get redirected back to the SP
6. Log in again from the SP with biometric comparison enabled and ensure you don't have to re-repeat the idv flow.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
