### PR TITLE
Always assign error_details for FormResponse with ActiveModel::Errors

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3744,7 +3744,7 @@ module AnalyticsEvents
     errors:,
     confirmed:,
     active_profile:,
-    error_details: {},
+    error_details:,
     **extra
   )
     track_event(
@@ -3774,7 +3774,7 @@ module AnalyticsEvents
     profile_deactivated:,
     pending_profile_invalidated:,
     pending_profile_pending_reasons:,
-    error_details: {},
+    error_details:,
     **extra
   )
     track_event(

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -18,7 +18,7 @@ class FormResponse
   def to_h
     hash = { success: success }
     hash[:errors] = errors if !serialize_error_details_only?
-    hash[:error_details] = flatten_details(error_details) if error_details.present?
+    hash[:error_details] = flatten_details(error_details) if !error_details.nil?
     hash.merge!(extra)
     hash
   end

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -174,30 +174,6 @@ RSpec.describe FormResponse do
         end
       end
 
-      it 'omits details if errors are empty' do
-        errors = ActiveModel::Errors.new(build_stubbed(:user))
-        response = FormResponse.new(success: true, errors: errors)
-        response_hash = {
-          success: true,
-          errors: {},
-        }
-
-        expect(response.to_h).to eq response_hash
-      end
-
-      it 'omits details if merged errors are empty' do
-        errors = ActiveModel::Errors.new(build_stubbed(:user))
-        response1 = FormResponse.new(success: true, errors: errors)
-        response2 = FormResponse.new(success: true, errors: errors)
-        combined_response = response1.merge(response2)
-        response_hash = {
-          success: true,
-          errors: {},
-        }
-
-        expect(combined_response.to_h).to eq response_hash
-      end
-
       context 'with error detail symbol defined as type option on error' do
         it 'returns a hash with success, errors, and error_details keys' do
           errors = ActiveModel::Errors.new(build_stubbed(:user))


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `FormResponse` to always include `error_details` in its serialized hash form, as long as the `errors` object is an instance of `ActiveModel::Errors`.

This is a continuation of the discussion at https://github.com/18F/identity-idp/pull/10132#discussion_r1499273060 , where `error_details`'s unpredictable presence requires accommodation via default values in method signatures. By always assigning a value, these defaults can be removed.

**Draft:** Unsure the full impact of these changes, awaiting test results.

## 📜 Testing Plan

TBD