### PR TITLE
LG-12636: Show recommended PIV option for .gov/.mil email

### DIFF
--- a/app/components/tag_component.rb
+++ b/app/components/tag_component.rb
@@ -1,0 +1,24 @@
+class TagComponent < BaseComponent
+  attr_reader :big, :informative, :tag_options
+  alias_method :big?, :big
+  alias_method :informative?, :informative
+
+  def initialize(big: false, informative: false, **tag_options)
+    @big = big
+    @informative = informative
+    @tag_options = tag_options
+  end
+
+  def css_class
+    classes = ['usa-tag', *tag_options[:class]]
+    classes << 'usa-tag--big' if big?
+    classes << 'usa-tag--informative' if informative?
+    classes
+  end
+
+  def call
+    content_tag(:span, content, **tag_options, class: css_class)
+  end
+
+  private :big, :informative
+end

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -11,7 +11,10 @@ module Users
     def index
       two_factor_options_form
       @presenter = two_factor_options_presenter
-      analytics.user_registration_2fa_setup_visit(enabled_mfa_methods_count:)
+      analytics.user_registration_2fa_setup_visit(
+        enabled_mfa_methods_count:,
+        gov_or_mil_email: gov_or_mil_email?,
+      )
     end
 
     def create
@@ -41,6 +44,10 @@ module Users
     end
 
     private
+
+    def gov_or_mil_email?
+      current_user.confirmed_email_addresses.any?(&:gov_or_mil?)
+    end
 
     def mfa_context
       @mfa_context ||= MfaContext.new(current_user)

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -31,6 +31,10 @@ class EmailAddress < ApplicationRecord
     Time.zone.now > expiration_time
   end
 
+  def gov_or_mil?
+    email.end_with?('.gov', '.mil')
+  end
+
   class << self
     def find_with_email(email)
       return nil if !email.is_a?(String) || email.empty?

--- a/app/presenters/two_factor_authentication/set_up_auth_app_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_auth_app_selection_presenter.rb
@@ -15,5 +15,9 @@ module TwoFactorAuthentication
     def info
       t('two_factor_authentication.two_factor_choice_options.auth_app_info')
     end
+
+    def phishing_resistant?
+      false
+    end
   end
 end

--- a/app/presenters/two_factor_authentication/set_up_backup_code_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_backup_code_selection_presenter.rb
@@ -12,6 +12,10 @@ module TwoFactorAuthentication
       t('two_factor_authentication.two_factor_choice_options.backup_code_info')
     end
 
+    def phishing_resistant?
+      false
+    end
+
     def single_configuration_only?
       true
     end

--- a/app/presenters/two_factor_authentication/set_up_phone_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_phone_selection_presenter.rb
@@ -12,6 +12,15 @@ module TwoFactorAuthentication
       t('two_factor_authentication.two_factor_choice_options.phone_info')
     end
 
+    def phishing_resistant?
+      false
+    end
+
+    def visible?
+      return false if IdentityConfig.store.hide_phone_mfa_signup
+      super
+    end
+
     def mfa_configuration_count
       user.phone_configurations.count
     end

--- a/app/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter.rb
@@ -12,8 +12,16 @@ module TwoFactorAuthentication
       t('two_factor_authentication.two_factor_choice_options.piv_cac_info')
     end
 
+    def phishing_resistant?
+      true
+    end
+
     def recommended?
       user.confirmed_email_addresses.any?(&:gov_or_mil?)
+    end
+
+    def desktop_only?
+      false
     end
 
     def single_configuration_only?

--- a/app/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter.rb
@@ -12,6 +12,10 @@ module TwoFactorAuthentication
       t('two_factor_authentication.two_factor_choice_options.piv_cac_info')
     end
 
+    def recommended?
+      user.confirmed_email_addresses.any?(&:gov_or_mil?)
+    end
+
     def single_configuration_only?
       true
     end

--- a/app/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter.rb
@@ -21,7 +21,7 @@ module TwoFactorAuthentication
     end
 
     def desktop_only?
-      false
+      true
     end
 
     def single_configuration_only?

--- a/app/presenters/two_factor_authentication/set_up_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_selection_presenter.rb
@@ -47,7 +47,7 @@ module TwoFactorAuthentication
       elsif phishing_resistant_required?
         phishing_resistant?
       elsif desktop_only?
-        browser.desktop?
+        !browser.mobile?
       else
         true
       end

--- a/app/presenters/two_factor_authentication/set_up_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_selection_presenter.rb
@@ -32,6 +32,10 @@ module TwoFactorAuthentication
       end
     end
 
+    def recommended?
+      false
+    end
+
     def single_configuration_only?
       false
     end

--- a/app/presenters/two_factor_authentication/set_up_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_selection_presenter.rb
@@ -90,10 +90,12 @@ module TwoFactorAuthentication
       single_configuration_only? && mfa_configuration_count > 0
     end
 
+    private :piv_cac_required, :phishing_resistant_required
+
+    private
+
     def browser
       @browser ||= BrowserCache.parse(user_agent)
     end
