### PR TITLE
LG-12195 Add a method to get resolved authn context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,6 +104,14 @@ class ApplicationController < ActionController::Base
     super
   end
 
+  def resolved_authn_context_result
+    @resolved_authn_context_result ||= AuthnContextResolver.new(
+      service_provider: current_sp,
+      vtr: sp_session[:vtr],
+      acr_values: sp_session[:acr_values],
+    ).resolve
+  end
+
   def context
     user_session[:context] || UserSessionContext::AUTHENTICATION_CONTEXT
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -458,6 +458,23 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe '#resolved_authn_context_result' do
+    it 'returns a resolved authn context result' do
+      sp = build(:service_provider, ial: 2)
+      acr_values = [
+        'http://idmanagement.gov/ns/assurance/aal/1',
+      ].join(' ')
+      sp_session = { vtr: nil, acr_values: acr_values }
+      allow(controller).to receive(:current_sp).and_return(sp)
+      allow(controller).to receive(:sp_session).and_return(sp_session)
+
+      result = subject.resolved_authn_context_result
+
+      expect(result.aal2?).to eq(true)
+      expect(result.identity_proofing?).to eq(true)
+    end
+  end
+
   describe '#sp_session_request_url_with_updated_params' do
     controller do
       def index


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-12195](https://cm-jira.usa.gov/browse/LG-12195)



## 🛠 Summary of changes

Added  `ApplicationController#resolved_authn_context_result` to return an authn context when supplied with the service provider, and vtr and acr values.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Make sure `application_controller_spec.rb` passes


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
