### PR TITLE
Remove unused `@ial` ivar from `Users::SessionsController`

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,7 +20,6 @@ module Users
     def new
       override_csp_for_google_analytics
 
-      @ial = sp_session_ial
       @issuer_forced_reauthentication = issuer_forced_reauthentication?(
         issuer: decorated_sp_session.sp_issuer,
       )

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -50,7 +50,7 @@
   <%= hidden_field_tag :platform_authenticator_available, id: 'platform_authenticator_available' %>
   <%= f.submit t('links.sign_in'), full_width: true, wide: false %>
 <% end %>
-<% if @ial && desktop_device? %>
+<% if desktop_device? %>
   <div class='margin-x-neg-1 margin-top-205'>
     <%= link_to(
           t('account.login.piv_cac'),
@@ -88,4 +88,3 @@
 
 <noscript><link rel="stylesheet" href="<%= no_js_detect_css_path(location: :sign_in) %>"></noscript>
 <%= javascript_packs_tag_once('platform-authenticator-available') %>
-

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'devise/sessions/new.html.erb' do
     allow(view).to receive(:decorated_sp_session).and_return(NullServiceProviderSession.new)
     allow_any_instance_of(ActionController::TestRequest).to receive(:path).
       and_return('/')
-    assign(:ial, 1)
   end
 
   it 'sets autocomplete attribute off' do


### PR DESCRIPTION
This ivar is part of a conditional that is used to determine if the link to authenticate with a PIV or CAC is visible.

It was added here: https://github.com/18F/identity-idp/commit/ccc40ed7e41e2f67063b3d7455b0990b0bd11bab

The computation for this value looks like this:

```ruby
def sp_session_ial
  sp_session[:ial].presence || 1
end
```

This will always have a truthy value unless the requested IAL is IALMax (the integer value corresponding to IALMax is 0). After reading through the commit history I beleive this IALMax behavior is unintentional.

I believe this value was originally intended to require the user to enter a password if identity proofing was required. It appears this requirement changed but the ivar was left behind. This commit removes it.
