### PR TITLE
Switch to have_current_path for MFA path comparison

### DIFF
--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
     scenario 'user can set up 2 MFA methods properly' do
       sign_in_before_2fa
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
 
       click_2fa_option('phone')
       click_2fa_option('backup_code')
@@ -23,7 +23,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
       expect(page).
         to have_content t('headings.add_info.phone')
 
-      expect(current_path).to eq phone_setup_path
+      expect(page).to have_current_path phone_setup_path
 
       fill_in 'new_phone_form_phone', with: '703-555-1212'
       click_send_one_time_code
@@ -31,7 +31,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq backup_code_setup_path
+      expect(page).to have_current_path backup_code_setup_path
 
       click_continue
 
@@ -41,13 +41,13 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
 
       expect(page).to have_content(t('notices.backup_codes_configured'))
       expect(fake_analytics).to have_logged_event('User registration: complete')
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
 
     scenario 'user can select 2 MFA methods and then chooses another method during' do
       sign_in_before_2fa
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
 
       click_2fa_option('phone')
       click_2fa_option('backup_code')
@@ -57,7 +57,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
       expect(page).
         to have_content t('headings.add_info.phone')
 
-      expect(current_path).to eq phone_setup_path
+      expect(page).to have_current_path phone_setup_path
 
       fill_in 'new_phone_form_phone', with: '703-555-1212'
       click_send_one_time_code
@@ -65,7 +65,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq backup_code_setup_path
+      expect(page).to have_current_path backup_code_setup_path
 
       click_link t('two_factor_authentication.choose_another_option')
 
@@ -83,21 +83,21 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
       click_submit_default
 
       expect(fake_analytics).to have_logged_event('User registration: complete')
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
 
     scenario 'user can select 2 MFA methods and complete after reauthn window' do
       allow(IdentityConfig.store).to receive(:reauthn_window).and_return(10)
       sign_in_before_2fa
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
 
       click_2fa_option('backup_code')
       click_2fa_option('auth_app')
 
       click_continue
 
-      expect(current_path).to eq authenticator_setup_path
+      expect(page).to have_current_path authenticator_setup_path
 
       fill_in_totp_name
 
@@ -108,10 +108,10 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
       check t('forms.messages.remember_device')
       click_submit_default
 
-      expect(current_path).to eq backup_code_setup_path
+      expect(page).to have_current_path backup_code_setup_path
       travel_to((IdentityConfig.store.reauthn_window + 5).seconds.from_now) do
         click_continue
-        expect(current_path).to eq login_two_factor_options_path
+        expect(page).to have_current_path login_two_factor_options_path
 
         find("label[for='two_factor_options_form_selection_auth_app']").click
         click_on t('forms.buttons.continue')
@@ -128,14 +128,14 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
 
         expect(page).to have_content(t('notices.backup_codes_configured'))
 
-        expect(current_path).to eq account_path
+        expect(page).to have_current_path account_path
       end
     end
 
     scenario 'user can select 1 MFA methods and will be prompted to add another method' do
       sign_in_before_2fa
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
 
       click_2fa_option('phone')
 
@@ -158,7 +158,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
 
       click_button t('mfa.skip')
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
 
     describe 'skipping second mfa' do
@@ -168,7 +168,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
           click_2fa_option('backup_code')
 
           click_continue
-          expect(current_path).to eq backup_code_setup_path
+          expect(page).to have_current_path backup_code_setup_path
 
           click_continue
           expect(page).to have_link(t('components.download_button.label'))
@@ -189,7 +189,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
           click_2fa_option('backup_code')
 
           click_continue
-          expect(current_path).to eq backup_code_setup_path
+          expect(page).to have_current_path backup_code_setup_path
 
           click_continue
           expect(page).to have_link(t('components.download_button.label'))
@@ -214,7 +214,7 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
           mock_webauthn_setup_challenge
           user = sign_up_and_set_password
           user.password = Features::SessionHelper::VALID_PASSWORD
-          expect(current_path).to eq authentication_methods_setup_path
+          expect(page).to have_current_path authentication_methods_setup_path
           # webauthn option is hidden in browsers that don't support it
           select_2fa_option('webauthn_platform', visible: :all)
 
@@ -242,13 +242,13 @@ RSpec.feature 'Multi Two Factor Authentication', allowed_extra_analytics: [:*] d
     before do
       sign_in_before_2fa
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
 
       click_2fa_option('backup_code')
 
       click_continue
 
-      expect(current_path).to eq backup_code_setup_path
+      expect(page).to have_current_path backup_code_setup_path
 
       click_continue
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates flakey specs to use `expect(page).to have_current_path …` instead of `expect(current_path).to eq …`.

These tests have been shown to be occasionally flakey.

Examples:

- https://gitlab.login.gov/lg/identity-idp/-/jobs/1068613
- https://gitlab.login.gov/lg/identity-idp/-/jobs/1057968

Related Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1709311154032829

The hypothesis is there's a race condition where the test signs in with a new user and assumes to arrive at the MFA setup screen. This does happen, but only after a series of redirects, where the [`sign_in_before_mfa` helper](https://github.com/18F/identity-idp/blob/d540121ca00697453faca9daef9f4778638f1db1/spec/support/features/session_helper.rb#L189) attempts to visit the account page.

The thought with using `have_current_path` is that it may help avoid some issues where the previous assertion would be made before the redirect is fully completed. While we [don't allow any default wait](https://github.com/18F/identity-idp/blob/d540121ca00697453faca9daef9f4778638f1db1/spec/support/capybara.rb#L45), Capybara [internally uses](https://github.com/teamcapybara/capybara/blob/c0cbf4024c1abd48b0c22c2930e7b05af58ab284/lib/capybara/session/matchers.rb#L74-L76) [its `document.synchronize` logic](https://github.com/teamcapybara/capybara/blob/master/lib/capybara/node/base.rb#L76) which may still help ["against asynchronicity problems"](https://github.com/teamcapybara/capybara/blob/c0cbf4024c1abd48b0c22c2930e7b05af58ab284/lib/capybara/node/base.rb#L44-L45) even if there is no measurable wait delay.

## 📜 Testing Plan

```
rspec spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
```