### PR TITLE
Update OIG report format

### DIFF
--- a/lib/data_requests/local/write_cloudwatch_logs.rb
+++ b/lib/data_requests/local/write_cloudwatch_logs.rb
@@ -4,6 +4,7 @@ module DataRequests
   module Local
     class WriteCloudwatchLogs
       HEADERS = %w[
+        uuid
         timestamp
         event_name
         success
@@ -14,19 +15,22 @@ module DataRequests
         user_agent
       ].freeze
 
-      attr_reader :cloudwatch_results, :output_dir
+      attr_reader :cloudwatch_results, :requesting_issuer_uuid, :csv
 
-      def initialize(cloudwatch_results, output_dir)
+      def initialize(cloudwatch_results:, requesting_issuer_uuid:, csv:, include_header: false)
         @cloudwatch_results = cloudwatch_results
-        @output_dir = output_dir
+        @csv = csv
+      end
+
+      def include_header?
+        !!@include_header
       end
 
       def call
-        CSV.open(File.join(output_dir, 'logs.csv'), 'w') do |csv|
-          csv << HEADERS
-          cloudwatch_results.each do |row|
-            csv << build_row(row)
-          end
+        csv << HEADERS if include_header?
+
+        cloudwatch_results.each do |row|
+          csv << build_row(row)
         end
       end
 
