### PR TITLE
LG-12307: if selfie req, no upload permitted

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -74,9 +74,17 @@ function DocumentCaptureReviewIssues({
           ]}
         />
       )}
-      <DocumentFrontAndBackCapture defaultSideProps={defaultSideProps} value={value} />
+      <DocumentFrontAndBackCapture
+        defaultSideProps={defaultSideProps}
+        value={value}
+        selfieCaptureEnabled={selfieCaptureEnabled}
+      />
       {selfieCaptureEnabled && (
-        <SelfieCaptureWithHeader defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
+        <SelfieCaptureWithHeader
+          defaultSideProps={defaultSideProps}
+          selfieValue={value.selfie}
+          selfieCaptureEnabled={selfieCaptureEnabled}
+        />
       )}
       <FormStepsButton.Submit />
       {exitQuestionSectionEnabled && <DocumentCaptureAbandon />}

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -19,6 +19,11 @@ interface DocumentSideAcuantCaptureProps {
   errors: FormStepError<{ front: string; back: string; selfie: string }>[];
   onError: OnErrorCallback;
   className?: string;
+  selfieCaptureEnabled: boolean;
+}
+
+function isUploadAllowed(selfieCaptureEnabled) {
+  return selfieCaptureEnabled === false;
 }
 
 /**
@@ -40,6 +45,7 @@ function DocumentSideAcuantCapture({
   errors,
   onError,
   className,
+  selfieCaptureEnabled,
 }: DocumentSideAcuantCaptureProps) {
   const error = errors.find(({ field }) => field === side)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
@@ -55,6 +61,7 @@ function DocumentSideAcuantCapture({
       /* i18n-tasks-use t('doc_auth.headings.selfie') */
       bannerText={t(`doc_auth.headings.${side}`)}
       value={value}
