### PR TITLE
Update base layout to be base-ier

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -451,7 +451,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_full_width(template, **opts)
-    render template, **opts, layout: 'base'
+    render template, **opts, layout: 'application'
   end
 
   def analytics_exception_info(exception)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,11 @@ module ApplicationHelper
     end
   end
 
+  def extends_layout(layout, **locals, &block)
+    @view_flow.get(:layout).replace capture(&block) # rubocop:disable Rails/HelperInstanceVariable
+    render template: "layouts/#{layout}", locals:
+  end
+
   def background_cls(cls)
     content_for(:background_cls) { cls }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,10 @@ module ApplicationHelper
   end
 
   def extends_layout(layout, **locals, &block)
-    @view_flow.get(:layout).replace capture(&block) # rubocop:disable Rails/HelperInstanceVariable
+    if block.present?
+      @view_flow.get(:layout).replace capture(&block) # rubocop:disable Rails/HelperInstanceVariable
+    end
+
     render template: "layouts/#{layout}", locals:
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,10 +27,6 @@ module ApplicationHelper
     render template: "layouts/#{layout}", locals:
   end
 
-  def background_cls(cls)
-    content_for(:background_cls) { cls }
-  end
-
   def sp_session
     session.fetch(:sp, {})
   end

--- a/app/views/layouts/account_side_nav.html.erb
+++ b/app/views/layouts/account_side_nav.html.erb
@@ -6,7 +6,9 @@
   <%= render 'accounts/mobile_nav' %>
 <% end %>
 
-<% content_for :content do %>
+<%= javascript_packs_tag_once('navigation') %>
+
+<%= extends_layout :application, body_class: 'site', disable_card: true, user_main_tag: false do %>
   <div class="grid-row grid-gap">
     <div class="display-none tablet:display-block tablet:grid-col-4">
       <%= render 'accounts/side_nav' %>
@@ -16,6 +18,3 @@
     </main>
   </div>
 <% end %>
-
-<%= javascript_packs_tag_once('navigation') %>
-<%= render template: 'layouts/base', locals: { disable_card: true, user_main_tag: false } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,37 @@
-<% background_cls 'tablet:bg-primary-lighter' %>
+<%= extends_layout :base, body_class: local_assigns.fetch(:body_class, 'site tablet:bg-primary-lighter') do %>
+  <%= link_to t('shared.skip_link'), '#main-content', class: 'usa-skipnav' %>
+  <div class="usa-overlay"></div>
+  <% if content_for?(:mobile_nav) %>
+    <div class="usa-header">
+      <%= yield(:mobile_nav) %>
+    </div>
+  <% end %>
+  <%= render 'shared/banner' %>
+  <%= content_tag(
+        local_assigns[:user_main_tag] == false ? 'div' : 'main',
+        class: 'site-wrap bg-primary-lighter',
+        id: local_assigns[:user_main_tag] == false ? nil : 'main-content',
+      ) do %>
+    <div class="grid-container padding-y-4 tablet:padding-y-8 <%= local_assigns[:disable_card].present? ? '' : 'card' %>">
+      <%= yield(:pre_flash_content) if content_for?(:pre_flash_content) %>
+      <%= render FlashComponent.new(flash: flash) %>
+      <%= yield %>
+    </div>
+  <% end %>
+  <%= render 'shared/footer_lite' %>
 
-<%= render template: 'layouts/base' %>
+  <% if current_user %>
+    <%= render partial: 'session_timeout/ping',
+               locals: {
+                 warning: session_timeout_warning,
+                 start: session_timeout_start,
+                 frequency: session_timeout_frequency,
+                 modal: session_modal,
+               } %>
+  <% elsif !@skip_session_expiration %>
+    <%= render partial: 'session_timeout/expire_session',
+               locals: {
+                 session_timeout_in: Devise.timeout_in,
+               } %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -60,42 +60,8 @@
   <%= yield(:head) if content_for?(:head) %>
 </head>
 
