### PR TITLE
Recognize SAML IALMax using authn context comparison in SAML protocol

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -133,7 +133,7 @@ module SamlIdpAuthConcern
     IdentityLinker.
       new(current_user, saml_request_service_provider).
       link_identity(
-        ial: ial_context.ial,
+        ial: resolved_authn_context_int_ial,
         rails_session_id: session.id,
       )
   end
@@ -148,9 +148,8 @@ module SamlIdpAuthConcern
 
   def ial_context
     @ial_context ||= IalContext.new(
-      ial: requested_ial_authn_context,
+      ial: resolved_authn_context_int_ial,
       service_provider: saml_request_service_provider,
-      authn_context_comparison: saml_request.requested_authn_context_comparison,
       user: current_user,
     )
   end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -114,7 +114,7 @@ class SamlIdpController < ApplicationController
   end
 
   def pii_requested_but_locked?
-    if resolved_authn_context_result.identity_proofing? || resolved_authn_context_result.ialmax?
+    if resolved_authn_context_result.identity_proofing_or_ialmax?
       current_user.identity_verified? &&
         !Pii::Cacher.new(current_user, user_session).exists_in_session?
     end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -114,7 +114,7 @@ class SamlIdpController < ApplicationController
   end
 
   def pii_requested_but_locked?
-    if (sp_session && sp_session_ial > 1) || ial_context.ialmax_requested?
+    if resolved_authn_context_result.identity_proofing? || resolved_authn_context_result.ialmax?
       current_user.identity_verified? &&
         !Pii::Cacher.new(current_user, user_session).exists_in_session?
     end
@@ -146,7 +146,9 @@ class SamlIdpController < ApplicationController
   end
 
   def requested_ial
-    return 'ialmax' if ial_context.ialmax_requested?
+    requested_ial_acr = FederatedProtocols::Saml.new(saml_request).ial
+    requested_ial_component = Vot::LegacyComponentValues.by_name[requested_ial_acr]
+    return 'ialmax' if requested_ial_component&.requirements&.include?(:ialmax)
 
     saml_request&.requested_ial_authn_context || 'none'
   end
@@ -174,9 +176,19 @@ class SamlIdpController < ApplicationController
     )
   end
 
+  def resolved_authn_context_int_ial
+    if resolved_authn_context_result.ialmax?
+      0
+    elsif resolved_authn_context_result.identity_proofing?
+      2
+    else
+      1
+    end
+  end
+
   def track_events
     analytics.sp_redirect_initiated(
-      ial: ial_context.ial,
+      ial: resolved_authn_context_int_ial,
       billed_ial: ial_context.bill_for_ial_1_or_2,
       sign_in_flow: session[:sign_in_flow],
     )

--- a/app/models/federated_protocols/saml.rb
+++ b/app/models/federated_protocols/saml.rb
@@ -9,7 +9,11 @@ module FederatedProtocols
     end
 
     def ial
-      request.requested_ial_authn_context || default_authn_context
+      if ialmax_requested_with_authn_context_comparison?
+        ::Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
+      else
+        request.requested_ial_authn_context || default_authn_context
+      end
     end
 
     def aal
@@ -53,6 +57,30 @@ module FederatedProtocols
     def current_service_provider
       return @current_service_provider if defined?(@current_service_provider)
       @current_service_provider = ServiceProvider.find_by(issuer: issuer)
+    end
+
+    ##
+    # A ServiceProvider can request an IAL authn context with a mimimum context comparison . In this
+    # case the IdP is expected to return a result with that IAL or a higher one.
+    #
+    # If a SP requests IAL1 with the mimium context comparison then the IdP can response with a
+    # IAL2 response. In order for this to happen the following need to be true:
+    #
+    # - The service provider is authorized to make IAL2 requests
+    # - The user has a verified account
+    #
+    # This methods checks that we are in a situation where the authn context comparison situation
+    # described above exists and the SP requirements are met (the requirement that the user is
+    # verified occurs as part of the IALMax functionality).
+    #
+    def ialmax_requested_with_authn_context_comparison?
+      return unless (current_service_provider&.ial || 1) > 1
+
+      acr_component_value = Vot::LegacyComponentValues.by_name[request.requested_ial_authn_context]
+      return unless acr_component_value.present?
+
+      !acr_component_value.requirements.include?(:identity_proofing) &&
+        request.requested_authn_context_comparison == 'minimum'
     end
   end
 end

