### PR TITLE
LG-12393: barcode attention should only be shown when image upload is successful

### DIFF
--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -78,6 +78,7 @@ class ImageUploadResponsePresenter
   end
 
   def ocr_pii
+    return unless success?
     return unless attention_with_barcode? && @form_response.respond_to?(:pii_from_doc)
     @form_response.pii_from_doc&.slice(:first_name, :last_name, :dob)
   end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -58,16 +58,15 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
         attach_images(
           Rails.root.join(
             'spec', 'fixtures',
-            'ial2_test_credential_barcode_attention_no_dob.yml'
+            'ial2_test_credential_barcode_attention_no_address.yml'
           ),
         )
         submit_images
 
-        expect(page).to have_content(t('doc_auth.errors.barcode_attention.heading'))
-        click_idv_continue
-
-        # should show try again
+        expect(page).to have_content(t('doc_auth.errors.alerts.address_check'))
         expect(page).to have_current_path(idv_document_capture_path)
+
+        click_try_again
         attach_images
         submit_images
         expect(page).to have_current_path(idv_ssn_path)

--- a/spec/fixtures/ial2_test_credential_barcode_attention_no_address.yml
+++ b/spec/fixtures/ial2_test_credential_barcode_attention_no_address.yml
@@ -1,0 +1,14 @@
+document:
+  first_name: Jane
+  last_name: Doe
+  middle_name: Q
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  dob: 10/06/1938
+  phone: +1 314-555-1212
+  state_id_jurisdiction: 'NY'
+  state_id_number: 'S59397998'
+failed_alerts:
+  - name: 2D Barcode Read
+    result: Attention


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12393](https://cm-jira.usa.gov/browse/LG-12393)

## 🛠 Summary of changes
Only present BarcodeWarning when the image upload is successful as in the doc auth and pii validation is successful.

## 📜 Testing Plan
- [ ] Submit doc auth image/yml that contains invalid pii and an attention doc auth result.
- [ ] Veify the failed ID screen is shown with the option to _Try Again_

## 👀 Screenshots


If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="617" alt="Screenshot 2024-02-12 at 8 49 05 PM" src="https://github.com/18F/identity-idp/assets/1261794/176c9dfc-ac95-4168-8f92-425f47b9f89e">
</details>

<details>
<summary>After:</summary>
<img width="527" alt="Screenshot 2024-02-12 at 8 53 19 PM" src="https://github.com/18F/identity-idp/assets/1261794/77d9f077-72ce-4b0b-a755-7497c242fed2">

</details>
