### PR TITLE
Stop reading from `sp_session[:aal_level_requested]`

### DIFF
--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -34,10 +34,6 @@ class StoreSpMetadataInSession
     @sp_request ||= ServiceProviderRequestProxy.from_uuid(request_id)
   end
 
-  def aal_level_requested_value
-    parsed_vot&.aal_level_requested
-  end
-
   def biometric_comparison_required_value
     parsed_vot&.biometric_comparison? || sp_request&.biometric_comparison_required
   end
@@ -48,7 +44,6 @@ class StoreSpMetadataInSession
       request_url: sp_request.url,
       request_id: sp_request.uuid,
       requested_attributes: sp_request.requested_attributes,
-      aal_level_requested: aal_level_requested_value,
       biometric_comparison_required: biometric_comparison_required_value,
       acr_values: sp_request.acr_values,
       vtr: sp_request.vtr,

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1122,7 +1122,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
         sp_request_id = ServiceProviderRequestProxy.last.uuid
 
         expect(session[:sp]).to eq(
-          aal_level_requested: 1,
           acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           issuer: 'urn:gov:gsa:openidconnect:test',
           request_id: sp_request_id,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1188,7 +1188,6 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
         sp_request_id = ServiceProviderRequestProxy.last.uuid
         expect(session[:sp]).to eq(
           issuer: saml_settings.issuer,
-          aal_level_requested: 1,
           acr_values: acr_values,
           request_url: @stored_request_url.gsub('authpost', 'auth'),
           request_id: sp_request_id,
@@ -1223,7 +1222,6 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
 
         expect(session[:sp]).to eq(
           issuer: saml_settings.issuer,
-          aal_level_requested: 1,
           acr_values: acr_values,
           request_url: @saml_request.request.original_url.gsub('authpost', 'auth'),
           request_id: sp_request_id,

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 1,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -67,7 +66,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -89,7 +87,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -112,7 +109,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -131,7 +127,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 1,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -151,7 +146,6 @@ RSpec.describe StoreSpMetadataInSession do
             expect(app_session[:sp]).to eq(
               {
                 issuer: issuer,
-                aal_level_requested: 2,
                 acr_values: request_acr,
                 request_url: request_url,
                 request_id: request_id,
@@ -171,7 +165,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -190,7 +183,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -209,7 +201,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -228,7 +219,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -247,7 +237,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -266,7 +255,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,
@@ -285,7 +273,6 @@ RSpec.describe StoreSpMetadataInSession do
           expect(app_session[:sp]).to eq(
             {
               issuer: issuer,
-              aal_level_requested: 2,
               acr_values: request_acr,
               request_url: request_url,
               request_id: request_id,


### PR DESCRIPTION
In #10170 we removed all reads to `sp_session[:aal_level_requested]`. Now that the change has been deployed we can safely stop writing to that key in the SP session. This commit reads that write and updates the relevant tests.