-<body class="site <%= yield(:background_cls) %>">
-  <%= link_to t('shared.skip_link'), '#main-content', class: 'usa-skipnav' %>
-  <div class="usa-overlay"></div>
-  <% if content_for?(:mobile_nav) %>
-    <div class="usa-header">
-      <%= yield(:mobile_nav) %>
-    </div>
-  <% end %>
-  <%= render 'shared/banner' %>
-  <%= content_tag(
-        local_assigns[:user_main_tag] == false ? 'div' : 'main',
-        class: 'site-wrap bg-primary-lighter',
-        id: local_assigns[:user_main_tag] == false ? nil : 'main-content',
-      ) do %>
-    <div class="grid-container padding-y-4 tablet:padding-y-8 <%= local_assigns[:disable_card].present? ? '' : 'card' %>">
-      <%= yield(:pre_flash_content) if content_for?(:pre_flash_content) %>
-      <%= render FlashComponent.new(flash: flash) %>
-      <%= content_for?(:content) ? yield(:content) : yield %>
-    </div>
-  <% end %>
-  <%= render 'shared/footer_lite' %>
-
-  <% if current_user %>
-    <%= render partial: 'session_timeout/ping',
-               locals: {
-                 warning: session_timeout_warning,
-                 start: session_timeout_start,
-                 frequency: session_timeout_frequency,
-                 modal: session_modal,
-               } %>
-  <% elsif !@skip_session_expiration %>
-    <%= render partial: 'session_timeout/expire_session',
-               locals: {
-                 session_timeout_in: Devise.timeout_in,
-               } %>
-  <% end %>
+<%= content_tag(:body, class: local_assigns[:body_class]) do %>
+  <%= yield %>
 
   <%= content_tag(
         :script,
@@ -111,6 +77,6 @@
   <%= render_javascript_pack_once_tags %>
 
   <%= render 'shared/dap_analytics' if IdentityConfig.store.participate_in_dap && !session_with_trust? %>
-</body>
+<% end %>
 
 </html>

--- a/app/views/layouts/flow_step.html.erb
+++ b/app/views/layouts/flow_step.html.erb
@@ -8,5 +8,4 @@
         ) %>
   <% end %>
 <% end %>
-<% content_for(:content) { render(template: step_template, locals: local_assigns) } %>
-<%= render template: 'layouts/base' %>
+<%= extends_layout :application { render(template: step_template, locals: local_assigns) } %>

--- a/app/views/layouts/flow_step.html.erb
+++ b/app/views/layouts/flow_step.html.erb
@@ -8,4 +8,4 @@
         ) %>
   <% end %>
 <% end %>
-<%= extends_layout(:base) { render(template: step_template, locals: local_assigns) } %>
+<%= render(template: step_template, locals: local_assigns) %>

--- a/app/views/layouts/flow_step.html.erb
+++ b/app/views/layouts/flow_step.html.erb
@@ -8,4 +8,4 @@
         ) %>
   <% end %>
 <% end %>
-<%= extends_layout :application { render(template: step_template, locals: local_assigns) } %>
+<%= extends_layout(:application) { render(template: step_template, locals: local_assigns) } %>

--- a/app/views/layouts/flow_step.html.erb
+++ b/app/views/layouts/flow_step.html.erb
@@ -8,4 +8,4 @@
         ) %>
   <% end %>
 <% end %>
-<%= extends_layout(:application) { render(template: step_template, locals: local_assigns) } %>
+<%= extends_layout(:base) { render(template: step_template, locals: local_assigns) } %>

--- a/app/views/layouts/no_card.html.erb
+++ b/app/views/layouts/no_card.html.erb
@@ -1,1 +1,1 @@
-<%= render template: 'layouts/base', locals: { disable_card: true } %>
+<%= extends_layout(:application, disable_card: true) { yield } %>

--- a/app/views/layouts/no_card.html.erb
+++ b/app/views/layouts/no_card.html.erb
@@ -1,1 +1,1 @@
-<%= extends_layout(:application, disable_card: true) { yield } %>
+<%= extends_layout(:application, body_class: 'site', disable_card: true) { yield } %>

--- a/app/views/openid_connect/shared/redirect.html.erb
+++ b/app/views/openid_connect/shared/redirect.html.erb
@@ -1,7 +1,5 @@
 <% self.title = t('headings.redirecting') %>
 
-<%= content_for(:head) do %>
-  <meta content="0;url=<%= @oidc_redirect_uri %>" http-equiv="refresh" />
-<% end %>
+<%= content_for(:meta_refresh, "0;url=#{@oidc_redirect_uri}") %>
 
 <%= extends_layout :base %>

--- a/app/views/openid_connect/shared/redirect.html.erb
+++ b/app/views/openid_connect/shared/redirect.html.erb
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title><%= t('headings.redirecting') %> | <%= APP_NAME %></title>
-    <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= render_stylesheet_once_tags %>
-    <meta content="0;url=<%= @oidc_redirect_uri %>" http-equiv="refresh" />
-  </head>
-  <body class="tablet:bg-primary-lighter">
-  </body>
-</html>
+<% self.title = t('headings.redirecting') %>
+
+<%= content_for(:head) do %>
+  <meta content="0;url=<%= @oidc_redirect_uri %>" http-equiv="refresh" />
+<% end %>
+
+<%= extends_layout :base %>

