### PR TITLE
Remap Pinpoint XV country code to XK (Kosovo)

### DIFF
--- a/config/pinpoint_supported_countries.yml
+++ b/config/pinpoint_supported_countries.yml
@@ -376,7 +376,7 @@ GP:
   supports_voice: false
 GQ:
   country_code: '240'
-  name: Equitorial Guinea
+  name: Equatorial Guinea
   supports_sms: true
   supports_voice: false
 GR:

--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -137,7 +137,7 @@ class PinpointSupportedCountries
       'BDE' => 'BD',
       'DN' => 'DM',
       'H' => 'HT',
-      'KV' => 'XK',
+      'XV' => 'XK',
       'TX' => 'TZ',
     }.fetch(iso_code, iso_code)
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an error causing all builds to fail due to missing phone data for the "XV" country code listed on [Pinpoint's documentation](https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-sms-countries.html). The Kosovo country code is "XK" in the Phonelib library, so the changes here introduce a mapping from "XV" to "XK".

Related resources:

- https://docs.aws.amazon.com/sms-voice/latest/userguide/phone-numbers-sms-by-country.html
- https://en.wikipedia.org/wiki/XK_(user_assigned_code)

## 📜 Testing Plan

Confirm no errors when running `make lint_country_dialing_codes`