### PR TITLE
LG-12617: Add additional profile details to IdV analytics logs

### DIFF
--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -50,7 +50,7 @@ module Idv
     def common_analytics_attributes
       {
         proofing_components: proofing_components,
-      }
+      }.compact
     end
 
     def proofing_components

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -50,7 +50,19 @@ module Idv
     def common_analytics_attributes
       {
         proofing_components: proofing_components,
+        active_profile_idv_level: active_profile&.idv_level,
+        pending_profile_idv_level: pending_profile&.idv_level,
       }.compact
+    end
+
+    def active_profile
+      return if !user&.respond_to?(:active_profile) || !user.active_profile
+      user.active_profile
+    end
+
+    def pending_profile
+      return if !user&.respond_to?(:pending_profile) || !user.pending_profile
+      user.pending_profile
     end
 
     def proofing_components

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -52,6 +52,8 @@ module Idv
         proofing_components: proofing_components,
         active_profile_idv_level: active_profile&.idv_level,
         pending_profile_idv_level: pending_profile&.idv_level,
+        profile_history: profile_history,
+
       }.compact
     end
 
@@ -63,6 +65,13 @@ module Idv
     def pending_profile
       return if !user&.respond_to?(:pending_profile) || !user.pending_profile
       user.pending_profile
+    end
+
+    def profile_history
+      return [] if !user&.respond_to?(:profiles)
+      (user&.profiles || []).
+        sort_by { |profile| profile.created_at }.
+        map { |profile| ProfileLogging.new(profile) }
     end
 
     def proofing_components

--- a/app/services/idv/profile_logging.rb
+++ b/app/services/idv/profile_logging.rb
@@ -1,0 +1,22 @@
+module Idv
+  ProfileLogging = Struct.new(:profile) do
+    def as_json
+      profile.slice(
+        %i[
+          id
+          active
+          idv_level
+          created_at
+          verified_at
+          activated_at
+          in_person_verification_pending_at
+          gpo_verification_pending_at
+          fraud_review_pending_at
+          fraud_rejection_at
+          fraud_pending_reason
+          deactivation_reason
+        ],
+      ).compact
+    end
+  end
+end

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -30,19 +30,18 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
     ).to eq([Idv::AnalyticsEventsEnhancer.const_source_location(:DECORATED_METHODS).first])
   end
 
-  it 'calls analytics method with original and decorated attributes' do
+  it 'calls analytics method with original attributes' do
     analytics.idv_final(extra: true)
-
-    expect(analytics.called_kwargs).to eq(extra: true, proofing_components: nil)
+    expect(analytics.called_kwargs).to eq(extra: true)
   end
 
   context 'with anonymous analytics user' do
     let(:user) { AnonymousUser.new }
 
-    it 'calls analytics method with original and decorated attributes' do
+    it 'calls analytics method with original attributes' do
       analytics.idv_final(extra: true)
 
-      expect(analytics.called_kwargs).to eq(extra: true, proofing_components: nil)
+      expect(analytics.called_kwargs).to eq(extra: true)
     end
   end
 

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -45,22 +45,36 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
     end
   end
 
-  context 'with proofing component' do
-    let(:proofing_components) do
-      ProofingComponent.new(source_check: Idp::Constants::Vendors::AAMVA)
-    end
+  describe 'proofing_components' do
+    let(:proofing_components) { nil }
 
     before do
       user.proofing_component = proofing_components
     end
 
-    it 'calls analytics method with original and decorated attributes' do
-      analytics.idv_final(extra: true)
+    context 'without proofing component' do
+      it 'calls analytics method with original attributes' do
+        analytics.idv_final(extra: true)
 
