### PR TITLE
Remove `Vot::Parser::Result#aal_level_requested?`

### DIFF
--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -26,14 +26,6 @@ module Vot
       def identity_proofing_or_ialmax?
         identity_proofing? || ialmax?
       end
-
-      def aal_level_requested
-        if aal2?
-          2
-        else
-          1
-        end
-      end
     end
 
     attr_reader :vector_of_trust, :acr_values


### PR DESCRIPTION
This method was used to compute the requested AAL level to support cases that had not started using the `#aal2`, `#hspd12?`, and `#phishing_resistant?` properties on `Vot::Parser::Result`.

The following PRs remove the final spots where the numeric AAL value was used:

- #10186
- #10187
- #10194

With those changes there are not more uses of this method and it can be safely removed.
