### PR TITLE
Send RISC password reset to confirmed emails

### DIFF
--- a/app/services/reset_user_password.rb
+++ b/app/services/reset_user_password.rb
@@ -32,7 +32,7 @@ class ResetUserPassword
   end
 
   def notify_user
-    user.email_addresses.each do |email_address|
+    user.confirmed_email_addresses.each do |email_address|
       UserMailer.with(user: user, email_address: email_address).please_reset_password.
         deliver_now_or_later
     end

--- a/spec/services/reset_user_password_spec.rb
+++ b/spec/services/reset_user_password_spec.rb
@@ -19,12 +19,13 @@ RSpec.describe ResetUserPassword do
         to(change { user.events.password_invalidated.size }.from(0).to(1))
     end
 
-    it 'notifies the user via email to each of their email addresses' do
+    it 'notifies the user via email to each of their confirmed email addresses' do
+      create(:email_address, user:, email: Faker::Internet.safe_email, confirmed_at: nil)
       expect { call }.
         to(change { ActionMailer::Base.deliveries.count }.by(2))
 
       mails = ActionMailer::Base.deliveries.last(2)
-      expect(mails.map(&:to).flatten).to match_array(user.email_addresses.map(&:email))
+      expect(mails.map(&:to).flatten).to match_array(user.confirmed_email_addresses.map(&:email))
     end
 
     it 'clears all remembered browsers by updating the remember_device_revoked_at timestamp' do


### PR DESCRIPTION
## 🛠 Summary of changes

Updates logic of password reset notifications to send to a user's confirmed email addresses, for consistency.

## 📜 Testing Plan

Verify that updated test passes:

```
rspec app/forms/security_event_form.rb
```

Testing this in practice may be more involved, either initializing the class in a `rails console` or enabling the `reset_password_on_auth_fraud_event` feature and sending a RISC event to the local server.