### PR TITLE
LG-12150 Write acr_values and vtr to identites table using identity linker

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -100,6 +100,8 @@ class OpenidConnectAuthorizeForm
       rails_session_id: rails_session_id,
       ial: ial_context.ial,
       aal: aal,
+      acr_values: acr_values,
+      vtr: vtr,
       requested_aal_value: requested_aal_value,
       scope: scope.join(' '),
       code_challenge: code_challenge,

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -100,7 +100,7 @@ class OpenidConnectAuthorizeForm
       rails_session_id: rails_session_id,
       ial: ial_context.ial,
       aal: aal,
-      acr_values: acr_values,
+      acr_values: acr_values&.join(' '),
       vtr: vtr,
       requested_aal_value: requested_aal_value,
       scope: scope.join(' '),

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -6,6 +6,8 @@ class IdentityLinker
     @service_provider = service_provider
     @ial = nil
     @aal = nil
+    @acr_values = nil
+    @vtr = nil
     @requested_aal_value = nil
   end
 
@@ -13,6 +15,8 @@ class IdentityLinker
     code_challenge: nil,
     ial: nil,
     aal: nil,
+    acr_values: nil,
+    vtr: nil,
     requested_aal_value: nil,
     nonce: nil,
     rails_session_id: nil,
@@ -30,6 +34,8 @@ class IdentityLinker
         code_challenge: code_challenge,
         ial: ial,
         aal: aal,
+        acr_values: acr_values,
+        vtr: vtr,
         requested_aal_value: requested_aal_value,
         nonce: nonce,
         rails_session_id: rails_session_id,

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -831,7 +831,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
         expect(identity.code_challenge).to eq(code_challenge)
         expect(identity.nonce).to eq(nonce)
         expect(identity.ial).to eq(1)
-        expect(identity.acr_values).to eq '[]'
+        expect(identity.acr_values).to eq ''
         expect(identity.vtr).to eq ['C1'].to_json
       end
     end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -831,6 +831,8 @@ RSpec.describe OpenidConnectAuthorizeForm do
         expect(identity.code_challenge).to eq(code_challenge)
         expect(identity.nonce).to eq(nonce)
         expect(identity.ial).to eq(1)
+        expect(identity.acr_values).to eq '[]'
+        expect(identity.vtr).to eq ['C1'].to_json
       end
     end
   end

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe IdentityLinker do
       nonce = SecureRandom.hex
       ial = 3
       acr_values = 'http://idmanagement.gov/ns/assurance/aal/1'
-      vtr = 'C2.Pb'
+      vtr = ['C2.Pb'].to_json
       scope = 'openid profile email'
       code_challenge = SecureRandom.hex
       verified_attributes = %w[address email]

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe IdentityLinker do
       rails_session_id = SecureRandom.hex
       nonce = SecureRandom.hex
       ial = 3
+      acr_values = 'http://idmanagement.gov/ns/assurance/aal/1'
+      vtr = 'C2.Pb'
       scope = 'openid profile email'
       code_challenge = SecureRandom.hex
       verified_attributes = %w[address email]
@@ -38,6 +40,8 @@ RSpec.describe IdentityLinker do
         rails_session_id: rails_session_id,
         nonce: nonce,
         ial: ial,
+        acr_values: acr_values,
+        vtr: vtr,
         scope: scope,
         code_challenge: code_challenge,
         verified_attributes: verified_attributes.map(&:to_sym),
@@ -48,6 +52,8 @@ RSpec.describe IdentityLinker do
       expect(last_identity.nonce).to eq(nonce)
       expect(last_identity.rails_session_id).to eq(rails_session_id)
       expect(last_identity.ial).to eq(ial)
+      expect(last_identity.acr_values).to eq(acr_values)
+      expect(last_identity.vtr).to eq(vtr)
       expect(last_identity.scope).to eq(scope)
       expect(last_identity.code_challenge).to eq(code_challenge)
       expect(last_identity.verified_attributes).to eq(verified_attributes)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket


[LG-12150](https://cm-jira.usa.gov/browse/LG-12150)



## 🛠 Summary of changes

This is part two of being able to create an identity token with acr and vectors of trust values. This writes acr_values and vtr params into the identities table so we will be able to read from them later when creating the id token.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
