### PR TITLE
Update nokogiri to 1.16.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
     net-ssh (6.1.0)
     newrelic_rpm (9.7.0)
     nio4r (2.7.0)
-    nokogiri (1.16.0)
+    nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     openssl (3.0.2)


### PR DESCRIPTION
## 🛠 Summary of changes

From `bundler-audit`:

```
Name: nokogiri
Version: 1.16.0
GHSA: https://github.com/advisories/GHSA-xc9x-jj77-9p9j
Criticality: Unknown
URL: [GHSA-xc9x-jj77-9p9j](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j)
Title: Improper Handling of Unexpected Data Type in Nokogiri
Solution: upgrade to '>= 1.16.2'
```