--- a/app/views/openid_connect/shared/redirect_js.html.erb
+++ b/app/views/openid_connect/shared/redirect_js.html.erb
@@ -1,28 +1,18 @@
-<!DOCTYPE html>
-<html class="no-js">
-  <head>
-    <meta charset="utf-8" />
-    <title><%= t('headings.redirecting') %> | <%= APP_NAME %></title>
-    <%= javascript_tag(nonce: true) do %>
-      document.documentElement.classList.replace('no-js', 'js');
-    <% end %>
-    <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= render_stylesheet_once_tags %>
-  </head>
-  <body class="tablet:bg-primary-lighter">
-    <div class="grid-container tablet:padding-y-6 no-js">
-      <div class="grid-row">
-        <div class="tablet:grid-col-6 tablet:grid-offset-3">
-          <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
+<% self.title = t('headings.redirecting') %>
 
-          <p>
-            <%= t('saml_idp.shared.saml_post_binding.no_js') %>
-          </p>
+<%= extends_layout :base do %>
+  <div class="grid-container tablet:padding-y-6 no-js">
+    <div class="grid-row">
+      <div class="tablet:grid-col-6 tablet:grid-offset-3">
+        <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
 
-          <%= link_to(t('forms.buttons.continue'), @oidc_redirect_uri, class: 'usa-button usa-button--wide usa-button--big', data: { click_immediate: '' }) %>
-        </div>
+        <p>
+          <%= t('saml_idp.shared.saml_post_binding.no_js') %>
+        </p>
+
+        <%= link_to(t('forms.buttons.continue'), @oidc_redirect_uri, class: 'usa-button usa-button--wide usa-button--big', data: { click_immediate: '' }) %>
       </div>
     </div>
-    <%= render_javascript_pack_once_tags 'click-immediate' %>
-  </body>
-</html>
+  </div>
+  <%= render_javascript_pack_once_tags 'click-immediate' %>
+<% end %>

--- a/app/views/shared/saml_post_form.html.erb
+++ b/app/views/shared/saml_post_form.html.erb
@@ -1,33 +1,23 @@
-<!DOCTYPE html>
-<html class="no-js">
-  <head>
-    <meta charset="utf-8" />
-    <%= javascript_tag(nonce: true) do %>
-      document.documentElement.classList.replace('no-js', 'js');
-    <% end %>
-    <%= csrf_meta_tags %>
-    <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= render_stylesheet_once_tags %>
-  </head>
-  <body>
-    <div class="grid-container tablet:padding-y-6 no-js">
-      <div class="grid-row">
-        <div class="tablet:grid-col-6 tablet:grid-offset-3">
-          <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
+<% self.title = t('headings.redirecting') %>
 
-          <p>
-            <%= t('saml_idp.shared.saml_post_binding.no_js') %>
-          </p>
+<%= extends_layout :base do %>
+  <div class="grid-container tablet:padding-y-6 no-js">
+    <div class="grid-row">
+      <div class="tablet:grid-col-6 tablet:grid-offset-3">
+        <%= render PageHeadingComponent.new.with_content(t('saml_idp.shared.saml_post_binding.heading')) %>
 
-          <%= simple_form_for('', url: action_url) do |f| %>
-            <% form_params.each do |key, val| %>
-              <%= hidden_field_tag(key, val) %>
-            <% end %>
-            <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: '' } %>
+        <p>
+          <%= t('saml_idp.shared.saml_post_binding.no_js') %>
+        </p>
+
+        <%= simple_form_for('', url: action_url) do |f| %>
+          <% form_params.each do |key, val| %>
+            <%= hidden_field_tag(key, val) %>
           <% end %>
-        </div>
+          <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: '' } %>
+        <% end %>
       </div>
     </div>
-    <%= render_javascript_pack_once_tags 'click-immediate' %>
-  </body>
-</html>
+  </div>
+  <%= render_javascript_pack_once_tags 'click-immediate' %>
+<% end %>

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'OIDC Authorization Confirmation', allowed_extra_analytics: [:*] d
     end
 
     shared_examples 'signin email after signing in again' do
-      it 'it confirms the user wants to continue to SP' do
+      it 'confirms the user wants to continue to SP' do
         second_email = create(:email_address, user: user1)
         sign_in_user(user1, second_email.email)
         visit_idp_from_ial1_oidc_sp


### PR DESCRIPTION
## 🛠 Summary of changes

This updates the "base" layout to be less opinionated, so that it can be used as a—wait for it—_base layout_ by more of our specialized layouts.

This is related to the comment at https://github.com/18F/identity-idp/pull/9985#discussion_r1468167530 .

**Why?**

- **Reduce duplication.** There's already a fair bit of duplication between `base.html` and alternative layouts like `saml_post_form.html.erb`
- **Avoid inconsistencies and errors.** For example, currently in production these specialized layouts lack a `lang` attribute on the `<html>` and therefore may read content in the wrong language for assistive technology
- **Improve compatibility of per-component assets.** I suspect this may indirectly address the issue described in #10065 regarding "automatic component asset loading doesn't work for components rendered in the `base.html.erb` base layout", because footer elements would be moved out of `base.html.erb` and into `application.html.erb`.

## 📜 Testing Plan

Verify no regressions in appearance of various layouts and layout customizations.