### PR TITLE
Adapt skipped strong password test for partial match behavior

### DIFF
--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -42,7 +42,7 @@ RSpec.shared_examples 'strong password' do |form_class|
     expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 
-  it 'does not allow a password containing words from the user email' do
+  it 'does not allow a password equal to a word from the user email' do
     user = build_stubbed(:user, email: 'janedoelongname@example.com', uuid: '123')
     allow(user).to receive(:reset_password_period_valid?).and_return(true)
     form = form_class.constantize.new(user)

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -42,13 +42,11 @@ RSpec.shared_examples 'strong password' do |form_class|
     expect(result.extra).to include(user_id: '123') if result.extra.present?
   end
 
-  # This test is disabled for now because zxcvbn doesn't support this
-  # feature yet. See: https://github.com/dropbox/zxcvbn/issues/227
-  xit 'does not allow a password containing words from the user email' do
-    user = build_stubbed(:user, email: 'janedoe@gmail.com', uuid: '123')
+  it 'does not allow a password containing words from the user email' do
+    user = build_stubbed(:user, email: 'janedoelongname@example.com', uuid: '123')
     allow(user).to receive(:reset_password_period_valid?).and_return(true)
     form = form_class.constantize.new(user)
-    password = 'janedoe gmail'
+    password = 'janedoelongname'
     errors = {
       password: ['Your password is not strong enough.' \
         ' Add another word or two.' \


### PR DESCRIPTION
## 🛠 Summary of changes

Updates and unskips a test aimed at checking password strength for a password containing a component of the user's email address.

**Why?**

- We should aim to minimize skipped tests, since:
   - There's usually little incentive or accountability to action toward unskipping them (this one has been skipped since 2018)
   - They're at a high risk of falling out of sync with application code
   - They can indicate a lack of sufficient test coverage
   - They create noise in continuous integration build logs
- zxcvbn is unmaintained (last release in 2017) and this feature is likely never going to be implemented
- Part of the intent of this check is supported, namely checking that a password is exactly equal to a component of the user's email address, and we can/should test for this

## 📜 Testing Plan

```
rspec spec/forms/password_form_spec.rb:16 spec/forms/reset_password_form_spec.rb:257 spec/forms/update_user_password_form_spec.rb:18
```