-
-    private :piv_cac_required, :phishing_resistant_required
   end
 end

--- a/app/presenters/two_factor_authentication/set_up_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_selection_presenter.rb
@@ -6,7 +6,12 @@ module TwoFactorAuthentication
     alias_method :piv_cac_required?, :piv_cac_required
     alias_method :phishing_resistant_required?, :phishing_resistant_required
 
-    def initialize(user:, piv_cac_required:, phishing_resistant_required:, user_agent:)
+    def initialize(
+      user:,
+      piv_cac_required: false,
+      phishing_resistant_required: false,
+      user_agent: nil
+    )
       @user = user
       @piv_cac_required = piv_cac_required
       @phishing_resistant_required = phishing_resistant_required

--- a/app/presenters/two_factor_authentication/set_up_webauthn_platform_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_webauthn_platform_selection_presenter.rb
@@ -1,10 +1,5 @@
 module TwoFactorAuthentication
   class SetUpWebauthnPlatformSelectionPresenter < SetUpSelectionPresenter
-    def initialize(user:, configuration: nil)
-      @user = user
-      @configuration = configuration
-    end
-
     def type
       :webauthn_platform
     end
@@ -30,6 +25,10 @@ module TwoFactorAuthentication
         'two_factor_authentication.two_factor_choice_options.webauthn_platform_info',
         app_name: APP_NAME,
       )
+    end
+
+    def phishing_resistant?
+      true
     end
 
     def single_configuration_only?

--- a/app/presenters/two_factor_authentication/set_up_webauthn_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/set_up_webauthn_selection_presenter.rb
@@ -16,6 +16,10 @@ module TwoFactorAuthentication
       t('two_factor_authentication.two_factor_choice_options.webauthn_info')
     end
 
+    def phishing_resistant?
+      true
+    end
+
     def mfa_configuration_count
       user.webauthn_configurations.where(platform_authenticator: [false, nil]).count
     end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -94,17 +94,6 @@ class TwoFactorOptionsPresenter
 
   private
 
-  def sorted_method_presenters
-    [
-      TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter,
-      TwoFactorAuthentication::SetUpAuthAppSelectionPresenter,
-      TwoFactorAuthentication::SetUpPhoneSelectionPresenter,
-      TwoFactorAuthentication::SetUpBackupCodeSelectionPresenter,
-      TwoFactorAuthentication::SetUpWebauthnSelectionPresenter,
-      TwoFactorAuthentication::SetUpPivCacSelectionPresenter,
-    ]
-  end
-
   def show_option?(option)
     case option
     when TwoFactorAuthentication::SetUpPivCacSelectionPresenter

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4744,10 +4744,16 @@ module AnalyticsEvents
 
   # Tracks when user visits MFA selection page
   # @param [Integer] enabled_mfa_methods_count Number of MFAs associated with user at time of visit
-  def user_registration_2fa_setup_visit(enabled_mfa_methods_count:, **extra)
+  # @param [Boolean] gov_or_mil_email Whether registered user has government email
+  def user_registration_2fa_setup_visit(
+    enabled_mfa_methods_count:,
+    gov_or_mil_email:,
+    **extra
+  )
     track_event(
       'User Registration: 2FA Setup visited',
       enabled_mfa_methods_count:,
+      gov_or_mil_email:,
       **extra,
     )
   end

--- a/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
+++ b/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
@@ -30,6 +30,13 @@
     <% end %>
     <span id="two_factor_options_form_selection_info_<%= option.type %>" aria-hidden="true" class="usa-checkbox__label-description">
       <%= option.info %>
+      <% if option.recommended? %>
+        <br />
+        <%= render TagComponent.new(
+              informative: true,
+              class: 'margin-top-1',
+            ).with_content(t('two_factor_authentication.recommended')) %>
+      <% end %>
     </span>
   </div>
 <% end %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -22,7 +22,7 @@
   </h2>
 
   <%= render IconListComponent.new(icon: :check_circle, color: :success) do |c| %>
-    <% @presenter.all_user_selected_options.each do |option| %>
+    <% @presenter.all_options_sorted.each do |option| %>
       <% if option.mfa_configuration_count > 0 %>
         <% c.with_item do %>
           <%= option.label %> <%= option.mfa_added_label %>

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -155,6 +155,7 @@ en:
       google_policy_link: Privacy Policy
       google_tos_link: Terms of Service
       login_tos_link: Mobile Terms of Use
+    recommended: Recommended
     totp_header_text: Enter your authentication app code
     two_factor_aal3_choice: Additional authentication required
     two_factor_aal3_choice_intro: This app requires a higher level of security. You

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -162,6 +162,7 @@ es:
       google_policy_link: aplican la política de privacidad
       google_tos_link: las condiciones de servicio
       login_tos_link: las condiciones de uso
+    recommended: Recomendado
     totp_header_text: Ingrese su código de la app de autenticación
     two_factor_aal3_choice: Se requiere autenticación adicional
     two_factor_aal3_choice_intro: Esta aplicación requiere un mayor nivel de

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -171,6 +171,7 @@ fr:
       google_policy_link: règles de confidentialité
       google_tos_link: conditions de service
       login_tos_link: conditions d’utilisation
