### PR TITLE
LG-12557: portrait match is received when not requested

### DIFF
--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -103,7 +103,8 @@ module DocAuth
         end
 
         # @return [:success, :fail, :not_processed]
-        # When selfie result is missing, return :not_processed
+        # When selfie result is missing or not requested:
+        #   return :not_processed
         # Otherwise:
         #   return :success if selfie check result == 'Pass'
         #   return :fail

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -108,7 +108,7 @@ module DocAuth
         #   return :success if selfie check result == 'Pass'
         #   return :fail
         def selfie_status
-          return :not_processed if selfie_result.nil?
+          return :not_processed if selfie_result.nil? || !@liveness_checking_enabled
           selfie_result == 'Pass' ? :success : :fail
         end
 

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -111,12 +111,12 @@ module DocAuth
       end
 
       def selfie_status
-        if portrait_match_results&.dig(:FaceMatchResult).nil?
-          return :success if @selfie_required
-          return :not_processed
+        if @selfie_required
+          return :success if portrait_match_results&.dig(:FaceMatchResult).nil?
+          portrait_match_results[:FaceMatchResult] == 'Pass' ? :success : :fail
+        else
+          :not_processed
         end
-
-        portrait_match_results[:FaceMatchResult] == 'Pass' ? :success : :fail
       end
 
       def workflow

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -86,7 +86,7 @@ module DocAuth
       end
 
       def success?
-        doc_auth_success? && (selfie_check_performed? ? selfie_passed? : true)
+        doc_auth_success? && (@selfie_required ? selfie_passed? : true)
       end
 
       def attention_with_barcode?
@@ -111,12 +111,12 @@ module DocAuth
       end
 
       def selfie_status
-        if @selfie_required
-          return :success if portrait_match_results&.dig(:FaceMatchResult).nil?
-          portrait_match_results[:FaceMatchResult] == 'Pass' ? :success : :fail
-        else
-          :not_processed
+        if portrait_match_results&.dig(:FaceMatchResult).nil?
+          return :success if @selfie_required
+          return :not_processed
         end
+
+        portrait_match_results[:FaceMatchResult] == 'Pass' ? :success : :fail
       end
 
       def workflow

--- a/app/services/document_capture_session_result.rb
+++ b/app/services/document_capture_session_result.rb
@@ -26,12 +26,7 @@ DocumentCaptureSessionResult = RedactedStruct.new(
     self[:selfie_status].to_sym
   end
 
-  def success_status
-    # doc_auth_success : including document, attention_with_barcode and id type verification
-    !!doc_auth_success && selfie_status != :fail && !!pii
-  end
-
-  alias_method :success?, :success_status
+  alias_method :success?, :success
   alias_method :attention_with_barcode?, :attention_with_barcode
   alias_method :pii_from_doc, :pii
 

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -268,6 +268,7 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController, allowed_extra_analy
         captured_at: document_capture_session_result_captured_at,
         doc_auth_success: document_capture_session_result_success,
         selfie_status: document_capture_session_result_success ? :success : :fail,
+        success: document_capture_session_result_success,
       ),
     )
   end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -192,11 +192,18 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
         expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
         expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
 
-        attach_and_submit_images
+        # doc auth is successful while liveness is not req'd
+        attach_images(
+          Rails.root.join(
+            'spec', 'fixtures',
+            'ial2_test_credential_no_liveness.yml'
+          ),
+        )
+        submit_images
 
         expect(page).to have_current_path(idv_ssn_url)
         expect_costing_for_document
-        expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MT')
+        expect(DocAuthLog.find_by(user_id: user.id).state).to eq('NY')
 
         expect(page).to have_current_path(idv_ssn_url)
         fill_out_ssn_form_ok

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -74,7 +74,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       let(:liveness_checking_enabled) { true }
       context 'when selfie status is failed' do
         let(:response) do
-          described_class.new(doc_auth_success_with_face_match_fail, config, liveness_checking_enabled, request_context)
+          described_class.new(
+            doc_auth_success_with_face_match_fail, config,
+            liveness_checking_enabled, request_context
+          )
         end
         it 'is a failed result' do
           expect(response.selfie_status).to eq(:fail)
@@ -93,7 +96,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       end
       context 'when selfie status passes' do
         let(:response) do
