### PR TITLE
LG-12283 handle missing PII in session

### DIFF
--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -18,19 +18,19 @@ module Idv
     skip_before_action :handle_fraud
 
     def show
-      if pii_is_missing
-        redirect_to_retrieve_pii
-        return
-      end
-
       analytics.idv_personal_key_visited(
         address_verification_method: idv_session.address_verification_mechanism,
         in_person_verification_pending: idv_session.profile&.in_person_verification_pending?,
+        pii_missing: pii_is_missing?,
         **opt_in_analytics_properties,
       )
-      add_proofing_component
 
-      finish_idv_session
+      if pii_is_missing?
+        redirect_to_retrieve_pii
+      else
+        add_proofing_component
+        finish_idv_session
+      end
     end
 
     def update
@@ -123,7 +123,7 @@ module Idv
       current_user.pending_in_person_enrollment.present?
     end
 
-    def pii_is_missing
+    def pii_is_missing?
       user_session[:encrypted_profiles].blank?
     end
 

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -21,7 +21,7 @@ module Idv
       analytics.idv_personal_key_visited(
         address_verification_method: idv_session.address_verification_mechanism,
         in_person_verification_pending: idv_session.profile&.in_person_verification_pending?,
-        pii_missing: pii_is_missing?,
+        encrypted_profiles_missing: pii_is_missing?,
         **opt_in_analytics_properties,
       )
 

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -19,6 +19,7 @@ module Idv
 
     def show
       if pii_is_missing
+        user_session[:stored_location] = request.original_fullpath
         redirect_to fix_broken_personal_key_url
         return
       end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -19,8 +19,7 @@ module Idv
 
     def show
       if pii_is_missing
-        user_session[:stored_location] = request.original_fullpath
-        redirect_to fix_broken_personal_key_url
+        redirect_to_retrieve_pii
         return
       end
 
@@ -126,6 +125,11 @@ module Idv
 
     def pii_is_missing
       user_session[:encrypted_profiles].blank?
+    end
+
+    def redirect_to_retrieve_pii
+      user_session[:stored_location] = request.original_fullpath
+      redirect_to fix_broken_personal_key_url
     end
   end
 end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -86,6 +86,21 @@ module Idv
     end
 
     def personal_key
+      # DEBUG
+      # idv_session.personal_key = nil
+
+      # Profile.transaction do
+      #   current_user.profiles.each do |profile|
+      #     pii = cacher.fetch(profile.id)
+      #     next if pii.nil?
+
+      #     new_personal_key = profile.encrypt_recovery_pii(pii, personal_key: new_personal_key)
+
+      #     profile.save!
+      #   end
+      # end
+      # END DEBUG
+
       idv_session.personal_key || generate_personal_key
     end
 

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -19,7 +19,7 @@ module Idv
 
     def show
       if pii_is_missing
-        handle_missing_pii
+        redirect_to fix_broken_personal_key_url
         return
       end
 
@@ -31,14 +31,6 @@ module Idv
       add_proofing_component
 
       finish_idv_session
-    end
-
-    def handle_missing_pii
-      redirect_to fix_broken_personal_key_url
-    end
-
-    def pii_is_missing
-      user_session[:encrypted_profiles].blank? && !current_user.pending_profile
     end
 
     def update
@@ -129,6 +121,10 @@ module Idv
     def in_person_enrollment?
       return false unless IdentityConfig.store.in_person_proofing_enabled
       current_user.pending_in_person_enrollment.present?
+    end
+
+    def pii_is_missing
+      user_session[:encrypted_profiles].blank?
     end
   end
 end

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -70,8 +70,6 @@ RSpec.describe Idv::PersonalKeyController, allowed_extra_analytics: [:*] do
     if mint_profile_from_idv_session
       idv_session.create_profile_from_applicant_with_password(password)
     end
-
-    pii_cacher.save(password)
   end
 
   describe '#step_info' do

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -190,6 +190,18 @@ RSpec.describe Idv::PersonalKeyController, allowed_extra_analytics: [:*] do
   end
 
   describe '#show' do
