### PR TITLE
Update Dependencies to Resolve Security Advisories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem 'profanity_filter'
 gem 'propshaft'
 gem 'rack', '>= 3.0'
 gem 'rack-attack', github: 'rack/rack-attack', ref: 'd9fedfae4f7f6409f33857763391f4e18a6d7467'
-gem 'rack-cors', '>= 1.0.5', '< 2.0.1', require: 'rack/cors'
+gem 'rack-cors', '>= 1.0.5', require: 'rack/cors'
 gem 'rack-headers_filter'
 gem 'rack-timeout', require: false
 gem 'redacted_struct'
@@ -81,7 +81,7 @@ gem 'view_component', '~> 3.0'
 gem 'webauthn', '~> 2.5.2'
 gem 'xmldsig', '~> 0.6'
 gem 'xmlenc', '~> 0.7', '>= 0.7.1'
-gem 'yard', require: false
+gem 'yard', '>= 0.9.35', require: false
 gem 'zlib', require: false
 
 # This version of the zxcvbn gem matches the data and behavior of the zxcvbn NPM package.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -729,7 +729,7 @@ GEM
       nokogiri (~> 1.11)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.34)
+    yard (0.9.35)
     zeitwerk (2.6.12)
     zlib (3.0.0)
     zonebie (0.6.1)
@@ -812,7 +812,7 @@ DEPENDENCIES
   puma (~> 6.0)
   rack (>= 3.0)
   rack-attack!
-  rack-cors (>= 1.0.5, < 2.0.1)
+  rack-cors (>= 1.0.5)
   rack-headers_filter
   rack-mini-profiler (>= 1.1.3)
   rack-test (>= 1.1.0)
@@ -856,7 +856,7 @@ DEPENDENCIES
   webmock
   xmldsig (~> 0.6)
   xmlenc (~> 0.7, >= 0.7.1)
-  yard
+  yard (>= 0.9.35)
   zlib
   zonebie
   zxcvbn (= 0.1.9)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

This ticket continues the work from yesterday (PR) to keep `main` free of security advisories.
1. [This PR](https://github.com/18F/identity-idp/pull/10173) yesterday locked the version of `rack-cors`, that's since been fixed ([here](https://github.com/saeloun/miru-web/pull/1681)) so I'm reverting that change.
2. There's a new security advisory about `yard` (included below). This PR addresses that too by forcing a newer version of yard.

A note: We've had three PRs about this in three days [[1](https://github.com/18F/identity-idp/pull/10159), [2](https://github.com/18F/identity-idp/pull/10159), [3](https://github.com/18F/identity-idp/pull/10185) (this one)] I'm not sure we need to do anything differently, but that'e enough of a pattern I'm asking about it [here in Slack](https://gsa-tts.slack.com/archives/C0NGESUN5/p1709213249877319).

```ruby
➜  identity-idp git:(main) bundle exec bundler-audit check --update                  
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up to date.
Updated ruby-advisory-db
ruby-advisory-db:
  advisories:   876 advisories
  last updated: 2024-02-28 16:01:01 -0800
  commit:       06f33746747e89af5634a5e6b41004ad7899a6c0
Name: yard
Version: 0.9.34
CVE: CVE-2024-27285
GHSA: GHSA-8mq4-9jjh-9xrc
Criticality: Medium
URL: https://github.com/advisories/GHSA-8mq4-9jjh-9xrc
Title: YARD's default template vulnerable to Cross-site Scripting in generated frames.html
Solution: upgrade to '>= 0.9.35'

Vulnerabilities found!
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
