### PR TITLE
LG-12458: Use Warden lock mechanism for session lockout

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -76,10 +76,9 @@ module Users
     end
 
     def process_locked_out_session
-      irs_attempts_api_tracker.login_rate_limited(
-        email: auth_params[:email],
-      )
-
+      irs_attempts_api_tracker.login_rate_limited(email: auth_params[:email])
+      warden.logout(:user)
+      warden.lock!
       flash[:error] = t('errors.sign_in.bad_password_limit')
       redirect_to root_url
     end

--- a/spec/features/visitors/bad_password_spec.rb
+++ b/spec/features/visitors/bad_password_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Visitor signs in with bad passwords and gets locked out',
               allowed_extra_analytics: [:*] do
-  let(:bad_email) { 'bad@email.com' }
+  let(:user) { create(:user, :fully_registered) }
   let(:bad_password) { 'badpassword' }
 
   scenario 'visitor tries too many bad passwords gets locked out then waits window seconds' do
@@ -12,17 +12,23 @@ RSpec.feature 'Visitor signs in with bad passwords and gets locked out',
       link_html: t('devise.failure.invalid_link_text'),
     )
     IdentityConfig.store.max_bad_passwords.times do
-      fill_in_credentials_and_submit(bad_email, bad_password)
+      fill_in_credentials_and_submit(user.email, bad_password)
       expect(page).to have_content(error_message)
       expect(page).to have_current_path(new_user_session_path)
     end
     2.times do
-      fill_in_credentials_and_submit(bad_email, bad_password)
+      fill_in_credentials_and_submit(user.email, bad_password)
+      expect(page).to have_current_path(new_user_session_path)
       expect(page).to have_content(t('errors.sign_in.bad_password_limit'))
     end
+    fill_in_credentials_and_submit(user.email, user.password)
+    expect(page).to have_current_path(new_user_session_path)
+    expect(page).to have_content(t('errors.sign_in.bad_password_limit'))
     travel_to(IdentityConfig.store.max_bad_passwords_window_in_seconds.seconds.from_now) do
-      fill_in_credentials_and_submit(bad_email, bad_password)
+      fill_in_credentials_and_submit(user.email, bad_password)
       expect(page).to have_content(error_message)
+      fill_in_credentials_and_submit(user.email, user.password)
+      expect(page).to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms'))
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-12458](https://cm-jira.usa.gov/browse/LG-12458)

## 🛠 Summary of changes

Updates session lockout mechanism to use Warden's lock functionality to prevent any accidental sign-ins from occurring in the request.

## 📜 Testing Plan

```
rspec spec/features/visitors/bad_password_spec.rb
```