+    recommended: Recommandation
     totp_header_text: Entrez votre code d’application d’authentification
     two_factor_aal3_choice: Authentification supplémentaire requise
     two_factor_aal3_choice_intro: Cette application nécessite un niveau de sécurité

--- a/spec/components/previews/tag_component_preview.rb
+++ b/spec/components/previews/tag_component_preview.rb
@@ -1,0 +1,26 @@
+class TagComponentPreview < BaseComponentPreview
+  # @!group Preview
+  def default
+    render TagComponent.new.with_content('Base')
+  end
+
+  def big
+    render TagComponent.new(big: true).with_content('Base')
+  end
+
+  def informative
+    render TagComponent.new(informative: true).with_content('Informative')
+  end
+
+  def big_and_informative
+    render TagComponent.new(big: true, informative: true).with_content('Informative')
+  end
+  # @!endgroup
+
+  # @param big toggle
+  # @param informative toggle
+  # @param text text
+  def workbench(big: false, informative: false, text: 'Base')
+    render TagComponent.new(big:, informative:).with_content(text)
+  end
+end

--- a/spec/components/tag_component_spec.rb
+++ b/spec/components/tag_component_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe TagComponent, type: :component do
+  let(:content) { 'Example' }
+
+  it 'renders a tag with default attributes' do
+    rendered = render_inline TagComponent.new.with_content(content)
+
+    expect(rendered).to have_css('.usa-tag', text: content)
+  end
+
+  context 'with big size' do
+    it 'renders with variant class' do
+      rendered = render_inline TagComponent.new(big: true).with_content(content)
+
+      expect(rendered).to have_css('.usa-tag.usa-tag--big')
+    end
+  end
+
+  context 'with informative style' do
+    it 'renders with variant class' do
+      rendered = render_inline TagComponent.new(informative: true).with_content(content)
+
+      expect(rendered).to have_css('.usa-tag.usa-tag--informative')
+    end
+  end
+
+  context 'with custom class' do
+    it 'renders with custom class' do
+      rendered = render_inline TagComponent.new(class: 'my-custom-class').with_content(content)
+
+      expect(rendered).to have_css('.usa-tag.my-custom-class')
+    end
+  end
+
+  context 'with tag options' do
+    it 'renders with attributes' do
+      rendered = render_inline TagComponent.new(data: { foo: 'bar' })
+
+      expect(rendered).to have_css('.usa-tag[data-foo="bar"]')
+    end
+  end
+end

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -88,4 +88,26 @@ RSpec.describe EmailAddress do
       expect(email_address.confirmation_period_expired?).to be_truthy
     end
   end
+
+  describe '#gov_or_mil?' do
+    subject(:result) { email_address.gov_or_mil? }
+
+    context 'with an email domain ending in anything other than .gov or .mil' do
+      let(:email) { 'example@example.com' }
+
+      it { expect(result).to eq(false) }
+    end
+
+    context 'with an email domain ending in .gov' do
+      let(:email) { 'example@example.gov' }
+
+      it { expect(result).to eq(true) }
+    end
+
+    context 'with an email domain ending in .mil' do
+      let(:email) { 'example@example.mil' }
+
+      it { expect(result).to eq(true) }
+    end
+  end
 end

--- a/spec/presenters/two_factor_authentication/set_up_auth_app_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_auth_app_selection_presenter_spec.rb
@@ -30,4 +30,10 @@ RSpec.describe TwoFactorAuthentication::SetUpAuthAppSelectionPresenter do
       )
     end
   end
+
+  describe '#phishing_resistant?' do
+    subject(:phishing_resistant) { presenter_without_mfa.phishing_resistant? }
+
+    it { expect(phishing_resistant).to eq(false) }
+  end
 end

--- a/spec/presenters/two_factor_authentication/set_up_auth_app_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_auth_app_selection_presenter_spec.rb
@@ -1,38 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe TwoFactorAuthentication::SetUpAuthAppSelectionPresenter do
-  let(:configuration) {}
-  let(:user_without_mfa) { create(:user) }
-  let(:user_with_mfa) { create(:user, :with_authentication_app) }
-  let(:presenter_without_mfa) do
-    described_class.new(user: user_without_mfa)
-  end
-  let(:presenter_with_mfa) do
-    described_class.new(user: user_with_mfa)
-  end
+  let(:user) { create(:user) }
+  let(:presenter) { described_class.new(user:) }
 
   describe '#type' do
     it 'returns auth_app' do
-      expect(presenter_without_mfa.type).to eq :auth_app
+      expect(presenter.type).to eq(:auth_app)
     end
   end
 
-  describe '#mfa_configuration' do
-    it 'return an empty string when user has not configured this authenticator' do
-      expect(presenter_without_mfa.mfa_configuration_description).to eq('')
+  describe '#mfa_configuration_description' do
+    subject(:mfa_configuration_description) { presenter.mfa_configuration_description }
+
+    context 'when user has not configured this authenticator' do
+      let(:user) { create(:user) }
+
+      it 'return an empty string' do
+        expect(mfa_configuration_description).to eq('')
+      end
     end
