### PR TITLE
LG-12070: Maintain incoming request for concurrent session logout

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -12,6 +12,7 @@ module OpenidConnect
 
     before_action :block_biometric_requests_in_production, only: [:index]
     before_action :build_authorize_form_from_params, only: [:index]
+    before_action :set_devise_failure_redirect_for_concurrent_session_logout
     before_action :pre_validate_authorize_form, only: [:index]
     before_action :sign_out_if_prompt_param_is_login_and_user_is_signed_in, only: [:index]
     before_action :store_request, only: [:index]
@@ -71,6 +72,10 @@ module OpenidConnect
 
     def redirect_to_reauthenticate
       redirect_to user_two_factor_authentication_url
+    end
+
+    def set_devise_failure_redirect_for_concurrent_session_logout
+      request.env['devise_session_limited_failure_redirect_url'] = request.url
     end
 
     def link_identity_to_service_provider

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -2,6 +2,8 @@ require 'saml_idp_constants'
 require 'saml_idp'
 
 class SamlIdpController < ApplicationController
+  before_action :set_devise_failure_redirect_for_concurrent_session_logout, only: [:auth, :logout]
+
   include SamlIdp::Controller
   include SamlIdpAuthConcern
   include SamlIdpLogoutConcern
@@ -17,7 +19,6 @@ class SamlIdpController < ApplicationController
 
   skip_before_action :verify_authenticity_token
   before_action :require_path_year
-  before_action :set_devise_failure_redirect_for_concurrent_session_logout, only: :logout
   before_action :handle_banned_user
   before_action :bump_auth_count, only: :auth
   before_action :redirect_to_sign_in, only: :auth, unless: :user_signed_in?

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -2,6 +2,8 @@ require 'saml_idp_constants'
 require 'saml_idp'
 
 class SamlIdpController < ApplicationController
+  # Ordering is significant, since failure URL must be assigned before any references to the user,
+  # as the concurrent session timeout occurs as a callback to Warden's `after_set_user` hook.
   before_action :set_devise_failure_redirect_for_concurrent_session_logout, only: [:auth, :logout]
 
   include SamlIdp::Controller

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -950,12 +950,8 @@ RSpec.describe 'OpenID Connect', allowed_extra_analytics: [:*] do
     end
 
     context 'when signed in with another browser' do
-      it 'redirects back to the client app after concurrent session logout' do
+      it 'redirects back to the client app if logging out after concurrent session logout' do
         user = user_with_2fa
-        service_provider = ServiceProvider.find_by(issuer: OidcAuthHelper::OIDC_IAL1_ISSUER)
-        IdentityLinker.new(user, service_provider).link_identity(
-          verified_attributes: %w[openid email],
-        )
 
         perform_in_browser(:one) do
           visit_idp_from_sp_with_ial1(:oidc)
@@ -978,6 +974,31 @@ RSpec.describe 'OpenID Connect', allowed_extra_analytics: [:*] do
           visit account_path
           expect(page).to_not have_content(t('headings.account.login_info'))
           expect(page).to have_content(t('headings.sign_in_without_sp'))
+        end
+      end
+
+      it 'maintains authentication request if logged out by concurrent session logout' do
+        user = user_with_2fa
+
+        perform_in_browser(:one) do
+          visit_idp_from_sp_with_ial1(:saml)
+          sign_in_live_with_2fa(user)
+        end
+
+        perform_in_browser(:two) do
+          visit_idp_from_sp_with_ial1(:saml)
+          sign_in_live_with_2fa(user)
+        end
+
+        perform_in_browser(:one) do
+          visit_idp_from_sp_with_ial1(:oidc)
+
+          expect(page).to have_content(
+            [
+              ServiceProvider.find_by(issuer: OidcAuthHelper::OIDC_IAL1_ISSUER).friendly_name,
+              t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
+            ].join(' '),
+          )
         end
       end
     end

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -109,10 +109,6 @@ RSpec.feature 'SAML logout', allowed_extra_analytics: [:*] do
     context 'when signed in with another browser' do
       it 'redirects to the SP after concurrent session logout' do
         user = user_with_2fa
-        service_provider = ServiceProvider.find_by(issuer: SamlAuthHelper::SP_ISSUER)
-        IdentityLinker.new(user, service_provider).link_identity(
-          verified_attributes: %w[openid email],
-        )
 
         perform_in_browser(:one) do
           visit_idp_from_sp_with_ial1(:saml)


### PR DESCRIPTION
## 🎫 Ticket

[LG-12070](https://cm-jira.usa.gov/browse/LG-12070)

Related issue: https://github.com/18F/identity-idp/issues/9407

## 🛠 Summary of changes

Updates OIDC and SAML controllers to set redirect URL ahead of concurrent session logout, to repeat the authentication request as redirect destination for the logout. This resolves an issue where authentication request details would otherwise be lost during the concurrent session logout.

The solution here is essentially the same as in LG-11777 (#9842), except applied to the authentication endpoints in addition to the logout endpoints handled there. 

## 📜 Testing Plan

Prerequisite: Have both [OIDC](https://github.com/18F/identity-oidc-sinatra) and [SAML](https://github.com/18F/identity-saml-sinatra) sample applications running separate from the IdP

1. Start at http://localhost:9292 (OIDC) or http://localhost:4567 (SAML)
2. Click "Sign in"
3. Complete sign in until returned to sample application
4. In a different browser or private browsing window, repeat Steps 1-3, using the same sample application
5. In your original browser, repeat Steps 1-2, using the **other** of the two links
6. Note that "X is using Login.gov..." text reflects the name of the sample application you came from in Step 5