@@ -60,6 +64,7 @@ module DataRequests
         user_agent = data.dig('properties', 'user_agent')
 
         [
+          requesting_issuer_uuid,
           timestamp,
           event_name,
           success,

--- a/lib/data_requests/local/write_cloudwatch_logs.rb
+++ b/lib/data_requests/local/write_cloudwatch_logs.rb
@@ -19,7 +19,9 @@ module DataRequests
 
       def initialize(cloudwatch_results:, requesting_issuer_uuid:, csv:, include_header: false)
         @cloudwatch_results = cloudwatch_results
+        @requesting_issuer_uuid = requesting_issuer_uuid
         @csv = csv
+        @include_header = include_header
       end
 
       def include_header?

--- a/lib/data_requests/local/write_user_events.rb
+++ b/lib/data_requests/local/write_user_events.rb
@@ -3,16 +3,21 @@ require 'csv'
 module DataRequests
   module Local
     class WriteUserEvents
-      attr_reader :user_report, :output_dir, :requesting_issuer_uuid
+      attr_reader :user_report, :requesting_issuer_uuid, :csv
 
-      def initialize(user_report, output_dir, requesting_issuer_uuid)
+      def initialize(user_report:, requesting_issuer_uuid:, csv:, include_header: false)
         @user_report = user_report
-        @output_dir = output_dir
+        @csv = csv
         @requesting_issuer_uuid = requesting_issuer_uuid
+        @include_header = include_header
+      end
+
+      def include_header?
+        !!@include_header
       end
 
       def call
-        CSV.open(File.join(output_dir, 'events.csv'), 'w') do |csv|
+        if include_header?
           csv << %w[
             uuid
             event_name
@@ -22,17 +27,17 @@ module DataRequests
             user_agent
             device_cookie
           ]
+        end
 
-          user_report[:user_events].each do |row|
-            csv << [requesting_issuer_uuid] + row.values_at(
-              :event_name,
-              :date_time,
-              :ip,
-              :disavowed_at,
-              :user_agent,
-              :device_cookie,
-            )
-          end
+        user_report[:user_events].each do |row|
+          csv << [requesting_issuer_uuid] + row.values_at(
+            :event_name,
+            :date_time,
+            :ip,
+            :disavowed_at,
+            :user_agent,
+            :device_cookie,
+          )
         end
       end
     end

--- a/lib/data_requests/local/write_user_info.rb
+++ b/lib/data_requests/local/write_user_info.rb
@@ -3,86 +3,120 @@ require 'csv'
 module DataRequests
   module Local
     class WriteUserInfo
-      attr_reader :user_report, :output_dir
+      attr_reader :user_report, :csv
 
-      def initialize(user_report, output_dir)
+      def initialize(user_report:, csv:, include_header: false)
         @user_report = user_report
-        @output_dir = output_dir
+        @csv = csv
+        @include_header = include_header
+      end
+
+      def include_header?
+        !!@include_header
       end
 
       def call
+        if include_header?
+          csv << %w[
+            uuid
+            type
+            value
+            created_at
+            confirmed_at
+          ]
+        end
+
+        write_not_found
         write_emails
         write_phone_configurations
         write_auth_app_configurations
         write_webauthn_configurations
         write_piv_cac_configurations
         write_backup_code_configurations
-        output_file.close
       end
 
       private
 
-      def output_file
-        @output_file ||= begin
-          output_path = File.join(output_dir, 'user.csv')
-          File.open(output_path, 'w')
-        end
+      def uuid
+        user_report[:requesting_issuer_uuid]
       end
 
-      def write_rows_to_csv(rows, *columns)
-        output_file.puts(columns.join(','))
-
-        return output_file.puts("No data\n\n") if rows.empty?
-
-        rows.each do |row|
-          output_file.puts CSV.generate_line(row.values_at(*columns))
+      def write_not_found
+        if user_report[:not_found]
+          csv << [
+            uuid,
+            'not found',
+          ]
         end
-        output_file.puts("\n")
       end
 
       def write_auth_app_configurations
-        output_file.puts('Auth app configurations:')
-        write_rows_to_csv(
-          user_report[:mfa_configurations][:auth_app_configurations],
-          :name, :created_at
-        )
+        user_report[:mfa_configurations][:auth_app_configurations].each do |auth_app_config|
+          csv << [
+            uuid,
+            'Auth app configuration',
+            auth_app_config[:name],
+            auth_app_config[:created_at],
+          ]
+        end
       end
 
       def write_backup_code_configurations
-        output_file.puts('Backup code configurations:')
-        write_rows_to_csv(
-          user_report[:mfa_configurations][:backup_code_configurations],
-          :created_at, :used_at
-        )
+        user_report[:mfa_configurations][:backup_code_configurations].each do |backup_code_config|
+          csv << [
+            uuid,
+            'Backup code configuration',
+            nil,
+            backup_code_config[:created_at],
+            backup_code_config[:used_at]
+          ]
+        end
       end
 
       def write_emails
-        output_file.puts('Emails:')
-        write_rows_to_csv(user_report[:email_addresses], :email, :created_at, :confirmed_at)
+        user_report[:email_addresses].each do |email|
+          csv << [
+            uuid,
+            'Email',
+            email[:email],
+            email[:created_at],
+            email[:confirmed_at],
+          ]
+        end
       end
 
       def write_phone_configurations
-        output_file.puts('Phone configurations:')
-        write_rows_to_csv(
-          user_report[:mfa_configurations][:phone_configurations],
-          :phone, :created_at, :confirmed_at
-        )
+        user_report[:mfa_configurations][:phone_configurations].each do |phone_config|
+          csv << [
+            uuid,
+            'Phone configuration',
+            phone_config[:phone],
+            phone_config[:created_at],
+            phone_config[:confirmed_at],
+          ]
+        end
       end
 
       def write_piv_cac_configurations
-        output_file.puts('PIV/CAC configurations:')
-        write_rows_to_csv(
-          user_report[:mfa_configurations][:piv_cac_configurations],
-          :name, :created_at
-        )
+        user_report[:mfa_configurations][:piv_cac_configurations].each do |piv_cac_config|
+          csv << [
+            uuid,
+            'PIV/CAC configuration',
+            piv_cac_config[:name],
+            piv_cac_config[:created_at],
+          ]
+        end
       end
 
       def write_webauthn_configurations
-        output_file.puts('WebAuthn configurations:')
-        write_rows_to_csv(
-          user_report[:mfa_configurations][:webauthn_configurations],
-          :name, :created_at
-        )
+        user_report[:mfa_configurations][:webauthn_configurations].each do |webauthn_config|
+          csv << [
+            uuid,
+            'WebAuthn configuration',
+            webauthn_config[:name],
+            webauthn_config[:created_at],
+          ]
+        end
       end
     end
   end

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -126,6 +126,34 @@ RSpec.describe DataPull do
           :user_events,
         )
       end
+
+      context 'with a UUID that is not found' do
+        let(:uuid) { 'abcdef' }
+        let(:argv) do
+          ['ig-request', uuid, '--requesting-issuer', service_provider.issuer]
+        end
+
+        it 'returns an empty hash for that user' do
+          data_pull.run
+
+          response = JSON.parse(stdout.string, symbolize_names: true)
+          expect(response.first).to eq(
+            user_id: nil,
+            login_uuid: nil,
+            requesting_issuer_uuid: uuid,
+            email_addresses: [],
+            mfa_configurations: {
+              phone_configurations: [],
+              auth_app_configurations: [],
+              webauthn_configurations: [],
+              piv_cac_configurations: [],
+              backup_code_configurations: [],
+            },
+            user_events: [],
+            not_found: true,
+          )
+        end
+      end
     end
   end
 

--- a/spec/lib/data_requests/local/write_user_events_spec.rb
+++ b/spec/lib/data_requests/local/write_user_events_spec.rb
@@ -5,18 +5,30 @@ RSpec.describe DataRequests::Local::WriteUserEvents do
   let(:requesting_issuer_uuid) { SecureRandom.uuid }
 
   describe '#call' do
