### PR TITLE
LG-12618: log the sp request components for enhanced idv events.

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -127,5 +127,7 @@ class Analytics
       vtr: session[:sp][:vtr],
       acr_values: session[:sp][:acr_values],
     ).resolve
+  rescue Vot::Parser::ParseException
+    return
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -111,7 +111,7 @@ class Analytics
 
     attributes = resolved_result.to_h
     attributes[:component_values] = resolved_result.component_values.map do |v|
-      v.to_h.slice(:name, :description)
+      v.to_h.slice(:name)
     end
     { sp_request: attributes }
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -113,6 +113,12 @@ class Analytics
     attributes[:component_values] = resolved_result.component_values.map do |v|
       v.to_h.slice(:name)
     end
+    attributes.reject! { |_key, value| value == false }
+    attributes.transform_keys! do |key|
+      key = key[0...-1].to_sym if key[-1] == '?'
+      key
+    end
+
     { sp_request: attributes }
   end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -4,14 +4,14 @@ class Analytics
   include AnalyticsEvents
   prepend Idv::AnalyticsEventsEnhancer
 
-  attr_reader :user, :request, :sp, :ahoy
+  attr_reader :user, :request, :sp, :session, :ahoy
 
   def initialize(user:, request:, sp:, session:, ahoy: nil)
     @user = user
     @request = request
     @sp = sp
-    @ahoy = ahoy || Ahoy::Tracker.new(request: request)
     @session = session
+    @ahoy = ahoy || Ahoy::Tracker.new(request: request)
   end
 
   def track_event(event, attributes = {})
@@ -42,13 +42,13 @@ class Analytics
   end
 
   def update_session_events_and_paths_visited_for_analytics(event)
-    @session[:events] ||= {}
-    @session[:first_event] = !@session[:events].key?(event)
-    @session[:events][event] = true
+    session[:events] ||= {}
+    session[:first_event] = !@session[:events].key?(event)
+    session[:events][event] = true
   end
 
   def first_event_this_session?
-    @session[:first_event]
+    session[:first_event]
   end
 
   def track_mfa_submit_event(attributes)
@@ -95,11 +95,11 @@ class Analytics
   end
 
   def session_duration
-    @session[:session_started_at].present? ? Time.zone.now - session_started_at : nil
+    session[:session_started_at].present? ? Time.zone.now - session_started_at : nil
   end
 
   def session_started_at
-    value = @session[:session_started_at]
+    value = session[:session_started_at]
     return value unless value.is_a?(String)
     Time.zone.parse(value)
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -110,15 +110,9 @@ class Analytics
     return if resolved_result.nil?
 
     attributes = resolved_result.to_h
-
-    component_values = {}
-    resolved_result.component_values.map do |v|
-      v.to_h.slice(:name)
-    end.each do |cv|
-      component_values[cv[:name]] = 1
-    end
-    attributes[:component_values] = component_values
-
+    attributes[:component_values] = resolved_result.component_values.map do |v|
+      [v.name, true]
+    end.to_h
     attributes.reject! { |_key, value| value == false }
     attributes.transform_keys! do |key|
       key.to_s.chomp('?').to_sym

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -111,7 +111,7 @@ class Analytics
 
     attributes = resolved_result.to_h
     attributes[:component_values] = resolved_result.component_values.map do |v|
-      [v.name, true]
+      [v.name.sub('http://idmanagement.gov/ns/assurance/ial/', 'L'), true]
     end.to_h
     attributes.reject! { |_key, value| value == false }
     attributes.transform_keys! do |key|

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -115,8 +115,7 @@ class Analytics
     end
     attributes.reject! { |_key, value| value == false }
     attributes.transform_keys! do |key|
-      key = key[0...-1].to_sym if key[-1] == '?'
-      key
+      key.to_s.chomp('?').to_sym
     end
 
     { sp_request: attributes }

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -110,9 +110,15 @@ class Analytics
     return if resolved_result.nil?
 
     attributes = resolved_result.to_h
-    attributes[:component_values] = resolved_result.component_values.map do |v|
+
+    component_values = {}
+    resolved_result.component_values.map do |v|
       v.to_h.slice(:name)
+    end.each do |cv|
+      component_values[cv[:name]] = 1
     end
+    attributes[:component_values] = component_values
+
     attributes.reject! { |_key, value| value == false }
     attributes.transform_keys! do |key|
       key.to_s.chomp('?').to_sym

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -111,7 +111,7 @@ class Analytics
 
     attributes = resolved_result.to_h
     attributes[:component_values] = resolved_result.component_values.map do |v|
-      [v.name.sub('http://idmanagement.gov/ns/assurance/ial/', 'L'), true]
+      [v.name.sub('http://idmanagement.gov/ns/assurance/', ''), true]
     end.to_h
     attributes.reject! { |_key, value| value == false }
     attributes.transform_keys! do |key|

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -107,7 +107,7 @@ class Analytics
 
   def sp_request_attributes
     resolved_result = resolved_authn_context_result
