### PR TITLE
LG-12249: Log sign-in flow for SP redirect analytics event

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -199,6 +199,7 @@ module OpenidConnect
       analytics.sp_redirect_initiated(
         ial: event_ial_context.ial,
         billed_ial: event_ial_context.bill_for_ial_1_or_2,
+        sign_in_flow: session[:sign_in_flow],
       )
       track_billing_events
     end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -175,6 +175,7 @@ class SamlIdpController < ApplicationController
     analytics.sp_redirect_initiated(
       ial: ial_context.ial,
       billed_ial: ial_context.bill_for_ial_1_or_2,
+      sign_in_flow: session[:sign_in_flow],
     )
     track_billing_events
   end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -57,6 +57,7 @@ module SignUp
 
       resend_confirmation = params[:user][:resend]
       session[:email] = @register_user_email_form.email
+      session[:sign_in_flow] = :create_account
 
       redirect_to sign_up_verify_email_url(resend: resend_confirmation)
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -32,6 +32,7 @@ module Users
     end
 
     def create
+      session[:sign_in_flow] = :sign_in
       return process_locked_out_session if session_bad_password_count_max_exceeded?
       return process_locked_out_user if current_user && user_locked_out?(current_user)
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4417,7 +4417,7 @@ module AnalyticsEvents
   # Tracks when a user is redirected back to the service provider
   # @param [Integer] ial
   # @param [Integer] billed_ial
-  # @param [String] sign_in_flow
+  # @param [String, nil] sign_in_flow
   def sp_redirect_initiated(ial:, billed_ial:, sign_in_flow:, **extra)
     track_event(
       'SP redirect initiated',

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4417,11 +4417,13 @@ module AnalyticsEvents
   # Tracks when a user is redirected back to the service provider
   # @param [Integer] ial
   # @param [Integer] billed_ial
-  def sp_redirect_initiated(ial:, billed_ial:, **extra)
+  # @param [String] sign_in_flow
+  def sp_redirect_initiated(ial:, billed_ial:, sign_in_flow:, **extra)
     track_event(
       'SP redirect initiated',
-      ial: ial,
-      billed_ial: billed_ial,
+      ial:,
+      billed_ial:,
+      sign_in_flow:,
       **extra,
     )
   end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -43,8 +43,10 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
 
     context 'user is signed in' do
       let(:user) { create(:user, :fully_registered) }
+      let(:sign_in_flow) { :sign_in }
       before do
         stub_sign_in user
+        session[:sign_in_flow] = sign_in_flow
       end
 
       context 'with valid params' do
@@ -122,6 +124,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               'SP redirect initiated',
               ial: 1,
               billed_ial: 1,
+              sign_in_flow:,
             )
 
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
@@ -269,6 +272,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                   'SP redirect initiated',
                   ial: 2,
                   billed_ial: 2,
+                  sign_in_flow:,
                 )
 
               IdentityLinker.new(user, service_provider).link_identity(ial: 2)
@@ -507,6 +511,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                     'SP redirect initiated',
                     ial: 0,
                     billed_ial: 2,
+                    sign_in_flow:,
                   )
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 2)
@@ -585,12 +590,12 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                        client_id: client_id,
                        user_sp_authorized: true,
                        code_digest: kind_of(String))
-                expect(@analytics).to receive(:track_event).
-                  with(
-                    'SP redirect initiated',
-                    ial: 0,
-                    billed_ial: 1,
-                  )
+                expect(@analytics).to receive(:track_event).with(
+                  'SP redirect initiated',
+                  ial: 0,
+                  billed_ial: 1,
+                  sign_in_flow:,
+                )
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -670,12 +675,12 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                        client_id: client_id,
                        user_sp_authorized: true,
                        code_digest: kind_of(String))
-                expect(@analytics).to receive(:track_event).
-                  with(
-                    'SP redirect initiated',
-                    ial: 0,
-                    billed_ial: 1,
-                  )
+                expect(@analytics).to receive(:track_event).with(
+                  'SP redirect initiated',
+                  ial: 0,
+                  billed_ial: 1,
+                  sign_in_flow:,
+                )
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -477,6 +477,22 @@ RSpec.feature 'Sign Up', allowed_extra_analytics: [:*] do
     expect(page).to have_current_path phone_setup_path
   end
 
+  it 'logs expected analytics events for end-to-end sign-up' do
+    analytics = FakeAnalytics.new
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(analytics)
+
+    visit_idp_from_sp_with_ial1(:oidc)
+    register_user
+    click_agree_and_continue
+
+    expect(analytics).to have_logged_event(
+      'SP redirect initiated',
+      ial: 1,
+      billed_ial: 1,
+      sign_in_flow: 'create_account',
+    )
+  end
+
   describe 'visiting the homepage by clicking the logo image' do
     context 'on the password confirmation screen' do
       before do


### PR DESCRIPTION
## 🎫 Ticket

[LG-12249](https://cm-jira.usa.gov/browse/LG-12249)

## 🛠 Summary of changes

Updates "SP redirect initiated" to include a detail describing the sign-in flow used to get to that point, either `:sign_in` or `:create_account`.

The intent of this detail is to be able to understand average times to create an account or sign in. This will be used in combination with the `session_duration` property to produce average/median/percentile values for account creation and sign in timings.

## 📜 Testing Plan

1. Have both `identity-idp` and either [OIDC sample app](https://github.com/18F/identity-oidc-sinatra) or [SAML sample app](https://github.com/18F/identity-saml-sinatra) running
2. In a separate terminal tab, run `EVENT_NAME="SP redirect initiated" make watch_events`
3. Start from http://localhost:9292 (OIDC) or http://localhost:4567 (SAML)
4. Click "Sign in"
5. Sign in or create an account
6. Complete the entire flow until you're returned to the partner application
7. In the terminal tab from Step 2, observe the "SP redirect initiated" event includes a `sign_in_flow` property value corresponding to the flow you started at Step 5