### PR TITLE
LG-12563 add vot to user info controller

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -21,8 +21,12 @@ class OpenidConnectUserInfoPresenter
     info.merge!(ial2_attributes) if scoper.ial2_scopes_requested? && ial2_data.present?
     info.merge!(x509_attributes) if scoper.x509_scopes_requested?
     info[:verified_at] = verified_at if scoper.verified_at_requested?
-    info[:ial] = Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[identity.ial]
-    info[:aal] = identity.requested_aal_value
+    if identity.vtr.nil?
+      info[:ial] = Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[identity.ial]
+      info[:aal] = identity.requested_aal_value
+    else
+      info[:vtr] = identity.vtr
+    end
 
     scoper.filter(info)
   end

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe OpenidConnect::UserInfoController, allowed_extra_analytics: [:*] 
   describe '#show' do
     subject(:action) do
       request.headers['HTTP_AUTHORIZATION'] = authorization_header
-      post :show, params: params
+      post :show
     end
-
-    let(:params) { {} }
 
     context 'without an authorization header' do
       let(:authorization_header) { nil }
@@ -93,43 +91,10 @@ RSpec.describe OpenidConnect::UserInfoController, allowed_extra_analytics: [:*] 
         OutOfBandSessionAccessor.new(identity.rails_session_id).put_empty_user_session(50)
       end
 
-      context 'without a vtr param' do
-        it 'renders user info without a vtr key' do
-          action
-          expect(response).to be_ok
-          expect(json_response).not_to have_key(:vtr)
-        end
-
-        it 'renders user info with an ial key' do
-          action
-          expect(response).to be_ok
-          expect(json_response).to have_key(:ial)
-        end
-
-        it 'renders user info with an aal key' do
-          action
-          expect(response).to be_ok
-          expect(json_response).to have_key(:aal)
-        end
-      end
-
-      context 'with a vtr param' do
-        let(:params) { { vtr: 'C1' } }
-
-        it 'renders user info with a vtr key' do
-          action
-          expect(json_response).to have_key(:vtr)
-        end
-
-        it 'renders user info without an ial key' do
-          action
-          expect(json_response).not_to have_key(:ial)
-        end
-
-        it 'renders user info without an aal key' do
-          action
-          expect(json_response).not_to have_key(:aal)
-        end
+      it 'renders user info' do
+        action
+        expect(response).to be_ok
+        expect(json_response[:sub]).to eq(identity.uuid)
       end
 
       it 'tracks analytics' do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -1255,10 +1255,18 @@ RSpec.describe 'OpenID Connect', allowed_extra_analytics: [:*] do
     expect(userinfo_response[:given_name]).to eq('John')
     expect(userinfo_response[:social_security_number]).to eq('111223333')
 
