### PR TITLE
Implement language picker expander as icon

### DIFF
--- a/app/assets/stylesheets/components/_language-picker.scss
+++ b/app/assets/stylesheets/components/_language-picker.scss
@@ -43,14 +43,6 @@
     }
   }
 
-  &::after {
-    content: '';
-    display: block;
-    width: 0.8125rem;
-    height: 0.8125rem;
-    background-size: 0.8125rem;
-  }
-
   &.usa-accordion__button[aria-expanded='false'],
   &.usa-accordion__button[aria-expanded='true'] {
     background-image: none;
@@ -60,28 +52,29 @@
     &:hover {
       background-color: transparent;
     }
-
-    &::after {
-      background-image: url('/angle-arrow-up.svg');
-
-      @include at-media('tablet') {
-        background-image: url('/angle-arrow-up-white.svg');
-      }
-    }
   }
 
   &.usa-accordion__button[aria-expanded='true'] {
     @include u-bg('primary');
     color: color('white');
-
-    &::after {
-      background-image: url('/angle-arrow-down-white.svg');
-    }
   }
 }
 
 .language-picker__label-text {
-  margin: 0 units(1);
+  margin-left: units(1);
+  margin-right: units(0.5);
+}
+
+.language-picker__expander {
+  transition: transform $project-easing;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+
+  .usa-accordion__button[aria-expanded='false'] & {
+    transform: rotate(-180deg);
+  }
 }
 
 .language-picker__list {

--- a/app/components/language_picker_component.html.erb
+++ b/app/components/language_picker_component.html.erb
@@ -11,6 +11,7 @@
     <span id="language-picker-description-<%= unique_id %>" class="language-picker__label-text">
       <%= t('i18n.language') %>
     </span>
+    <%= render IconComponent.new(icon: :expand_more, size: 3, class: 'language-picker__expander') %>
   <% end %>
   <ul
     id="language-picker-<%= unique_id %>"


### PR DESCRIPTION
## 🛠 Summary of changes

Updates footer language picker expander icon to use `IconComponent`.

This is a planned follow-on to #10065.

**Why?**

- Eliminates at least one network request (image) from the common layout
- Simplifies and reduces the size of the application stylesheet
- Consolidates on a common icon glyph for this sort of expander, also used in the "Here's how you know" banner (single "expand_more" icon vs. [six variations of `angle-arrow-*`](https://github.com/18F/identity-design-system/tree/main/src/img)
   - Enables us to delete those icons from the design system
- Avoids flickering that can occur initially when expanding, due to network request for separate image (rotates a single image instead)
- Nifty animation! (disabled when [preferred](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion), for improved accessibility)

## 👀 Screenshots

https://github.com/18F/identity-idp/assets/1779930/0ea98d26-7acb-4996-9e57-2b084043c926