### PR TITLE
LG-12305: hybrid handoff image upload for non-selfie doc auth

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -10,6 +10,9 @@ module Idv
     before_action :confirm_hybrid_handoff_needed, only: :show
 
     def show
+      @upload_enabled = idv_session.desktop_selfie_test_mode_enabled? ||
+                        !idv_session.selfie_check_required
+
       analytics.idv_doc_auth_hybrid_handoff_visited(**analytics_arguments)
 
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).call(

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -10,8 +10,8 @@ module Idv
     before_action :confirm_hybrid_handoff_needed, only: :show
 
     def show
-      @upload_enabled = idv_session.desktop_selfie_test_mode_enabled? ||
-                        !idv_session.selfie_check_required
+      @upload_disabled = idv_session.selfie_check_required &&
+                         !idv_session.desktop_selfie_test_mode_enabled?
 
       analytics.idv_doc_auth_hybrid_handoff_visited(**analytics_arguments)
 

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -54,7 +54,7 @@
   </div>
 </div>
 
-<% if @upload_enabled %>
+<% unless @upload_disabled %>
   <hr class="margin-y-4" />
   <div class="grid-row grid-gap grid-gap-2">
     <div class="grid-col-12 tablet:grid-col-auto">

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -54,34 +54,35 @@
   </div>
 </div>
 
-<hr class="margin-y-4" />
-<div class="grid-row grid-gap grid-gap-2">
-  <div class="grid-col-12 tablet:grid-col-auto">
-    <%= image_tag(
-          asset_url('idv/laptop-icon.svg'),
-          alt: t('image_description.laptop'),
-          width: 88,
-          height: 88,
-        ) %>
+<% if @upload_enabled %>
+  <hr class="margin-y-4" />
+  <div class="grid-row grid-gap grid-gap-2">
+    <div class="grid-col-12 tablet:grid-col-auto">
+      <%= image_tag(
+            asset_url('idv/laptop-icon.svg'),
+            alt: t('image_description.laptop'),
+            width: 88,
+            height: 88,
+          ) %>
+    </div>
+    <div class="grid-col-12 tablet:grid-col-fill">
+      <h2 class="margin-y-105">
+        <%= t('doc_auth.headings.upload_from_computer') %>
+      </h2>
+      <%= t('doc_auth.info.upload_from_computer') %>&nbsp;
+      <%= simple_form_for(
+            :doc_auth,
+            url: url_for(type: :desktop),
+            method: 'PUT',
+            class: 'margin-bottom-4',
+            html: {
+              id: 'form-to-submit-photos-through-desktop',
+              'aria-label': t('forms.buttons.upload_photos'),
+            },
+          ) do |f| %>
+        <%= f.submit t('forms.buttons.upload_photos'), outline: true %>
+      <% end %>
+    </div>
   </div>
-  <div class="grid-col-12 tablet:grid-col-fill">
-    <h2 class="margin-y-105">
-      <%= t('doc_auth.headings.upload_from_computer') %>
-    </h2>
-    <%= t('doc_auth.info.upload_from_computer') %>&nbsp;
-    <%= simple_form_for(
-          :doc_auth,
-          url: url_for(type: :desktop),
-          method: 'PUT',
-          class: 'margin-bottom-4',
-          html: {
-            id: 'form-to-submit-photos-through-desktop',
-            'aria-label': t('forms.buttons.upload_photos'),
-          },
-        ) do |f| %>
-      <%= f.submit t('forms.buttons.upload_photos'), outline: true %>
-    <% end %>
-  </div>
-</div>
-
+<% end %>
 <%= render 'idv/doc_auth/cancel', step: 'hybrid_handoff' %>

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -54,6 +54,12 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
     end
 
     context 'attention barcode with invalid pii is uploaded', allow_browser_log: true do
+      let(:desktop_selfie_mode) { false }
+      # test disabled desktop selfie mode allows upload for doc auth w/o selfie
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
+          and_return(desktop_selfie_mode)
+      end
       it 'try again and page show doc type inline error message' do
         attach_images(
           Rails.root.join(

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -509,8 +509,10 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               complete_doc_auth_steps_before_hybrid_handoff_step
               # we still have option to continue
               expect(page).to have_current_path(idv_hybrid_handoff_path)
-              click_on t('forms.buttons.upload_photos')
-              expect(page).to have_current_path(idv_hybrid_handoff_path)
+              expect(page).to have_content(t('doc_auth.headings.upload_from_phone'))
+              expect(page).not_to have_content(t('doc_auth.info.upload_from_computer'))
+              click_on t('forms.buttons.send_link')
+              expect(page).to have_current_path(idv_link_sent_path)
             end
           end
         end
@@ -523,6 +525,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               complete_doc_auth_steps_before_hybrid_handoff_step
               # we still have option to continue on handoff, since it's desktop no skip_hand_off
               expect(page).to have_current_path(idv_hybrid_handoff_path)
+              expect(page).to have_content(t('doc_auth.info.upload_from_computer'))
+              expect(page).to have_content(t('doc_auth.headings.upload_from_phone'))
               click_on t('forms.buttons.upload_photos')
               expect(page).to have_current_path(idv_document_capture_url)
               expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -502,7 +502,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             and_return(desktop_selfie_mode)
         end
         describe 'when desktop selfie not allowed' do
-          it 'cannot proceed to document capture page' do
+          it 'can only proceed to link sent page' do
             perform_in_browser(:desktop) do
               visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
               sign_in_and_2fa_user(user)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-12305](https://cm-jira.usa.gov/browse/LG-12305)

## 🛠 Summary of changes
Only show the Send Link option on the hybrid handoff page when a selfie is req'd and _doc_auth_selfie_desktop_test_mode_ FF is disabled

## 📜 Testing Plan
On Desktop:
- using image upload (doc_auth_selfie_desktop_test_mode: true)
  - [ ] set _doc_auth_selfie_desktop_test_mode_ FF to  true
  - [ ] complete doc auth via _Upload Photos_
- using hybrid mobile (Send Link)
  - [ ] set _doc_auth_selfie_desktop_test_mode_ FF to  false
  - [ ] verify that upload photos option is  not present on hybrid handoff page
  - [ ] complete doc auth via _Send Link_

On Mobile:
  - [ ] Complete doc auth

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
