### PR TITLE
LG-12074: Rename selfie image added events to match naming convention

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -45,11 +45,10 @@ class FrontendLogController < ApplicationController
   # rubocop:enable Layout/LineLength
 
   ALLOWED_EVENTS = %i[
-    idv_sdk_selfie_image_added
     idv_sdk_selfie_image_capture_closed_without_photo
     idv_sdk_selfie_image_capture_failed
     idv_sdk_selfie_image_capture_opened
-    idv_selfie_image_file_uploaded
+    idv_selfie_image_added
     phone_input_country_changed
   ].freeze
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -408,7 +408,7 @@ function AcuantCapture(
       });
 
       trackEvent(
-        name === 'selfie' ? 'idv_selfie_image_file_uploaded' : `IdV: ${name} image added`,
+        name === 'selfie' ? 'idv_selfie_image_added' : `IdV: ${name} image added`,
         analyticsPayload,
       );
     }
@@ -519,7 +519,7 @@ function AcuantCapture(
       failedImageResubmission: false,
     });
 
-    trackEvent('idv_sdk_selfie_image_added', { captureAttempts });
+    trackEvent('idv_selfie_image_added', { captureAttempts });
 
     onChangeAndResetError(image, analyticsPayload);
     onResetFailedCaptureAttempts();
@@ -593,7 +593,10 @@ function AcuantCapture(
       failedImageResubmission: false,
     });
 
-    trackEvent(`IdV: ${name} image added`, analyticsPayload);
+    trackEvent(
+      name === 'selfie' ? 'idv_selfie_image_added' : `IdV: ${name} image added`,
+      analyticsPayload,
+    );
 
     if (assessment === 'success') {
       onChangeAndResetError(data, analyticsPayload);

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2842,9 +2842,10 @@ module AnalyticsEvents
     )
   end
 
+  # User closed the SDK for taking a selfie without submitting a photo
   # @param [Integer] captureAttempts number of attempts to capture / upload an image
   #                  (previously called "attempt")
-  # User closed the SDK for taking a selfie without submitting a photo
+  # rubocop:disable Naming/VariableName,Naming/MethodParameterName
   def idv_sdk_selfie_image_capture_closed_without_photo(captureAttempts: nil, **extra)
     track_event(
       :idv_sdk_selfie_image_capture_closed_without_photo,
@@ -2852,14 +2853,16 @@ module AnalyticsEvents
       **extra,
     )
   end
+  # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
+  # User encountered an error with the SDK selfie process
+  #   Error code 1: camera permission not granted
+  #   Error code 2: unexpected errors
   # @param [Integer] sdk_error_code SDK code for the error encountered
   # @param [String] sdk_error_message SDK message for the error encountered
   # @param [Integer] captureAttempts number of attempts to capture / upload an image
   #                  (previously called "attempt")
-  # User encountered an error with the SDK selfie process
-  # Error code 1: camera permission not granted
-  # Error code 2: unexpected errors
+  # rubocop:disable Naming/VariableName,Naming/MethodParameterName
   def idv_sdk_selfie_image_capture_failed(
     sdk_error_code:,
     sdk_error_message:,
@@ -2874,13 +2877,17 @@ module AnalyticsEvents
       **extra,
     )
   end
+  # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
-  # @param [Integer] captureAttempts number of attempts to capture / upload an image
   # User opened the SDK to take a selfie
+  # @param [Integer] captureAttempts number of attempts to capture / upload an image
+  # rubocop:disable Naming/VariableName,Naming/MethodParameterName
   def idv_sdk_selfie_image_capture_opened(captureAttempts: nil, **extra)
     track_event(:idv_sdk_selfie_image_capture_opened, captureAttempts: captureAttempts, **extra)
   end
+  # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
+  # User took a selfie image with the SDK, or uploaded a selfie using the file picker
   # @param [Integer] captureAttempts number of attempts to capture / upload an image
   #                  (previously called "attempt")
   # @param [Integer] failedImageResubmission
@@ -2891,7 +2898,7 @@ module AnalyticsEvents
   # @param [Integer] size size of image added in bytes
   # @param [String] source
   # @param [Integer] width width of image added in pixels
