### PR TITLE
LG-12492 Update getting started screen for legacy selfies

### DIFF
--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -13,6 +13,7 @@ module Idv
         call('welcome', :view, true)
 
       @presenter = Idv::WelcomePresenter.new(decorated_sp_session)
+      @title = @presenter.title
     end
 
     def update

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -12,8 +12,7 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('welcome', :view, true)
 
-      @sp_name = decorated_sp_session.sp_name || APP_NAME
-      @title = t('doc_auth.headings.welcome', sp_name: @sp_name)
+      @presenter = Idv::WelcomePresenter.new(decorated_sp_session)
     end
 
     def update

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -13,7 +13,6 @@ module Idv
         call('welcome', :view, true)
 
       @presenter = Idv::WelcomePresenter.new(decorated_sp_session)
-      @title = @presenter.title
     end
 
     def update

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -1,11 +1,17 @@
 module Idv
   class WelcomePresenter
+    include ActionView::Helpers::TranslationHelper
+
     def initialize(sp_session)
       @sp_session = sp_session
     end
 
     def sp_name
       sp_session.sp_name || APP_NAME
+    end
+
+    def title
+      t('doc_auth.headings.welcome', sp_name: sp_name)
     end
 
     private

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -1,0 +1,15 @@
+module Idv
+  class WelcomePresenter
+    def initialize(sp_session)
+      @sp_session = sp_session
+    end
+
+    def sp_name
+      sp_session.sp_name || APP_NAME
+    end
+
+    private
+
+    attr_accessor :sp_session
+  end
+end

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -25,11 +25,19 @@ module Idv
     end
 
     def explanation_text(help_link)
-      t(
-        'doc_auth.info.getting_started_html',
-        sp_name: sp_name,
-        link_html: help_link,
-      )
+      if selfie_required?
+        t(
+          'doc_auth.info.stepping_up_html',
+          sp_name:,
+          link_html: help_link,
+        )
+      else
+        t(
+          'doc_auth.info.getting_started_html',
+          sp_name: sp_name,
+          link_html: help_link,
+        )
+      end
     end
 
     private

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -14,6 +14,10 @@ module Idv
       t('doc_auth.headings.welcome', sp_name: sp_name)
     end
 
+    def selfie_required?
+      sp_session.selfie_required?
+    end
+
     private
 
     attr_accessor :sp_session

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -1,9 +1,15 @@
 module Idv
   class WelcomePresenter
     include ActionView::Helpers::TranslationHelper
+    include Rails.application.routes.url_helpers
+    include LinkHelper
+    include ActionView::Helpers::UrlHelper
+
+    attr_accessor :url_options
 
     def initialize(sp_session)
       @sp_session = sp_session
+      @url_options = {}
     end
 
     def sp_name
@@ -16,6 +22,14 @@ module Idv
 
     def selfie_required?
       sp_session.selfie_required?
+    end
+
+    def explanation_text(help_link)
+      t(
+        'doc_auth.info.getting_started_html',
+        sp_name: sp_name,
+        link_html: help_link,
+      )
     end
 
     private

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -40,42 +40,43 @@ module Idv
       end
     end
 
-    def bullet_header(index)
-      case index
-      when 1
+    def bullet_points
+      [
         if selfie_required?
-          t('doc_auth.instructions.bullet1_with_selfie')
+          bullet_point(
+            t('doc_auth.instructions.bullet1_with_selfie'),
+            t('doc_auth.instructions.text1_with_selfie'),
+          )
         else
-          t('doc_auth.instructions.bullet1')
-        end
-      when 2
-        t('doc_auth.instructions.bullet2')
-      when 3
-        t('doc_auth.instructions.bullet3')
-      when 4
-        t('doc_auth.instructions.bullet4', app_name: sp_name)
-      end
-    end
+          bullet_point(
+            t('doc_auth.instructions.bullet1'),
+            t('doc_auth.instructions.text1'),
+          )
+        end,
 
-    def bullet_text(index)
-      case index
-      when 1
-        if selfie_required?
-          t('doc_auth.instructions.text1_with_selfie')
-        else
-          t('doc_auth.instructions.text1')
-        end
-      when 2
-        t('doc_auth.instructions.text2')
-      when 3
-        t('doc_auth.instructions.text3')
-      when 4
-        t('doc_auth.instructions.text4')
-      end
+        bullet_point(
+          t('doc_auth.instructions.bullet2'),
+          t('doc_auth.instructions.text2'),
+        ),
+
+        bullet_point(
+          t('doc_auth.instructions.bullet3'),
+          t('doc_auth.instructions.text3'),
+        ),
+
+        bullet_point(
+          t('doc_auth.instructions.bullet4', app_name: sp_name),
+          t('doc_auth.instructions.text4'),
+        ),
+      ]
     end
 
     private
 
     attr_accessor :decorated_sp_session
+
+    def bullet_point(bullet, text)
+      OpenStruct.new(bullet: bullet, text: text)
+    end
   end
 end

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -7,13 +7,13 @@ module Idv
 
     attr_accessor :url_options
 
-    def initialize(sp_session)
-      @sp_session = sp_session
+    def initialize(decorated_sp_session)
+      @decorated_sp_session = decorated_sp_session
       @url_options = {}
     end
 
     def sp_name
-      sp_session.sp_name || APP_NAME
+      decorated_sp_session.sp_name || APP_NAME
     end
 
     def title
@@ -21,7 +21,7 @@ module Idv
     end
 
     def selfie_required?
-      sp_session.selfie_required?
+      decorated_sp_session.selfie_required?
     end
 
     def explanation_text(help_link)
@@ -76,6 +76,6 @@ module Idv
 
     private
 
-    attr_accessor :sp_session
+    attr_accessor :decorated_sp_session
   end
 end

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -40,6 +40,40 @@ module Idv
       end
     end
 
+    def bullet_header(index)
+      case index
+      when 1
+        if selfie_required?
+          t('doc_auth.instructions.bullet1_with_selfie')
+        else
+          t('doc_auth.instructions.bullet1')
+        end
+      when 2
+        t('doc_auth.instructions.bullet2')
+      when 3
+        t('doc_auth.instructions.bullet3')
+      when 4
+        t('doc_auth.instructions.bullet4')
+      end
+    end
+
+    def bullet_text(index)
+      case index
+      when 1
+        if selfie_required?
+          t('doc_auth.instructions.text1_with_selfie')
+        else
+          t('doc_auth.instructions.text1')
+        end
+      when 2
+        t('doc_auth.instructions.text2')
+      when 3
+        t('doc_auth.instructions.text3')
+      when 4
+        t('doc_auth.instructions.text4')
+      end
+    end
+
     private
 
     attr_accessor :sp_session

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -53,7 +53,7 @@ module Idv
       when 3
         t('doc_auth.instructions.bullet3')
       when 4