-    return resolved_result if resolved_result.nil?
+    return if resolved_result.nil?
 
     attributes = resolved_result.to_h
     attributes[:component_values] = resolved_result.component_values.map do |v|

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -50,37 +50,12 @@ module Idv
     def common_analytics_attributes
       {
         proofing_components: proofing_components,
-      }.merge({
-        sp_request: sp_request_components,
-      }.compact)
+      }
     end
 
     def proofing_components
       return if !user&.respond_to?(:proofing_component) || !user.proofing_component
       ProofingComponentsLogging.new(user.proofing_component)
-    end
-
-    def sp_request_components
-      resolved_result = resolved_authn_context_result
-      return resolved_result if resolved_result.nil?
-
-      components = resolved_result.to_h
-      components[:component_values] = resolved_result.component_values.map do |v|
-        v.to_h.slice(:name, :description)
-      end
-      components
-    end
-
-    def resolved_authn_context_result
-      return nil if sp.nil? || session[:sp].blank?
-
-      service_provider = ServiceProvider.find_by(issuer: sp)
-
-      AuthnContextResolver.new(
-        service_provider:,
-        vtr: session[:sp][:vtr],
-        acr_values: session[:sp][:acr_values],
-      ).resolve
     end
   end
 end

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -74,8 +74,10 @@ module Idv
     def resolved_authn_context_result
       return nil if sp.nil? || session[:sp].blank?
 
+      service_provider = ServiceProvider.find_by(issuer: sp)
+
       AuthnContextResolver.new(
-        service_provider: sp,
+        service_provider:,
         vtr: session[:sp][:vtr],
         acr_values: session[:sp][:acr_values],
       ).resolve

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -50,12 +50,35 @@ module Idv
     def common_analytics_attributes
       {
         proofing_components: proofing_components,
-      }
+      }.merge({
+        sp_request: sp_request_components,
+      }.compact)
     end
 
     def proofing_components
       return if !user&.respond_to?(:proofing_component) || !user.proofing_component
       ProofingComponentsLogging.new(user.proofing_component)
+    end
+
+    def sp_request_components
+      resolved_result = resolved_authn_context_result
+      return resolved_result if resolved_result.nil?
+
+      components = resolved_result.to_h
+      components[:component_values] = resolved_result.component_values.map do |v|
+        v.to_h.slice(:name, :description)
+      end
+      components
+    end
+
+    def resolved_authn_context_result
+      return nil if sp.nil? || session[:sp].blank?
+
+      AuthnContextResolver.new(
+        service_provider: sp,
+        vtr: session[:sp][:vtr],
+        acr_values: session[:sp][:acr_values],
+      ).resolve
     end
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -263,9 +263,9 @@ RSpec.describe Analytics do
           aal2?: true,
           biometric_comparison?: false,
           component_values: [
-            { name: 'C1', description: 'Multi-factor authentication' },
-            { name: 'C2', description: 'AAL2 conformant features are engaged' },
-            { name: 'P1', description: 'Identity proofing is performed' },
+            { name: 'C1' },
+            { name: 'C2' },
+            { name: 'P1' },
           ],
           hspd12?: false,
           ialmax?: false,
@@ -291,7 +291,7 @@ RSpec.describe Analytics do
           aal2?: true,
           biometric_comparison?: false,
           component_values: [
-            { name: 'http://idmanagement.gov/ns/assurance/ial/2', description: 'Legacy IAL2' },
+            { name: 'http://idmanagement.gov/ns/assurance/ial/2' },
           ],
           hspd12?: false,
           ialmax?: false,

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Analytics do
       let(:expected_attributes) do
         {
           sp_request: {
-            component_values: { 'http://idmanagement.gov/ns/assurance/ial/1' => true },
+            component_values: { 'L1' => true },
           },
         }
       end
@@ -330,7 +330,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: { 'http://idmanagement.gov/ns/assurance/ial/2' => true },
+            component_values: { 'L2' => true },
             identity_proofing: true,
           },
         }
@@ -350,7 +350,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: { 'http://idmanagement.gov/ns/assurance/ial/0' => true },
+            component_values: { 'L0' => true },
             ialmax: true,
           },
         }

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Analytics do
       let(:expected_attributes) do
         {
           sp_request: {
-            component_values: { 'L1' => true },
+            component_values: { 'ial/1' => true },
           },
         }
       end
@@ -330,7 +330,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: { 'L2' => true },
+            component_values: { 'ial/2' => true },
             identity_proofing: true,
           },
         }
@@ -350,7 +350,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: { 'L0' => true },
+            component_values: { 'ial/0' => true },
             ialmax: true,
           },
         }

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: { 'C1' => 1, 'C2' => 1, 'P1' => 1 },
+            component_values: { 'C1' => true, 'C2' => true, 'P1' => true },
             identity_proofing: true,
           },
         }
