### PR TITLE
LG-12081: set inline error when there is pii error.

### DIFF
--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -66,7 +66,7 @@ module Idv
     def self.present_error(existing_errors)
       return if existing_errors.blank?
       if existing_errors.any? do |k, v|
-        %i[name dob address1 state zipcode jurisdiction state_id_number dob_min_age].include?(k)
+        PII_ERROR_KEYS.include?(k)
       end
         existing_errors[:front] = [I18n.t('doc_auth.errors.general.multiple_front_id_failures')]
         existing_errors[:back] = [I18n.t('doc_auth.errors.general.multiple_back_id_failures')]
@@ -79,6 +79,8 @@ module Idv
     end
 
     private
+
+    PII_ERROR_KEYS = %i[name dob address1 state zipcode jurisdiction state_id_number dob_min_age]
 
     attr_reader :pii_from_doc
 

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -58,9 +58,8 @@ module Idv
       keypaths
     end
 
-    # Modifies the errors object and consolidate/mutate it,
-    # used in image_upload_response_presenter to customizer
-    # error message rendering for pii errors
+    # Modifies the errors object, used in image_upload_response_presenter to customize
+    # error messages for rendering  pii errors
     #
     # errors: The DocPiiForm errors object
     def self.present_error(existing_errors)

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -64,13 +64,10 @@ module Idv
     # errors: The DocPiiForm errors object
     def self.present_error(existing_errors)
       return if existing_errors.blank?
-      if existing_errors.any? do |k, v|
-        PII_ERROR_KEYS.include?(k)
-      end
+      if existing_errors.any? { |k, v| PII_ERROR_KEYS.include?(k) }
         existing_errors[:front] = [I18n.t('doc_auth.errors.general.multiple_front_id_failures')]
         existing_errors[:back] = [I18n.t('doc_auth.errors.general.multiple_back_id_failures')]
       end
-
       if existing_errors.many? { |k, v| %i[name dob dob_min_age state].include?(k) }
         existing_errors.slice!(:front, :back)
         existing_errors[:pii] = [I18n.t('doc_auth.errors.general.no_liveness')]

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -1,6 +1,7 @@
 module Idv
   class DocPiiForm
     include ActiveModel::Model
+    include ActiveModel::Validations::Callbacks
 
     validate :name_valid?
     validate :dob_valid?
@@ -16,6 +17,8 @@ module Idv
     validates_presence_of :state_id_number, { message: proc {
       I18n.t('doc_auth.errors.general.no_liveness')
     } }
+
+    after_validation :set_inline_error
 
     attr_reader :first_name, :last_name, :dob, :address1, :state, :zipcode, :attention_with_barcode,
                 :jurisdiction, :state_id_number
@@ -103,6 +106,21 @@ module Idv
 
     def dob_min_age_error
       I18n.t('doc_auth.errors.pii.birth_date_min_age')
+    end
+
+    def set_inline_error
+      if errors.any?
+        errors.add(
+          :front,
+          I18n.t('doc_auth.errors.general.multiple_front_id_failures'),
+          type: :front,
+        )
+        errors.add(
+          :back,
+          I18n.t('doc_auth.errors.general.multiple_back_id_failures'),
+          type: :back,
+        )
+      end
     end
   end
 end

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -11,10 +11,8 @@ class ImageUploadResponsePresenter
   end
 
   def errors
-    form_response_errors = @form_response.errors.clone
-    if form_response_errors.many? { |k, v| %i[name dob dob_min_age state].include?(k) }
-      form_response_errors = { pii: [I18n.t('doc_auth.errors.general.no_liveness')] }
-    end
+    form_response_errors = @form_response.errors.deep_dup
+    Idv::DocPiiForm.present_error(form_response_errors)
     form_response_errors.except(:hints).flat_map do |key, errs|
       Array(errs).map { |err| { field: key, message: err } }
     end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -1240,6 +1240,14 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
             field: 'dob',
             message: I18n.t('doc_auth.errors.alerts.birth_date_checks'),
           },
+          {
+            field: 'front',
+            message: I18n.t('doc_auth.errors.general.multiple_front_id_failures'),
+          },
+          {
+            field: 'back',
+            message: I18n.t('doc_auth.errors.general.multiple_back_id_failures'),
+          },
         ]
       end
     end

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -440,6 +440,19 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
         sleep(10)
       end
 