+    context 'when we have no personal key or encrypted profiles in the session' do
+      it 'redirects to get the users password and fetch the PII' do
+        controller.idv_session.personal_key = nil
+        controller.user_session[:encrypted_profiles] = nil
+
+        response = get :show
+
+        expect(controller.user_session[:needs_new_personal_key]).to be true
+        expect(response).to redirect_to(capture_password_path)
+      end
+    end
+
     context 'profile has been created from idv_session' do
       it 'does not redirect' do
         get :show

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -233,10 +233,12 @@ RSpec.describe Idv::PersonalKeyController, allowed_extra_analytics: [:*] do
 
         context 'due to fraud review' do
           let!(:pending_profile) do
-            create(:profile,
-                   :fraud_review_pending,
-                   :with_pii,
-                   user: user)
+            create(
+              :profile,
+              :fraud_review_pending,
+              :with_pii,
+              user: user,
+            )
           end
 
           it 'does not redirect' do
@@ -247,10 +249,12 @@ RSpec.describe Idv::PersonalKeyController, allowed_extra_analytics: [:*] do
 
         context 'due to in person proofing' do
           let!(:pending_profile) do
-            create(:profile,
-                   :in_person_verification_pending,
-                   :with_pii,
-                   user: user)
+            create(
+              :profile,
+              :in_person_verification_pending,
+              :with_pii,
+              user: user,
+            )
           end
 
           it 'does not redirect' do

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Idv::PersonalKeyController, allowed_extra_analytics: [:*] do
 
         response = get :show
 
-        expect(controller.user_session[:needs_new_personal_key]).to be true
+        expect(controller.user_session[:stored_location]).to eq(idv_personal_key_path)
         expect(response).to redirect_to(capture_password_path)
       end
     end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
-        address_verification_method: 'phone', in_person_verification_pending: false,
+        address_verification_method: 'phone', encrypted_profiles_missing: false, in_person_verification_pending: false,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {
@@ -237,7 +237,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
-        address_verification_method: 'phone', in_person_verification_pending: false,
+        address_verification_method: 'phone', encrypted_profiles_missing: false, in_person_verification_pending: false,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {
@@ -448,7 +448,9 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: personal key visited' => {
         in_person_verification_pending: true,
-        proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }, address_verification_method: 'phone'
+        address_verification_method: 'phone',
+        encrypted_profiles_missing: false,
+        proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: personal key acknowledgment toggled' => {
         checked: true,
@@ -563,7 +565,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
-        address_verification_method: 'phone', in_person_verification_pending: false,
+        address_verification_method: 'phone', in_person_verification_pending: false, encrypted_profiles_missing: false,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {


### PR DESCRIPTION
## 🎫 Ticket

[LG-12283](https://cm-jira.usa.gov/browse/LG-12283)

## 🛠 Summary of changes

Added code to `PersonalKeyController#show` to catch a situation where we very occasionally have no PII available in the session when we are about to try to encrypt PII from the session.

In this case, we redirect to the code for a missing or bad personal key, which prompts the user for their password and retrieves the PII. We also arrange to return here afterward.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Add a call to `binding.pry` at the top of `PersonalKeyController#show`
- [ ] Start the server, create a user, and proceed through IdV until you hit the pry (this will be after you enter your password to encrypt your PII, and just before the app is about to render the personal key page).
- [ ] Clear the PII out of the session and continue execution with the commands:
```
idv_session.personal_key = nil
user_session[:encrypted_profiles] = nil
continue
```
- [ ] Verify that you are prompted to re-enter your password again.
- [ ] After re-entering your password, you will hit the pry again. This time, leave the PII in the session and continue:
```
continue
```
- [ ] Verify that you are on the personal key page.
- [ ] Continue, and verify that IdV completes successfully

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Re-entering your password:</summary>

![Screenshot 2024-02-15 at 9 35 27 PM](https://github.com/18F/identity-idp/assets/101212334/249f2fa4-3a0c-47ef-9083-5823e5b3b20d)

</details>

<details>
<summary>Personal key page:</summary>

![Screenshot 2024-02-15 at 9 38 08 PM](https://github.com/18F/identity-idp/assets/101212334/4fbcfede-abb9-4983-9163-3f2ad6032073)

</details>
