### PR TITLE
LG-12300 Exclude Deleted Users from the Reuse Report

### DIFF
--- a/app/services/reporting/account_reuse_report.rb
+++ b/app/services/reporting/account_reuse_report.rb
@@ -96,6 +96,8 @@ module Reporting
       self
     end
 
+    # Each EntityReuseSummary (there are two - apps and agencies) contains
+    # a ReuseDetailSection which is made up of individual ReuseDetailRows
     ReuseDetailSection = Struct.new(:detail_rows) do
       def initialize(detail_rows: [ReuseDetailRow.new])
         super(detail_rows:)

--- a/app/services/reporting/account_reuse_report.rb
+++ b/app/services/reporting/account_reuse_report.rb
@@ -143,6 +143,10 @@ module Reporting
       self
     end
 
+    # The Reuse Report has two parts: One for sp(app) reuse and one for agency reuse
+    # The EntityReuseSummary is the structure for each part, it consists of:
+    # - A ReuseDetailsSection (made up of ReuseDetailRows)
+    # - A Summary Row (which holds the data for 2+ Entities)
     EntityReuseSummary = Struct.new(
       :details_section,
       :total_all_users, :total_all_percent,
@@ -179,20 +183,25 @@ module Reporting
           end
         end
 
-        results.each_with_index do |details_section, section_index|
-          details_section.select { |details| details.num_entities >= 10 }.
-            reduce do |summary_row, captured_row|
-              # Delete any rows after the first captured_row (which becomes the summary_row)
-              details_section.delete(captured_row) if captured_row != summary_row
-              summary_row.update_details(
-                num_entities: "10-#{captured_row.num_entities}",
-                entity_type: summary_row.entity_type,
-                num_all_users: summary_row.num_all_users + captured_row.num_all_users,
-                all_percent: summary_row.all_percent + captured_row.all_percent,
-                num_idv_users: summary_row.num_idv_users + captured_row.num_idv_users,
-                idv_percent: summary_row.idv_percent + captured_row.idv_percent,
-              )
-            end
+        # If there are rows that capture data on 10 or more entities,
+        # they all get condensed into one row here
+        results.each do |details_section|
+          # Only condense the rows if there is more than one row in the 10+ range
+          if details_section.count { |details| details.num_entities >= 10 } > 1
+            details_section.select { |details| details.num_entities >= 10 }.
+              reduce do |condensed_row, captured_row|
+                # Delete any rows after the first captured_row (which becomes the condensed_row)
+                details_section.delete(captured_row) if captured_row != condensed_row
+                condensed_row.update_details(
+                  num_entities: "10-#{captured_row.num_entities}",
+                  entity_type: condensed_row.entity_type,
+                  num_all_users: condensed_row.num_all_users + captured_row.num_all_users,
+                  all_percent: condensed_row.all_percent + captured_row.all_percent,
+                  num_idv_users: condensed_row.num_idv_users + captured_row.num_idv_users,
+                  idv_percent: condensed_row.idv_percent + captured_row.idv_percent,
+                )
+              end
+          end
         end
 
         self.details_section = results
@@ -249,6 +258,8 @@ module Reporting
                 , identities.user_id
             FROM
                 identities
+            JOIN
+                users on users.id = identities.user_id
             WHERE
                 identities.created_at < %{query_date}
             GROUP BY
@@ -256,7 +267,7 @@ module Reporting
         ) sps_per_all_users
         GROUP BY
             sps_per_all_users.num_apps
-        HAVING 
+        HAVING
             sps_per_all_users.num_apps > 1
         ORDER BY
             num_apps ASC
@@ -280,6 +291,8 @@ module Reporting
                 , identities.user_id
             FROM
                 identities
+            JOIN
+                users on users.id = identities.user_id
             WHERE
                 identities.last_ial2_authenticated_at IS NOT NULL
             AND
@@ -289,7 +302,7 @@ module Reporting
         ) sps_per_idv_users
         GROUP BY
             sps_per_idv_users.num_apps
-        HAVING 
+        HAVING
             sps_per_idv_users.num_apps > 1
         ORDER BY
             num_apps ASC
@@ -314,6 +327,8 @@ module Reporting
           FROM
               identities
           JOIN
