### PR TITLE
LG-12465 VPAT 1.1.1 Safari VoiceOver svg with null alt

### DIFF
--- a/app/components/badge_component.html.erb
+++ b/app/components/badge_component.html.erb
@@ -1,4 +1,4 @@
 <%= content_tag('div', **tag_options, class: ['lg-verification-badge', *tag_options[:class]]) do %>
-  <%= image_tag(asset_path("alerts/#{icon}.svg"), size: 16, alt: '', role: 'img') %>
+  <%= image_tag(asset_path("alerts/#{icon}.svg"), size: 16, alt: '', role: 'presentation') %>
   <%= content %>
 <% end %>

--- a/app/components/badge_component.html.erb
+++ b/app/components/badge_component.html.erb
@@ -1,4 +1,4 @@
 <%= content_tag('div', **tag_options, class: ['lg-verification-badge', *tag_options[:class]]) do %>
-  <%= image_tag(asset_path("alerts/#{icon}.svg"), size: 16, alt: '') %>
+  <%= image_tag(asset_path("alerts/#{icon}.svg"), size: 16, alt: '', role: 'img') %>
   <%= content %>
 <% end %>

--- a/app/components/badge_component.html.erb
+++ b/app/components/badge_component.html.erb
@@ -1,4 +1,4 @@
 <%= content_tag('div', **tag_options, class: ['lg-verification-badge', *tag_options[:class]]) do %>
-  <%= image_tag(asset_path("alerts/#{icon}.svg"), size: 16, alt: '', role: 'presentation') %>
+  <%= image_tag(asset_path("alerts/#{icon}.svg"), size: 16, alt: '', role: 'img') %>
   <%= content %>
 <% end %>

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -1,6 +1,6 @@
 <% self.title = @content.heading %>
 
-<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'presentation' %>
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'img' %>
 
 <%= render PageHeadingComponent.new.with_content(@content.heading) %>
 

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -1,6 +1,6 @@
 <% self.title = @content.heading %>
 
-<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'img' %>
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'presentation' %>
 
 <%= render PageHeadingComponent.new.with_content(@content.heading) %>
 

--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -1,6 +1,6 @@
 <% self.title = @content.heading %>
 
-<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'img' %>
 
 <%= render PageHeadingComponent.new.with_content(@content.heading) %>
 

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -1,7 +1,7 @@
 <% self.title = t('openid_connect.logout.heading', app_name: APP_NAME) %>
 
 <div class='text-center'>
-  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'presentation') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'img') %>
   <% if @service_provider_name.present? %>
     <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading_with_sp', app_name: APP_NAME, service_provider_name: @service_provider_name)) %>
   <% else %>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -1,7 +1,7 @@
 <% self.title = t('openid_connect.logout.heading', app_name: APP_NAME) %>
 
 <div class='text-center'>
-  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'img') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'presentation') %>
   <% if @service_provider_name.present? %>
     <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading_with_sp', app_name: APP_NAME, service_provider_name: @service_provider_name)) %>
   <% else %>

--- a/app/views/openid_connect/logout/index.html.erb
+++ b/app/views/openid_connect/logout/index.html.erb
@@ -1,7 +1,7 @@
 <% self.title = t('openid_connect.logout.heading', app_name: APP_NAME) %>
 
 <div class='text-center'>
-  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'img') %>
   <% if @service_provider_name.present? %>
     <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading_with_sp', app_name: APP_NAME, service_provider_name: @service_provider_name)) %>
   <% else %>

--- a/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
+++ b/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
@@ -17,7 +17,7 @@
       "two_factor_options_form_selection_#{option.type}",
       class: 'usa-checkbox__label usa-checkbox__label--illustrated',
     ) do %>
-  <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: '', class: 'usa-checkbox__image') %>
+  <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: '', class: 'usa-checkbox__image', role: 'presentation') %>
   <div class="usa-checkbox__label--text">
     <span class="margin-right-2"><%= option.label %></span>
     <%= content_tag(

--- a/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
+++ b/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
@@ -17,7 +17,7 @@
       "two_factor_options_form_selection_#{option.type}",
       class: 'usa-checkbox__label usa-checkbox__label--illustrated',
     ) do %>
-  <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: '', class: 'usa-checkbox__image', role: 'presentation') %>
+  <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: '', class: 'usa-checkbox__image', role: 'img') %>
   <div class="usa-checkbox__label--text">
     <span class="margin-right-2"><%= option.label %></span>
     <%= content_tag(

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -31,7 +31,7 @@
                   asset_url('icon-dot-gov.svg'),
                   size: 40,
                   alt: '',
-                  role: 'presentation',
+                  role: 'img',
                   aria: { hidden: true },
                   class: 'usa-banner__icon usa-media-block__img',
                 ) %>
@@ -47,7 +47,7 @@
                   asset_url('icon-https.svg'),
                   size: 40,
                   alt: '',
-                  role: 'presentation',
+                  role: 'img',
                   aria: { hidden: true },
                   class: 'usa-banner__icon usa-media-block__img',
                 ) %>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -31,7 +31,7 @@
                   asset_url('icon-dot-gov.svg'),
                   size: 40,
                   alt: '',
