### PR TITLE
LG-12263 Remove legacy SP-sesison values from completions controller

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -3,7 +3,7 @@ module SignUp
     include SecureHeadersConcern
 
     before_action :confirm_two_factor_authenticated
-    before_action :confirm_identity_verified, if: :ial2?
+    before_action :confirm_identity_verified, if: :identity_proofing_required?
     before_action :confirm_selfie_captured, if: :selfie_required?
     before_action :apply_secure_headers_override, only: [:show, :update]
     before_action :verify_needs_completions_screen
@@ -55,16 +55,13 @@ module SignUp
       )
     end
 
-    def ial2?
-      sp_session[:ial2]
-    end
-
-    def ial_max?
-      sp_session[:ialmax]
+    def identity_proofing_required?
+      resolved_authn_context_result.identity_proofing?
     end
 
     def ial2_requested?
-      !!(ial2? || (ial_max? && current_user.identity_verified?))
+      resolved_authn_context_result.identity_proofing? ||
+        (resolved_authn_context_result.ialmax? && current_user.identity_verified?)
     end
 
     def selfie_required?
@@ -91,8 +88,8 @@ module SignUp
 
     def analytics_attributes(page_occurence)
       attributes = {
-        ial2: sp_session[:ial2],
-        ialmax: sp_session[:ialmax],
+        ial2: resolved_authn_context_result.identity_proofing?,
+        ialmax: resolved_authn_context_result.ialmax?,
         service_provider_name: decorated_sp_session.sp_name,
         sp_session_requested_attributes: sp_session[:requested_attributes],
         sp_request_requested_attributes: service_provider_request.requested_attributes,

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           subject.session[:sp] = {
             issuer: current_sp.issuer,
             acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-            ial2: false,
             requested_attributes: [:email],
             request_url: 'http://localhost:3000',
           }
@@ -44,7 +43,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           expect(@analytics).to have_received(:track_event).with(
             'User registration: agency handoff visited',
             ial2: false,
-            ialmax: nil,
+            ialmax: false,
             service_provider_name: subject.decorated_sp_session.sp_name,
             page_occurence: '',
             needs_completion_screen_reason: :new_sp,
@@ -69,8 +68,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           stub_sign_in(user)
           subject.session[:sp] = {
             issuer: current_sp.issuer,
-            acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-            ial2: true,
+            acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
             requested_attributes: [:email],
             request_url: 'http://localhost:3000',
           }
@@ -83,7 +81,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           expect(@analytics).to have_received(:track_event).with(
             'User registration: agency handoff visited',
             ial2: true,
-            ialmax: nil,
+            ialmax: false,
             service_provider_name: subject.decorated_sp_session.sp_name,
             page_occurence: '',
             needs_completion_screen_reason: :new_sp,
@@ -145,8 +143,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           subject.session[:sp] = {
             issuer: current_sp.issuer,
             acr_values: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-            ial2: false,
-            ialmax: true,
             requested_attributes: [:email],
             request_url: 'http://localhost:3000',
           }
@@ -222,11 +218,12 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         user = create(:user)
         sp = create(:service_provider, issuer: 'https://awesome')
         stub_sign_in(user)
-        subject.session[:sp] = { issuer: sp.issuer,
-                                 ial2: false,
-                                 acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-                                 requested_attributes: [:email],
-                                 request_url: 'http://localhost:3000' }
+        subject.session[:sp] = {
+          issuer: sp.issuer,
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          requested_attributes: [:email],
+          request_url: 'http://localhost:3000',
+        }
         get :show
 
         expect(response).to render_template(:show)
@@ -251,7 +248,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         stub_sign_in(user)
         subject.session[:sp] = {
           acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          ial2: false,
           issuer: 'foo',
           request_url: 'http://example.com',
         }
@@ -262,7 +258,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         expect(@analytics).to have_received(:track_event).with(
           'User registration: complete',
           ial2: false,
-          ialmax: nil,
+          ialmax: false,
           service_provider_name: subject.decorated_sp_session.sp_name,
           page_occurence: 'agency-page',
           needs_completion_screen_reason: :new_sp,
@@ -297,7 +293,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         stub_sign_in(user)
         subject.session[:sp] = {
           acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          ial2: false,
           issuer: 'foo',
           requested_attributes: ['email'],
         }
@@ -314,7 +309,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           stub_sign_in(user)
           subject.session[:sp] = {
             acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-            ial2: false,
             issuer: 'foo',
             request_url: 'http://example.com',
           }
@@ -325,7 +319,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           expect(@analytics).to have_received(:track_event).with(
             'User registration: complete',
             ial2: false,
-            ialmax: nil,
+            ialmax: false,
             service_provider_name: subject.decorated_sp_session.sp_name,
             page_occurence: 'agency-page',
             needs_completion_screen_reason: :new_sp,
@@ -352,7 +346,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         subject.session[:sp] = {
           issuer: sp.issuer,
           acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-          ial2: true,
           request_url: 'http://example.com',
           requested_attributes: ['email'],
         }
@@ -363,7 +356,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         expect(@analytics).to have_received(:track_event).with(
           'User registration: complete',
           ial2: true,
-          ialmax: nil,
+          ialmax: false,
           service_provider_name: subject.decorated_sp_session.sp_name,
           page_occurence: 'agency-page',
           needs_completion_screen_reason: :new_sp,
@@ -433,7 +426,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
       xit 'does not log a reproofing event during initial proofing' do
         stub_sign_in(user)
         subject.session[:sp] = {
-          ial2: false,
           issuer: 'foo',
           request_url: 'http://example.com',
           acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
@@ -447,7 +439,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
 
         stub_sign_in(user)
         subject.session[:sp] = {
-          ial2: false,
           issuer: 'foo',
           request_url: 'http://example.com',
           acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
@@ -476,7 +467,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
         user.profiles.create(verified_at: Time.zone.now, active: true, activated_at: Time.zone.now)
         stub_sign_in(user)
         subject.session[:sp] = {
-          ial2: false,
           request_url: 'http://example.com',
           acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
         }


### PR DESCRIPTION
The `sp_session[:ial2]` and `sp_session[:ialmax]` values are being retired in favor of `resolved_authn_context_result.identity_proofing?` and `resolved_authn_context_result.ialmax?`. This commit does the work of removing these 2 values from `SignUp::CompletionsController`. This removes the last of the references for `sp_session[:ialmax]` so once this is merged and deployed we can stop writing that value.
