### PR TITLE
Render an error when a biometric is requested with a vector of trust

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -10,8 +10,8 @@ module OpenidConnect
     include BillableEventTrackable
     include ForcedReauthenticationConcern
 
-    before_action :block_biometric_requests_in_production, only: [:index]
     before_action :build_authorize_form_from_params, only: [:index]
+    before_action :block_biometric_requests_in_production, only: [:index]
     before_action :set_devise_failure_redirect_for_concurrent_session_logout
     before_action :pre_validate_authorize_form, only: [:index]
     before_action :sign_out_if_prompt_param_is_login_and_user_is_signed_in, only: [:index]
@@ -48,10 +48,15 @@ module OpenidConnect
     private
 
     def block_biometric_requests_in_production
-      if params['biometric_comparison_required'] == 'true' &&
+      if biometric_comparison_requested? &&
          !FeatureManagement.idv_allow_selfie_check?
         render_not_acceptable
       end
+    end
+
+    def biometric_comparison_requested?
+      @authorize_form.parsed_vector_of_trust&.biometric_comparison? ||
+        params['biometric_comparison_required']
     end
 
     def check_sp_active

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -160,6 +160,19 @@ class OpenidConnectAuthorizeForm
     @biometric_comparison_required
   end
 
+  def parsed_vector_of_trust
+    return @parsed_vector_of_trust if defined?(@parsed_vector_of_trust)
+    return @parsed_vector_of_trust = nil if vtr.blank?
+
+    @parsed_vector_of_trust = begin
+      if vtr.is_a?(Array) && !vtr.empty?
+        Vot::Parser.new(vector_of_trust: vtr.first).parse
+      end
+    rescue Vot::Parser::ParseException
+      nil
+    end
+  end
+
   private
 
   attr_reader :identity, :success
@@ -311,19 +324,6 @@ class OpenidConnectAuthorizeForm
       return OpenidConnectAttributeScoper::VALID_SCOPES
     end
     OpenidConnectAttributeScoper::VALID_IAL1_SCOPES
-  end
-
-  def parsed_vector_of_trust
-    return @parsed_vector_of_trust if defined?(@parsed_vector_of_trust)
-    return @parsed_vector_of_trust = nil if vtr.blank?
-
-    @parsed_vector_of_trust = begin
-      if vtr.is_a?(Array) && !vtr.empty?
-        Vot::Parser.new(vector_of_trust: vtr.first).parse
-      end
-    rescue Vot::Parser::ParseException
-      nil
-    end
   end
 
   def validate_privileges

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -162,7 +162,6 @@ class OpenidConnectAuthorizeForm
 
   def parsed_vector_of_trust
     return @parsed_vector_of_trust if defined?(@parsed_vector_of_trust)
-    return @parsed_vector_of_trust = nil if vtr.blank?
 
     @parsed_vector_of_trust = begin
       if vtr.is_a?(Array) && !vtr.empty?

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -365,6 +365,50 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 end
               end
             end
+
+            context 'SP has a vector of trust that includes a biometric comparison' do
+              let(:selfie_capture_enabled) { true }
+              before do
+                params[:acr_values] = nil
+                params[:vtr] = ['C1.C2.P1.Pb'].to_json
+                expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
+                  and_return(selfie_capture_enabled)
+                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
+                  and_return('server_side')
+                allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
+                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                user.identities.last.update!(
+                  verified_attributes: %w[given_name family_name birthdate verified_at],
+                )
+                allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
+              end
+
+              context 'selfie check was performed' do
+                it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
+                  user.active_profile.idv_level = :unsupervised_with_selfie
+
+                  action
+
+                  expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+                end
+              end
+
+              context 'selfie check was not performed' do
+                it 'redirects to have the user verify their account' do
+                  action
+                  expect(controller).to redirect_to(idv_url)
+                end
+              end
+
+              context 'selfie capture not enabled, biometric_comparison_check requested by sp' do
+                let(:selfie_capture_enabled) { false }
+                it 'returns status not_acceptable' do
+                  action
+
+                  expect(response.status).to eq(406)
+                end
+              end
+            end
           end
 
           context 'account is not already verified' do


### PR DESCRIPTION
In #9837 we modified the IdP to render a 406 if biometric comparison was requested but not allowed for the current environment.

This change applied to the query parameter method for requesting biometric comparison which was the only way to request biometric comparison at the time. Since then we have enabled biometric comparison requests using vectors of trust but did not port over the feature for blocking biometric comparison requests in environments where they are not allowed.

This commit applies the feature to requests that use a vector of trust to request biometric comparison.