+              users on users.id = identities.user_id
+          JOIN
               service_providers sp ON identities.service_provider = sp.issuer
           JOIN
               agencies ON sp.agency_id = agencies.id
@@ -324,7 +339,7 @@ module Reporting
       ) agencies_per_user
       GROUP BY
           agencies_per_user.num_agencies
-      HAVING 
+      HAVING
           agencies_per_user.num_agencies > 1
       ORDER BY
           num_agencies ASC
@@ -349,6 +364,8 @@ module Reporting
             FROM
                 identities
             JOIN
+                users on users.id = identities.user_id
+            JOIN
                 service_providers sp ON identities.service_provider = sp.issuer
             JOIN
                 agencies ON sp.agency_id = agencies.id
@@ -361,7 +378,7 @@ module Reporting
         ) agencies_per_user
         GROUP BY
             agencies_per_user.num_agencies
-        HAVING 
+        HAVING
             agencies_per_user.num_agencies > 1
         ORDER BY
             num_agencies ASC

--- a/spec/services/reporting/account_reuse_report_spec.rb
+++ b/spec/services/reporting/account_reuse_report_spec.rb
@@ -151,123 +151,141 @@ RSpec.describe Reporting::AccountReuseReport do
       # This will give 9 users with 2 agencies for the IDV agency report
       # This will give 13 users with 2 agencies for the ALL agency report
 