-        t('doc_auth.instructions.bullet4')
+        t('doc_auth.instructions.bullet4', app_name: sp_name)
       end
     end
 

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -1,15 +1,15 @@
 <% self.title = @title %>
 <%= render JavascriptRequiredComponent.new(
       header: t('idv.welcome.no_js_header'),
-      intro: t('idv.welcome.no_js_intro', sp_name: @sp_name),
+      intro: t('idv.welcome.no_js_intro', sp_name: @presenter.sp_name),
       location: :idv_welcome,
     ) do %>
-<%= render PageHeadingComponent.new.with_content(@title) %>
+<%= render PageHeadingComponent.new.with_content(@presenter.title) %>
   <p>
-    <% if decorated_sp_session.selfie_required? then %>
+    <% if @presenter.selfie_required? then %>
       <%= t(
             'doc_auth.info.stepping_up_html',
-            sp_name: @sp_name,
+            sp_name: @presenter.sp_name,
             link_html: new_tab_link_to(
               t('doc_auth.info.getting_started_learn_more'),
               help_center_redirect_path(
@@ -24,7 +24,7 @@
     <% else %>
       <%= t(
             'doc_auth.info.getting_started_html',
-            sp_name: @sp_name,
+            sp_name: @presenter.sp_name,
             link_html: new_tab_link_to(
               t('doc_auth.info.getting_started_learn_more'),
               help_center_redirect_path(
@@ -42,7 +42,7 @@
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>
 
   <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
-    <% if decorated_sp_session.selfie_required? %>
+    <% if @presenter.selfie_required? %>
       <%= c.with_item(heading: t('doc_auth.instructions.bullet1_with_selfie')) do %>
         <p><%= t('doc_auth.instructions.text1_with_selfie') %></p>
       <% end %>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -6,35 +6,18 @@
     ) do %>
 <%= render PageHeadingComponent.new.with_content(@presenter.title) %>
   <p>
-    <% if @presenter.selfie_required? then %>
-      <%= t(
-        'doc_auth.info.stepping_up_html',
-        sp_name: @presenter.sp_name,
-        link_html: new_tab_link_to(
-          t('doc_auth.info.getting_started_learn_more'),
-          help_center_redirect_path(
-            category: 'verify-your-identity',
-            article: 'how-to-verify-your-identity',
-            flow: :idv,
-            step: :welcome,
-            location: 'intro_paragraph',
-          ),
-        ),
-      ) %>
-    <% else %>
-      <%= @presenter.explanation_text(
-            new_tab_link_to(
-              t('doc_auth.info.getting_started_learn_more'),
-              help_center_redirect_path(
-                category: 'verify-your-identity',
-                article: 'how-to-verify-your-identity',
-                flow: :idv,
-                step: :welcome,
-                location: 'intro_paragraph',
-              )
-            )
-          )%>
-    <% end %>
+    <%= @presenter.explanation_text(
+      new_tab_link_to(
+        t('doc_auth.info.getting_started_learn_more'),
+        help_center_redirect_path(
+          category: 'verify-your-identity',
+          article: 'how-to-verify-your-identity',
+          flow: :idv,
+          step: :welcome,
+          location: 'intro_paragraph',
+        )
+      )
+    )%>
   </p>
 
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -12,19 +12,19 @@
       <% @info_message = 'doc_auth.info.getting_started_html' %>
     <% end %>
     <%= t(
-      @info_message,
-      sp_name: @sp_name,
-      link_html: new_tab_link_to(
-        t('doc_auth.info.getting_started_learn_more'),
-        help_center_redirect_path(
-          category: 'verify-your-identity',
-          article: 'how-to-verify-your-identity',
-          flow: :idv,
-          step: :welcome,
-          location: 'intro_paragraph',
-        ),
-      ),
-    ) %>
+          @info_message,
+          sp_name: @sp_name,
+          link_html: new_tab_link_to(
+            t('doc_auth.info.getting_started_learn_more'),
+            help_center_redirect_path(
+              category: 'verify-your-identity',
+              article: 'how-to-verify-your-identity',
+              flow: :idv,
+              step: :welcome,
+              location: 'intro_paragraph',
+            ),
+          ),
+        ) %>
   </p>
 
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -23,31 +23,19 @@
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>
 
   <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
-    <% if @presenter.selfie_required? %>
-      <%= c.with_item(heading: t('doc_auth.instructions.bullet1_with_selfie')) do %>
-        <p><%= t('doc_auth.instructions.text1_with_selfie') %></p>
+    <% 4.times do |i| %>
+      <%= c.with_item(heading: @presenter.bullet_header(i)) do %>
+        <p><%= @presenter.bullet_text(i) %></p>
       <% end %>
-    <% else %>
-      <%= c.with_item(heading: t('doc_auth.instructions.bullet1')) do %>
-        <p><%= t('doc_auth.instructions.text1') %></p>
-      <% end %>
-    <% end %>
-    <%= c.with_item(heading: t('doc_auth.instructions.bullet2')) do %>
-      <p><%= t('doc_auth.instructions.text2') %></p>
-    <% end %>
-    <%= c.with_item(heading: t('doc_auth.instructions.bullet3')) do %>
-      <p><%= t('doc_auth.instructions.text3') %></p>
-    <% end %>
-    <%= c.with_item(heading: t('doc_auth.instructions.bullet4', app_name: APP_NAME)) do %>
-      <p><%= t('doc_auth.instructions.text4') %></p>
     <% end %>
   <% end %>
-<%= simple_form_for(
-      :doc_auth,
-      url: url_for,
-      method: 'put',
-      html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
-    ) do |f| %>
+
+  <%= simple_form_for(
+    :doc_auth,
+    url: url_for,
+    method: 'put',
+    html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
+  ) do |f| %>
 
   <div class="margin-top-4">
     <%= render(

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -23,9 +23,9 @@
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>
 
   <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
-    <% (1..4).each do |bullet_index| %>
-      <%= c.with_item(heading: @presenter.bullet_header(bullet_index)) do %>
-        <p><%= @presenter.bullet_text(bullet_index) %></p>
+    <% @presenter.bullet_points.each do |point| %>
+      <%= c.with_item(heading: point.bullet) do %>
+        <p><%= point.text %></p>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -8,24 +8,22 @@
   <p>
     <% if @presenter.selfie_required? then %>
       <%= t(
-            'doc_auth.info.stepping_up_html',
-            sp_name: @presenter.sp_name,
-            link_html: new_tab_link_to(
-              t('doc_auth.info.getting_started_learn_more'),
-              help_center_redirect_path(
-                category: 'verify-your-identity',
-                article: 'how-to-verify-your-identity',
-                flow: :idv,
-                step: :welcome,
-                location: 'intro_paragraph',
-              ),
-            ),
-          ) %>
+        'doc_auth.info.stepping_up_html',
+        sp_name: @presenter.sp_name,
+        link_html: new_tab_link_to(
+          t('doc_auth.info.getting_started_learn_more'),
+          help_center_redirect_path(
+            category: 'verify-your-identity',
+            article: 'how-to-verify-your-identity',
+            flow: :idv,
+            step: :welcome,
+            location: 'intro_paragraph',
+          ),
+        ),
+      ) %>
     <% else %>
-      <%= t(
-            'doc_auth.info.getting_started_html',
-            sp_name: @presenter.sp_name,
-            link_html: new_tab_link_to(
+      <%= @presenter.explanation_text(
+            new_tab_link_to(
               t('doc_auth.info.getting_started_learn_more'),
               help_center_redirect_path(
                 category: 'verify-your-identity',
@@ -33,9 +31,9 @@
                 flow: :idv,
                 step: :welcome,
                 location: 'intro_paragraph',
-              ),
-            ),
-          ) %>
+              )
+            )
+          )%>
     <% end %>
   </p>
 

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -7,24 +7,36 @@
 <%= render PageHeadingComponent.new.with_content(@title) %>
   <p>
     <% if decorated_sp_session.selfie_required? then %>
-      <% @info_message = 'doc_auth.info.stepping_up_html' %>
-    <% else %>
-      <% @info_message = 'doc_auth.info.getting_started_html' %>
-    <% end %>
-    <%= t(
-          @info_message,
-          sp_name: @sp_name,
-          link_html: new_tab_link_to(
-            t('doc_auth.info.getting_started_learn_more'),
-            help_center_redirect_path(
-              category: 'verify-your-identity',
-              article: 'how-to-verify-your-identity',
-              flow: :idv,
-              step: :welcome,
-              location: 'intro_paragraph',
-            ),
+      <%= t(
+        'doc_auth.info.stepping_up_html',
+        sp_name: @sp_name,
+        link_html: new_tab_link_to(
+          t('doc_auth.info.getting_started_learn_more'),
+          help_center_redirect_path(
+            category: 'verify-your-identity',
+            article: 'how-to-verify-your-identity',
+            flow: :idv,
+            step: :welcome,
+            location: 'intro_paragraph',
           ),
-        ) %>
+        ),
+      ) %>
+    <% else %>
+      <%= t(
+        'doc_auth.info.getting_started_html',
+        sp_name: @sp_name,
+        link_html: new_tab_link_to(
+          t('doc_auth.info.getting_started_learn_more'),
+          help_center_redirect_path(
+            category: 'verify-your-identity',
+            article: 'how-to-verify-your-identity',
+            flow: :idv,
+            step: :welcome,
+            location: 'intro_paragraph',
+          ),
+        ),
+      ) %>
+    <% end %>
   </p>
 
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -7,17 +7,17 @@
 <%= render PageHeadingComponent.new.with_content(@presenter.title) %>
   <p>
     <%= @presenter.explanation_text(
-      new_tab_link_to(
-        t('doc_auth.info.getting_started_learn_more'),
-        help_center_redirect_path(
-          category: 'verify-your-identity',
-          article: 'how-to-verify-your-identity',
-          flow: :idv,
-          step: :welcome,
-          location: 'intro_paragraph',
-        )
-      )
-    )%>
+          new_tab_link_to(
+            t('doc_auth.info.getting_started_learn_more'),
+            help_center_redirect_path(
+              category: 'verify-your-identity',
+              article: 'how-to-verify-your-identity',
+              flow: :idv,
+              step: :welcome,
+              location: 'intro_paragraph',
+            ),
+          ),
+        ) %>
   </p>
 
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>
@@ -31,11 +31,11 @@
   <% end %>
 
   <%= simple_form_for(
-    :doc_auth,
-    url: url_for,
-    method: 'put',
-    html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
-  ) do |f| %>
+        :doc_auth,
+        url: url_for,
+        method: 'put',
+        html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
+      ) do |f| %>
 
   <div class="margin-top-4">
     <%= render(

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -8,34 +8,34 @@
   <p>
     <% if decorated_sp_session.selfie_required? then %>
       <%= t(
-        'doc_auth.info.stepping_up_html',
-        sp_name: @sp_name,
-        link_html: new_tab_link_to(
-          t('doc_auth.info.getting_started_learn_more'),
-          help_center_redirect_path(
-            category: 'verify-your-identity',
-            article: 'how-to-verify-your-identity',
-            flow: :idv,
-            step: :welcome,
-            location: 'intro_paragraph',
-          ),
-        ),
-      ) %>
+            'doc_auth.info.stepping_up_html',
+            sp_name: @sp_name,
+            link_html: new_tab_link_to(
+              t('doc_auth.info.getting_started_learn_more'),
+              help_center_redirect_path(
+                category: 'verify-your-identity',
+                article: 'how-to-verify-your-identity',
+                flow: :idv,
+                step: :welcome,
+                location: 'intro_paragraph',
+              ),
+            ),
+          ) %>
     <% else %>
       <%= t(
-        'doc_auth.info.getting_started_html',
-        sp_name: @sp_name,
-        link_html: new_tab_link_to(
-          t('doc_auth.info.getting_started_learn_more'),
-          help_center_redirect_path(
-            category: 'verify-your-identity',
-            article: 'how-to-verify-your-identity',
-            flow: :idv,
-            step: :welcome,
-            location: 'intro_paragraph',
-          ),
-        ),
-      ) %>
+            'doc_auth.info.getting_started_html',
+            sp_name: @sp_name,
+            link_html: new_tab_link_to(
+              t('doc_auth.info.getting_started_learn_more'),
+              help_center_redirect_path(
+                category: 'verify-your-identity',
+                article: 'how-to-verify-your-identity',
+                flow: :idv,
+                step: :welcome,
+                location: 'intro_paragraph',
+              ),
+            ),
+          ) %>
     <% end %>
   </p>
 

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -1,4 +1,4 @@
-<% self.title = @title %>
+<% self.title = @presenter.title %>
 <%= render JavascriptRequiredComponent.new(
       header: t('idv.welcome.no_js_header'),
       intro: t('idv.welcome.no_js_intro', sp_name: @presenter.sp_name),

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -6,20 +6,25 @@
     ) do %>
 <%= render PageHeadingComponent.new.with_content(@title) %>
   <p>
+    <% if decorated_sp_session.selfie_required? then %>
+      <% @info_message = 'doc_auth.info.stepping_up_html' %>
+    <% else %>
+      <% @info_message = 'doc_auth.info.getting_started_html' %>
+    <% end %>
     <%= t(
-          'doc_auth.info.getting_started_html',
-          sp_name: @sp_name,
-          link_html: new_tab_link_to(
-            t('doc_auth.info.getting_started_learn_more'),
-            help_center_redirect_path(
-              category: 'verify-your-identity',
-              article: 'how-to-verify-your-identity',
-              flow: :idv,
-              step: :welcome,
-              location: 'intro_paragraph',
-            ),
-          ),
-        ) %>
+      @info_message,
+      sp_name: @sp_name,
+      link_html: new_tab_link_to(
+        t('doc_auth.info.getting_started_learn_more'),
+        help_center_redirect_path(
+          category: 'verify-your-identity',
+          article: 'how-to-verify-your-identity',
+          flow: :idv,
+          step: :welcome,
+          location: 'intro_paragraph',
+        ),
+      ),
+    ) %>
   </p>
 
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -23,9 +23,9 @@
   <h2><%= t('doc_auth.instructions.getting_started') %></h2>
 
   <%= render ProcessListComponent.new(heading_level: :h3, class: 'margin-y-3') do |c| %>
