### PR TITLE
Add a comment describing the use of "P6" for AAMVA requests

### DIFF
--- a/app/services/proofing/aamva/request/verification_request.rb
+++ b/app/services/proofing/aamva/request/verification_request.rb
@@ -105,6 +105,9 @@ module Proofing
         end
 
         def message_destination_id
+          # Note: AAMVA uses this field to route the request to the appropriate state DMV.
+          #       We are required to use 'P6' as the jurisdiction when we make requests
+          #       in the AAMVA CERT/Test environment.
           return 'P6' if config.cert_enabled.to_s == 'true'
           applicant.state_id_data.state_id_jurisdiction
         end


### PR DESCRIPTION
I was doing some research and was flummoxed by the hard-coded "P6" in AAMVA verification requests. I did a little research and added what I learned as a comment.