### PR TITLE
Clean PIV session detail after deletion (2)

### DIFF
--- a/app/controllers/users/piv_cac_controller.rb
+++ b/app/controllers/users/piv_cac_controller.rb
@@ -1,6 +1,7 @@
 module Users
   class PivCacController < ApplicationController
     include ReauthenticationRequiredConcern
+    include PivCacConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_recently_authenticated_2fa
@@ -33,6 +34,7 @@ module Users
         create_user_event(:piv_cac_disabled)
         revoke_remember_device(current_user)
         deliver_push_notification
+        clear_piv_cac_information
 
         flash[:success] = presenter.delete_success_alert_text
         redirect_to account_path

--- a/spec/controllers/users/piv_cac_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_controller_spec.rb
@@ -139,6 +139,12 @@ RSpec.describe Users::PivCacController do
       expect(flash[:success]).to eq(presenter.delete_success_alert_text)
     end
 
+    it 'removes the piv/cac information from the user session' do
+      controller.user_session[:decrypted_x509] = {}
+      response
+      expect(controller.user_session[:decrypted_x509]).to be_nil
+    end
+
     it 'logs the submission attempt' do
       response
 


### PR DESCRIPTION
## 🛠 Summary of changes

Adds missing PIV behavior for deleted PIV, expected to remove cached `user_session` detail. This carries forward from the original implementation preceding #9861, removed in #10218.

https://github.com/18F/identity-idp/blob/b456d8556fc684179c015e818539cd3082574ad7/app/controllers/users/piv_cac_authentication_setup_controller.rb#L39

This is the same as #10220, but applied to the no-JS fallback controller (`Users::PivCacController`) in addition to the JavaScript API controller (`Api::Internal::TwoFactorAuthentication::PivCacController`).

## 📜 Testing Plan

```
rspec spec/controllers/api/internal/two_factor_authentication/piv_cac_controller_spec.rb
```