### PR TITLE
Return a default result from `#resolved_authn_context_result` when no SP is present

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -105,6 +105,8 @@ class ApplicationController < ActionController::Base
   end
 
   def resolved_authn_context_result
+    return @resolved_authn_context_result if defined?(@resolved_authn_context_result)
+
     if current_sp.nil?
       @resolved_authn_context_result ||= Vot::Parser::Result.no_sp_result
     else
@@ -121,6 +123,8 @@ class ApplicationController < ActionController::Base
   end
 
   def current_sp
+    return @current_sp if defined?(@current_sp)
+
     @current_sp ||= sp_from_sp_session || sp_from_request_id
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -105,11 +105,15 @@ class ApplicationController < ActionController::Base
   end
 
   def resolved_authn_context_result
-    @resolved_authn_context_result ||= AuthnContextResolver.new(
-      service_provider: current_sp,
-      vtr: sp_session[:vtr],
-      acr_values: sp_session[:acr_values],
-    ).resolve
+    if current_sp.nil?
+      @resolved_authn_context_result ||= Vot::Parser::Result.no_sp_result
+    else
+      @resolved_authn_context_result ||= AuthnContextResolver.new(
+        service_provider: current_sp,
+        vtr: sp_session[:vtr],
+        acr_values: sp_session[:acr_values],
+      ).resolve
+    end
   end
 
   def context

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,9 +108,9 @@ class ApplicationController < ActionController::Base
     return @resolved_authn_context_result if defined?(@resolved_authn_context_result)
 
     if current_sp.nil?
-      @resolved_authn_context_result ||= Vot::Parser::Result.no_sp_result
+      @resolved_authn_context_result = Vot::Parser::Result.no_sp_result
     else
-      @resolved_authn_context_result ||= AuthnContextResolver.new(
+      @resolved_authn_context_result = AuthnContextResolver.new(
         service_provider: current_sp,
         vtr: sp_session[:vtr],
         acr_values: sp_session[:acr_values],
@@ -123,8 +123,6 @@ class ApplicationController < ActionController::Base
   end
 
   def current_sp
-    return @current_sp if defined?(@current_sp)
-
     @current_sp ||= sp_from_sp_session || sp_from_request_id
   end
 

--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -9,7 +9,19 @@ module Vot
       :identity_proofing?,
       :biometric_comparison?,
       :ialmax?,
-    )
+    ) do
+      def self.no_sp_result
+        self.new(
+          component_values: [],
+          aal2?: false,
+          phishing_resistant?: false,
+          hspd12?: false,
+          identity_proofing?: false,
+          biometric_comparison?: false,
+          ialmax?: false,
+        )
+      end
+    end
 
     attr_reader :vector_of_trust, :acr_values
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -473,6 +473,19 @@ RSpec.describe ApplicationController do
       expect(result.aal2?).to eq(true)
       expect(result.identity_proofing?).to eq(true)
     end
+
+    context 'without an SP' do
+      it 'returns a no-SP result' do
+        sp = nil
+        sp_session = {}
+        allow(controller).to receive(:current_sp).and_return(sp)
+        allow(controller).to receive(:sp_session).and_return(sp_session)
+
+        result = subject.resolved_authn_context_result
+
+        expect(result).to eq(Vot::Parser::Result.no_sp_result)
+      end
+    end
   end
 
   describe '#sp_session_request_url_with_updated_params' do


### PR DESCRIPTION
Currently when there is no SP present `ApplicationController#resolved_authn_context_result` raises an error when it tries to resolve an Authn Context without a VoT or ACR values. This creates an issue when this method is called outside the context of a service provider request.

In order to let the method be called outside of an SP context this commit introduces a no-SP result which can be returned when no SP is present. This allows the method to be called and requirements for authentication and identity-verification to be inspected without a service provider.

This method opts to base the conditional on whether an SP is present rather than whether ACR values or a VoT is present. This preserves behavior where a missing ACR value and VoT will cause an error to be raised. In the case where those values are missing and an SP is present we want to raise an error rather than proceeding with a no-SP result.
