### PR TITLE
LG-11737 Removing providers without integrations

### DIFF
--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -26,7 +26,7 @@ class DestroyableRecords
 
     stdout.puts '********'
     stdout.puts 'Integration:'
-    if integration.blank?
+    if integration.nil?
       stdout.puts 'No associated integration'
     else
       stdout.puts integration.attributes.to_yaml
@@ -58,15 +58,17 @@ class DestroyableRecords
   end
 
   def destroy_records
-    stdout.puts 'Destroying integration usages'
-    integration_usages.each do |integration_usage|
-      integration_usage.destroy!
-    end
-    integration.reload
+    if integration
+      stdout.puts 'Destroying integration usages'
+      integration_usages.each do |integration_usage|
+        integration_usage.destroy!
+      end
+      integration.reload
 
-    stdout.puts "Destroying integration with issuer #{integration.issuer}"
-    integration.destroy!
-    service_provider.reload
+      stdout.puts "Destroying integration with issuer #{integration.issuer}"
+      integration.destroy!
+      service_provider.reload
+    end
 
     stdout.puts "Destroying service provider issuer #{service_provider.issuer}"
     service_provider.destroy!
@@ -79,11 +81,11 @@ class DestroyableRecords
   private
 
   def integration_usages
-    integration&.integration_usages || []
+    integration&.integration_usages
   end
 
   def iaa_orders
-    integration&.iaa_orders || []
+    integration&.iaa_orders
   end
 
   def in_person_enrollments

--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -60,11 +60,8 @@ class DestroyableRecords
   def destroy_records
     if integration
       stdout.puts 'Destroying integration usages'
-      integration_usages.each do |integration_usage|
-        integration_usage.destroy!
-      end
+      integration_usages.destroy_all
       integration.reload
-
       stdout.puts "Destroying integration with issuer #{integration.issuer}"
       integration.destroy!
       service_provider.reload

--- a/lib/cleanup/destroyable_records.rb
+++ b/lib/cleanup/destroyable_records.rb
@@ -58,7 +58,7 @@ class DestroyableRecords
   end
 
   def destroy_records
-    if integration
+    if integration.present?
       stdout.puts 'Destroying integration usages'
       integration_usages.destroy_all
       integration.reload

--- a/spec/lib/cleanup/destroyable_records_spec.rb
+++ b/spec/lib/cleanup/destroyable_records_spec.rb
@@ -106,6 +106,17 @@ RSpec.describe DestroyableRecords do
       expect(iaa_order.integrations.include? integration).to be false
     end
 
+    context 'integration without integration usages' do
+      # int factory has no usages by default
+      let!(:integration) { create(:integration) }
+      let!(:service_provider) { integration.service_provider }
+
+      it 'destroys the integration' do
+        deleted_int = Agreements::Integration.find_by(id: integration.id)
+        expect(deleted_int).to be nil
+      end
+    end
+
     context 'no integration' do
       # sp factory has no integrations by default
       let!(:service_provider) { create(:service_provider) }

--- a/spec/lib/cleanup/destroyable_records_spec.rb
+++ b/spec/lib/cleanup/destroyable_records_spec.rb
@@ -106,13 +106,13 @@ RSpec.describe DestroyableRecords do
       expect(iaa_order.integrations.include? integration).to be false
     end
 
-    describe 'integration without usages or iaa_orders' do
-      let!(:empty_integration) { create(:integration) }
-      let!(:service_provider) { empty_integration.service_provider }
+    context 'no integration' do
+      # sp factory has no integrations by default
+      let!(:service_provider) { create(:service_provider) }
 
-      it 'destroys the integration' do
-        deleted_int = Agreements::Integration.find_by(id: empty_integration.id)
-        expect(deleted_int).to be nil
+      it 'destroys the service provider' do
+        deleted_sp = ServiceProvider.find_by(id: service_provider.id)
+        expect(deleted_sp).to be nil
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-11737](https://cm-jira.usa.gov/browse/LG-11737)

## 🛠 Summary of changes

Was a little too hasty with #10106 and realized the issue stems not from `nil` `integration_usage` needing to be an empty array but for service providers which have no integrations at all
