### PR TITLE
Lg-12150 add vtr and acr_values to identity table

### DIFF
--- a/db/primary_migrate/20240215212318_add_vtr_and_acrvalues_to_identities.rb
+++ b/db/primary_migrate/20240215212318_add_vtr_and_acrvalues_to_identities.rb
@@ -1,0 +1,6 @@
+class AddVtrAndAcrvaluesToIdentities < ActiveRecord::Migration[7.1]
+  def change
+    add_column :identities, :vtr, :string
+    add_column :identities, :acr_values, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_10_142935) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_15_212318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -288,6 +288,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_142935) do
     t.datetime "deleted_at", precision: nil
     t.integer "aal"
     t.text "requested_aal_value"
+    t.string "vtr"
+    t.string "acr_values"
     t.index ["access_token"], name: "index_identities_on_access_token", unique: true
     t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
     t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", unique: true


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-12150](https://cm-jira.usa.gov/browse/LG-12150)



## 🛠 Summary of changes

This PR is the first of a series of steps of getting acr values and vots into the identity token we send back to the service provider. 

We first want to add acr_values and vtr to the identities table so that they will be saved so we can use them later in the creation of the identity token.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
