### PR TITLE
Remove fallback logging for unknown frontend event

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -56,13 +56,12 @@ class FrontendLogController < ApplicationController
   EVENT_MAP = ALLOWED_EVENTS.index_by(&:to_s).merge(LEGACY_EVENT_MAP).freeze
 
   def create
-    result = frontend_logger.track_event(log_params[:event], log_params[:payload].to_h)
+    success = frontend_logger.track_event(log_params[:event], log_params[:payload].to_h)
 
-    if result
-      render json: { success: true }, status: :ok
+    if success
+      render json: { success: }, status: :ok
     else
-      render json: { success: false, error_message: 'invalid event' },
-             status: :bad_request
+      render json: { success:, error_message: 'invalid event' }, status: :bad_request
     end
   end
 

--- a/app/services/frontend_logger.rb
+++ b/app/services/frontend_logger.rb
@@ -25,8 +25,6 @@ class FrontendLogger
       analytics_method.call(**hash_from_kwargs(attributes, analytics_method))
       true
     else
-      # 2023-10-31 - Temporary
-      analytics.track_event("Frontend (warning): #{name}", attributes)
       false
     end
   end

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -31,10 +31,9 @@ RSpec.describe FrontendLogController do
       end
 
       context 'with invalid event name' do
-        it 'logs with warning' do
+        it 'responds as unsuccessful' do
           action
 
-          expect(fake_analytics).to have_logged_event('Frontend (warning): Custom Event')
           expect(response).to have_http_status(:bad_request)
           expect(json[:success]).to eq(false)
           expect(json[:error_message]).to eq('invalid event')
@@ -239,10 +238,9 @@ RSpec.describe FrontendLogController do
       end
 
       context 'with invalid event name' do
-        it 'logs with warning' do
+        it 'responds as unsuccessful' do
           action
 
-          expect(fake_analytics).to have_logged_event('Frontend (warning): Custom Event')
           expect(response).to have_http_status(:bad_request)
           expect(json[:success]).to eq(false)
           expect(json[:error_message]).to eq('invalid event')

--- a/spec/services/frontend_logger_spec.rb
+++ b/spec/services/frontend_logger_spec.rb
@@ -37,15 +37,13 @@ RSpec.describe FrontendLogger do
     context 'with unknown event' do
       let(:name) { :test_event }
 
-      it 'logs unknown event with warning' do
-        call
-
-        expect(analytics).to have_logged_event('Frontend (warning): test_event')
-      end
+      it { expect(call).to eq(false) }
     end
 
     context 'with method handler' do
       let(:name) { 'method' }
+
+      it { expect(call).to eq(true) }
 
       it 'calls method with attributes based on signature' do
         call
@@ -56,6 +54,8 @@ RSpec.describe FrontendLogger do
 
     context 'with proc handler' do
       let(:name) { 'proc' }
+
+      it { expect(call).to eq(true) }
 
       it 'calls the method and passes analytics and attributes' do
         call


### PR DESCRIPTION
## 🛠 Summary of changes

Removes fallback logging for frontend events which aren't recognized.

This was added as a temporary measure in #9438 to ensure that we hadn't missed any frontend events.

There are no logs associated with this event, indicating that all of our event names are captured.

## 📜 Testing Plan

```
rspec spec/controllers/frontend_log_controller_spec.rb spec/services/frontend_logger_spec.rb
```

Bonus: Initiate a request to `POST /api/logger` with an unrecognized event name and verify you get a 400 response.
