### PR TITLE
LG-12262 Stop reading from `sp_session[:ial2]`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -257,7 +257,7 @@ class ApplicationController < ActionController::Base
   def user_needs_to_reactivate_account?
     return false if current_user.password_reset_profile.blank?
     return false if pending_profile_newer_than_password_reset_profile?
-    sp_session[:ial2] == true
+    resolved_authn_context_result.identity_proofing?
   end
 
   def pending_profile_newer_than_password_reset_profile?

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -60,8 +60,7 @@ module SignUp
     end
 
     def ial2_requested?
-      resolved_authn_context_result.identity_proofing? ||
-        (resolved_authn_context_result.ialmax? && current_user.identity_verified?)
+      resolved_authn_context_result.identity_proofing_or_ialmax? && current_user.identity_verified?
     end
 
     def selfie_required?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,7 +50,7 @@ module ApplicationHelper
   end
 
   def ial2_requested?
-    sp_session && sp_session[:ial2]
+    resolved_authn_context_result.identity_proofing?
   end
 
   def cancel_link_text

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe Idv::PersonalKeyController, allowed_extra_analytics: [:*] do
   describe '#update' do
     context 'user selected phone verification' do
       it 'redirects to sign up completed for an sp' do
-        subject.session[:sp] = { ial2: true }
+        subject.session[:sp] = { issuer: create(:service_provider).issuer }
         patch :update
 
         expect(response).to redirect_to sign_up_completed_url

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           requested_attributes: [:email],
           request_url: 'http://localhost:3000',
         }
+
         get :show
 
         expect(response).to render_template(:show)

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -72,7 +72,10 @@ RSpec.describe Users::PersonalKeysController do
 
     context 'user needs to reactive account' do
       it 'redirects to the sign up completed url for ial 1' do
-        controller.session[:sp] = { ial2: false }
+        controller.session[:sp] = {
+          issuer: create(:service_provider).issuer,
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        }
 
         user = create(:user, :fully_registered)
         create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })
@@ -86,7 +89,10 @@ RSpec.describe Users::PersonalKeysController do
       end
 
       it 'redirects to the reactivate account url for ial 2' do
-        controller.session[:sp] = { ial2: true }
+        controller.session[:sp] = {
+          issuer: create(:service_provider).issuer,
+          acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        }
 
         user = create(:user, :fully_registered)
         create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -148,20 +148,6 @@ module Features
       user
     end
 
-    def begin_sign_up_with_sp_and_ial(ial2:)
-      user = create(:user)
-      login_as(user, scope: :user, run_callbacks: false)
-
-      Warden.on_next_request do |proxy|
-        session = proxy.env['rack.session']
-        sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-        session[:sp] = { ial2: ial2, issuer: sp.issuer, request_id: '123' }
-      end
-
-      visit account_path
-      user
-    end
-
     def sign_up_and_set_password
       user = sign_up
       user.password = VALID_PASSWORD
@@ -368,25 +354,6 @@ module Features
       expect(field[:spellcheck]).to eq('false')
 
       field.set(personal_key)
-    end
-
-    def ial1_sp_session
-      Warden.on_next_request do |proxy|
-        session = proxy.env['rack.session']
-        sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
-        session[:sp] = {
-          ial2: false,
-          issuer: sp.issuer,
-          requested_attributes: [:email],
-        }
-      end
-    end
-
-    def ial2_sp_session(request_url: 'http://localhost:3000')
-      Warden.on_next_request do |proxy|
-        session = proxy.env['rack.session']
-        session[:sp] = { ial2: true, request_url: request_url }
-      end
     end
 
     def cookies


### PR DESCRIPTION
We are replacing the `sp_sesison[:ial2]` value with checks against `resolved_authn_context_result.identity_proofing?`. This commit removes the places where we are reading `sp_sesison[:ial2]`. Once this is merged and fully deployed we can stop writing `sp_session[:ial2]`.
