### PR TITLE
Lock to `rack-cors 2.0.0` to avoid problem with `rack-cors 2.0.1`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem 'profanity_filter'
 gem 'propshaft'
 gem 'rack', '>= 3.0'
 gem 'rack-attack', github: 'rack/rack-attack', ref: 'd9fedfae4f7f6409f33857763391f4e18a6d7467'
-gem 'rack-cors', '>= 1.0.5', require: 'rack/cors'
+gem 'rack-cors', '>= 1.0.5', '< 2.0.1', require: 'rack/cors'
 gem 'rack-headers_filter'
 gem 'rack-timeout', require: false
 gem 'redacted_struct'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,7 +485,7 @@ GEM
     raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.9.1)
-    rack-cors (2.0.1)
+    rack-cors (2.0.0)
       rack (>= 2.0.0)
     rack-headers_filter (0.0.1)
     rack-mini-profiler (3.3.0)
@@ -812,7 +812,7 @@ DEPENDENCIES
   puma (~> 6.0)
   rack (>= 3.0)
   rack-attack!
-  rack-cors (>= 1.0.5)
+  rack-cors (>= 1.0.5, < 2.0.1)
   rack-headers_filter
   rack-mini-profiler (>= 1.1.3)
   rack-test (>= 1.1.0)


### PR DESCRIPTION
## 🛠 Summary of changes

Right now all lint tasks are failing in `main` because there's a newly reported file permission vulnerability in `rack-cors` ([link](https://github.com/cyu/rack-cors/issues/274)) version 2.0.1 (latest). This PR addresses that by locking our version to 2.0.0, the latest version of `rack-cors` without this vulnerability ([link](https://github.com/rubysec/ruby-advisory-db/pull/755)).

Presumably we'll be able to use 2.0.1 again once they've patched the problem.

The error:
```ruby
--- bundler-audit ---
bundle exec bundler-audit check --update
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up to date.
Updated ruby-advisory-db
ruby-advisory-db:
  advisories:   875 advisories
  last updated: 2024-02-27 14:25:50 -0800
  commit:       1c7d5b5233d4c1ace4b6141bb949a2d54028d18e
Name: rack-cors
Version: 2.0.1
CVE: CVE-2024-27456
GHSA: GHSA-785g-282q-pwvx
Criticality: Unknown
URL: https://github.com/advisories/GHSA-785g-282q-pwvx
Title: Rack CORS Middleware has Insecure File Permissions
Solution: remove or disable this gem until a patch is available!

Vulnerabilities found!
make: *** [lint] Error 1
```

## 📜 Testing Plan

- [ ] Run `make lint` in `main` notice the failure.
- [ ] Run `make lint` in this branch, the failure is gone.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