-    it 'return an # added when user has configured this authenticator' do
-      expect(presenter_with_mfa.mfa_configuration_description).to eq(
-        t(
-          'two_factor_authentication.two_factor_choice_options.configurations_added',
-          count: 1,
-        ),
-      )
+
+    context 'when user has configured this authenticator' do
+      let(:user) { create(:user, :with_authentication_app) }
+
+      it 'returns text with number of added authenticators' do
+        expect(mfa_configuration_description).to eq(
+          t(
+            'two_factor_authentication.two_factor_choice_options.configurations_added',
+            count: 1,
+          ),
+        )
+      end
     end
   end
 
   describe '#phishing_resistant?' do
-    subject(:phishing_resistant) { presenter_without_mfa.phishing_resistant? }
+    subject(:phishing_resistant) { presenter.phishing_resistant? }
 
     it { expect(phishing_resistant).to eq(false) }
   end

--- a/spec/presenters/two_factor_authentication/set_up_backup_code_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_backup_code_selection_presenter_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe TwoFactorAuthentication::SetUpBackupCodeSelectionPresenter do
+  let(:user) { create(:user) }
+  let(:presenter) { described_class.new(user:) }
+
+  describe '#phishing_resistant?' do
+    subject(:phishing_resistant) { presenter.phishing_resistant? }
+
+    it { expect(phishing_resistant).to eq(false) }
+  end
+end

--- a/spec/presenters/two_factor_authentication/set_up_phone_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_phone_selection_presenter_spec.rb
@@ -49,4 +49,10 @@ RSpec.describe TwoFactorAuthentication::SetUpPhoneSelectionPresenter do
         to eq(t('two_factor_authentication.two_factor_choice_options.phone_info'))
     end
   end
+
+  describe '#phishing_resistant?' do
+    subject(:phishing_resistant) { presenter_without_mfa.phishing_resistant? }
+
+    it { expect(phishing_resistant).to eq(false) }
+  end
 end

--- a/spec/presenters/two_factor_authentication/set_up_phone_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_phone_selection_presenter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe TwoFactorAuthentication::SetUpPhoneSelectionPresenter do
     context 'user with configured authenticator' do
       let(:user) { create(:user, :with_phone) }
 