--- a/app/presenters/saml_request_presenter.rb
+++ b/app/presenters/saml_request_presenter.rb
@@ -41,7 +41,8 @@ class SamlRequestPresenter
   end
 
   def ialmax_authn_context?
-    ial_context.ialmax_requested?
+    ial_acr_value = FederatedProtocols::Saml.new(request).ial
+    Vot::LegacyComponentValues.by_name[ial_acr_value]&.requirements&.include?(:ialmax)
   end
 
   def authn_context
@@ -52,7 +53,6 @@ class SamlRequestPresenter
     @ial_context ||= IalContext.new(
       ial: request.requested_ial_authn_context || default_ial_context,
       service_provider: service_provider,
-      authn_context_comparison: request.requested_authn_context_comparison,
     )
   end
 

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -34,7 +34,7 @@ class AttributeAsserter
     attrs = default_attrs
     add_email(attrs) if bundle.include? :email
     add_all_emails(attrs) if bundle.include? :all_emails
-    add_bundle(attrs) if user.active_profile.present? && ial_context.ial2_or_greater?
+    add_bundle(attrs) if should_add_proofed_attributes?
     add_verified_at(attrs) if bundle.include?(:verified_at) && ial_context.ial2_service_provider?
     add_aal(attrs)
     add_ial(attrs) if authn_request.requested_ial_authn_context || !service_provider.ial.nil?
@@ -51,12 +51,21 @@ class AttributeAsserter
                 :decrypted_pii,
                 :user_session
 
+  def should_add_proofed_attributes?
+    return false if !user.active_profile.present?
+    ial_context.ial2_or_greater? || ial_max_requested?
+  end
+
+  def ial_max_requested?
+    ial_acr_value = FederatedProtocols::Saml.new(authn_request).ial
+    Vot::LegacyComponentValues.by_name[ial_acr_value]&.requirements&.include?(:ialmax)
+  end
+
   def ial_context
     @ial_context ||= IalContext.new(
       ial: authn_context,
       service_provider: service_provider,
       user: user,
-      authn_context_comparison: authn_request&.requested_authn_context_comparison,
     )
   end
 
@@ -126,12 +135,17 @@ class AttributeAsserter
 
   def add_ial(attrs)
     requested_context = authn_request.requested_ial_authn_context
-    context = if ial_context.ialmax_requested? && ial_context.ial2_requested?
-                sp_ial # IAL2 since IALMAX only works for IAL2 SPs
+    context = if ialmax_requested_and_fullfilable?
+                # IAL2 since IALMAX only works for IAL2 SPs
+                sp_ial
               else
                 requested_context.presence || sp_ial
               end
     attrs[:ial] = { getter: ial_getter_function(context) } if context
+  end
+
+  def ialmax_requested_and_fullfilable?
+    ial_max_requested? && user.active_profile.present?
   end
 
   def sp_ial

--- a/app/services/ial_context.rb
+++ b/app/services/ial_context.rb
@@ -2,16 +2,15 @@
 
 # Wraps up logic for querying the IAL level of an authorization request
 class IalContext
-  attr_reader :ial, :service_provider, :user, :authn_context_comparison
+  attr_reader :ial, :service_provider, :user
 
   # @param ial [String, Integer] IAL level as either an integer (see ::Idp::Constants::IAL2, etc)
   #   or a string see Saml::Idp::Constants contexts
   # @param service_provider [ServiceProvider, nil]
-  def initialize(ial:, service_provider:, user: nil, authn_context_comparison: nil)
-    @authn_context_comparison = authn_context_comparison
+  def initialize(ial:, service_provider:, user: nil)
     @service_provider = service_provider
     @user = user
-    @ial = int_ial(ial)
+    @ial = convert_ial_to_int(ial)
   end
 
   def ial2_service_provider?
