### PR TITLE
LG-12657: Make Idv::AnalyticsEventsEnhancer opt-out

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,11 @@ IdentityIdp/UrlOptionsLinter:
   Exclude:
     - 'spec/**/*.rb'
 
+IdentityIdp/EnhancedIdvEventsLinter:
+  Enabled: true
+  Include:
+    - 'app/services/analytics_events.rb'
+
 IdentityIdp/ErrorsAddLinter:
   Enabled: true
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ require:
   - rubocop-rspec
   - rubocop-performance
   - ./lib/linters/analytics_event_name_linter.rb
+  - ./lib/linters/enhanced_idv_events_linter.rb
   - ./lib/linters/localized_validation_message_linter.rb
   - ./lib/linters/image_size_linter.rb
   - ./lib/linters/mail_later_linter.rb

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -624,7 +624,7 @@ module AnalyticsEvents
     success:,
     use_alternate_sdk:,
     liveness_checking_required:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: Acuant SDK loaded',
@@ -635,6 +635,7 @@ module AnalyticsEvents
       success: success,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -665,8 +666,8 @@ module AnalyticsEvents
   end
 
   # User visited idv address page
-  def idv_address_visit
-    track_event('IdV: address visited')
+  def idv_address_visit(**extra)
+    track_event('IdV: address visited', **extra)
   end
 
   # @param [String] acuantCaptureMode
@@ -723,7 +724,7 @@ module AnalyticsEvents
     use_alternate_sdk:,
     liveness_checking_required:,
     width:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: back image added',
@@ -752,6 +753,7 @@ module AnalyticsEvents
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
       width: width,
+      **extra,
     )
   end
 
@@ -770,7 +772,7 @@ module AnalyticsEvents
     source:,
     use_alternate_sdk:,
     liveness_checking_required:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: back image clicked',
@@ -781,23 +783,26 @@ module AnalyticsEvents
       source: source,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
   # @param [String] liveness_checking_required Whether or not the selfie is required
-  def idv_barcode_warning_continue_clicked(liveness_checking_required:, **_extra)
+  def idv_barcode_warning_continue_clicked(liveness_checking_required:, **extra)
     track_event(
       'Frontend: IdV: barcode warning continue clicked',
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
 
   # @param [String] liveness_checking_required Whether or not the selfie is required
-  def idv_barcode_warning_retake_photos_clicked(liveness_checking_required:, **_extra)
+  def idv_barcode_warning_retake_photos_clicked(liveness_checking_required:, **extra)
     track_event(
       'Frontend: IdV: barcode warning retake photos clicked',
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
 
@@ -856,7 +861,7 @@ module AnalyticsEvents
     flow_path:,
     use_alternate_sdk:,
     liveness_checking_required:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: Capture troubleshooting dismissed',
@@ -865,6 +870,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
 
@@ -954,10 +960,11 @@ module AnalyticsEvents
     track_event('IdV: doc auth link_sent visited', **extra)
   end
 
-  def idv_doc_auth_randomizer_defaulted
+  def idv_doc_auth_randomizer_defaulted(**extra)
     track_event(
       'IdV: doc_auth random vendor error',
       error: 'document_capture_session_uuid_key missing',
+      **extra,
     )
   end
 
@@ -1275,7 +1282,7 @@ module AnalyticsEvents
     flow_path:,
     ids:,
     use_alternate_sdk:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: exit optional questions',
@@ -1284,6 +1291,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       ids: ids,
       use_alternate_sdk: use_alternate_sdk,
+      **extra,
     )
   end
 
@@ -1394,7 +1402,7 @@ module AnalyticsEvents
     use_alternate_sdk:,
     liveness_checking_required:,
     width:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: front image added',
@@ -1423,6 +1431,7 @@ module AnalyticsEvents
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
       width: width,
+      **extra,
     )
   end
 
@@ -1441,7 +1450,7 @@ module AnalyticsEvents
     source:,
     use_alternate_sdk:,
     liveness_checking_required: nil,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: front image clicked',