-      expect(analytics.called_kwargs).to match(
-        extra: true,
-        proofing_components: kind_of(Idv::ProofingComponentsLogging),
-      )
+        expect(analytics.called_kwargs).to match(
+          extra: true,
+        )
+      end
+    end
+
+    context 'with proofing component' do
+      let(:proofing_components) do
+        ProofingComponent.new(source_check: Idp::Constants::Vendors::AAMVA)
+      end
+
+      it 'calls analytics method with original attributes and proofing_components' do
+        analytics.idv_final(extra: true)
+
+        expect(analytics.called_kwargs).to match(
+          extra: true,
+          proofing_components: kind_of(Idv::ProofingComponentsLogging),
+        )
+      end
     end
   end
 end

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -77,4 +77,47 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
       end
     end
   end
+
+  describe 'active_profile_idv_level' do
+    context 'without an active profile' do
+      it 'calls analytics method with original attributes but not active_profile_idv_level' do
+        analytics.idv_final(extra: true)
+        expect(analytics.called_kwargs).to match(extra: true)
+      end
+    end
+
+    context 'with an active profile' do
+      let(:user) { create(:user) }
+      let!(:profile) { create(:profile, :active, user: user) }
+
+      it 'calls analytics method with original attributes and active_profile_idv_level' do
+        analytics.idv_final(extra: true)
+        expect(analytics.called_kwargs).to match(
+          extra: true,
+          active_profile_idv_level: 'legacy_unsupervised',
+        )
+      end
+    end
+  end
+
+  describe 'pending_profile_idv_level' do
+    context 'without a pending profile' do
+      it 'calls analytics method with original attributes but not pending_profile_idv_level' do
+        analytics.idv_final(extra: true)
+        expect(analytics.called_kwargs).to match(extra: true)
+      end
+    end
+
+    context 'with a pending profile' do
+      let(:user) { create(:user) }
+      let!(:profile) { create(:profile, :verify_by_mail_pending, user: user) }
+
+      it 'calls analytics method with original attributes and pending_profile_idv_level' do
+        analytics.idv_final(extra: true)
+        expect(analytics.called_kwargs).to include(
+          pending_profile_idv_level: 'legacy_unsupervised',
+        )
+      end
+    end
+  end
 end

--- a/spec/services/idv/profile_logging_spec.rb
+++ b/spec/services/idv/profile_logging_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Idv::ProfileLogging do
+  describe '#as_json' do
+    context 'active profile' do
+      let(:profile) { create(:profile, :active) }
+
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(%i[id active activated_at created_at idv_level verified_at]),
+        )
+      end
+    end
+
+    context 'gpo pending profile' do
+      let(:profile) { create(:profile, :verify_by_mail_pending) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level
+               gpo_verification_pending_at],
+          ),
+        )
+      end
+    end
+
+    context 'in person pending profile' do
+      let(:profile) { create(:profile, :in_person_verification_pending) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level
+               in_person_verification_pending_at],
+          ),
+        )
+      end
+    end
+
+    context 'fraud review pending' do
+      let(:profile) { create(:profile, :fraud_review_pending) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level
+               fraud_pending_reason fraud_review_pending_at],
+          ),
+        )
+      end
+    end
+
+    context 'fraud rejection' do
+      let(:profile) { create(:profile, :fraud_rejection) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level fraud_pending_reason fraud_rejection_at],
+          ),
+        )
+      end
+    end
+
+    context 'password reset profile' do
+      let(:profile) { create(:profile, :password_reset) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level deactivation_reason],
+          ),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12617](https://cm-jira.usa.gov/browse/LG-12617)

## 🛠 Summary of changes

This PR starts augmenting identity verification related analytics events with information about the user's existing profiles:

* `active_profile_idv_level` contains the level of identity verification for the user's active profile (if any)
* `pending_profile_idv_level` contains the level of identity verification for the user's pending profile (if any)
* `profile_history` contains an array with metadata about the user's profiles. This includes various `*_at` timestamps and other flags. `nil` values are excluded.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Start monitoring your `events.log`: `tail -f log/events.log`
- Go through identity verification and verify that `profile_history` is added to IdV events
- Reset your password
- Go back through identity verification and verify that `profile_history` on new events includes the user's old profile and, after verification, their new one as well.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
