### PR TITLE
Fix issue where DEFAULT_AAL ACR value led to SP default AAL resolution

### DIFF
--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -56,7 +56,8 @@ class AuthnContextResolver
 
   def acr_aal_component_values
     vot_parser_result.component_values.filter do |component_value|
-      component_value.name.include?('aal')
+      component_value.name.include?('aal') ||
+        component_value.name == Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
     end
   end
 

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -153,6 +153,22 @@ RSpec.describe AuthnContextResolver do
         expect(result.aal2?).to eq(true)
         expect(result.phishing_resistant?).to eq(true)
       end
+
+      it 'does not use the default AAL if the default AAL ACR value is present' do
+        service_provider = build(:service_provider, default_aal: 2)
+
+        acr_values = [
+          'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo',
+        ].join(' ')
+
+        result = AuthnContextResolver.new(
+          service_provider: service_provider,
+          vtr: nil,
+          acr_values: acr_values,
+        ).resolve
+
+        expect(result.aal2?).to eq(false)
+      end
     end
 
     context 'IAL2 service provider' do


### PR DESCRIPTION
The `AuthnContextResolver` consumes ACR values and VTR values and determine what requirements are for identity and authentication. It also includes SP defaults in this resolution if a value is not requested.

The `AuthnContextResolver` was looking at whether the AAL ACR values contained the substring `aal` to determine if an AAL ACR value was requested. If none was requested it used the SP default AAL. `urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo` is the ACR value for the default AAL (i.e. AAL1) and it does not include the `aal` substring. As a result it was not recognized as a requested AAL value and SP defaults were applied.

This commit fixes the issue above by checking for requested AAL values that include the `aal` substring or are the default AAL value.

[skip changelog]