@@ -1452,6 +1461,7 @@ module AnalyticsEvents
       source: source,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -1565,7 +1575,7 @@ module AnalyticsEvents
     acuant_version:,
     flow_path:,
     use_alternate_sdk:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: Image capture failed',
@@ -1576,6 +1586,7 @@ module AnalyticsEvents
       acuant_version: acuant_version,
       flow_path: flow_path,
       use_alternate_sdk: use_alternate_sdk,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -2391,8 +2402,8 @@ module AnalyticsEvents
   end
 
   # User visits IdV
-  def idv_intro_visit
-    track_event('IdV: intro visited')
+  def idv_intro_visit(**extra)
+    track_event('IdV: intro visited', **extra)
   end
 
   # @param [String] enrollment_id
@@ -2425,20 +2436,22 @@ module AnalyticsEvents
   def idv_link_sent_capture_doc_polling_complete(
     isCancelled:,
     isRateLimited:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: Link sent capture doc polling complete',
       isCancelled: isCancelled,
       isRateLimited: isRateLimited,
+      **extra,
     )
   end
 
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
-  def idv_link_sent_capture_doc_polling_started(**_extra)
+  def idv_link_sent_capture_doc_polling_started(**extra)
     track_event(
       'Frontend: IdV: Link sent capture doc polling started',
+      **extra,
     )
   end
 
@@ -2497,8 +2510,8 @@ module AnalyticsEvents
   end
 
   # Tracks when user reaches verify errors due to being rejected due to fraud
-  def idv_not_verified_visited
-    track_event('IdV: Not verified visited')
+  def idv_not_verified_visited(**extra)
+    track_event('IdV: Not verified visited', **extra)
   end
 
   # Tracks if a user clicks the 'acknowledge' checkbox during personal
@@ -2934,7 +2947,7 @@ module AnalyticsEvents
     source:,
     liveness_checking_required:,
     width:,
-    **_extra
+    **extra
   )
     track_event(
       :idv_selfie_image_added,
@@ -2948,6 +2961,7 @@ module AnalyticsEvents
       source: source,
       liveness_checking_required: liveness_checking_required,
       width: width,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -3099,7 +3113,7 @@ module AnalyticsEvents
     flow_path:,
     location:,
     use_alternate_sdk:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: warning action triggered',
@@ -3108,6 +3122,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       location: location,
       use_alternate_sdk: use_alternate_sdk,
+      **extra,
     )
   end
 
@@ -3132,7 +3147,7 @@ module AnalyticsEvents
     subheading:,
     use_alternate_sdk:,
     liveness_checking_required:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: warning shown',
@@ -3146,6 +3161,7 @@ module AnalyticsEvents
       subheading: subheading,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
 

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -1,48 +1,132 @@
 module Idv
   module AnalyticsEventsEnhancer
