### PR TITLE
LG-12265: Stop reading from sp_session[:piv_cac_requested]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -405,7 +405,7 @@ class ApplicationController < ActionController::Base
       service_provider: sp_from_sp_session,
       auth_methods_session:,
       aal_level_requested: sp_session[:aal_level_requested],
-      piv_cac_requested: sp_session[:piv_cac_requested],
+      piv_cac_requested: resolved_authn_context_result.hspd12?,
       phishing_resistant_requested: resolved_authn_context_result.phishing_resistant?,
     )
   end

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -58,7 +58,7 @@ module Users
       @piv_cac_login_form ||= UserPivCacLoginForm.new(
         token: params[:token],
         nonce: piv_cac_nonce,
-        piv_cac_required: sp_session[:piv_cac_requested],
+        piv_cac_required: resolved_authn_context_result.hspd12?,
       )
     end
 

--- a/app/services/vot/legacy_component_values.rb
+++ b/app/services/vot/legacy_component_values.rb
@@ -53,7 +53,7 @@ module Vot
     )
     AAL2_PHISHING_RESISTANT = ComponentValue.new(
       name: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
-      description: 'Legacy AAL2 with phishing resitance',
+      description: 'Legacy AAL2 with phishing resistance',
       implied_component_values: [],
       requirements: [:aal2, :phishing_resistant],
     )

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -264,7 +264,6 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
       before do
         stub_sign_in(user)
         controller.session[:sp] = {
-          phishing_resistant_requeste: true,
           issuer: service_provider.issuer,
           acr_values: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
         }

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -259,9 +259,15 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
     end
 
     context 'when SP requires PIV/CAC' do
+      let(:service_provider) { create(:service_provider) }
+
       before do
         stub_sign_in(user)
-        controller.session[:sp] = { phishing_resistant_requeste: true, piv_cac_requested: true }
+        controller.session[:sp] = {
+          phishing_resistant_requeste: true,
+          issuer: service_provider.issuer,
+          acr_values: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+        }
       end
 
       it 'redirects to MFA setup if no PIV/CAC is enabled' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12265](https://cm-jira.usa.gov/browse/LG-12265)

## 🛠 Summary of changes

In a previous commit the `resolved_authn_context_result` was introduced to return a `Vot::Parser::Result` object that described the requirements for the current SP request considering SP default options. This is intended to be used to replace the keys in the `sp_session` that serve this purpose including the `piv_cac_requested` key.

This commit replaces places where the `sp_session[:piv_cac_requested]` value is read with new reads to the `resolved_authn_context_result`.
