### PR TITLE
Modify `ServiceProviderSession#mfa_expiration_interval` to not require an argument

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -17,7 +17,7 @@ module RememberDeviceConcern
     return unless UserSessionContext.authentication_context?(context)
     return if remember_device_cookie.nil?
 
-    expiration_time = decorated_sp_session.mfa_expiration_interval(resolved_authn_context_result)
+    expiration_time = decorated_sp_session.mfa_expiration_interval
     return unless remember_device_cookie.valid_for_user?(
       user: current_user,
       expiration_interval: expiration_time,
@@ -37,7 +37,7 @@ module RememberDeviceConcern
   def remember_device_expired_for_sp?
     expired_for_interval?(
       current_user,
-      decorated_sp_session.mfa_expiration_interval(resolved_authn_context_result),
+      decorated_sp_session.mfa_expiration_interval,
     )
   end
 

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -15,7 +15,7 @@ class NullServiceProviderSession
     view_context.root_url
   end
 
-  def mfa_expiration_interval(_authentication_context)
+  def mfa_expiration_interval
     IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
   end
 

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -88,12 +88,12 @@ class ServiceProviderSession
     end
   end
 
-  def mfa_expiration_interval(authorization_context)
+  def mfa_expiration_interval
     aal_1_expiration = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
     aal_2_expiration = IdentityConfig.store.remember_device_expiration_minutes_aal_2.minutes
     return aal_2_expiration if sp_aal > 1
     return aal_2_expiration if sp_ial > 1
-    return aal_2_expiration if authorization_context.aal_level_requested > 1
+    return aal_2_expiration if resolved_authn_context_result.aal2?
 
     aal_1_expiration
   end
@@ -130,16 +130,20 @@ class ServiceProviderSession
 
   attr_reader :sp, :view_context, :sp_session, :service_provider_request
 
+  def resolved_authn_context_result
+    @resolved_authn_context_result ||= AuthnContextResolver.new(
+      service_provider: sp,
+      vtr: sp_session[:vtr],
+      acr_values: sp_session[:acr_values],
+    ).resolve
+  end
+
   def sp_aal
     sp.default_aal || 1
   end
 
   def sp_ial
     sp.ial || 1
-  end
-
-  def requested_aal(authorization_context)
-    authorization_context.aal_level_requested
   end
 
   def request_url

--- a/spec/decorators/null_service_provider_session_spec.rb
+++ b/spec/decorators/null_service_provider_session_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe NullServiceProviderSession do
 
   describe '#mfa_expiration_interval' do
     it 'returns the AAL1 expiration interval' do
-      expect(subject.mfa_expiration_interval(nil)).to eq(30.days)
+      expect(subject.mfa_expiration_interval).to eq(30.days)
     end
   end
 

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ServiceProviderSession do
     )
   end
   let(:sp) { build_stubbed(:service_provider) }
-  let(:sp_session) { {} }
+  let(:sp_session) { { acr_values: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF } }
   let(:service_provider_request) { ServiceProviderRequest.new }
   let(:sp_name) { subject.sp_name }
   let(:sp_create_link) { '/sign_up/enter_email' }
@@ -241,24 +241,12 @@ RSpec.describe ServiceProviderSession do
   end
 
   describe '#mfa_expiration_interval' do
-    let(:authorization_context) do
-      Vot::Parser::Result.new(
-        component_values: [],
-        aal2?: false,
-        phishing_resistant?: false,
-        hspd12?: false,
-        identity_proofing?: false,
-        biometric_comparison?: false,
-        ialmax?: false,
-      )
-    end
-
     context 'with an AAL2 sp' do
       before do
         allow(sp).to receive(:default_aal).and_return(2)
       end
 
-      it { expect(subject.mfa_expiration_interval(authorization_context)).to eq(0.hours) }
+      it { expect(subject.mfa_expiration_interval).to eq(0.hours) }
     end
 
     context 'with an IAL2 sp' do
@@ -266,11 +254,16 @@ RSpec.describe ServiceProviderSession do
         allow(sp).to receive(:ial).and_return(2)
       end
 
-      it { expect(subject.mfa_expiration_interval(authorization_context)).to eq(0.hours) }
+      it { expect(subject.mfa_expiration_interval).to eq(0.hours) }
     end
 
-    context 'with an sp that is not AAL2 or IAL2' do
-      it { expect(subject.mfa_expiration_interval(authorization_context)).to eq(30.days) }
+    context 'with an sp that is not AAL2 or IAL2 and AAL1 requested' do
+      it { expect(subject.mfa_expiration_interval).to eq(30.days) }
+    end
+
+    context 'with an sp that is not AAL2 or IAL2 and AAL2 requested' do
+      let(:sp_session) { { acr_values: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF } }
+      it { expect(subject.mfa_expiration_interval).to eq(0.hours) }
     end
   end
 


### PR DESCRIPTION
We modified the `mfa_expiration_interval` to use the `AuthnContextResolver` result to determine the SP session expiration. It uses this to determine if a non-AAL2 SP has made an AAL2 request in order to use the AAL2 expiration.

Prior to this commit the result was passed in from the application controller. We do not need to do this, however, since the SP session and the SP are both already passed in to the decorator. This commit uses those to compute the resolved authn context in the decorator.