-      users_to_query = [
-        { id: 1, # 3 apps, 2 agencies
+      mock_users_to_query = [
+        { # 3 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(3),
-          sp_timestamp: Array.new(3) { in_query } },
-        { id: 2, # 3 apps, 2 agencies
+          sp_timestamp: Array.new(3) { in_query },
+        },
+        { # 3 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(3),
-          sp_timestamp: [in_query, in_query, out_of_query] },
-        { id: 3, # 3 apps, 2 agencies
+          sp_timestamp: [in_query, in_query, out_of_query],
+        },
+        { # 3 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(3),
-          sp_timestamp: [in_query, out_of_query, out_of_query] },
-        { id: 4, # 3 apps, 2 agencies
+          sp_timestamp: [in_query, out_of_query, out_of_query],
+        },
+        { # 3 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(3),
-          sp_timestamp: [in_query, out_of_query, out_of_query] },
-        { id: 5, # 3 apps, 2 agencies
+          sp_timestamp: [in_query, out_of_query, out_of_query],
+        },
+        { # 3 apps, 2 agencies
           created_timestamp: out_of_query,
           sp: all_agency_apps.first(3),
-          sp_timestamp: Array.new(3) { out_of_query } },
-        { id: 6, # 2 apps, 2 agencies
+          sp_timestamp: Array.new(3) { out_of_query },
+        },
+        { # 2 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(2),
-          sp_timestamp: Array.new(2) { in_query } },
-        { id: 7, # 2 apps, 1 agency
+          sp_timestamp: Array.new(2) { in_query },
+        },
+        { # 2 apps, 1 agency
           created_timestamp: in_query,
           sp: agency1_apps.first(2),
-          sp_timestamp: Array.new(2) { in_query } },
-        { id: 8, # 2 apps, 2 agencies
+          sp_timestamp: Array.new(2) { in_query },
+        },
+        { # 2 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(2),
-          sp_timestamp: [in_query, out_of_query] },
-        { id: 9,  # 2 apps, 1 agency
+          sp_timestamp: [in_query, out_of_query],
+        },
+        { # 2 apps, 1 agency
           created_timestamp: in_query,
           sp: agency1_apps.first(2),
-          sp_timestamp: [in_query, out_of_query] },
-        { id: 10, # 2 apps, 2 agencies
+          sp_timestamp: [in_query, out_of_query],
+        },
+        { # 2 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(2),
-          sp_timestamp: Array.new(2) { out_of_query } },
-        { id: 11, # 2 apps, 2 agencies
+          sp_timestamp: Array.new(2) { out_of_query },
+        },
+        { # 2 apps, 2 agencies
           created_timestamp: out_of_query,
           sp: all_agency_apps.first(2),
-          sp_timestamp: Array.new(2) { out_of_query } },
-        { id: 12,
+          sp_timestamp: Array.new(2) { out_of_query },
+        },
+        { # 1 app, 1 agency
           created_timestamp: in_query,
           sp: [sp_a],
-          sp_timestamp: [in_query] },
-        { id: 13,
+          sp_timestamp: [in_query],
+        },
+        { # 1 app, 1 agency
           created_timestamp: in_query,
           sp: [sp_a],
-          sp_timestamp: [out_of_query] },
-        { id: 14,
+          sp_timestamp: [out_of_query],
+        },
+        { # 1 app, 1 agency
           created_timestamp: out_of_query,
           sp: [sp_a],
-          sp_timestamp: [out_of_query] },
-        { id: 15, # 12 apps, 2 agencies
+          sp_timestamp: [out_of_query],
+        },
+        { # 12 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps,
-          sp_timestamp: Array.new(12) { in_query } },
-        { id: 16, # 11 apps, 2 agencies
+          sp_timestamp: Array.new(12) { in_query },
+        },
+        { # 11 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(11),
-          sp_timestamp: Array.new(11) { in_query } },
-        { id: 17, # 11 apps, 2 agencies
+          sp_timestamp: Array.new(11) { in_query },
+        },
+        { # 11 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(11),
-          sp_timestamp: Array.new(11) { in_query } },
-        { id: 18, # 10 apps, 2 agencies
+          sp_timestamp: Array.new(11) { in_query },
+        },
+        { # 10 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(10),
-          sp_timestamp: Array.new(10) { in_query } },
-        { id: 19, # 10 apps, 2 agencies
+          sp_timestamp: Array.new(10) { in_query },
+        },
+        { # 10 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(10),
-          sp_timestamp: Array.new(10) { in_query } },
-        { id: 20, # 10 apps, 2 agencies
+          sp_timestamp: Array.new(10) { in_query },
+        },
+        { # 10 apps, 2 agencies
           created_timestamp: in_query,
           sp: all_agency_apps.first(10),
-          sp_timestamp: Array.new(9) { in_query } + Array.new(1) { out_of_query } },
-        { id: 21, # 3 apps, 2 agencies - User gets deleted
-          created_timestamp: in_query,
+          sp_timestamp: Array.new(9) { in_query } + Array.new(1) { out_of_query },
+        },
+        { # 3 apps, 2 agencies - Last user gets deleted
+          created_timestamp: in_query - 1.day, # change so last is unique
           sp: all_agency_apps.first(3),
-          sp_timestamp: Array.new(3) { in_query } },
+          sp_timestamp: Array.new(3) { in_query },
+        },
       ]
 
-      users_to_query.each do |user|
-        user[:sp].each_with_index do |sp, i|
+      mock_users_to_query.each do |mock_user|
+        current_user = create(:user, :fully_registered, registered_at: in_query)
+
+        mock_user[:sp].each_with_index do |sp, i|
           ServiceProviderIdentity.create(
-            user_id: user[:id],
+            user_id: current_user[:id],
             service_provider: sp,
-            created_at: user[:created_timestamp],
+            created_at: mock_user[:created_timestamp],
             last_ial2_authenticated_at: in_query,
-            verified_at: user[:sp_timestamp][i],
+            verified_at: mock_user[:sp_timestamp][i],
           )
         end
 
-        if user[:id] == 21
-          user_to_delete = User.create({ id: user[:id] })
-          DeletedUser.create_from_user(user_to_delete)
-          user_to_delete.destroy!
+        if mock_user == mock_users_to_query.last
+          DeletedUser.create_from_user(current_user)
+          current_user.destroy!
         else
-          User.create({ id: user[:id] })
+          create(
+            :profile,
+            :active,
+            activated_at: in_query,
+            user: current_user,
+          )
         end
       end
 
-      # Create active profiles for total_proofed_identities
-      # These 30 profiles will yield 20 active profiles in the results
-      20.times do
-        create(
-          :profile,
-          :active,
-          activated_at: in_query,
-          user: create(:user, :fully_registered, registered_at: in_query),
-        )
-      end
+      # Create active profiles that are out of query for total_proofed_identities
       10.times do
         create(
           :profile,


### PR DESCRIPTION
changelog: Internal, Reporting, Exclude deleted users from Reuse Rate Report

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12300](https://cm-jira.usa.gov/browse/LG-12300)

## 🛠 Summary of changes

The Reuse Rate Report within the Monthly Key Metrics Report had been including deleted users in the results, these changes remove the deleted users from the queries so they are not counted.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
