### PR TITLE
Remove nonexistent route reference for backup codes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,7 +286,6 @@ Rails.application.routes.draw do
     patch '/backup_code_continue' => 'users/backup_code_setup#continue'
     get '/backup_code_regenerate' => 'users/backup_code_setup#edit'
     get '/backup_code_delete' => 'users/backup_code_setup#confirm_delete'
-    get '/backup_code_create' => 'users/backup_code_setup#confirm_create'
     delete '/backup_code_delete' => 'users/backup_code_setup#delete'
     get '/confirm_backup_codes' => 'users/backup_code_setup#confirm_backup_codes'
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a route reference to a controller action which does not exist and is not referenced anywhere.

This appears to have been partially implemented in #3405.

See related NewRelic error: https://onenr.io/0KQXoG4XLja

## 📜 Testing Plan

1. Visit http://localhost:3000/backup_code_create

Before: 500 error page
After: 404 error page