### PR TITLE
Show YAML File Name on Mobile

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -217,6 +217,10 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
   const innerHintId = `${hintId}-inner`;
   const labelId = `${inputId}-label`;
   const showInnerHint: boolean = !value && !isValuePending && !isMobile;
+  // In test only we allow the upload of yaml files, but because they're text files
+  // they don't have a preview. This shows the name of the file in the upload
+  // box (using the existing preview) when the file name ends with .yml
+  const isYamlFile: boolean = value instanceof window.File && value.name.endsWith('.yml');
 
   /**
    * In response to a file input change event, confirms that the file is valid before calling
@@ -344,7 +348,7 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
         onDrop={() => setIsDraggingOver(false)}
       >
         <div className="usa-file-input__target">
-          {value && !isValuePending && (
+          {value && !isValuePending && (!isMobile || isYamlFile) && (
             <div className="usa-file-input__preview-heading">
               <span>
                 {value instanceof window.File && (

--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -220,7 +220,7 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
   // In test only we allow the upload of yaml files, but because they're text files
   // they don't have a preview. This shows the name of the file in the upload
   // box (using the existing preview) when the file name ends with .yml
-  const isYamlFile: boolean = value instanceof window.File && value.name.endsWith('.yml');
+  const isYAMLFile: boolean = value instanceof window.File && value.name.endsWith('.yml');
 
   /**
    * In response to a file input change event, confirms that the file is valid before calling
@@ -348,7 +348,7 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
         onDrop={() => setIsDraggingOver(false)}
       >
         <div className="usa-file-input__target">
-          {value && !isValuePending && (!isMobile || isYamlFile) && (
+          {value && !isValuePending && (!isMobile || isYAMLFile) && (
             <div className="usa-file-input__preview-heading">
               <span>
                 {value instanceof window.File && (

--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -344,7 +344,7 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
         onDrop={() => setIsDraggingOver(false)}
       >
         <div className="usa-file-input__target">
-          {value && !isValuePending && !isMobile && (
+          {value && !isValuePending && (
             <div className="usa-file-input__preview-heading">
               <span>
                 {value instanceof window.File && (

--- a/spec/javascript/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/file-input-spec.jsx
@@ -492,4 +492,23 @@ describe('document-capture/components/file-input', () => {
 
     expect(getByText('File loaded').classList.contains('usa-sr-only')).to.be.true();
   });
+
+  it('shows the file name on mobile for a yaml file', async () => {
+    const ymlFile = await getFixtureFile('ial2_test_credential.yml');
+    const { container } = render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <FileInput label="File" value={ymlFile} />
+      </DeviceContext.Provider>,
+    );
+    expect(container.querySelector('.usa-file-input__preview-heading')).to.be.ok();
+  });
+
+  it('doesnt show the file name on mobile for an image file', () => {
+    const { container } = render(
+      <DeviceContext.Provider value={{ isMobile: true }}>
+        <FileInput label="File" value={file} />
+      </DeviceContext.Provider>,
+    );
+    expect(container.querySelector('.usa-file-input__preview-heading')).to.not.be.ok();
+  });
 });


### PR DESCRIPTION

## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-12520

## 🛠 Summary of changes

Show the file name on mobile for yaml files to avoid developer confusion while testing. Also makes the display better while testing. [Slack thread](https://gsa-tts.slack.com/archives/C05HSH9RQ57/p1708542109438079).

## 📜 Testing Plan

- [x] On a mobile device
    - [x] Go to the front/back upload page.
    - [x] Upload a yaml file.
    - [x] Note that the name of the yaml file appears in the upload box.
    - [x] Upload an image from your camera roll.
    - [x] Note that the name of the file does not appear above the image.
    - [x] Upload an image using the AcuantSDK. Note that the image takes up the whole preview box. There shouldn't be the `Change file` link in the box like there was for the yaml file.
- [x] On desktop
    - [x] Go to the front/back upload page.
    - [x] Upload a yaml file.
    - [x] Note that the name of the yaml file appears in the upload box.
    - [x] Upload an image from your camera roll.
    - [x] Note that the name of the file does appear above the image.


## 👀 Screenshots

These screenshots are not all of the desired state, they're just here to cue you on what we're looking for.

<details>
<summary>Screenshots</summary>

![TestFaceMatchFailBeforeSelfieCapture](https://github.com/18F/identity-idp/assets/6818839/07d0e2af-4c52-4eda-9343-5ab96400ef2e)
![SDKUploadWithIncorrectChangeFileLink](https://github.com/18F/identity-idp/assets/6818839/cb4318a3-669d-4084-aabb-d68504e7fc29)
![YAMLFileWorkingOnMobile](https://github.com/18F/identity-idp/assets/6818839/a83d4189-6497-45a1-a122-1075276f7ee5)
![ImageUploadIncorrectlyShowingFileNameMobile](https://github.com/18F/identity-idp/assets/6818839/55945752-a03d-4aac-a523-fe7774920ec6)


</details>
