### PR TITLE
LG-12266: Stop reading from sp_session[:phishing_resistant_requested]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -405,7 +405,7 @@ class ApplicationController < ActionController::Base
       auth_methods_session:,
       aal_level_requested: sp_session[:aal_level_requested],
       piv_cac_requested: sp_session[:piv_cac_requested],
-      phishing_resistant_requested: sp_session[:phishing_resistant_requested],
+      phishing_resistant_requested: resolved_authn_context_result.phishing_resistant?,
     )
   end
   delegate :user_needs_sp_auth_method_setup?, to: :service_provider_mfa_policy

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -44,6 +44,8 @@ FactoryBot.define do
 
     trait :in_person_proofing_enabled do
       in_person_proofing_enabled { true }
+      ial { 2 }
+      redirect_uris { ['http://localhost:7654/auth/result'] }
     end
 
     trait :irs do

--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -7,35 +7,34 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
   let(:user) { user_with_2fa }
   let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
 
+  let(:in_person_proofing_enabled) { true }
+  let(:in_person_proofing_opt_in_enabled) { false }
+  let(:service_provider_in_person_proofing_enabled) { true }
+
+  before do
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) {
+      in_person_proofing_enabled
+    }
+    allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) {
+      in_person_proofing_opt_in_enabled
+    }
+    allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
+      and_return(service_provider_in_person_proofing_enabled)
+    visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+    sign_in_via_branded_page(user)
+    complete_doc_auth_steps_before_agreement_step
+    complete_agreement_step
+  end
+
   context 'when ipp is enabled and opt-in ipp is disabled' do
     context 'and when sp has opted into ipp' do
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { true }
-        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { false }
-        allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-          and_return(true)
-        sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-
-        complete_doc_auth_steps_before_agreement_step
-        complete_agreement_step
-      end
-
       it 'skips when disabled and redirects to hybrid handoff' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
       end
     end
 
     context 'and when sp has not opted into ipp' do
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { true }
-        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { false }
-        allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-          and_return(false)
-        sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-
-        complete_doc_auth_steps_before_agreement_step
-        complete_agreement_step
-      end
+      let(:service_provider_in_person_proofing_enabled) { false }
 
       it 'skips when disabled and redirects to hybrid handoff' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
@@ -45,16 +44,8 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
 
   context 'when ipp is disabled and opt-in ipp is enabled' do
     context 'and when sp has opted into ipp' do
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { false }
-        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
-        allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-          and_return(true)
-        sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-
-        complete_doc_auth_steps_before_agreement_step
-        complete_agreement_step
-      end
+      let(:in_person_proofing_enabled) { false }
+      let(:in_person_proofing_opt_in_enabled) { true }
 
       it 'skips when disabled and redirects to hybrid handoff' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
@@ -62,16 +53,9 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'and when sp has not opted into ipp' do
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { false }
-        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
-        allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-          and_return(false)
-        sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-
-        complete_doc_auth_steps_before_agreement_step
-        complete_agreement_step
-      end
+      let(:in_person_proofing_enabled) { false }
+      let(:in_person_proofing_opt_in_enabled) { true }
+      let(:service_provider_in_person_proofing_enabled) { false }
 
       it 'skips when disabled and redirects to hybrid handoff' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
@@ -81,16 +65,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
 
   context 'when both ipp and opt-in ipp are disabled' do
     context 'and when sp has opted into ipp' do
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { false }
-        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { false }
-        allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-          and_return(true)
-        sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-
-        complete_doc_auth_steps_before_agreement_step
-        complete_agreement_step
-      end
+      let(:in_person_proofing_enabled) { false }
 
       it 'skips when disabled and redirects to hybrid handoff' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
@@ -98,16 +73,8 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'and when sp has not opted into ipp' do
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { false }
-        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { false }
-        allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-          and_return(false)
-        sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-
-        complete_doc_auth_steps_before_agreement_step
-        complete_agreement_step
-      end
+      let(:in_person_proofing_enabled) { false }
+      let(:service_provider_in_person_proofing_enabled) { false }
 
       it 'skips when disabled and redirects to hybrid handoff' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
