### PR TITLE
Target specific failing files for ESLint React overrides

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,8 @@
         "selector": "AssignmentExpression[left.property.name='href'][right.type=/(Template)?Literal/]",
         "message": "Do not assign window.location.href to a string or string template to avoid losing i18n parameters"
       }
-    ]
+    ],
+    "react-hooks/exhaustive-deps": "error"
   },
   "settings": {
     "import/internal-regex": "^@18f/identity-"
@@ -50,69 +51,80 @@
       }
     },
     {
-      // Turn off react linting rules for most packages/files
       "files": [
-        "spec/**",
-        "app/javascript/packs/**",
-        "app/javascript/packages/address-search/**",
-        "app/javascript/packages/components/**",
-        "app/javascript/packages/compose-components/**",
-        "app/javascript/packages/form-steps/**",
-        "app/javascript/packages/react-hooks/**",
-        "app/javascript/packages/react-i18n/**",
-        "app/javascript/packages/spinner-button/**",
-        "app/javascript/packages/step-indicator/**",
-        "app/javascript/packages/validated-field/**",
-        "app/javascript/packages/verify-flow/**",
-        // In progress: enabling these rules for all files in packages/document-capture
-        "app/javascript/packages/document-capture/context/**",
-        "app/javascript/packages/document-capture/higher-order/**",
-        "app/javascript/packages/document-capture/hooks/**",
-        // Comment out a file to enable react lint rules for that file only
+        "app/javascript/packages/address-search/components/address-input.tsx",
+        "app/javascript/packages/address-search/components/full-address-search-input.tsx",
+        "app/javascript/packages/components/hooks/use-focus-trap.ts",
+        "app/javascript/packages/components/hooks/use-toggle-body-class-by-presence.ts",
         "app/javascript/packages/document-capture/components/acuant-camera.tsx",
         "app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx",
         "app/javascript/packages/document-capture/components/acuant-capture.tsx",
         "app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx",
-        "app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx",
-        "app/javascript/packages/document-capture/components/barcode-attention-warning.tsx",
         "app/javascript/packages/document-capture/components/callback-on-mount.jsx",
-        "app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx",
         "app/javascript/packages/document-capture/components/document-capture-warning.tsx",
         "app/javascript/packages/document-capture/components/document-capture.tsx",
-        "app/javascript/packages/document-capture/components/document-side-acuant-capture.jsx",
-        "app/javascript/packages/document-capture/components/documents-step.jsx",
         "app/javascript/packages/document-capture/components/file-image.jsx",
         "app/javascript/packages/document-capture/components/file-input.tsx",
-        "app/javascript/packages/document-capture/components/hybrid-doc-capture-warning.spec.tsx",
-        "app/javascript/packages/document-capture/components/hybrid-doc-capture-warning.tsx",
-        "app/javascript/packages/document-capture/components/in-person-call-to-action.spec.tsx",
-        "app/javascript/packages/document-capture/components/in-person-call-to-action.tsx",
-        "app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx",
         "app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx",
-        "app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.spec.tsx",
         "app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx",
-        "app/javascript/packages/document-capture/components/in-person-outage-alert.spec.tsx",
-        "app/javascript/packages/document-capture/components/in-person-outage-alert.tsx",
-        "app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx",
-        "app/javascript/packages/document-capture/components/in-person-prepare-step.tsx",
         "app/javascript/packages/document-capture/components/in-person-switch-back-step.tsx",
-        "app/javascript/packages/document-capture/components/in-person-troubleshooting-options.tsx",
         "app/javascript/packages/document-capture/components/review-issues-step.tsx",
-        "app/javascript/packages/document-capture/components/status-message.jsx",
-        "app/javascript/packages/document-capture/components/submission-complete.tsx",
         "app/javascript/packages/document-capture/components/submission-interstitial.jsx",
-        "app/javascript/packages/document-capture/components/submission-status.tsx",
+        "app/javascript/packages/document-capture/context/acuant.tsx",
+        "app/javascript/packages/document-capture/hooks/use-cookie.js",
+        "app/javascript/packages/form-steps/form-steps.spec.tsx",
+        "app/javascript/packages/form-steps/form-steps.tsx",
+        "app/javascript/packages/form-steps/use-history-param.ts",
+        "app/javascript/packages/react-hooks/use-did-update-effect.ts",
+        "app/javascript/packages/react-hooks/use-immutable-callback.ts",
+        "app/javascript/packages/react-hooks/use-object-memo.ts"
+      ],
+      "rules": {
+        "react-hooks/exhaustive-deps": "off"
+      }
+    },
+    {
+      "files": [
+        "app/javascript/packages/address-search/components/in-person-locations.spec.tsx",
+        "app/javascript/packages/components/spinner-dots.jsx",
+        "app/javascript/packages/document-capture/components/acuant-capture.tsx",
+        "app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx",
+        "app/javascript/packages/document-capture/components/document-side-acuant-capture.jsx",
+        "app/javascript/packages/document-capture/components/file-image.jsx",
+        "app/javascript/packages/document-capture/components/file-input.tsx",
+        "app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.tsx",
+        "app/javascript/packages/document-capture/components/in-person-location-post-office-search-step.tsx",
+        "app/javascript/packages/document-capture/components/in-person-prepare-step.tsx",
+        "app/javascript/packages/document-capture/components/submission-interstitial.jsx",
         "app/javascript/packages/document-capture/components/submission.jsx",
-        "app/javascript/packages/document-capture/components/suspense-error-boundary.jsx",
-        "app/javascript/packages/document-capture/components/tip-list.tsx",
-        "app/javascript/packages/document-capture/components/unknown-error.tsx",
+        "spec/javascript/packages/document-capture/context/failed-capture-attempts-spec.jsx",
+        "spec/javascript/packages/document-capture/hooks/use-async-spec.jsx"
+      ],
+      "rules": {
+        "react/prop-types": "off"
+      }
+    },
+    {
+      "files": [
+        "app/javascript/packages/components/status-page.spec.tsx",
         "app/javascript/packages/document-capture/components/warning.tsx"
       ],
       "rules": {
-        "react/prop-types": "off",
-        "react/display-name": "off",
-        "react/jsx-key": "off",
-        "react-hooks/exhaustive-deps": "off",
+        "react/jsx-key": "off"
+      }
+    },
+    {
+      "files": ["app/javascript/packages/document-capture/higher-order/with-props.jsx"],
+      "rules": {
+        "react/display-name": "off"
+      }
+    },
+    {
+      "files": [
+        "app/javascript/packages/form-steps/form-steps.spec.tsx",
+        "spec/javascript/spec_helper.js"
+      ],
+      "rules": {
         "react-hooks/rules-of-hooks": "off"
       }
     }


### PR DESCRIPTION
## 🛠 Summary of changes

Updates existing React ESLint overrides to specifically target individual failures in individual files.

Also escalates ESLint warnings to errors. Warnings are ignored; either we care enough to fail the build or they shouldn't be flagged at all.

**Why?**

- Prevent the addition of new files with problems (i.e. avoid directory glob pattern exclusions)
- Prevent the addition of new problems in existing files which don't already have that problem (i.e. per-rule file overrides)
- Avoid maintenance overhead for non-problematic files ([example](https://github.com/18F/identity-idp/pull/10023#pullrequestreview-1860379901))

## 📜 Testing Plan

`yarn lint` passes