+      allowUpload={isUploadAllowed(selfieCaptureEnabled)}
       onChange={(nextValue, metadata) => {
         onChange({
           [side]: nextValue,

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -22,7 +22,7 @@ interface DocumentSideAcuantCaptureProps {
   selfieCaptureEnabled: boolean;
 }
 
-function isUploadAllowed(selfieCaptureEnabled) {
+function isUploadAllowed(selfieCaptureEnabled: boolean) {
   return selfieCaptureEnabled === false;
 }
 

--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -32,9 +32,11 @@ export function DocumentCaptureSubheaderOne({
 export function SelfieCaptureWithHeader({
   defaultSideProps,
   selfieValue,
+  selfieCaptureEnabled,
 }: {
   defaultSideProps: DefaultSideProps;
   selfieValue: ImageValue;
+  selfieCaptureEnabled: boolean;
 }) {
   const { t } = useI18n();
   return (
@@ -55,6 +57,7 @@ export function SelfieCaptureWithHeader({
         key="selfie"
         side="selfie"
         value={selfieValue}
+        selfieCaptureEnabled={selfieCaptureEnabled}
       />
     </>
   );
@@ -63,12 +66,15 @@ export function SelfieCaptureWithHeader({
 export function DocumentFrontAndBackCapture({
   defaultSideProps,
   value,
+  selfieCaptureEnabled,
 }: {
   defaultSideProps: DefaultSideProps;
   value: Record<string, ImageValue>;
+  selfieCaptureEnabled: boolean;
 }) {
   type DocumentSide = 'front' | 'back';
   const documentsSides: DocumentSide[] = ['front', 'back'];
+
   return (
     <>
       {documentsSides.map((side) => (
@@ -77,6 +83,7 @@ export function DocumentFrontAndBackCapture({
           key={side}
           side={side}
           value={value[side]}
+          selfieCaptureEnabled={selfieCaptureEnabled} // need to define
         />
       ))}
     </>
@@ -135,9 +142,17 @@ function DocumentsStep({
           t('doc_auth.tips.document_capture_id_text3'),
         ].concat(!isMobile ? [t('doc_auth.tips.document_capture_id_text4')] : [])}
       />
-      <DocumentFrontAndBackCapture defaultSideProps={defaultSideProps} value={value} />
+      <DocumentFrontAndBackCapture
+        defaultSideProps={defaultSideProps}
+        value={value}
+        selfieCaptureEnabled={selfieCaptureEnabled}
+      />
       {selfieCaptureEnabled && (
-        <SelfieCaptureWithHeader defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
+        <SelfieCaptureWithHeader
+          defaultSideProps={defaultSideProps}
+          selfieValue={value.selfie}
+          selfieCaptureEnabled={selfieCaptureEnabled}
+        />
       )}
       {isLastStep ? <FormStepsButton.Submit /> : <FormStepsButton.Continue />}
       {exitQuestionSectionEnabled && <DocumentCaptureAbandon />}

--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -83,7 +83,7 @@ export function DocumentFrontAndBackCapture({
           key={side}
           side={side}
           value={value[side]}
-          selfieCaptureEnabled={selfieCaptureEnabled} // need to define
+          selfieCaptureEnabled={selfieCaptureEnabled}
         />
       ))}
     </>

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.jsx
@@ -1,0 +1,40 @@
+import { DeviceContext, FeatureFlagContext } from '@18f/identity-document-capture';
+import DocumentsStep from '@18f/identity-document-capture/components/documents-step';
+import { render } from '../../../support/document-capture';
+
+describe('DocumentSideAcuantCapture', () => {
+  context('when selfie is _not_ enabled', () => {
+    it('_does_ display a photo upload button', () => {
+      const { queryAllByText } = render(
+        <FeatureFlagContext.Provider value={{ selfieCaptureEnabled: false }}>
+          <DeviceContext.Provider value={{ isMobile: true }}>
+            <DocumentsStep />
+          </DeviceContext.Provider>
+        </FeatureFlagContext.Provider>,
+      );
+
+      const takeOrUploadPictureText = queryAllByText(
+        'doc_auth.buttons.take_or_upload_picture_html',
+      );
+      expect(takeOrUploadPictureText).to.have.lengthOf(2);
+    });
+  });
+
+  context('when selfie _is_ enabled', () => {
+    it('does _not_ display a photo upload button', () => {
+      const { queryAllByText } = render(
+        <FeatureFlagContext.Provider value={{ selfieCaptureEnabled: true }}>
+          <DeviceContext.Provider value={{ isMobile: true }}>
+            <DocumentsStep />
+          </DeviceContext.Provider>
+        </FeatureFlagContext.Provider>,
+      );
+
+      const takePictureText = queryAllByText('doc_auth.buttons.take_picture');
+      expect(takePictureText).to.have.lengthOf(3);
+
+      const notExpectedText = 'doc_auth.buttons.take_or_upload_picture_html';
+      expect(queryAllByText(notExpectedText)).to.be.an('array').that.is.empty;
+    });
+  });
+});


### PR DESCRIPTION
## 🎫 Ticket

[LG-12307](https://cm-jira.usa.gov/browse/LG-12307)

## 🛠 Summary of changes

When selfie capture is enabled, prevent image upload from being possible. 

## 📜 Testing Plan

Part 1 (the change):

- [ ] Set `doc_auth_selfie_capture_enabled: true` in your `application.yml`
- [ ] Make sure you're using a mobile device
- [ ] Use the `test/oidc/login` path and select `Sign in with Biometric`
- [ ] Follow the flow to the doc auth section
- [ ] Make sure you do **_not_** see an upload button, as in the after screenshot below, for:
    - [ ] front image
    - [ ] back image
    - [ ] selfie

Part 2 (making sure the unaffected flow remains unaffected):

- [ ] Set `doc_auth_selfie_capture_enabled: false` in your `application.yml`
- [ ] Make sure you're using a mobile device
- [ ] Use the `test/oidc/login` path and select `Sign in with IAL2`
- [ ] Follow the flow to the doc auth section
- [ ] Make sure you **_do_** see an upload button, as in the before screenshot below, for:
    - [ ] front image
    - [ ] back image
- [ ] Make sure you do not see a selfie option

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

![before](https://github.com/18F/identity-idp/assets/35475380/2b125c6b-a3ce-4193-a4b9-b4c9f532413c)

</details>

<details>
<summary>After:</summary>

![after](https://github.com/18F/identity-idp/assets/35475380/54a2c7a4-f7ef-470c-aa6f-b1b24afbb212)

</details>
