### PR TITLE
LG-12372: sdk autocaptured id images route to non-cropping workflow

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -86,7 +86,7 @@ module Idv
           back_image: back_image_bytes,
           selfie_image: liveness_checking_required ? selfie_image_bytes : nil,
           image_source: image_source,
-          id_images_cropped: acuant_sdk_autocaptured_id?,
+          images_cropped: acuant_sdk_autocaptured_id?,
           user_uuid: user_uuid,
           uuid_prefix: uuid_prefix,
           liveness_checking_required: liveness_checking_required,

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -86,7 +86,7 @@ module Idv
           back_image: back_image_bytes,
           selfie_image: liveness_checking_required ? selfie_image_bytes : nil,
           image_source: image_source,
-          image_cropped: acuant_sdk_autocaptured_id?,
+          id_images_cropped: acuant_sdk_autocaptured_id?,
           user_uuid: user_uuid,
           uuid_prefix: uuid_prefix,
           liveness_checking_required: liveness_checking_required,

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -394,8 +394,7 @@ module Idv
     end
 
     def acuant_sdk_autocaptured_id?
-      acuant_sdk_captured_id? &&
-        image_metadata.dig(:front, :acuantCaptureMode) == 'AUTO' &&
+      image_metadata.dig(:front, :acuantCaptureMode) == 'AUTO' &&
         image_metadata.dig(:back, :acuantCaptureMode) == 'AUTO'
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -206,7 +206,7 @@ module Idv
     end
 
     def image_source
-      if acuant_sdk_captured?
+      if acuant_sdk_captured_id?
         DocAuth::ImageSources::ACUANT_SDK
       else
         DocAuth::ImageSources::UNKNOWN

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -252,7 +252,7 @@ module Idv
       end
 
       if !IdentityConfig.store.doc_auth_selfie_desktop_test_mode &&
-         liveness_checking_required && !acuant_sdk_capture?
+         liveness_checking_required && !acuant_sdk_captured?
         errors.add(
           :selfie, t('doc_auth.errors.not_a_file'),
           type: :not_a_file

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -86,6 +86,7 @@ module Idv
           back_image: back_image_bytes,
           selfie_image: liveness_checking_required ? selfie_image_bytes : nil,
           image_source: image_source,
+          image_cropped: acuant_sdk_autocaptured_id?,
           user_uuid: user_uuid,
           uuid_prefix: uuid_prefix,
           liveness_checking_required: liveness_checking_required,
@@ -205,7 +206,7 @@ module Idv
     end
 
     def image_source
-      if acuant_sdk_capture?
+      if acuant_sdk_captured?
         DocAuth::ImageSources::ACUANT_SDK
       else
         DocAuth::ImageSources::UNKNOWN
@@ -378,12 +379,24 @@ module Idv
       }
     end
 
-    def acuant_sdk_capture?
+    def acuant_sdk_captured?
+      acuant_sdk_captured_id? &&
+        (liveness_checking_required ? acuant_sdk_captured_selfie? : true)
+    end
+
+    def acuant_sdk_captured_id?
       image_metadata.dig(:front, :source) == Idp::Constants::Vendors::ACUANT &&
-        image_metadata.dig(:back, :source) == Idp::Constants::Vendors::ACUANT &&
-        (liveness_checking_required ?
-          image_metadata.dig(:selfie, :source) == Idp::Constants::Vendors::ACUANT :
-           true)
+        image_metadata.dig(:back, :source) == Idp::Constants::Vendors::ACUANT
+    end
+
+    def acuant_sdk_captured_selfie?
+      image_metadata.dig(:selfie, :source) == Idp::Constants::Vendors::ACUANT
+    end
+
+    def acuant_sdk_autocaptured_id?
+      acuant_sdk_captured_id? &&
+        image_metadata.dig(:front, :acuantCaptureMode) == 'AUTO' &&
+        image_metadata.dig(:back, :acuantCaptureMode) == 'AUTO'
     end
 
     def image_metadata

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -41,6 +41,7 @@ module DocAuth
         front_image:,
         back_image:,
         image_source:,