-    <% 4.times do |i| %>
-      <%= c.with_item(heading: @presenter.bullet_header(i)) do %>
-        <p><%= @presenter.bullet_text(i) %></p>
+    <% (1..4).each do |bullet_index| %>
+      <%= c.with_item(heading: @presenter.bullet_header(bullet_index)) do %>
+        <p><%= @presenter.bullet_text(bullet_index) %></p>
       <% end %>
     <% end %>
   <% end %>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -231,7 +231,8 @@ en:
         too_many_faces: TOO MANY FACES
       ssn: We need your Social Security number to verify your name, date of birth and
         address.
-      stepping_up_html: 'Verify your identity again and take a photo of yourself to access this service. %{link_html}'
+      stepping_up_html: 'Verify your identity again and take a photo of yourself to
+        access this service. %{link_html}'
       tag: Recommended
       upload_from_computer: Don’t have a phone? Upload photos of your ID from this computer.
       upload_from_phone: You won’t have to sign in again, and you’ll switch back to

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -231,6 +231,7 @@ en:
         too_many_faces: TOO MANY FACES
       ssn: We need your Social Security number to verify your name, date of birth and
         address.
+      stepping_up_html: 'Verify your identity again and take a photo of yourself to access this service. %{link_html}'
       tag: Recommended
       upload_from_computer: Don’t have a phone? Upload photos of your ID from this computer.
       upload_from_phone: You won’t have to sign in again, and you’ll switch back to

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -269,7 +269,8 @@ es:
         too_many_faces: HAY DEMASIADAS CARAS
       ssn: Necesitamos su número de Seguro Social para validar su nombre, fecha de
         nacimiento y dirección.
