### PR TITLE
LG-12445: fix mock proofer to evaluate errors when Attention with Barcode

### DIFF
--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -18,6 +18,7 @@ module DocAuth
           doc_type_supported: id_type_supported?,
           selfie_live: selfie_live?,
           selfie_quality_good: selfie_quality_good?,
+          selfie_status: selfie_status,
           extra: {
             doc_auth_result: doc_auth_result,
             portrait_match_results: portrait_match_results,
@@ -85,7 +86,7 @@ module DocAuth
       end
 
       def success?
-        (errors.blank? || attention_with_barcode?) && id_type_supported?
+        doc_auth_success? && (selfie_check_performed? ? selfie_passed? : true)
       end
 
       def attention_with_barcode?

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -34,12 +34,17 @@ module DocAuth
         @errors ||= begin
           file_data = parsed_data_from_uploaded_file
 
-          if file_data.blank? || attention_with_barcode?
+          if file_data.blank?
             {}
           else
             doc_auth_result = file_data.dig('doc_auth_result')
             image_metrics = file_data.dig('image_metrics')
-            failed = file_data.dig('failed_alerts')
+
+            if attention_with_barcode?
+              failed_file_data = file_data.dup.dig('failed_alerts')
+              failed_file_data.delete(ATTENTION_WITH_BARCODE_ALERT)
+            end
+            failed = failed_file_data
             passed = file_data.dig('passed_alerts')
             face_match_result = file_data.dig('portrait_match_results', 'FaceMatchResult')
             classification_info = file_data.dig('classification_info')

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -39,12 +39,7 @@ module DocAuth
           else
             doc_auth_result = file_data.dig('doc_auth_result')
             image_metrics = file_data.dig('image_metrics')
-
-            if attention_with_barcode?
-              failed_file_data = file_data.dup.dig('failed_alerts')
-              failed_file_data.delete(ATTENTION_WITH_BARCODE_ALERT)
-            end
-            failed = failed_file_data
+            failed = failed_file_data(file_data.dup)
             passed = file_data.dig('passed_alerts')
             face_match_result = file_data.dig('portrait_match_results', 'FaceMatchResult')
             classification_info = file_data.dig('classification_info')
@@ -259,6 +254,14 @@ module DocAuth
           portrait_match_results: selfie_check_performed? ? portrait_match_results : nil,
           extra: { liveness_checking_required: liveness_enabled },
         }.compact
+      end
+
+      def failed_file_data(failed_data)
+        if attention_with_barcode?
+          failed_data = failed_data.dig('failed_alerts')
+          failed_data.delete(ATTENTION_WITH_BARCODE_ALERT)
+        end
+        failed_data
       end
     end
   end

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -39,7 +39,7 @@ module DocAuth
           else
             doc_auth_result = file_data.dig('doc_auth_result')
             image_metrics = file_data.dig('image_metrics')
-            failed = failed_file_data(file_data.dup)
+            failed = failed_file_data(file_data.dig('failed_alerts')&.dup)
             passed = file_data.dig('passed_alerts')
             face_match_result = file_data.dig('portrait_match_results', 'FaceMatchResult')
             classification_info = file_data.dig('classification_info')
@@ -256,12 +256,11 @@ module DocAuth
         }.compact
       end
 
-      def failed_file_data(failed_data)
+      def failed_file_data(failed_alerts_data)
         if attention_with_barcode?
-          failed_data = failed_data.dig('failed_alerts')
-          failed_data.delete(ATTENTION_WITH_BARCODE_ALERT)
+          failed_alerts_data&.delete(ATTENTION_WITH_BARCODE_ALERT)
         end
-        failed_data
+        failed_alerts_data
       end
     end
   end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -383,6 +383,47 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
           inline_error = strip_tags(t('doc_auth.errors.general.selfie_failure'))
           expect(page).to have_content(inline_error)
         end
+
+        context 'with Attention with Barcode' do
+          it 'try again and page show selfie fail inline error message' do
+            visit_idp_from_oidc_sp_with_ial2
+            sign_in_and_2fa_user(user)
+            complete_doc_auth_steps_before_document_capture_step
+            attach_images(
+              Rails.root.join(
+                'spec', 'fixtures',
+                'ial2_test_credential_barcode_attention_liveness_fail.yml'
+              ),
+            )
+            attach_selfie(
+              Rails.root.join(
+                'spec', 'fixtures',
+                'ial2_test_credential_barcode_attention_liveness_fail.yml'
+              ),
+            )
+            submit_images
+            message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+            expect(page).to have_content(message)
+            detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live'))
+            security_message = strip_tags(
+              t(
+                'idv.warning.attempts_html',
+                count: IdentityConfig.store.doc_auth_max_attempts - 1,
+              ),
+            )
+
+            expect(page).to have_content(detail_message << "\n" << security_message)
+            review_issues_header = strip_tags(
+              t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+            )
+            expect(page).to have_content(review_issues_header)
+            expect(page).to have_current_path(idv_document_capture_path)
+            click_try_again
+            expect(page).to have_current_path(idv_document_capture_path)
+            inline_error = strip_tags(t('doc_auth.errors.general.selfie_failure'))
+            expect(page).to have_content(inline_error)
+          end
+        end
       end
 
       context 'when selfie check is not enabled (flag off, and/or in production)' do

--- a/spec/fixtures/ial2_test_credential_barcode_attention_liveness_fail.yml
+++ b/spec/fixtures/ial2_test_credential_barcode_attention_liveness_fail.yml
@@ -1,0 +1,24 @@
+portrait_match_results:
+  # returns the portrait match result
+  FaceMatchResult: Fail
+  # returns the liveness result
+  FaceErrorMessage: 'Liveness: NotLive'
+doc_auth_result: Attention
+document:
+  first_name: Jane
+  last_name: Doe
+  middle_name: Q
+  address1: 1800 F Street
+  address2: Apt 3
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  dob: 10/06/1938
+  phone: +1 314-555-1212
+  state_id_jurisdiction: 'ND'
+  state_id_number: 'S59397998'
+  state_id_type: drivers_license
+failed_alerts:
+  - name: 2D Barcode Read
+    result: Attention
+


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12445](https://cm-jira.usa.gov/browse/LG-12445)

## 🛠 Summary of changes

- Mock proofer to set the selfie status in DocAuth::Response
- Mock proofer  include selfie status when evaluating success

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Submit yaml with attention barcode and failed selfie
- [ ] Verify Try Again screen is shown

## 👀 Screenshots
<details>
<summary>Before:</summary>
<img width="604" alt="Screenshot 2024-02-23 at 9 32 57 AM" src="https://github.com/18F/identity-idp/assets/1261794/4041c1eb-455d-4fe7-83da-4f1e1f6032f0">
</details>

<details>
<summary>After:</summary>
<img width="556" alt="Screenshot 2024-02-23 at 3 52 57 PM" src="https://github.com/18F/identity-idp/assets/1261794/2009f78a-de94-408b-b013-9dd2f82ce2c8">
</details>
