### PR TITLE
Set allow_failure: true for production_deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -532,7 +532,7 @@ stop-review-app:
 
 deploy_production:
   stage: deploy_production
-  allow_failure: false
+  allow_failure: true
   needs:
     - job: build-review-image
   resource_group: $CI_ENVIRONMENT_SLUG.review-app.identitysandbox.gov


### PR DESCRIPTION
Follow-up to #10020 that will hopefully let CI go green on `main`