### PR TITLE
Drop unused monthly_auth_counts table (LG-12483)

### DIFF
--- a/app/models/monthly_auth_count.rb
+++ b/app/models/monthly_auth_count.rb
@@ -1,2 +1,0 @@
-class MonthlyAuthCount < ApplicationRecord
-end

--- a/db/primary_migrate/20240216184124_drop_monthly_auth_counts.rb
+++ b/db/primary_migrate/20240216184124_drop_monthly_auth_counts.rb
@@ -1,0 +1,17 @@
+class DropMonthlyAuthCounts < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    drop_table :monthly_auth_counts
+  end
+
+  def down
+    create_table :monthly_auth_counts do |t|
+      t.string :issuer, null: false
+      t.string :year_month, null: false
+      t.integer :user_id, null: false
+      t.integer :auth_count, default: 1, null: false
+    end
+    add_index :monthly_auth_counts, %i[issuer year_month user_id], algorithm: :concurrently, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_15_212318) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_16_184124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -362,14 +362,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_15_212318) do
     t.datetime "ftp_at", precision: nil, null: false
     t.integer "letter_requests_count", null: false
     t.index ["ftp_at"], name: "index_letter_requests_to_usps_ftp_logs_on_ftp_at"
-  end
-
-  create_table "monthly_auth_counts", force: :cascade do |t|
-    t.string "issuer", null: false
-    t.string "year_month", null: false
-    t.integer "user_id", null: false
-    t.integer "auth_count", default: 1, null: false
-    t.index ["issuer", "year_month", "user_id"], name: "index_monthly_auth_counts_on_issuer_and_year_month_and_user_id", unique: true
   end
 
   create_table "notification_phone_configurations", force: :cascade do |t|


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12483](https://cm-jira.usa.gov/browse/LG-12483)

## 🛠 Summary of changes

We stopped using this table in #3634, and that PR created `monthly_sp_auth_counts`. That table was dropped in #7312. Along similar lines, this PR drops the `monthly_auth_counts` table.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