-      it 'returns number of added authenticators' do
+      it 'returns text with number of added authenticators' do
         expect(mfa_configuration_description).to eq(
           t(
             'two_factor_authentication.two_factor_choice_options.configurations_added',

--- a/spec/presenters/two_factor_authentication/set_up_phone_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_phone_selection_presenter_spec.rb
@@ -1,58 +1,75 @@
 require 'rails_helper'
 
 RSpec.describe TwoFactorAuthentication::SetUpPhoneSelectionPresenter do
-  let(:user_without_mfa) { create(:user) }
-  let(:user_with_mfa) { create(:user, :with_phone) }
-  let(:presenter_with_mfa) { described_class.new(user: user_with_mfa) }
-  let(:presenter_without_mfa) { described_class.new(user: user_without_mfa) }
+  let(:user) { create(:user) }
+  let(:presenter) { described_class.new(user:) }
 
   describe '#info' do
-    context 'when a user does not have a phone configuration (first time)' do
-      it 'includes a note about choosing voice or sms' do
-        expect(presenter_without_mfa.info).
-          to include(t('two_factor_authentication.two_factor_choice_options.phone_info'))
-      end
-
-      it 'does not include a masked number' do
-        expect(presenter_without_mfa.info).to_not include('***')
-      end
+    it 'includes a note about choosing voice or sms' do
+      expect(presenter.info).to eq(
+        t('two_factor_authentication.two_factor_choice_options.phone_info'),
+      )
     end
   end
 
   describe '#disabled?' do
-    it { expect(presenter_without_mfa.disabled?).to eq(false) }
+    subject(:disabled) { presenter.disabled? }
+
+    it { expect(disabled).to eq(false) }
 
     context 'all phone vendor outage' do
       before do
         allow_any_instance_of(OutageStatus).to receive(:all_phone_vendor_outage?).and_return(true)
       end
 
-      it { expect(presenter_without_mfa.disabled?).to eq(true) }
+      it { expect(disabled).to eq(true) }
     end
   end
 
   describe '#mfa_configuration' do
-    it 'returns an empty string when user has not configured this authenticator' do
-      expect(presenter_without_mfa.mfa_configuration_description).to eq('')
-    end
-    it 'returns an # added when user has configured this authenticator' do
-      expect(presenter_with_mfa.mfa_configuration_description).to eq(
-        t(
-          'two_factor_authentication.two_factor_choice_options.configurations_added',
-          count: 1,
-        ),
-      )
+    subject(:mfa_configuration_description) { presenter.mfa_configuration_description }
+
+    context 'user without configured authenticator' do
+      let(:user) { create(:user) }
+
+      it 'returns an empty string' do
+        expect(mfa_configuration_description).to eq('')
+      end
     end
 
-    it 'does not include a note to select an additional mfa on additional setup' do
-      expect(presenter_with_mfa.info).
-        to eq(t('two_factor_authentication.two_factor_choice_options.phone_info'))
+    context 'user with configured authenticator' do
+      let(:user) { create(:user, :with_phone) }
+
+      it 'returns number of added authenticators' do
+        expect(mfa_configuration_description).to eq(
+          t(
+            'two_factor_authentication.two_factor_choice_options.configurations_added',
+            count: 1,
+          ),
+        )
+      end
     end
   end
 
   describe '#phishing_resistant?' do
-    subject(:phishing_resistant) { presenter_without_mfa.phishing_resistant? }
+    subject(:phishing_resistant) { presenter.phishing_resistant? }
 
     it { expect(phishing_resistant).to eq(false) }
+  end
+
+  describe '#visible?' do
+    subject(:visible) { presenter.visible? }
+
+    it 'defaults to the result of the base class' do
+      expect(visible).to eq(TwoFactorAuthentication::SetUpSelectionPresenter.new(user:).visible?)
+    end
+
+    context 'with phone option configured to be hidden during signup' do
+      before do
+        allow(IdentityConfig.store).to receive(:hide_phone_mfa_signup).and_return(true)
+      end
+
+      it { expect(visible).to eq(false) }
+    end
   end
 end

--- a/spec/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter_spec.rb
@@ -47,4 +47,10 @@ RSpec.describe TwoFactorAuthentication::SetUpPivCacSelectionPresenter do
       it { expect(recommended).to eq(true) }
     end
   end
+
+  describe '#phishing_resistant?' do
+    subject(:phishing_resistant) { presenter.phishing_resistant? }
+
+    it { expect(phishing_resistant).to eq(true) }
+  end
 end

--- a/spec/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter_spec.rb
@@ -1,31 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe TwoFactorAuthentication::SetUpPivCacSelectionPresenter do
-  let(:user_without_mfa) { create(:user) }
-  let(:user_with_mfa) { create(:user, :with_piv_or_cac) }
-  let(:presenter_without_mfa) do
-    described_class.new(user: user_without_mfa)
-  end
-  let(:presenter_with_mfa) do
-    described_class.new(user: user_with_mfa)
-  end
+  let(:user) { create(:user) }
+  subject(:presenter) { described_class.new(user:) }
 
   describe '#type' do
     it 'returns piv_cac' do
-      expect(presenter_without_mfa.type).to eq :piv_cac
+      expect(presenter.type).to eq :piv_cac
     end
   end
 
   describe '#mfa_configruation' do
-    it 'returns an empty string when user has not configured piv/cac' do
-      expect(presenter_without_mfa.mfa_configuration_description).to eq('')
+    subject(:description) { presenter.mfa_configuration_description }
+
+    context 'user has not configured piv/cac' do
+      let(:user) { create(:user) }
+
+      it 'returns an empty string' do
+        expect(description).to eq('')
+      end
     end
-    it 'returns the translated string for added when user has configured piv/cac' do
-      expect(presenter_with_mfa.mfa_configuration_description).to eq(
-        t(
-          'two_factor_authentication.two_factor_choice_options.no_count_configuration_added',
-        ),
-      )
+
+    context 'user has configured piv/cac' do
+      let(:user) { create(:user, :with_piv_or_cac) }
+
+      it 'returns the translated string for added' do
+        expect(description).to eq(
+          t('two_factor_authentication.two_factor_choice_options.no_count_configuration_added'),
+        )
+      end
+    end
+  end
+
+  describe '#recommended?' do
+    subject(:recommended) { presenter.recommended? }
+
+    context 'with a confirmed email address ending in anything other than .gov or .mil' do
+      let(:user) { create(:user, email: 'example@example.com') }
+
+      it { expect(recommended).to eq(false) }
+    end
+
+    context 'with a confirmed email address ending in .gov or .mil' do
+      let(:user) { create(:user, email: 'example@example.gov') }
+
+      it { expect(recommended).to eq(true) }
     end
   end
 end

--- a/spec/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_piv_cac_selection_presenter_spec.rb
@@ -53,4 +53,10 @@ RSpec.describe TwoFactorAuthentication::SetUpPivCacSelectionPresenter do
 
     it { expect(phishing_resistant).to eq(true) }
   end
+
+  describe '#desktop_only?' do
+    subject(:desktop_only) { presenter.desktop_only? }
+
+    it { expect(desktop_only).to eq(true) }
+  end
 end

--- a/spec/presenters/two_factor_authentication/set_up_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_selection_presenter_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe TwoFactorAuthentication::SetUpSelectionPresenter do
     end
   end
 
+  describe '#phishing_resistant?' do
+    it 'raises with missing implementation' do
+      expect do
+        placeholder_presenter_class.new(user:).phishing_resistant?
+      end.to raise_error(NotImplementedError)
+    end
+  end
+
   describe '#recommended?' do
     subject(:recommended) { presenter.recommended? }
 

--- a/spec/presenters/two_factor_authentication/set_up_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_selection_presenter_spec.rb
@@ -1,13 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe TwoFactorAuthentication::SetUpSelectionPresenter do
-  let(:placeholder_presenter_class) do
-    Class.new(TwoFactorAuthentication::SetUpSelectionPresenter)
-  end
+  include UserAgentHelper
 
+  let(:presenter_class) { TwoFactorAuthentication::SetUpSelectionPresenter }
   let(:user) { build(:user) }
+  let(:piv_cac_required) { false }
+  let(:phishing_resistant_required) { false }
+  let(:user_agent) { desktop_user_agent }
 
-  subject(:presenter) { described_class.new(user: user) }
+  subject(:presenter) do
+    presenter_class.new(user:, piv_cac_required:, phishing_resistant_required:, user_agent:)
+  end
 
   describe '#render_in' do
     it 'renders captured block content' do
@@ -91,27 +95,109 @@ RSpec.describe TwoFactorAuthentication::SetUpSelectionPresenter do
 
   describe '#type' do
     it 'raises with missing implementation' do
-      expect { placeholder_presenter_class.new(user:).type }.to raise_error(NotImplementedError)
+      expect { presenter.type }.to raise_error(NotImplementedError)
     end
   end
 
   describe '#label' do
     it 'raises with missing implementation' do
-      expect { placeholder_presenter_class.new(user:).label }.to raise_error(NotImplementedError)
+      expect { presenter.label }.to raise_error(NotImplementedError)
     end
   end
 
   describe '#info' do
     it 'raises with missing implementation' do
-      expect { placeholder_presenter_class.new(user:).info }.to raise_error(NotImplementedError)
+      expect { presenter.info }.to raise_error(NotImplementedError)
     end
   end
 
   describe '#phishing_resistant?' do
     it 'raises with missing implementation' do
-      expect do
-        placeholder_presenter_class.new(user:).phishing_resistant?
-      end.to raise_error(NotImplementedError)
+      expect { presenter.phishing_resistant? }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#visible?' do
+    subject(:visible) { presenter.visible? }
+
+    it { expect(visible).to eq(true) }
+
+    context 'with piv cac required' do
+      let(:piv_cac_required) { true }
+
+      context 'with non-piv type selection' do
+        let(:presenter_class) do
+          Class.new(super()) do
+            def type
+              :not_piv_cac
+            end
+          end
+        end
+
+        it { expect(visible).to eq(false) }
+      end
+
+      context 'with piv type selection' do
+        let(:presenter_class) do
+          Class.new(super()) do
+            def type
+              :piv_cac
+            end
+          end
+        end
+
+        it { expect(visible).to eq(true) }
+      end
+    end
+
+    context 'with phishing resistant required' do
+      let(:phishing_resistant_required) { true }
+
+      context 'with non-phishing resistant selection' do
+        let(:presenter_class) do
+          Class.new(super()) do
+            def phishing_resistant?
+              false
+            end
+          end
+        end
+
+        it { expect(visible).to eq(false) }
+      end
+
+      context 'with phishing resistant selection' do
+        let(:presenter_class) do
+          Class.new(super()) do
+            def phishing_resistant?
+              true
+            end
+          end
+        end
+
+        it { expect(visible).to eq(true) }
+      end
+    end
+
+    context 'with selection supporting desktop only' do
+      let(:presenter_class) do
+        Class.new(super()) do
+          def desktop_only?
+            true
+          end
+        end
+      end
+
+      context 'on mobile device' do
+        let(:user_agent) { mobile_user_agent }
+
+        it { expect(visible).to eq(false) }
+      end
+
+      context 'on desktop device' do
+        let(:user_agent) { desktop_user_agent }
+
+        it { expect(visible).to eq(true) }
+      end
     end
   end
 

--- a/spec/presenters/two_factor_authentication/set_up_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_selection_presenter_spec.rb
@@ -106,4 +106,10 @@ RSpec.describe TwoFactorAuthentication::SetUpSelectionPresenter do
       expect { placeholder_presenter_class.new(user:).info }.to raise_error(NotImplementedError)
     end
   end
+
+  describe '#recommended?' do
+    subject(:recommended) { presenter.recommended? }
+
+    it { expect(recommended).to eq(false) }
+  end
 end

--- a/spec/presenters/two_factor_authentication/set_up_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_selection_presenter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TwoFactorAuthentication::SetUpSelectionPresenter do
   let(:user) { build(:user) }
   let(:piv_cac_required) { false }
   let(:phishing_resistant_required) { false }
-  let(:user_agent) { desktop_user_agent }
+  let(:user_agent) {}
 
   subject(:presenter) do
     presenter_class.new(user:, piv_cac_required:, phishing_resistant_required:, user_agent:)
@@ -186,6 +186,8 @@ RSpec.describe TwoFactorAuthentication::SetUpSelectionPresenter do
           end
         end
       end
+
+      it { expect(visible).to eq(true) }
 
       context 'on mobile device' do
         let(:user_agent) { mobile_user_agent }

--- a/spec/presenters/two_factor_authentication/set_up_webauthn_platform_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_webauthn_platform_selection_presenter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter 
     context 'when user has configured this authenticator' do
       let(:user) { create(:user, :with_webauthn_platform) }
 
-      it 'returns number of added authenticators' do
+      it 'returns text with number of added authenticators' do
         expect(mfa_configuration_description).to eq(
           t(
             'two_factor_authentication.two_factor_choice_options.no_count_configuration_added',

--- a/spec/presenters/two_factor_authentication/set_up_webauthn_platform_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_webauthn_platform_selection_presenter_spec.rb
@@ -1,73 +1,71 @@
 require 'rails_helper'
 
 RSpec.describe TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter do
-  let(:user_without_mfa) { create(:user) }
-  let(:user_with_mfa) { create(:user) }
-  let(:configuration) {}
-  let(:presenter_without_mfa) do
-    described_class.new(user: user_without_mfa)
-  end
-  let(:presenter_with_mfa) do
-    described_class.new(user: user_with_mfa)
-  end
+  let(:user) { create(:user) }
   subject(:presenter) do
-    TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter.new(
-      user:,
-      configuration: user.webauthn_configurations.platform_authenticators.first,
-    )
+    TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter.new(user:)
   end
 
   describe '#type' do
     it 'returns webauthn_platform' do
-      expect(presenter_without_mfa.type).to eq :webauthn_platform
+      expect(presenter.type).to eq(:webauthn_platform)
     end
   end
 
   describe '#render_in' do
-    let(:user) { create(:user) }
+    let(:view_context) { instance_double(ActionView::Base) }
+    subject(:rendered) { presenter.render_in(view_context) { 'content' } }
+
     it 'renders a WebauthnInputComponent' do
-      view_context = instance_double(ActionView::Base)
       expect(view_context).to receive(:render) do |component, &block|
         expect(component).to be_instance_of(WebauthnInputComponent)
         expect(component.passkey_supported_only?).to be(true)
         expect(block.call).to eq('content')
       end
 
-      presenter.render_in(view_context) { 'content' }
+      rendered
     end
 
     context 'with configured authenticator' do
       let(:user) { create(:user, :with_webauthn_platform) }
 
       it 'renders a WebauthnInputComponent with passkey_supported_only false' do
-        view_context = instance_double(ActionView::Base)
         expect(view_context).to receive(:render) do |component, &block|
           expect(component.passkey_supported_only?).to be(true)
         end
 
-        presenter.render_in(view_context)
+        rendered
       end
     end
   end
 
-  describe '#mfa_configuration' do
-    it 'returns an empty string when user has not configured this authenticator' do
-      expect(presenter_without_mfa.mfa_configuration_description).to eq('')
+  describe '#mfa_configuration_description' do
+    subject(:mfa_configuration_description) { presenter.mfa_configuration_description }
+
+    context 'when user has not configured this authenticator' do
+      let(:user) { create(:user) }
+
+      it 'returns an empty string' do
+        expect(mfa_configuration_description).to eq('')
+      end
     end
 
-    it 'returns an # added when user has configured this authenticator' do
-      create(:webauthn_configuration, platform_authenticator: true, user: user_with_mfa)
-      expect(presenter_with_mfa.mfa_configuration_description).to eq(
-        t(
-          'two_factor_authentication.two_factor_choice_options.no_count_configuration_added',
-          count: 1,
-        ),
-      )
+    context 'when user has configured this authenticator' do
+      let(:user) { create(:user, :with_webauthn_platform) }
+
+      it 'returns number of added authenticators' do
+        expect(mfa_configuration_description).to eq(
+          t(
+            'two_factor_authentication.two_factor_choice_options.no_count_configuration_added',
+            count: 1,
+          ),
+        )
+      end
     end
   end
 
   describe '#phishing_resistant?' do
-    subject(:phishing_resistant) { presenter_without_mfa.phishing_resistant? }
+    subject(:phishing_resistant) { presenter.phishing_resistant? }
 
     it { expect(phishing_resistant).to eq(true) }
   end

--- a/spec/presenters/two_factor_authentication/set_up_webauthn_platform_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_webauthn_platform_selection_presenter_spec.rb
@@ -65,4 +65,10 @@ RSpec.describe TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter 
       )
     end
   end
+
+  describe '#phishing_resistant?' do
+    subject(:phishing_resistant) { presenter_without_mfa.phishing_resistant? }
+
+    it { expect(phishing_resistant).to eq(true) }
+  end
 end

--- a/spec/presenters/two_factor_authentication/set_up_webauthn_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/set_up_webauthn_selection_presenter_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe TwoFactorAuthentication::SetUpWebauthnSelectionPresenter do
       )
     end
   end
+
+  describe '#phishing_resistant?' do
+    subject(:phishing_resistant) { presenter_without_mfa.phishing_resistant? }
+
+    it { expect(phishing_resistant).to eq(true) }
+  end
 end

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -85,6 +85,37 @@ RSpec.describe TwoFactorOptionsPresenter do
     end
   end
 
+  describe '#all_options_sorted' do
+    it 'returns all options' do
+      expect(presenter.options.map(&:class)).to eq [
+        TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter,
+        TwoFactorAuthentication::SetUpAuthAppSelectionPresenter,
+        TwoFactorAuthentication::SetUpPhoneSelectionPresenter,
+        TwoFactorAuthentication::SetUpBackupCodeSelectionPresenter,
+        TwoFactorAuthentication::SetUpWebauthnSelectionPresenter,
+        TwoFactorAuthentication::SetUpPivCacSelectionPresenter,
+      ]
+    end
+
+    context 'when a presenter which is recommended' do
+      before do
+        allow_any_instance_of(TwoFactorAuthentication::SetUpPivCacSelectionPresenter).
+          to receive(:recommended?).and_return(true)
+      end
+
+      it 'orders options by recommended' do
+        expect(presenter.options.map(&:class)).to eq [
+          TwoFactorAuthentication::SetUpPivCacSelectionPresenter,
+          TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter,
+          TwoFactorAuthentication::SetUpAuthAppSelectionPresenter,
+          TwoFactorAuthentication::SetUpPhoneSelectionPresenter,
+          TwoFactorAuthentication::SetUpBackupCodeSelectionPresenter,
+          TwoFactorAuthentication::SetUpWebauthnSelectionPresenter,
+        ]
+      end
+    end
+  end
+
   describe '#skip_path' do
     subject(:skip_path) { presenter.skip_path }
     it { expect(skip_path).to be_nil }

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -80,9 +80,11 @@ class FakeAnalytics < Analytics
       method_name = caller.
         grep(/analytics_events\.rb/)&.
         first&.
-        match(/:in `(?<method_name>[^']+)'/)&.[](:method_name)
+        match(/:in `(?<method_name>[^']+)'/)&.
+        [](:method_name)&.
+        to_sym
 
-      if method_name && !allowed_extra_analytics.include?(:*)
+      if method_name && (allowed_extra_analytics & [:*, method_name]).blank?
         analytics_method = AnalyticsEvents.instance_method(method_name)
 
         param_names = analytics_method.

--- a/spec/support/user_agent_helper.rb
+++ b/spec/support/user_agent_helper.rb
@@ -1,4 +1,9 @@
 module UserAgentHelper
+  def desktop_user_agent
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' \
+      'Chrome/58.0.3029.110 Safari/537.36'
+  end
+
   def mobile_user_agent
     'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) \
 AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1'

--- a/spec/views/partials/multi_factor_authentication/_mfa_selection.html.erb_spec.rb
+++ b/spec/views/partials/multi_factor_authentication/_mfa_selection.html.erb_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe 'partials/multi_factor_authentication/_mfa_selection.html.erb' do
   let(:form_builder) do
     SimpleForm::FormBuilder.new(form_object.model_name.param_key, form_object, view_context, {})
   end
+  let(:option) { presenter.options.first }
+  subject(:rendered) { render(partial: 'mfa_selection', locals: { form: form_builder, option: }) }
 
   context 'before selecting options' do
     subject(:rendered) do
@@ -141,6 +143,22 @@ RSpec.describe 'partials/multi_factor_authentication/_mfa_selection.html.erb' do
           count: 10,
         ),
       )
+    end
+  end
+
+  describe 'recommended tag' do
+    it 'does not render recommended tag' do
+      expect(rendered).not_to have_css('.usa-tag', text: t('two_factor_authentication.recommended'))
+    end
+
+    context 'when option is recommended' do
+      before do
+        allow(option).to receive(:recommended?).and_return(true)
+      end
+
+      it 'renders with recommended tag' do
+        expect(rendered).to have_css('.usa-tag', text: t('two_factor_authentication.recommended'))
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-12636](https://cm-jira.usa.gov/browse/LG-12636)

## 🛠 Summary of changes

Recommends PIV as an MFA option in account creation for users with a ".gov" or ".mil" email:

- Sorts the option to appear first in the selection list
- Displays a "Recommended" tag

## 📜 Testing Plan

Repeat the following steps with and without a ".gov" or ".mil" email:

1. Go to http://localhost:3000
2. Click "Create an account"
3. Complete account creation up until MFA selection
4. Observe:
   - If you entered a ".gov" or ".mil" email for your account, PIV appears first and has a "Recommended" tag
   - Otherwise, PIV appears last and does not have a "Recommended" tag
   - All other options are unaffected

## 👀 Screenshots

Before|After
---|---
![localhost_3000_authentication_methods_setup(Computer Standard) (1)](https://github.com/18F/identity-idp/assets/1779930/9095a7f6-7e49-4d0d-9948-02f335bf8492)|![localhost_3000_authentication_methods_setup(Computer Standard)](https://github.com/18F/identity-idp/assets/1779930/c8c4e647-57b7-4062-b7cd-c96802ce5c68)