-      stepping_up_html: 'Verifica tu identidad de nuevo y tómate una foto para acceder a este servicio. %{link_html}'
+      stepping_up_html: 'Verifica tu identidad de nuevo y tómate una foto para acceder
+        a este servicio. %{link_html}'
       tag: Recomendado
       upload_from_computer: ¿No tiene teléfono? Suba fotos de su documento de
         identidad desde esta computadora.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -269,6 +269,7 @@ es:
         too_many_faces: HAY DEMASIADAS CARAS
       ssn: Necesitamos su número de Seguro Social para validar su nombre, fecha de
         nacimiento y dirección.
+      stepping_up_html: 'Verifica tu identidad de nuevo y tómate una foto para acceder a este servicio. %{link_html}'
       tag: Recomendado
       upload_from_computer: ¿No tiene teléfono? Suba fotos de su documento de
         identidad desde esta computadora.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -279,6 +279,7 @@ fr:
         too_many_faces: TROP DE VISAGES
       ssn: Nous avons besoin de votre numéro de sécurité sociale pour vérifier votre
         nom, date de naissance et adresse.
+      stepping_up_html: 'Vérifiez à nouveau votre identité et prenez une photo de vous pour accéder à ce service. %{link_html}'
       tag: Recommandation
       upload_from_computer: Vous n’avez pas de téléphone ? Téléchargez les photos de
         votre carte d’identité depuis cet ordinateur.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -279,7 +279,8 @@ fr:
         too_many_faces: TROP DE VISAGES
       ssn: Nous avons besoin de votre numéro de sécurité sociale pour vérifier votre
         nom, date de naissance et adresse.
-      stepping_up_html: 'Vérifiez à nouveau votre identité et prenez une photo de vous pour accéder à ce service. %{link_html}'
+      stepping_up_html: 'Vérifiez à nouveau votre identité et prenez une photo de vous
+        pour accéder à ce service. %{link_html}'
       tag: Recommandation
       upload_from_computer: Vous n’avez pas de téléphone ? Téléchargez les photos de
         votre carte d’identité depuis cet ordinateur.

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -150,6 +150,7 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
     expect(page).to have_current_path(idv_welcome_path)
 
     expect(page).to have_content t('doc_auth.headings.welcome', sp_name: sp_name)