-  # User took a selfie image with the SDK, or uploaded a selfie using the file picker
+  # rubocop:disable Naming/VariableName,Naming/MethodParameterName
   def idv_selfie_image_added(
     captureAttempts:,
     failedImageResubmission:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2844,14 +2844,6 @@ module AnalyticsEvents
 
   # @param [Integer] captureAttempts number of attempts to capture / upload an image
   #                  (previously called "attempt")
-  # User captured and approved of their selfie
-  # rubocop:disable Naming/VariableName,Naming/MethodParameterName
-  def idv_sdk_selfie_image_added(captureAttempts: nil, **extra)
-    track_event(:idv_sdk_selfie_image_added, captureAttempts: captureAttempts, **extra)
-  end
-
-  # @param [Integer] captureAttempts number of attempts to capture / upload an image
-  #                  (previously called "attempt")
   # User closed the SDK for taking a selfie without submitting a photo
   def idv_sdk_selfie_image_capture_closed_without_photo(captureAttempts: nil, **extra)
     track_event(
@@ -2899,8 +2891,8 @@ module AnalyticsEvents
   # @param [Integer] size size of image added in bytes
   # @param [String] source
   # @param [Integer] width width of image added in pixels
-  # User uploaded a selfie using the file picker
-  def idv_selfie_image_file_uploaded(
+  # User took a selfie image with the SDK, or uploaded a selfie using the file picker
+  def idv_selfie_image_added(
     captureAttempts:,
     failedImageResubmission:,
     fingerprint:,
@@ -2913,7 +2905,7 @@ module AnalyticsEvents
     **_extra
   )
     track_event(
-      :idv_selfie_image_file_uploaded,
+      :idv_selfie_image_added,
       captureAttempts: captureAttempts,
       failedImageResubmission: failedImageResubmission,
       fingerprint: fingerprint,

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -514,7 +514,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, skip_hybrid_handoff: nil, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false, selfie_check_required: boolean, liveness_checking_required: true
       },
-      :idv_selfie_image_file_uploaded => {
+      :idv_selfie_image_added => {
         captureAttempts: 1, failedImageResubmission: nil, fingerprint: 'aIzxkX_iMtoxFOURZr55qkshs53emQKUOr7VfTf6G1Q', flow_path: 'standard', height: 38, mimeType: 'image/png', size: 3694, source: 'upload', width: 284
       },
       'IdV: doc auth ssn visited' => {

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -1206,7 +1206,7 @@ describe('document-capture/components/acuant-capture', () => {
       expect(trackEvent).to.be.calledWith('IdV: Acuant SDK loaded');
 
       expect(trackEvent).to.have.been.calledWith(
-        'idv_sdk_selfie_image_added',
+        'idv_selfie_image_added',
         sinon.match({
           captureAttempts: sinon.match.number,
         }),


### PR DESCRIPTION
## 🎫 Ticket

[LG-12074](https://cm-jira.usa.gov/browse/LG-12074)

## 🛠 Summary of changes

Rename both:

1.  `idv_selfie_image_file_uploaded`
2. `idv_sdk_selfie_image_added`

events to: `idv_selfie_image_added`.

The rename process also brought up some linting issues, so fixed a few rubocop issues as well. More detail in [the relevant commit](https://github.com/18F/identity-idp/commit/613002fd5af21cd868b5cfbfdc321f0d969ee99c).

## 📜 Testing Plan

- [ ] Set `doc_auth_selfie_capture_enabled: true`
- [ ] Run `make watch_events`
- [ ] Follow the flow through to the document capture page
- [ ] Capture and accept selfie once with SDK
- [ ] Capture and accept selfie once with file upload
- [ ] Make sure both times you see `idv_selfie_image_added`
- [ ] Make sure you do not see `idv_selfie_image_file_uploaded` or `idv_sdk_selfie_image_added`

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

```
# upload

{
  "name": "idv_selfie_image_file_uploaded",
  "properties": {
    "event_properties": {
      "captureAttempts": 2,
      "failedImageResubmission": null,
      "fingerprint": "mQn63VZVopk1n6vFCoZSnpLjPSkygU_iQi2zmctKeFo",
      "flow_path": "standard",
      "height": null,
      "mimeType": "application/x-yaml",
      "size": 491,
      "source": "upload",
      "width": null
    },
    "new_event": true,
    "path": "/api/logger",
    "session_duration": 263.295446,
    "user_id": "c34a118d-7b96-4095-8cff-6397b677c182",
    "locale": "en",
    "user_ip": "192.168.0.14",
    "hostname": "192.168.0.19",
    "pid": 49469,
    "service_provider": "urn:gov:gsa:openidconnect:sp:test",
    "trace_id": null,
    "git_sha": "d9fba9f0",
    "git_branch": "main",
    "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Mobile/15E148 Safari/604.1",
    "browser_name": "Safari",
    "browser_version": "17.3.1",
    "browser_platform_name": "iOS (iPhone)",
    "browser_platform_version": "17.3.1",
    "browser_device_name": "iPhone",
    "browser_mobile": true,
    "browser_bot": false
  },
  "time": "2024-03-05T22:30:54.295Z",
  "id": "ecce1362-af18-48de-a7ed-ff671bf8f76b",
  "visitor_id": "d0349fb9-b0e7-4f1c-a4f3-6b5e8a075888",
  "visit_id": "b9fb2dd8-e4fa-4370-b3ec-b22795a22e93",
  "log_filename": "events.log"
}

# sdk

{
  "name": "idv_sdk_selfie_image_added",
  "properties": {
    "event_properties": {
      "captureAttempts": 3
    },
    "new_event": true,
    "path": "/api/logger",
    "session_duration": 325.013298,
    "user_id": "c34a118d-7b96-4095-8cff-6397b677c182",
    "locale": "en",
    "user_ip": "192.168.0.14",
    "hostname": "192.168.0.19",
    "pid": 49469,
    "service_provider": "urn:gov:gsa:openidconnect:sp:test",
    "trace_id": null,
    "git_sha": "d9fba9f0",
    "git_branch": "main",
    "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Mobile/15E148 Safari/604.1",
    "browser_name": "Safari",
    "browser_version": "17.3.1",
    "browser_platform_name": "iOS (iPhone)",
    "browser_platform_version": "17.3.1",
    "browser_device_name": "iPhone",
    "browser_mobile": true,
    "browser_bot": false
  },
  "time": "2024-03-05T22:31:56.014Z",
  "id": "05913fbc-fe8d-4fe3-b4c2-8a34f5524581",
  "visitor_id": "d0349fb9-b0e7-4f1c-a4f3-6b5e8a075888",
  "visit_id": "b9fb2dd8-e4fa-4370-b3ec-b22795a22e93",
  "log_filename": "events.log"
}
```

</details>

<details>
<summary>After:</summary>

```
# upload

{
  "name": "idv_selfie_image_added",
  "properties": {
    "event_properties": {
      "captureAttempts": 1,
      "failedImageResubmission": null,
      "fingerprint": "mQn63VZVopk1n6vFCoZSnpLjPSkygU_iQi2zmctKeFo",
      "flow_path": "standard",
      "height": null,
      "mimeType": "application/x-yaml",
      "size": 491,
      "source": "upload",
      "width": null
    },
    "new_event": true,
    "path": "/api/logger",
    "session_duration": 574.216564,
    "user_id": "c2db16f1-c77d-44a3-bf31-22725872960b",
    "locale": "en",
    "user_ip": "192.168.0.19",
    "hostname": "192.168.0.19",
    "pid": 94814,
    "service_provider": "urn:gov:gsa:openidconnect:sp:test",
    "trace_id": null,
    "git_sha": "613002fd",
    "git_branch": "brittany/lg-12074-rename-selfie-image-added-events",
    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
    "browser_name": "Chrome",
    "browser_version": "122.0.0.0",
    "browser_platform_name": "macOS",
    "browser_platform_version": "10.15.7",
    "browser_device_name": "Unknown",
    "browser_mobile": false,
    "browser_bot": false
  },
  "time": "2024-03-05T21:40:57.217Z",
  "id": "2c89324d-3fa9-4b99-9a8e-c4d3694c75b9",
  "visitor_id": "7a34c3e3-9d19-427b-b823-d43a2e24802a",
  "visit_id": "e7145c29-03a9-4f1c-befe-c386d39e2cfd",
  "log_filename": "events.log"
}

# sdk

{
  "name": "idv_selfie_image_added",
  "properties": {
    "event_properties": {
      "captureAttempts": 1,
      "failedImageResubmission": null,
      "fingerprint": null,
      "flow_path": "standard",
      "height": null,
      "mimeType": null,
      "size": null,
      "source": null,
      "width": null
    },
    "new_event": true,
    "path": "/api/logger",
    "session_duration": 367.343111,
    "user_id": "709d8956-613d-43e3-ae88-3de1107263f5",
    "locale": "en",
    "user_ip": "192.168.0.14",
    "hostname": "192.168.0.19",
    "pid": 94814,
    "service_provider": "urn:gov:gsa:openidconnect:sp:test",
    "trace_id": null,
    "git_sha": "613002fd",
    "git_branch": "brittany/lg-12074-rename-selfie-image-added-events",
    "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Mobile/15E148 Safari/604.1",
    "browser_name": "Safari",
    "browser_version": "17.3.1",
    "browser_platform_name": "iOS (iPhone)",
    "browser_platform_version": "17.3.1",
    "browser_device_name": "iPhone",
    "browser_mobile": true,
    "browser_bot": false
  },
  "time": "2024-03-05T22:09:24.344Z",
  "id": "0ec3268d-d24b-4217-8215-5d029bfe1c7c",
  "visitor_id": "d0349fb9-b0e7-4f1c-a4f3-6b5e8a075888",
  "visit_id": "b9fb2dd8-e4fa-4370-b3ec-b22795a22e93",
  "log_filename": "events.log"
}
```

</details>
