### PR TITLE
LG-11897: Send Text on Account Deletion

### DIFF
--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -1,6 +1,7 @@
 ---
 en:
   telephony:
+    account_deleted_notice: This text message confirms you have deleted your %{app_name} account. 
     account_reset_cancellation_notice: Your request to delete your %{app_name} account has been cancelled.
     account_reset_notice: As requested, your %{app_name} account will be deleted in
       24 hours. Don't want to delete your account? Sign in to your %{app_name}

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -1,6 +1,7 @@
 ---
 es:
   telephony:
+    account_deleted_notice: Este SMS confirma que ha eliminado su cuenta de %{app_name}. 
     account_reset_cancellation_notice: Su solicitud para eliminar su cuenta de %{app_name} ha sido cancelada.
     account_reset_notice: Según lo solicitado, su cuenta %{app_name} se eliminará en
       24 horas. ¿No quieres eliminar tu cuenta? Inicie sesión en su cuenta

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -1,6 +1,7 @@
 ---
 fr:
   telephony:
+    account_deleted_notice: Cet SMS confirme que vous avez supprimé votre compte %{app_name}.
     account_reset_cancellation_notice: Votre demande de suppression de votre compte %{app_name} a été annulée.
     account_reset_notice: Comme demandé, votre compte %{app_name} sera supprimé dans
       les 24 heures. Vous ne voulez pas supprimer votre compte? Connectez-vous à

--- a/lib/telephony.rb
+++ b/lib/telephony.rb
@@ -80,6 +80,7 @@ module Telephony
                  :send_doc_auth_link,
                  :send_personal_key_regeneration_notice,
                  :send_personal_key_sign_in_notice,
+                 :send_account_deleted_notice,
                  :send_account_reset_notice,
                  :send_account_reset_cancellation_notice,
                  :send_notification

--- a/lib/telephony/alert_sender.rb
+++ b/lib/telephony/alert_sender.rb
@@ -2,6 +2,13 @@ module Telephony
   class AlertSender
     SMS_MAX_LENGTH = 160
 
+    def send_account_deleted_notice(to:, country_code:)
+      message = I18n.t('telephony.account_deleted_notice', app_name: APP_NAME)
+      response = adapter.deliver(message: message, to: to, country_code: country_code)
+      log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
+      response
+    end
+
     def send_account_reset_notice(to:, country_code:)
       message = I18n.t('telephony.account_reset_notice', app_name: APP_NAME)
       response = adapter.deliver(message: message, to: to, country_code: country_code)

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -74,7 +74,14 @@ RSpec.describe Users::DeleteController do
       allow(UserMailer).to receive(:account_delete_submitted).and_call_original
       stub_signed_in_user
       delete
-      expect(UserMailer).not_to have_received(:account_delete_submitted)
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+    end
+
+    it 'text user of account deletion' do
+      allow(Telephony).to receive(:send_account_deleted_notice).and_call_original
+      stub_signed_in_user
+      delete
+      expect(Telephony).to have_received(:send_account_deleted_notice)
     end
 
     it 'logs a succesful submit' do
@@ -114,6 +121,7 @@ RSpec.describe Users::DeleteController do
     user = create(
       :user,
       :fully_registered,
+      :with_phone,
       email: 'old_email@example.com',
       password: ControllerHelper::VALID_PASSWORD,
     )

--- a/spec/lib/telephony/alert_sender_spec.rb
+++ b/spec/lib/telephony/alert_sender_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe Telephony::AlertSender do
     Telephony::Test::Message.clear_messages
   end
 
+  describe 'send_account_deleted_notice' do
+    it 'sends the correct message' do
+      subject.send_account_deleted_notice(to: recipient, country_code: 'US')
+
+      last_message = Telephony::Test::Message.messages.last
+      expect(last_message.to).to eq(recipient)
+      expect(last_message.body).to eq(
+        I18n.t('telephony.account_deleted_notice', app_name: APP_NAME),
+      )
+    end
+  end
+
   describe 'send_account_reset_notice' do
     it 'sends the correct message' do
       subject.send_account_reset_notice(to: recipient, country_code: 'US')


### PR DESCRIPTION

## 🎫 Ticket

[LG-11897](https://cm-jira.usa.gov/browse/LG-11897)

## 🛠 Summary of changes
Send a text if a user has phone when they delete their account to notify them. 