@@ -43,19 +42,6 @@ class IalContext
   end
 
   private
-
-  def int_ial(input)
-    return 0 if saml_ialmax?(input)
-
-    convert_ial_to_int(input)
-  end
-
-  def saml_ialmax?(input)
-    int_ial_from_request = convert_ial_to_int(input)
-    return false unless int_ial_from_request.present?
-
-    service_provider&.ial == 2 && authn_context_comparison == 'minimum' && int_ial_from_request < 2
-  end
 
   def convert_ial_to_int(input)
     Integer(input)

--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -21,6 +21,10 @@ module Vot
           ialmax?: false,
         )
       end
+
+      def identity_proofing_or_ialmax?
+        identity_proofing? || ialmax?
+      end
     end
 
     attr_reader :vector_of_trust, :acr_values

--- a/spec/presenters/saml_request_presenter_spec.rb
+++ b/spec/presenters/saml_request_presenter_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe SamlRequestPresenter do
           phone address1 address2 city state zipcode foo
         ]
         service_provider = ServiceProvider.new(attribute_bundle: all_attributes)
+        allow(request).to receive(
+          :service_provider,
+        ).and_return(
+          double(identifier: service_provider.issuer),
+        )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
 
         expect(presenter.requested_attributes).to eq(%i[email all_emails verified_at])
@@ -43,6 +48,11 @@ RSpec.describe SamlRequestPresenter do
 
         sp_attributes = %w[email first_name last_name ssn zipcode]
         service_provider = ServiceProvider.new(attribute_bundle: sp_attributes, ial: 2)
