### PR TITLE
Fix a bug where OIDC rendered 406 when `biometric_comparison_required` param was false

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -56,7 +56,7 @@ module OpenidConnect
 
     def biometric_comparison_requested?
       @authorize_form.parsed_vector_of_trust&.biometric_comparison? ||
-        params['biometric_comparison_required']
+        params['biometric_comparison_required'] == 'true'
     end
 
     def check_sp_active


### PR DESCRIPTION
[This commit](https://github.com/18F/identity-idp/commit/fab35dc2accf4f34fbe194baf553abea8e3384d4#diff-7573b68de62ddd44e4f64f6cff7b8df4e7c95e980d037978f18092da163b787bL51) modified the check against `params[:biometric_comparison_required]` in `OpenidConnect::AuthorizationController`. The value of the param is a string so when `'false'` is passed as a param it is truthy.

This commit fixes the issue and adds a test.
