### PR TITLE
LG-12332: fix mock client to pass when using real image.

### DIFF
--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -77,7 +77,7 @@ module DocAuth
 
         get_results(
           instance_id: instance_id,
-          selfie_required: !selfie_image.blank? || liveness_checking_required,
+          selfie_required: liveness_checking_required,
         )
       end
 

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -75,10 +75,13 @@ module DocAuth
         back_image_response = post_back_image(image: back_image, instance_id: instance_id)
         return back_image_response unless back_image_response.success?
 
-        get_results(instance_id: instance_id)
+        get_results(
+          instance_id: instance_id,
+          selfie_required: !selfie_image.blank? || liveness_checking_required,
+        )
       end
 
-      def get_results(instance_id:)
+      def get_results(instance_id:, selfie_required: false)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
         error_response = http_error_response(self.class.last_uploaded_back_image, 'result')
         return error_response if error_response
@@ -91,6 +94,7 @@ module DocAuth
         ResultResponse.new(
           self.class.last_uploaded_back_image,
           overriden_config,
+          selfie_required,
         )
       end
       # rubocop:enable Lint/UnusedMethodArgument

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -7,9 +7,10 @@ module DocAuth
 
       attr_reader :uploaded_file, :config
 
-      def initialize(uploaded_file, config)
+      def initialize(uploaded_file, config, selfie_required = false)
         @uploaded_file = uploaded_file.to_s
         @config = config
+        @selfie_required = selfie_required
         super(
           success: success?,
           errors: errors,
@@ -138,8 +139,12 @@ module DocAuth
       end
 
       def selfie_status
-        return :not_processed if portrait_match_results&.dig(:FaceMatchResult).nil?
-        portrait_match_results[:FaceMatchResult] == 'Pass' ? :success : :fail
+        if @selfie_required
+          return :success if portrait_match_results&.dig(:FaceMatchResult).nil?
+          portrait_match_results[:FaceMatchResult] == 'Pass' ? :success : :fail
+        else
+          :not_processed
+        end
       end
 
       private

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -193,6 +193,11 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
         failed_alerts: []
       YAML
 
+      image_no_setting = <<~YAML
+        doc_auth_result: Passed
+        failed_alerts: []
+      YAML
+
       it 'sets selfie_check_performed to true' do
         response = client.post_images(
           front_image: image,
@@ -203,6 +208,19 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
 
         expect(response.selfie_check_performed?).to be(true)
         expect(response.extra).to have_key(:portrait_match_results)
+      end
+
+      it 'returns selfie status with default setting' do
+        response = client.post_images(
+          front_image: image_no_setting,
+          back_image: image_no_setting,
+          liveness_checking_required: liveness_checking_required,
+          selfie_image: image_no_setting,
+        )
+
+        expect(response.selfie_check_performed?).to be(true)
+        expect(response.selfie_status).to eq(:success)
+        expect(response.extra).to_not have_key(:portrait_match_results)
       end
     end
 

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DocAuth::Mock::ResultResponse do
   let(:warn_notifier) { instance_double('Proc') }
-
+  let(:selfie_required) { false }
   subject(:response) do
     config = DocAuth::Mock::Config.new(
       dpi_threshold: 290,
@@ -10,12 +10,12 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       glare_threshold: 40,
       warn_notifier: warn_notifier,
     )
-    described_class.new(input, config)
+    described_class.new(input, config, selfie_required)
   end
 
   context 'with an image file' do
     let(:input) { DocAuthImageFixtures.document_front_image }
-
+    let(:selfie_required) { true }
     it 'returns a successful response with the default PII' do
       expect(response.success?).to eq(true)
       expect(response.errors).to eq({})
@@ -23,6 +23,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.pii_from_doc).
         to eq(Idp::Constants::MOCK_IDV_APPLICANT)
       expect(response.attention_with_barcode?).to eq(false)
+      expect(response.selfie_status).to eq(:success)
     end
   end
 
@@ -659,7 +660,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
           failed_alerts: []
         YAML
       end
-      let(:selfie_check_performed) { true }
+      let(:selfie_required) { true }
 
       it 'returns the expected values' do
         selfie_results = {
@@ -686,7 +687,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
           failed_alerts: []
         YAML
       end
-      let(:selfie_check_performed) { true }
+      let(:selfie_required) { true }
 
       it 'returns the expected values' do
         selfie_results = {
@@ -705,7 +706,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
 
   context 'when a selfie check is not performed' do
     let(:input) { DocAuthImageFixtures.document_front_image }
-    let(:selfie_check_performed) { false }
+    let(:selfie_required) { false }
 
     it 'returns the expected values' do
       expect(response.selfie_check_performed?).to eq(false)


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12332](https://cm-jira.usa.gov/browse/LG-12332)


## 🛠 Summary of changes
When selfie image(not yaml) attached, mock client failed to pass in dev mode, due to the fact that we default to :not_processed for `selfie_status`.

So we changed to return `:success` if selfie is required and missing` portrait_match_results` in `result_response`.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
