### PR TITLE
LG-12355: store reference in doc auth response extras for failed LN  http requests

### DIFF
--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -70,6 +70,7 @@ module DocAuth
             selfie_quality_good: false,
             vendor_status_code: status_code,
             vendor_status_message: status_message,
+            reference: @reference,
           }.compact,
         )
       end
@@ -146,13 +147,14 @@ module DocAuth
       end
 
       def settings
+        @reference = uuid
         {
           Type: 'Initiate',
           Settings: {
             Mode: request_mode,
             Locale: config.locale,
             Venue: 'online',
-            Reference: uuid,
+            Reference: @reference,
           },
         }
       end

--- a/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
         expect(result.class).to eq(DocAuth::LexisNexis::Responses::TrueIdResponse)
         expect(result.doc_auth_success?).to eq(false)
         result_hash = result.to_h
+        expect(result_hash[:reference]).not_to be_nil
         expect(result_hash[:selfie_status]).to eq(:fail)
         expect(result.selfie_live?).to eq(true)
         expect(result.selfie_quality_good?).to eq(false)
@@ -206,6 +207,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
         result_hash = result.to_h
         expect(result_hash[:vendor]).to eq('TrueID')
         expect(result_hash[:doc_auth_success]).to eq(false)
+        expect(result_hash[:reference]).not_to be_nil
         expect(result_hash[:selfie_status]).to eq(:not_processed)
         expect(result_hash[:vendor_status_code]).to eq(status_code)
         expect(result_hash[:vendor_status_message]).to eq(status_message)
@@ -236,6 +238,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
           result_hash = result.to_h
           expect(result_hash[:vendor]).to eq('TrueID')
           expect(result_hash[:doc_auth_success]).to eq(false)
+          expect(result_hash[:reference]).not_to be_nil
           expect(result_hash[:selfie_status]).to eq(:not_processed)
           expect(result_hash[:vendor_status_code]).to be_nil
           expect(result_hash[:vendor_status_message]).to be_nil


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-12355](https://cm-jira.usa.gov/browse/LG-12355)

## 🛠 Summary of changes
Store reference sent in LN request in DocAuth::Response extras for failed requests.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