-    # ToDo
-    # expect(aal stuff)
-    # expect(ial_stuff)
-    # expect(vtr)
+    if vtr.present?
+      expect(userinfo_response).not_to have_key(:ial)
+      expect(userinfo_response).not_to have_key(:aal)
+      expect(userinfo_response[:vtr]).to eq(Array(vtr).to_json)
+    else
+      expect(userinfo_response[:ial]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
+      expect(userinfo_response[:aal]).to eq(
+        Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+      )
+      expect(userinfo_response).not_to have_key(:vtr)
+    end
+
     user
   end
 end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe 'OpenID Connect', allowed_extra_analytics: [:*] do
     end
 
     it 'succeeds with a vtr param' do
-      allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
       oidc_end_client_secret_jwt(vtr: 'C1.C2.P1')
     end
   end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -1254,6 +1254,11 @@ RSpec.describe 'OpenID Connect', allowed_extra_analytics: [:*] do
     expect(userinfo_response[:email]).to eq(user.email)
     expect(userinfo_response[:given_name]).to eq('John')
     expect(userinfo_response[:social_security_number]).to eq('111223333')
+
+    # ToDo
+    # expect(aal stuff)
+    # expect(ial_stuff)
+    # expect(vtr)
     user
   end
 end

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
             expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
             expect(user_info[:ial]).to eq(ial)
             expect(user_info[:aal]).to eq(aal)
+            expect(user_info).not_to have_key(:vtr)
           end
         end
       end
@@ -60,6 +61,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
             expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
             expect(user_info[:ial]).to eq(ial_value)
             expect(user_info[:aal]).to eq(aal)
+            expect(user_info).not_to have_key(:vtr)
           end
         end
 
@@ -71,6 +73,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
             expect(user_info[:phone]).to eq(nil)
             expect(user_info[:phone_verified]).to eq(nil)
             expect(user_info[:address]).to eq(nil)
+            expect(user_info).not_to have_key(:vtr)
           end
         end
       end
@@ -281,6 +284,33 @@ RSpec.describe OpenidConnectUserInfoPresenter do
               end
             end
           end
+        end
+      end
+    end
+
+    context 'with a vtr parameter' do
+      let(:identity) do
+        build(
+          :service_provider_identity,
+          rails_session_id: rails_session_id,
+          user: create(:user, profiles: [profile]),
+          service_provider: service_provider.issuer,
+          scope: scope,
+          aal: 2,
+          vtr: ['C1'].to_json,
+        )
+      end
+
+      it 'has basic attributes' do
+        aggregate_failures do
+          expect(user_info[:sub]).to eq(identity.uuid)
+          expect(user_info[:iss]).to eq(root_url)
+          expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
+          expect(user_info[:email_verified]).to eq(true)
+          expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
+          expect(user_info).not_to have_key(:ial)
+          expect(user_info).not_to have_key(:aal)
+          expect(user_info[:vtr]).to eq(['C1'].to_json)
         end
       end
     end

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -27,198 +27,41 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   describe '#user_info' do
     subject(:user_info) { presenter.user_info }
 
-    context 'basic ial1' do
-      it 'has basic attributes' do
-        ial = Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[identity.ial]
-        aal = Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF
+    context 'without a vtr parameter' do
+      context 'basic ial1' do
+        it 'has basic attributes' do
+          ial = Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[identity.ial]
+          aal = Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF
 
-        aggregate_failures do
-          expect(user_info[:sub]).to eq(identity.uuid)
-          expect(user_info[:iss]).to eq(root_url)
-          expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
-          expect(user_info[:email_verified]).to eq(true)
-          expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
-          expect(user_info[:ial]).to eq(ial)
-          expect(user_info[:aal]).to eq(aal)
-        end
-      end
-    end
-
-    context 'ialmax' do
-      let(:ial) { Idp::Constants::IAL_MAX }
-      let(:ial_value) { Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[ial] }
-      let(:aal) { Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF }
-      before { identity.ial = ial }
-
-      it 'has basic attributes' do
-        aggregate_failures do
-          expect(user_info[:sub]).to eq(identity.uuid)
-          expect(user_info[:iss]).to eq(root_url)
-          expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
-          expect(user_info[:email_verified]).to eq(true)
-          expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
-          expect(user_info[:ial]).to eq(ial_value)
-          expect(user_info[:aal]).to eq(aal)
-        end
-      end
-
-      it 'does not return ial2 attributes' do
-        aggregate_failures do
-          expect(user_info[:given_name]).to eq(nil)
-          expect(user_info[:family_name]).to eq(nil)
-          expect(user_info[:birthdate]).to eq(nil)
-          expect(user_info[:phone]).to eq(nil)
-          expect(user_info[:phone_verified]).to eq(nil)
-          expect(user_info[:address]).to eq(nil)
-        end
-      end
-    end
-
-    context 'when a piv/cac was used as second factor' do
-      let(:x509) do
-        {
-          subject: x509_subject,
-        }
-      end
-
-      let(:x509_subject) { 'x509-subject' }
-
-      before do
-        OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
-      end
-
-      context 'when the identity has piv/cac associated' do
-        let(:identity) do
-          build(
-            :service_provider_identity,
-            rails_session_id: rails_session_id,
-            user: create(:user, :with_piv_or_cac),
-            scope: scope,
-          )
-        end
-
-        context 'when the scope includes all attributes' do
-          it 'returns x509 attributes' do
-            aggregate_failures do
-              expect(user_info[:x509_subject]).to eq(x509_subject)
-            end
-          end
-
-          it 'renders values as simple strings as json' do
-            json = user_info.as_json
-
-            expect(json['x509_subject']).to eq(x509_subject)
+          aggregate_failures do
+            expect(user_info[:sub]).to eq(identity.uuid)
+            expect(user_info[:iss]).to eq(root_url)
+            expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
+            expect(user_info[:email_verified]).to eq(true)
+            expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
+            expect(user_info[:ial]).to eq(ial)
+            expect(user_info[:aal]).to eq(aal)
           end
         end
       end
 
-      context 'when the identity has no piv/cac associated' do
-        context 'when the scope includes all attributes' do
-          it 'returns no x509 attributes' do
-            aggregate_failures do
-              expect(user_info[:x509_subject]).to be_blank
-            end
+      context 'ialmax' do
+        let(:ial) { Idp::Constants::IAL_MAX }
+        let(:ial_value) { Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[ial] }
+        let(:aal) { Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF }
+        before { identity.ial = ial }
+
+        it 'has basic attributes' do
+          aggregate_failures do
+            expect(user_info[:sub]).to eq(identity.uuid)
+            expect(user_info[:iss]).to eq(root_url)
+            expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
+            expect(user_info[:email_verified]).to eq(true)
+            expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
+            expect(user_info[:ial]).to eq(ial_value)
+            expect(user_info[:aal]).to eq(aal)
           end
         end
-      end
-    end
-
-    context 'when there is decrypted ial2 session data in redis' do
-      let(:pii) do
-        {
-          first_name: 'John',
-          last_name: 'Smith',
-          dob: '12/31/1970',
-          address1: '123 Fake St',
-          address2: 'Apt 456',
-          city: 'Washington',
-          state: 'DC',
-          zipcode: '  12345-1234',
-          phone: '(703) 555-5555',
-          ssn: '666661234',
-        }
-      end
-
-      before do
-        OutOfBandSessionAccessor.new(rails_session_id).put_pii(
-          profile_id: profile.id,
-          pii: pii,
-          expiration: 5.minutes.to_i,
-        )
-      end
-
-      context 'when the identity has ial2 access' do
-        before { identity.ial = Idp::Constants::IAL2 }
-
-        context 'when the scope includes all attributes' do
-          it 'returns ial2 attributes' do
-            aggregate_failures do
-              expect(user_info[:given_name]).to eq('John')
-              expect(user_info[:family_name]).to eq('Smith')
-              expect(user_info[:birthdate]).to eq('1970-12-31')
-              expect(user_info[:phone]).to eq('+17035555555')
-              expect(user_info[:phone_verified]).to eq(true)
-              expect(user_info[:address]).to eq(
-                formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
-                street_address: "123 Fake St\nApt 456",
-                locality: 'Washington',
-                region: 'DC',
-                postal_code: '12345',
-              )
-              expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
-              expect(user_info[:social_security_number]).to eq('666661234')
-            end
-          end
-
-          it 'renders values as simple strings as json' do
-            json = user_info.as_json
-
-            expect(json['given_name']).to eq('John')
-          end
-        end
-
-        context 'when the scope only includes minimal attributes' do
-          let(:scope) { 'openid email phone' }
-
-          it 'returns attributes allowed by the scope' do
-            aggregate_failures do
-              expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
-              expect(user_info[:email_verified]).to eq(true)
-              expect(user_info[:given_name]).to eq(nil)
-              expect(user_info[:family_name]).to eq(nil)
-              expect(user_info[:birthdate]).to eq(nil)
-              expect(user_info[:phone]).to eq('+17035555555')
-              expect(user_info[:phone_verified]).to eq(true)
-              expect(user_info[:address]).to eq(nil)
-              expect(user_info[:verified_at]).to eq(nil)
-              expect(user_info[:social_security_number]).to eq(nil)
-            end
-          end
-        end
-
-        context 'verified_at' do
-          let(:scope) { 'openid profile:verified_at' }
-
-          context 'when the service provider has ial1 access' do
-            let(:service_provider_ial) { 1 }
-
-            it 'does not provide verified_at' do
-              expect(user_info[:verified_at]).to eq(nil)
-            end
-          end
-
-          context 'when the service provider has ial2 access' do
-            let(:service_provider_ial) { 2 }
-
-            it 'provides verified_at' do
-              expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
-            end
-          end
-        end
-      end
-
-      context 'when the identity only has ial1 access' do
-        before { identity.ial = Idp::Constants::IAL1 }
 
         it 'does not return ial2 attributes' do
           aggregate_failures do
@@ -232,51 +75,210 @@ RSpec.describe OpenidConnectUserInfoPresenter do
         end
       end
 
-      context 'when the identity has ialmax access' do
-        before { identity.ial = Idp::Constants::IAL_MAX }
+      context 'when a piv/cac was used as second factor' do
+        let(:x509) do
+          {
+            subject: x509_subject,
+          }
+        end
 
-        context 'when the scope includes all attributes' do
-          it 'returns ial2 attributes' do
-            aggregate_failures do
-              expect(user_info[:given_name]).to eq('John')
-              expect(user_info[:family_name]).to eq('Smith')
-              expect(user_info[:birthdate]).to eq('1970-12-31')
-              expect(user_info[:phone]).to eq('+17035555555')
-              expect(user_info[:phone_verified]).to eq(true)
-              expect(user_info[:address]).to eq(
-                formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
-                street_address: "123 Fake St\nApt 456",
-                locality: 'Washington',
-                region: 'DC',
-                postal_code: '12345',
-              )
-              expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
-              expect(user_info[:social_security_number]).to eq('666661234')
-            end
+        let(:x509_subject) { 'x509-subject' }
+
+        before do
+          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
+        end
+
+        context 'when the identity has piv/cac associated' do
+          let(:identity) do
+            build(
+              :service_provider_identity,
+              rails_session_id: rails_session_id,
+              user: create(:user, :with_piv_or_cac),
+              scope: scope,
+            )
           end
 
-          it 'renders values as simple strings as json' do
-            json = user_info.as_json
+          context 'when the scope includes all attributes' do
+            it 'returns x509 attributes' do
+              aggregate_failures do
+                expect(user_info[:x509_subject]).to eq(x509_subject)
+              end
+            end
 
-            expect(json['given_name']).to eq('John')
+            it 'renders values as simple strings as json' do
+              json = user_info.as_json
+
+              expect(json['x509_subject']).to eq(x509_subject)
+            end
           end
         end
 
-        context 'when the scope only includes minimal attributes' do
-          let(:scope) { 'openid email phone' }
+        context 'when the identity has no piv/cac associated' do
+          context 'when the scope includes all attributes' do
+            it 'returns no x509 attributes' do
+              aggregate_failures do
+                expect(user_info[:x509_subject]).to be_blank
+              end
+            end
+          end
+        end
+      end
 
-          it 'returns attributes allowed by the scope' do
+      context 'when there is decrypted ial2 session data in redis' do
+        let(:pii) do
+          {
+            first_name: 'John',
+            last_name: 'Smith',
+            dob: '12/31/1970',
+            address1: '123 Fake St',
+            address2: 'Apt 456',
+            city: 'Washington',
+            state: 'DC',
+            zipcode: '  12345-1234',
+            phone: '(703) 555-5555',
+            ssn: '666661234',
+          }
+        end
+
+        before do
+          OutOfBandSessionAccessor.new(rails_session_id).put_pii(
+            profile_id: profile.id,
+            pii: pii,
+            expiration: 5.minutes.to_i,
+          )
+        end
+
+        context 'when the identity has ial2 access' do
+          before { identity.ial = Idp::Constants::IAL2 }
+
+          context 'when the scope includes all attributes' do
+            it 'returns ial2 attributes' do
+              aggregate_failures do
+                expect(user_info[:given_name]).to eq('John')
+                expect(user_info[:family_name]).to eq('Smith')
+                expect(user_info[:birthdate]).to eq('1970-12-31')
+                expect(user_info[:phone]).to eq('+17035555555')
+                expect(user_info[:phone_verified]).to eq(true)
+                expect(user_info[:address]).to eq(
+                  formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
+                  street_address: "123 Fake St\nApt 456",
+                  locality: 'Washington',
+                  region: 'DC',
+                  postal_code: '12345',
+                )
+                expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
+                expect(user_info[:social_security_number]).to eq('666661234')
+              end
+            end
+
+            it 'renders values as simple strings as json' do
+              json = user_info.as_json
+
+              expect(json['given_name']).to eq('John')
+            end
+          end
+
+          context 'when the scope only includes minimal attributes' do
+            let(:scope) { 'openid email phone' }
+
+            it 'returns attributes allowed by the scope' do
+              aggregate_failures do
+                expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
+                expect(user_info[:email_verified]).to eq(true)
+                expect(user_info[:given_name]).to eq(nil)
+                expect(user_info[:family_name]).to eq(nil)
+                expect(user_info[:birthdate]).to eq(nil)
+                expect(user_info[:phone]).to eq('+17035555555')
+                expect(user_info[:phone_verified]).to eq(true)
+                expect(user_info[:address]).to eq(nil)
+                expect(user_info[:verified_at]).to eq(nil)
+                expect(user_info[:social_security_number]).to eq(nil)
+              end
+            end
+          end
+
+          context 'verified_at' do
+            let(:scope) { 'openid profile:verified_at' }
+
+            context 'when the service provider has ial1 access' do
+              let(:service_provider_ial) { 1 }
+
+              it 'does not provide verified_at' do
+                expect(user_info[:verified_at]).to eq(nil)
+              end
+            end
+
+            context 'when the service provider has ial2 access' do
+              let(:service_provider_ial) { 2 }
+
+              it 'provides verified_at' do
+                expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
+              end
+            end
+          end
+        end
+
+        context 'when the identity only has ial1 access' do
+          before { identity.ial = Idp::Constants::IAL1 }
+
+          it 'does not return ial2 attributes' do
             aggregate_failures do
-              expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
-              expect(user_info[:email_verified]).to eq(true)
               expect(user_info[:given_name]).to eq(nil)
               expect(user_info[:family_name]).to eq(nil)
               expect(user_info[:birthdate]).to eq(nil)
-              expect(user_info[:phone]).to eq('+17035555555')
-              expect(user_info[:phone_verified]).to eq(true)
+              expect(user_info[:phone]).to eq(nil)
+              expect(user_info[:phone_verified]).to eq(nil)
               expect(user_info[:address]).to eq(nil)
-              expect(user_info[:verified_at]).to eq(nil)
-              expect(user_info[:social_security_number]).to eq(nil)
+            end
+          end
+        end
+
+        context 'when the identity has ialmax access' do
+          before { identity.ial = Idp::Constants::IAL_MAX }
+
+          context 'when the scope includes all attributes' do
+            it 'returns ial2 attributes' do
+              aggregate_failures do
+                expect(user_info[:given_name]).to eq('John')
+                expect(user_info[:family_name]).to eq('Smith')
+                expect(user_info[:birthdate]).to eq('1970-12-31')
+                expect(user_info[:phone]).to eq('+17035555555')
+                expect(user_info[:phone_verified]).to eq(true)
+                expect(user_info[:address]).to eq(
+                  formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
+                  street_address: "123 Fake St\nApt 456",
+                  locality: 'Washington',
+                  region: 'DC',
+                  postal_code: '12345',
+                )
+                expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
+                expect(user_info[:social_security_number]).to eq('666661234')
+              end
+            end
+
+            it 'renders values as simple strings as json' do
+              json = user_info.as_json
+
+              expect(json['given_name']).to eq('John')
+            end
+          end
+
+          context 'when the scope only includes minimal attributes' do
+            let(:scope) { 'openid email phone' }
+
+            it 'returns attributes allowed by the scope' do
+              aggregate_failures do
+                expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
+                expect(user_info[:email_verified]).to eq(true)
+                expect(user_info[:given_name]).to eq(nil)
+                expect(user_info[:family_name]).to eq(nil)
+                expect(user_info[:birthdate]).to eq(nil)
+                expect(user_info[:phone]).to eq('+17035555555')
+                expect(user_info[:phone_verified]).to eq(true)
+                expect(user_info[:address]).to eq(nil)
+                expect(user_info[:verified_at]).to eq(nil)
+                expect(user_info[:social_security_number]).to eq(nil)
+              end
             end
           end
         end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12563](https://cm-jira.usa.gov/browse/LG-12563)

## 🛠 Summary of changes

Added code to `UserinfoController` to report VoT information as part of the user info iff the SP asks for it.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify by inspection that the new specs in this PR cover the desired behavior
