### PR TITLE
Remove temporary 50/50 state fix from the SAML controller

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -104,7 +104,6 @@ class SamlIdpController < ApplicationController
     SamlEndpoint.new(params[:path_year]).saml_metadata
   end
 
-
   def prompt_for_password_if_ial2_request_and_pii_locked
     return unless pii_requested_but_locked?
     redirect_to capture_password_url

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -104,15 +104,9 @@ class SamlIdpController < ApplicationController
     SamlEndpoint.new(params[:path_year]).saml_metadata
   end
 
-  def ialmax_request_with_ial1_acr_and_pii_requested_and_locked?
-    requested_ial == 'ialmax' &&
-      current_user.identity_verified? &&
-      !Pii::Cacher.new(current_user, user_session).exists_in_session?
-  end
 
   def prompt_for_password_if_ial2_request_and_pii_locked
-    return unless pii_requested_but_locked? ||
-                  ialmax_request_with_ial1_acr_and_pii_requested_and_locked?
+    return unless pii_requested_but_locked?
     redirect_to capture_password_url
   end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -731,10 +731,9 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
         )
       end
       let(:sign_in_flow) { :sign_in }
-      let(:skip_sign_in) { false }
 
       before do
-        stub_sign_in(user) unless skip_sign_in
+        stub_sign_in(user)
         session[:sign_in_flow] = sign_in_flow
         IdentityLinker.new(user, ServiceProvider.find_by(issuer: sp1_issuer)).link_identity(ial: 2)
         user.identities.last.update!(
@@ -822,41 +821,6 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
 
         it 'redirects to password capture if profile is verified but not in session' do
           saml_get_auth(ialmax_settings)
-          expect(response).to redirect_to capture_password_url
-        end
-      end
-
-      context 'profile is not in the session and an incorrect ACR value was stored' do
-        let(:pii) { nil }
-        let(:skip_sign_in) { true }
-
-        before do
-          IdentityLinker.new(
-            user,
-            ServiceProvider.find_by(issuer: sp1_issuer),
-          ).link_identity(ial: 2)
-          user.identities.last.update!(
-            verified_attributes: %w[email given_name family_name social_security_number address],
-          )
-          allow(subject).to receive(:attribute_asserter) { asserter }
-        end
-
-        it 'redirects the user to capture password' do
-          params = {
-            SAMLRequest: CGI.unescape(saml_request(ialmax_settings)),
-            path_year: SamlAuthHelper::PATH_YEAR,
-          }
-
-          # Initial request to store the SP request
-          get :auth, params: params
-
-          # The old code would store the IAL1 authn context instead of the IALMAX context
-          # This commit duplicates that behavior by overriding the value in the session here
-          controller.session[:sp][:acr_values] = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-          stub_sign_in(user)
-
-          get :auth, params: params
-
           expect(response).to redirect_to capture_password_url
         end
       end


### PR DESCRIPTION
A previous change introduced a temporary fix to avoid a 50/50 state issue in the SAML controller (ref: https://github.com/18F/identity-idp/pull/10141).

That was intended to be temporary. Once it is deployed and stable the code can be removed. This change removes that code.
