### PR TITLE
Clean PIV session detail after deletion

### DIFF
--- a/app/controllers/api/internal/two_factor_authentication/piv_cac_controller.rb
+++ b/app/controllers/api/internal/two_factor_authentication/piv_cac_controller.rb
@@ -4,6 +4,7 @@ module Api
       class PivCacController < ApplicationController
         include CsrfTokenConcern
         include ReauthenticationRequiredConcern
+        include PivCacConcern
 
         before_action :render_unauthorized, unless: :recently_authenticated_2fa?
 
@@ -38,6 +39,7 @@ module Api
             create_user_event(:piv_cac_disabled)
             revoke_remember_device(current_user)
             deliver_push_notification
+            clear_piv_cac_information
             render json: { success: true }
           else
             render json: { success: false, error: result.first_error_message }, status: :bad_request

--- a/spec/controllers/api/internal/two_factor_authentication/piv_cac_controller_spec.rb
+++ b/spec/controllers/api/internal/two_factor_authentication/piv_cac_controller_spec.rb
@@ -142,6 +142,12 @@ RSpec.describe Api::Internal::TwoFactorAuthentication::PivCacController do
       end
     end
 
+    it 'removes the piv/cac information from the user session' do
+      controller.user_session[:decrypted_x509] = {}
+      response
+      expect(controller.user_session[:decrypted_x509]).to be_nil
+    end
+
     it 'logs a user event for the removed credential' do
       expect { response }.to change { user.events.piv_cac_disabled.size }.by 1
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds missing PIV behavior for deleted PIV, expected to remove cached `user_session` detail. This carries forward from the original implementation preceding #9861, removed in #10218.

https://github.com/18F/identity-idp/blob/b456d8556fc684179c015e818539cd3082574ad7/app/controllers/users/piv_cac_authentication_setup_controller.rb#L39

## 📜 Testing Plan

```
rspec spec/controllers/api/internal/two_factor_authentication/piv_cac_controller_spec.rb
```