### PR TITLE
Convert file-base64-cache.js to typescript

### DIFF
--- a/app/javascript/packages/document-capture/context/file-base64-cache.ts
+++ b/app/javascript/packages/document-capture/context/file-base64-cache.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-const FileBase64CacheContext = createContext(/** @type {WeakMap<Blob,string>} */ (new WeakMap()));
+const FileBase64CacheContext = createContext(new WeakMap());
 
 FileBase64CacheContext.displayName = 'FileBase64CacheContext';
 

--- a/app/javascript/packages/document-capture/context/file-base64-cache.ts
+++ b/app/javascript/packages/document-capture/context/file-base64-cache.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-const FileBase64CacheContext = createContext(new WeakMap());
+const FileBase64CacheContext = createContext(new WeakMap<Blob, string>());
 
 FileBase64CacheContext.displayName = 'FileBase64CacheContext';
 


### PR DESCRIPTION
## 🛠 Summary of changes

Converting `file-base-64-cache.js` to typescript.