@@ -284,11 +284,11 @@ RSpec.describe Analytics do
             aal2: true,
             biometric_comparison: true,
             component_values: {
-              'C1' => 1,
-              'C2' => 1,
-              'Ca' => 1,
-              'P1' => 1,
-              'Pb' => 1,
+              'C1' => true,
+              'C2' => true,
+              'Ca' => true,
+              'P1' => true,
+              'Pb' => true,
             },
             identity_proofing: true,
             phishing_resistant: true,
@@ -311,7 +311,7 @@ RSpec.describe Analytics do
       let(:expected_attributes) do
         {
           sp_request: {
-            component_values: { 'http://idmanagement.gov/ns/assurance/ial/1' => 1 },
+            component_values: { 'http://idmanagement.gov/ns/assurance/ial/1' => true },
           },
         }
       end
@@ -330,7 +330,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: { 'http://idmanagement.gov/ns/assurance/ial/2' => 1 },
+            component_values: { 'http://idmanagement.gov/ns/assurance/ial/2' => true },
             identity_proofing: true,
           },
         }
@@ -350,7 +350,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: { 'http://idmanagement.gov/ns/assurance/ial/0' => 1 },
+            component_values: { 'http://idmanagement.gov/ns/assurance/ial/0' => true },
             ialmax: true,
           },
         }

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: [{ name: 'C1' }, { name: 'C2' }, { name: 'P1' }],
+            component_values: { 'C1' => 1, 'C2' => 1, 'P1' => 1 },
             identity_proofing: true,
           },
         }
@@ -283,13 +283,13 @@ RSpec.describe Analytics do
           sp_request: {
             aal2: true,
             biometric_comparison: true,
-            component_values: [
-              { name: 'C1' },
-              { name: 'C2' },
-              { name: 'Ca' },
-              { name: 'P1' },
-              { name: 'Pb' },
-            ],
+            component_values: {
+              'C1' => 1,
+              'C2' => 1,
+              'Ca' => 1,
+              'P1' => 1,
+              'Pb' => 1,
+            },
             identity_proofing: true,
             phishing_resistant: true,
           },
@@ -311,9 +311,7 @@ RSpec.describe Analytics do
       let(:expected_attributes) do
         {
           sp_request: {
-            component_values: [
-              { name: 'http://idmanagement.gov/ns/assurance/ial/1' },
-            ],
+            component_values: { 'http://idmanagement.gov/ns/assurance/ial/1' => 1 },
           },
         }
       end
@@ -332,9 +330,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: [
-              { name: 'http://idmanagement.gov/ns/assurance/ial/2' },
-            ],
+            component_values: { 'http://idmanagement.gov/ns/assurance/ial/2' => 1 },
             identity_proofing: true,
           },
         }
@@ -354,9 +350,7 @@ RSpec.describe Analytics do
         {
           sp_request: {
             aal2: true,
-            component_values: [
-              { name: 'http://idmanagement.gov/ns/assurance/ial/0' },
-            ],
+            component_values: { 'http://idmanagement.gov/ns/assurance/ial/0' => 1 },
             ialmax: true,
           },
         }

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
   end
 
   context 'with requested authn context' do
-    let(:sp) { create(:service_provider) }
+    let(:sp) { create(:service_provider).issuer }
     let(:session) { { sp: { vtr: ['C1.P1'] } } }
 
     it 'calls analytics method with original and decorated attributes' do

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -68,31 +68,4 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
       )
     end
   end
-
-  context 'with requested authn context' do
-    let(:sp) { create(:service_provider).issuer }
-    let(:session) { { sp: { vtr: ['C1.P1'] } } }
-
-    it 'calls analytics method with original and decorated attributes' do
-      analytics.idv_final(extra: true)
-
-      expect(analytics.called_kwargs).to match(
-        extra: true,
-        proofing_components: nil,
-        sp_request: {
-          aal2?: true,
-          biometric_comparison?: false,
-          component_values: [
-            { name: 'C1', description: 'Multi-factor authentication' },
-            { name: 'C2', description: 'AAL2 conformant features are engaged' },
-            { name: 'P1', description: 'Identity proofing is performed' },
-          ],
-          hspd12?: false,
-          ialmax?: false,
-          identity_proofing?: true,
-          phishing_resistant?: false,
-        },
-      )
-    end
-  end
 end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -144,9 +144,11 @@ class FakeAnalytics < Analytics
   attr_reader :events
   attr_accessor :user
 
-  def initialize(user: AnonymousUser.new)
+  def initialize(user: AnonymousUser.new, sp: nil, session: nil)
     @events = Hash.new
     @user = user
+    @sp = sp
+    @session = session
   end
 
   def track_event(event, attributes = {})


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12618](https://cm-jira.usa.gov/browse/LG-12618)

## 🛠 Summary of changes

This change logs the resolved authn context in CloudWatch events under the key `sp_request` and provides a hash with the following keys, if they are true:

- `aal2`
- `biometric_comparison`
- `component_values` - `{ 'value' => true, 'value2' => true }`
- `hspd12`
- `ialmax`
- `identity_proofing`
- `phishing_resistant`

If there isn't a vtr or acr_values saved in the session, the `sp_request` will not be included at all.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

