### PR TITLE
LG-12374 Integrate `resolved_authn_context_result` into `ServiceProviderMfaPolicy`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -402,11 +402,8 @@ class ApplicationController < ActionController::Base
   def service_provider_mfa_policy
     @service_provider_mfa_policy ||= ServiceProviderMfaPolicy.new(
       user: current_user,
-      service_provider: sp_from_sp_session,
       auth_methods_session:,
-      aal_level_requested: resolved_authn_context_result.aal_level_requested,
-      piv_cac_requested: resolved_authn_context_result.hspd12?,
-      phishing_resistant_requested: resolved_authn_context_result.phishing_resistant?,
+      resolved_authn_context_result:,
     )
   end
   delegate :user_needs_sp_auth_method_setup?, to: :service_provider_mfa_policy


### PR DESCRIPTION
The `ServiceProviderMfaPolicy` is intended to look at the current SP request context and at the user and determine 2 critical things:

1. Does the user need to authenticate with a different MFA method to satisfy SP requirements? This is done with the `#user_needs_sp_auth_method_verification?` method.
2. Does the user need to setup a new MFA method to statisfy SP requirements? This is done with the `#user_needs_sp_auth_method_setup?` method.

In order to compute this the `ServiceProviderMfaPolicy` needs to consider a number of things:

1. The default AAL of the service provider
2. Parameters specified in the service provider request (phishing-resistant auth or PIV/CAC requirements)
3. The auth methods the user has setup
4. The auth method the user used to authenticate things

The `AuthnContextResolver` looks at the service provider and the service provider request and builds a struct with properties to describe the SP requirements. This considers both the SP defaults and the parameters in the SP request. For MFA these properties are `#hspd12?`, `#phishing_resistant?`, and `#aal2?`.

The `ApplicationController` has a `#resolved_authn_context_result` method which returns a result struct from the `AuthnContextResolver` that is built using the current SP context. This commit passes the result into the
 `ServiceProviderMfaPolicy`. This allows the result to be inspected for requirements for the SP context instead of having the `ServiceProviderMfaPolicy` compute them itself. This leads to a simplification of the `ServiceProviderMfaPolicy` where it only needs to consider the following:

1. The SP authentication context described by `resolved_authn_context_result` (this covers the SP request and SP defaults)
2. The auth methods the user has setup
3. The auth method the user used to authenticate things