+        image_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         selfie_image: nil,

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -41,7 +41,7 @@ module DocAuth
         front_image:,
         back_image:,
         image_source:,
-        image_cropped: false,
+        id_images_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         selfie_image: nil,

--- a/app/services/doc_auth/acuant/acuant_client.rb
+++ b/app/services/doc_auth/acuant/acuant_client.rb
@@ -41,7 +41,7 @@ module DocAuth
         front_image:,
         back_image:,
         image_source:,
-        id_images_cropped: false,
+        images_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         selfie_image: nil,

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -17,7 +17,7 @@ module DocAuth
         back_image:,
         selfie_image: nil,
         image_source: nil,
-        image_cropped: false,
+        id_images_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         liveness_checking_required: false
@@ -30,7 +30,7 @@ module DocAuth
           back_image: back_image,
           selfie_image: selfie_image,
           image_source: image_source,
-          image_cropped: image_cropped,
+          id_images_cropped: id_images_cropped,
           liveness_checking_required: liveness_checking_required,
         ).fetch
       end

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -17,7 +17,7 @@ module DocAuth
         back_image:,
         selfie_image: nil,
         image_source: nil,
-        id_images_cropped: false,
+        images_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         liveness_checking_required: false
@@ -30,7 +30,7 @@ module DocAuth
           back_image: back_image,
           selfie_image: selfie_image,
           image_source: image_source,
-          id_images_cropped: id_images_cropped,
+          images_cropped: images_cropped,
           liveness_checking_required: liveness_checking_required,
         ).fetch
       end

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -17,6 +17,7 @@ module DocAuth
         back_image:,
         selfie_image: nil,
         image_source: nil,
+        image_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         liveness_checking_required: false
@@ -29,6 +30,7 @@ module DocAuth
           back_image: back_image,
           selfie_image: selfie_image,
           image_source: image_source,
+          image_cropped: image_cropped,
           liveness_checking_required: liveness_checking_required,
         ).fetch
       end

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -19,7 +19,7 @@ module DocAuth
           @front_image = front_image
           @back_image = back_image
           @selfie_image = selfie_image
-          @image_source = image_source # tbd
+          @image_source = image_source
           @images_cropped = images_cropped
           # when set to required, be sure to pass in selfie_image
           @liveness_checking_required = liveness_checking_required

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -72,7 +72,7 @@ module DocAuth
         end
 
         def workflow
-          if acuant_sdk_source? && image_cropped
+          if acuant_sdk_source? && @image_cropped
             include_liveness? ?
               config.trueid_liveness_nocropping_workflow :
               config.trueid_noliveness_nocropping_workflow

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -11,7 +11,7 @@ module DocAuth
           front_image:,
           back_image:,
           selfie_image: nil,
-          image_source: nil, # tbd
+          image_source: nil,
           images_cropped: false,
           liveness_checking_required: false
         )

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -11,16 +11,16 @@ module DocAuth
           front_image:,
           back_image:,
           selfie_image: nil,
-          image_source: nil,
-          id_images_cropped: false,
+          image_source: nil, # tbd
+          images_cropped: false,
           liveness_checking_required: false
         )
           super(config: config, user_uuid: user_uuid, uuid_prefix: uuid_prefix)
           @front_image = front_image
           @back_image = back_image
           @selfie_image = selfie_image
-          @image_source = image_source
-          @id_images_cropped = id_images_cropped
+          @image_source = image_source # tbd
+          @images_cropped = images_cropped
           # when set to required, be sure to pass in selfie_image
           @liveness_checking_required = liveness_checking_required
         end
@@ -72,7 +72,7 @@ module DocAuth
         end
 
         def workflow
-          if acuant_sdk_source? && @id_images_cropped
+          if @images_cropped
             include_liveness? ?
               config.trueid_liveness_nocropping_workflow :
               config.trueid_noliveness_nocropping_workflow

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -12,7 +12,7 @@ module DocAuth
           back_image:,
           selfie_image: nil,
           image_source: nil,
