### PR TITLE
LG-12261 Stop reading from `sp_session[:ial]`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -387,8 +387,11 @@ class ApplicationController < ActionController::Base
     I18n.locale = LocaleChooser.new(params[:locale], request).locale
   end
 
-  def sp_session_ial
-    sp_session[:ial].presence || 1
+  def pii_requested_but_locked?
+    if resolved_authn_context_result.identity_proofing? || resolved_authn_context_result.ialmax?
+      current_user.identity_verified? &&
+        !Pii::Cacher.new(current_user, user_session).exists_in_session?
+    end
   end
 
   def mfa_policy

--- a/app/controllers/concerns/billable_event_trackable.rb
+++ b/app/controllers/concerns/billable_event_trackable.rb
@@ -41,7 +41,7 @@ module BillableEventTrackable
   def session_has_been_billed_flag_key
     issuer = sp_session[:issuer]
 
-    if sp_session_ial == 1
+    if !resolved_authn_context_result.identity_proofing?
       "auth_counted_#{issuer}ial1"
     else
       "auth_counted_#{issuer}"

--- a/app/controllers/concerns/idv_session_concern.rb
+++ b/app/controllers/concerns/idv_session_concern.rb
@@ -53,13 +53,7 @@ module IdvSessionConcern
   def redirect_unless_sp_requested_verification
     return if !IdentityConfig.store.idv_sp_required
     return if idv_session_user.profiles.any?
-
-    ial_context = IalContext.new(
-      ial: sp_session_ial,
-      service_provider: sp_from_sp_session,
-      user: idv_session_user,
-    )
-    return if ial_context.ial2_or_greater?
+    return if resolved_authn_context_result.identity_proofing?
 
     redirect_to account_url
   end

--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -22,7 +22,7 @@ module VerifySpAttributesConcern
       current_user,
       current_sp,
     ).link_identity(
-      ial: sp_session_ial,
+      ial: linked_identity_ial,
       verified_attributes: sp_session[:requested_attributes],
       last_consented_at: Time.zone.now,
       clear_deleted_at: true,
@@ -60,6 +60,16 @@ module VerifySpAttributesConcern
     verification_timestamp = current_user.active_profile&.verified_at
 
     verification_timestamp.present? && last_estimated_consent < verification_timestamp
+  end
+
+  def linked_identity_ial
+    if resolved_authn_context_result.ialmax?
+      0
+    elsif resolved_authn_context_result.identity_proofing?
+      2
+    else
+      1
+    end
   end
 
   def find_sp_session_identity

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -189,12 +189,6 @@ module OpenidConnect
       ).call
     end
 
