### PR TITLE
LG-12033: remove selfie_check_performed attribute from DocumentCaptureSessionResult

### DIFF
--- a/app/services/document_capture_session_result.rb
+++ b/app/services/document_capture_session_result.rb
@@ -10,12 +10,11 @@ DocumentCaptureSessionResult = RedactedStruct.new(
   :failed_back_image_fingerprints,
   :failed_selfie_image_fingerprints,
   :captured_at,
-  :selfie_check_performed,
   :doc_auth_success, :selfie_status,
   keyword_init: true,
   allowed_members: [:id, :success, :attention_with_barcode, :failed_front_image_fingerprints,
                     :failed_back_image_fingerprints, :failed_selfie_image_fingerprints,
-                    :captured_at, :selfie_check_performed, :doc_auth_success, :selfie_status]
+                    :captured_at, :doc_auth_success, :selfie_status]
 ) do
   include DocAuth::SelfieConcern
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket
[LG-12033](https://cm-jira.usa.gov/browse/LG-12033)

## 🛠 Summary of changes
Remove the selfie_check_performed attribute from the DocumentCaptureSession result which is no longer used.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