+      it 'shows selfie inline error messages for both front and back' do
+        expect(page).to have_css(
+          '.usa-error-message[role="alert"]',
+          text: t('doc_auth.errors.general.multiple_front_id_failures'),
+          count: 1,
+        )
+        expect(page).to have_css(
+          '.usa-error-message[role="alert"]',
+          text: t('doc_auth.errors.general.multiple_back_id_failures'),
+          count: 1,
+        )
+      end
+
       it 'stops user submitting the same images again' do
         expect(fake_analytics).to have_logged_event(
           'IdV: doc auth document_capture visited',

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -293,12 +293,6 @@ RSpec.describe Idv::DocPiiForm do
       expect(result.errors[:state_id_number]).to eq(
         [I18n.t('doc_auth.errors.general.no_liveness')],
       )
-      expect(result.errors[:front]).to eq(
-        [I18n.t('doc_auth.errors.general.multiple_front_id_failures')],
-      )
-      expect(result.errors[:back]).to eq(
-        [I18n.t('doc_auth.errors.general.multiple_back_id_failures')],
-      )
     end
   end
 end

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -293,6 +293,12 @@ RSpec.describe Idv::DocPiiForm do
       expect(result.errors[:state_id_number]).to eq(
         [I18n.t('doc_auth.errors.general.no_liveness')],
       )
+      expect(result.errors[:front]).to eq(
+        [I18n.t('doc_auth.errors.general.multiple_front_id_failures')],
+      )
+      expect(result.errors[:back]).to eq(
+        [I18n.t('doc_auth.errors.general.multiple_back_id_failures')],
+      )
     end
   end
 end

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -270,6 +270,51 @@ RSpec.describe ImageUploadResponsePresenter do
       end
     end
 
+    context 'pii_error' do
+      describe 'there are multiple pii errors' do
+        let(:form_response) do
+          FormResponse.new(
+            success: false,
+            errors: {
+              dob: 'Invalid dob',
+              name: 'Missing',
+            },
+            extra: extra_attributes,
+          )
+        end
+        it 'processes multiple pii errors' do
+          expect(presenter.errors).to include(
+            hash_including(field: :pii),
+            hash_including(field: :front),
+            hash_including(field: :back),
+          )
+        end
+      end
+      describe 'there is one related pii error' do
+        let(:form_response) do
+          FormResponse.new(
+            success: false,
+            errors: {
+              dob_min_age: 'age too young',
+            },
+            extra: extra_attributes,
+          )
+        end
+        it 'processes the pii error' do
+          expect(presenter.errors).to include(
+            hash_including(field: :dob_min_age),
+            hash_including(
+              field: :front,
+              message: I18n.t('doc_auth.errors.general.multiple_front_id_failures'),
+            ),
+            hash_including(
+              field: :back,
+              message: I18n.t('doc_auth.errors.general.multiple_back_id_failures'),
+            ),
+          )
+        end
+      end
+    end
     context 'with form response as attention with barcode' do
       let(:form_response) do
         response = DocAuth::Response.new(


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-12081](https://cm-jira.usa.gov/browse/LG-12081)


## 🛠 Summary of changes

Here I kind of flag it for `front` and `back` error in `DocPiiForm` using `after_validation` callback. This works nicely but it includes the `front` and `back` as the part of `error_details` in event log.

The other way is like hat @amirbey  did to consolidate the error like following, but doing here is kind of scattering the logic around and is not the best for awareness.

https://github.com/18F/identity-idp/blob/a199bdd3545917f941ede1c3c5dc6ce08786a281/app/presenters/image_upload_response_presenter.rb#L15-L17.  

```ruby
if form_response_errors.one? { |k, v| %i[name dob dob_min_age state ... ... ].include?(k) }
      form_response_errors.merge!(
       front: [I18n.t('doc_auth.errors.general.multiple_front_id_failures')],
       back: [I18n.t('doc_auth.errors.general.multiple_back_id_failures')],
      )
end
```

But either way, we need see whether we need to reconcile with this existing behavior. @amirbey  and @eileen-nava, @night-jellyfish, what do you think?




## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1: login with selfie option enabled
- [ ] Step 2: Enter doc auth workfloww
- [ ] Step 3: Upload test yaml file that has pii error, like missing dob
```yaml
document:
  first_name: Jane
  last_name: Doe
  middle_name: Q
  address1: 1800 F Street
  address2: Apt 3
  city: Bayside
  state: NY
  zipcode: '11364'
  phone: +1 314-555-1212
```
- [ ] Step 4: submit and read the warning and go to review error page
- [ ] Step 5: verify inline error messages for both front and back images, no inline error for selfie.

## 👀 Screenshots

<summary>After:</summary>

![LG-12081-with-selfie-en](https://github.com/18F/identity-idp/assets/130466753/9f4434b6-3285-4535-ba5d-9ba46147b5db)

![LG-12081-with-selfie-es](https://github.com/18F/identity-idp/assets/130466753/c4cea89e-6858-484a-b027-31e49eaaa724)

![LG-12081-with-selfie-fr](https://github.com/18F/identity-idp/assets/130466753/8ffd7f93-af96-48df-b36a-d142206c0bb8)

Non-selfie:

![LG-12081-nonselfie](https://github.com/18F/identity-idp/assets/130466753/ddcf92bf-7fee-45a6-8c9d-38efc65b9499)