-          image_cropped: false,
+          id_images_cropped: false,
           liveness_checking_required: false
         )
           super(config: config, user_uuid: user_uuid, uuid_prefix: uuid_prefix)
@@ -20,7 +20,7 @@ module DocAuth
           @back_image = back_image
           @selfie_image = selfie_image
           @image_source = image_source
-          @image_cropped = image_cropped
+          @id_images_cropped = id_images_cropped
           # when set to required, be sure to pass in selfie_image
           @liveness_checking_required = liveness_checking_required
         end
@@ -72,7 +72,7 @@ module DocAuth
         end
 
         def workflow
-          if acuant_sdk_source? && @image_cropped
+          if acuant_sdk_source? && @id_images_cropped
             include_liveness? ?
               config.trueid_liveness_nocropping_workflow :
               config.trueid_noliveness_nocropping_workflow

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -12,6 +12,7 @@ module DocAuth
           back_image:,
           selfie_image: nil,
           image_source: nil,
+          image_cropped: false,
           liveness_checking_required: false
         )
           super(config: config, user_uuid: user_uuid, uuid_prefix: uuid_prefix)
@@ -19,6 +20,7 @@ module DocAuth
           @back_image = back_image
           @selfie_image = selfie_image
           @image_source = image_source
+          @image_cropped = image_cropped
           # when set to required, be sure to pass in selfie_image
           @liveness_checking_required = liveness_checking_required
         end
@@ -70,7 +72,7 @@ module DocAuth
         end
 
         def workflow
-          if acuant_sdk_source?
+          if acuant_sdk_source? && image_cropped
             include_liveness? ?
               config.trueid_liveness_nocropping_workflow :
               config.trueid_noliveness_nocropping_workflow

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -58,7 +58,7 @@ module DocAuth
         back_image:,
         selfie_image: nil,
         image_source: nil,
-        id_images_cropped: false,
+        images_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         liveness_checking_required: false

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -58,7 +58,7 @@ module DocAuth
         back_image:,
         selfie_image: nil,
         image_source: nil,
-        image_cropped: false,
+        id_images_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         liveness_checking_required: false

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -58,6 +58,7 @@ module DocAuth
         back_image:,
         selfie_image: nil,
         image_source: nil,
+        image_cropped: false,
         user_uuid: nil,
         uuid_prefix: nil,
         liveness_checking_required: false

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -369,6 +369,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
               user_uuid: an_instance_of(String),
               uuid_prefix: nil,
               liveness_checking_required: true,
+              id_images_cropped: false,
             ).and_call_original
 
           action
@@ -390,6 +391,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
             user_uuid: an_instance_of(String),
             uuid_prefix: nil,
             liveness_checking_required: false,
+            id_images_cropped: false,
           ).and_call_original
 
         action
@@ -1288,6 +1290,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
             user_uuid: an_instance_of(String),
             uuid_prefix: nil,
             liveness_checking_required: true,
+            id_images_cropped: false,
           ).and_call_original
 
         action

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
               user_uuid: an_instance_of(String),
               uuid_prefix: nil,
               liveness_checking_required: true,
-              id_images_cropped: false,
+              images_cropped: false,
             ).and_call_original
 
           action
@@ -391,7 +391,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
             user_uuid: an_instance_of(String),
             uuid_prefix: nil,
             liveness_checking_required: false,
-            id_images_cropped: false,
+            images_cropped: false,
           ).and_call_original
 
         action
@@ -1290,7 +1290,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
             user_uuid: an_instance_of(String),
             uuid_prefix: nil,
             liveness_checking_required: true,
-            id_images_cropped: false,
+            images_cropped: false,
           ).and_call_original
 
         action

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -757,9 +757,8 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
             let(:selfie_image_metadata) do
               { width: 10, height: 10, mimeType: 'image/png', source: 'upload' }.to_json
             end
-            let(:image_source) { DocAuth::ImageSources::UNKNOWN }
 