-    DECORATED_METHODS = %i[
-      idv_cancellation_confirmed
-      idv_cancellation_go_back
-      idv_cancellation_visited
-      idv_forgot_password
-      idv_forgot_password_confirmed
-      idv_final
-      idv_gpo_address_letter_enqueued
-      idv_gpo_address_letter_requested
-      idv_in_person_ready_to_verify_visit
-      idv_letter_enqueued_visit
-      idv_personal_key_acknowledgment_toggled
-      idv_personal_key_downloaded
-      idv_personal_key_submitted
-      idv_personal_key_visited
-      idv_phone_confirmation_form_submitted
-      idv_phone_confirmation_otp_rate_limit_attempts
-      idv_phone_confirmation_otp_rate_limit_locked_out
-      idv_phone_confirmation_otp_rate_limit_sends
-      idv_phone_confirmation_otp_resent
-      idv_phone_confirmation_otp_sent
-      idv_phone_confirmation_otp_submitted
-      idv_phone_confirmation_otp_visit
-      idv_phone_confirmation_vendor_submitted
-      idv_phone_error_visited
-      idv_phone_of_record_visited
-      idv_phone_otp_delivery_selection_visit
-      idv_phone_otp_delivery_selection_submitted
-      idv_proofing_resolution_result_missing
-      idv_enter_password_submitted
-      idv_enter_password_visited
-      idv_please_call_visited
-      idv_start_over
-    ].freeze
-
-    DECORATED_METHODS.each do |method_name|
-      define_method(method_name) do |**kwargs|
-        super(**kwargs, **common_analytics_attributes)
-      end
-    end
+    IGNORED_METHODS = %i[
+      idv_acuant_sdk_loaded
+      idv_address_submitted
+      idv_address_visit
+      idv_back_image_added
+      idv_back_image_clicked
+      idv_barcode_warning_continue_clicked
+      idv_barcode_warning_retake_photos_clicked
+      idv_capture_troubleshooting_dismissed
+      idv_consent_checkbox_toggled
+      idv_doc_auth_agreement_submitted
+      idv_doc_auth_agreement_visited
+      idv_doc_auth_capture_complete_visited
+      idv_doc_auth_document_capture_submitted
+      idv_doc_auth_document_capture_visited
+      idv_doc_auth_exception_visited
+      idv_doc_auth_failed_image_resubmitted
+      idv_doc_auth_how_to_verify_submitted
+      idv_doc_auth_how_to_verify_visited
+      idv_doc_auth_hybrid_handoff_submitted
+      idv_doc_auth_hybrid_handoff_visited
+      idv_doc_auth_link_sent_submitted
+      idv_doc_auth_link_sent_visited
+      idv_doc_auth_randomizer_defaulted
+      idv_doc_auth_redo_ssn_submitted
+      idv_doc_auth_ssn_submitted
+      idv_doc_auth_ssn_visited
+      idv_doc_auth_submitted_image_upload_form
+      idv_doc_auth_submitted_image_upload_vendor
+      idv_doc_auth_submitted_pii_validation
+      idv_doc_auth_verify_proofing_results
+      idv_doc_auth_verify_submitted
+      idv_doc_auth_verify_visited
+      idv_doc_auth_warning_visited
+      idv_doc_auth_welcome_submitted
+      idv_doc_auth_welcome_visited
+      idv_exit_optional_questions
+      idv_front_image_added
+      idv_front_image_clicked
+      idv_gpo_confirm_start_over_before_letter_visited
+      idv_gpo_confirm_start_over_visited
+      idv_gpo_expired
+      idv_gpo_reminder_email_sent
+      idv_image_capture_failed
+      idv_in_person_email_reminder_job_email_initiated
+      idv_in_person_email_reminder_job_exception
+      idv_in_person_location_submitted
+      idv_in_person_location_visited
+      idv_in_person_locations_request_failure
+      idv_in_person_locations_searched
+      idv_in_person_prepare_submitted
+      idv_in_person_prepare_visited
+      idv_in_person_proofing_address_visited
+      idv_in_person_proofing_cancel_update_state_id
+      idv_in_person_proofing_enrollments_ready_for_status_check_job_completed
+      idv_in_person_proofing_enrollments_ready_for_status_check_job_ingestion_error
+      idv_in_person_proofing_enrollments_ready_for_status_check_job_started
+      idv_in_person_proofing_nontransliterable_characters_submitted
+      idv_in_person_proofing_redo_state_id_submitted
+      idv_in_person_proofing_residential_address_submitted
+      idv_in_person_proofing_state_id_submitted
+      idv_in_person_proofing_state_id_visited
+      idv_in_person_ready_to_verify_sp_link_clicked
+      idv_in_person_ready_to_verify_what_to_bring_link_clicked
+      idv_in_person_send_proofing_notification_attempted
+      idv_in_person_send_proofing_notification_job_completed
+      idv_in_person_send_proofing_notification_job_exception
+      idv_in_person_send_proofing_notification_job_skipped
+      idv_in_person_send_proofing_notification_job_started
+      idv_in_person_switch_back_submitted
+      idv_in_person_switch_back_visited
+      idv_in_person_usps_proofing_enrollment_code_email_received
+      idv_in_person_usps_proofing_results_job_completed
+      idv_in_person_usps_proofing_results_job_deadline_passed_email_exception
+      idv_in_person_usps_proofing_results_job_deadline_passed_email_initiated
+      idv_in_person_usps_proofing_results_job_email_initiated
+      idv_in_person_usps_proofing_results_job_enrollment_incomplete
+      idv_in_person_usps_proofing_results_job_enrollment_updated
+      idv_in_person_usps_proofing_results_job_exception
+      idv_in_person_usps_proofing_results_job_please_call_email_initiated
+      idv_in_person_usps_proofing_results_job_started
+      idv_in_person_usps_proofing_results_job_unexpected_response
+      idv_in_person_usps_proofing_results_job_user_sent_to_fraud_review
+      idv_in_person_usps_request_enroll_exception
+      idv_intro_visit
+      idv_ipp_deactivated_for_never_visiting_post_office
+      idv_link_sent_capture_doc_polling_complete
+      idv_link_sent_capture_doc_polling_started
+      idv_mail_only_warning_visited
+      idv_mobile_device_and_camera_check
+      idv_native_camera_forced
+      idv_not_verified_visited
+      idv_phone_use_different
+      idv_request_letter_visited
+      idv_sdk_selfie_image_capture_closed_without_photo
+      idv_sdk_selfie_image_capture_failed
+      idv_sdk_selfie_image_capture_opened
+      idv_selfie_image_added
+      idv_session_error_visited
+      idv_usps_auth_token_refresh_job_completed
+      idv_usps_auth_token_refresh_job_network_error
+      idv_usps_auth_token_refresh_job_started
+      idv_verify_by_mail_enter_code_submitted
+      idv_verify_by_mail_enter_code_visited
+      idv_verify_in_person_troubleshooting_option_clicked
+      idv_warning_action_triggered
+      idv_warning_shown
+    ].to_set.freeze
 
     def self.included(_mod)
       raise 'this mixin is intended to be prepended, not included'