+    expect(page).not_to have_content('Verify your identity again and take a photo of yourself to access this service')
   end
 
   def validate_agreement_page

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -150,7 +150,11 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
     expect(page).to have_current_path(idv_welcome_path)
 
     expect(page).to have_content t('doc_auth.headings.welcome', sp_name: sp_name)
-    expect(page).not_to have_content('Verify your identity again and take a photo of yourself to access this service')
+
+    stepping_up_info_message = t('doc_auth.info.stepping_up_html',
+                                 sp_name: sp.name,
+                                 link_html: '')
+    expect(page).not_to have_content(stepping_up_info_message)
   end
 
   def validate_agreement_page

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -151,9 +151,11 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
 
     expect(page).to have_content t('doc_auth.headings.welcome', sp_name: sp_name)
 
-    stepping_up_info_message = t('doc_auth.info.stepping_up_html',
-                                 sp_name: sp.name,
-                                 link_html: '')
+    stepping_up_info_message = t(
+      'doc_auth.info.stepping_up_html',
+      sp_name: sp.name,
+      link_html: '',
+    )
     expect(page).not_to have_content(stepping_up_info_message)
   end
 

--- a/spec/features/idv/step_up_spec.rb
+++ b/spec/features/idv/step_up_spec.rb
@@ -20,7 +20,12 @@ RSpec.describe 'IdV step up flow', allowed_extra_analytics: [:*] do
     sign_in_live_with_2fa(user)
 
     expect(page).to have_current_path(idv_welcome_path)
-    expect(page).to have_content('Verify your identity again and take a photo of yourself to access this service')
+
+    stepping_up_info_message = t('doc_auth.info.stepping_up_html',
+                                 sp_name: sp.name,
+                                 link_html: '')
+
+    expect(page).to have_content(stepping_up_info_message)
 
     complete_proofing_steps(with_selfie: true)
   end

--- a/spec/features/idv/step_up_spec.rb
+++ b/spec/features/idv/step_up_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'IdV step up flow', allowed_extra_analytics: [:*] do
     sign_in_live_with_2fa(user)
 
     expect(page).to have_current_path(idv_welcome_path)
+    expect(page).to have_content('Verify your identity again and take a photo of yourself to access this service')
 
     complete_proofing_steps(with_selfie: true)
   end

--- a/spec/features/idv/step_up_spec.rb
+++ b/spec/features/idv/step_up_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe 'IdV step up flow', allowed_extra_analytics: [:*] do
 
     expect(page).to have_current_path(idv_welcome_path)
 
-    stepping_up_info_message = t('doc_auth.info.stepping_up_html',
-                                 sp_name: sp.name,
-                                 link_html: '')
+    stepping_up_info_message = t(
+      'doc_auth.info.stepping_up_html',
+      sp_name: sp.name,
+      link_html: '',
+    )
 
     expect(page).to have_content(stepping_up_info_message)
 

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Idv::WelcomePresenter do
-  # include ActionView::Helpers::UrlHelper
-  # include ActionView::Helpers::TagHelper
-  # include Rails.application.routes.url_helpers
-  # include LinkHelper
-
   subject(:presenter) { Idv::WelcomePresenter.new(decorated_sp_session) }
 
   let(:sp) { build(:service_provider) }
@@ -69,13 +64,13 @@ RSpec.describe Idv::WelcomePresenter do
     context 'when a selfie is not required' do
       it 'uses the no selfie bullet point 1 header' do
         expect(presenter.bullet_header(1)).to eq(
-          t('doc_auth.instructions.bullet1')
+          t('doc_auth.instructions.bullet1'),
         )
       end
 
       it 'uses the no selfie bullet point 1 text' do
         expect(presenter.bullet_text(1)).to eq(
-          t('doc_auth.instructions.text1')
+          t('doc_auth.instructions.text1'),
         )
       end
     end
@@ -91,50 +86,50 @@ RSpec.describe Idv::WelcomePresenter do
 
       it 'uses the selfie bullet point 1 header' do
         expect(presenter.bullet_header(1)).to eq(
-          t('doc_auth.instructions.bullet1_with_selfie')
+          t('doc_auth.instructions.bullet1_with_selfie'),
         )
       end
 
       it 'uses the selfie bullet point 1 text' do
         expect(presenter.bullet_text(1)).to eq(
-          t('doc_auth.instructions.text1_with_selfie')
+          t('doc_auth.instructions.text1_with_selfie'),
         )
       end
     end
 
     it 'shows the bullet point 2 header' do
       expect(presenter.bullet_header(2)).to eq(
-        t('doc_auth.instructions.bullet2')
+        t('doc_auth.instructions.bullet2'),
       )
     end
 
     it 'shows the bullet point 2 text' do
       expect(presenter.bullet_text(2)).to eq(
-        t('doc_auth.instructions.text2')
+        t('doc_auth.instructions.text2'),
       )
     end
 
     it 'shows the bullet point 3 header' do
       expect(presenter.bullet_header(3)).to eq(
-        t('doc_auth.instructions.bullet3')
+        t('doc_auth.instructions.bullet3'),
       )
     end
 
     it 'shows the bullet point 3 text' do
       expect(presenter.bullet_text(3)).to eq(
-        t('doc_auth.instructions.text3')
+        t('doc_auth.instructions.text3'),
       )
     end
 
     it 'shows the bullet point 4 header' do
       expect(presenter.bullet_header(4)).to eq(
-        t('doc_auth.instructions.bullet4')
+        t('doc_auth.instructions.bullet4'),
       )
     end
 
     it 'shows the bullet point 4 text' do
       expect(presenter.bullet_text(4)).to eq(
-        t('doc_auth.instructions.text4')
+        t('doc_auth.instructions.text4'),
       )
     end
   end

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe Idv::WelcomePresenter do
   end
 
   it 'gives us the correct sp_name' do
-    expect(presenter.sp_name).to eq('Test Service Provider')
+    expect(presenter.sp_name).to eq(sp.name)
   end
 
   it 'gives us the correct title' do
-    expect(presenter.title).to eq(t('doc_auth.headings.welcome', sp_name: 'Test Service Provider'))
+    expect(presenter.title).to eq(t('doc_auth.headings.welcome', sp_name: sp.name))
   end
 
   describe 'the explanation' do
@@ -32,7 +32,7 @@ RSpec.describe Idv::WelcomePresenter do
         expect(presenter.explanation_text(help_link)).to eq(
           t(
             'doc_auth.info.getting_started_html',
-            sp_name: 'Test Service Provider',
+            sp_name: sp.name,
             link_html: help_link,
           ),
         )