-            it 'sets image source to unknown' do
+            it 'sets image source to acuant sdk' do
               form.submit
             end
           end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
 
         context 'validates image source' do
           let(:selfie_image_metadata) do
-            { width: 40, height: 40, mimeType: 'image/png', source: 'acuant' }.to_json
+            { width: 40, height: 40, mimeType: 'image/png', source: 'acuant' }
           end
           before do
             allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
@@ -110,10 +110,10 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
 
           context 'images sourced by acuant sdk' do
             let(:front_image_metadata) do
-              { width: 40, height: 40, mimeType: 'image/png', source: 'acuant' }.to_json
+              { width: 40, height: 40, mimeType: 'image/png', source: 'acuant' }
             end
             let(:back_image_metadata) do
-              { width: 20, height: 20, mimeType: 'image/png', source: 'acuant' }.to_json
+              { width: 20, height: 20, mimeType: 'image/png', source: 'acuant' }
             end
             it 'is valid' do
               expect(form.valid?).to eq(true)
@@ -121,7 +121,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
 
             context 'selfie is uploaded' do
               let(:selfie_image_metadata) do
-                { width: 40, height: 40, mimeType: 'image/png', source: 'upload' }.to_json
+                { width: 40, height: 40, mimeType: 'image/png', source: 'upload' }
               end
               it 'is invalid' do
                 expect(form.valid?).to eq(false)

--- a/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
-  let(:image_source) { nil }
+  let(:images_cropped) { false }
   let(:workflow) { 'NOLIVENESS.CROPPING.WORKFLOW' }
   let(:image_upload_url) do
     URI.join(
@@ -35,15 +35,15 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
       )
     end
 
-    context 'with acuant image source' do
-      let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
+    context 'with cropped images' do
+      let(:images_cropped) { true }
       let(:workflow) { 'NOLIVENESS.NOCROPPING.WORKFLOW' }
 
       it 'sends an upload image request for the front and back DL images' do
         result = client.post_images(
           front_image: DocAuthImageFixtures.document_front_image,
           back_image: DocAuthImageFixtures.document_back_image,
-          image_source: image_source,
+          images_cropped: images_cropped,
         )
 
         expect(result.success?).to eq(true)
@@ -51,15 +51,14 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
       end
     end
 
-    context 'with unknown image source' do
-      let(:image_source) { DocAuth::ImageSources::UNKNOWN }
+    context 'with non-cropped images' do
       let(:workflow) { 'NOLIVENESS.CROPPING.WORKFLOW' }
 
       it 'sends an upload image request for the front and back DL images' do
         result = client.post_images(
           front_image: DocAuthImageFixtures.document_front_image,
           back_image: DocAuthImageFixtures.document_back_image,
-          image_source: image_source,
+          images_cropped: images_cropped,
         )
 
         expect(result.success?).to eq(true)
@@ -76,7 +75,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
         result = client.post_images(
           front_image: DocAuthImageFixtures.document_front_image,
           back_image: DocAuthImageFixtures.document_back_image,
-          image_source: image_source,
+          images_cropped: images_cropped,
         )
 
         expect(result.success?).to eq(false)
@@ -91,7 +90,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
       result = client.post_images(
         front_image: DocAuthImageFixtures.document_front_image,
         back_image: DocAuthImageFixtures.document_back_image,
-        image_source: image_source,
+        images_cropped: images_cropped,
       )
 
       expect(result.success?).to eq(false)
@@ -109,7 +108,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
       result = client.post_images(
         front_image: DocAuthImageFixtures.document_front_image,
         back_image: DocAuthImageFixtures.document_back_image,
-        image_source: image_source,
+        images_cropped: images_cropped,
       )
 
       expect(result.success?).to eq(false)
@@ -136,7 +135,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
         result = client.post_images(
           front_image: DocAuthImageFixtures.document_front_image,
           back_image: DocAuthImageFixtures.document_back_image,
-          image_source: image_source,
+          images_cropped: images_cropped,
           selfie_image: DocAuthImageFixtures.selfie_image,
           liveness_checking_required: true,
         )
