### PR TITLE
Update ImageUploadsController spec to use have_logged_event

### DIFF
--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -56,21 +56,10 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
         stub_analytics
         stub_attempts_tracker
 
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).not_to receive(:track_event).with(
           'IdV: doc auth image upload form submitted,',
-          success: false,
-          errors: {
-            front: ['Please fill in this field.'],
-          },
-          error_details: {
-            front: { blank: true },
-          },
-          user_id: user.uuid,
-          submit_attempts: 1,
-          remaining_submit_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
-          pii_like_keypaths: pii_like_keypaths,
-          flow_path: 'standard',
-        ).exactly(0).times
+          any_args,
+        )
 
         expect(@analytics).not_to receive(:track_event).with(
           'IdV: doc auth image upload vendor submitted',


### PR DESCRIPTION
## 🎫 Ticket

Related to work underway for [LG-12657](https://cm-jira.usa.gov/browse/LG-12657)

## 🛠 Summary of changes

Over on #10230 I am doing some work that involves touching a lot of analytics-related specs. I noticed that the spec for `Idv::ImageUploadsController` was using syntax like:

```ruby
expect(@analytics).to receive(:track_event).with('event name', { big list of args })
```

This PR updates the spec to use [the `have_logged_event` matcher](https://github.com/18F/identity-idp/blob/main/spec/support/fake_analytics.rb#L180), which will make some of my changes a little easier.

The biggest thing here is that `have_logged_event` needs to be called _after_ the action, rather than before, so this meant moving some code around.