### PR TITLE
Document analytics properties for password reset

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3737,14 +3737,23 @@ module AnalyticsEvents
   # confirmed email
   # @param [Boolean, nil] active_profile if the account the reset is being requested for has an
   # active proofed profile
+  # @param [Hash] error_details Details for error that occurred in unsuccessful submission
   # The user entered an email address to request a password reset
-  def password_reset_email(success:, errors:, confirmed:, active_profile:, **extra)
+  def password_reset_email(
+    success:,
+    errors:,
+    confirmed:,
+    active_profile:,
+    error_details: {},
+    **extra
+  )
     track_event(
       'Password Reset: Email Submitted',
-      success: success,
-      errors: errors,
-      confirmed: confirmed,
-      active_profile: active_profile,
+      success:,
+      errors:,
+      error_details:,
+      confirmed:,
+      active_profile:,
       **extra,
     )
   end
@@ -3753,13 +3762,29 @@ module AnalyticsEvents
   # @param [Hash] errors
   # @param [Boolean] profile_deactivated if the active profile for the account was deactivated
   # (the user will need to use their personal key to reactivate their profile)
+  # @param [Boolean] pending_profile_invalidated Whether a pending profile was invalidated as a
+  # result of the password reset
+  # @param [String] pending_profile_pending_reasons Comma-separated list of the pending states
+  # associated with the associated profile.
+  # @param [Hash] error_details Details for error that occurred in unsuccessful submission
   # The user changed the password for their account via the password reset flow
-  def password_reset_password(success:, errors:, profile_deactivated:, **extra)
+  def password_reset_password(
+    success:,
+    errors:,
+    profile_deactivated:,
+    pending_profile_invalidated:,
+    pending_profile_pending_reasons:,
+    error_details: {},
+    **extra
+  )
     track_event(
       'Password Reset: Password Submitted',
-      success: success,
-      errors: errors,
-      profile_deactivated: profile_deactivated,
+      success:,
+      errors:,
+      error_details:,
+      profile_deactivated:,
+      pending_profile_invalidated:,
+      pending_profile_pending_reasons:,
       **extra,
     )
   end
@@ -4683,6 +4708,7 @@ module AnalyticsEvents
   # @param [Hash] errors
   # @param [Hash] error_details
   # @param [String] user_id
+  # @param [Boolean] rate_limited
   # @param [String] domain_name
   def user_registration_email(
     success:,
@@ -4690,18 +4716,20 @@ module AnalyticsEvents
     errors:,
     error_details: nil,
     user_id: nil,
+    email_already_exists: nil,
     domain_name: nil,
     **extra
   )
     track_event(
       'User Registration: Email Submitted',
       {
-        success: success,
-        rate_limited: rate_limited,
-        errors: errors,
-        error_details: error_details,
-        user_id: user_id,
-        domain_name: domain_name,
+        success:,
+        rate_limited:,
+        errors:,
+        error_details:,
+        user_id:,
+        email_already_exists:,
+        domain_name:,
         **extra,
       }.compact,
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4708,7 +4708,7 @@ module AnalyticsEvents
   # @param [Hash] errors
   # @param [Hash] error_details
   # @param [String] user_id
-  # @param [Boolean] rate_limited
+  # @param [Boolean] email_already_exists
   # @param [String] domain_name
   def user_registration_email(
     success:,

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Users::ResetPasswordsController, devise: true, allowed_extra_analytics: [:*] do
+RSpec.describe Users::ResetPasswordsController, devise: true do
   let(:password_error_message) do
     t('errors.attributes.password.too_short.other', count: Devise.password_length.first)
   end
@@ -409,6 +409,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true, allowed_extra_anal
           analytics_hash = {
             success: true,
             errors: {},
+            error_details: {},
             user_id: user.uuid,
             profile_deactivated: false,
             pending_profile_invalidated: false,
@@ -464,6 +465,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true, allowed_extra_anal
         analytics_hash = {
           success: true,
           errors: {},
+          error_details: {},
           user_id: user.uuid,
           profile_deactivated: true,
           pending_profile_invalidated: false,
@@ -516,6 +518,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true, allowed_extra_anal
         analytics_hash = {
           success: true,
           errors: {},
+          error_details: {},
           user_id: user.uuid,
           profile_deactivated: false,
           pending_profile_invalidated: false,
@@ -552,6 +555,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true, allowed_extra_anal
         analytics_hash = {
           success: true,
           errors: {},
+          error_details: {},
           user_id: 'nonexistent-uuid',
           confirmed: false,
           active_profile: false,
@@ -583,6 +587,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true, allowed_extra_anal
         {
           success: true,
           errors: {},
+          error_details: {},
           user_id: user.uuid,
           confirmed: true,
           active_profile: false,
@@ -616,6 +621,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true, allowed_extra_anal
         {
           success: true,
           errors: {},
+          error_details: {},
           user_id: user.uuid,
           confirmed: false,
           active_profile: false,
@@ -663,6 +669,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true, allowed_extra_anal
         analytics_hash = {
           success: true,
           errors: {},
+          error_details: {},
           user_id: user.uuid,
           confirmed: true,
           active_profile: true,

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -42,11 +42,13 @@ RSpec.shared_examples 'strong password' do |form_class|
     expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 
-  it 'does not allow a password containing words from the user email' do
-    user = build_stubbed(:user, email: 'janedoelongname@example.com', uuid: '123')
+  # This test is disabled for now because zxcvbn doesn't support this
+  # feature yet. See: https://github.com/dropbox/zxcvbn/issues/227
+  xit 'does not allow a password containing words from the user email' do
+    user = build_stubbed(:user, email: 'janedoe@gmail.com', uuid: '123')
     allow(user).to receive(:reset_password_period_valid?).and_return(true)
     form = form_class.constantize.new(user)
-    password = 'janedoelongname'
+    password = 'janedoe gmail'
     errors = {
       password: ['Your password is not strong enough.' \
         ' Add another word or two.' \

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -42,13 +42,11 @@ RSpec.shared_examples 'strong password' do |form_class|
     expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 
-  # This test is disabled for now because zxcvbn doesn't support this
-  # feature yet. See: https://github.com/dropbox/zxcvbn/issues/227
-  xit 'does not allow a password containing words from the user email' do
-    user = build_stubbed(:user, email: 'janedoe@gmail.com', uuid: '123')
+  it 'does not allow a password containing words from the user email' do
+    user = build_stubbed(:user, email: 'janedoelongname@example.com', uuid: '123')
     allow(user).to receive(:reset_password_period_valid?).and_return(true)
     form = form_class.constantize.new(user)
-    password = 'janedoe gmail'
+    password = 'janedoelongname'
     errors = {
       password: ['Your password is not strong enough.' \
         ' Add another word or two.' \


### PR DESCRIPTION
## 🛠 Summary of changes

Updates method signatures in `AnalyticsEvents` to add missing properties logged for password reset.

Prompted by a [Slack request](https://gsa-tts.slack.com/archives/C05MGJ72GU9/p1708535373643259) made more difficult by lack of full properties documentation.

## 📜 Testing Plan

```
rspec spec/controllers/users/reset_passwords_controller_spec.rb
```