@@ -160,7 +159,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
         result = client.post_images(
           front_image: DocAuthImageFixtures.document_front_image,
           back_image: DocAuthImageFixtures.document_back_image,
-          image_source: image_source,
+          images_cropped: images_cropped,
           selfie_image: DocAuthImageFixtures.selfie_image,
           liveness_checking_required: true,
         )
@@ -194,7 +193,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
         result = client.post_images(
           front_image: DocAuthImageFixtures.document_front_image,
           back_image: DocAuthImageFixtures.document_back_image,
-          image_source: image_source,
+          images_cropped: images_cropped,
           selfie_image: DocAuthImageFixtures.selfie_image,
           liveness_checking_required: true,
         )
@@ -225,7 +224,7 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
           result = client.post_images(
             front_image: DocAuthImageFixtures.document_front_image,
             back_image: DocAuthImageFixtures.document_back_image,
-            image_source: image_source,
+            images_cropped: images_cropped,
             selfie_image: DocAuthImageFixtures.selfie_image,
             liveness_checking_required: true,
           )

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
   let(:cropping_non_liveness_flow) { 'test_workflow_cropping' }
   let(:non_cropping_liveness_flow) { 'test_workflow_liveness' }
   let(:cropping_liveness_flow) { 'test_workflow_liveness_cropping' }
