### PR TITLE
Fix attaching of selfie image in specs

### DIFF
--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -117,8 +117,12 @@ module DocAuthHelper
   end
 
   def complete_document_capture_step(with_selfie: false)
-    attach_images
-    attach_selfie if with_selfie
+    if with_selfie
+      attach_liveness_images
+    else
+      attach_images
+    end
+
     submit_images
   end
 


### PR DESCRIPTION
Fixes a broken test run on main by using `attach_liveness_images` instead of `attach_selfie` in doc auth helper.