-          described_class.new(success_with_liveness_response, config, liveness_checking_enabled, request_context)
+          described_class.new(
+            success_with_liveness_response, config, liveness_checking_enabled,
+            request_context
+          )
         end
         it 'is a successful result' do
           expect(response.selfie_status).to eq(:success)
@@ -365,13 +371,19 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     context 'when liveness enabled' do
       let(:liveness_checking_enabled) { true }
       it 'returns Failed for visible_pattern when it gets passed and failed value ' do
-        output = described_class.new(failure_response_no_liveness, config, liveness_checking_enabled).to_h
+        output = described_class.new(
+          failure_response_no_liveness, config,
+          liveness_checking_enabled
+        ).to_h
         expect(output.to_h[:log_alert_results]).
           to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
       end
 
       it 'returns Failed for liveness failure' do
-        response = described_class.new(failure_response_with_liveness, config, liveness_checking_enabled)
+        response = described_class.new(
+          failure_response_with_liveness, config,
+          liveness_checking_enabled
+        )
         output = response.to_h
         expect(output[:success]).to eq(false)
         expect(response.doc_auth_success?).to eq(false)

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
   let(:config) do
     DocAuth::LexisNexis::Config.new
   end
-  let(:liveness_enabled) { false }
+  let(:liveness_checking_enabled) { false }
   let(:workflow) { 'default_workflow' }
   let(:request_context) do
     {
@@ -62,7 +62,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
   end
   context 'when the response is a success' do
     let(:response) do
-      described_class.new(success_response, config, liveness_enabled, request_context)
+      described_class.new(success_response, config, liveness_checking_enabled, request_context)
     end
 
     it 'is a successful result' do
@@ -71,10 +71,10 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     end
 
     context 'when a portrait match is returned' do
-      let(:liveness_enabled) { true }
+      let(:liveness_checking_enabled) { true }
       context 'when selfie status is failed' do
         let(:response) do
-          described_class.new(doc_auth_success_with_face_match_fail, config, liveness_enabled, request_context)
+          described_class.new(doc_auth_success_with_face_match_fail, config, liveness_checking_enabled, request_context)
         end
         it 'is a failed result' do
           expect(response.selfie_status).to eq(:fail)
@@ -83,7 +83,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         end
 
         context 'when a liveness check was not requested' do
-          let(:liveness_enabled) { false }
+          let(:liveness_checking_enabled) { false }
           it 'is a successful result' do
             expect(response.selfie_status).to eq(:not_processed)
             expect(response.success?).to eq(true)
@@ -93,7 +93,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       end
       context 'when selfie status passes' do
         let(:response) do
-          described_class.new(success_with_liveness_response, config, liveness_enabled, request_context)
+          described_class.new(success_with_liveness_response, config, liveness_checking_enabled, request_context)
         end
         it 'is a successful result' do
           expect(response.selfie_status).to eq(:success)
@@ -363,15 +363,15 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(errors[:hints]).to eq(true)
     end
     context 'when liveness enabled' do
-      let(:liveness_enabled) { true }
+      let(:liveness_checking_enabled) { true }
       it 'returns Failed for visible_pattern when it gets passed and failed value ' do
-        output = described_class.new(failure_response_no_liveness, config, liveness_enabled).to_h
+        output = described_class.new(failure_response_no_liveness, config, liveness_checking_enabled).to_h
         expect(output.to_h[:log_alert_results]).
           to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
       end
 
       it 'returns Failed for liveness failure' do
-        response = described_class.new(failure_response_with_liveness, config, liveness_enabled)
+        response = described_class.new(failure_response_with_liveness, config, liveness_checking_enabled)
         output = response.to_h
         expect(output[:success]).to eq(false)
         expect(response.doc_auth_success?).to eq(false)
@@ -380,7 +380,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
 
       it 'produces expected hash output' do
         output = described_class.new(
-          failure_response_with_all_failures, config, liveness_enabled,
+          failure_response_with_all_failures, config, liveness_checking_enabled,
           request_context
         ).to_h
 
@@ -479,7 +479,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
 
     it 'produces reasonable output for a TrueID failure without details' do
       output = described_class.new(
-        failure_response_empty, config, liveness_enabled,
+        failure_response_empty, config, liveness_checking_enabled,
         request_context
       ).to_h
 
@@ -496,7 +496,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     it 'produces reasonable output for a malformed TrueID response' do
       allow(NewRelic::Agent).to receive(:notice_error)
       output = described_class.new(
-        failure_response_malformed, config, liveness_enabled,
+        failure_response_malformed, config, liveness_checking_enabled,
         request_context
       ).to_h
 

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
   let(:success_with_liveness_response) do
     instance_double(Faraday::Response, status: 200, body: LexisNexisFixtures.true_id_response_success_with_liveness)
   end
+  let(:doc_auth_success_with_face_match_fail) do
+    instance_double(Faraday::Response, status: 200, body: LexisNexisFixtures.true_id_response_with_face_match_fail)
+  end
   let(:failure_response_face_match_fail) do
     instance_double(Faraday::Response, status: 200, body: LexisNexisFixtures.true_id_response_with_face_match_fail)
   end
@@ -66,6 +69,30 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(response.successful_result?).to eq(true)
       expect(response.to_h[:vendor]).to eq('TrueID')
     end
+
+    context 'when a portrait match is returned' do
+      context 'when selfie status if failed' do
+        let(:response) do
+          described_class.new(doc_auth_success_with_face_match_fail, config, liveness_enabled, request_context)
+        end
+        it 'is a successful result' do
+          expect(response.selfie_status).to eq(:fail)
+          expect(response.success?).to eq(true)
+          expect(response.to_h[:vendor]).to eq('TrueID')
+        end
+      end
+      context 'when selfie status if failed' do
+        let(:response) do
+          described_class.new(success_with_liveness_response, config, liveness_enabled, request_context)
+        end
+        it 'is a successful result' do
+          expect(response.selfie_status).to eq(:success)
+          expect(response.success?).to eq(true)
+          expect(response.to_h[:vendor]).to eq('TrueID')
+        end
+      end
+    end
+
     it 'has no error messages' do
       expect(response.error_messages).to be_empty
     end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -71,17 +71,27 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     end
 
     context 'when a portrait match is returned' do
-      context 'when selfie status if failed' do
+      let(:liveness_enabled) { true }
+      context 'when selfie status is failed' do
         let(:response) do
           described_class.new(doc_auth_success_with_face_match_fail, config, liveness_enabled, request_context)
         end
-        it 'is a successful result' do
+        it 'is a failed result' do
           expect(response.selfie_status).to eq(:fail)
-          expect(response.success?).to eq(true)
+          expect(response.success?).to eq(false)
           expect(response.to_h[:vendor]).to eq('TrueID')
         end
+
+        context 'when a liveness check was not requested' do
+          let(:liveness_enabled) { false }
+          it 'is a successful result' do
+            expect(response.selfie_status).to eq(:not_processed)
+            expect(response.success?).to eq(true)
+            expect(response.to_h[:vendor]).to eq('TrueID')
+          end
+        end
       end
-      context 'when selfie status if failed' do
+      context 'when selfie status passes' do
         let(:response) do
           described_class.new(success_with_liveness_response, config, liveness_enabled, request_context)
         end
@@ -352,84 +362,86 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(errors[:back]).to contain_exactly(DocAuth::Errors::FALLBACK_FIELD_LEVEL)
       expect(errors[:hints]).to eq(true)
     end
+    context 'when liveness enabled' do
+      let(:liveness_enabled) { true }
+      it 'returns Failed for visible_pattern when it gets passed and failed value ' do
+        output = described_class.new(failure_response_no_liveness, config, liveness_enabled).to_h
+        expect(output.to_h[:log_alert_results]).
+          to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
+      end
 
-    it 'returns Failed for visible_pattern when it gets passed and failed value ' do
-      output = described_class.new(failure_response_no_liveness, config).to_h
-      expect(output.to_h[:log_alert_results]).
-        to match(a_hash_including(visible_pattern: { no_side: 'Failed' }))
-    end
+      it 'returns Failed for liveness failure' do
+        response = described_class.new(failure_response_with_liveness, config, liveness_enabled)
+        output = response.to_h
+        expect(output[:success]).to eq(false)
+        expect(response.doc_auth_success?).to eq(false)
+        expect(response.selfie_status).to eq(:fail)
+      end
 
-    it 'returns Failed for liveness failure' do
-      response = described_class.new(failure_response_with_liveness, config)
-      output = response.to_h
-      expect(output[:success]).to eq(false)
-      expect(response.doc_auth_success?).to eq(false)
-      expect(response.selfie_status).to eq(:fail)
-    end
+      it 'produces expected hash output' do
+        output = described_class.new(
+          failure_response_with_all_failures, config, liveness_enabled,
+          request_context
+        ).to_h
 
-    it 'produces expected hash output' do
-      output = described_class.new(
-        failure_response_with_all_failures, config, liveness_enabled,
-        request_context
-      ).to_h
-
-      expect(output).to match(
-        success: false,
-        exception: nil,
-        errors: {
-          general: [DocAuth::Errors::GENERAL_ERROR],
-          front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
-          back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
-          hints: true,
-        },
-        attention_with_barcode: false,
-        doc_type_supported: true,
-        conversation_id: a_kind_of(String),
-        request_id: a_kind_of(String),
-        reference: a_kind_of(String),
-        vendor: 'TrueID',
-        billed: true,
-        log_alert_results: a_hash_including('2d_barcode_content': { no_side: 'Failed' }),
-        transaction_status: 'failed',
-        transaction_reason_code: 'failed_true_id',
-        product_status: 'pass',
-        decision_product_status: 'fail',
-        doc_auth_result: 'Failed',
-        processed_alerts: a_hash_including(:passed, :failed),
-        address_line2_present: false,
-        alert_failure_count: a_kind_of(Numeric),
-        portrait_match_results: {
-          'FaceMatchResult' => 'Fail',
-          'FaceMatchScore' => '0',
-          'FaceStatusCode' => '0',
-          'FaceErrorMessage' => 'Liveness: PoorQuality',
-        },
-        image_metrics: a_hash_including(:front, :back),
-        'ClassificationMode' => 'Automatic',
-        'DocAuthResult' => 'Failed',
-        'DocClass' => 'DriversLicense',
-        'DocClassCode' => 'DriversLicense',
-        'DocClassName' => 'Drivers License',
-        'DocumentName' => 'Connecticut (CT) Driver License',
-        'DocIssuerCode' => 'CT',
-        'DocIssuerType' => 'StateProvince',
-        'DocIssuerName' => 'Connecticut',
-        'DocIssue' => '2009',
-        'DocIssueType' => 'Driver License',
-        'DocIsGeneric' => 'false',
-        'OrientationChanged' => 'false',
-        'PresentationChanged' => 'false',
-        classification_info: {
-          Front: a_hash_including(:ClassName, :CountryCode, :IssuerType),
-          Back: a_hash_including(:ClassName, :CountryCode, :IssuerType),
-        },
-        doc_auth_success: false,
-        selfie_status: :fail,
-        selfie_live: true,
-        selfie_quality_good: false,
-        liveness_enabled: false,
-        workflow: anything,
-      )
+        expect(output).to match(
+          success: false,
+          exception: nil,
+          errors: {
+            general: [DocAuth::Errors::GENERAL_ERROR],
+            front: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+            back: [DocAuth::Errors::FALLBACK_FIELD_LEVEL],
+            hints: true,
+          },
+          attention_with_barcode: false,
+          doc_type_supported: true,
+          conversation_id: a_kind_of(String),
+          request_id: a_kind_of(String),
+          reference: a_kind_of(String),
+          vendor: 'TrueID',
+          billed: true,
+          log_alert_results: a_hash_including('2d_barcode_content': { no_side: 'Failed' }),
+          transaction_status: 'failed',
+          transaction_reason_code: 'failed_true_id',
+          product_status: 'pass',
+          decision_product_status: 'fail',
+          doc_auth_result: 'Failed',
+          processed_alerts: a_hash_including(:passed, :failed),
+          address_line2_present: false,
+          alert_failure_count: a_kind_of(Numeric),
+          portrait_match_results: {
+            'FaceMatchResult' => 'Fail',
+            'FaceMatchScore' => '0',
+            'FaceStatusCode' => '0',
+            'FaceErrorMessage' => 'Liveness: PoorQuality',
+          },
+          image_metrics: a_hash_including(:front, :back),
+          'ClassificationMode' => 'Automatic',
+          'DocAuthResult' => 'Failed',
+          'DocClass' => 'DriversLicense',
+          'DocClassCode' => 'DriversLicense',
+          'DocClassName' => 'Drivers License',
+          'DocumentName' => 'Connecticut (CT) Driver License',
+          'DocIssuerCode' => 'CT',
+          'DocIssuerType' => 'StateProvince',
+          'DocIssuerName' => 'Connecticut',
+          'DocIssue' => '2009',
+          'DocIssueType' => 'Driver License',
+          'DocIsGeneric' => 'false',
+          'OrientationChanged' => 'false',
+          'PresentationChanged' => 'false',
+          classification_info: {
+            Front: a_hash_including(:ClassName, :CountryCode, :IssuerType),
+            Back: a_hash_including(:ClassName, :CountryCode, :IssuerType),
+          },
+          doc_auth_success: false,
+          selfie_status: :fail,
+          selfie_live: true,
+          selfie_quality_good: false,
+          liveness_enabled: true,
+          workflow: anything,
+        )
+      end
     end
     it 'produces appropriate errors with document tampering' do
       output = described_class.new(failure_response_tampering, config).to_h

--- a/spec/services/document_capture_session_result_spec.rb
+++ b/spec/services/document_capture_session_result_spec.rb
@@ -53,72 +53,83 @@ RSpec.describe DocumentCaptureSessionResult do
     end
 
     describe '#success?' do
-      it 'reports true when doc_auth_success is true and selfie_status is :not_processed' do
+      # it 'reports true when doc_auth_success is true and selfie_status is :not_processed' do
+      #   result = DocumentCaptureSessionResult.new(
+      #     id: id,
+      #     success: false,
+      #     pii: pii,
+      #     attention_with_barcode: false,
+      #     selfie_status: :not_processed,
+      #     doc_auth_success: true,
+      #   )
+      #   expect(result.success?).to eq(true)
+      # end
+      # it 'reports correctly from false when missing doc_auth_success and selfie_status' do
+      #   result = DocumentCaptureSessionResult.new(
+      #     id: id,
+      #     success: true,
+      #     pii: pii,
+      #     attention_with_barcode: false,
+      #   )
+      #   expect(result.success?).to eq(false)
+      # end
+      # it 'reports failure when selfie_status is :fail' do
+      #   result = DocumentCaptureSessionResult.new(
+      #     id: id,
+      #     success: false,
+      #     pii: pii,
+      #     attention_with_barcode: false,
+      #     selfie_status: :fail,
+      #     doc_auth_success: true,
+      #   )
+      #   expect(result.success?).to eq(false)
+      # end
+
+      # it 'reports failure when doc_auth_success is false' do
+      #   result = DocumentCaptureSessionResult.new(
+      #     id: id,
+      #     success: false,
+      #     pii: pii,
+      #     attention_with_barcode: false,
+      #     selfie_status: :success,
+      #     doc_auth_success: false,
+      #   )
+      #   expect(result.success?).to eq(false)
+      # end
+
+      # describe 'when success field, doc_auth_success, and selfie_status conflict' do
+      #   it 'reports correct result' do
+      #     result = DocumentCaptureSessionResult.new(
+      #       id: id,
+      #       success: false,
+      #       pii: pii,
+      #       attention_with_barcode: false,
+      #       selfie_status: :not_processed,
+      #       doc_auth_success: true,
+      #     )
+      #     expect(result.success?).to eq(true)
+
+      #     result = DocumentCaptureSessionResult.new(
+      #       id: id,
+      #       success: true,
+      #       pii: pii,
+      #       attention_with_barcode: false,
+      #       selfie_status: :fail,
+      #       doc_auth_success: true,
+      #     )
+      #     expect(result.success?).to eq(false)
+      #   end
+      # end
+      it 'returns the value in the success attribute' do
         result = DocumentCaptureSessionResult.new(
           id: id,
-          success: false,
+          success: 'hello world',
           pii: pii,
           attention_with_barcode: false,
           selfie_status: :not_processed,
           doc_auth_success: true,
         )
-        expect(result.success?).to eq(true)
-      end
-      it 'reports correctly from false when missing doc_auth_success and selfie_status' do
-        result = DocumentCaptureSessionResult.new(
-          id: id,
-          success: true,
-          pii: pii,
-          attention_with_barcode: false,
-        )
-        expect(result.success?).to eq(false)
-      end
-      it 'reports failure when selfie_status is :fail' do
-        result = DocumentCaptureSessionResult.new(
-          id: id,
-          success: false,
-          pii: pii,
-          attention_with_barcode: false,
-          selfie_status: :fail,
-          doc_auth_success: true,
-        )
-        expect(result.success?).to eq(false)
-      end
-
-      it 'reports failure when doc_auth_success is false' do
-        result = DocumentCaptureSessionResult.new(
-          id: id,
-          success: false,
-          pii: pii,
-          attention_with_barcode: false,
-          selfie_status: :success,
-          doc_auth_success: false,
-        )
-        expect(result.success?).to eq(false)
-      end
-
-      describe 'when success field, doc_auth_success, and selfie_status conflict' do
-        it 'reports correct result' do
-          result = DocumentCaptureSessionResult.new(
-            id: id,
-            success: false,
-            pii: pii,
-            attention_with_barcode: false,
-            selfie_status: :not_processed,
-            doc_auth_success: true,
-          )
-          expect(result.success?).to eq(true)
-
-          result = DocumentCaptureSessionResult.new(
-            id: id,
-            success: true,
-            pii: pii,
-            attention_with_barcode: false,
-            selfie_status: :fail,
-            doc_auth_success: true,
-          )
-          expect(result.success?).to eq(false)
-        end
+        expect(result.success?).to eq('hello world')
       end
     end
   end

--- a/spec/services/document_capture_session_result_spec.rb
+++ b/spec/services/document_capture_session_result_spec.rb
@@ -53,83 +53,16 @@ RSpec.describe DocumentCaptureSessionResult do
     end
 
     describe '#success?' do
-      # it 'reports true when doc_auth_success is true and selfie_status is :not_processed' do
-      #   result = DocumentCaptureSessionResult.new(
-      #     id: id,
-      #     success: false,
-      #     pii: pii,
-      #     attention_with_barcode: false,
-      #     selfie_status: :not_processed,
-      #     doc_auth_success: true,
-      #   )
-      #   expect(result.success?).to eq(true)
-      # end
-      # it 'reports correctly from false when missing doc_auth_success and selfie_status' do
-      #   result = DocumentCaptureSessionResult.new(
-      #     id: id,
-      #     success: true,
-      #     pii: pii,
-      #     attention_with_barcode: false,
-      #   )
-      #   expect(result.success?).to eq(false)
-      # end
-      # it 'reports failure when selfie_status is :fail' do
-      #   result = DocumentCaptureSessionResult.new(
-      #     id: id,
-      #     success: false,
-      #     pii: pii,
-      #     attention_with_barcode: false,
-      #     selfie_status: :fail,
-      #     doc_auth_success: true,
-      #   )
-      #   expect(result.success?).to eq(false)
-      # end
-
-      # it 'reports failure when doc_auth_success is false' do
-      #   result = DocumentCaptureSessionResult.new(
-      #     id: id,
-      #     success: false,
-      #     pii: pii,
-      #     attention_with_barcode: false,
-      #     selfie_status: :success,
-      #     doc_auth_success: false,
-      #   )
-      #   expect(result.success?).to eq(false)
-      # end
-
-      # describe 'when success field, doc_auth_success, and selfie_status conflict' do
-      #   it 'reports correct result' do
-      #     result = DocumentCaptureSessionResult.new(
-      #       id: id,
-      #       success: false,
-      #       pii: pii,
-      #       attention_with_barcode: false,
-      #       selfie_status: :not_processed,
-      #       doc_auth_success: true,
-      #     )
-      #     expect(result.success?).to eq(true)
-
-      #     result = DocumentCaptureSessionResult.new(
-      #       id: id,
-      #       success: true,
-      #       pii: pii,
-      #       attention_with_barcode: false,
-      #       selfie_status: :fail,
-      #       doc_auth_success: true,
-      #     )
-      #     expect(result.success?).to eq(false)
-      #   end
-      # end
       it 'returns the value in the success attribute' do
         result = DocumentCaptureSessionResult.new(
           id: id,
-          success: 'hello world',
-          pii: pii,
+          success: true,
+          pii: nil,
           attention_with_barcode: false,
-          selfie_status: :not_processed,
-          doc_auth_success: true,
+          selfie_status: :fail,
+          doc_auth_success: false,
         )
-        expect(result.success?).to eq('hello world')
+        expect(result.success?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
[skip changelog]

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-12557](https://cm-jira.usa.gov/browse/LG-12557)

## 🛠 Summary of changes
- TrueIDResponse only parse and store portrait match when a portrait match was requested
- - Restore use of :success in Document capture result

## 📜 Testing Plan
- unit test coverage

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->