### PR TITLE
LG-12678 Updates nil return value to false

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -160,7 +160,7 @@ class OpenidConnectUserInfoPresenter
     )
       x509_data.presented
     else
-      x509_data.presented.raw
+      !!x509_data.presented.raw
     end
   end
 

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
               aggregate_failures do
                 expect(user_info[:x509_subject]).to be_blank
                 expect(user_info[:x509_issuer]).to be_blank
-                expect(user_info[:x509_presented]).to be_blank
+                expect(user_info[:x509_presented]).to be false
               end
             end
           end


### PR DESCRIPTION

## 🎫 TicketLink to the relevant ticket:
[LG-12678](https://cm-jira.usa.gov/browse/LG-12678)

## 🛠 Summary of changes
We updated the documented values to boolean -- so returning `false` when piv/cac is not used makes more sense, rather than a `nil` return. (Boolean is more straightforward, and easier for partners using typed languages)

