### PR TITLE
Remove OS version from new device mailer preview

### DIFF
--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -59,7 +59,7 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.with(user: user, email_address: email_address_record).new_device_sign_in(
       date: 'February 25, 2019 15:02',
       location: 'Washington, DC',
-      device_name: 'Chrome ABC on macOS 123',
+      device_name: 'Chrome 123 on macOS',
       disavowal_token: SecureRandom.hex,
     )
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the content for the new device mailer preview to more realistically match what a real user would receive.

As of #9904 (LG-11899), we no longer include operating system version in device names, so the example content "macOS 123" should be stripped of the version identifier.

An alternative approach could be to use the actual parsed device name from the current request user agent, which would help keep this more guaranteed as in-sync, but is perhaps too real / identifying to the current browser?

## 📜 Testing Plan

1. Go to http://localhost:3000/rails/mailers/user_mailer/new_device_sign_in
2. Observe there is no OS version shown