### PR TITLE
Remove no-JavaScript tracking from Sign In page

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -86,5 +86,4 @@
   </p>
 <% end %>
 
-<noscript><link rel="stylesheet" href="<%= no_js_detect_css_path(location: :sign_in) %>"></noscript>
 <%= javascript_packs_tag_once('platform-authenticator-available') %>

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -74,15 +74,6 @@ RSpec.describe 'devise/sessions/new.html.erb' do
     )
   end
 
-  it 'includes tracking script for no-JavaScript' do
-    render
-
-    expect(rendered).to have_css(
-      "link[rel='stylesheet'][href='#{no_js_detect_css_path(location: :sign_in)}']",
-      visible: false,
-    )
-  end
-
   context 'when SP is present' do
     let(:sp) do
       build_stubbed(


### PR DESCRIPTION
## 🛠 Summary of changes

Removes no-JavaScript tracking from the Sign In page.

See #9693 for additional context. This effectively reverts #9693, while keeping additional supports for location-specific analytics currently used within identity verification flows.

While the intent of #9693 was toward understanding no-JavaScript usage and this analysis has yet to be performed, it's been live in production long enough to create queryable historical data that could be used for a future analysis.

## 📜 Testing Plan

Repeat Testing Plan from #9693, verifying that you never see "no_js_detect_stylesheet_loaded" event.