@@ -117,16 +84,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
 
   context 'when both ipp and opt-in ipp are enabled' do
     context 'and when sp has opted into ipp' do
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { true }
-        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
-        allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-          and_return(true)
-
-        sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-        complete_doc_auth_steps_before_agreement_step
-        complete_agreement_step
-      end
+      let(:in_person_proofing_opt_in_enabled) { true }
 
       it 'displays expected content and requires a choice' do
         expect(page).to have_current_path(idv_how_to_verify_path)
@@ -148,16 +106,8 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'and when sp has not opted into ipp' do
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { true }
-        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
-        allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-          and_return(false)
-
-        sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-        complete_doc_auth_steps_before_agreement_step
-        complete_agreement_step
-      end
+      let(:in_person_proofing_opt_in_enabled) { true }
+      let(:service_provider_in_person_proofing_enabled) { false }
 
       it 'skips when disabled and redirects to hybrid handoff' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
@@ -167,23 +117,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
 
   describe 'navigating to How To Verify from Agreement page in 50/50 state
    when the sp has opted into ipp' do
-    let(:user) { user_with_2fa }
-    before do
-      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { true }
-      allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) {
-                                       initial_opt_in_enabled
-                                     }
-      allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
-        and_return(true)
-
-      sign_in_and_2fa_user(user, issuer: ipp_service_provider.issuer)
-      complete_doc_auth_steps_before_agreement_step
-      complete_agreement_step
-    end
-
     context 'opt in false at start but true during navigation' do
-      let(:initial_opt_in_enabled) { false }
-
       it 'should be bounced back from Hybrid Handoff to How to Verify' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
         allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
@@ -193,7 +127,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'opt in true at start but false during navigation' do
-      let(:initial_opt_in_enabled) { true }
+      let(:in_person_proofing_opt_in_enabled) { true }
 
       it 'should be redirected to Hybrid Handoff page when opt in is false' do
         expect(page).to have_current_path(idv_how_to_verify_url)
@@ -204,7 +138,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'Going back from Hybrid Handoff with opt in disabled midstream' do
-      let(:initial_opt_in_enabled) { true }
+      let(:in_person_proofing_opt_in_enabled) { true }
       before do
         complete_how_to_verify_step(remote: true)
       end
@@ -220,8 +154,6 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'Going back from Hybrid Handoff with opt in enabled midstream' do
-      let(:initial_opt_in_enabled) { false }
-
       it 'should go back to the Agreement step from Hybrid Handoff with opt in toggled midstream' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
         allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
@@ -231,7 +163,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'Going back from Hybrid Handoff with opt in enabled the whole time' do
-      let(:initial_opt_in_enabled) { true }
+      let(:in_person_proofing_opt_in_enabled) { true }
       before do
         complete_how_to_verify_step(remote: true)
       end
@@ -244,8 +176,6 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'Going back from Hybrid Handoff with opt in disabled the whole time' do
-      let(:initial_opt_in_enabled) { false }
-
       it 'should be not be bounced back to How to Verify' do
         expect(page).to have_current_path(idv_hybrid_handoff_url)
         page.go_back
@@ -254,7 +184,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'Going back from Document Capture with opt in disabled midstream' do
-      let(:initial_opt_in_enabled) { true }
+      let(:in_person_proofing_opt_in_enabled) { true }
       before do
         complete_how_to_verify_step(remote: false)
       end
@@ -270,7 +200,6 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'Going back from Document Capture with opt in enabled midstream' do
-      let(:initial_opt_in_enabled) { false }
       before do
         complete_hybrid_handoff_step
       end
@@ -284,7 +213,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'Going back from Document Capture with opt in enabled the whole time' do
-      let(:initial_opt_in_enabled) { true }
+      let(:in_person_proofing_opt_in_enabled) { true }
       before do
         complete_how_to_verify_step(remote: false)
       end
@@ -297,7 +226,6 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     end
 
     context 'Going back from Document Capture with opt in disabled the whole time' do
-      let(:initial_opt_in_enabled) { false }
       before do
         complete_hybrid_handoff_step
       end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12266](https://cm-jira.usa.gov/browse/LG-12266)

## 🛠 Summary of changes

In a previous commit the `resolved_authn_context_result` was introduced to return a `Vot::Parser::Result` object that described the requirements for the current SP request considering SP default options. This is intended to be used to replace the keys in the `sp_session` that serve this purpose including the `phishing_resistant_requested` key.

This commit replaces places where the `sp_session[:phishing_resistant_requested]` value is read with new reads to the `resolved_authn_context_result`.

