### PR TITLE
LG-12205 Update UI for Opt-in IPP

### DIFF
--- a/app/assets/stylesheets/components/_radio-button.scss
+++ b/app/assets/stylesheets/components/_radio-button.scss
@@ -21,9 +21,6 @@
   }
 
   .usa-radio__label--text {
-    h3,
-    label {
-      @include u-text('gray-70');
-    }
+    @include u-text('gray-70');
   }
 }

--- a/app/assets/stylesheets/components/_radio-button.scss
+++ b/app/assets/stylesheets/components/_radio-button.scss
@@ -21,8 +21,8 @@
   }
 
   .usa-radio__label--text {
-    h2,
-    h3 {
+    h3,
+    label {
       @include u-text('gray-70');
     }
   }

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -30,7 +30,8 @@
             <span class="usa-tag usa-tag--informative">
               <%= t('doc_auth.tips.most_common') %>
             </span>
-            <h2 class="h3"><%= t('doc_auth.headings.verify_online') %></h2>
+            <br />
+            <label><%= t('doc_auth.headings.verify_online') %></label>
             <span class="usa-radio__label-description">
               <p><%= t('doc_auth.info.verify_online_instruction') %></p>
               <p><%= t('doc_auth.info.verify_online_description') %></p>
@@ -53,7 +54,7 @@
                         alt: t('image_description.post_office')
           %>
           <div class="usa-radio__label--text">
-            <h3><%= t('doc_auth.headings.verify_at_post_office') %></h3>
+             <label><%= t('doc_auth.headings.verify_at_post_office') %> </label>
             <span class="usa-radio__label-description">
               <p><%= t('doc_auth.info.verify_at_post_office_instruction') %></p>
               <p><%= t('doc_auth.info.verify_at_post_office_description') %></p>

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -31,7 +31,7 @@
               <%= t('doc_auth.tips.most_common') %>
             </span>
             <br />
-            <label><%= t('doc_auth.headings.verify_online') %></label>
+            <%= t('doc_auth.headings.verify_online') %>
             <span class="usa-radio__label-description">
               <p><%= t('doc_auth.info.verify_online_instruction') %></p>
               <p><%= t('doc_auth.info.verify_online_description') %></p>
@@ -54,7 +54,7 @@
                         alt: t('image_description.post_office')
           %>
           <div class="usa-radio__label--text">
-             <label><%= t('doc_auth.headings.verify_at_post_office') %> </label>
+            <%= t('doc_auth.headings.verify_at_post_office') %>
             <span class="usa-radio__label-description">
               <p><%= t('doc_auth.info.verify_at_post_office_instruction') %></p>
               <p><%= t('doc_auth.info.verify_at_post_office_description') %></p>
@@ -67,7 +67,7 @@
 
 <%= render(
       'shared/troubleshooting_options',
-      heading_tag: :h3,
+      heading_tag: :h2,
       heading: t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
       options: [
         {

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -81,7 +81,7 @@ module DocAuthHelper
       app_name: APP_NAME,
     )
     find(
-      'label.usa-radio__label',
+      'label',
       text: text_for_method,
       wait: 5,
     ).click

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -81,7 +81,7 @@ module DocAuthHelper
       app_name: APP_NAME,
     )
     find(
-      'label',
+      'label.usa-radio__label',
       text: text_for_method,
       wait: 5,
     ).click


### PR DESCRIPTION
## 🎫 Ticket
[LG-12205 ](https://cm-jira.usa.gov/browse/LG-12205) Update UI for Opt-in IPP

## 🛠 Summary of changes

1. ~~Use the label tag for Verify your identity online and Verify your identity at a Post Office (rather than h2 and h3 tags)~~ I did not use the label tag. That would have been a label tag nested in a label tag, see Andrew's comment.
2. Change the text color of the items with the label tag to #454545 (back to grey rather than the default blue)
3. Ensure "Most Common" is on the top line and the text "Verify your identity online" is on the line below
4. Change the h3 text Want to learn more about how to verify your identity? to be an h2 tag

## 📜 Testing Plan
- [ ] Step 1 Inside identity-idp in config.application.yml enable `in_person_proofing_opt_in_enabled`
- [ ] Step 2 Follow the instructions [here](https://docs.google.com/document/d/1FG9s8Cih9NGbrz7ag4WPLK_W10di-1xfDKy0Fjrg0fM/edit#heading=h.hepkwzlgvxf3) to run identity-idp locally along with identity-oidc-sinatra locally - so that you can come into the app via localhost:9292 
- [ ] Step 3 Move to the flow until you land on /verify/how_to_verify and inspect the UI for the ac- continue to move through flow to confirm everything is working as you'd expect, you can also turn on VoiceOver for some accessibility testing

## 👀 Screenshots

<details>
<summary>Before:</summary>

<img width="1226" alt="Screenshot 2024-02-27 at 9 34 58 AM" src="https://github.com/18F/identity-idp/assets/125507397/7b1ccba7-bc0e-4add-902a-82c5dde7ced3">

</details>

<details>
<summary>After:</summary>

![Screenshot 2024-02-28 at 8 45 30 AM](https://github.com/18F/identity-idp/assets/125507397/0c77fe0d-07d9-475e-81f2-3fbf2abea9b1)
 
To show color
![Screenshot 2024-02-28 at 8 46 01 AM](https://github.com/18F/identity-idp/assets/125507397/555e096f-4d7c-4f79-a9a8-a2f9ebef14ee)

![Screenshot 2024-02-28 at 8 46 08 AM](https://github.com/18F/identity-idp/assets/125507397/6dde97fd-18f9-4c91-8721-255617a86c92)


</details>
