### PR TITLE
LG-12655: selfie hints are voiced when voice accessibility is enabled

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -29,7 +29,7 @@ function AcuantSelfieCaptureCanvas({
   const acuantCaptureContainerId = 'acuant-face-capture-container';
   return isReady ? (
     <div id={acuantCaptureContainerId}>
-      <p className="document-capture-selfie-feedback">{imageCaptureText}</p>
+      <p aria-live='assertive' className="document-capture-selfie-feedback">{imageCaptureText}</p>
     </div>
   ) : (
     <FullScreenLoadingSpinner

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -29,7 +29,9 @@ function AcuantSelfieCaptureCanvas({
   const acuantCaptureContainerId = 'acuant-face-capture-container';
   return isReady ? (
     <div id={acuantCaptureContainerId}>
-      <p aria-live='assertive' className="document-capture-selfie-feedback">{imageCaptureText}</p>
+      <p aria-live="assertive" className="document-capture-selfie-feedback">
+        {imageCaptureText}
+      </p>
     </div>
   ) : (
     <FullScreenLoadingSpinner


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-12655](https://cm-jira.usa.gov/browse/LG-12655)

## 🛠 Summary of changes
Allow selfie hints to be read out by screen reader.

## 📜 Testing Plan
- [ ] Enable screen reader on browser
- [ ] Attempt to capture a selfie using the SDK
- [ ] Move your face around the screen and verify that the hints are voiced by the screen reader

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
