### PR TITLE
LG-12354: Store error code and message for 400 doc auth responses from LN

### DIFF
--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -15,7 +15,7 @@ module DocAuth
 
         handle_http_response(http_response)
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-        handle_connection_error(e)
+        handle_connection_error(exception: e)
       end
 
       def metric_name
@@ -45,10 +45,15 @@ module DocAuth
         ].join(' ')
         exception = DocAuth::RequestError.new(message, http_response.status)
 
-        handle_connection_error(exception)
+        response_body = JSON.parse(http_response.body)
+        handle_connection_error(
+          exception: exception,
+          status_code: response_body.dig('status', 'code'),
+          status_message: response_body.dig('status', 'message'),
+        )
       end
 
-      def handle_connection_error(exception)
+      def handle_connection_error(exception:, status_code: nil, status_message: nil)
         NewRelic::Agent.notice_error(exception)
         DocAuth::Response.new(
           success: false,
@@ -58,7 +63,9 @@ module DocAuth
             vendor: 'TrueID',
             selfie_live: false,
             selfie_quality_good: false,
-          },
+            vendor_status_code: status_code,
+            vendor_status_message: status_message,
+          }.compact,
         )
       end
 

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -45,7 +45,7 @@ module DocAuth
         ].join(' ')
         exception = DocAuth::RequestError.new(message, http_response.status)
 
-        response_body = JSON.parse(http_response.body)
+        response_body = http_response.body.present? ? JSON.parse(http_response.body) : {}
         handle_connection_error(
           exception: exception,
           status_code: response_body.dig('status', 'code'),

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -45,7 +45,12 @@ module DocAuth
         ].join(' ')
         exception = DocAuth::RequestError.new(message, http_response.status)
 
-        response_body = http_response.body.present? ? JSON.parse(http_response.body) : {}
+        response_body = begin
+          http_response.body.present? ? JSON.parse(http_response.body) : {}
+        rescue JSON::JSONError
+          {}
+        end
+
         handle_connection_error(
           exception: exception,
           status_code: response_body.dig('status', 'code'),

--- a/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
@@ -176,9 +176,9 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
     end
 
     describe 'when http request failed' do
+      let(:status_code) { 1002 }
+      let(:status_message) { 'The request sent by the client was syntactically incorrect.' }
       it 'return failed response with correct statuses' do
-        status_code = 1002
-        status_message = 'The request sent by the client was syntactically incorrect.'
         stub_request(:post, image_upload_url).
           to_return(
             body: {

--- a/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
@@ -177,7 +177,18 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
 
     describe 'when http request failed' do
       it 'return failed response with correct statuses' do
-        stub_request(:post, image_upload_url).to_return(body: '', status: 401)
+        status_code = 1002
+        status_message = 'The request sent by the client was syntactically incorrect.'
+        stub_request(:post, image_upload_url).
+          to_return(
+            body: {
+              status: {
+                code: status_code,
+                message: status_message,
+              },
+            }.to_json,
+            status: 401,
+          )
 
         result = client.post_images(
           front_image: DocAuthImageFixtures.document_front_image,
@@ -196,6 +207,8 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
         expect(result_hash[:vendor]).to eq('TrueID')
         expect(result_hash[:doc_auth_success]).to eq(false)
         expect(result_hash[:selfie_status]).to eq(:not_processed)
+        expect(result_hash[:vendor_status_code]).to eq(status_code)
+        expect(result_hash[:vendor_status_message]).to eq(status_message)
         expect(result.class).to eq(DocAuth::Response)
       end
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->
## Background
Doc auth requests are failing with 400 and analytics do not contain any details as to why.  This change logs the error status code and message provided by the vendor.

https://gsa-tts.slack.com/archives/C05HSH9RQ57/p1706638806036759

## 🎫 Ticket
[LG-12354](https://cm-jira.usa.gov/browse/LG-12354)

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