-                  role: 'img',
+                  role: 'presentation',
                   aria: { hidden: true },
                   class: 'usa-banner__icon usa-media-block__img',
                 ) %>
@@ -47,7 +47,7 @@
                   asset_url('icon-https.svg'),
                   size: 40,
                   alt: '',
-                  role: 'img',
+                  role: 'presentation',
                   aria: { hidden: true },
                   class: 'usa-banner__icon usa-media-block__img',
                 ) %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,6 +1,6 @@
 <footer class="footer">
   <%= new_tab_link_to('https://www.gsa.gov', class: 'display-none tablet:display-inline') do %>
-    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'float-left margin-right-1') %>
+    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'float-left margin-right-1', role: 'img') %>
     <%= t('shared.footer_lite.gsa') %>
   <% end %>
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,6 +1,6 @@
 <footer class="footer">
   <%= new_tab_link_to('https://www.gsa.gov', class: 'display-none tablet:display-inline') do %>
-    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'float-left margin-right-1', role: 'img') %>
+    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'float-left margin-right-1', role: 'presentation') %>
     <%= t('shared.footer_lite.gsa') %>
   <% end %>
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,6 +1,6 @@
 <footer class="footer">
   <%= new_tab_link_to('https://www.gsa.gov', class: 'display-none tablet:display-inline') do %>
-    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'float-left margin-right-1', role: 'presentation') %>
+    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'float-left margin-right-1', role: 'img') %>
     <%= t('shared.footer_lite.gsa') %>
   <% end %>
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>

--- a/app/views/sign_up/registrations/_sp_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_sp_registration_heading.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'presentation') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'img') %>
   <h1 class="margin-bottom-4 text-primary text-normal">
     <strong><%= decorated_sp_session.sp_name %></strong>
     <%= t('headings.create_account_with_sp.sp_text', app_name: APP_NAME) %>

--- a/app/views/sign_up/registrations/_sp_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_sp_registration_heading.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'img') %>
   <h1 class="margin-bottom-4 text-primary text-normal">
     <strong><%= decorated_sp_session.sp_name %></strong>
     <%= t('headings.create_account_with_sp.sp_text', app_name: APP_NAME) %>

--- a/app/views/sign_up/registrations/_sp_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_sp_registration_heading.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'img') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'presentation') %>
   <h1 class="margin-bottom-4 text-primary text-normal">
     <strong><%= decorated_sp_session.sp_name %></strong>
     <%= t('headings.create_account_with_sp.sp_text', app_name: APP_NAME) %>

--- a/app/views/users/backup_code_setup/reminder.html.erb
+++ b/app/views/users/backup_code_setup/reminder.html.erb
@@ -1,6 +1,6 @@
 <% self.title = t('forms.backup_code.title') %>
 
-<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4' %>
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'img' %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code_reminder.heading')) %>
 

--- a/app/views/users/backup_code_setup/reminder.html.erb
+++ b/app/views/users/backup_code_setup/reminder.html.erb
@@ -1,6 +1,6 @@
 <% self.title = t('forms.backup_code.title') %>
 
-<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'img' %>
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'presentation' %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code_reminder.heading')) %>
 

--- a/app/views/users/backup_code_setup/reminder.html.erb
+++ b/app/views/users/backup_code_setup/reminder.html.erb
@@ -1,6 +1,6 @@
 <% self.title = t('forms.backup_code.title') %>
 
-<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'presentation' %>
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'img' %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code_reminder.heading')) %>
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -1,6 +1,6 @@
 <% self.title = @presenter.page_title %>
 
-<%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2', role: 'presentation' %>
+<%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2', role: 'img' %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -1,6 +1,6 @@
 <% self.title = @presenter.page_title %>
 
-<%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2' %>
+<%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2', role: 'img' %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -1,6 +1,6 @@
 <% self.title = @presenter.page_title %>
 
-<%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2', role: 'img' %>
+<%= image_tag asset_url(@presenter.image_path), alt: '', width: '90', class: 'margin-left-1 margin-bottom-2', role: 'presentation' %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -176,16 +176,16 @@ RSpec::Matchers.define :tag_decorative_svgs_with_role do
   end
 
   match do |page|
-    expect(decorative_svgs(page)).to all satisfy { |img| img[:role] == 'img' }
+    expect(decorative_svgs(page)).to all satisfy { |img| img[:role] == 'presentation' }
   end
 
   failure_message do |page|
-    img_tags = decorative_svgs(page).reject { |img| img[:role] == 'img' }
+    img_tags = decorative_svgs(page).reject { |img| img[:role] == 'presentation' }
                 .map { |img| %|<img alt="#{img[:alt]}" src="#{img[:src]}" class="#{img[:class]}">| }
                 .join("\n")
 
     <<~STR
-      Expect all decorative SVGs to have role="img", but found ones without:
+      Expect all decorative SVGs to have role="presentation", but found ones without:
       #{img_tags}
     STR
   end

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -310,7 +310,10 @@ class AccessibleName
 end
 
 def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
