### PR TITLE
LG-11893: Fix Doubled 'attempts' Warning

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -100,13 +100,15 @@ function DocumentCaptureWarning({
           />
         </div>
 
-        {!isFailedDocType && remainingAttempts <= DISPLAY_ATTEMPTS && (
-          <p>
-            <HtmlTextWithStrongNoWrap
-              text={t('idv.failure.attempts_html', { count: remainingAttempts })}
-            />
-          </p>
-        )}
+        {!isFailedDocType &&
+          !isFailedSelfieLivenessOrQuality &&
+          remainingAttempts <= DISPLAY_ATTEMPTS && (
+            <p>
+              <HtmlTextWithStrongNoWrap
+                text={t('idv.failure.attempts_html', { count: remainingAttempts })}
+              />
+            </p>
+          )}
       </Warning>
       {nonIppOrFailedResult && <Cancel />}
     </>

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -50,8 +50,13 @@ describe('DocumentCaptureWarning', () => {
   function renderContent({
     isFailedDocType,
     isFailedResult,
-    isFailedSelfieLivenessOrQuality,
+    isFailedSelfieLivenessOrQuality = false,
     inPersonUrl,
+  } : {
+    isFailedDocType: boolean;
+    isFailedResult: boolean;
+    isFailedSelfieLivenessOrQuality?: boolean;
+    inPersonUrl: string;
   }) {
     const unknownFieldErrors = [
       {

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -47,7 +47,12 @@ describe('DocumentCaptureWarning', () => {
     }
   }
 
-  function renderContent({ isFailedDocType, isFailedResult, inPersonUrl }) {
+  function renderContent({
+    isFailedDocType,
+    isFailedResult,
+    isFailedSelfieLivenessOrQuality,
+    inPersonUrl,
+  }) {
     const unknownFieldErrors = [
       {
         field: 'general',
@@ -60,6 +65,7 @@ describe('DocumentCaptureWarning', () => {
           <DocumentCaptureWarning
             isFailedDocType={isFailedDocType}
             isFailedResult={isFailedResult}
+            isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
             remainingAttempts={2}
             unknownFieldErrors={unknownFieldErrors}
             actionOnClick={() => {}}
@@ -91,7 +97,7 @@ describe('DocumentCaptureWarning', () => {
     context('not failed result', () => {
       const isFailedResult = false;
       it('renders not failed doc type', () => {
-        const { getByRole, getByText } = renderContent({
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType: false,
           isFailedResult,
           inPersonUrl,
@@ -100,6 +106,7 @@ describe('DocumentCaptureWarning', () => {
         validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
         expect(getByText('general error')).to.be.ok();
+        expect(queryByText('idv.warning.attempts_html')).to.be.null();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
         // ipp section
@@ -110,7 +117,7 @@ describe('DocumentCaptureWarning', () => {
 
       it('renders with failed doc type', () => {
         const isFailedDocType = true;
-        const { getByRole, getByText } = renderContent({
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
@@ -120,6 +127,7 @@ describe('DocumentCaptureWarning', () => {
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(getByText(/idv.warning.attempts_html/)).to.be.ok();
+        expect(queryByText('idv.failure.attempts_html')).to.null();
         expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
         // ipp section
         validateIppSection(true);
@@ -132,7 +140,7 @@ describe('DocumentCaptureWarning', () => {
       const isFailedResult = true;
       it('renders not failed doc type', () => {
         const isFailedDocType = false;
-        const { getByRole, getByText } = renderContent({
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
@@ -142,6 +150,7 @@ describe('DocumentCaptureWarning', () => {
         validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
+        expect(queryByText('idv.warning.attempts_html')).to.be.null();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
         // the ipp section isn't displayed with isFailedResult=true
@@ -152,7 +161,7 @@ describe('DocumentCaptureWarning', () => {
 
       it('renders with failed doc type', () => {
         const isFailedDocType = true;
-        const { getByRole, getByText } = renderContent({
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
@@ -163,6 +172,7 @@ describe('DocumentCaptureWarning', () => {
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(getByText(/idv.warning.attempts_html/)).to.be.ok();
+        expect(queryByText('idv.failure.attempts_html')).to.null();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
         // ipp section not existing
         validateIppSection(false);
@@ -170,27 +180,28 @@ describe('DocumentCaptureWarning', () => {
         validateTroubleShootingSection();
       });
 
-      /*
       it('renders with successful selfie', () => {
         const isFailedDocType = false;
-        const { getByRole, getByText } = renderContent({
+        const isFailedSelfieLivenessOrQuality = true;
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType,
+          isFailedSelfieLivenessOrQuality,
           isFailedResult,
           inPersonUrl,
         });
 
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
+        validateHeader('errors.doc_auth.selfie_not_live_or_poor_quality_heading', 1, true);
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
-        expect(getByText(/general error/)).to.be.ok();
-        expect(getByText(/idv.warning.attempts_html/)).to.be.ok();
+        expect(getByText('general error')).to.be.ok();
+        expect(getByText('idv.warning.attempts_html')).to.be.ok();
+        expect(queryByText('idv.failure.attempts_html')).to.null();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
         // ipp section not existing
         validateIppSection(false);
         // troubleshooting section
         validateTroubleShootingSection();
       });
-      */
     });
   });
 
@@ -216,7 +227,7 @@ describe('DocumentCaptureWarning', () => {
       const isFailedResult = false;
       it('renders not failed doc type', () => {
         const isFailedDocType = false;
-        const { getByRole, getByText } = renderContent({
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
@@ -226,6 +237,7 @@ describe('DocumentCaptureWarning', () => {
         validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
+        expect(queryByText('idv.warning.attempts_html')).to.null();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
         // ipp section not displayed for non ipp
@@ -236,7 +248,7 @@ describe('DocumentCaptureWarning', () => {
 
       it('renders with failed doc type', () => {
         const isFailedDocType = true;
-        const { getByRole, getByText } = renderContent({
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
@@ -247,6 +259,7 @@ describe('DocumentCaptureWarning', () => {
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(getByText(/idv.warning.attempts_html/)).to.be.ok();
+        expect(queryByText('idv.failure.attempts_html')).to.null();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
         // ipp section not displayed for non ipp
         validateIppSection(false);
@@ -259,7 +272,7 @@ describe('DocumentCaptureWarning', () => {
       const isFailedResult = true;
       it('renders not failed doc type', () => {
         const isFailedDocType = false;
-        const { getByRole, getByText } = renderContent({
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
@@ -269,6 +282,7 @@ describe('DocumentCaptureWarning', () => {
         validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
+        expect(queryByText('idv.warning.attempts_html')).to.be.null();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
         // the ipp section isn't displayed with isFailedResult=true
@@ -279,7 +293,7 @@ describe('DocumentCaptureWarning', () => {
 
       it('renders with failed doc type', () => {
         const isFailedDocType = true;
-        const { getByRole, getByText } = renderContent({
+        const { getByRole, getByText, queryByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
@@ -289,6 +303,7 @@ describe('DocumentCaptureWarning', () => {
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(getByText(/idv.warning.attempts_html/)).to.be.ok();
+        expect(queryByText('idv.failure.attempts_html')).to.null();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
         // ipp section not existing
         validateIppSection(false);

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -47,7 +47,7 @@ describe('DocumentCaptureWarning', () => {
     }
   }
 
-  function renderCcontent(isFailedDocType, isFailedResult, inPersonUrl) {
+  function renderContent({ isFailedDocType, isFailedResult, inPersonUrl }) {
     const unknownFieldErrors = [
       {
         field: 'general',
@@ -77,7 +77,7 @@ describe('DocumentCaptureWarning', () => {
       const isFailedResult = false;
       const isFailedDocType = false;
 
-      renderCcontent(isFailedDocType, isFailedResult, inPersonUrl);
+      renderContent({ isFailedDocType, isFailedResult, inPersonUrl });
 
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
@@ -91,7 +91,11 @@ describe('DocumentCaptureWarning', () => {
     context('not failed result', () => {
       const isFailedResult = false;
       it('renders not failed doc type', () => {
-        const { getByRole, getByText } = renderCcontent(false, isFailedResult, inPersonUrl);
+        const { getByRole, getByText } = renderContent({
+          isFailedDocType: false,
+          isFailedResult,
+          inPersonUrl,
+        });
 
         validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
@@ -106,11 +110,11 @@ describe('DocumentCaptureWarning', () => {
 
       it('renders with failed doc type', () => {
         const isFailedDocType = true;
-        const { getByRole, getByText } = renderCcontent(
+        const { getByRole, getByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
-        );
+        });
         // error message section
         validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
@@ -128,11 +132,11 @@ describe('DocumentCaptureWarning', () => {
       const isFailedResult = true;
       it('renders not failed doc type', () => {
         const isFailedDocType = false;
-        const { getByRole, getByText } = renderCcontent(
+        const { getByRole, getByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
-        );
+        });
 
         // error message section
         validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
@@ -148,11 +152,11 @@ describe('DocumentCaptureWarning', () => {
 
       it('renders with failed doc type', () => {
         const isFailedDocType = true;
-        const { getByRole, getByText } = renderCcontent(
+        const { getByRole, getByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
-        );
+        });
 
         // error message section
         validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
@@ -165,6 +169,28 @@ describe('DocumentCaptureWarning', () => {
         // troubleshooting section
         validateTroubleShootingSection();
       });
+
+      /*
+      it('renders with successful selfie', () => {
+        const isFailedDocType = false;
+        const { getByRole, getByText } = renderContent({
+          isFailedDocType,
+          isFailedResult,
+          inPersonUrl,
+        });
+
+        // error message section
+        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
+        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        expect(getByText(/general error/)).to.be.ok();
+        expect(getByText(/idv.warning.attempts_html/)).to.be.ok();
+        expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
+        // ipp section not existing
+        validateIppSection(false);
+        // troubleshooting section
+        validateTroubleShootingSection();
+      });
+      */
     });
   });
 
@@ -175,7 +201,7 @@ describe('DocumentCaptureWarning', () => {
       const isFailedResult = true;
       const isFailedDocType = true;
 
-      renderCcontent(isFailedDocType, isFailedResult, inPersonUrl);
+      renderContent({ isFailedDocType, isFailedResult, inPersonUrl });
 
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
@@ -190,11 +216,11 @@ describe('DocumentCaptureWarning', () => {
       const isFailedResult = false;
       it('renders not failed doc type', () => {
         const isFailedDocType = false;
-        const { getByRole, getByText } = renderCcontent(
+        const { getByRole, getByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
-        );
+        });
 
         // error message section
         validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
@@ -210,11 +236,11 @@ describe('DocumentCaptureWarning', () => {
 
       it('renders with failed doc type', () => {
         const isFailedDocType = true;
-        const { getByRole, getByText } = renderCcontent(
+        const { getByRole, getByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
-        );
+        });
 
         // error message section
         validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
@@ -233,11 +259,11 @@ describe('DocumentCaptureWarning', () => {
       const isFailedResult = true;
       it('renders not failed doc type', () => {
         const isFailedDocType = false;
-        const { getByRole, getByText } = renderCcontent(
+        const { getByRole, getByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
-        );
+        });
 
         // error message section
         validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
@@ -253,11 +279,11 @@ describe('DocumentCaptureWarning', () => {
 
       it('renders with failed doc type', () => {
         const isFailedDocType = true;
-        const { getByRole, getByText } = renderCcontent(
+        const { getByRole, getByText } = renderContent({
           isFailedDocType,
           isFailedResult,
           inPersonUrl,
-        );
+        });
         // error message section
         validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
         validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -52,11 +52,6 @@ describe('DocumentCaptureWarning', () => {
     isFailedResult,
     isFailedSelfieLivenessOrQuality = false,
     inPersonUrl,
-  } : {
-    isFailedDocType: boolean;
-    isFailedResult: boolean;
-    isFailedSelfieLivenessOrQuality?: boolean;
-    inPersonUrl: string;
   }) {
     const unknownFieldErrors = [
       {


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-11893

## 🛠 Summary of changes

After [this PR](https://github.com/18F/identity-idp/pull/9975) merged the attempts header started showing up twice in some situations.

![Screenshot 2024-02-01 at 10 24 39 AM](https://github.com/18F/identity-idp/assets/6818839/5f4059b3-4414-4e98-8708-93bffac9fab8)

This is because we have two very similar (but not identical) headers:
- `idv.failure.attempts_html`
- `idv.warning.attempts_html`
In the situation where the `isFailedDocType == false` and `isFailedSelfieLivenessOrQuality == true` we were sometimes showing both headers.

I wasn't able to reproduce for some reason, so I instead wrote a test.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Run the modified spec file without the changes to `document-capture-warning.tsx`
    - [ ] `git checkout charley/lg-11893-fix-double-attempt-warning`
    - [ ] `git checkout main -- app/javascript/packages/document-capture/components/document-capture-warning.tsx`
    - [ ] `yarn run mocha spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx`
    - [ ] The selfie test should fail because it's seeing both `idv.failure.attempts_html` and `idv.warning.attempts_html`.
- [ ] Now, apply the changes in `document-capture-warning.tsx` (by checking out the version in this branch again)
    - [ ] The tests should now pass.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
