### PR TITLE
LG-12200: Remove selfie_success field from DocumentCaptureSessionResult

### DIFF
--- a/app/services/document_capture_session_result.rb
+++ b/app/services/document_capture_session_result.rb
@@ -11,12 +11,11 @@ DocumentCaptureSessionResult = RedactedStruct.new(
   :failed_selfie_image_fingerprints,
   :captured_at,
   :selfie_check_performed,
-  :doc_auth_success, :selfie_status, :selfie_success,
+  :doc_auth_success, :selfie_status,
   keyword_init: true,
   allowed_members: [:id, :success, :attention_with_barcode, :failed_front_image_fingerprints,
                     :failed_back_image_fingerprints, :failed_selfie_image_fingerprints,
-                    :captured_at, :selfie_check_performed, :doc_auth_success, :selfie_status,
-                    :selfie_success]
+                    :captured_at, :selfie_check_performed, :doc_auth_success, :selfie_status]
 ) do
   include DocAuth::SelfieConcern
 


### PR DESCRIPTION
## 🎫 Ticket
[LG-12200: Remove the selfie_success field from DocumentCaptureSessionResult](https://cm-jira.usa.gov/browse/LG-12200)


## 🛠 Summary of changes
- Follow-up to [LG-12159: Change selfie_success to return a symbol](https://cm-jira.usa.gov/browse/LG-12159) and PR #9953 
- In the above PR, we renamed `selfie_success` to `selfie_status`
- We are removing `selfie_success` in this PR
- As you can see, it is quite a petite PR!



## 📜 Testing Plan
- Run automated tests