-    def pii_requested_but_locked?
-      sp_session && sp_session_ial > 1 &&
-        current_user.identity_verified? &&
-        !Pii::Cacher.new(current_user, user_session).exists_in_session?
-    end
-
     def track_events
       event_ial_context = IalContext.new(
         ial: @authorize_form.ial,

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -113,13 +113,6 @@ class SamlIdpController < ApplicationController
     request.env['devise_session_limited_failure_redirect_url'] = request.url
   end
 
-  def pii_requested_but_locked?
-    if resolved_authn_context_result.identity_proofing_or_ialmax?
-      current_user.identity_verified? &&
-        !Pii::Cacher.new(current_user, user_session).exists_in_session?
-    end
-  end
-
   def capture_analytics
     analytics_payload = result.to_h.merge(
       endpoint: api_saml_auth_path(path_year: params[:path_year]),

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -126,7 +126,7 @@ module SignUp
     end
 
     def send_in_person_completion_survey
-      return unless sp_session_ial == ::Idp::Constants::IAL2
+      return unless resolved_authn_context_result.identity_proofing?
 
       Idv::InPerson::CompletionSurveySender.send_completion_survey(
         current_user,

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -3,7 +3,7 @@ module Users
     include ReauthenticationRequiredConcern
 
     before_action :confirm_two_factor_authenticated
-    before_action :capture_password_if_pii_requested_but_locked
+    before_action :capture_password_if_pii_present_but_locked
     before_action :confirm_recently_authenticated_2fa
 
     def edit
@@ -33,7 +33,7 @@ module Users
 
     private
 
-    def capture_password_if_pii_requested_but_locked
+    def capture_password_if_pii_present_but_locked
       return unless current_user.identity_verified? &&
                     !Pii::Cacher.new(current_user, user_session).exists_in_session?
       user_session[:stored_location] = request.url

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -79,22 +79,13 @@ module Users
     end
 
     def next_step
-      if ial_context.ial2_requested? && current_user.identity_verified? &&
-         !Pii::Cacher.new(current_user, user_session).exists_in_session?
+      if pii_requested_but_locked?
         capture_password_url
       elsif !current_user.accepted_rules_of_use_still_valid?
         rules_of_use_path
       else
         after_sign_in_path_for(current_user)
       end
-    end
-
-    def ial_context
-      @ial_context ||= IalContext.new(
-        ial: sp_session_ial,
-        service_provider: current_sp,
-        user: piv_cac_login_form.user,
-      )
     end
 
     def process_invalid_submission

--- a/spec/controllers/concerns/billable_event_trackable_spec.rb
+++ b/spec/controllers/concerns/billable_event_trackable_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BillableEventTrackable do
       :request_id,
       :user_session,
       :sp_session,
-      :sp_session_ial,
+      :resolved_authn_context_result,
       :session,
     ) do
       include BillableEventTrackable
@@ -33,7 +33,7 @@ RSpec.describe BillableEventTrackable do
       current_user:,
       request_id:,
       user_session: {},
-      sp_session_ial: 1,
+      resolved_authn_context_result: double(identity_proofing?: false),
       sp_session: {
         issuer: current_sp.issuer,
       },

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -194,13 +194,13 @@ RSpec.describe IdvController, allowed_extra_analytics: [:*] do
 
     describe 'SP for IdV requirement' do
       let(:current_sp) { create(:service_provider) }
-      let(:ial) { 2 }
+      let(:acr_values) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
       let(:user) { build(:user, password: ControllerHelper::VALID_PASSWORD) }
 
       before do
         stub_sign_in(user)
         if current_sp.present?
-          session[:sp] = { issuer: current_sp.issuer, ial: ial }
+          session[:sp] = { issuer: current_sp.issuer, acr_values: acr_values }
         else
           session[:sp] = {}
         end
@@ -237,7 +237,7 @@ RSpec.describe IdvController, allowed_extra_analytics: [:*] do
       end
 
       context 'with an SP context that does not require IdV' do
-        let(:ial) { 1 }
+        let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
 
         context 'when an SP is required' do
           let(:idv_sp_required) { true }
@@ -266,7 +266,7 @@ RSpec.describe IdvController, allowed_extra_analytics: [:*] do
       end
 
       context 'with an SP context that requires IdV' do
-        let(:ial) { 2 }
+        let(:acr_values) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
 
         context 'when an SP is required' do
           let(:idv_sp_required) { true }

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         stub_sign_in(user)
         subject.session[:sp] = {
           issuer: current_sp.issuer,
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         }
         get :show
 
@@ -31,6 +32,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           stub_sign_in(user)
           subject.session[:sp] = {
             issuer: current_sp.issuer,
+            acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             ial2: false,
             requested_attributes: [:email],
             request_url: 'http://localhost:3000',
@@ -67,6 +69,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           stub_sign_in(user)
           subject.session[:sp] = {
             issuer: current_sp.issuer,
+            acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             ial2: true,
             requested_attributes: [:email],
             request_url: 'http://localhost:3000',
@@ -141,6 +144,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           stub_sign_in(user)
           subject.session[:sp] = {
             issuer: current_sp.issuer,
+            acr_values: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
             ial2: false,
             ialmax: true,
             requested_attributes: [:email],
@@ -220,6 +224,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         stub_sign_in(user)
         subject.session[:sp] = { issuer: sp.issuer,
                                  ial2: false,
+                                 acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
                                  requested_attributes: [:email],
                                  request_url: 'http://localhost:3000' }
         get :show
@@ -245,6 +250,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
       it 'tracks analytics' do
         stub_sign_in(user)
         subject.session[:sp] = {
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           ial2: false,
           issuer: 'foo',
           request_url: 'http://example.com',
@@ -271,7 +277,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         stub_sign_in(user)
         subject.session[:sp] = {
           issuer: 'foo',
-          ial: 1,
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           request_url: 'http://example.com',
           requested_attributes: ['email'],
         }
@@ -290,6 +296,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
       it 'redirects to account page if the session request_url is removed' do
         stub_sign_in(user)
         subject.session[:sp] = {
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           ial2: false,
           issuer: 'foo',
           requested_attributes: ['email'],
@@ -306,6 +313,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           DisposableEmailDomain.create(name: 'temporary.com')
           stub_sign_in(user)
           subject.session[:sp] = {
+            acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             ial2: false,
             issuer: 'foo',
             request_url: 'http://example.com',
@@ -343,6 +351,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         sp = create(:service_provider, issuer: 'https://awesome')
         subject.session[:sp] = {
           issuer: sp.issuer,
+          acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           ial2: true,
           request_url: 'http://example.com',
           requested_attributes: ['email'],
@@ -371,7 +380,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         sp = create(:service_provider, issuer: 'https://awesome')
         subject.session[:sp] = {
           issuer: sp.issuer,
-          ial: 2,
+          acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           request_url: 'http://example.com',
           requested_attributes: %w[email first_name verified_at],
         }
@@ -395,12 +404,11 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         sp = create(:service_provider, issuer: 'https://awesome')
         subject.session[:sp] = {
           issuer: sp.issuer,
-          ial: 2,
+          acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           request_url: 'http://example.com',
           requested_attributes: %w[email first_name verified_at],
         }
         allow(@linker).to receive(:link_identity).with(
-          ial: 2,
           verified_attributes: %w[email first_name verified_at],
           last_consented_at: now,
           clear_deleted_at: true,
@@ -428,6 +436,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           ial2: false,
           issuer: 'foo',
           request_url: 'http://example.com',
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         }
         patch :update
       end
@@ -441,6 +450,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           ial2: false,
           issuer: 'foo',
           request_url: 'http://example.com',
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         }
 
         expect(original_profile.activated_at).to be_present
@@ -468,6 +478,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         subject.session[:sp] = {
           ial2: false,
           request_url: 'http://example.com',
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         }
 
         patch :update

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -44,7 +44,12 @@ RSpec.describe Users::PivCacLoginController do
 
       context 'with a valid token' do
         let(:service_provider) { create(:service_provider) }
-        let(:sp_session) { { ial: 1, issuer: service_provider.issuer } }
+        let(:sp_session) do
+          {
+            acr_values: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            issuer: service_provider.issuer,
+          }
+        end
         let(:nonce) { SecureRandom.base64(20) }
         let(:data) do
           {
@@ -175,7 +180,12 @@ RSpec.describe Users::PivCacLoginController do
               end
 
               context 'ial2 service_level' do
-                let(:sp_session) { { ial: Idp::Constants::IAL2, issuer: service_provider.issuer } }
+                let(:sp_session) do
+                  {
+                    acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                    issuer: service_provider.issuer,
+                  }
+                end
 
                 it 'redirects to account' do
                   expect(response).to redirect_to(account_url)
@@ -184,7 +194,10 @@ RSpec.describe Users::PivCacLoginController do
 
               context 'ial_max service level' do
                 let(:sp_session) do
-                  { ial: Idp::Constants::IAL_MAX, issuer: service_provider.issuer }
+                  {
+                    acr_values: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+                    issuer: service_provider.issuer,
+                  }
                 end
 
                 it 'redirects to the after_sign_in_path_for' do
@@ -203,7 +216,12 @@ RSpec.describe Users::PivCacLoginController do
               end
 
               context 'ial2 service_level' do
-                let(:sp_session) { { ial: Idp::Constants::IAL2, issuer: service_provider.issuer } }
+                let(:sp_session) do
+                  {
+                    acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                    issuer: service_provider.issuer,
+                  }
+                end
 
                 it 'redirects to the capture_password_url' do
                   expect(response).to redirect_to(capture_password_url)
@@ -212,7 +230,10 @@ RSpec.describe Users::PivCacLoginController do
 
               context 'ial_max service_level' do
                 let(:sp_session) do
-                  { ial: Idp::Constants::IAL_MAX, issuer: service_provider.issuer }
+                  {
+                    acr_values: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+                    issuer: service_provider.issuer,
+                  }
                 end
 
                 it 'redirects to the capture_password_url' do


### PR DESCRIPTION
In a previous commit the `resolved_authn_context_result` was introduced to return a `Vot::Parser::Result` object that described the requirements for the current SP request considering SP default options. This is intended to be used to replace the keys in the `sp_session` that serve this purpose including the `ial` key.

This commit replaces places where the `sp_session[:ial]` value is read with new reads to the `resolved_authn_context_result`.
