### PR TITLE
LG-12428:  extract_pii_from_doc refactor

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -30,15 +30,14 @@ module Idv
     end
 
     def extract_pii_from_doc(user, store_in_session: false)
-      if defined?(idv_session) # hybrid mobile does not have idv_session
+      if defined?(idv_session)
         idv_session.had_barcode_read_failure = stored_result.attention_with_barcode?
         if store_in_session
-          idv_session.pii_from_doc = response.pii_from_doc # this requires a response
+          idv_session.pii_from_doc = stored_result.pii
           idv_session.selfie_check_performed = stored_result.selfie_check_performed?
         end
       end
-      # this must be moved or pass in response
-      track_document_issuing_state(user, response.pii_from_doc[:state])
+      track_document_issuing_state(user, stored_result.pii[:state])
     end
 
     def stored_result

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -38,7 +38,7 @@ module Idv
         end
       end
 
-      track_document_issuing_state(user, response.pii_from_doc[:state])
+      track_document_issuing_state(user, stored_result.pii_from_doc[:state])
     end
 
     def stored_result

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -29,17 +29,15 @@ module Idv
       FormResponse.new(**form_response_params)
     end
 
-    # @param [DocAuth::Response,
-    #   DocumentCaptureSessionResult] response
-    def extract_pii_from_doc(user, response, store_in_session: false)
+    def extract_pii_from_doc(user, store_in_session: false)
       if defined?(idv_session) # hybrid mobile does not have idv_session
-        idv_session.had_barcode_read_failure = response.attention_with_barcode?
+        idv_session.had_barcode_read_failure = stored_result.attention_with_barcode?
         if store_in_session
-          idv_session.pii_from_doc = response.pii_from_doc
-          idv_session.selfie_check_performed = response.selfie_check_performed?
+          idv_session.pii_from_doc = response.pii_from_doc # this requires a response
+          idv_session.selfie_check_performed = stored_result.selfie_check_performed?
         end
       end
-
+      # this must be moved or pass in response
       track_document_issuing_state(user, response.pii_from_doc[:state])
     end
 

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -30,14 +30,15 @@ module Idv
     end
 
     def extract_pii_from_doc(user, store_in_session: false)
-      if defined?(idv_session)
+      if defined?(idv_session) # hybrid mobile does not have idv_session
         idv_session.had_barcode_read_failure = stored_result.attention_with_barcode?
         if store_in_session
-          idv_session.pii_from_doc = stored_result.pii
+          idv_session.pii_from_doc = stored_result.pii_from_doc
           idv_session.selfie_check_performed = stored_result.selfie_check_performed?
         end
       end
-      track_document_issuing_state(user, stored_result.pii[:state])
+
+      track_document_issuing_state(user, response.pii_from_doc[:state])
     end
 
     def stored_result

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -97,7 +97,6 @@ module Idv
       else
         extra = { stored_result_present: stored_result.present? }
         failure(I18n.t('doc_auth.errors.general.network_error'), extra)
-        # no response is returned here
       end
     end
   end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -91,12 +91,13 @@ module Idv
     def handle_stored_result
       if stored_result&.success? && selfie_requirement_met?
         save_proofing_components(current_user)
-        extract_pii_from_doc(current_user, stored_result, store_in_session: true)
+        extract_pii_from_doc(current_user, store_in_session: true)
         flash[:success] = t('doc_auth.headings.capture_complete')
         successful_response
       else
         extra = { stored_result_present: stored_result.present? }
         failure(I18n.t('doc_auth.errors.general.network_error'), extra)
+        # no response is returned here
       end
     end
   end

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -63,7 +63,7 @@ module Idv
       def handle_stored_result
         if stored_result&.success? && selfie_requirement_met?
           save_proofing_components(document_capture_user)
-          extract_pii_from_doc(document_capture_user, stored_result)
+          extract_pii_from_doc(document_capture_user)
           successful_response
         else
           extra = { stored_result_present: stored_result.present? }

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -80,12 +80,7 @@ module Idv
     end
 
     def take_photo_with_phone_successful?
-      document_capture_session_result.present? && document_capture_session_result.success? &&
-        selfie_requirement_met?
-    end
-
-    def document_capture_session_result
-      @document_capture_session_result ||= document_capture_session&.load_result
+      stored_result&.success? && selfie_requirement_met?
     end
   end
 end

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -26,7 +26,7 @@ module Idv
 
       # The doc capture flow will have fetched the results already. We need
       # to fetch them again here to add the PII to this session
-      handle_document_verification_success(document_capture_session_result)
+      handle_document_verification_success
       idv_session.redo_document_capture = nil
 
       redirect_to idv_ssn_url
@@ -63,9 +63,9 @@ module Idv
       }.merge(ab_test_analytics_buckets)
     end
 
-    def handle_document_verification_success(get_results_response)
+    def handle_document_verification_success
       save_proofing_components(current_user)
-      extract_pii_from_doc(current_user, get_results_response, store_in_session: true)
+      extract_pii_from_doc(current_user, store_in_session: true)
       idv_session.flow_path = 'hybrid'
     end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12428](https://cm-jira.usa.gov/browse/LG-12428)


Background
DocumentCaptureConcern#extract_pii_from_doc is a bit misleading.  it declares response in it's signature as if it receives a DocAuth::Response when in fact the argument passed is a DocumentCaptureSessionResult which does not need to be passed as an argument.


## 🛠 Summary of changes

1. remove the confusing and unnecessary response argument from the extract_pii_from_doc method
2. remove DocumentCaptureController#document_capture_session_result method that was used to fetch the argument passed in to extract_pii_from_doc

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
