### PR TITLE
LG-12672: handoff page update when selfie required

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -63,6 +63,7 @@ module Idv
                          idv_session.flow_path == 'standard' && (
                            # mobile
                            idv_session.skip_hybrid_handoff ||
+                            idv_session.skip_doc_auth ||
                             !idv_session.selfie_check_required || # desktop but selfie not required
                              idv_session.desktop_selfie_test_mode_enabled?
                          )

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -13,6 +13,8 @@ module Idv
       @upload_disabled = idv_session.selfie_check_required &&
                          !idv_session.desktop_selfie_test_mode_enabled?
 
+      @selfie_required = idv_session.selfie_check_required
+
       analytics.idv_doc_auth_hybrid_handoff_visited(**analytics_arguments)
 
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).call(
@@ -34,6 +36,13 @@ module Idv
       else
         bypass_send_link_steps
       end
+    end
+
+    def in_person
+      idv_session.opted_in_to_in_person_proofing = true
+      idv_session.flow_path = 'standard'
+      idv_session.skip_doc_auth = true
+      redirect_to idv_document_capture_url
     end
 
     def self.selected_remote(idv_session:)

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -38,13 +38,6 @@ module Idv
       end
     end
 
-    def in_person
-      idv_session.opted_in_to_in_person_proofing = true
-      idv_session.flow_path = 'standard'
-      idv_session.skip_doc_auth = true
-      redirect_to idv_document_capture_url
-    end
-
     def self.selected_remote(idv_session:)
       if IdentityConfig.store.in_person_proofing_opt_in_enabled &&
          IdentityConfig.store.in_person_proofing_enabled &&

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -8,6 +8,7 @@
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
       ) %>
 <% end %>
+<%#   ============== Non Selfie Section ==========    %>
 <% if !@selfie_required %>
 
   <%= render PageHeadingComponent.new do %>
@@ -54,6 +55,7 @@
       <% end %>
     </div>
   </div>
+<%#   ============== Selfie Section ==========    %>
 <% else %>
   <div class="grid-row grid-gap grid-gap-2">
   <div class="grid-col-12 tablet:grid-col-auto">
@@ -66,7 +68,7 @@
   </div>
   <div class="grid-col-12 tablet:grid-col-fill">
     <%= render PageHeadingComponent.new do %>
-      <%= 'Enter your phone number to switch devices' %>
+      <%= t('doc_auth.headings.hybrid_handoff_selfie') %>
     <% end %>
     <%= t('doc_auth.info.upload_from_phone') %>
     <%= simple_form_for(
@@ -87,14 +89,6 @@
       <%= f.submit t('forms.buttons.send_link') %>
     <% end %>
   </div>
-  </div>
-  <div class="margin-top-4 padding-top-2 border-top border-primary-light">
-    <p class="margin-top-1">
-    <strong>Don’t have a mobile phone?</strong> You can verify your identity at a United States Post Office instead.
-    </p>
-    <p class="margin-top-1">
-      <%= link_to t('in_person_proofing.headings.prepare'), idv_hybrid_handoff_in_person_path %>
-    </p>
   </div>
 <% end %>
 

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -8,16 +8,54 @@
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
       ) %>
 <% end %>
+<% if !@selfie_required %>
 
-<%= render PageHeadingComponent.new do %>
-  <%= t('doc_auth.headings.hybrid_handoff') %>
-<% end %>
+  <%= render PageHeadingComponent.new do %>
+    <%= t('doc_auth.headings.hybrid_handoff') %>
+  <% end %>
 
-<p>
-  <%= t('doc_auth.info.hybrid_handoff') %>
-</p>
+  <p>
+    <%= t('doc_auth.info.hybrid_handoff') %>
+  </p>
 
-<div class="grid-row grid-gap grid-gap-2">
+  <div class="grid-row grid-gap grid-gap-2">
+    <div class="grid-col-12 tablet:grid-col-auto">
+      <%= image_tag(
+            asset_url('idv/phone-icon.svg'),
+            alt: t('image_description.camera_mobile_phone'),
+            width: 88,
+            height: 88,
+          ) %>
+    </div>
+    <div class="grid-col-12 tablet:grid-col-fill">
+      <div class="usa-tag usa-tag--informative">
+        <%= t('doc_auth.info.tag') %>
+      </div>
+      <h2 class="margin-y-105">
+        <%= t('doc_auth.headings.upload_from_phone') %>
+      </h2>
+      <%= t('doc_auth.info.upload_from_phone') %>
+      <%= simple_form_for(
+            idv_phone_form,
+            as: :doc_auth,
+            url: url_for(type: :mobile, combined: true),
+            method: 'PUT',
+            html: { autocomplete: 'off',
+                    id: 'form-to-submit-photos-through-mobile',
+                    'aria-label': t('forms.buttons.send_link') },
+          ) do |f| %>
+        <%= render PhoneInputComponent.new(
+              form: f,
+              required: true,
+              delivery_methods: [:sms],
+              class: 'margin-bottom-4',
+            ) %>
+        <%= f.submit t('forms.buttons.send_link') %>
+      <% end %>
+    </div>
+  </div>
+<% else %>
+  <div class="grid-row grid-gap grid-gap-2">
   <div class="grid-col-12 tablet:grid-col-auto">
     <%= image_tag(
           asset_url('idv/phone-icon.svg'),
@@ -27,12 +65,9 @@
         ) %>
   </div>
   <div class="grid-col-12 tablet:grid-col-fill">
