### PR TITLE
LG-12307: don't allow upload when selfie capture is enabled

### DIFF
--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -44,8 +44,8 @@ function DocumentSideAcuantCapture({
 }: DocumentSideAcuantCaptureProps) {
   const error = errors.find(({ field }) => field === side)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
-  const { isSelfieCaptureEnabled, isSelfieDesktopMode } = useContext(SelfieCaptureContext);
-  const isUploadAllowed = isSelfieDesktopMode || !isSelfieCaptureEnabled;
+  const { isSelfieCaptureEnabled, isSelfieDesktopTestMode } = useContext(SelfieCaptureContext);
+  const isUploadAllowed = isSelfieDesktopTestMode || !isSelfieCaptureEnabled;
 
   return (
     <AcuantCapture

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -44,7 +44,8 @@ function DocumentSideAcuantCapture({
 }: DocumentSideAcuantCaptureProps) {
   const error = errors.find(({ field }) => field === side)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
-  const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
+  const { isSelfieCaptureEnabled, isSelfieDesktopMode } = useContext(SelfieCaptureContext);
+  const isUploadAllowed = isSelfieDesktopMode || !isSelfieCaptureEnabled;
 
   return (
     <AcuantCapture
@@ -77,7 +78,7 @@ function DocumentSideAcuantCapture({
       errorMessage={error ? error.message : undefined}
       name={side}
       className={className}
-      allowUpload={!isSelfieCaptureEnabled}
+      allowUpload={isUploadAllowed}
     />
   );
 }

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -7,6 +7,7 @@ import type {
   RegisterFieldCallback,
 } from '@18f/identity-form-steps';
 import AcuantCapture from './acuant-capture';
+import SelfieCaptureContext from '../context/selfie-capture';
 
 interface DocumentSideAcuantCaptureProps {
   side: 'front' | 'back' | 'selfie';
@@ -43,6 +44,8 @@ function DocumentSideAcuantCapture({
 }: DocumentSideAcuantCaptureProps) {
   const error = errors.find(({ field }) => field === side)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
+  const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
+
   return (
     <AcuantCapture
       ref={registerField(side, { isRequired: true })}
@@ -74,6 +77,7 @@ function DocumentSideAcuantCapture({
       errorMessage={error ? error.message : undefined}
       name={side}
       className={className}
+      allowUpload={!isSelfieCaptureEnabled}
     />
   );
 }

--- a/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
+++ b/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
@@ -149,9 +149,7 @@ function FailedCaptureAttemptsContextProvider({
     failedCaptureAttempts >= maxCaptureAttemptsBeforeNativeCamera ||
     failedSubmissionAttempts >= maxSubmissionAttemptsBeforeNativeCamera;
 
-  const forceNativeCamera = isSelfieCaptureEnabled
-    ? false
-    : hasExhaustedAttempts;
+  const forceNativeCamera = isSelfieCaptureEnabled ? false : hasExhaustedAttempts;
 
   return (
     <FailedCaptureAttemptsContext.Provider

--- a/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
+++ b/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
@@ -1,6 +1,7 @@
-import { createContext, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
 import type { ReactNode } from 'react';
 import useCounter from '../hooks/use-counter';
+import SelfieCaptureContext from './selfie-capture';
 
 interface CaptureAttemptMetadata {
   isAssessedAsGlare: boolean;
@@ -125,6 +126,7 @@ function FailedCaptureAttemptsContextProvider({
     useCounter();
   const [failedSubmissionAttempts, incrementFailedSubmissionAttempts] = useCounter();
   const [failedCameraPermissionAttempts, incrementFailedCameraPermissionAttempts] = useCounter();
+  const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
 
   const [failedSubmissionImageFingerprints, setFailedSubmissionImageFingerprints] =
     useState<UploadedImageFingerprints>(failedFingerprints);
@@ -143,9 +145,13 @@ function FailedCaptureAttemptsContextProvider({
     incrementFailedCameraPermissionAttempts();
   }
 
-  const forceNativeCamera =
+  const failedAttemptsGreaterThanOrEqualToMaxAttempts =
     failedCaptureAttempts >= maxCaptureAttemptsBeforeNativeCamera ||
     failedSubmissionAttempts >= maxSubmissionAttemptsBeforeNativeCamera;
+
+  const forceNativeCamera = isSelfieCaptureEnabled
+    ? false
+    : failedAttemptsGreaterThanOrEqualToMaxAttempts;
 
   return (
     <FailedCaptureAttemptsContext.Provider

--- a/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
+++ b/app/javascript/packages/document-capture/context/failed-capture-attempts.tsx
@@ -145,13 +145,13 @@ function FailedCaptureAttemptsContextProvider({
     incrementFailedCameraPermissionAttempts();
   }
 
-  const failedAttemptsGreaterThanOrEqualToMaxAttempts =
+  const hasExhaustedAttempts =
     failedCaptureAttempts >= maxCaptureAttemptsBeforeNativeCamera ||
     failedSubmissionAttempts >= maxSubmissionAttemptsBeforeNativeCamera;
 
   const forceNativeCamera = isSelfieCaptureEnabled
     ? false
-    : failedAttemptsGreaterThanOrEqualToMaxAttempts;
+    : hasExhaustedAttempts;
 
   return (
     <FailedCaptureAttemptsContext.Provider

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -5,10 +5,15 @@ interface SelfieCaptureProps {
    * Specify whether to show the selfie capture on the doc capture screen.
    */
   isSelfieCaptureEnabled: boolean;
+  /**
+   * Specify whether to allow uploads for selfie when in test mode.
+   */
+  isSelfieDesktopMode: boolean;
 }
 
 const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
+  isSelfieDesktopMode: false,
 });
 
 SelfieCaptureContext.displayName = 'SelfieCaptureContext';

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -8,12 +8,12 @@ interface SelfieCaptureProps {
   /**
    * Specify whether to allow uploads for selfie when in test mode.
    */
-  isSelfieDesktopMode: boolean;
+  isSelfieDesktopTestMode: boolean;
 }
 
 const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
-  isSelfieDesktopMode: false,
+  isSelfieDesktopTestMode: false,
 });
 
 SelfieCaptureContext.displayName = 'SelfieCaptureContext';

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -178,6 +178,14 @@ const App = composeComponents(
     },
   ],
   [
+    SelfieCaptureContext.Provider,
+    {
+      value: {
+        isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
+      },
+    },
+  ],
+  [
     FailedCaptureAttemptsContextProvider,
     {
       maxCaptureAttemptsBeforeNativeCamera: Number(maxCaptureAttemptsBeforeNativeCamera),
@@ -189,14 +197,6 @@ const App = composeComponents(
     {
       value: {
         exitQuestionSectionEnabled: String(uiExitQuestionSectionEnabled) === 'true',
-      },
-    },
-  ],
-  [
-    SelfieCaptureContext.Provider,
-    {
-      value: {
-        isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
       },
     },
   ],

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -39,6 +39,7 @@ interface AppRootData {
   skipDocAuth: string;
   howToVerifyURL: string;
   uiExitQuestionSectionEnabled: string;
+  docAuthSelfieDesktopTestMode: string;
 }
 
 const appRoot = document.getElementById('document-capture-form')!;
@@ -106,6 +107,7 @@ const {
   skipDocAuth,
   howToVerifyUrl,
   uiExitQuestionSectionEnabled = '',
+  docAuthSelfieDesktopTestMode,
 } = appRoot.dataset as DOMStringMap & AppRootData;
 
 let parsedUsStatesTerritories = [];
@@ -182,6 +184,7 @@ const App = composeComponents(
     {
       value: {
         isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
+        isSelfieDesktopMode: String(docAuthSelfieDesktopTestMode) === 'true',
       },
     },
   ],

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -184,7 +184,7 @@ const App = composeComponents(
     {
       value: {
         isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
-        isSelfieDesktopMode: String(docAuthSelfieDesktopTestMode) === 'true',
+        isSelfieDesktopTestMode: String(docAuthSelfieDesktopTestMode) === 'true',
       },
     },
   ],

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -37,6 +37,7 @@
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
       doc_auth_selfie_capture: FeatureManagement.idv_allow_selfie_check? && doc_auth_selfie_capture,
+      doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
       ui_exit_question_section_enabled: IdentityConfig.store.doc_auth_exit_question_section_enabled,

--- a/spec/javascript/packages/document-capture/components/document-capture-abandon-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-abandon-spec.tsx
@@ -41,6 +41,7 @@ describe('DocumentCaptureAbandon', () => {
                 cancelURL: '/cancel',
                 exitURL: '/exit',
                 currentStep: 'document_capture',
+                accountURL: '',
               }}
             >
               <I18nContext.Provider
@@ -137,6 +138,7 @@ describe('DocumentCaptureAbandon', () => {
                 cancelURL: '/cancel',
                 exitURL: '/exit',
                 currentStep: 'document_capture',
+                accountURL: '',
               }}
             >
               <I18nContext.Provider

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.jsx
@@ -11,12 +11,12 @@ describe('DocumentSideAcuantCapture', () => {
   context('when selfie is _not_ enabled', () => {
     it('_does_ display a photo upload button', () => {
       const { queryAllByText } = render(
-        <SelfieCaptureContext.Provider value={{ isSelfieCaptureEnabled: false }}>
-          <DeviceContext.Provider value={{ isMobile: true }}>
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <SelfieCaptureContext.Provider value={{ isSelfieCaptureEnabled: false }}>
             <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
             <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
-          </DeviceContext.Provider>
-        </SelfieCaptureContext.Provider>,
+          </SelfieCaptureContext.Provider>
+        </DeviceContext.Provider>,
       );
 
       const takeOrUploadPictureText = queryAllByText(

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.jsx
@@ -1,0 +1,48 @@
+import { DeviceContext, SelfieCaptureContext } from '@18f/identity-document-capture';
+import DocumentSideAcuantCapture from '@18f/identity-document-capture/components/document-side-acuant-capture';
+import { render } from '../../../support/document-capture';
+
+describe('DocumentSideAcuantCapture', () => {
+  const DEFAULT_PROPS = {
+    errors: [],
+    registerField: () => undefined,
+  };
+
+  context('when selfie is _not_ enabled', () => {
+    it('_does_ display a photo upload button', () => {
+      const { queryAllByText } = render(
+        <SelfieCaptureContext.Provider value={{ isSelfieCaptureEnabled: false }}>
+          <DeviceContext.Provider value={{ isMobile: true }}>
+            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+          </DeviceContext.Provider>
+        </SelfieCaptureContext.Provider>,
+      );
+
+      const takeOrUploadPictureText = queryAllByText(
+        'doc_auth.buttons.take_or_upload_picture_html',
+      );
+      expect(takeOrUploadPictureText).to.have.lengthOf(2);
+    });
+  });
+
+  context('when selfie _is_ enabled', () => {
+    it('does _not_ display a photo upload button', () => {
+      const { queryAllByText } = render(
+        <SelfieCaptureContext.Provider value={{ isSelfieCaptureEnabled: true }}>
+          <DeviceContext.Provider value={{ isMobile: true }}>
+            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="selfie" />
+          </DeviceContext.Provider>
+        </SelfieCaptureContext.Provider>,
+      );
+
+      const takePictureText = queryAllByText('doc_auth.buttons.take_picture');
+      expect(takePictureText).to.have.lengthOf(3);
+
+      const notExpectedText = 'doc_auth.buttons.take_or_upload_picture_html';
+      expect(queryAllByText(notExpectedText)).to.be.an('array').that.is.empty;
+    });
+  });
+});

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -1,18 +1,24 @@
 import { DeviceContext, SelfieCaptureContext } from '@18f/identity-document-capture';
 import DocumentSideAcuantCapture from '@18f/identity-document-capture/components/document-side-acuant-capture';
+import { expect } from 'chai';
 import { render } from '../../../support/document-capture';
 
 describe('DocumentSideAcuantCapture', () => {
   const DEFAULT_PROPS = {
     errors: [],
     registerField: () => undefined,
+    value: '',
+    onChange: () => undefined,
+    onError: () => undefined,
   };
 
   context('when selfie is _not_ enabled', () => {
     it('_does_ display a photo upload button', () => {
       const { queryAllByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
-          <SelfieCaptureContext.Provider value={{ isSelfieCaptureEnabled: false }}>
+          <SelfieCaptureContext.Provider
+            value={{ isSelfieCaptureEnabled: false, isSelfieDesktopMode: false }}
+          >
             <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
             <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
           </SelfieCaptureContext.Provider>
@@ -29,13 +35,15 @@ describe('DocumentSideAcuantCapture', () => {
   context('when selfie _is_ enabled', () => {
     it('does _not_ display a photo upload button', () => {
       const { queryAllByText } = render(
-        <SelfieCaptureContext.Provider value={{ isSelfieCaptureEnabled: true }}>
-          <DeviceContext.Provider value={{ isMobile: true }}>
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <SelfieCaptureContext.Provider
+            value={{ isSelfieCaptureEnabled: true, isSelfieDesktopMode: false }}
+          >
             <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
             <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
             <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="selfie" />
-          </DeviceContext.Provider>
-        </SelfieCaptureContext.Provider>,
+          </SelfieCaptureContext.Provider>
+        </DeviceContext.Provider>,
       );
 
       const takePictureText = queryAllByText('doc_auth.buttons.take_picture');

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -13,44 +13,163 @@ describe('DocumentSideAcuantCapture', () => {
   };
 
   context('when selfie is _not_ enabled', () => {
-    it('_does_ display a photo upload button', () => {
-      const { queryAllByText } = render(
-        <DeviceContext.Provider value={{ isMobile: true }}>
-          <SelfieCaptureContext.Provider
-            value={{ isSelfieCaptureEnabled: false, isSelfieDesktopMode: false }}
-          >
-            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
-            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
-          </SelfieCaptureContext.Provider>
-        </DeviceContext.Provider>,
-      );
+    context('and using mobile', () => {
+      context('and doc_auth_selfie_desktop_test_mode is false', () => {
+        it('_does_ display a photo upload button', () => {
+          const { queryAllByText } = render(
+            <DeviceContext.Provider value={{ isMobile: true }}>
+              <SelfieCaptureContext.Provider
+                value={{ isSelfieCaptureEnabled: false, isSelfieDesktopTestMode: false }}
+              >
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+              </SelfieCaptureContext.Provider>
+            </DeviceContext.Provider>,
+          );
 
-      const takeOrUploadPictureText = queryAllByText(
-        'doc_auth.buttons.take_or_upload_picture_html',
-      );
-      expect(takeOrUploadPictureText).to.have.lengthOf(2);
+          const takeOrUploadPictureText = queryAllByText(
+            'doc_auth.buttons.take_or_upload_picture_html',
+          );
+          expect(takeOrUploadPictureText).to.have.lengthOf(2);
+        });
+      });
+
+      context('and doc_auth_selfie_desktop_test_mode is true', () => {
+        it('_does_ display a photo upload button', () => {
+          const { queryAllByText } = render(
+            <DeviceContext.Provider value={{ isMobile: true }}>
+              <SelfieCaptureContext.Provider
+                value={{ isSelfieCaptureEnabled: false, isSelfieDesktopTestMode: true }}
+              >
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+              </SelfieCaptureContext.Provider>
+            </DeviceContext.Provider>,
+          );
+
+          const takeOrUploadPictureText = queryAllByText(
+            'doc_auth.buttons.take_or_upload_picture_html',
+          );
+          expect(takeOrUploadPictureText).to.have.lengthOf(2);
+        });
+      });
+    });
+
+    context('and using desktop', () => {
+      context('and doc_auth_selfie_desktop_test_mode is false', () => {
+        it('shows a file pick area for each field', () => {
+          const { queryAllByText } = render(
+            <DeviceContext.Provider value={{ isMobile: false }}>
+              <SelfieCaptureContext.Provider
+                value={{ isSelfieCaptureEnabled: false, isSelfieDesktopTestMode: false }}
+              >
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+              </SelfieCaptureContext.Provider>
+            </DeviceContext.Provider>,
+          );
+
+          const uploadPictureText = queryAllByText('doc_auth.forms.choose_file_html');
+          expect(uploadPictureText).to.have.lengthOf(2);
+        });
+      });
+
+      context('and doc_auth_selfie_desktop_test_mode is true', () => {
+        it('shows a file pick area for each field', () => {
+          const { queryAllByText } = render(
+            <DeviceContext.Provider value={{ isMobile: false }}>
+              <SelfieCaptureContext.Provider
+                value={{ isSelfieCaptureEnabled: false, isSelfieDesktopTestMode: true }}
+              >
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+              </SelfieCaptureContext.Provider>
+            </DeviceContext.Provider>,
+          );
+
+          const uploadPictureText = queryAllByText('doc_auth.forms.choose_file_html');
+          expect(uploadPictureText).to.have.lengthOf(2);
+        });
+      });
     });
   });
 
   context('when selfie _is_ enabled', () => {
-    it('does _not_ display a photo upload button', () => {
-      const { queryAllByText } = render(
-        <DeviceContext.Provider value={{ isMobile: true }}>
-          <SelfieCaptureContext.Provider
-            value={{ isSelfieCaptureEnabled: true, isSelfieDesktopMode: false }}
-          >
-            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
-            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
-            <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="selfie" />
-          </SelfieCaptureContext.Provider>
-        </DeviceContext.Provider>,
-      );
+    context('and using mobile', () => {
+      context('and doc_auth_selfie_desktop_test_mode is false', () => {
+        it('does _not_ display a photo upload button', () => {
+          const { queryAllByText } = render(
+            <DeviceContext.Provider value={{ isMobile: true }}>
+              <SelfieCaptureContext.Provider
+                value={{ isSelfieCaptureEnabled: true, isSelfieDesktopTestMode: false }}
+              >
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="selfie" />
+              </SelfieCaptureContext.Provider>
+            </DeviceContext.Provider>,
+          );
 
-      const takePictureText = queryAllByText('doc_auth.buttons.take_picture');
-      expect(takePictureText).to.have.lengthOf(3);
+          const takePictureText = queryAllByText('doc_auth.buttons.take_picture');
+          expect(takePictureText).to.have.lengthOf(3);
 
-      const notExpectedText = 'doc_auth.buttons.take_or_upload_picture_html';
-      expect(queryAllByText(notExpectedText)).to.be.an('array').that.is.empty;
+          const takeOrUploadPictureText = queryAllByText(
+            'doc_auth.buttons.take_or_upload_picture_html',
+          );
+          expect(takeOrUploadPictureText).to.have.lengthOf(0);
+        });
+      });
+
+      context('and doc_auth_selfie_desktop_test_mode is true', () => {
+        it('does _not_ display a photo upload button', () => {
+          const { queryAllByText } = render(
+            <DeviceContext.Provider value={{ isMobile: true }}>
+              <SelfieCaptureContext.Provider
+                value={{ isSelfieCaptureEnabled: true, isSelfieDesktopTestMode: true }}
+              >
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="selfie" />
+              </SelfieCaptureContext.Provider>
+            </DeviceContext.Provider>,
+          );
+
+          const takePictureText = queryAllByText('doc_auth.buttons.take_picture');
+          expect(takePictureText).to.have.lengthOf(3);
+
+          const takeOrUploadPictureText = queryAllByText(
+            'doc_auth.buttons.take_or_upload_picture_html',
+          );
+          expect(takeOrUploadPictureText).to.have.lengthOf(3);
+        });
+      });
+    });
+
+    context('and using desktop', () => {
+      context('and doc_auth_selfie_desktop_test_mode is false', () => {
+        it('never loads these components', () => {
+          // noop
+        });
+      });
+
+      context('and doc_auth_selfie_desktop_test_mode is true', () => {
+        it('shows a file pick area for each field', () => {
+          const { queryAllByText } = render(
+            <DeviceContext.Provider value={{ isMobile: false }}>
+              <SelfieCaptureContext.Provider
+                value={{ isSelfieCaptureEnabled: true, isSelfieDesktopTestMode: true }}
+              >
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="selfie" />
+              </SelfieCaptureContext.Provider>
+            </DeviceContext.Provider>,
+          );
+
+          const uploadPictureText = queryAllByText('doc_auth.forms.choose_file_html');
+          expect(uploadPictureText).to.have.lengthOf(3);
+        });
+      });
     });
   });
 });

--- a/spec/javascript/packages/document-capture/context/failed-capture-attempts-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/failed-capture-attempts-spec.jsx
@@ -215,6 +215,7 @@ describe('FailedCaptureAttemptsContext testing of forceNativeCamera logic', () =
       rerender({});
       expect(result.current.failedSubmissionAttempts).to.equal(3);
       expect(result.current.forceNativeCamera).to.equal(false);
+
       expect(trackEvent).to.not.have.been.calledWith(
         'IdV: Native camera forced after failed attempts',
       );

--- a/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
@@ -6,7 +6,7 @@ describe('document-capture/context/feature-flag', () => {
   it('has expected default properties', () => {
     const { result } = renderHook(() => useContext(SelfieCaptureContext));
 
-    expect(result.current).to.have.keys(['isSelfieCaptureEnabled']);
+    expect(result.current).to.have.keys(['isSelfieCaptureEnabled', 'isSelfieDesktopMode']);
     expect(result.current.isSelfieCaptureEnabled).to.be.a('boolean');
   });
 });

--- a/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
@@ -6,7 +6,7 @@ describe('document-capture/context/feature-flag', () => {
   it('has expected default properties', () => {
     const { result } = renderHook(() => useContext(SelfieCaptureContext));
 
-    expect(result.current).to.have.keys(['isSelfieCaptureEnabled', 'isSelfieDesktopMode']);
+    expect(result.current).to.have.keys(['isSelfieCaptureEnabled', 'isSelfieDesktopTestMode']);
     expect(result.current.isSelfieCaptureEnabled).to.be.a('boolean');
   });
 });

--- a/spec/javascript/support/document-capture.jsx
+++ b/spec/javascript/support/document-capture.jsx
@@ -1,5 +1,6 @@
 import { render as baseRender, cleanup } from '@testing-library/react';
 import sinon from 'sinon';
+// @ts-ignore
 import { UploadContextProvider } from '@18f/identity-document-capture';
 
 /** @typedef {import('@testing-library/react').RenderOptions} BaseRenderOptions */
@@ -44,8 +45,12 @@ export function render(element, options = {}) {
   return baseRender(element, {
     ...baseRenderOptions,
     wrapper: ({ children }) => (
-      <UploadContextProvider upload={upload} isMockClient={isMockClient}>
-        {baseWrapper({ children })}
+      <
+// @ts-ignore
+      UploadContextProvider upload={upload} isMockClient={isMockClient}>
+        {
+// @ts-ignore
+        baseWrapper({ children })}
       </UploadContextProvider>
     ),
   });
@@ -57,10 +62,15 @@ export function useAcuant() {
     // resetting the global variables, since otherwise the component's effect unsubscribe will
     // attempt to reference globals that no longer exist.
     cleanup();
+    // @ts-ignore
     delete window.AcuantJavascriptWebSdk;
+    // @ts-ignore
     delete window.AcuantCamera;
+    // @ts-ignore
     delete window.AcuantCameraUI;
+    // @ts-ignore
     delete window.AcuantPassiveLiveness;
+    // @ts-ignore
     delete window.loadAcuantSdk;
   });
 
@@ -75,6 +85,7 @@ export function useAcuant() {
       triggerCapture = sinon.stub(),
     } = {}) {
       window.AcuantJavascriptWebSdk = {
+        // @ts-ignore
         initialize: (_credentials, _endpoint, { onSuccess, onFail }) =>
           isSuccess ? onSuccess() : onFail(401, 'Server returned a 401 (missing credentials).'),
         startWorkers: sinon.stub().callsArg(0),
@@ -82,13 +93,16 @@ export function useAcuant() {
         REPEAT_FAIL_CODE: 'repeat-fail-code',
         SEQUENCE_BREAK_CODE: 'sequence-break-code',
       };
+      // @ts-ignore
       window.AcuantCamera = { isCameraSupported, triggerCapture };
       window.AcuantCameraUI = {
         start: sinon.stub().callsFake((...args) => {
           const camera = document.getElementById('acuant-camera');
           const canvas = document.createElement('canvas');
           canvas.id = 'acuant-ui-canvas';
+          // @ts-ignore
           camera.appendChild(canvas);
+          // @ts-ignore
           camera.dispatchEvent(new window.CustomEvent('acuantcameracreated'));
           start(...args);
         }),
@@ -97,7 +111,9 @@ export function useAcuant() {
       window.AcuantPassiveLiveness = { start: selfieStart, end: selfieEnd };
       window.loadAcuantSdk = () => {};
       const sdkScript = document.querySelector('[data-acuant-sdk]');
+      // @ts-ignore
       sdkScript.onload();
+      // @ts-ignore
       sdkScript.onload = null;
     },
   };

--- a/spec/javascript/support/document-capture.jsx
+++ b/spec/javascript/support/document-capture.jsx
@@ -45,12 +45,12 @@ export function render(element, options = {}) {
   return baseRender(element, {
     ...baseRenderOptions,
     wrapper: ({ children }) => (
-      <
-// @ts-ignore
-      UploadContextProvider upload={upload} isMockClient={isMockClient}>
+      // @ts-ignore
+      <UploadContextProvider upload={upload} isMockClient={isMockClient}>
         {
-// @ts-ignore
-        baseWrapper({ children })}
+          // @ts-ignore
+          baseWrapper({ children })
+        }
       </UploadContextProvider>
     ),
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "app/javascript/packs",
     "spec/javascript/spec_helper.d.ts",
     "spec/javascript/**/*.ts",
+    "spec/javascript/**/*.tsx",
     "./*.js",
     "scripts"
   ],


### PR DESCRIPTION
## 🎫 Ticket

[LG-12307](https://cm-jira.usa.gov/browse/LG-12307)

## 🛠 Summary of changes

When doc auth with selfie is required, the FE only allows adding ID and selfie images using the Acuant SDK.

(unless `doc_auth_selfie_desktop_test_mode: true`, then we still want to allow uploads)

## 📜 Testing Plan

This one is a bit involved when it comes to testing. This is because between the differences between mobile and desktop, and the two flags:

```
  doc_auth_selfie_capture_enabled
  doc_auth_selfie_desktop_test_mode
```

... there are 8 different states it can be in. To make it a little easier, I made [an Excel spreadsheet](https://docs.google.com/spreadsheets/d/11S1jxzrPiM1022fGoSjYBkdh1KXTRU2k-KU6lAA7vmU/edit#gid=0) with the 8 states and what their expected result are.

- [ ] Choose a line [in the spreadsheet](https://docs.google.com/spreadsheets/d/11S1jxzrPiM1022fGoSjYBkdh1KXTRU2k-KU6lAA7vmU/edit#gid=0) of possible outcomes
- [ ] Make the needed adjustments to the two flags in your `application.yml`
- [ ] Start / Restart the server (if this is your second+ time through)
- [ ] Get to the doc auth capture screen (if you follow these directions you should only need one account and can mostly cut the server on this page and just reload)
- [ ] Test the outcome according to the "Expected outcome" column for the line of the spreadsheet you're on
- [ ] Mark how it went under the "When testing PR" column
- [ ] ctrl + c out of the server (don't run make setup)
- [ ] start again

In addition, note that you can fail the SDK capture by trying to take a photo of your laptop trackpad. If it's too well lit, SDK capture may still pass, but you can put a hand over your phone to cause a shadow that will make it fail.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

![image](https://github.com/18F/identity-idp/assets/35475380/bef57d4e-a9da-4de8-b2e5-a0f3a56bc362)

</details>

<details>
<summary>After:</summary>

![image](https://github.com/18F/identity-idp/assets/35475380/29d275e4-176f-4146-8d37-13703f8602d7)

</details>