### PR TITLE
Add an OIDC with VTR feature spec

### DIFF
--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -56,6 +56,11 @@ RSpec.describe 'OpenID Connect', allowed_extra_analytics: [:*] do
       expect(current_path).to eq(openid_connect_authorize_path)
       expect(page).to have_content(t('openid_connect.authorization.errors.prompt_invalid'))
     end
+
+    it 'succeeds with a vtr param' do
+      allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
+      oidc_end_client_secret_jwt(vtr: 'C1.C2.P1')
+    end
   end
 
   context 'with client_secret_jwt' do
@@ -1154,12 +1159,22 @@ RSpec.describe 'OpenID Connect', allowed_extra_analytics: [:*] do
     end
   end
 
-  def oidc_end_client_secret_jwt(prompt: nil, user: nil, redirs_to: nil)
+  def oidc_end_client_secret_jwt(vtr: nil, prompt: nil, user: nil, redirs_to: nil)
     client_id = 'urn:gov:gsa:openidconnect:sp:server'
     state = SecureRandom.hex
     nonce = SecureRandom.hex
 
-    visit_idp_from_ial2_oidc_sp(prompt: prompt, state: state, nonce: nonce, client_id: client_id)
+    if vtr.present?
+      visit_idp_from_oidc_sp_with_vtr(
+        vtr: vtr,
+        prompt: prompt,
+        state: state,
+        nonce: nonce,
+        client_id: client_id,
+      )
+    else
+      visit_idp_from_ial2_oidc_sp(prompt: prompt, state: state, nonce: nonce, client_id: client_id)
+    end
     continue_as(user.email) if user
     if redirs_to
       expect(URI(oidc_redirect_url).path).to eq(redirs_to)
@@ -1214,11 +1229,18 @@ RSpec.describe 'OpenID Connect', allowed_extra_analytics: [:*] do
     expect(sub).to be_present
     expect(decoded_id_token[:nonce]).to eq(nonce)
     expect(decoded_id_token[:aud]).to eq(client_id)
-    expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
     expect(decoded_id_token[:iss]).to eq(root_url)
     expect(decoded_id_token[:email]).to eq(user.email)
     expect(decoded_id_token[:given_name]).to eq('John')
     expect(decoded_id_token[:social_security_number]).to eq('111223333')
+
+    if vtr.present?
+      expect(decoded_id_token[:acr]).to eq(nil)
+      expect(decoded_id_token[:vot]).to eq(Array(vtr).first)
+    else
+      expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
+      expect(decoded_id_token[:vot]).to eq(nil)
+    end
 
     access_token = token_response[:access_token]
     expect(access_token).to be_present

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -16,6 +16,13 @@ module OidcAuthHelper
     oidc_path
   end
 
+  def visit_idp_from_oidc_sp_with_vtr(vtr:, **args)
+    params = vtr_params(vtr: vtr, **args)
+    oidc_path = openid_connect_authorize_path params
+    visit oidc_path
+    oidc_path
+  end
+
   def visit_idp_from_ial_max_oidc_sp(**args)
     args[:acr_values] = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
     params = ial2_params(**args)
@@ -96,6 +103,29 @@ module OidcAuthHelper
       ial2_params[:biometric_comparison_required] = 'true'
     end
     ial2_params
+  end
+
+  def vtr_params(
+    vtr:,
+    prompt: nil,
+    state: SecureRandom.hex,
+    nonce: SecureRandom.hex,
+    client_id: OIDC_ISSUER,
+    scope: 'openid email profile:name social_security_number',
+    tid: nil
+  )
+    vtr_params = {
+      client_id: client_id,
+      response_type: 'code',
+      vtr: Array(vtr).to_json,
+      scope: scope,
+      redirect_uri: 'http://localhost:7654/auth/result',
+      state: state,
+      nonce: nonce,
+    }
+    vtr_params[:tid] = tid if tid
+    vtr_params[:prompt] = prompt if prompt
+    vtr_params
   end
 
   def include_phishing_resistant(params)


### PR DESCRIPTION
This commit adds a feature spec for an OIDC authentication using VTR. This spec makes a request for a proofed user with a VTR and validates everything works as expected including the identity token attributes and user info response.