+    end
+
+    def self.prepended(mod)
+      mod.instance_methods.each do |method_name|
+        if should_enhance_method?(method_name)
+          mod.define_method method_name do |**kwargs|
+            super(**kwargs, **common_analytics_attributes)
+          end
+        end
+      end
+    end
+
+    def self.should_enhance_method?(method_name)
+      return false if IGNORED_METHODS.include?(method_name)
+
+      method_name.start_with?('idv_')
     end
 
     private

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -50,7 +50,7 @@ module Idv
     def common_analytics_attributes
       {
         proofing_components: proofing_components,
-      }
+      }.compact
     end
 
     def proofing_components

--- a/lib/linters/enhanced_idv_events_linter.rb
+++ b/lib/linters/enhanced_idv_events_linter.rb
@@ -1,0 +1,200 @@
+module RuboCop
+  module Cop
+    module IdentityIdp
+      class EnhancedIdvEventsLinter < RuboCop::Cop::Base
+        extend AutoCorrector
+        include MultilineElementLineBreaks
+
+        RESTRICT_ON_SEND = [:track_event]
+
+        ENHANCED_ARGS = [:proofing_components].freeze
+
+        def on_send(track_event_send)
+          method = track_event_send.each_ancestor(:def).first
+          return if !should_check_method?(method.method_name)
+
+          ENHANCED_ARGS.each do |arg_name|
+            check_arg_present_on_event_method(arg_name, method)
+            check_arg_present_in_track_event_send(arg_name, track_event_send)
+          end
+        end
+
+        private
+
+        def check_arg_present_in_track_event_send(arg_name, track_event_send)
+          # We expect there is a hash that includes arg_name
+          hash_arg = track_event_send.each_descendant.find do |node|
+            next unless node.hash_type?
+            node.pairs.any? { |pair| pair.key.type == :sym && pair.key.value == arg_name }
+          end
+
+          return if hash_arg
+
+          message = "#{arg_name} is missing from track_event call."
+          add_offense(track_event_send, message:) do |corrector|
+            correct_arg_missing_from_track_event_send(arg_name, track_event_send, corrector)
+          end
+        end
+
+        def check_arg_present_on_event_method(arg_name, method)
+          arg = method.arguments.find { |a| a.name == arg_name }
+          return if arg
+
+          add_offense(method, message: "Method is missing #{arg_name} argument.") do |corrector|
+            correct_arg_missing_from_event_method(arg_name, method, corrector)
+          end
+        end
+
+        def correct_arg_missing_from_event_method(arg_name, method, corrector)
+          arg = method.arguments.find { |a| a.kwarg_type? && a.name == arg_name }
+          return if arg
+
+          kwrest = method.arguments.find { |a| a.kwrestarg_type? }
+          return if !kwrest
+
+          new_arg = "#{arg_name}: nil"
+
+          if all_on_same_line?(method.arguments)
+            indent = indentation_for_node(method)
+
+            proposed_line_length = [
+              indent.length,
+              method.method_name.length + 2,
+              method.arguments.map { |arg| arg.source }.join(', ').length,
+              new_arg.length + 1,
+            ].sum
+
+            if proposed_line_length > max_line_length
+              make_method_args_multiline(corrector, method)
+              corrector.insert_before(kwrest, "\n#{indent}  #{new_arg},")
+            else
+              corrector.insert_before(kwrest, "#{new_arg}, ")
+            end
+          else
+            indent = indentation_for_node(kwrest)
+            corrector.insert_before(kwrest, "#{new_arg},\n#{indent}")
+          end
+        end
+
+        def correct_arg_missing_from_track_event_send(arg_name, track_event_send, corrector)
+          hash_arg = track_event_send.arguments.find { |arg| arg.hash_type? }
+          return unless hash_arg
+
+          return if hash_arg.pairs.any? { |pair| pair.key.value == arg_name }
+
+          # Put the reference into the hash, before the splat
+          kwsplat = hash_arg.children.find { |child| child.kwsplat_type? }
+          return unless kwsplat
+
+          new_arg = "#{arg_name}: #{arg_name},"
+          if all_on_same_line?(track_event_send.arguments)
+            indent = indentation_for_node(track_event_send)
+
+            # We might need to convert this to a multi-line invocation
+            proposed_line_length = [
+              indent.length,
+              track_event_send.method_name.length + 2,
+              track_event_send.arguments.map { |arg| arg.source }.join(', ').length,
+              new_arg.length + 1,
+            ].sum
+
+            if proposed_line_length > max_line_length
+              make_send_multiline(corrector, track_event_send)
+              corrector.insert_before(kwsplat, "\n#{indent}  #{new_arg}")
+            else
+              corrector.insert_before(kwsplat, "#{new_arg} ")
+            end
+          else
+            # Assume that we are doing 1 arg per line
+            indent = indentation_for_node(kwsplat)
+            corrector.insert_before(kwsplat, "#{new_arg}\n#{indent}")
+          end
+        end
+
+        def events_enhancer_class
+          # Idv::AnalyticsEventsEnhancer keeps its own record of which
+          # methods it wants to "enhance".
+
+          # Force the class to be reloaded (this supports LSP-type use cases
+          # where the rubocop process may be long-lived.)
+          idv = begin
+            Object.const_get(:Idv)
+          rescue
+            nil
+          end
+
+          idv&.send(:remove_const, 'AnalyticsEventsEnhancer')
+
+          file = File.expand_path(
+            '../../app/services/idv/analytics_events_enhancer.rb',
+            __dir__,
+          )
+
+          load(file)
+
+          ::Idv::AnalyticsEventsEnhancer
+        end
+
+        def make_method_args_multiline(corrector, method)
+          indent = indentation_for_node(method)
+          arg_indent = "\n#{indent}  "
+          paren_indent = "\n#{indent}"
+
+          method.arguments.each do |arg|
+            remove_whitespace_before(arg, corrector)
+            corrector.insert_before(arg, arg_indent)
+          end
+
+          corrector.insert_before(
+            method.arguments.source_range.with(
+              begin_pos: method.arguments.source_range.end_pos - 1,
+            ),
+            paren_indent,
+          )
+        end
+
+        def make_send_multiline(corrector, send)
+          indent = indentation_for_node(send)
+          arg_indent = "\n#{indent}  "
+          paren_indent = "\n#{indent}"
+
+          send.arguments.each do |arg|
+            if arg.hash_type?
+              arg.children.each do |child|
+                remove_whitespace_before(child, corrector)
+                corrector.insert_before(child, arg_indent)
+              end
+            else
+              remove_whitespace_before(arg, corrector)
+              corrector.insert_before(arg, arg_indent)
+            end
+          end
+
+          corrector.insert_before(send.loc.end, paren_indent)
+        end
+
+        def indentation_for_node(node)
+          source_line = processed_source.lines[node.loc.line - 1]
+          m = /^(\s+)/.match(source_line)
+          m[1]
+        end
+
+        def max_line_length
+          config.for_cop('Layout/LineLength')['Max'] || 100
+        end
+
+        def remove_whitespace_before(node, corrector)
+          char_before = node.source_range.with(
+            begin_pos: node.source_range.begin_pos - 1,
+            end_pos: node.source_range.begin_pos,
+          )
+          corrector.remove_preceding(node, 1) if /\s/.match?(char_before.source)
+        end
+
+        def should_check_method?(method_name)
+          events_enhancer_class&.should_enhance_method?(method_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/linters/enhanced_idv_events_linter.rb
+++ b/lib/linters/enhanced_idv_events_linter.rb
@@ -16,10 +16,43 @@ module RuboCop
           ENHANCED_ARGS.each do |arg_name|
             check_arg_present_on_event_method(arg_name, method)
             check_arg_present_in_track_event_send(arg_name, track_event_send)
+            check_arg_has_docs(arg_name, method)
           end
         end
 
         private
+
+        def check_arg_has_docs(arg_name, method)
+          pattern = Regexp.new("# @param \\[.+\\] #{arg_name}")
+          has_docs = preceding_lines(method).any? do |line|
+            line.is_a?(Parser::Source::Comment) && pattern.match?(line.text)
+          end
+
+          return if has_docs
+
+          add_offense(
+            method,
+            message: "Missing @param documentation comment for #{arg_name}",
+          ) do |corrector|
+            last_param_line = preceding_lines(method).reverse.find do |line|
+              line.is_a?(Parser::Source::Comment) && /@param/.match?(line.text)
+            end
+
+            comment = "# @param [Object] #{arg_name} TODO: Write doc comment"
+            indent = indentation_for_node(method)
+            if last_param_line
+              corrector.insert_after(
+                last_param_line,
+                "\n#{indent}#{comment}",
+              )
+            else
+              corrector.insert_before(
+                method,
+                "#{comment}\n#{indent}",
+              )
+            end
+          end
+        end
 
         def check_arg_present_in_track_event_send(arg_name, track_event_send)
           # We expect there is a hash that includes arg_name
@@ -181,6 +214,10 @@ module RuboCop
 
         def max_line_length
           config.for_cop('Layout/LineLength')['Max'] || 100
+        end
+
+        def preceding_lines(node)
+          processed_source.ast_with_comments[node].select { |line| line.loc.line < node.loc.line }
         end
 
         def remove_whitespace_before(node, corrector)

--- a/spec/lib/linters/enhanced_idv_events_linter_spec.rb
+++ b/spec/lib/linters/enhanced_idv_events_linter_spec.rb
@@ -1,0 +1,254 @@
+require 'rubocop'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
+require_relative '../../../lib/linters/enhanced_idv_events_linter'
+
+RSpec.describe RuboCop::Cop::IdentityIdp::EnhancedIdvEventsLinter do
+  include CopHelper
+  include RuboCop::RSpec::ExpectOffense
+
+  let(:config) { RuboCop::Config.new }
+  let(:cop) { RuboCop::Cop::IdentityIdp::EnhancedIdvEventsLinter.new(config) }
+
+  it 'does not register an offense for non-idv methods' do
+    expect_no_offenses(<<~RUBY)
+      module AnalyticsEvents
+        def a_non_idv_method
+            track_event(:a_non_idv_method)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for ignored methods' do
+    expect_no_offenses(<<~RUBY)
+      module AnalyticsEvents
+        def idv_acuant_sdk_loaded
+            track_event(:idv_acuant_sdk_loaded)
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when an idv_ is missing proofing_components' do
+    expect_offense(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method
+        ^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: Method is missing proofing_components argument.
+            track_event(:idv_my_method)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: proofing_components is missing from track_event call.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when an idv_ method is missing proofing_components with **extra' do
+    expect_offense(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(**extra)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: Method is missing proofing_components argument.
+          track_event(:idv_my_method, **extra)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: proofing_components is missing from track_event call.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(proofing_components: nil, **extra)
+          track_event(:idv_my_method, proofing_components: proofing_components, **extra)
+        end
+      end
+    RUBY
+  end
+
+  it 'registers offense when idv_ method missing proofing_components with **extra and other args' do
+    expect_offense(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(other:, **extra)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: Method is missing proofing_components argument.
+          track_event(:idv_my_method, other: other, **extra)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: proofing_components is missing from track_event call.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(other:, proofing_components: nil, **extra)
+          track_event(:idv_my_method, other: other, proofing_components: proofing_components, **extra)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when an proofing_components present on track_event call' do
+    expect_no_offenses(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(proofing_components: nil, **extra)
+          track_event(:idv_my_method, proofing_components: proofing_components, **extra)
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when an proofing_components is missing from track_event call' do
+    expect_offense(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(proofing_components: nil, **extra)
+          track_event(:idv_my_method, **extra)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: proofing_components is missing from track_event call.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(proofing_components: nil, **extra)
+          track_event(:idv_my_method, proofing_components: proofing_components, **extra)
+        end
+      end
+    RUBY
+  end
+
+  it 'can put the track_event arg on its own line if needed' do
+    expect_offense(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(proofing_components: nil, **extra)
+          track_event(
+          ^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: proofing_components is missing from track_event call.
+            :idv_my_method,
+            **extra,
+          )
+        end    
+      end
+    RUBY
+    expect_correction(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(proofing_components: nil, **extra)
+          track_event(
+            :idv_my_method,
+            proofing_components: proofing_components,
+            **extra,
+          )
+        end    
+      end
+    RUBY
+  end
+
+  it 'can put the method arg on its own line if needed' do
+    expect_offense(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(
+        ^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: Method is missing proofing_components argument.
+          foo:,
+          bar:,
+          **extra
+        )
+          track_event(:idv_my_method, proofing_components: proofing_components, **extra)
+        end    
+      end
+    RUBY
+    expect_correction(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method(
+          foo:,
+          bar:,
+          proofing_components: nil,
+          **extra
+        )
+          track_event(:idv_my_method, proofing_components: proofing_components, **extra)
+        end    
+      end
+    RUBY
+  end
+
+  it 'handles track_event calls with a hash arg' do
+    expect_no_offenses(<<~RUBY)
+        module AnalyticsEvents
+          def idv_my_method(
+            type:,
+            proofing_components: nil,
+            limiter_expires_at: nil,
+            remaining_submit_attempts: nil,
+            **extra
+          )
+          track_event(
+            'IdV: phone error visited',
+            {
+              type: type,
+              proofing_components: proofing_components,
+              limiter_expires_at: limiter_expires_at,
+              remaining_submit_attempts: remaining_submit_attempts,
+              **extra,
+            }.compact,
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'breaks track_event calls across lines' do
+    allow(cop).to receive(:max_line_length).and_return(100)
+    expect_offense(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method_that_is_really_really_long(**extra)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: Method is missing proofing_components argument.
+          track_event(:idv_my_method_that_is_really_really_long, **extra)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: proofing_components is missing from track_event call.
+        end    
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method_that_is_really_really_long(proofing_components: nil, **extra)
+          track_event(
+            :idv_my_method_that_is_really_really_long,
+            proofing_components: proofing_components,
+            **extra
+          )
+        end    
+      end
+    RUBY
+  end
+
+  it 'can break method definitions across lines' do
+    allow(cop).to receive(:max_line_length).and_return(100)
+
+    expect_offense(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method_that_is_really_really_long(step_name:, remaining_submit_attempts:, **extra)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: Method is missing proofing_components argument.
+          track_event(
+          ^^^^^^^^^^^^ IdentityIdp/EnhancedIdvEventsLinter: proofing_components is missing from track_event call.
+            :idv_my_method_that_is_really_really_long,
+            step_name: step_name,
+            remaining_submit_attempts: remaining_submit_attempts,
+            **extra,
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module AnalyticsEvents
+        def idv_my_method_that_is_really_really_long(
+          step_name:,
+          remaining_submit_attempts:,
+          proofing_components: nil,
+          **extra
+        )
+          track_event(
+            :idv_my_method_that_is_really_really_long,
+            step_name: step_name,
+            remaining_submit_attempts: remaining_submit_attempts,
+            proofing_components: proofing_components,
+            **extra,
+          )
+        end
+      end
+    RUBY
+  end
+end

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -30,19 +30,18 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
     ).to eq([Idv::AnalyticsEventsEnhancer.const_source_location(:DECORATED_METHODS).first])
   end
 
-  it 'calls analytics method with original and decorated attributes' do
+  it 'calls analytics method with original attributes' do
     analytics.idv_final(extra: true)
-
-    expect(analytics.called_kwargs).to eq(extra: true, proofing_components: nil)
+    expect(analytics.called_kwargs).to eq(extra: true)
   end
 
   context 'with anonymous analytics user' do
     let(:user) { AnonymousUser.new }
 
-    it 'calls analytics method with original and decorated attributes' do
+    it 'calls analytics method with original attributes' do
       analytics.idv_final(extra: true)
 
-      expect(analytics.called_kwargs).to eq(extra: true, proofing_components: nil)
+      expect(analytics.called_kwargs).to eq(extra: true)
     end
   end
 

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -45,22 +45,36 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
     end
   end
 
-  context 'with proofing component' do
-    let(:proofing_components) do
-      ProofingComponent.new(source_check: Idp::Constants::Vendors::AAMVA)
-    end
+  describe 'proofing_components' do
+    let(:proofing_components) { nil }
 
     before do
       user.proofing_component = proofing_components
     end
 
-    it 'calls analytics method with original and decorated attributes' do
-      analytics.idv_final(extra: true)
+    context 'without proofing component' do
+      it 'calls analytics method with original attributes' do
+        analytics.idv_final(extra: true)
 
-      expect(analytics.called_kwargs).to match(
-        extra: true,
-        proofing_components: kind_of(Idv::ProofingComponentsLogging),
-      )
+        expect(analytics.called_kwargs).to match(
+          extra: true,
+        )
+      end
+    end
+
+    context 'with proofing component' do
+      let(:proofing_components) do
+        ProofingComponent.new(source_check: Idp::Constants::Vendors::AAMVA)
+      end
+
+      it 'calls analytics method with original attributes and proofing_components' do
+        analytics.idv_final(extra: true)
+
+        expect(analytics.called_kwargs).to match(
+          extra: true,
+          proofing_components: kind_of(Idv::ProofingComponentsLogging),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12657](https://cm-jira.usa.gov/browse/LG-12657)

## 🛠 Summary of changes

In working on #10216, I realized that the list of events that `Idv::AnalyticsEventsEnhancer` enhances has gotten a little stale. Specifically, we haven't been adding new events to it.

This PR:

* Updates `Idv::AnalyticsEventsEnhancer` to "enhance" **any method** that starts with `idv_` (note that this is the _method name_, not the event name, so old-style "IdV:" and new-style "idv_" events will be covered).
* Allows "opting out" of enhancement for specific events.
* Adds linter support for verifying "enhanced" method arguments are correctly passed to `track_event`

Initially, the list of "opted out" methods just includes any frontend events that were not previously "opted in". The net change of this PR is that all `idv_*` events logged by the backend will now have `proofing_components` added to them (this will be expanded to additional new properties in subsequent PRs).

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through identity verification
- [ ] Verify that certain events like `IdV: doc auth verify submitted` now have `proofing_components` 