-  expect(page).to be_axe_clean.according_to :section508, :"best-practice", :wcag21aa
+  expect(page).to be_axe_clean.according_to(
+    :section508, :"best-practice",
+    :wcag21aa
+  ).skipping('aria-allowed-role')
   expect(page).to have_valid_idrefs
   expect(page).to label_required_fields
   expect(page).to have_valid_markup if validate_markup

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -170,6 +170,27 @@ RSpec::Matchers.define :have_unique_form_landmark_labels do
   end
 end
 
+RSpec::Matchers.define :tag_decorative_svgs_with_role do
+  def decorative_svgs(page)
+    page.all(:css, 'img[alt=""][src$=".svg" i]')
+  end
+
+  match do |page|
+    expect(decorative_svgs(page)).to all satisfy { |img| img[:role] == 'img' }
+  end
+
+  failure_message do |page|
+    img_tags = decorative_svgs(page).reject { |img| img[:role] == 'img' }
+                .map { |img| %|<img alt="#{img[:alt]}" src="#{img[:src]}" class="#{img[:class]}">| }
+                .join("\n")
+
+    <<~STR
+      Expect all decorative SVGs to have role="img", but found ones without:
+      #{img_tags}
+    STR
+  end
+end
+
 class AccessibleName
   attr_reader :page
 
@@ -293,6 +314,7 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
   expect(page).to have_valid_idrefs
   expect(page).to label_required_fields
   expect(page).to have_valid_markup if validate_markup
+  expect(page).to tag_decorative_svgs_with_role
 end
 
 def activate_skip_link

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -313,7 +313,10 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
   expect(page).to be_axe_clean.according_to(
     :section508, :"best-practice",
     :wcag21aa
-  ).excluding('img[alt=""][src$=".svg" i]')
+  ).
+    # Axe flags redundant img role on img elements, but is necessary for a Safari bug
+    # See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#identifying_svg_as_an_image
+    excluding('img[alt=""][src$=".svg" i]')
   expect(page).to have_valid_idrefs
   expect(page).to label_required_fields
   expect(page).to have_valid_markup if validate_markup

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -180,9 +180,9 @@ RSpec::Matchers.define :tag_decorative_svgs_with_role do
   end
 
   failure_message do |page|
-    img_tags = decorative_svgs(page).reject { |img| img[:role] == 'img' }
-                .map { |img| %|<img alt="#{img[:alt]}" src="#{img[:src]}" class="#{img[:class]}">| }
-                .join("\n")
+    img_tags = decorative_svgs(page).reject { |img| img[:role] == 'img' }.
+      map { |img| %(<img alt="#{img[:alt]}" src="#{img[:src]}" class="#{img[:class]}">) }.
+      join("\n")
 
     <<~STR
       Expect all decorative SVGs to have role="img", but found ones without:

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -313,7 +313,7 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
   expect(page).to be_axe_clean.according_to(
     :section508, :"best-practice",
     :wcag21aa
-  ).skipping('aria-allowed-role')
+  ).excluding('img[alt=""][src$=".svg" i]')
   expect(page).to have_valid_idrefs
   expect(page).to label_required_fields
   expect(page).to have_valid_markup if validate_markup

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -176,16 +176,16 @@ RSpec::Matchers.define :tag_decorative_svgs_with_role do
   end
 
   match do |page|
-    expect(decorative_svgs(page)).to all satisfy { |img| img[:role] == 'presentation' }
+    expect(decorative_svgs(page)).to all satisfy { |img| img[:role] == 'img' }
   end
 
   failure_message do |page|
-    img_tags = decorative_svgs(page).reject { |img| img[:role] == 'presentation' }
+    img_tags = decorative_svgs(page).reject { |img| img[:role] == 'img' }
                 .map { |img| %|<img alt="#{img[:alt]}" src="#{img[:src]}" class="#{img[:class]}">| }
                 .join("\n")
 
     <<~STR
-      Expect all decorative SVGs to have role="presentation", but found ones without:
+      Expect all decorative SVGs to have role="img", but found ones without:
       #{img_tags}
     STR
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-12465](https://cm-jira.usa.gov/browse/LG-12465)



## 🛠 Summary of changes

Instead of skipping over SVG images with alt="" attribute, VoiceOver in Safari is reading them as 'image'. Multi-part SVG would read 'image, image, image, etc.' Adding role='img' to the SVG eliminates the bug.
https://a11y-101.com/development/svg


## 📜 Testing Plan

Using MacOS with Safari and VoiceOver capability
- [ ] go to http://localhost:3000 and setup a new account
- [ ] Add 1 MFA method
- [ ] When you get to /auth_method_confirmation go into Mac settings and pick Accessibility
- [ ] Click VoiceOver, Open VoiceOver Utility and click the slider to activate
- [ ] In the Authentication method confirmation window click refresh. The screen should reload and VoiceOver should be reading through the document.
- [ ] Observe that it no longer stops on the svg but skips to the heading below as intended.

Before fix
https://github.com/18F/identity-idp/assets/135744319/6ae9386e-7ef5-4690-b8b1-f74e7b04b24b

After fix
https://github.com/18F/identity-idp/assets/135744319/9891c134-1aa4-4363-8c55-71ad0dc5e808


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
