### PR TITLE
LG-12172 implement tmx rejection screen and refactor please call code

### DIFF
--- a/app/controllers/concerns/fraud_review_concern.rb
+++ b/app/controllers/concerns/fraud_review_concern.rb
@@ -26,6 +26,7 @@ module FraudReviewConcern
 
   def in_person_prevent_fraud_redirection?
     IdentityConfig.store.in_person_proofing_enforce_tmx &&
+      !current_user.in_person_enrollment_status.nil? &&
       current_user.in_person_enrollment_status != 'passed'
   end
 

--- a/app/controllers/concerns/fraud_review_concern.rb
+++ b/app/controllers/concerns/fraud_review_concern.rb
@@ -4,11 +4,9 @@ module FraudReviewConcern
   delegate :fraud_check_failed?,
            :fraud_review_pending?,
            :fraud_rejection?,
-           :ipp_fraud_review_pending?,
            to: :fraud_review_checker
 
   def handle_fraud
-    in_person_handle_pending_fraud_review
     handle_pending_fraud_review
     handle_fraud_rejection
   end
@@ -16,25 +14,19 @@ module FraudReviewConcern
   def handle_pending_fraud_review
     # If the user has not passed IPP at a post office, allow them to
     # complete another enrollment by not redirecting to please call
-    return if in_person_can_perform_fraud_review?
+    # or rejection screen
+    return if in_person_prevent_fraud_redirection?
     redirect_to_fraud_review if fraud_review_pending?
   end
 
   def handle_fraud_rejection
+    return if in_person_prevent_fraud_redirection?
     redirect_to_fraud_rejection if fraud_rejection?
   end
 
-  def in_person_handle_pending_fraud_review
-    return unless in_person_can_perform_fraud_review?
-    if fraud_review_pending? && current_user.in_person_enrollment_status == 'passed'
-      redirect_to_fraud_review
-    end
-  end
-
-  def in_person_can_perform_fraud_review?
+  def in_person_prevent_fraud_redirection?
     IdentityConfig.store.in_person_proofing_enforce_tmx &&
-      current_user.in_person_enrollment_status != 'canceled' &&
-      !current_user.in_person_enrollment_status.nil?
+      current_user.in_person_enrollment_status != 'passed'
   end
 
   def redirect_to_fraud_review

--- a/app/views/idv/not_verified/show.html.erb
+++ b/app/views/idv/not_verified/show.html.erb
@@ -2,6 +2,7 @@
       'idv/shared/error',
       title: t('titles.failure.information_not_verified'),
       heading: t('idv.failure.verify.heading'),
+      action: { text: t('idv.failure.verify.exit', app_name: APP_NAME), url: :return_to_sp_failure_to_proof, method: :get },
     ) do %>
     <p>
       <% if decorated_sp_session.sp_name.present? %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -145,6 +145,7 @@ en:
       timeout: We are experiencing higher than usual wait time processing your
         request. Please try again.
       verify:
+        exit: Exit %{app_name}
         fail_link_html: Get help at <strong>%{sp_name}</strong>
         fail_text: to access services.
         heading: We couldn’t verify your identity

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -155,6 +155,7 @@ es:
       timeout: Estamos experimentando un tiempo de espera superior al habitual al
         procesar su solicitud. Inténtalo de nuevo.
       verify:
+        exit: Salir de %{app_name}
         fail_link_html: Obtenga ayuda en <strong>%{sp_name}</strong>
         fail_text: para acceder a los servicios.
         heading: No hemos podido verificar su identidad

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -161,6 +161,7 @@ fr:
       timeout: Le temps d’attente pour le traitement de votre demande est plus long
         que d’habitude Veuillez réessayer.
       verify:
+        exit: Quitter %{app_name}
         fail_link_html: Obtenez de l’aide auprès de <strong>%{sp_name}</strong>
         fail_text: pour accéder aux services.
         heading: Nous n’avons pas pu vérifier votre identité

--- a/spec/controllers/idv/please_call_controller_spec.rb
+++ b/spec/controllers/idv/please_call_controller_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Idv::PleaseCallController do
       expect(response).to render_template :show
     end
 
-    it 'returns true from in_person_can_perform_fraud_review' do
-      expect(subject.in_person_can_perform_fraud_review?).to eq(true)
+    it 'returns false from in_person_prevent_fraud_redirection' do
+      expect(subject.in_person_prevent_fraud_redirection?).to eq(false)
     end
 
     it 'redirects a user who is not fraud review pending' do
@@ -93,6 +93,22 @@ RSpec.describe Idv::PleaseCallController do
       expect(response).to redirect_to(idv_not_verified_url)
     end
 
+    context 'user fails ipp' do
+      let!(:enrollment) { create(:in_person_enrollment, :failed, user: user, profile: profile) }
+
+      it 'returns true from in_person_prevent_fraud_redirection' do
+        expect(subject.in_person_prevent_fraud_redirection?).to eq(true)
+      end
+
+      it 'does not redirect a user who has been fraud rejected' do
+        profile.reject_for_fraud(notify_user: false)
+
+        get :show
+
+        expect(response).not_to redirect_to(idv_not_verified_url)
+      end
+    end
+
     context 'in person proofing and tmx disabled' do
       let(:in_person_proofing_enabled) { true }
       let(:in_person_proofing_enforce_tmx) { false }
