### PR TITLE
Include email_address_id when logging that an email was sent

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -46,7 +46,11 @@ class UserMailer < ActionMailer::Base
   end
 
   def add_metadata
-    message.instance_variable_set(:@_metadata, { user: user, action: action_name })
+    message.instance_variable_set(
+      :@_metadata, {
+        user: user, email_address: email_address, action: action_name
+      }
+    )
   end
 
   def email_confirmation_instructions(token, request_id:, instructions:)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -412,11 +412,13 @@ module AnalyticsEvents
   # Logs after an email is sent
   # @param [String] action type of email being sent
   # @param [String, nil] ses_message_id AWS SES Message ID
-  def email_sent(action:, ses_message_id:, **extra)
+  # @param [Integer] email_address_id Database identifier for email address record
+  def email_sent(action:, ses_message_id:, email_address_id:, **extra)
     track_event(
       'Email Sent',
       action: action,
       ses_message_id: ses_message_id,
+      email_address_id: email_address_id,
       **extra,
     )
   end

--- a/lib/email_delivery_observer.rb
+++ b/lib/email_delivery_observer.rb
@@ -2,8 +2,12 @@ class EmailDeliveryObserver
   def self.delivered_email(mail)
     metadata = mail.instance_variable_get(:@_metadata) || {}
     user = metadata[:user] || AnonymousUser.new
+    email_address_id = metadata[:email_address]&.id
     action = metadata[:action]
-    Analytics.new(user: user, request: nil, sp: nil, session: {}).
-      email_sent(action: action, ses_message_id: mail.header[:ses_message_id]&.value)
+    Analytics.new(user: user, request: nil, sp: nil, session: {}).email_sent(
+      action: action,
+      ses_message_id: mail.header[:ses_message_id]&.value,
+      email_address_id: email_address_id,
+    )
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

This adds additional metadata and logs the `email_address` record identifier we sent the email to so that we can better debug issues with email delivery.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
