### PR TITLE
Ignore frontend errors not originating from application script

### DIFF
--- a/app/javascript/packages/analytics/is-trackable-error-event.spec.ts
+++ b/app/javascript/packages/analytics/is-trackable-error-event.spec.ts
@@ -25,6 +25,16 @@ describe('isTrackableErrorEvent', () => {
     });
   });
 
+  context('with non-javascript filename', () => {
+    const event = new ErrorEvent('error', {
+      filename: new URL('foo', window.location.origin).toString(),
+    });
+
+    it('returns false', () => {
+      expect(isTrackableErrorEvent(event)).to.be.false();
+    });
+  });
+
   context('with filename from the same host', () => {
     const event = new ErrorEvent('error', {
       filename: new URL('foo.js', window.location.origin).toString(),

--- a/app/javascript/packages/analytics/is-trackable-error-event.ts
+++ b/app/javascript/packages/analytics/is-trackable-error-event.ts
@@ -1,6 +1,7 @@
 function isTrackableErrorEvent(event: ErrorEvent): boolean {
   try {
-    return new URL(event.filename).host === window.location.host;
+    const { host, pathname } = new URL(event.filename);
+    return host === window.location.host && pathname.endsWith('.js');
   } catch {
     return false;
   }


### PR DESCRIPTION
## 🛠 Summary of changes

Updates logic of `isTrackableError` to ignore any errors which occur from the same host, but which aren't from JavaScript files.

Following #10027, data for `filename` shows that errors are originating from filenames such as `https://secure.login.gov/`. The hypothesis is that app webviews or browser extensions may be injecting scripts evaluated on the page and throwing errors, which we want to ignore.

## 📜 Testing Plan

1. `echo "setTimeout(() => { throw new Error('example'); }, 100)" >> app/javascript/packages/analytics/index.ts`
2. `NODE_ENV=production yarn build`
3. `rails s`
4. Go to http://localhost:3000
5. Validate NewRelic logging. Easiest way is to add a `binding.pry` at [the `notice_error` call](https://github.com/18F/identity-idp/blob/0f8b27c92021d875eab5bcdb399d229427c29e95/app/services/frontend_error_logger.rb#L5-L9) and check that it's triggered