### PR TITLE
Fix border on MFA when editing with multiple

### DIFF
--- a/app/components/manageable_authenticator_component.scss
+++ b/app/components/manageable_authenticator_component.scss
@@ -58,7 +58,9 @@
   @include u-padding(1);
   @include u-border(1px, 'primary-light');
 
-  lg-manageable-authenticator + lg-manageable-authenticator & {
+  lg-manageable-authenticator:not(.manageable-authenticator--editing)
+    + lg-manageable-authenticator
+    & {
     border-top: none;
   }
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a minor visual defect which occurs when editing a multi-factor authentication method and there are additional methods that follow, where there should be a top border on items that follow.

## 📜 Testing Plan

Prerequisite: Have an account with 2 or more of the following types MFA: Security key, face or touch unlock, PIV, authenticator app.

1. Go to the account page
2. Edit one of your authenticators where another authenticator exists after
3. Verify no issues with border appearance

## 👀 Screenshots

Before|After
---|---
![Screenshot 2024-03-13 at 10 57 45 AM](https://github.com/18F/identity-idp/assets/1779930/af76af6a-f719-4f9c-aca4-f47f0535210d)|![Screenshot 2024-03-13 at 10 58 24 AM](https://github.com/18F/identity-idp/assets/1779930/7d5d7fd5-ddbb-47f1-8b2c-17fdb8b50c13)
