### PR TITLE
Add documentation for missing piv_cac_login arguments

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4003,12 +4003,14 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name PIV/CAC login
   # @param [Boolean] success
   # @param [Hash] errors
+  # @param [String,nil] key_id
   # tracks piv cac login event
-  def piv_cac_login(success:, errors:, **extra)
+  def piv_cac_login(success:, errors:, key_id:, **extra)
     track_event(
       :piv_cac_login,
-      success: success,
-      errors: errors,
+      success:,
+      errors:,
+      key_id:,
       **extra,
     )
   end

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -4,16 +4,13 @@ RSpec.describe Users::PivCacLoginController do
   describe 'GET new' do
     before do
       stub_analytics
-      allow(@analytics).to receive(:track_event)
     end
 
     context 'without a token' do
       before { get :new }
 
       it 'tracks the piv cac login' do
-        expect(@analytics).to have_received(:track_event).with(
-          :piv_cac_login_visited,
-        )
+        expect(@analytics).to have_logged_event(:piv_cac_login_visited)
       end
 
       it 'redirects to root url' do
@@ -27,13 +24,11 @@ RSpec.describe Users::PivCacLoginController do
       context 'an invalid token' do
         before { get :new, params: { token: token } }
         it 'tracks the login attempt' do
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             :piv_cac_login,
-            {
-              errors: {},
-              key_id: nil,
-              success: false,
-            },
+            errors: {},
+            key_id: nil,
+            success: false,
           )
         end
 
@@ -73,15 +68,13 @@ RSpec.describe Users::PivCacLoginController do
           end
 
           it 'tracks the login attempt' do
-            expect(@analytics).to have_received(:track_event).with(
+            expect(@analytics).to have_logged_event(
               :piv_cac_login,
-              {
-                errors: {
-                  type: 'user.not_found',
-                },
-                key_id: nil,
-                success: false,
+              errors: {
+                type: 'user.not_found',
               },
+              key_id: nil,
+              success: false,
             )
           end
 
@@ -112,13 +105,11 @@ RSpec.describe Users::PivCacLoginController do
           end
 
           it 'tracks the login attempt' do
-            expect(@analytics).to have_received(:track_event).with(
+            expect(@analytics).to have_logged_event(
               :piv_cac_login,
-              {
-                errors: {},
-                key_id: nil,
-                success: true,
-              },
+              errors: {},
+              key_id: nil,
+              success: true,
             )
           end
 
@@ -137,9 +128,9 @@ RSpec.describe Users::PivCacLoginController do
           end
 
           it 'tracks the user_marked_authed event' do
-            expect(@analytics).to have_received(:track_event).with(
+            expect(@analytics).to have_logged_event(
               'User marked authenticated',
-              { authentication_type: :valid_2fa },
+              authentication_type: :valid_2fa,
             )
           end
 
@@ -164,9 +155,9 @@ RSpec.describe Users::PivCacLoginController do
 
           describe 'it handles the otp_context' do
             it 'tracks the user_marked_authed event' do
-              expect(@analytics).to have_received(:track_event).with(
+              expect(@analytics).to have_logged_event(
                 'User marked authenticated',
-                { authentication_type: :valid_2fa },
+                authentication_type: :valid_2fa,
               )
             end
 


### PR DESCRIPTION
## 🎫 Ticket

Incidentally relates to [LG-12706](https://cm-jira.usa.gov/browse/LG-12706), as it further complicates the issues described there.

## 🛠 Summary of changes

Updates `piv_cac_login` method YARDoc to include missing `key_id` method, and revises tests to ensure enforcement using new enforcement features added in #9946.

## 📜 Testing Plan

Build should pass.