### PR TITLE
Remove extraneous `use_vot_in_sp_requests` setting

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -322,7 +322,6 @@ team_ursula_email: ''
 test_ssn_allowed_list: ''
 totp_code_interval: 30
 unauthorized_scope_enabled: false
-use_vot_in_sp_requests: true
 usps_upload_enabled: false
 usps_upload_sftp_timeout: 5
 valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3", "http://idmanagement.gov/ns/assurance/ial/1", "http://idmanagement.gov/ns/assurance/ial/2", "http://idmanagement.gov/ns/assurance/ial/0", "http://idmanagement.gov/ns/assurance/ial/2?strict=true", "urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo", "http://idmanagement.gov/ns/assurance/aal/2", "http://idmanagement.gov/ns/assurance/aal/3", "http://idmanagement.gov/ns/assurance/aal/3?hspd12=true","http://idmanagement.gov/ns/assurance/aal/2?phishing_resistant=true","http://idmanagement.gov/ns/assurance/aal/2?hspd12=true"]'


### PR DESCRIPTION
The `use_vot_in_sp_requests` was set twice in the config. Confusingly it was set to 2 different values. This commit removes the first one and lets the previously computed value of `false` prevail.
