### PR TITLE
LG-12308: validate images are sourced by sdk when liveness check is required

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -250,7 +250,8 @@ module Idv
         )
       end
 
-      if liveness_checking_required && !acuant_sdk_capture?
+      if !IdentityConfig.store.doc_auth_selfie_desktop_test_mode &&
+         liveness_checking_required && !acuant_sdk_capture?
         errors.add(
           :selfie, t('doc_auth.errors.not_a_file'),
           type: :not_a_file

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -249,6 +249,13 @@ module Idv
           type: :not_a_file
         )
       end
+
+      if liveness_checking_required && !acuant_sdk_capture?
+        errors.add(
+          :selfie, t('doc_auth.errors.not_a_file'),
+          type: :not_a_file
+        )
+      end
     end
 
     def validate_duplicate_images

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -92,6 +92,43 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
         it 'is valid' do
           expect(form.valid?).to eq(true)
         end
+
+        context 'validates image source' do
+          let(:selfie_image_metadata) do
+            { width: 40, height: 40, mimeType: 'image/png', source: 'acuant' }.to_json
+          end
+          before do
+            allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
+              and_return(false)
+          end
+
+          context 'id images are uploaded' do
+            it 'is invalid' do
+              expect(form.valid?).to eq(false)
+            end
+          end
+
+          context 'images sourced by acuant sdk' do
+            let(:front_image_metadata) do
+              { width: 40, height: 40, mimeType: 'image/png', source: 'acuant' }.to_json
+            end
+            let(:back_image_metadata) do
+              { width: 20, height: 20, mimeType: 'image/png', source: 'acuant' }.to_json
+            end
+            it 'is valid' do
+              expect(form.valid?).to eq(true)
+            end
+
+            context 'selfie is uploaded' do
+              let(:selfie_image_metadata) do
+                { width: 40, height: 40, mimeType: 'image/png', source: 'upload' }.to_json
+              end
+              it 'is invalid' do
+                expect(form.valid?).to eq(false)
+              end
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-12308](https://cm-jira.usa.gov/browse/LG-12308)

## 🛠 Summary of changes
Add image upload validation to verify tha image files are all sourced by sdk when doc auth with selfie is required.

## 📜 Testing Plan
- complete doc auth with selfie on desktop
- complete doc auth with selfie on mobile (w/ doc_auth_selfie_desktop_test_mode disabled and prior to merge of [PR for LG-12307](https://github.com/18F/identity-idp/pull/10165))
  - attempt to upload images and fail
  - successfully submit images via sdk

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