-    it 'writes a file with event information' do
-      user_report = JSON.parse(
+    let(:user_report) do
+      JSON.parse(
         File.read('spec/fixtures/data_request.json'), symbolize_names: true
       ).first
+    end
 
-      Dir.mktmpdir do |dir|
-        described_class.new(user_report, dir, requesting_issuer_uuid).call
-        events = File.read(File.join(dir, 'events.csv'))
-        csv = CSV.parse(events, headers: true)
-        expect(csv.first['uuid']).to eq(requesting_issuer_uuid)
-        expect(csv.count).to eq(user_report[:user_events].length)
-      end
+    let(:io) { StringIO.new }
+    let(:csv) { CSV.new(io) }
+
+    subject(:writer) do
+      described_class.new(
+        user_report:,
+        requesting_issuer_uuid:,
+        csv:,
+        include_header: true,
+      )
+    end
+
+    it 'writes a file with event information' do
+      writer.call
+
+      parsed = CSV.parse(io.string, headers: true)
+      expect(parsed.first['uuid']).to eq(requesting_issuer_uuid)
+      expect(parsed.count).to eq(user_report[:user_events].length)
     end
   end
 end

--- a/spec/lib/data_requests/local/write_user_info_spec.rb
+++ b/spec/lib/data_requests/local/write_user_info_spec.rb
@@ -3,24 +3,68 @@ require 'data_requests/local'
 
 RSpec.describe DataRequests::Local::WriteUserInfo do
   describe '#call' do
-    it 'writes a file with user information' do
-      user_report = JSON.parse(
+    let(:io) { StringIO.new }
+    let(:csv) { CSV.new(io) }
+
+    subject(:instance) do
+      DataRequests::Local::WriteUserInfo.new(
+        user_report:,
+        csv:,
+        include_header: true,
+      )
+    end
+
+    let(:user_report) do
+      JSON.parse(
         File.read('spec/fixtures/data_request.json'), symbolize_names: true
       ).first
+    end
+    let(:uuid) { user_report[:requesting_issuer_uuid] }
 
-      Dir.mktmpdir do |dir|
-        described_class.new(user_report, dir).call
-        user = File.read(File.join(dir, 'user.csv'))
-        headings = user.split("\n\n").map do |info_group|
-          info_group.split("\n").first
-        end
+    it 'adds user information to the CSV' do
+      instance.call
 
-        expect(headings).to include('Emails:')
-        expect(headings).to include('Phone configurations:')
-        expect(headings).to include('Auth app configurations:')
-        expect(headings).to include('WebAuthn configurations:')
-        expect(headings).to include('PIV/CAC configurations:')
-        expect(headings).to include('Backup code configurations:')
+      parsed = CSV.parse(io.string, headers: true)
+
+      email_row = parsed.find { |r| r['type'] == 'Email' }
+      expect(email_row['uuid']).to eq(uuid)
+      expect(email_row['value']).to eq('test@example.com')
+      expect(email_row['created_at']).to be_present
+      expect(email_row['confirmed_at']).to be_present
+
+      phone_row = parsed.find { |r| r['type'] == 'Phone configuration' }
+      expect(phone_row['uuid']).to eq(uuid)
+      expect(phone_row['value']).to eq('+1 555-555-5555')
+      expect(phone_row['created_at']).to be_present
+      expect(email_row['confirmed_at']).to be_present
+    end
+
+    context 'with a not_found user' do
+      let(:uuid) { SecureRandom.hex  }
+      let(:user_report) do
+        {
+          user_id: nil,
+          login_uuid: nil,
+          requesting_issuer_uuid: uuid,
+          email_addresses: [],
+          mfa_configurations: {
+            phone_configurations: [],
+            auth_app_configurations: [],
+            webauthn_configurations: [],
+            piv_cac_configurations: [],
+            backup_code_configurations: [],
+          },
+          user_events: [],
+          not_found: true,
+        }
+      end
+
+      it 'writes a not found row' do
+        instance.call
+
+        parsed = CSV.parse(io.string, headers: true)
+        expect(parsed.first['uuid']).to eq(uuid)
+        expect(parsed.first['type']).to eq('not found')
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-12335](https://cm-jira.usa.gov/browse/LG-12335)

## 🛠 Summary of changes

Update output format of logs and data for OIG requests
    
- **Before**: one directory with 3 files per user
- **After**: 3 files that each contain items by UUID

Also, adds "not found" rows to `users.csv` to highlight inputs that didn't turn up any results

## 📜 Testing Plan

- [ ] Send a sample report to OIG investigators to confirm format matches expectations
