### PR TITLE
Fix yard CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -729,7 +729,7 @@ GEM
       nokogiri (~> 1.11)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.34)
+    yard (0.9.35)
     zeitwerk (2.6.12)
     zlib (3.0.0)
     zonebie (0.6.1)


### PR DESCRIPTION
## 🛠 Summary of changes

```
Name: yard
Version: 0.9.34
CVE: https://github.com/advisories/GHSA-8mq4-9jjh-9xrc
GHSA: https://github.com/advisories/GHSA-8mq4-9jjh-9xrc
Criticality: Medium
URL: https://github.com/advisories/GHSA-8mq4-9jjh-9xrc
Title: YARD's default template vulnerable to Cross-site Scripting in generated frames.html
Solution: upgrade to '>= 0.9.35'
```