### PR TITLE
LG-11737: delete unused service providers

### DIFF
--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -26,7 +26,7 @@ class DestroyableRecords
 
     stdout.puts '********'
     stdout.puts 'Integration:'
-    if integration.nil?
+    if integration.blank?
       stdout.puts 'No associated integration'
     else
       stdout.puts integration.attributes.to_yaml
@@ -46,7 +46,7 @@ class DestroyableRecords
 
     stdout.puts '*******'
     stdout.puts 'These are the IAA orders that will be affected: \n'
-    if iaa_orders.nil?
+    if iaa_orders.blank?
       stdout.puts 'No IAA orders will be affected'
     else
       stdout.puts 'These are the IAA orders that will be affected: \n'
@@ -79,11 +79,11 @@ class DestroyableRecords
   private
 
   def integration_usages
-    integration&.integration_usages
+    integration&.integration_usages || []
   end
 
   def iaa_orders
-    integration&.iaa_orders
+    integration&.iaa_orders || []
   end
 
   def in_person_enrollments

--- a/spec/lib/cleanup/destroyable_records_spec.rb
+++ b/spec/lib/cleanup/destroyable_records_spec.rb
@@ -106,6 +106,16 @@ RSpec.describe DestroyableRecords do
       expect(iaa_order.integrations.include? integration).to be false
     end
 
+    describe 'integration without usages or iaa_orders' do
+      let!(:empty_integration) { create(:integration) }
+      let!(:service_provider) { empty_integration.service_provider }
+
+      it 'destroys the integration' do
+        deleted_int = Agreements::Integration.find_by(id: empty_integration.id)
+        expect(deleted_int).to be nil
+      end
+    end
+
     it 'does not delete unrelated objects' do
       iu2.reload
       iaa_order.reload


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-11737](https://cm-jira.usa.gov/browse/LG-11737)


## 🛠 Summary of changes
 
When going to delete some unused service providers ran into an error where it tried to loop through integration usages but some of the unused SP's do not have any associated usages (or iaa_orders). Tweaked the script to account for SP's that don't have these associations. 

