### PR TITLE
LG-11625 Redirect to new personal key screen instead of show personal key flash

### DIFF
--- a/app/controllers/accounts/connected_accounts_controller.rb
+++ b/app/controllers/accounts/connected_accounts_controller.rb
@@ -8,7 +8,6 @@ module Accounts
     def show
       @presenter = AccountShowPresenter.new(
         decrypted_pii: nil,
-        personal_key: flash[:personal_key],
         sp_session_request_url: sp_session_request_url_with_updated_params,
         sp_name: decorated_sp_session.sp_name,
         user: current_user,

--- a/app/controllers/accounts/history_controller.rb
+++ b/app/controllers/accounts/history_controller.rb
@@ -8,7 +8,6 @@ module Accounts
     def show
       @presenter = AccountShowPresenter.new(
         decrypted_pii: nil,
-        personal_key: flash[:personal_key],
         sp_session_request_url: sp_session_request_url_with_updated_params,
         sp_name: decorated_sp_session.sp_name,
         user: current_user,

--- a/app/controllers/accounts/two_factor_authentication_controller.rb
+++ b/app/controllers/accounts/two_factor_authentication_controller.rb
@@ -9,7 +9,6 @@ module Accounts
       session[:account_redirect_path] = account_two_factor_authentication_path
       @presenter = AccountShowPresenter.new(
         decrypted_pii: nil,
-        personal_key: flash[:personal_key],
         sp_session_request_url: sp_session_request_url_with_updated_params,
         sp_name: decorated_sp_session.sp_name,
         user: current_user,

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -11,7 +11,6 @@ class AccountsController < ApplicationController
     cacher = Pii::Cacher.new(current_user, user_session)
     @presenter = AccountShowPresenter.new(
       decrypted_pii: cacher.fetch(current_user.active_or_pending_profile&.id),
-      personal_key: flash[:personal_key],
       sp_session_request_url: sp_session_request_url_with_updated_params,
       sp_name: decorated_sp_session.sp_name,
       user: current_user,

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,6 @@ class EventsController < ApplicationController
     analytics.events_visit
     @presenter = AccountShowPresenter.new(
       decrypted_pii: nil,
-      personal_key: nil,
       sp_session_request_url: sp_session_request_url_with_updated_params,
       sp_name: decorated_sp_session.sp_name,
       user: current_user,

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -51,8 +51,13 @@ module Users
       # that the user remains authenticated.
       bypass_sign_in current_user
 
-      flash[:personal_key] = @update_user_password_form.personal_key
-      redirect_to account_url, flash: { info: t('notices.password_changed') }
+      flash[:info] = t('notices.password_changed')
+      if @update_user_password_form.personal_key.present?
+        user_session[:personal_key] = @update_user_password_form.personal_key
+        redirect_to manage_personal_key_url
+      else
+        redirect_to account_url
+      end
     end
 
     def send_password_reset_risc_event

--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -35,10 +35,10 @@ module Users
     end
 
     def handle_success(result)
-      flash[:personal_key] = result.extra[:personal_key]
+      user_session[:personal_key] = result.extra[:personal_key]
       irs_attempts_api_tracker.idv_personal_key_generated
       reactivate_account_session.clear
-      redirect_to account_url
+      redirect_to manage_personal_key_url
     end
 
     def verify_password_form

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -1,20 +1,14 @@
 class AccountShowPresenter
-  attr_reader :user, :decrypted_pii, :personal_key, :locked_for_session, :pii,
-              :sp_session_request_url, :sp_name
+  attr_reader :user, :decrypted_pii, :locked_for_session, :pii, :sp_session_request_url, :sp_name
 
-  def initialize(decrypted_pii:, personal_key:, sp_session_request_url:, sp_name:, user:,
+  def initialize(decrypted_pii:, sp_session_request_url:, sp_name:, user:,
                  locked_for_session:)
     @decrypted_pii = decrypted_pii
-    @personal_key = personal_key
     @user = user
     @sp_name = sp_name
     @sp_session_request_url = sp_session_request_url
     @locked_for_session = locked_for_session
     @pii = determine_pii
-  end
-
-  def show_personal_key_partial?
-    personal_key.present?
   end
 
   def show_password_reset_partial?
@@ -41,7 +35,6 @@ class AccountShowPresenter
   def showing_any_partials?
     show_service_provider_continue_partial? ||
       show_password_reset_partial? ||
-      show_personal_key_partial? ||
       show_gpo_partial?
   end
 

--- a/app/views/accounts/_personal_key.html.erb
+++ b/app/views/accounts/_personal_key.html.erb
@@ -1,8 +1,0 @@
-<%= render AlertComponent.new(type: :warning, class: 'margin-bottom-2', text_tag: 'div') do %>
-  <p>
-    <%= t('idv.messages.personal_key') %>
-  </p>
-  <div class="margin-bottom-1 padding-y-1 padding-x-2 display-inline-block font-mono-lg bg-white radius-sm">
-    <%= presenter.personal_key %>
-  </div>
-<% end %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -2,10 +2,6 @@
 
 <% if @presenter.showing_any_partials? %>
   <div class="margin-bottom-4">
-    <% if @presenter.show_personal_key_partial? %>
-      <%= render 'accounts/personal_key', presenter: @presenter %>
-    <% end %>
-
     <% if @presenter.show_password_reset_partial? %>
       <%= render 'accounts/password_reset', presenter: @presenter %>
     <% end %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -259,8 +259,6 @@ en:
         timeframe_html: You’ll get a letter with a <strong>verification code</strong> in
           <strong>5 to 10 days</strong>.
       otp_delivery_method_description: If you entered a landline above, please select “Phone call” below.
-      personal_key: This is your new personal key. Write it down and keep it in a safe
-        place. You will need it if you ever lose your password.
       phone:
         alert_html: '<strong>Enter a phone number that is:</strong>'
         description: We’ll check this number with records and send you a one-time code.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -276,8 +276,6 @@ es:
           verificación</strong> en un plazo de <strong>5 a 10 días</strong>.
       otp_delivery_method_description: Si ha introducido un teléfono fijo más arriba,
         seleccione “Llamada telefónica” más abajo.
-      personal_key: Esta es su nueva clave personal. Escríbala y guárdela en un lugar
-        seguro. La necesitará si pierde su contraseña.
       phone:
         alert_html: '<strong>Introduzca un número de teléfono que sea:</strong>'
         description: Comprobaremos este número con los registros y le enviaremos un

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -285,9 +285,6 @@ fr:
           vérification</strong> dans un délai de <strong>5 à 10 jours</strong>.
       otp_delivery_method_description: Si vous avez saisi une ligne fixe ci-dessus,
         veuillez sélectionner « Appel téléphonique » ci-dessous.
-      personal_key: Il s’agit de votre nouvelle clé personnelle. Notez-la et
-        conservez-la dans un endroit sécuritaire. Vous en aurez besoin si vous
-        perdez votre mot de passe.
       phone:
         alert_html: '<strong>Entrez un numéro de téléphone qui est :</strong>'
         description: Nous vérifierons ce numéro dans nos archives et vous enverrons un

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -94,7 +94,6 @@ RSpec.describe AccountsController do
 
         presenter = AccountShowPresenter.new(
           decrypted_pii: nil,
-          personal_key: nil,
           sp_session_request_url: nil,
           sp_name: nil,
           user: user,
@@ -149,7 +148,6 @@ RSpec.describe AccountsController do
 
           presenter = AccountShowPresenter.new(
             decrypted_pii: nil,
-            personal_key: nil,
             sp_session_request_url: nil,
             sp_name: nil,
             user: user,

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
         )
         expect(response).to redirect_to account_url
         expect(flash[:info]).to eq t('notices.password_changed')
-        expect(flash[:personal_key]).to be_nil
+        expect(controller.user_session[:personal_key]).to be_nil
       end
 
       it 'updates the user password and regenerates personal key' do
@@ -64,8 +64,10 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
           ),
         )
 
-        expect(flash[:personal_key]).to eq(assigns(:update_user_password_form).personal_key)
-        expect(flash[:personal_key]).to be_present
+        expect(controller.user_session[:personal_key]).to eq(
+          assigns(:update_user_password_form).personal_key,
+        )
+        expect(response).to redirect_to manage_personal_key_url
       end
 
       it 'creates a user Event for the password change' do

--- a/spec/controllers/users/verify_password_controller_spec.rb
+++ b/spec/controllers/users/verify_password_controller_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe Users::VerifyPasswordController do
             expect(@irs_attempts_api_tracker).to have_received(:idv_personal_key_generated)
           end
 
-          it 'redirects to the account page' do
-            expect(response).to redirect_to(account_url)
+          it 'redirects to the manage personal key page' do
+            expect(response).to redirect_to(manage_personal_key_url)
           end
 
           it 'sets a new personal key as a flash message' do
-            expect(flash[:personal_key]).to eq(key)
+            expect(controller.user_session[:personal_key]).to eq(key)
           end
         end
 

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -24,8 +24,12 @@ RSpec.feature 'Password recovery via personal key', allowed_extra_analytics: [:*
 
     reactivate_profile(new_password, personal_key)
 
-    expect(page).to have_content t('idv.messages.personal_key')
-    expect(page).to have_content t('headings.account.verified_account')
+    expect(page).to have_content(t('forms.personal_key_partial.header'))
+    expect(page).to have_current_path(manage_personal_key_path)
+
+    personal_key = PersonalKeyGenerator.new(user).normalize(scrape_personal_key)
+
+    expect(user.reload.valid_personal_key?(personal_key)).to eq(true)
   end
 
   scenario 'resets password and reactivates profile with no personal key', email: true, js: true do

--- a/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
+++ b/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
@@ -51,7 +51,11 @@ RSpec.feature 'Password recovery via personal key for a GPO-verified user',
     fill_in 'Password', with: new_password
     click_continue
 
-    expect(page).to have_content t('idv.messages.personal_key')
-    expect(page).to have_content t('headings.account.verified_account')
+    expect(page).to have_content(t('forms.personal_key_partial.header'))
+    expect(page).to have_current_path(manage_personal_key_path)
+
+    personal_key = PersonalKeyGenerator.new(user).normalize(scrape_personal_key)
+
+    expect(user.reload.valid_personal_key?(personal_key)).to eq(true)
   end
 end

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -146,8 +146,16 @@ RSpec.feature 'User profile', allowed_extra_analytics: [:*] do
                 with: 'this is a great sentence'
         click_button 'Update'
 
-        expect(current_path).to eq account_path
-        expect(page).to have_content(t('idv.messages.personal_key'))
+        expect(page).to have_content(t('forms.personal_key_partial.header'))
+        expect(page).to have_current_path(manage_personal_key_path)
+
+        personal_key = PersonalKeyGenerator.new(profile.user).normalize(scrape_personal_key)
+
+        expect(profile.user.reload.valid_personal_key?(personal_key)).to eq(true)
+
+        click_continue
+
+        expect(current_path).to eq(account_path)
       end
 
       it 'allows the user reactivate their profile by reverifying', js: true do

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe AccountShowPresenter do
           dob: birthday
         )
         profile_index = AccountShowPresenter.new(
-          decrypted_pii: decrypted_pii, personal_key: '', user: user,
-          sp_session_request_url: nil, sp_name: nil,
-          locked_for_session: false
+          decrypted_pii: decrypted_pii,
+          user: user,
+          sp_session_request_url: nil,
+          sp_name: nil,
+          locked_for_session: false,
         )
 
         expect(profile_index.header_personalization).to eq first_name
@@ -28,9 +30,11 @@ RSpec.describe AccountShowPresenter do
         email_address = user.reload.email_addresses.last
         email_address.update!(last_sign_in_at: 1.minute.from_now)
         profile_index = AccountShowPresenter.new(
-          decrypted_pii: {}, personal_key: '', user: user,
-          sp_session_request_url: nil, sp_name: nil,
-          locked_for_session: false
+          decrypted_pii: {},
+          user: user,
+          sp_session_request_url: nil,
+          sp_name: nil,
+          locked_for_session: false,
         )
 
         expect(profile_index.header_personalization).to eq email_address.email
@@ -47,9 +51,11 @@ RSpec.describe AccountShowPresenter do
         ).to receive(:enabled?).and_return(true)
 
         profile_index = AccountShowPresenter.new(
-          decrypted_pii: {}, personal_key: '', user: user,
-          sp_session_request_url: nil, sp_name: nil,
-          locked_for_session: false
+          decrypted_pii: {},
+          user: user,
+          sp_session_request_url: nil,
+          sp_name: nil,
+          locked_for_session: false,
         )
 
         expect(profile_index.totp_content).to eq t('account.index.auth_app_enabled')
@@ -63,9 +69,11 @@ RSpec.describe AccountShowPresenter do
           TwoFactorAuthentication::AuthAppPolicy,
         ).to receive(:enabled?).and_return(false)
         profile_index = AccountShowPresenter.new(
-          decrypted_pii: {}, personal_key: '', user: user,
-          sp_session_request_url: nil, sp_name: nil,
-          locked_for_session: false
+          decrypted_pii: {},
+          user: user,
+          sp_session_request_url: nil,
+          sp_name: nil,
+          locked_for_session: false,
         )
 
         expect(profile_index.totp_content).to eq t('account.index.auth_app_disabled')
@@ -81,7 +89,6 @@ RSpec.describe AccountShowPresenter do
 
       account_show = AccountShowPresenter.new(
         decrypted_pii: {},
-        personal_key: '',
         sp_session_request_url: nil,
         sp_name: nil,
         user: user.reload,
@@ -100,7 +107,6 @@ RSpec.describe AccountShowPresenter do
 
       account_show = AccountShowPresenter.new(
         decrypted_pii: {},
-        personal_key: '',
         sp_session_request_url: nil,
         sp_name: nil,
         user: user.reload,
@@ -120,7 +126,6 @@ RSpec.describe AccountShowPresenter do
     subject(:account_show) do
       AccountShowPresenter.new(
         decrypted_pii: decrypted_pii,
-        personal_key: '',
         sp_session_request_url: nil,
         sp_name: nil,
         user: user,
@@ -158,7 +163,6 @@ RSpec.describe AccountShowPresenter do
         user = profile.user
         profile_index = AccountShowPresenter.new(
           decrypted_pii: {},
-          personal_key: '',
           user: user,
           sp_session_request_url: nil,
           sp_name: nil,
@@ -182,7 +186,6 @@ RSpec.describe AccountShowPresenter do
         user = profile.user
         profile_index = AccountShowPresenter.new(
           decrypted_pii: {},
-          personal_key: '',
           user: user,
           sp_session_request_url: nil,
           sp_name: nil,
@@ -201,7 +204,6 @@ RSpec.describe AccountShowPresenter do
 
         profile_index = AccountShowPresenter.new(
           decrypted_pii: {},
-          personal_key: '',
           user: user,
           sp_session_request_url: nil,
           sp_name: nil,

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -163,13 +163,12 @@ RSpec.shared_examples 'signing in as IAL2 after resetting password' do |sp|
 
     reactivate_profile(new_password, user.personal_key)
 
-    expect(current_path).to eq account_path
-    expect(page).to have_content(t('idv.messages.personal_key'))
+    expect(page).to have_content(t('forms.personal_key_partial.header'))
+    expect(page).to have_current_path(manage_personal_key_path)
 
-    sp_friendly_name = ServiceProvider.find_by(issuer: service_provider_issuer(sp)).friendly_name
-    click_link t('account.index.continue_to_service_provider', service_provider: sp_friendly_name)
+    check t('forms.personal_key.required_checkbox')
+    click_continue
 
-    click_submit_default if current_path == complete_saml_path
     click_agree_and_continue
 
     expect(current_url).to eq complete_saml_url if sp == :saml

--- a/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe 'accounts/connected_accounts/show.html.erb' do
     assign(
       :presenter,
       AccountShowPresenter.new(
-        decrypted_pii: nil, personal_key: nil, user: user,
-        sp_session_request_url: nil, sp_name: nil,
-        locked_for_session: false
+        decrypted_pii: nil,
+        user: user,
+        sp_session_request_url: nil,
+        sp_name: nil,
+        locked_for_session: false,
       ),
     )
   end

--- a/spec/views/accounts/history/show.html.erb_spec.rb
+++ b/spec/views/accounts/history/show.html.erb_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe 'accounts/history/show.html.erb' do
     assign(
       :presenter,
       AccountShowPresenter.new(
-        decrypted_pii: nil, personal_key: nil, user: user,
-        sp_session_request_url: nil, sp_name: nil,
-        locked_for_session: false
+        decrypted_pii: nil,
+        user: user,
+        sp_session_request_url: nil,
+        sp_name: nil,
+        locked_for_session: false,
       ),
     )
   end

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe 'accounts/show.html.erb' do
     assign(
       :presenter,
       AccountShowPresenter.new(
-        decrypted_pii: nil, personal_key: nil, user: user,
-        sp_session_request_url: nil, sp_name: nil,
-        locked_for_session: false
+        decrypted_pii: nil,
+        user: user,
+        sp_session_request_url: nil,
+        sp_name: nil,
+        locked_for_session: false,
       ),
     )
   end
@@ -162,9 +164,11 @@ RSpec.describe 'accounts/show.html.erb' do
       assign(
         :presenter,
         AccountShowPresenter.new(
-          decrypted_pii: nil, personal_key: 'abc123', user: user,
-          sp_session_request_url: sp.return_to_sp_url, sp_name: sp.friendly_name,
-          locked_for_session: false
+          decrypted_pii: nil,
+          user: user,
+          sp_session_request_url: sp.return_to_sp_url,
+          sp_name: sp.friendly_name,
+          locked_for_session: false,
         ),
       )
     end

--- a/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
+++ b/spec/views/accounts/two_factor_authentication/show.html.erb_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe 'accounts/two_factor_authentication/show.html.erb' do
     assign(
       :presenter,
       AccountShowPresenter.new(
-        decrypted_pii: nil, personal_key: nil, user: user,
-        sp_session_request_url: nil, sp_name: nil,
-        locked_for_session: false
+        decrypted_pii: nil,
+        user: user,
+        sp_session_request_url: nil,
+        sp_name: nil,
+        locked_for_session: false,
       ),
     )
   end
@@ -31,9 +33,11 @@ RSpec.describe 'accounts/two_factor_authentication/show.html.erb' do
       assign(
         :presenter,
         AccountShowPresenter.new(
-          decrypted_pii: nil, personal_key: nil, user: user,
-          sp_session_request_url: nil, sp_name: nil,
-          locked_for_session: false
+          decrypted_pii: nil,
+          user: user,
+          sp_session_request_url: nil,
+          sp_name: nil,
+          locked_for_session: false,
         ),
       )
     end


### PR DESCRIPTION
Prior to this commit there were 2 cases where a personal key was shown to a user in a flash message:

- When the user resets their password and recovers their PII with a personal key
- When the user changes their password from account screen

In both cases the user had to have an identity proofed account for the flash to appear.

The flash had some issues. It was a distinct experience from the typical personal key issuance. The flash was hard to miss and did not include the features we build to ensure users save their personal key.

This commit removes the flash message and redirects the user to the personal key screen when they need to be presented with a personal key in all cases.

This is what the flash looked like:
![image](https://github.com/18F/identity-idp/assets/963654/d379b5b1-c32a-4ec9-9b5a-060904ec78d3)

The personal key screen looks like this:
![image](https://github.com/18F/identity-idp/assets/963654/95747579-96d1-4142-970d-b2d1f0e16def)