@@ -52,7 +52,7 @@ RSpec.describe Idv::WelcomePresenter do
         expect(presenter.explanation_text(help_link)).to eq(
           t(
             'doc_auth.info.stepping_up_html',
-            sp_name: 'Test Service Provider',
+            sp_name: sp.name,
             link_html: help_link,
           ),
         )
@@ -123,7 +123,7 @@ RSpec.describe Idv::WelcomePresenter do
 
     it 'shows the bullet point 4 header' do
       expect(presenter.bullet_header(4)).to eq(
-        t('doc_auth.instructions.bullet4'),
+        t('doc_auth.instructions.bullet4', app_name: sp.name),
       )
     end
 

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -64,4 +64,78 @@ RSpec.describe Idv::WelcomePresenter do
       end
     end
   end
+
+  describe 'the bullet points' do
+    context 'when a selfie is not required' do
+      it 'uses the no selfie bullet point 1 header' do
+        expect(presenter.bullet_header(1)).to eq(
+          t('doc_auth.instructions.bullet1')
+        )
+      end
+
+      it 'uses the no selfie bullet point 1 text' do
+        expect(presenter.bullet_text(1)).to eq(
+          t('doc_auth.instructions.text1')
+        )
+      end
+    end
+
+    context 'when a selfie is required' do
+      let(:sp_session) do
+        { biometric_comparison_required: true }
+      end
+
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      end
+
+      it 'uses the selfie bullet point 1 header' do
+        expect(presenter.bullet_header(1)).to eq(
+          t('doc_auth.instructions.bullet1_with_selfie')
+        )
+      end
+
+      it 'uses the selfie bullet point 1 text' do
+        expect(presenter.bullet_text(1)).to eq(
+          t('doc_auth.instructions.text1_with_selfie')
+        )
+      end
+    end
+
+    it 'shows the bullet point 2 header' do
+      expect(presenter.bullet_header(2)).to eq(
+        t('doc_auth.instructions.bullet2')
+      )
+    end
+
+    it 'shows the bullet point 2 text' do
+      expect(presenter.bullet_text(2)).to eq(
+        t('doc_auth.instructions.text2')
+      )
+    end
+
+    it 'shows the bullet point 3 header' do
+      expect(presenter.bullet_header(3)).to eq(
+        t('doc_auth.instructions.bullet3')
+      )
+    end
+
+    it 'shows the bullet point 3 text' do
+      expect(presenter.bullet_text(3)).to eq(
+        t('doc_auth.instructions.text3')
+      )
+    end
+
+    it 'shows the bullet point 4 header' do
+      expect(presenter.bullet_header(4)).to eq(
+        t('doc_auth.instructions.bullet4')
+      )
+    end
+
+    it 'shows the bullet point 4 text' do
+      expect(presenter.bullet_text(4)).to eq(
+        t('doc_auth.instructions.text4')
+      )
+    end
+  end
 end

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -63,13 +63,13 @@ RSpec.describe Idv::WelcomePresenter do
   describe 'the bullet points' do
     context 'when a selfie is not required' do
       it 'uses the no selfie bullet point 1 header' do