@@ -105,8 +121,8 @@ RSpec.describe Idv::PleaseCallController do
           and_return(in_person_proofing_enforce_tmx)
       end
 
-      it 'returns false from in_person_can_perform_fraud_review' do
-        expect(subject.in_person_can_perform_fraud_review?).to eq(false)
+      it 'returns false from in_person_prevent_fraud_redirection' do
+        expect(subject.in_person_prevent_fraud_redirection?).to eq(false)
       end
     end
   end

--- a/spec/views/idv/not_verified/show.html.erb_spec.rb
+++ b/spec/views/idv/not_verified/show.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/not_verified/show.html.erb' do
+  let(:sp_name) { nil }
+
+  before do
+    allow(view).to receive(:decorated_sp_session).and_return(
+      instance_double(ServiceProviderSession, sp_name: sp_name),
+    )
+
+    render
+  end
+
+  context 'without an sp' do
+    it 'renders the fail link text with application name' do
+      expect(rendered).to have_text(
+        strip_tags(
+          t(
+            'idv.failure.verify.fail_link_html',
+            sp_name: APP_NAME,
+          ),
+        ),
+      )
+    end
+  end
+
+  context 'with an sp' do
+    let(:sp_name) { 'Department of Departments' }
+    it 'renders the fail link text with the SP name' do
+      expect(rendered).to have_text(
+        strip_tags(
+          t('idv.failure.verify.fail_link_html', sp_name: sp_name),
+        ),
+      )
+    end
+  end
+
+  describe('exit button') do
+    it 'is rendered' do
+      expect(rendered).to have_selector(
+        'a',
+        text: t('idv.failure.verify.exit', app_name: APP_NAME),
+      )
+    end
+    it 'links to the right place' do
+      expect(rendered).to have_link(
+        t('idv.failure.verify.exit', app_name: APP_NAME),
+        href: return_to_sp_failure_to_proof_path,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12172](https://cm-jira.usa.gov/browse/LG-12172)

## 🛠 Summary of changes

This simplifies and extends the logic used to implement [LG-11995](https://github.com/18F/identity-idp/pull/10033). The reason I could simplify is that we're targeting both reject and review methods instead of just one. So there's no need to isolate as much code.

## 📜 Testing Plan

- [x]  Fire up the local server
- [x]  Create a new user - make sure to hang on to the mock login info you use to create the account
- [x]  Proceed through the IPP flow
- [x]  On SSN page use the drop down to select Reject
- [x]  Proceed through the rest of the flow to the barcode page to create the enrollment
- [x]  Code comment out enrollment_outcomes[:enrollments_passed] += 1 from app/jobs/get_usps_proofing_results_job.rb
- [x]  Open the rails console: rails c
- [x]  Save the latest enrollment you just created: e = InPersonEnrollment.last
- [x]  Create a new mock JSON blob: json = UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_results_response
- [x]  Save that response as a response: res = JSON.parse(json)
- [x]  Update the user's profile: e.profile.update!(fraud_pending_reason: 2)
- [x]  Initiate job: GetUspsProofingResultsJob.new.send(:process_enrollment_response, e, res)
- [x] Update the user: User.last.pending_profile.reject_for_fraud(notify_user: false)
- [x] Reload the enrollment: e.reload
- [x]  Login again, and attempt to navigate past the /account page
- [x]  You should end up on the /not_verified page

### Test with a failed enrollment:
- [x]  Fire up the local server
- [x]  Create a new user - make sure to hang on to the mock login info you use to create the account
- [x]  Proceed through the IPP flow
- [x]  On SSN page use the drop down to select Reject
- [x]  Proceed through the rest of the flow to the barcode page to create the enrollment
- [x]  Code comment out enrollment_outcomes[:enrollments_failed] += 1 from app/jobs/get_usps_proofing_results_job.rb
- [x]  Open the rails console: rails c
- [x]  Save the latest enrollment you just created: e = InPersonEnrollment.last
- [x]  Create a new mock JSON blob: json = UspsInPersonProofing::Mock::Fixtures.request_failed_proofing_results_response
- [x]  Save that response as a response: res = JSON.parse(json)
- [x]  Update the user's profile: e.profile.update!(fraud_pending_reason: 2)
- [x]  Initiate job: GetUspsProofingResultsJob.new.send(:process_enrollment_response, e, res)
- [x]  Update the user: User.last.pending_profile.reject_for_fraud(notify_user: false)
- [x]  Reload the enrollment: e.reload
- [x]  Login again, and attempt to navigate past the /account page
- [x]  You should not hit the not verified page with a failed enrollment

### Screenshots:

<details>
<summary>Completed design:</summary>
<img width="664" alt="Screenshot 2024-02-22 at 1 44 00 PM" src="https://github.com/18F/identity-idp/assets/14644234/7766192a-20f4-41f5-8b2a-49d9534681dd">
<img width="660" alt="Screenshot 2024-02-22 at 1 44 12 PM" src="https://github.com/18F/identity-idp/assets/14644234/3e718ecb-87fe-4a58-9346-1402c04baf24">
<img width="685" alt="Screenshot 2024-02-22 at 1 44 22 PM" src="https://github.com/18F/identity-idp/assets/14644234/aaf11679-713a-4552-b6f9-c759c6783c5b">
</details>