### PR TITLE
Remove nonessential_email_banlist config

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -102,8 +102,6 @@ class UserMailer < ActionMailer::Base
   end
 
   def password_changed(disavowal_token:)
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       @disavowal_token = disavowal_token
       mail(to: email_address.email, subject: t('devise.mailer.password_updated.subject'))
@@ -111,8 +109,6 @@ class UserMailer < ActionMailer::Base
   end
 
   def phone_added(disavowal_token:)
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       @disavowal_token = disavowal_token
       mail(to: email_address.email, subject: t('user_mailer.phone_added.subject'))
@@ -120,8 +116,6 @@ class UserMailer < ActionMailer::Base
   end
 
   def personal_key_sign_in(disavowal_token:)
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       @disavowal_token = disavowal_token
       mail(to: email_address.email, subject: t('user_mailer.personal_key_sign_in.subject'))
@@ -129,8 +123,6 @@ class UserMailer < ActionMailer::Base
   end
 
   def new_device_sign_in(date:, location:, device_name:, disavowal_token:)
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       @login_date = date
       @login_location = location
@@ -144,8 +136,6 @@ class UserMailer < ActionMailer::Base
   end
 
   def personal_key_regenerated
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       mail(to: email_address.email, subject: t('user_mailer.personal_key_regenerated.subject'))
     end
@@ -207,8 +197,6 @@ class UserMailer < ActionMailer::Base
   end
 
   def letter_reminder
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       mail(to: email_address.email, subject: t('user_mailer.letter_reminder.subject'))
     end
@@ -228,16 +216,12 @@ class UserMailer < ActionMailer::Base
   end
 
   def email_added
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       mail(to: email_address.email, subject: t('user_mailer.email_added.subject'))
     end
   end
 
   def email_deleted
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       mail(to: email_address.email, subject: t('user_mailer.email_deleted.subject'))
     end
@@ -252,8 +236,6 @@ class UserMailer < ActionMailer::Base
 
   # remove disavowal_token after next deploy
   def account_verified(date_time:, sp_name:, disavowal_token: nil) # rubocop:disable Lint/UnusedMethodArgument
-    return unless email_should_receive_nonessential_notifications?(email_address.email)
-
     with_user_locale(user) do
       @date = I18n.l(date_time, format: :event_date)
       @sp_name = sp_name
@@ -448,13 +430,6 @@ class UserMailer < ActionMailer::Base
   end
 
   private
-
-  def email_should_receive_nonessential_notifications?(email)
-    banlist = IdentityConfig.store.nonessential_email_banlist
-    return true if banlist.empty?
-    modified_email = email.gsub(/\+[^@]+@/, '@')
-    !banlist.include?(modified_email)
-  end
 
   def account_reset_deletion_period_interval
     current_time = Time.zone.now

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -403,7 +403,6 @@ development:
   logo_upload_enabled: true
   max_bad_passwords: 5
   newrelic_license_key: ''
-  nonessential_email_banlist: '["banned_email@gmail.com"]'
   otp_delivery_blocklist_findtime: 5
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
@@ -473,7 +472,6 @@ production:
   logins_per_ip_period: 20
   logins_per_ip_track_only_mode: true
   newrelic_license_key: ''
-  nonessential_email_banlist: '[]'
   openid_connect_redirect: server_side
   openid_connect_content_security_form_action_enabled: true
   otp_delivery_blocklist_findtime: 5
@@ -548,7 +546,6 @@ test:
   max_mail_events: 2
   otp_min_attempts_remaining_warning_count: 1
   newrelic_license_key: ''
-  nonessential_email_banlist: '["banned_email@gmail.com"]'
   otp_delivery_blocklist_findtime: 1
   otp_delivery_blocklist_maxretry: 2
   otps_per_ip_limit: 3

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -322,7 +322,6 @@ class IdentityConfig
     config.add(:minimum_wait_before_another_usps_letter_in_hours, type: :integer)
     config.add(:mx_timeout, type: :integer)
     config.add(:newrelic_license_key, type: :string)
-    config.add(:nonessential_email_banlist, type: :json)
     config.add(
       :openid_connect_redirect,
       type: :string,

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -114,12 +114,6 @@ RSpec.describe UserMailer, type: :mailer do
       )
       expect_email_body_to_have_help_and_contact_links
     end
-
-    it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.with(user: user, email_address: banned_email_address).
-        password_changed(disavowal_token: '123abc')
-      expect(mail.to).to eq(nil)
-    end
   end
 
   describe '#personal_key_sign_in' do
@@ -146,13 +140,6 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.html_part.body).to include(
         '/events/disavow?disavowal_token=asdf1234',
       )
-    end
-
-    it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.with(user: user, email_address: banned_email_address).
-        personal_key_sign_in(disavowal_token: 'asdf1234')
-
-      expect(mail.to).to eq(nil)
     end
   end
 
@@ -216,17 +203,6 @@ RSpec.describe UserMailer, type: :mailer do
       )
       expect_email_body_to_have_help_and_contact_links
     end
-
-    it 'does not send mail to emails in nonessential email banlist' do
-      email_address = EmailAddress.new(email: banned_email)
-      mail = UserMailer.with(user: user, email_address: email_address).new_device_sign_in(
-        date: date,
-        location: location,
-        device_name: device_name,
-        disavowal_token: disavowal_token,
-      )
-      expect(mail.to).to eq(nil)
-    end
   end
 
   describe '#personal_key_regenerated' do
@@ -249,12 +225,6 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.html_part.body).to have_content(
         t('user_mailer.personal_key_regenerated.intro'),
       )
-    end
-
-    it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.with(user: user, email_address: banned_email_address).
-        personal_key_regenerated
-      expect(mail.to).to eq(nil)
     end
   end
 
@@ -315,12 +285,6 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.html_part.body).to have_content(
         t('user_mailer.phone_added.intro', app_name: APP_NAME),
       )
-    end
-
-    it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.with(user: user, email_address: banned_email_address).
-        phone_added(disavowal_token: disavowal_token)
-      expect(mail.to).to eq(nil)
     end
   end
 
@@ -568,11 +532,6 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.html_part.body).
         to have_content(strip_tags(t('user_mailer.letter_reminder.info_html', link_html: APP_NAME)))
     end
-
-    it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.with(user: user, email_address: banned_email_address).letter_reminder
-      expect(mail.to).to eq(nil)
-    end
   end
 
   describe '#account_verified' do
@@ -596,16 +555,6 @@ RSpec.describe UserMailer, type: :mailer do
 
     it 'renders the subject' do
       expect(mail.subject).to eq t('user_mailer.account_verified.subject', sp_name: sp_name)
-    end
-
-    it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.with(user: user, email_address: banned_email_address).
-        account_verified(
-          date_time: date_time,
-          sp_name: sp_name,
-          disavowal_token: disavowal_token,
-        )
-      expect(mail.to).to eq(nil)
     end
 
     it 'links to the forgot password page' do


### PR DESCRIPTION
The roots of this setting appear to have been related to have been related to [agencies doing load testing](https://gsa-tts.slack.com/archives/CG64NU5C7/p1576615942003900) and not wanting to be flooded with emails. However I don't think we have used it much since its creation, and support for it seems to be inconsistently applied.
