### PR TITLE
Remove unnecessary background styles from language picker

### DIFF
--- a/app/assets/stylesheets/components/_language-picker.scss
+++ b/app/assets/stylesheets/components/_language-picker.scss
@@ -22,11 +22,7 @@
 .language-picker__label {
   align-items: center;
   display: flex;
-  background-position: right units(1.5) center;
-  background-position-y: calc(50% + 2px);
-  padding: units(0.5);
-  padding-left: units(1);
-  padding-right: units(1);
+  padding: units(0.5) units(1);
   border-color: transparent;
 
   @include at-media-max('tablet') {


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a few language picker styles leftover after #10098, where prior to that pull request the expander icon was implemented as a background image.

These styles do nothing because the background image is always removed:

https://github.com/18F/identity-idp/blob/ddf78f0bfa51cfa1408924501d6e4fb819092fff/app/assets/stylesheets/components/_language-picker.scss#L46-L49

This was noticed as part of adapting the styles to the brochure site in https://github.com/GSA-TTS/identity-site/pull/1219 .

I also simplified multiple `padding` styles to a single shorthand `Y X` format ([reference](https://developer.mozilla.org/en-US/docs/Web/CSS/padding#syntax)).

## 📜 Testing Plan

Verify no regression in the appearance of the language picker, notably the expander icon, on both desktop and mobile.