-    <div class="usa-tag usa-tag--informative">
-      <%= t('doc_auth.info.tag') %>
-    </div>
-    <h2 class="margin-y-105">
-      <%= t('doc_auth.headings.upload_from_phone') %>
-    </h2>
+    <%= render PageHeadingComponent.new do %>
+      <%= 'Enter your phone number to switch devices' %>
+    <% end %>
     <%= t('doc_auth.info.upload_from_phone') %>
     <%= simple_form_for(
           idv_phone_form,
@@ -52,7 +87,16 @@
       <%= f.submit t('forms.buttons.send_link') %>
     <% end %>
   </div>
-</div>
+  </div>
+  <div class="margin-top-4 padding-top-2 border-top border-primary-light">
+    <p class="margin-top-1">
+    <strong>Don’t have a mobile phone?</strong> You can verify your identity at a United States Post Office instead.
+    </p>
+    <p class="margin-top-1">
+      <%= link_to t('in_person_proofing.headings.prepare'), idv_hybrid_handoff_in_person_path %>
+    </p>
+  </div>
+<% end %>
 
 <% unless @upload_disabled %>
   <hr class="margin-y-4" />

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -163,6 +163,7 @@ en:
       front: Front of your driver’s license or state ID
       how_to_verify: Choose how you want to verify your identity
       hybrid_handoff: How would you like to add your ID?
+      hybrid_handoff_selfie: Enter your phone number to switch devices
       interstitial: We are processing your images
       lets_go: How verifying your identity works
       no_ssn: Don’t have a Social Security number?

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -194,6 +194,7 @@ es:
       front: Anverso de su licencia de conducir o identificación estatal
       how_to_verify: Elija cómo quiere verificar su identidad
       hybrid_handoff: '¿Cómo desea añadir su documento de identidad?'
+      hybrid_handoff_selfie: Ingrese su número de celular para cambiar de dispositivo
       interstitial: Estamos procesando sus imágenes
       lets_go: Cómo funciona la verificación de su identidad
       no_ssn: ¿No tiene un número de Seguro Social?

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -203,6 +203,7 @@ fr:
       front: Recto de votre permis de conduire ou de votre carte d’identité de l’État
       how_to_verify: Choisissez la manière dont vous souhaitez confirmer votre identité
       hybrid_handoff: Comment voulez-vous ajouter votre identifiant ?
+      hybrid_handoff_selfie: Saisissez votre numéro de téléphone pour changer d’appareil
       interstitial: Nous traitons vos images
       lets_go: Comment fonctionne la vérification de votre identité
       no_ssn: Vous n’avez pas de numéro de sécurité sociale?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,7 +342,6 @@ Rails.application.routes.draw do
       put '/hybrid_mobile/document_capture' => 'hybrid_mobile/document_capture#update'
       get '/hybrid_mobile/capture_complete' => 'hybrid_mobile/capture_complete#show'
       get '/hybrid_handoff' => 'hybrid_handoff#show'
-      get '/hybrid_handoff/in_person' => 'hybrid_handoff#in_person'
       put '/hybrid_handoff' => 'hybrid_handoff#update'
       get '/link_sent' => 'link_sent#show'
       put '/link_sent' => 'link_sent#update'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,6 +342,7 @@ Rails.application.routes.draw do
       put '/hybrid_mobile/document_capture' => 'hybrid_mobile/document_capture#update'
       get '/hybrid_mobile/capture_complete' => 'hybrid_mobile/capture_complete#show'
       get '/hybrid_handoff' => 'hybrid_handoff#show'
+      get '/hybrid_handoff/in_person' => 'hybrid_handoff#in_person'
       put '/hybrid_handoff' => 'hybrid_handoff#update'
       get '/link_sent' => 'link_sent#show'
       put '/link_sent' => 'link_sent#update'

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -529,7 +529,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               complete_doc_auth_steps_before_hybrid_handoff_step
               # we still have option to continue
               expect(page).to have_current_path(idv_hybrid_handoff_path)
-              expect(page).to have_content(t('doc_auth.headings.upload_from_phone'))
+              expect(page).to have_content(t('doc_auth.headings.hybrid_handoff_selfie'))
+              expect(page).not_to have_content(t('doc_auth.headings.hybrid_handoff'))
               expect(page).not_to have_content(t('doc_auth.info.upload_from_computer'))
               click_on t('forms.buttons.send_link')
               expect(page).to have_current_path(idv_link_sent_path)
@@ -545,8 +546,9 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               complete_doc_auth_steps_before_hybrid_handoff_step
               # we still have option to continue on handoff, since it's desktop no skip_hand_off
               expect(page).to have_current_path(idv_hybrid_handoff_path)
+              expect(page).to have_content(t('doc_auth.headings.hybrid_handoff_selfie'))
+              expect(page).not_to have_content(t('doc_auth.headings.hybrid_handoff'))
               expect(page).to have_content(t('doc_auth.info.upload_from_computer'))
-              expect(page).to have_content(t('doc_auth.headings.upload_from_phone'))
               click_on t('forms.buttons.upload_photos')
               expect(page).to have_current_path(idv_document_capture_url)
               expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -230,7 +230,7 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
       it 'has expected UI elements' do
         mobile_form = find('#form-to-submit-photos-through-mobile')
         expect(mobile_form).to have_name(t('forms.buttons.send_link'))
-        expect(page).to have_selector('h1', text: 'Enter your phone number to switch devices')
+        expect(page).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff_selfie'))
       end
     end
 

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -17,9 +17,9 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
   before do
     allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
       and_return(doc_auth_selfie_capture_enabled)
-    allow_any_instance_of(ServiceProviderSession).to receive(:sp_name).and_return('Test SP')
-
-    visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: biometric_comparison_required)
+    if biometric_comparison_required
+      visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: biometric_comparison_required)
+    end
     sign_in_and_2fa_user
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ApplicationController).to receive(:irs_attempts_api_tracker).
@@ -220,8 +220,6 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
   context 'on a desktop device and selfie is allowed' do
     let(:doc_auth_selfie_capture_enabled) { true }
     before do