+        allow(request).to receive(
+          :service_provider,
+        ).and_return(
+          double(identifier: service_provider.issuer),
+        )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
 
         expect(presenter.requested_attributes).to eq(
@@ -67,6 +77,11 @@ RSpec.describe SamlRequestPresenter do
 
         sp_attributes = %w[email first_name last_name ssn zipcode all_emails]
         service_provider = ServiceProvider.new(attribute_bundle: sp_attributes, ial: 1)
+        allow(request).to receive(
+          :service_provider,
+        ).and_return(
+          double(identifier: service_provider.issuer),
+        )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
 
         expect(presenter.requested_attributes).to eq(%i[email all_emails])
@@ -85,6 +100,11 @@ RSpec.describe SamlRequestPresenter do
           attribute_bundle: %w[
             email first_name last_name dob foo ssn phone verified_at
           ],
+        )
+        allow(request).to receive(
+          :service_provider,
+        ).and_return(
+          double(identifier: service_provider.issuer),
         )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
         valid_attributes = %i[
@@ -105,6 +125,11 @@ RSpec.describe SamlRequestPresenter do
 
         service_provider = ServiceProvider.new(
           attribute_bundle: %w[address1 address2 city state zipcode],
+        )
+        allow(request).to receive(
+          :service_provider,
+        ).and_return(
+          double(identifier: service_provider.issuer),
         )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
 

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -544,9 +544,14 @@ RSpec.describe AttributeAsserter do
           expected_ial = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
           expect(user.asserted_attributes[:ial][:getter].call(user)).to eq expected_ial
         end
+
+        it 'does not include proofed attributes' do
+          expect(user.asserted_attributes[:first_name]).to eq(nil)
+          expect(user.asserted_attributes[:phone]).to eq(nil)
+        end
       end
 
-      context 'service provider requests IALMAX with IAL2 user' do
+      context 'IAL2 service provider requests IALMAX with IAL2 user' do
         let(:service_provider_ial) { 2 }
         let(:subject) do
           described_class.new(
@@ -563,6 +568,7 @@ RSpec.describe AttributeAsserter do
           user.identities << identity
           allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
             and_return(%w[email phone first_name])
+          ServiceProvider.find_by(issuer: sp1_issuer).update!(ial: 2)
           subject.build
         end
 
@@ -574,6 +580,47 @@ RSpec.describe AttributeAsserter do
           expected_ial = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
           expect(user.asserted_attributes[:ial][:getter].call(user)).to eq expected_ial
         end
+
+        it 'includes proofed attributes' do
+          expect(user.asserted_attributes[:first_name][:getter].call(user)).to eq('Jåné')
+          expect(user.asserted_attributes[:phone][:getter].call(user)).to eq('+18888675309')
+        end
+      end
+    end
+
+    context 'non-IAL2 service provider requests IALMAX with IAL2 user' do
+      let(:service_provider_ial) { 1 }
+      let(:subject) do
+        described_class.new(
+          user: user,
+          name_id_format: name_id_format,
+          service_provider: service_provider,
+          authn_request: ialmax_authn_request,
+          decrypted_pii: decrypted_pii,
+          user_session: user_session,
+        )
+      end
+
+      before do
+        user.identities << identity
+        allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+          and_return(%w[email phone first_name])
+        ServiceProvider.find_by(issuer: sp1_issuer).update!(ial: 1)
+        subject.build
+      end
+
+      it 'includes ial' do
+        expect(user.asserted_attributes.keys).to include(:ial)
+      end
+
+      it 'creates a getter function for ial attribute' do
+        expected_ial = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+        expect(user.asserted_attributes[:ial][:getter].call(user)).to eq expected_ial
+      end
+
+      it 'includes proofed attributes' do
+        expect(user.asserted_attributes[:first_name]).to eq(nil)
+        expect(user.asserted_attributes[:phone]).to eq(nil)
       end
     end
 

--- a/spec/services/ial_context_spec.rb
+++ b/spec/services/ial_context_spec.rb
@@ -10,14 +10,12 @@ RSpec.describe IalContext do
     )
   end
   let(:user) { nil }
-  let(:authn_context_comparison) { nil }
 
   subject(:ial_context) do
     IalContext.new(
       ial: ial,
       service_provider: service_provider,
       user: user,
-      authn_context_comparison: authn_context_comparison,
     )
   end
 
@@ -118,27 +116,6 @@ RSpec.describe IalContext do
     context 'when ialmax is requested' do
       let(:ial) { Idp::Constants::IAL_MAX }
       it { expect(ial_context.ialmax_requested?).to eq(true) }
-    end
-
-    context 'when ial 1 is requested without Comparison=minimum and ial 2 SP' do
-      let(:ial) { Idp::Constants::IAL1 }
-      let(:authn_context_comparison) { 'exact' }
-      let(:sp_ial) { 2 }
-      it { expect(ial_context.ialmax_requested?).to eq(false) }
-    end
-
-    context 'when ial 1 is requested with Comparison=minimum and ial 2 SP' do
-      let(:ial) { Idp::Constants::IAL1 }
-      let(:authn_context_comparison) { 'minimum' }
-      let(:sp_ial) { 2 }
-      it { expect(ial_context.ialmax_requested?).to eq(true) }
-    end
-
-    context 'when ial 1 is requested with Comparison=minimum and ial 1 SP' do
-      let(:ial) { Idp::Constants::IAL1 }
-      let(:authn_context_comparison) { 'minimum' }
-      let(:sp_ial) { 1 }
-      it { expect(ial_context.ialmax_requested?).to eq(false) }
     end
 
     context 'when ial 2 is requested' do


### PR DESCRIPTION
SAML SPs can request IALMax by using an IAL authn context that does not require proofing and including a Authn Context Comparison value of "minimum". This essentially says that the "IAL1" Authn context is the minimum acceptable context so "IAL2" is also acceptable.

This is problematic for the new `AuthnContextResolver` since it does not have visibility into these attributes on the SAML request when resolving the authn context.

This commit addresses the issue by returning the IALMax Authentication Context Reference from `Saml#ial` in this case. This way the IALMax value is picked up downstream by the `AuthnContextResolver`.

This type of request has a few differences from an IALMax request with the IALMax authn context reference:

- If a service provider that cannot make IAL2 requests makes an IAL1 request in this way it will always be serviced without proofed attributes. An IALMax request with the IALMax authn context reference for a service provider that cannot make IAL2 requests results in an error.
- If a service provider is not on the list of SPs that can make an IALMax request but requests IALMax in this way it will be allowed. I am not sure if this is intended but it is the behavior prior to this commit so it is not a regression.
