### PR TITLE
Remove unused stored_location analytics parameter

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -23,10 +23,7 @@ module Users
       @issuer_forced_reauthentication = issuer_forced_reauthentication?(
         issuer: decorated_sp_session.sp_issuer,
       )
-      analytics.sign_in_page_visit(
-        flash: flash[:alert],
-        stored_location: session['user_return_to'],
-      )
+      analytics.sign_in_page_visit(flash: flash[:alert])
       super
     end
 
@@ -134,7 +131,6 @@ module Users
         user_id: user.uuid,
         user_locked_out: user_locked_out?(user),
         bad_password_count: session[:bad_password_count].to_i,
-        stored_location: session['user_return_to'],
         sp_request_url_present: sp_session[:request_url].present?,
         remember_device: remember_device_cookie.present?,
       )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -353,7 +353,6 @@ module AnalyticsEvents
   # @param [String] user_id
   # @param [Boolean] user_locked_out if the user is currently locked out of their second factor
   # @param [String] bad_password_count represents number of prior login failures
-  # @param [String] stored_location the URL to return to after signing in
   # @param [Boolean] sp_request_url_present if was an SP request URL in the session
   # @param [Boolean] remember_device if the remember device cookie was present
   # Tracks authentication attempts at the email/password screen
@@ -362,7 +361,6 @@ module AnalyticsEvents
     user_id:,
     user_locked_out:,
     bad_password_count:,
-    stored_location:,
     sp_request_url_present:,
     remember_device:,
     **extra
@@ -373,7 +371,6 @@ module AnalyticsEvents
       user_id: user_id,
       user_locked_out: user_locked_out,
       bad_password_count: bad_password_count,
-      stored_location: stored_location,
       sp_request_url_present: sp_request_url_present,
       remember_device: remember_device,
       **extra,
@@ -4365,15 +4362,9 @@ module AnalyticsEvents
   end
 
   # @param [String] flash
-  # @param [String] stored_location
   # tracks when a user visits the sign in page
-  def sign_in_page_visit(flash:, stored_location:, **extra)
-    track_event(
-      'Sign in page visited',
-      flash: flash,
-      stored_location: stored_location,
-      **extra,
-    )
+  def sign_in_page_visit(flash:, **extra)
+    track_event('Sign in page visited', flash:, **extra)
   end
 
   # @param [Boolean] success

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe Users::SessionsController, devise: true do
         user_id: user.uuid,
         user_locked_out: false,
         bad_password_count: 1,
-        stored_location: nil,
         sp_request_url_present: false,
         remember_device: false,
       }
@@ -94,7 +93,6 @@ RSpec.describe Users::SessionsController, devise: true do
         user_id: 'anonymous-uuid',
         user_locked_out: false,
         bad_password_count: 1,
-        stored_location: nil,
         sp_request_url_present: false,
         remember_device: false,
       }
@@ -133,7 +131,6 @@ RSpec.describe Users::SessionsController, devise: true do
         user_id: user.uuid,
         user_locked_out: true,
         bad_password_count: 0,
-        stored_location: nil,
         sp_request_url_present: false,
         remember_device: false,
       }
@@ -157,7 +154,6 @@ RSpec.describe Users::SessionsController, devise: true do
         user_id: user.uuid,
         user_locked_out: false,
         bad_password_count: 2,
-        stored_location: nil,
         sp_request_url_present: false,
         remember_device: false,
       }
@@ -176,7 +172,6 @@ RSpec.describe Users::SessionsController, devise: true do
         user_id: 'anonymous-uuid',
         user_locked_out: false,
         bad_password_count: 1,
-        stored_location: nil,
         sp_request_url_present: true,
         remember_device: false,
       }
@@ -251,7 +246,6 @@ RSpec.describe Users::SessionsController, devise: true do
           user_id: user.uuid,
           user_locked_out: false,
           bad_password_count: 0,
-          stored_location: nil,
           sp_request_url_present: false,
           remember_device: false,
         }
@@ -378,7 +372,6 @@ RSpec.describe Users::SessionsController, devise: true do
           user_id: user.uuid,
           user_locked_out: false,
           bad_password_count: 0,
-          stored_location: nil,
           sp_request_url_present: false,
           remember_device: true,
         }
@@ -404,7 +397,6 @@ RSpec.describe Users::SessionsController, devise: true do
           user_id: user.uuid,
           user_locked_out: false,
           bad_password_count: 0,
-          stored_location: nil,
           sp_request_url_present: false,
           remember_device: true,
         }

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Users::SessionsController, devise: true do
 
     it 'tracks the successful authentication for existing user' do
       user = create(:user, :fully_registered)
-      subject.session['user_return_to'] = mock_valid_site
 
       stub_analytics
       stub_attempts_tracker
@@ -52,7 +51,6 @@ RSpec.describe Users::SessionsController, devise: true do
         user_id: user.uuid,
         user_locked_out: false,
         bad_password_count: 0,
-        stored_location: mock_valid_site,
         sp_request_url_present: false,
         remember_device: false,
       }
@@ -513,12 +511,10 @@ RSpec.describe Users::SessionsController, devise: true do
       it 'tracks page visit, any alert flashes, and the Devise stored location' do
         stub_analytics
         allow(controller).to receive(:flash).and_return(alert: 'hello')
-        subject.session['user_return_to'] = mock_valid_site
 
         expect(@analytics).to receive(:track_event).with(
           'Sign in page visited',
           flash: 'hello',
-          stored_location: mock_valid_site,
         )
 
         get :new


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the `stored_location` analytics property from the 'Sign in page visited' and 'Email and Password Authentication' analytics events.

This references a session value `user_return_to` that is not assigned, last referenced removed in #5413.

Tangentially-related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1706906370684589

**Why?**

- Reduce logging payload size for frequent analytics events
- Avoid misleading developers to imply we track return location for sign-in, since we don't ([LG-3737](https://cm-jira.usa.gov/browse/LG-3737))

## 📜 Testing Plan

1. In a separate terminal process, run `make watch_events`
2. Go to http://localhost:3000
3. Observe logged event for "Sign in page visited" does not include `stored_location`
4. Sign in
5. Observe logged event for "Email and password authentication" does not include `stored_location`