-      expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-        and_return(true)
       complete_doc_auth_steps_before_hybrid_handoff_step
     end
 

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -12,22 +12,41 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
     }
   end
 
-  it 'has a form for starting mobile doc auth with an aria label tag' do
-    expect(rendered).to have_selector(
-      :xpath,
-      "//form[@aria-label=\"#{t('forms.buttons.send_link')}\"]",
-    )
-  end
+  context 'when selfie is not required' do
+    before do
+      @selfie_required = false
+    end
+    it 'has a form for starting mobile doc auth with an aria label tag' do
+      expect(rendered).to have_selector(
+        :xpath,
+        "//form[@aria-label=\"#{t('forms.buttons.send_link')}\"]",
+      )
+    end
 
-  it 'has a form for starting desktop doc auth with an aria label tag' do
-    expect(rendered).to have_selector(
-      :xpath,
-      "//form[@aria-label=\"#{t('forms.buttons.upload_photos')}\"]",
-    )
-  end
+    it 'has a form for starting desktop doc auth with an aria label tag' do
+      expect(rendered).to have_selector(
+        :xpath,
+        "//form[@aria-label=\"#{t('forms.buttons.upload_photos')}\"]",
+      )
+    end
 
-  it 'displays the expected headings from the "a" case' do
-    expect(rendered).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
-    expect(rendered).to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
+    it 'displays the expected headings from the "a" case' do
+      expect(rendered).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
+      expect(rendered).to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
+    end
+  end
+  context 'when selfie is required' do
+    before do
+      @selfie_required = true
+    end
+    it 'has a form for starting mobile doc auth with an aria label tag' do
+      expect(rendered).to have_selector(
+        :xpath,
+        "//form[@aria-label=\"#{t('forms.buttons.send_link')}\"]",
+      )
+    end
+    it 'displays the expected headings from the "a" case' do
+      expect(rendered).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff_selfie'))
+    end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-12672](https://cm-jira.usa.gov/browse/LG-12672)


## 🛠 Summary of changes

UI update for hybrid handoff page when selfie is required.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
On desktop , with `doc_auth_selfie_desktop_test_mode: false`.

- [ ] Step 1: Login with selfie required.
- [ ] Step 2: Proceed to hybrid handoff page, verify the new header and phone icon position.
- [ ] Step 3: On the safe side, verify the send link function works if needed.
- [ ] Step 4: Login with selfie not required.
- [ ] Step 5: Proceed to hybrid handoff page, verify the old UI elements.


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>After:</summary>

![En-Handoff](https://github.com/18F/identity-idp/assets/130466753/8e41a1f0-f204-40e5-8424-0ac75c97833a)

![Es-Handoff](https://github.com/18F/identity-idp/assets/130466753/8c5466f8-e3cc-4b07-8733-c3f9ffa7d847)

![Fr-Handoff](https://github.com/18F/identity-idp/assets/130466753/c50881fc-9a5f-442b-902a-df1361f5a3e1)

</details>
