### PR TITLE
Add **extra where missing from track_event calls

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -624,7 +624,7 @@ module AnalyticsEvents
     success:,
     use_alternate_sdk:,
     liveness_checking_required:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: Acuant SDK loaded',
@@ -635,6 +635,7 @@ module AnalyticsEvents
       success: success,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -665,8 +666,8 @@ module AnalyticsEvents
   end
 
   # User visited idv address page
-  def idv_address_visit
-    track_event('IdV: address visited')
+  def idv_address_visit(**extra)
+    track_event('IdV: address visited', **extra)
   end
 
   # @param [String] acuantCaptureMode
@@ -723,7 +724,7 @@ module AnalyticsEvents
     use_alternate_sdk:,
     liveness_checking_required:,
     width:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: back image added',
@@ -752,6 +753,7 @@ module AnalyticsEvents
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
       width: width,
+      **extra,
     )
   end
 
@@ -770,7 +772,7 @@ module AnalyticsEvents
     source:,
     use_alternate_sdk:,
     liveness_checking_required:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: back image clicked',
@@ -781,23 +783,26 @@ module AnalyticsEvents
       source: source,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
   # @param [String] liveness_checking_required Whether or not the selfie is required
-  def idv_barcode_warning_continue_clicked(liveness_checking_required:, **_extra)
+  def idv_barcode_warning_continue_clicked(liveness_checking_required:, **extra)
     track_event(
       'Frontend: IdV: barcode warning continue clicked',
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
 
   # @param [String] liveness_checking_required Whether or not the selfie is required
-  def idv_barcode_warning_retake_photos_clicked(liveness_checking_required:, **_extra)
+  def idv_barcode_warning_retake_photos_clicked(liveness_checking_required:, **extra)
     track_event(
       'Frontend: IdV: barcode warning retake photos clicked',
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
 
@@ -856,7 +861,7 @@ module AnalyticsEvents
     flow_path:,
     use_alternate_sdk:,
     liveness_checking_required:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: Capture troubleshooting dismissed',
@@ -865,6 +870,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
 
@@ -954,10 +960,11 @@ module AnalyticsEvents
     track_event('IdV: doc auth link_sent visited', **extra)
   end
 
-  def idv_doc_auth_randomizer_defaulted
+  def idv_doc_auth_randomizer_defaulted(**extra)
     track_event(
       'IdV: doc_auth random vendor error',
       error: 'document_capture_session_uuid_key missing',
+      **extra,
     )
   end
 
@@ -1275,7 +1282,7 @@ module AnalyticsEvents
     flow_path:,
     ids:,
     use_alternate_sdk:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: exit optional questions',
@@ -1284,6 +1291,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       ids: ids,
       use_alternate_sdk: use_alternate_sdk,
+      **extra,
     )
   end
 
@@ -1394,7 +1402,7 @@ module AnalyticsEvents
     use_alternate_sdk:,
     liveness_checking_required:,
     width:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: front image added',
@@ -1423,6 +1431,7 @@ module AnalyticsEvents
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
       width: width,
+      **extra,
     )
   end
 
@@ -1441,7 +1450,7 @@ module AnalyticsEvents
     source:,
     use_alternate_sdk:,
     liveness_checking_required: nil,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: front image clicked',
@@ -1452,6 +1461,7 @@ module AnalyticsEvents
       source: source,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -1565,7 +1575,7 @@ module AnalyticsEvents
     acuant_version:,
     flow_path:,
     use_alternate_sdk:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: Image capture failed',
@@ -1576,6 +1586,7 @@ module AnalyticsEvents
       acuant_version: acuant_version,
       flow_path: flow_path,
       use_alternate_sdk: use_alternate_sdk,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -2391,8 +2402,8 @@ module AnalyticsEvents
   end
 
   # User visits IdV
-  def idv_intro_visit
-    track_event('IdV: intro visited')
+  def idv_intro_visit(**extra)
+    track_event('IdV: intro visited', **extra)
   end
 
   # @param [String] enrollment_id
@@ -2425,20 +2436,22 @@ module AnalyticsEvents
   def idv_link_sent_capture_doc_polling_complete(
     isCancelled:,
     isRateLimited:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: Link sent capture doc polling complete',
       isCancelled: isCancelled,
       isRateLimited: isRateLimited,
+      **extra,
     )
   end
 
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
-  def idv_link_sent_capture_doc_polling_started(**_extra)
+  def idv_link_sent_capture_doc_polling_started(**extra)
     track_event(
       'Frontend: IdV: Link sent capture doc polling started',
+      **extra,
     )
   end
 
@@ -2497,8 +2510,8 @@ module AnalyticsEvents
   end
 
   # Tracks when user reaches verify errors due to being rejected due to fraud
-  def idv_not_verified_visited
-    track_event('IdV: Not verified visited')
+  def idv_not_verified_visited(**extra)
+    track_event('IdV: Not verified visited', **extra)
   end
 
   # Tracks if a user clicks the 'acknowledge' checkbox during personal
@@ -2934,7 +2947,7 @@ module AnalyticsEvents
     source:,
     liveness_checking_required:,
     width:,
-    **_extra
+    **extra
   )
     track_event(
       :idv_selfie_image_added,
@@ -2948,6 +2961,7 @@ module AnalyticsEvents
       source: source,
       liveness_checking_required: liveness_checking_required,
       width: width,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -3099,7 +3113,7 @@ module AnalyticsEvents
     flow_path:,
     location:,
     use_alternate_sdk:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: warning action triggered',
@@ -3108,6 +3122,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       location: location,
       use_alternate_sdk: use_alternate_sdk,
+      **extra,
     )
   end
 
@@ -3132,7 +3147,7 @@ module AnalyticsEvents
     subheading:,
     use_alternate_sdk:,
     liveness_checking_required:,
-    **_extra
+    **extra
   )
     track_event(
       'Frontend: IdV: warning shown',
@@ -3146,6 +3161,7 @@ module AnalyticsEvents
       subheading: subheading,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      **extra,
     )
   end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Related to work for 
[LG-12657](https://cm-jira.usa.gov/browse/LG-12657)

## 🛠 Summary of changes

There a few methods in analytics_events.rb that are missing `**extra` args and a few `track_event` calls where `**extra` is not passed through. This PR just adds an `**extra` arg where missing and ensures that it is passed through to `track_event`.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