-        expect(presenter.bullet_header(1)).to eq(
+        expect(presenter.bullet_points[0].bullet).to eq(
           t('doc_auth.instructions.bullet1'),
         )
       end
 
       it 'uses the no selfie bullet point 1 text' do
-        expect(presenter.bullet_text(1)).to eq(
+        expect(presenter.bullet_points[0].text).to eq(
           t('doc_auth.instructions.text1'),
         )
       end
@@ -85,50 +85,50 @@ RSpec.describe Idv::WelcomePresenter do
       end
 
       it 'uses the selfie bullet point 1 header' do
-        expect(presenter.bullet_header(1)).to eq(
+        expect(presenter.bullet_points[0].bullet).to eq(
           t('doc_auth.instructions.bullet1_with_selfie'),
         )
       end
 
       it 'uses the selfie bullet point 1 text' do
-        expect(presenter.bullet_text(1)).to eq(
+        expect(presenter.bullet_points[0].text).to eq(
           t('doc_auth.instructions.text1_with_selfie'),
         )
       end
     end
 
     it 'shows the bullet point 2 header' do
-      expect(presenter.bullet_header(2)).to eq(
+      expect(presenter.bullet_points[1].bullet).to eq(
         t('doc_auth.instructions.bullet2'),
       )
     end
 
     it 'shows the bullet point 2 text' do
-      expect(presenter.bullet_text(2)).to eq(
+      expect(presenter.bullet_points[1].text).to eq(
         t('doc_auth.instructions.text2'),
       )
     end
 
     it 'shows the bullet point 3 header' do
-      expect(presenter.bullet_header(3)).to eq(
+      expect(presenter.bullet_points[2].bullet).to eq(
         t('doc_auth.instructions.bullet3'),
       )
     end
 
     it 'shows the bullet point 3 text' do
-      expect(presenter.bullet_text(3)).to eq(
+      expect(presenter.bullet_points[2].text).to eq(
         t('doc_auth.instructions.text3'),
       )
     end
 
     it 'shows the bullet point 4 header' do
-      expect(presenter.bullet_header(4)).to eq(
+      expect(presenter.bullet_points[3].bullet).to eq(
         t('doc_auth.instructions.bullet4', app_name: sp.friendly_name),
       )
     end
 
     it 'shows the bullet point 4 text' do
-      expect(presenter.bullet_text(4)).to eq(
+      expect(presenter.bullet_points[3].text).to eq(
         t('doc_auth.instructions.text4'),
       )
     end

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -7,11 +7,15 @@ RSpec.describe Idv::WelcomePresenter do
     build(:service_provider)
   end
 
+  let(:sp_session) do
+    {}
+  end
+
   let(:decorated_sp_session) do
     ServiceProviderSession.new(
       sp: sp,
       view_context: nil,
-      sp_session: {},
+      sp_session: sp_session,
       service_provider_request: nil,
     )
   end
@@ -22,5 +26,25 @@ RSpec.describe Idv::WelcomePresenter do
 
   it 'gives us the correct title' do
     expect(presenter.title).to eq(t('doc_auth.headings.welcome', sp_name: 'Test Service Provider'))
+  end
+
+  context 'when a selfie is not required' do
+    it 'says so' do
+      expect(presenter.selfie_required?).to be(false)
+    end
+  end
+
+  context 'when a selfie is required' do
+    let(:sp_session) do
+      { biometric_comparison_required: true }
+    end
+
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+    end
+
+    it 'says so' do
+      expect(presenter.selfie_required?).to be(true)
+    end
   end
 end

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -8,13 +8,9 @@ RSpec.describe Idv::WelcomePresenter do
 
   subject(:presenter) { Idv::WelcomePresenter.new(decorated_sp_session) }
 
-  let(:sp) do
-    build(:service_provider)
-  end
+  let(:sp) { build(:service_provider) }
 
-  let(:sp_session) do
-    {}
-  end
+  let(:sp_session) { {} }
 
   let(:decorated_sp_session) do
     ServiceProviderSession.new(
@@ -33,57 +29,39 @@ RSpec.describe Idv::WelcomePresenter do
     expect(presenter.title).to eq(t('doc_auth.headings.welcome', sp_name: 'Test Service Provider'))
   end
 
-  context 'when a selfie is not required' do
-    it 'says so' do
-      expect(presenter.selfie_required?).to be(false)
-    end
-  end
+  describe 'the explanation' do
+    let(:help_link) { '<a href="https://www.example.com>Learn more about verifying your identity</a>' }
 
-  context 'when a selfie is not required' do
-    it 'renders the getting started message' do
-      help_link = '<a target="_blank" class="usa-link--external" rel="noopener noreferrer" href="https://www.example.com">Learn more about verifying your identity<span class="usa-sr-only">(opens new tab)</span></a>'.html_safe
-
-      puts
-      puts presenter.explanation_text(help_link)
-      puts
-      puts t(
-        'doc_auth.info.getting_started_html',
-        sp_name: 'Test Service Provider',
-        link_html: help_link,
-      )
-      puts
-
-      expect(presenter.explanation_text(help_link)).to eq(
-        t(
-          'doc_auth.info.getting_started_html',
-          sp_name: 'Test Service Provider',
-          link_html: help_link,
-        ),
-      )
-    end
-  end
-
-  context 'when a selfie is required' do
-    let(:sp_session) do
-      { biometric_comparison_required: true }
+    context 'when a selfie is not required' do
+      it 'uses the getting started message' do
+        expect(presenter.explanation_text(help_link)).to eq(
+          t(
+            'doc_auth.info.getting_started_html',
+            sp_name: 'Test Service Provider',
+            link_html: help_link,
+          ),
+        )
+      end
     end
 
-    before do
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
-    end
+    context 'when a selfie is required' do
+      let(:sp_session) do
+        { biometric_comparison_required: true }
+      end
 
-    xit 'renders the stepping up message' do
-      expect(presenter.explanation_text).to eq(
-        t(
-          'doc_auth.info.stepping_up_html',
-          sp_name: 'Test Service Provider',
-          link_html: t('doc_auth.info.getting_started_learn_more'),
-        ),
-      )
-    end
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      end
 
-    it 'says so' do
-      expect(presenter.selfie_required?).to be(true)
+      it 'uses the stepping up message' do
+        expect(presenter.explanation_text(help_link)).to eq(
+          t(
+            'doc_auth.info.stepping_up_html',
+            sp_name: 'Test Service Provider',
+            link_html: help_link,
+          ),
+        )
+      end
     end
   end
 end

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -19,4 +19,8 @@ RSpec.describe Idv::WelcomePresenter do
   it 'gives us the correct sp_name' do
     expect(presenter.sp_name).to eq('Test Service Provider')
   end
+
+  it 'gives us the correct title' do
+    expect(presenter.title).to eq(t('doc_auth.headings.welcome', sp_name: 'Test Service Provider'))
+  end
 end

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Idv::WelcomePresenter do
+  # include ActionView::Helpers::UrlHelper
+  # include ActionView::Helpers::TagHelper
+  # include Rails.application.routes.url_helpers
+  # include LinkHelper
+
   subject(:presenter) { Idv::WelcomePresenter.new(decorated_sp_session) }
 
   let(:sp) do
@@ -34,6 +39,30 @@ RSpec.describe Idv::WelcomePresenter do
     end
   end
 
+  context 'when a selfie is not required' do
+    it 'renders the getting started message' do
+      help_link = '<a target="_blank" class="usa-link--external" rel="noopener noreferrer" href="https://www.example.com">Learn more about verifying your identity<span class="usa-sr-only">(opens new tab)</span></a>'.html_safe
+
+      puts
+      puts presenter.explanation_text(help_link)
+      puts
+      puts t(
+        'doc_auth.info.getting_started_html',
+        sp_name: 'Test Service Provider',
+        link_html: help_link,
+      )
+      puts
+
+      expect(presenter.explanation_text(help_link)).to eq(
+        t(
+          'doc_auth.info.getting_started_html',
+          sp_name: 'Test Service Provider',
+          link_html: help_link,
+        ),
+      )
+    end
+  end
+
   context 'when a selfie is required' do
     let(:sp_session) do
       { biometric_comparison_required: true }
@@ -41,6 +70,16 @@ RSpec.describe Idv::WelcomePresenter do
 
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+    end
+
+    xit 'renders the stepping up message' do
+      expect(presenter.explanation_text).to eq(
+        t(
+          'doc_auth.info.stepping_up_html',
+          sp_name: 'Test Service Provider',
+          link_html: t('doc_auth.info.getting_started_learn_more'),
+        ),
+      )
     end
 
     it 'says so' do

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe Idv::WelcomePresenter do
   end
 
   it 'gives us the correct sp_name' do
-    expect(presenter.sp_name).to eq(sp.name)
+    expect(presenter.sp_name).to eq(sp.friendly_name)
   end
 
   it 'gives us the correct title' do
-    expect(presenter.title).to eq(t('doc_auth.headings.welcome', sp_name: sp.name))
+    expect(presenter.title).to eq(t('doc_auth.headings.welcome', sp_name: sp.friendly_name))
   end
 
   describe 'the explanation' do
@@ -32,7 +32,7 @@ RSpec.describe Idv::WelcomePresenter do
         expect(presenter.explanation_text(help_link)).to eq(
           t(
             'doc_auth.info.getting_started_html',
-            sp_name: sp.name,
+            sp_name: sp.friendly_name,
             link_html: help_link,
           ),
         )
@@ -52,7 +52,7 @@ RSpec.describe Idv::WelcomePresenter do
         expect(presenter.explanation_text(help_link)).to eq(
           t(
             'doc_auth.info.stepping_up_html',
-            sp_name: sp.name,
+            sp_name: sp.friendly_name,
             link_html: help_link,
           ),
         )
@@ -123,7 +123,7 @@ RSpec.describe Idv::WelcomePresenter do
 
     it 'shows the bullet point 4 header' do
       expect(presenter.bullet_header(4)).to eq(
-        t('doc_auth.instructions.bullet4', app_name: sp.name),
+        t('doc_auth.instructions.bullet4', app_name: sp.friendly_name),
       )
     end
 

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Idv::WelcomePresenter do
+  subject(:presenter) { Idv::WelcomePresenter.new(decorated_sp_session) }
+
+  let(:sp) do
+    build(:service_provider)
+  end
+
+  let(:decorated_sp_session) do
+    ServiceProviderSession.new(
+      sp: sp,
+      view_context: nil,
+      sp_session: {},
+      service_provider_request: nil,
+    )
+  end
+
+  it 'gives us the correct sp_name' do
+    expect(presenter.sp_name).to eq('Test Service Provider')
+  end
+end

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -64,4 +64,3 @@ RSpec.describe 'idv/welcome/show.html.erb' do
     end
   end
 end
- 

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -1,25 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe 'idv/welcome/show.html.erb' do
-  let(:user_fully_authenticated) { true }
-  let(:sp_name) { nil }
+  include Devise::Test::ControllerHelpers
+
   let(:selfie_required) { false }
+  let(:selfie_capture_enabled) { false }
   let(:user) { create(:user) }
+  let(:sp_session) { {} }
 
   before do
-    @decorated_sp_session = instance_double(ServiceProviderSession)
-    allow(@decorated_sp_session).to receive(:sp_name).and_return(sp_name)
-    allow(@decorated_sp_session).to receive(:selfie_required?).and_return(selfie_required)
-    @sp_name = @decorated_sp_session.sp_name || APP_NAME
-    @title = t('doc_auth.headings.welcome', sp_name: @sp_name)
-    allow(view).to receive(:decorated_sp_session).and_return(@decorated_sp_session)
-    allow(view).to receive(:user_fully_authenticated?).and_return(user_fully_authenticated)
-    allow(view).to receive(:user_signing_up?).and_return(false)
-    allow(view).to receive(:url_for).and_wrap_original do |method, *args, &block|
-      method.call(*args, &block)
-    rescue
-      ''
-    end
+    sp = build(:service_provider)
+    decorated_sp_session = ServiceProviderSession.new(
+      sp: sp,
+      view_context: nil,
+      sp_session: sp_session,
+      service_provider_request: nil,
+    )
+    presenter = Idv::WelcomePresenter.new(decorated_sp_session)
+    assign(:presenter, presenter)
+
+    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+      and_return(selfie_capture_enabled)
   end
 
   context 'in doc auth with an authenticated user' do
@@ -33,7 +34,9 @@ RSpec.describe 'idv/welcome/show.html.erb' do
     end
 
     it 'renders the welcome template' do
-      expect(rendered).to have_content(@title)
+      expect(rendered).to have_content(
+        t('doc_auth.headings.welcome', sp_name: 'Test Service Provider'),
+      )
       expect(rendered).to have_content(t('doc_auth.instructions.getting_started'))
       expect(rendered).to have_content(t('doc_auth.instructions.bullet1'))
       expect(rendered).to have_link(
@@ -49,7 +52,11 @@ RSpec.describe 'idv/welcome/show.html.erb' do
     end
 
     context 'when the SP requests IAL2 verification' do
-      let(:selfie_required) { true }
+      let(:sp_session) do
+        { biometric_comparison_required: true }
+      end
+
+      let(:selfie_capture_enabled) { true }
 
       it 'renders a modified welcome template' do
         expect(rendered).to have_content(t('doc_auth.instructions.bullet1_with_selfie'))
@@ -57,3 +64,4 @@ RSpec.describe 'idv/welcome/show.html.erb' do
     end
   end
 end
+ 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12492](https://cm-jira.usa.gov/browse/LG-12942)

## 🛠 Summary of changes

Changed the welcome screen text for users who are undergoing step-up IdV (they were verified without a selfie, but now must be re-verified with a selfie).

## 📜 Testing Plan

- Create a user and proceed through IdV.
- Verify that the new text does not appear on the getting started
  screen
- Stop the app and enable selfies (Change `NullServiceProviderSession#selfie_required?` to return true)
- Restart the app and re-enter IdV
- Verify that the new text appears on the getting started screen.




## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Beginning initial IdV:</summary>

<img width="623" alt="Screenshot 2024-03-05 at 2 24 39 PM" src="https://github.com/18F/identity-idp/assets/101212334/1ca8f369-730b-47a5-a0ef-f826fe479057">

</details>

<details>
<summary>Beginning initial IdV (French):</summary>

![Screenshot 2024-03-11 at 10 19 45 AM](https://github.com/18F/identity-idp/assets/101212334/dc72e869-dade-4021-8068-b6bcddb73523)

</details>

<details>
<summary>Beginning initial IdV (Spanish):</summary>

![Screenshot 2024-03-11 at 10 20 24 AM](https://github.com/18F/identity-idp/assets/101212334/57fb28db-c0af-4bde-bacb-3a0977b3c8bd)

</details>

<details>
<summary>Beginning step-up IdV:</summary>
<img width="621" alt="Screenshot 2024-03-05 at 2 26 00 PM" src="https://github.com/18F/identity-idp/assets/101212334/9f814a86-37ec-4dd0-95a3-4f40fe748236">

</details>
<details>
<summary>Beginning step-up IdV (French):</summary>

![Screenshot 2024-03-11 at 10 38 46 AM](https://github.com/18F/identity-idp/assets/101212334/e9263312-9b79-4126-813b-4a45bbb27b35)

</details>
<details>
<summary>Beginning step-up IdV (Spanish):</summary>

![Screenshot 2024-03-11 at 10 39 12 AM](https://github.com/18F/identity-idp/assets/101212334/b9ca0637-f16b-463f-a391-bfc20e6dcab0)

</details>