### PR TITLE
Load error tracking script asynchronously

### DIFF
--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -6,33 +6,29 @@ module ScriptHelper
     without_preload_links_header { javascript_include_tag(...) }
   end
 
-  def javascript_packs_tag_once(*names, prepend: false)
-    @scripts ||= []
-    if prepend
-      @scripts = names | @scripts
-    else
-      @scripts |= names
-    end
+  def javascript_packs_tag_once(*names, async: nil)
+    attributes = { async: }
+    @scripts = @scripts.to_h.merge(names.index_with(attributes))
     nil
   end
 
   alias_method :enqueue_component_scripts, :javascript_packs_tag_once
 
-  def render_javascript_pack_once_tags(*names)
-    names = names.presence || @scripts
-    if names && (sources = AssetSources.get_sources(*names)).present?
-      safe_join(
-        [
-          javascript_assets_tag(*names),
-          *sources.map do |source|
-            javascript_include_tag(
-              source,
-              crossorigin: local_crossorigin_sources? ? true : nil,
-              integrity: AssetSources.get_integrity(source),
-            )
-          end,
-        ],
-      )
+  def render_javascript_pack_once_tags(...)
+    capture do
+      javascript_packs_tag_once(...)
+      return if @scripts.blank?
+      concat javascript_assets_tag
+      @scripts.each do |name, attributes|
+        AssetSources.get_sources(name).each do |source|
+          concat javascript_include_tag(
+            source,
+            **attributes,
+            crossorigin: local_crossorigin_sources? ? true : nil,
+            integrity: AssetSources.get_integrity(source),
+          )
+        end
+      end
     end
   end
 
@@ -46,8 +42,8 @@ module ScriptHelper
     Rails.env.development? && ENV['WEBPACK_PORT'].present?
   end
 
-  def javascript_assets_tag(*names)
-    assets = AssetSources.get_assets(*names)
+  def javascript_assets_tag
+    assets = AssetSources.get_assets(*@scripts.keys)
     if assets.present?
       asset_map = assets.index_with { |path| asset_path(path, host: asset_host(path)) }
       content_tag(

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -6,8 +6,7 @@ module ScriptHelper
     without_preload_links_header { javascript_include_tag(...) }
   end
 
-  def javascript_packs_tag_once(*names, async: nil)
-    attributes = { async: }
+  def javascript_packs_tag_once(*names, **attributes)
     @scripts = @scripts.to_h.merge(names.index_with(attributes))
     nil
   end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -106,8 +106,8 @@
         { type: 'application/json', data: { config: '' } },
         false,
       ) %>
-  <%= javascript_packs_tag_once('application', prepend: true) %>
-  <%= javascript_packs_tag_once('track-errors') if BrowserSupport.supported?(request.user_agent) %>
+  <%= javascript_packs_tag_once('application') %>
+  <%= javascript_packs_tag_once('track-errors', async: true) if BrowserSupport.supported?(request.user_agent) %>
   <%= render_javascript_pack_once_tags %>
 
   <%= render 'shared/dap_analytics' if IdentityConfig.store.participate_in_dap && !session_with_trust? %>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -16,7 +16,7 @@
     <% else %>
       <%= yield %>
     <% end %>
-    <%= javascript_packs_tag_once('application', prepend: true) %>
+    <%= javascript_packs_tag_once('application') %>
     <%= render_javascript_pack_once_tags %>
   </body>
 </html>

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe ScriptHelper do
         end
       end
 
-      context 'with async option' do
+      context 'with attributes' do
         before do
           javascript_packs_tag_once('track-errors', async: true)
           allow(AssetSources).to receive(:get_sources).with('track-errors').
@@ -112,7 +112,7 @@ RSpec.describe ScriptHelper do
             and_return([])
         end
 
-        it 'adds async attribute' do
+        it 'adds attribute' do
           output = render_javascript_pack_once_tags
 
           expect(output).to have_css(

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe ScriptHelper do
 
     context 'scripts enqueued' do
       before do
+        javascript_packs_tag_once('application')
         javascript_packs_tag_once('document-capture', 'document-capture')
-        javascript_packs_tag_once('application', prepend: true)
-        allow(AssetSources).to receive(:get_sources).with('application', 'document-capture').
-          and_return(['/application.js', '/document-capture.js'])
+        allow(AssetSources).to receive(:get_sources).with('application').
+          and_return(['/application.js'])
+        allow(AssetSources).to receive(:get_sources).with('document-capture').
+          and_return(['/document-capture.js'])
         allow(AssetSources).to receive(:get_assets).with('application', 'document-capture').
           and_return(['clock.svg', 'sprite.svg'])
       end
@@ -94,6 +96,27 @@ RSpec.describe ScriptHelper do
 
           expect(output).to have_css(
             "script[src^='/application.js'][integrity^='sha256-']",
+            count: 1,
+            visible: :all,
+          )
+        end
+      end
+
+      context 'with async option' do
+        before do
+          javascript_packs_tag_once('track-errors', async: true)
+          allow(AssetSources).to receive(:get_sources).with('track-errors').
+            and_return(['/track-errors.js'])
+          allow(AssetSources).to receive(:get_assets).
+            with('application', 'document-capture', 'track-errors').
+            and_return([])
+        end
+
+        it 'adds async attribute' do
+          output = render_javascript_pack_once_tags
+
+          expect(output).to have_css(
+            "script[src^='/track-errors.js'][async]",
             count: 1,
             visible: :all,
           )


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the ScriptHelper module to support per-script attributes, to be able to support loading the error tracking script asynchronously.

This is a continuation of the idea raised at https://github.com/18F/identity-idp/pull/8950#discussion_r1309333539 .

Specifically, `async` scripts will allow a page to finish loading before the script has been loaded and evaluated, thus reducing the time to complete page load ([see MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async)). The effect here will probably not be dramatic, as the `track-errors` script is already the last element of the page (would not block rendering or initialization of other JavaScript) and is reasonably small (1.3kb minified and brotli'd).

Supporting arbitrary attributes could support future work such as opting JavaScript to be loaded as `type="module"`.

Lastly, in order to support this, support was removed for the `prepend` option. `prepend` was initially needed because the `application` pack included prerequisites that were assumed to have been run before any other script, but the last of these side-effects (`window.LoginGov.Modal`) was removed in #7174, so it is no longer necessary.

## 📜 Testing Plan

Verify there are no regressions in the loading of scripts.

Verify in the page inspector that the `track-errors.js` script is loaded with an `async` attribute.