### PR TITLE
LG-12249: Set sign-in flow session value for PIV sign-in

### DIFF
--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -34,6 +34,7 @@ module TwoFactorAuthentication
         success: result.success?,
         subject_dn: piv_cac_verification_form.x509_dn,
       )
+      session[:sign_in_flow] = :sign_in
       if result.success?
         handle_valid_piv_cac
       else

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true, allowed_extra_anal
       expect(subject).to_not receive(:create_user_event)
 
       post :create, params: { user: { email: 'TEST@example.com ', terms_accepted: '1' } }
+      expect(subject.session[:sign_in_flow]).to eq(:create_account)
     end
 
     it 'tracks unsuccessful user registration' do

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -301,6 +301,10 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
         it 'resets the x509 session information' do
           expect(subject.user_session[:decrypted_x509]).to be_nil
         end
+
+        it 'sets session value for sign in flow' do
+          expect(subject.session[:sign_in_flow]).to eq(:sign_in)
+        end
       end
 
       describe 'when user submits a valid piv/cac' do
@@ -314,6 +318,10 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
 
         it 'resets second_factor_locked_at' do
           expect(subject.current_user.reload.second_factor_locked_at).to eq nil
+        end
+
+        it 'sets session value for sign in flow' do
+          expect(subject.session[:sign_in_flow]).to eq(:sign_in)
         end
       end
     end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Users::SessionsController, devise: true do
         with(email: user.email, success: true)
 
       post :create, params: { user: { email: user.email, password: user.password } }
+      expect(subject.session[:sign_in_flow]).to eq(:sign_in)
     end
 
     it 'tracks the unsuccessful authentication for existing user' do
@@ -85,6 +86,7 @@ RSpec.describe Users::SessionsController, devise: true do
         with('Email and Password Authentication', analytics_hash)
 
       post :create, params: { user: { email: user.email.upcase, password: 'invalid_password' } }
+      expect(subject.session[:sign_in_flow]).to eq(:sign_in)
     end
 
     it 'tracks the authentication attempt for nonexistent user' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-12249](https://cm-jira.usa.gov/browse/LG-12249)

## 🛠 Summary of changes

Assigns `session[:sign_in_flow]` to `:sign_in` when attempting to authenticate using a PIV.

This builds upon #10029 to cover additional sign-in flows.

## 📜 Testing Plan

Repeat testing instructions from #10029, specifically using PIV to sign in.