### PR TITLE
LG-11980: log captureAttempts for selfie capture opened, closed and failed analytics events

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -500,13 +500,13 @@ function AcuantCapture(
   }
 
   function onSelfieCaptureOpen() {
-    trackEvent('idv_sdk_selfie_image_capture_opened');
+    trackEvent('idv_sdk_selfie_image_capture_opened', { captureAttempts });
 
     setIsCapturingEnvironment(true);
   }
 
   function onSelfieCaptureClosed() {
-    trackEvent('idv_sdk_selfie_image_capture_closed_without_photo');
+    trackEvent('idv_sdk_selfie_image_capture_closed_without_photo', { captureAttempts });
 
     setIsCapturingEnvironment(false);
   }
@@ -530,6 +530,7 @@ function AcuantCapture(
     trackEvent('idv_sdk_selfie_image_capture_failed', {
       sdk_error_code: error.code,
       sdk_error_message: error.message,
+      captureAttempts,
     });
 
     // Internally, Acuant sets a cookie to bail on guided capture if initialization had

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2850,6 +2850,8 @@ module AnalyticsEvents
 
   # @param [Integer] sdk_error_code SDK code for the error encountered
   # @param [String] sdk_error_message SDK message for the error encountered
+  # @param [Integer] captureAttempts number of attempts to capture / upload an image
+  #                  (previously called "attempt")
   # User encountered an error with the SDK selfie process
   # Error code 1: camera permission not granted
   # Error code 2: unexpected errors

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2833,7 +2833,7 @@ module AnalyticsEvents
   #                  (previously called "attempt")
   # User captured and approved of their selfie
   # rubocop:disable Naming/VariableName,Naming/MethodParameterName
-  def idv_sdk_selfie_image_added(captureAttempts:, **extra)
+  def idv_sdk_selfie_image_added(captureAttempts: nil, **extra)
     track_event(:idv_sdk_selfie_image_added, captureAttempts: captureAttempts, **extra)
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2837,6 +2837,8 @@ module AnalyticsEvents
     track_event(:idv_sdk_selfie_image_added, captureAttempts: captureAttempts, **extra)
   end
 
+  # @param [Integer] captureAttempts number of attempts to capture / upload an image
+  #                  (previously called "attempt")
   # User closed the SDK for taking a selfie without submitting a photo
   def idv_sdk_selfie_image_capture_closed_without_photo(captureAttempts: nil, **extra)
     track_event(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2838,7 +2838,7 @@ module AnalyticsEvents
   end
 
   # User closed the SDK for taking a selfie without submitting a photo
-  def idv_sdk_selfie_image_capture_closed_without_photo(captureAttempts:, **extra)
+  def idv_sdk_selfie_image_capture_closed_without_photo(captureAttempts: nil, **extra)
     track_event(
       :idv_sdk_selfie_image_capture_closed_without_photo,
       captureAttempts: captureAttempts,
@@ -2854,7 +2854,7 @@ module AnalyticsEvents
   def idv_sdk_selfie_image_capture_failed(
     sdk_error_code:,
     sdk_error_message:,
-    captureAttempts:,
+    captureAttempts: nil,
     **extra
   )
     track_event(
@@ -2868,7 +2868,7 @@ module AnalyticsEvents
 
   # @param [Integer] captureAttempts number of attempts to capture / upload an image
   # User opened the SDK to take a selfie
-  def idv_sdk_selfie_image_capture_opened(captureAttempts:, **extra)
+  def idv_sdk_selfie_image_capture_opened(captureAttempts: nil, **extra)
     track_event(:idv_sdk_selfie_image_capture_opened, captureAttempts: captureAttempts, **extra)
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2836,11 +2836,14 @@ module AnalyticsEvents
   def idv_sdk_selfie_image_added(captureAttempts:, **extra)
     track_event(:idv_sdk_selfie_image_added, captureAttempts: captureAttempts, **extra)
   end
-  # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
   # User closed the SDK for taking a selfie without submitting a photo
-  def idv_sdk_selfie_image_capture_closed_without_photo(**extra)
-    track_event(:idv_sdk_selfie_image_capture_closed_without_photo, **extra)
+  def idv_sdk_selfie_image_capture_closed_without_photo(captureAttempts:, **extra)
+    track_event(
+      :idv_sdk_selfie_image_capture_closed_without_photo,
+      captureAttempts: captureAttempts,
+      **extra,
+    )
   end
 
   # @param [Integer] sdk_error_code SDK code for the error encountered
@@ -2848,18 +2851,25 @@ module AnalyticsEvents
   # User encountered an error with the SDK selfie process
   # Error code 1: camera permission not granted
   # Error code 2: unexpected errors
-  def idv_sdk_selfie_image_capture_failed(sdk_error_code:, sdk_error_message:, **extra)
+  def idv_sdk_selfie_image_capture_failed(
+    sdk_error_code:,
+    sdk_error_message:,
+    captureAttempts:,
+    **extra
+  )
     track_event(
       :idv_sdk_selfie_image_capture_failed,
       sdk_error_code: sdk_error_code,
       sdk_error_message: sdk_error_message,
+      captureAttempts: captureAttempts,
       **extra,
     )
   end
 
+  # @param [Integer] captureAttempts number of attempts to capture / upload an image
   # User opened the SDK to take a selfie
-  def idv_sdk_selfie_image_capture_opened(**extra)
-    track_event(:idv_sdk_selfie_image_capture_opened, **extra)
+  def idv_sdk_selfie_image_capture_opened(captureAttempts:, **extra)
+    track_event(:idv_sdk_selfie_image_capture_opened, captureAttempts: captureAttempts, **extra)
   end
 
   # @param [Integer] captureAttempts number of attempts to capture / upload an image
@@ -2873,7 +2883,6 @@ module AnalyticsEvents
   # @param [String] source
   # @param [Integer] width width of image added in pixels
   # User uploaded a selfie using the file picker
-  # rubocop:disable Naming/VariableName,Naming/MethodParameterName
   def idv_selfie_image_file_uploaded(
     captureAttempts:,
     failedImageResubmission:,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-11980](https://cm-jira.usa.gov/browse/LG-11980)

## 🛠 Summary of changes
Add captureAttempts attribute to the following analytics events:

- idv_sdk_selfie_image_capture_opened
- idv_sdk_selfie_image_capture_closed_without_photo
- idv_sdk_selfie_image_capture_failed

## 📜 Testing Plan
On mobile, attempt Doc Auth with Selfie using AutoCapture
- [ ]  click on the selfie image thumbnail  and close the selfie capture screen without capturing an image
- [ ] refresh the page, click on the selfie upload icon, deny permissions and then re-click the selfie capture thumbnail
- [ ] Observe the  logs to verify the following events contain captureAttempts data:
  - idv_sdk_selfie_image_capture_opened
  - idv_sdk_selfie_image_capture_closed_without_photo
  - idv_sdk_selfie_image_capture_failed


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
