### PR TITLE
Use `sp_from_sp_session` for `ApplicationController#resolved_authn_context_result`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,11 +107,12 @@ class ApplicationController < ActionController::Base
   def resolved_authn_context_result
     return @resolved_authn_context_result if defined?(@resolved_authn_context_result)
 
-    if current_sp.nil?
+    service_provider = sp_from_sp_session
+    if service_provider.nil?
       @resolved_authn_context_result = Vot::Parser::Result.no_sp_result
     else
       @resolved_authn_context_result = AuthnContextResolver.new(
-        service_provider: current_sp,
+        service_provider: service_provider,
         vtr: sp_session[:vtr],
         acr_values: sp_session[:acr_values],
       ).resolve

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -465,7 +465,7 @@ RSpec.describe ApplicationController do
         'http://idmanagement.gov/ns/assurance/aal/1',
       ].join(' ')
       sp_session = { vtr: nil, acr_values: acr_values }
-      allow(controller).to receive(:current_sp).and_return(sp)
+      allow(controller).to receive(:sp_from_sp_session).and_return(sp)
       allow(controller).to receive(:sp_session).and_return(sp_session)
 
       result = subject.resolved_authn_context_result
@@ -478,7 +478,7 @@ RSpec.describe ApplicationController do
       it 'returns a no-SP result' do
         sp = nil
         sp_session = {}
-        allow(controller).to receive(:current_sp).and_return(sp)
+        allow(controller).to receive(:sp_from_sp_session).and_return(sp)
         allow(controller).to receive(:sp_session).and_return(sp_session)
 
         result = subject.resolved_authn_context_result


### PR DESCRIPTION
The `Application#resolved_authn_context_result` method uses the SP session to compute the resolved authn context. The `current_sp` method returns the current SP either by using the issuer in the SP sesison or by using the SP associated with a request ID param.

When `current_sp` is getting an SP associated with a request ID param then there is not an SP session. This leads to an error when computing the resolved authn context.

This change only passes the SP from the session into the `AuthnContextResolver` when computing the resolved authn context.