+  let(:images_cropped) { false }
 
   let(:config) do
     DocAuth::LexisNexis::Config.new(
@@ -31,6 +32,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
       front_image: DocAuthImageFixtures.document_front_image,
       back_image: DocAuthImageFixtures.document_back_image,
       image_source: image_source,
+      images_cropped: images_cropped,
       user_uuid: applicant[:uuid],
       uuid_prefix: applicant[:uuid_prefix],
       selfie_image: selfie_image,
@@ -104,41 +106,49 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
   context 'with liveness_checking_enabled as false' do
     context 'when liveness checking is NOT required' do
       let(:liveness_checking_required) { false }
-      context 'with acuant image source' do
-        let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
-        it_behaves_like 'a successful request'
-        it 'uses non-cropping non-liveness workflow' do
-          expect(subject.send(:workflow)).to eq(non_cropping_non_liveness_flow)
-        end
-        it 'does not include a nil selfie in the request body sent to TrueID' do
-          body_as_json = subject.send(:body)
-          body_as_hash = JSON.parse(body_as_json)
-          expect(body_as_hash['Document']).not_to have_key('Selfie')
-        end
-      end
-      context 'with unknown image source' do
-        let(:image_source) { DocAuth::ImageSources::UNKNOWN }
+
+      it_behaves_like 'a successful request'
+
+      context 'with non-cropped images' do
         it 'uses cropping non-liveness workflow' do
           expect(subject.send(:workflow)).to eq(cropping_non_liveness_flow)
         end
+      end
+
+      it 'does not include a nil selfie in the request body sent to TrueID' do
+        body_as_json = subject.send(:body)
+        body_as_hash = JSON.parse(body_as_json)
+        expect(body_as_hash['Document']).not_to have_key('Selfie')
+      end
+
+      context 'with cropped images' do
+        let(:images_cropped) { true }
+
+        it 'uses non-cropping non-liveness workflow' do
+          expect(subject.send(:workflow)).to eq(non_cropping_non_liveness_flow)
+        end
+
         it_behaves_like 'a successful request'
       end
     end
 
     context 'when liveness checking is required' do
       let(:liveness_checking_required) { true }
-      context 'with acuant image source' do
-        let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
+
+      context 'with non-cropped images' do
+        it 'uses non-cropping non-liveness workflow' do
+          expect(subject.send(:workflow)).to eq(cropping_non_liveness_flow)
+        end
+
+        it_behaves_like 'a successful request'
+      end
+
+      context 'with cropped images' do
+        let(:images_cropped) { true }
         it 'uses non-cropping non-liveness workflow' do
           expect(subject.send(:workflow)).to eq(non_cropping_non_liveness_flow)
         end
-        it_behaves_like 'a successful request'
-      end
-      context 'with unknown image source' do
-        let(:image_source) { DocAuth::ImageSources::UNKNOWN }
-        it 'uses cropping non-liveness workflow' do
-          expect(subject.send(:workflow)).to eq(cropping_non_liveness_flow)
-        end
+
         it_behaves_like 'a successful request'
       end
     end
@@ -153,17 +163,16 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
 
     context 'when liveness checking is NOT required' do
       let(:liveness_checking_required) { false }
-      context 'with acuant image source' do
-        let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
-        it 'use non-cropping non-liveness workflow' do
-          expect(subject.send(:workflow)).to eq(non_cropping_non_liveness_flow)
+      context 'with non-cropped images' do
+        it 'use cropping non-liveness workflow' do
+          expect(subject.send(:workflow)).to eq(cropping_non_liveness_flow)
         end
         it_behaves_like 'a successful request'
       end
-      context 'with unknown image source' do
-        let(:image_source) { DocAuth::ImageSources::UNKNOWN }
-        it 'use cropping non-liveness workflow' do
-          expect(subject.send(:workflow)).to eq(cropping_non_liveness_flow)
+      context 'with cropped images' do
+        let(:images_cropped) { true }
+        it 'use non-cropping non-liveness workflow' do
+          expect(subject.send(:workflow)).to eq(non_cropping_non_liveness_flow)
         end
         it_behaves_like 'a successful request'
       end
@@ -171,35 +180,40 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
 
     context 'when liveness checking is required' do
       let(:liveness_checking_required) { true }
-      context 'with acuant image source' do
-        let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
-        it 'use non-cropping liveness workflow' do
-          expect(subject.send(:workflow)).to eq(non_cropping_liveness_flow)
-        end
-        it_behaves_like 'a successful request'
-      end
-      context 'with unknown image source' do
-        let(:image_source) { DocAuth::ImageSources::UNKNOWN }
+
+      context 'with non-cropped images' do
         it 'use cropping liveness workflow' do
           expect(subject.send(:workflow)).to eq(cropping_liveness_flow)
+        end
+
+        it_behaves_like 'a successful request'
+      end
+
+      context 'with cropped images' do
+        let(:images_cropped) { true }
+        it 'use non-cropping liveness workflow' do
+          expect(subject.send(:workflow)).to eq(non_cropping_liveness_flow)
         end
         it_behaves_like 'a successful request'
       end
 
       context 'when hosted env is prod' do
         let(:selfie_check_allowed) { false }
-        context 'with acuant image source' do
-          let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
-          it 'use non-cropping non-liveness workflow' do
-            expect(subject.send(:workflow)).to eq(non_cropping_non_liveness_flow)
-          end
-          it_behaves_like 'a successful request'
-        end
-        context 'with unknown image source' do
-          let(:image_source) { DocAuth::ImageSources::UNKNOWN }
+
+        context 'with non-cropped images' do
           it 'use cropping non-liveness workflow' do
             expect(subject.send(:workflow)).to eq(cropping_non_liveness_flow)
           end
+          it_behaves_like 'a successful request'
+        end
+
+        context 'with cropped images' do
+          let(:images_cropped) { true }
+
+          it 'use non-cropping non-liveness workflow' do
+            expect(subject.send(:workflow)).to eq(non_cropping_non_liveness_flow)
+          end
+
           it_behaves_like 'a successful request'
         end
       end
@@ -207,7 +221,6 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
   end
 
   context 'with non 200 http status code' do
-    let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
     it 'is a network error with 5xx status' do
       stub_request(:post, full_url).to_return(body: '{}', status: 500)
       response = subject.fetch


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-12372](https://cm-jira.usa.gov/browse/LG-12372)

## 🛠 Summary of changes
Only use TrueID cropped workflows when ID images are cropped (autocaptured via Acuant SDK)

## 📜 Testing Plan
- Tested via unit tests

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
