### PR TITLE
Guarantee uniqueness of MFA spec factory names

### DIFF
--- a/spec/factories/auth_app_configurations.rb
+++ b/spec/factories/auth_app_configurations.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   Faker::Config.locale = :en
 
   factory :auth_app_configuration do
-    name { Faker::Lorem.word }
+    name { Faker::Lorem.unique.words.join(' ') }
     otp_secret_key { SecureRandom.hex(16) }
     user
   end

--- a/spec/factories/piv_cac_configurations.rb
+++ b/spec/factories/piv_cac_configurations.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   Faker::Config.locale = :en
 
   factory :piv_cac_configuration do
-    name { Faker::Lorem.word }
+    name { Faker::Lorem.unique.words.join(' ') }
     x509_dn_uuid { 'helloworld' }
     user
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates spec factories for `AuthAppConfiguration` and `PivCacConfigurations` to ensure uniqueness of the generated name.

Previous flakey test failures demonstrate that this isn't always unique ([example](https://gitlab.login.gov/lg/identity-idp/-/jobs/1025178)).

`Faker::Lorem.word` chooses a single word from [a set of 251 words](https://github.com/faker-ruby/faker/blob/main/lib/locales/en/lorem.yml#L4C14-L4C1948), so the likelihood of conflict between two samples is reasonably high.

The Faker library documents how to ensure unique values, using the `.unique` method: https://github.com/faker-ruby/faker#ensuring-unique-values

## 📜 Testing Plan

Build should pass.