### PR TITLE
Add server-side validation for frontend errors filtering 

### DIFF
--- a/app/forms/frontend_error_form.rb
+++ b/app/forms/frontend_error_form.rb
@@ -1,0 +1,30 @@
+class FrontendErrorForm
+  include ActiveModel::Model
+  include ActionView::Helpers::TranslationHelper
+
+  validate :validate_filename_extension
+  validate :validate_filename_host
+
+  attr_reader :filename
+
+  def submit(filename:)
+    @filename = filename
+
+    FormResponse.new(success: valid?, errors:, serialize_error_details_only: true)
+  end
+
+  private
+
+  def validate_filename_extension
+    return if File.extname(filename) == '.js'
+    errors.add(:filename, :invalid_extension, message: t('errors.general'))
+  end
+
+  def validate_filename_host
+    begin
+      return if URI(filename).host == IdentityConfig.store.domain_name
+    rescue URI::InvalidURIError; end
+
+    errors.add(:filename, :invalid_host, message: t('errors.general'))
+  end
+end

--- a/app/services/frontend_error_logger.rb
+++ b/app/services/frontend_error_logger.rb
@@ -2,6 +2,8 @@ class FrontendErrorLogger
   class FrontendError < StandardError; end
 
   def self.track_error(name:, message:, stack:, filename:)
+    return unless FrontendErrorForm.new.submit(filename:).success?
+
     NewRelic::Agent.notice_error(
       FrontendError.new,
       expected: true,

--- a/spec/forms/frontend_error_form_spec.rb
+++ b/spec/forms/frontend_error_form_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe FrontendErrorForm do
+  let(:filename) { 'https://example.com/foo.js' }
+
+  subject(:form) { described_class.new }
+
+  before do
+    allow(IdentityConfig.store).to receive(:domain_name).and_return('example.com')
+  end
+
+  describe '#submit' do
+    subject(:result) { form.submit(filename:) }
+
+    context 'with valid filename' do
+      let(:filename) { 'https://example.com/foo.js' }
+
+      it 'is successful' do
+        expect(result.success?).to eq(true)
+        expect(result.errors).to eq({})
+      end
+    end
+
+    context 'with filename without extension' do
+      let(:filename) { 'https://example.com/foo' }
+
+      it 'is unsuccessful' do
+        expect(result.success?).to eq(false)
+        expect(result.errors).to eq(filename: [t('errors.general')])
+      end
+    end
+
+    context 'with filename having extension other than js' do
+      let(:filename) { 'https://example.com/foo.txt' }
+
+      it 'is unsuccessful' do
+        expect(result.success?).to eq(false)
+        expect(result.errors).to eq(filename: [t('errors.general')])
+      end
+    end
+
+    context 'with filename from a different host' do
+      let(:filename) { 'https://wrong.example.com/foo.js' }
+
+      it 'is unsuccessful' do
+        expect(result.success?).to eq(false)
+        expect(result.errors).to eq(filename: [t('errors.general')])
+      end
+    end
+
+    context 'with filename that cannot be parsed as url' do
+      let(:filename) { '{' }
+
+      it 'is unsuccessful' do
+        expect(result.success?).to eq(false)
+        expect(result.errors).to eq(filename: [t('errors.general'), t('errors.general')])
+      end
+    end
+  end
+end

--- a/spec/services/frontend_error_logger_spec.rb
+++ b/spec/services/frontend_error_logger_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe FrontendErrorLogger do
+  let(:valid) { true }
+
+  before do
+    allow_any_instance_of(FrontendErrorForm).to receive(:submit).
+      and_return(FormResponse.new(success: valid))
+  end
+
   describe '.track_event' do
     it 'notices an expected error to NewRelic with custom parameters' do
       expect(NewRelic::Agent).to receive(:notice_error).with(
@@ -24,15 +31,17 @@ RSpec.describe FrontendErrorLogger do
       )
     end
 
-    context 'with filename other than js' do
-      it 'notices an expected error to NewRelic with custom parameters' do
+    context 'with unsuccessful validation of request parameters' do
+      let(:valid) { false }
+
+      it 'does not notice an error' do
         expect(NewRelic::Agent).not_to receive(:notice_error)
 
         FrontendErrorLogger.track_error(
           name: 'name',
           message: 'message',
           stack: 'stack',
-          filename: 'filename',
+          filename: 'filename.js',
         )
       end
     end

--- a/spec/services/frontend_error_logger_spec.rb
+++ b/spec/services/frontend_error_logger_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FrontendErrorLogger do
             name: 'name',
             message: 'message',
             stack: 'stack',
-            filename: 'filename',
+            filename: 'filename.js',
           },
         },
       )
@@ -20,8 +20,21 @@ RSpec.describe FrontendErrorLogger do
         name: 'name',
         message: 'message',
         stack: 'stack',
-        filename: 'filename',
+        filename: 'filename.js',
       )
+    end
+
+    context 'with filename other than js' do
+      it 'notices an expected error to NewRelic with custom parameters' do
+        expect(NewRelic::Agent).not_to receive(:notice_error)
+
+        FrontendErrorLogger.track_error(
+          name: 'name',
+          message: 'message',
+          stack: 'stack',
+          filename: 'filename',
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds server-side validation to match the client-side error filtering performed to limit errors to those thrown within Login.gov scripts.

This is a follow-up to the suggestion at https://github.com/18F/identity-idp/pull/10087#discussion_r1490151966

## 📜 Testing Plan

Repeat Testing Plan from #10087

```
rspec spec/forms/frontend_error_form_spec.rb spec/services/frontend_error_logger_spec.rb
```