### PR TITLE
Blackscreen Fix Attempt: Remove Hint Text Update from `onPhotoTaken`

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -509,12 +509,14 @@ function AcuantCapture(
   function onSelfieCaptureOpen() {
     trackEvent('idv_sdk_selfie_image_capture_opened', { captureAttempts });
 
+    setImageCaptureText('');
     setIsCapturingEnvironment(true);
   }
 
   function onSelfieCaptureClosed() {
     trackEvent('idv_sdk_selfie_image_capture_closed_without_photo', { captureAttempts });
 
+    setImageCaptureText('');
     setIsCapturingEnvironment(false);
   }
 

--- a/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-camera.tsx
@@ -110,7 +110,6 @@ function AcuantSelfieCamera({
       },
       onPhotoTaken: () => {
         // The photo has been taken and it's showing a preview with a button to accept or retake the image.
-        onImageCaptureFeedback('');
       },
       onPhotoRetake: () => {
         // Triggered when retake button is tapped


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:

https://cm-jira.usa.gov/browse/LG-12671

Slack thread with additional context and reasoning [here](https://gsa-tts.slack.com/archives/C05HSH9RQ57/p1710519415603379?thread_ts=1710518388.562059&cid=C05HSH9RQ57).

## 🛠 Summary of changes

This PR removes the code to reset the hint text when selfie capture closes because it may be the cause of the black screen problem. This is not a certain thing, but it's worth trying.

## 📜 Testing Plan
To test this:
- Check out `main` and go to the front/back/selfie page with selfie enabled.
- Open the selfie capture, paying special attention to the hint text and how it changes.
- Open/close selfie capture, again paying attention to how the hint text changes.
- Check out this PR `charley/attempt-to-fix-blackscreen-1` and repeat the earlier steps, looking at the hint text.
- Note any differences (there should be a few).
- If the differences are minor and look acceptable to Kelli, then this PR should be merged.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
