### PR TITLE
LG-12631: handoff ipp

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -119,12 +119,9 @@ module Idv
       # Only allow direct access to document capture if IPP available
       return false unless IdentityConfig.store.in_person_doc_auth_button_enabled &&
                           Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
-      case params[:step]
-      when 'hybrid_handoff'
-        @previous_step_url = idv_hybrid_handoff_path
-      else
+      params[:step] == 'hybrid_handoff' ?
+        @previous_step_url = idv_hybrid_handoff_path :
         @previous_step_url = nil
-      end
       # allow
       idv_session.flow_path = 'standard'
       idv_session.skip_doc_auth_from_handoff = true

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -113,6 +113,8 @@ module Idv
     end
 
     def allow_direct_ipp?
+      return false unless idv_session.welcome_visited == true &&
+                          idv_session.idv_consent_given == true
       # not allowed when no step param and action:show(get request)
       return false if params[:step].blank? || params[:action].to_s != 'show' ||
                       idv_session.flow_path == 'hybrid'

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -136,7 +136,6 @@ module Idv
                     Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
       case params[:step]
       when 'hybrid_handoff'
-        Rails.logger.debug { "set previous step url to #{idv_hybrid_handoff_path}" }
         @previous_step_url = idv_hybrid_handoff_path
         idv_session.opted_in_to_in_person_proofing = nil
         idv_session.flow_path = 'standard'

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -119,9 +119,7 @@ module Idv
       # Only allow direct access to document capture if IPP available
       return false unless IdentityConfig.store.in_person_doc_auth_button_enabled &&
                           Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
-      params[:step] == 'hybrid_handoff' ?
-        @previous_step_url = idv_hybrid_handoff_path :
-        @previous_step_url = nil
+      @previous_step_url = params[:step] == 'hybrid_handoff' ? idv_hybrid_handoff_path : nil
       # allow
       idv_session.flow_path = 'standard'
       idv_session.skip_doc_auth_from_handoff = true

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -113,8 +113,8 @@ module Idv
     end
 
     def allow_direct_ipp?
-      return false unless idv_session.welcome_visited == true &&
-                          idv_session.idv_consent_given == true
+      return false unless idv_session.welcome_visited &&
+                          idv_session.idv_consent_given
       # not allowed when no step param and action:show(get request)
       return false if params[:step].blank? || params[:action].to_s != 'show' ||
                       idv_session.flow_path == 'hybrid'

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -47,6 +47,7 @@ module Idv
         sp_name: decorated_sp_session.sp_name,
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         skip_doc_auth: idv_session.skip_doc_auth,
+        skip_doc_auth_from_handoff: idv_session.skip_doc_auth_from_handoff,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
         doc_auth_selfie_capture: decorated_sp_session.selfie_required?,
       }.merge(
@@ -62,7 +63,7 @@ module Idv
         preconditions: ->(idv_session:, user:) {
                          idv_session.flow_path == 'standard' && (
                            # mobile
-                           idv_session.skip_doc_auth ||
+                           idv_session.skip_doc_auth_from_handoff ||
                            idv_session.skip_hybrid_handoff ||
                             idv_session.skip_doc_auth ||
                             !idv_session.selfie_check_required || # desktop but selfie not required
@@ -126,8 +127,8 @@ module Idv
       end
       # allow
       idv_session.flow_path = 'standard'
-      idv_session.skip_doc_auth = true
-      idv_session.skip_hybrid_handoff = false
+      idv_session.skip_doc_auth_from_handoff = true
+      idv_session.skip_hybrid_handoff = nil
       true
     end
   end

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -14,7 +14,7 @@ module Idv
                          !idv_session.desktop_selfie_test_mode_enabled?
 
       @opt_in_ipp_enabled = IdentityConfig.store.in_person_doc_auth_button_enabled &&
-        Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
+                            Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
 
       @selfie_required = idv_session.selfie_check_required
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -64,7 +64,7 @@ module Idv
                          idv_session.idv_consent_given &&
                            (self.selected_remote(idv_session: idv_session) || # from opt-in screen
                              # back from ipp doc capture screen
-                             idv_session.skip_doc_auth_from_handoff == true)
+                             idv_session.skip_doc_auth_from_handoff)
                        },
         undo_step: ->(idv_session:, user:) do
           idv_session.flow_path = nil

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -13,8 +13,10 @@ module Idv
       @upload_disabled = idv_session.selfie_check_required &&
                          !idv_session.desktop_selfie_test_mode_enabled?
 
-      @opt_in_ipp_enabled = IdentityConfig.store.in_person_doc_auth_button_enabled &&
-                            Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
+      @direct_ipp_with_selfie_enabled = IdentityConfig.store.in_person_doc_auth_button_enabled &&
+                                        Idv::InPersonConfig.enabled_for_issuer?(
+                                          decorated_sp_session.sp_issuer,
+                                        )
 
       @selfie_required = idv_session.selfie_check_required
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -49,11 +49,9 @@ module Idv
       if IdentityConfig.store.in_person_proofing_opt_in_enabled &&
          IdentityConfig.store.in_person_proofing_enabled &&
          idv_session.service_provider&.in_person_proofing_enabled
-        idv_session.skip_doc_auth == false ||
-          idv_session.skip_doc_auth_from_handoff == true
+        idv_session.skip_doc_auth == false
       else
-        idv_session.skip_doc_auth.nil? || idv_session.skip_doc_auth == false ||
-          idv_session.skip_doc_auth_from_handoff == true
+        idv_session.skip_doc_auth.nil? || idv_session.skip_doc_auth == false
       end
     end
 
@@ -64,7 +62,9 @@ module Idv
         next_steps: [:link_sent, :document_capture],
         preconditions: ->(idv_session:, user:) {
                          idv_session.idv_consent_given &&
-                          self.selected_remote(idv_session: idv_session)
+                           (self.selected_remote(idv_session: idv_session) || # from opt-in screen
+                             # back from ipp doc capture screen
+                             idv_session.skip_doc_auth_from_handoff == true)
                        },
         undo_step: ->(idv_session:, user:) do
           idv_session.flow_path = nil

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -25,8 +25,8 @@ module Idv
         true
       )
 
-      # yes if we on hand off, skip_doc_auth not avail yet
-      idv_session.skip_doc_auth = nil
+      # reset if we visit or come back
+      idv_session.skip_doc_auth_from_handoff = nil
       render :show, locals: extra_view_variables
     end
 
@@ -48,10 +48,10 @@ module Idv
          IdentityConfig.store.in_person_proofing_enabled &&
          idv_session.service_provider&.in_person_proofing_enabled
         idv_session.skip_doc_auth == false ||
-          !idv_session.skip_hybrid_handoff
+          idv_session.skip_doc_auth_from_handoff == true
       else
         idv_session.skip_doc_auth.nil? || idv_session.skip_doc_auth == false ||
-          !idv_session.skip_hybrid_handoff
+          idv_session.skip_doc_auth_from_handoff == true
       end
     end
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -25,6 +25,8 @@ module Idv
         true
       )
 
+      # yes if we on hand off, skip_doc_auth not avail yet
+      idv_session.skip_doc_auth = nil
       render :show, locals: extra_view_variables
     end
 
@@ -45,9 +47,11 @@ module Idv
       if IdentityConfig.store.in_person_proofing_opt_in_enabled &&
          IdentityConfig.store.in_person_proofing_enabled &&
          idv_session.service_provider&.in_person_proofing_enabled
-        idv_session.skip_doc_auth == false
+        idv_session.skip_doc_auth == false ||
+          !idv_session.skip_hybrid_handoff
       else
-        idv_session.skip_doc_auth.nil? || idv_session.skip_doc_auth == false
+        idv_session.skip_doc_auth.nil? || idv_session.skip_doc_auth == false ||
+          !idv_session.skip_hybrid_handoff
       end
     end
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -13,6 +13,9 @@ module Idv
       @upload_disabled = idv_session.selfie_check_required &&
                          !idv_session.desktop_selfie_test_mode_enabled?
 
+      @opt_in_ipp_enabled = IdentityConfig.store.in_person_doc_auth_button_enabled &&
+        Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
+
       @selfie_required = idv_session.selfie_check_required
 
       analytics.idv_doc_auth_hybrid_handoff_visited(**analytics_arguments)

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -37,7 +37,8 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
   const { t } = useI18n();
   const { flowPath } = useContext(UploadContext);
   const { trackSubmitEvent, trackVisitEvent } = useContext(AnalyticsContext);
-  const { inPersonFullAddressEntryEnabled, inPersonURL, skipDocAuth } = useContext(InPersonContext);
+  const { inPersonFullAddressEntryEnabled, inPersonURL, skipDocAuth, skipDocAuthFromHandoff } =
+    useContext(InPersonContext);
   const appName = getConfigValue('appName');
 
   useDidUpdateEffect(onStepChange, [stepName]);
@@ -137,7 +138,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
 
   // If the user got here by opting-in to in-person proofing, when skipDocAuth === true,
   // then set steps to inPersonSteps
-  const steps: FormStep[] = skipDocAuth ? inPersonSteps : defaultSteps;
+  const steps: FormStep[] = skipDocAuth || skipDocAuthFromHandoff ? inPersonSteps : defaultSteps;
 
   // If the user got here by opting-in to in-person proofing, when skipDocAuth === true,
   // then set stepIndicatorPath to VerifyFlowPath.IN_PERSON

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -145,9 +145,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
   // or opting-in ipp from handoff page, and selfie is required, when skipDocAuthFromHandoff === true
   // then set stepIndicatorPath to VerifyFlowPath.IN_PERSON
   const stepIndicatorPath =
-    (stepName && ['location', 'prepare', 'switch_back'].includes(stepName)) ||
-    skipDocAuth ||
-    skipDocAuthFromHandoff
+    (stepName && ['location', 'prepare', 'switch_back'].includes(stepName)) || isInPersonStepEnabled
       ? VerifyFlowPath.IN_PERSON
       : VerifyFlowPath.DEFAULT;
 
@@ -186,7 +184,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
             onStepSubmit={trackSubmitEvent}
             autoFocus={!!submissionError}
             titleFormat={`%{step} - ${appName}`}
-            initialStep={skipDocAuth ? steps[0].name : undefined}
+            initialStep={isInPersonStepEnabled ? steps[0].name : undefined}
           />
         </>
       )}

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -140,10 +140,13 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
   // then set steps to inPersonSteps
   const steps: FormStep[] = skipDocAuth || skipDocAuthFromHandoff ? inPersonSteps : defaultSteps;
 
-  // If the user got here by opting-in to in-person proofing, when skipDocAuth === true,
+  // If the user got here by opting-in to in-person proofing, when skipDocAuth === true;
+  // or opting-in ipp from handoff page, and selfie is required, when skipDocAuthFromHandoff === true
   // then set stepIndicatorPath to VerifyFlowPath.IN_PERSON
   const stepIndicatorPath =
-    (stepName && ['location', 'prepare', 'switch_back'].includes(stepName)) || skipDocAuth
+    (stepName && ['location', 'prepare', 'switch_back'].includes(stepName)) ||
+    skipDocAuth ||
+    skipDocAuthFromHandoff
       ? VerifyFlowPath.IN_PERSON
       : VerifyFlowPath.DEFAULT;
 

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -138,7 +138,8 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
 
   // If the user got here by opting-in to in-person proofing, when skipDocAuth === true,
   // then set steps to inPersonSteps
-  const steps: FormStep[] = skipDocAuth || skipDocAuthFromHandoff ? inPersonSteps : defaultSteps;
+  const isInPersonStepEnabled = skipDocAuth || skipDocAuthFromHandoff;
+  const steps: FormStep[] = isInPersonStepEnabled ? inPersonSteps : defaultSteps;
 
   // If the user got here by opting-in to in-person proofing, when skipDocAuth === true;
   // or opting-in ipp from handoff page, and selfie is required, when skipDocAuthFromHandoff === true

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -20,12 +20,14 @@ function InPersonPrepareStep({ toPreviousStep }) {
     inPersonOutageMessageEnabled,
     inPersonOutageExpectedUpdateDate,
     skipDocAuth,
+    skipDocAuthFromHandoff,
     howToVerifyURL,
     previousStepURL,
   } = useContext(InPersonContext);
 
   function goBack() {
-    if (skipDocAuth && previousStepURL) {
+    if (skipDocAuthFromHandoff && previousStepURL) {
+      // directly from handoff page
       forceRedirect(previousStepURL);
     } else if (skipDocAuth && howToVerifyURL) {
       forceRedirect(howToVerifyURL);

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.tsx
@@ -21,10 +21,13 @@ function InPersonPrepareStep({ toPreviousStep }) {
     inPersonOutageExpectedUpdateDate,
     skipDocAuth,
     howToVerifyURL,
+    previousStepURL,
   } = useContext(InPersonContext);
 
   function goBack() {
-    if (skipDocAuth && howToVerifyURL) {
+    if (skipDocAuth && previousStepURL) {
+      forceRedirect(previousStepURL);
+    } else if (skipDocAuth && howToVerifyURL) {
       forceRedirect(howToVerifyURL);
     } else {
       toPreviousStep();

--- a/app/javascript/packages/document-capture/context/in-person.ts
+++ b/app/javascript/packages/document-capture/context/in-person.ts
@@ -50,6 +50,12 @@ export interface InPersonContextProps {
   skipDocAuth?: boolean;
 
   /**
+   * Flag set when user select IPP from handoff page when IPP is available
+   * and selfie is required
+   */
+  skipDocAuthFromHandoff?: boolean;
+
+  /**
    * URL for Opt-in IPP, used when in_person_proofing_opt_in_enabled is enabled
    */
   howToVerifyURL?: string;

--- a/app/javascript/packages/document-capture/context/in-person.ts
+++ b/app/javascript/packages/document-capture/context/in-person.ts
@@ -53,6 +53,11 @@ export interface InPersonContextProps {
    * URL for Opt-in IPP, used when in_person_proofing_opt_in_enabled is enabled
    */
   howToVerifyURL?: string;
+
+  /**
+   * URL for going back to previous steps in Doc Auth, like handoff and howToVerify
+   */
+  previousStepURL?: string;
 }
 
 const InPersonContext = createContext<InPersonContextProps>({

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -38,6 +38,7 @@ interface AppRootData {
   securityAndPrivacyHowItWorksUrl: string;
   skipDocAuth: string;
   howToVerifyURL: string;
+  previousStepUrl: string;
   uiExitQuestionSectionEnabled: string;
   docAuthSelfieDesktopTestMode: string;
 }
@@ -106,6 +107,7 @@ const {
   usStatesTerritories = '',
   skipDocAuth,
   howToVerifyUrl,
+  previousStepUrl,
   uiExitQuestionSectionEnabled = '',
   docAuthSelfieDesktopTestMode,
 } = appRoot.dataset as DOMStringMap & AppRootData;
@@ -132,6 +134,7 @@ const App = composeComponents(
         usStatesTerritories: parsedUsStatesTerritories,
         skipDocAuth: skipDocAuth === 'true',
         howToVerifyURL: howToVerifyUrl,
+        previousStepURL: previousStepUrl,
       },
     },
   ],

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -37,6 +37,7 @@ interface AppRootData {
   optedInToInPersonProofing: string;
   securityAndPrivacyHowItWorksUrl: string;
   skipDocAuth: string;
+  skipDocAuthFromHandoff: string;
   howToVerifyURL: string;
   previousStepUrl: string;
   uiExitQuestionSectionEnabled: string;
@@ -106,6 +107,7 @@ const {
   optedInToInPersonProofing,
   usStatesTerritories = '',
   skipDocAuth,
+  skipDocAuthFromHandoff,
   howToVerifyUrl,
   previousStepUrl,
   uiExitQuestionSectionEnabled = '',
@@ -133,6 +135,7 @@ const App = composeComponents(
         optedInToInPersonProofing: optedInToInPersonProofing === 'true',
         usStatesTerritories: parsedUsStatesTerritories,
         skipDocAuth: skipDocAuth === 'true',
+        skipDocAuthFromHandoff: skipDocAuthFromHandoff === 'true',
         howToVerifyURL: howToVerifyUrl,
         previousStepURL: previousStepUrl,
       },

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -25,6 +25,7 @@ module Idv
       selfie_check_performed
       selfie_check_required
       skip_doc_auth
+      skip_doc_auth_from_handoff
       skip_hybrid_handoff
       ssn
       threatmetrix_review_status

--- a/app/views/idv/document_capture/show.html.erb
+++ b/app/views/idv/document_capture/show.html.erb
@@ -9,5 +9,6 @@
       acuant_version: acuant_version,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
       skip_doc_auth: skip_doc_auth,
+      skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
     ) %>

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -88,11 +88,17 @@
           ) %>
       <%= f.submit t('forms.buttons.send_link') %>
     <% end %>
-
-    <% if @opt_in_ipp_enabled %>
-      <%= link_to 'Verify in person2', idv_document_capture_path(step: :hybrid_handoff) %>
-    <% end %>
   </div>
+  <% if @opt_in_ipp_enabled %>
+    <div class="margin-top-4 padding-top-2 border-top border-primary-light">
+      <p class="margin-top-1">
+        <%= t('doc_auth.info.hybrid_handoff_ipp_html') %>'
+      </p>
+      <p class="margin-top-1 margin-bottom-0">
+        <%= link_to t('in_person_proofing.headings.prepare'), idv_document_capture_path(step: :hybrid_handoff) %>
+      </p>
+    </div>
+  <% end %>
   </div>
 <% end %>
 

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -90,7 +90,7 @@
     <% end %>
 
     <% if @opt_in_ipp_enabled %>
-      <%= link_to 'Verify in person2', idv_document_capture_path(opt_in_ipp: true) %>
+      <%= link_to 'Verify in person2', idv_document_capture_path(step: :hybrid_handoff) %>
     <% end %>
   </div>
   </div>

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -88,6 +88,10 @@
           ) %>
       <%= f.submit t('forms.buttons.send_link') %>
     <% end %>
+
+    <% if @opt_in_ipp_enabled %>
+      <%= link_to 'Verify in person2', idv_document_capture_path(opt_in_ipp: true) %>
+    <% end %>
   </div>
   </div>
 <% end %>

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -92,7 +92,7 @@
   <% if @direct_ipp_with_selfie_enabled %>
     <div class="margin-top-4 padding-top-2 border-top border-primary-light">
       <p class="margin-top-1">
-        <%= t('doc_auth.info.hybrid_handoff_ipp_html') %>'
+        <%= t('doc_auth.info.hybrid_handoff_ipp_html') %>
       </p>
       <p class="margin-top-1 margin-bottom-0">
         <%= link_to t('in_person_proofing.headings.prepare'), idv_document_capture_path(step: :hybrid_handoff) %>

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -89,7 +89,7 @@
       <%= f.submit t('forms.buttons.send_link') %>
     <% end %>
   </div>
-  <% if @opt_in_ipp_enabled %>
+  <% if @direct_ipp_with_selfie_enabled %>
     <div class="margin-top-4 padding-top-2 border-top border-primary-light">
       <p class="margin-top-1">
         <%= t('doc_auth.info.hybrid_handoff_ipp_html') %>'

--- a/app/views/idv/hybrid_mobile/document_capture/show.html.erb
+++ b/app/views/idv/hybrid_mobile/document_capture/show.html.erb
@@ -9,5 +9,6 @@
       acuant_version: acuant_version,
       opted_in_to_in_person_proofing: false,
       skip_doc_auth: false,
+      skip_doc_auth_from_handoff: nil,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
     ) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -39,6 +39,7 @@
       doc_auth_selfie_capture: FeatureManagement.idv_allow_selfie_check? && doc_auth_selfie_capture,
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
       skip_doc_auth: skip_doc_auth,
+      skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       how_to_verify_url: idv_how_to_verify_url,
       previous_step_url: @previous_step_url,
       ui_exit_question_section_enabled: IdentityConfig.store.doc_auth_exit_question_section_enabled,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -40,6 +40,7 @@
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
       skip_doc_auth: skip_doc_auth,
       how_to_verify_url: idv_how_to_verify_url,
+      previous_step_url: @previous_step_url,
       ui_exit_question_section_enabled: IdentityConfig.store.doc_auth_exit_question_section_enabled,
     } %>
   <%= simple_form_for(

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -208,6 +208,7 @@ en:
         at a participating Post Office
       how_to_verify_troubleshooting_options_header: Want to learn more about how to verify your identity?
       hybrid_handoff: We’ll collect information about you by reading your state‑issued ID.
+      hybrid_handoff_ipp_html: <strong>Don’t have a mobile phone?</strong> You can verify your identity at a United States Post Office instead.
       image_loaded: Image loaded
       image_loading: Image loading
       image_updated: Image updated

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -208,7 +208,8 @@ en:
         at a participating Post Office
       how_to_verify_troubleshooting_options_header: Want to learn more about how to verify your identity?
       hybrid_handoff: We’ll collect information about you by reading your state‑issued ID.
-      hybrid_handoff_ipp_html: <strong>Don’t have a mobile phone?</strong> You can verify your identity at a United States Post Office instead.
+      hybrid_handoff_ipp_html: <strong>Don’t have a mobile phone?</strong> You can
+        verify your identity at a United States Post Office instead.
       image_loaded: Image loaded
       image_loading: Image loading
       image_updated: Image updated

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -243,6 +243,7 @@ es:
       how_to_verify_troubleshooting_options_header: ¿Quiere saber más sobre cómo verificar su identidad?
       hybrid_handoff: Recopilaremos información sobre usted leyendo su documento de
         identidad expedido por el estado.
+      hybrid_handoff_ipp_html: <strong>¿No tiene celular?</strong> Como alternativa, puede verificar su identidad en una oficina de correos de Estados Unidos.
       image_loaded: Imagen cargada
       image_loading: Cargando la imagen
       image_updated: Imagen actualizada

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -243,7 +243,9 @@ es:
       how_to_verify_troubleshooting_options_header: ¿Quiere saber más sobre cómo verificar su identidad?
       hybrid_handoff: Recopilaremos información sobre usted leyendo su documento de
         identidad expedido por el estado.
-      hybrid_handoff_ipp_html: <strong>¿No tiene celular?</strong> Como alternativa, puede verificar su identidad en una oficina de correos de Estados Unidos.
+      hybrid_handoff_ipp_html: <strong>¿No tiene celular?</strong> Como alternativa,
+        puede verificar su identidad en una oficina de correos de Estados
+        Unidos.
       image_loaded: Imagen cargada
       image_loading: Cargando la imagen
       image_updated: Imagen actualizada

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -251,7 +251,9 @@ fr:
       how_to_verify_troubleshooting_options_header: Vous voulez en savoir plus sur la façon de vérifier votre identité?
       hybrid_handoff: Nous recueillons des informations sur vous en lisant votre carte
         d’identité délivrée par l’État.
-      hybrid_handoff_ipp_html: <strong>Vous n’avez pas de téléphone cellulaire?</strong> Vous pouvez vérifier votre identité dans un bureau de poste américain.
+      hybrid_handoff_ipp_html: <strong>Vous n’avez pas de téléphone
+        cellulaire?</strong> Vous pouvez vérifier votre identité dans un bureau
+        de poste américain.
       image_loaded: Image chargée
       image_loading: Chargement de l’image
       image_updated: Image mise à jour

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -251,6 +251,7 @@ fr:
       how_to_verify_troubleshooting_options_header: Vous voulez en savoir plus sur la façon de vérifier votre identité?
       hybrid_handoff: Nous recueillons des informations sur vous en lisant votre carte
         d’identité délivrée par l’État.
+      hybrid_handoff_ipp_html: <strong>Vous n’avez pas de téléphone cellulaire?</strong> Vous pouvez vérifier votre identité dans un bureau de poste américain.
       image_loaded: Image chargée
       image_loading: Chargement de l’image
       image_updated: Image mise à jour

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -82,22 +82,6 @@ RSpec.describe Idv::DocumentCaptureController, allowed_extra_analytics: [:*] do
         :check_for_mail_only_outage,
       )
     end
-
-    it 'includes allow ipp check before_action and after_action' do
-      expect(subject).to have_actions(
-        :before,
-        :confirm_ipp_allowed,
-      )
-    end
-  end
-
-  describe 'after_actions' do
-    it 'includes clean up ipp check after_action' do
-      expect(subject).to have_actions(
-        :after,
-        :cleanup_ipp_allowed,
-      )
-    end
   end
 
   describe '#show' do
@@ -273,7 +257,6 @@ RSpec.describe Idv::DocumentCaptureController, allowed_extra_analytics: [:*] do
         allow(IdentityConfig.store).to receive(:in_person_doc_auth_button_enabled).and_return(true)
         get :show, params: { step: 'hybrid_handoff' }
         expect(response).to render_template :show
-        expect(subject.idv_session.skip_doc_auth).to be_falsey
       end
     end
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -257,6 +257,7 @@ RSpec.describe Idv::DocumentCaptureController, allowed_extra_analytics: [:*] do
         allow(IdentityConfig.store).to receive(:in_person_doc_auth_button_enabled).and_return(true)
         get :show, params: { step: 'hybrid_handoff' }
         expect(response).to render_template :show
+        expect(subject.idv_session.skip_doc_auth_from_handoff).to eq(true)
       end
     end
 
@@ -270,6 +271,7 @@ RSpec.describe Idv::DocumentCaptureController, allowed_extra_analytics: [:*] do
         subject.idv_session.skip_hybrid_handoff = nil
         get :show, params: { step: 'hybrid_handoff' }
         expect(response).to redirect_to(idv_hybrid_handoff_url)
+        expect(subject.idv_session.skip_doc_auth_from_handoff).to_not eq(true)
       end
     end
   end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe Idv::HybridHandoffController, allowed_extra_analytics: [:*] do
           allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
             and_return(false)
           subject.idv_session.skip_doc_auth = nil
+          subject.idv_session.skip_hybrid_handoff = true
         end
 
         it 'redirects to how to verify' do
@@ -235,6 +236,7 @@ RSpec.describe Idv::HybridHandoffController, allowed_extra_analytics: [:*] do
           allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
             and_return(false)
           subject.idv_session.skip_doc_auth = true
+          subject.idv_session.skip_hybrid_handoff = true
         end
 
         it 'redirects to the how to verify page' do

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -212,7 +212,6 @@ RSpec.describe Idv::HybridHandoffController, allowed_extra_analytics: [:*] do
           allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
             and_return(false)
           subject.idv_session.skip_doc_auth = nil
-          subject.idv_session.skip_hybrid_handoff = true
         end
 
         it 'redirects to how to verify' do

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -615,3 +615,56 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
     SpCost.where(ial: 2, issuer: 'urn:gov:gsa:openidconnect:sp:server', cost_type: cost_type.to_s)
   end
 end
+
+RSpec.feature 'direct access to IPP on desktop', :js, allowed_extra_analytics: [:*] do
+  include IdvStepHelper
+  include DocAuthHelper
+  context 'direct access to IPP before handoff page' do
+    let(:in_person_proofing_enabled) { true }
+    let(:sp_ipp_enabled) { true }
+    let(:in_person_proofing_opt_in_enabled) { true }
+    let(:doc_auth_selfie_capture_enabled) { true }
+    let(:biometric_comparison_required) { true }
+    let(:user) { user_with_2fa }
+
+    before do
+      service_provider = create(:service_provider, :active, :in_person_proofing_enabled)
+      unless sp_ipp_enabled
+        service_provider.in_person_proofing_enabled = false
+        service_provider.save!
+      end
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).and_return(false)
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(
+        in_person_proofing_enabled,
+      )
+      allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(
+        in_person_proofing_opt_in_enabled,
+      )
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+        and_return(doc_auth_selfie_capture_enabled)
+      allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
+        and_return(sp_ipp_enabled)
+      visit_idp_from_sp_with_ial2(
+        :oidc,
+        **{ client_id: service_provider.issuer,
+            biometric_comparison_required: biometric_comparison_required },
+      )
+      sign_in_via_branded_page(user)
+      complete_doc_auth_steps_before_agreement_step
+    end
+
+    shared_examples 'does not allow direct ipp access' do
+      it 'redirects back to agreement page' do
+        visit idv_document_capture_path(step: 'hybrid_handoff')
+        expect(page).to have_current_path(idv_agreement_path)
+      end
+    end
+    context 'when selfie is enabled' do
+      it_behaves_like 'does not allow direct ipp access'
+    end
+    context 'when selfie is disabled' do
+      let(:biometric_comparison_required) { false }
+      it_behaves_like 'does not allow direct ipp access'
+    end
+  end
+end

--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -119,8 +119,10 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
    when the sp has opted into ipp' do
     context 'opt in false at start but true during navigation' do
       it 'should be bounced back from Hybrid Handoff to How to Verify' do
+        sleep(5)
         expect(page).to have_current_path(idv_hybrid_handoff_url)
         allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
+        sleep(5)
         page.refresh
         expect(page).to have_current_path(idv_how_to_verify_url)
       end

--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -119,10 +119,8 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
    when the sp has opted into ipp' do
     context 'opt in false at start but true during navigation' do
       it 'should be bounced back from Hybrid Handoff to How to Verify' do
-        sleep(5)
         expect(page).to have_current_path(idv_hybrid_handoff_url)
         allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled) { true }
-        sleep(5)
         page.refresh
         expect(page).to have_current_path(idv_how_to_verify_url)
       end

--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
   let(:in_person_proofing_enabled) { true }
   let(:in_person_proofing_opt_in_enabled) { false }
   let(:service_provider_in_person_proofing_enabled) { true }
-
+  let(:biometric_comparison_required) { false }
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) {
       in_person_proofing_enabled
@@ -20,7 +20,10 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
     }
     allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
       and_return(service_provider_in_person_proofing_enabled)
-    visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+    visit_idp_from_sp_with_ial2(
+      :oidc, **{ client_id: ipp_service_provider.issuer,
+                 biometric_comparison_required: biometric_comparison_required }
+    )
     sign_in_via_branded_page(user)
     complete_doc_auth_steps_before_agreement_step
     complete_agreement_step
@@ -102,6 +105,28 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
         page.go_back
         complete_how_to_verify_step(remote: false)
         expect(page).to have_current_path(idv_document_capture_path)
+      end
+
+      context 'when selfie is enabled' do
+        include InPersonHelper
+
+        let(:biometric_comparison_required) { false }
+        before do
+          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
+            and_return(true)
+        end
+        it 'goes to direct IPP if selected and can come back' do
+          expect(page).to have_current_path(idv_how_to_verify_path)
+          expect(page).to have_content(t('doc_auth.headings.how_to_verify'))
+          complete_how_to_verify_step(remote: false)
+          expect(page).to have_current_path(idv_document_capture_path)
+          expect_in_person_step_indicator_current_step(
+            t('step_indicator.flows.idv.find_a_post_office'),
+          )
+          expect(page).to have_content(t('headings.verify'))
+          click_on t('forms.buttons.back')
+          expect(page).to have_current_path(idv_how_to_verify_path)
+        end
       end
     end
 

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -243,4 +243,38 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
       end
     end
   end
+  context 'on a desktop choose ipp', js: true do
+    let(:in_person_doc_auth_button_enabled) { true }
+    let(:sp_ipp_enabled) { true }
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_doc_auth_button_enabled).
+        and_return(in_person_doc_auth_button_enabled)
+      allow(Idv::InPersonConfig).to receive(:enabled_for_issuer?).with(anything).
+        and_return(sp_ipp_enabled)
+      complete_doc_auth_steps_before_hybrid_handoff_step
+    end
+
+    context 'when ipp is enabled' do
+      it 'proceeds to ipp if selected and can go back' do
+        expect(page).to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
+        click_on t('in_person_proofing.headings.prepare')
+        expect(page).to have_current_path(idv_document_capture_path({ step: 'hybrid_handoff' }))
+        click_on t('forms.buttons.back')
+        expect(page).to have_current_path(idv_hybrid_handoff_path)
+      end
+    end
+
+    context 'when ipp is disabled' do
+      let(:in_person_doc_auth_button_enabled) { false }
+      let(:sp_ipp_enabled) { false }
+      it 'has no ipp option can be selected' do
+        expect(page).to_not have_content(
+          strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')),
+        )
+        expect(page).to_not have_content(
+          t('in_person_proofing.headings.prepare'),
+        )
+      end
+    end
+  end
 end

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -284,32 +284,63 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
   include DocAuthHelper
   include InPersonHelper
 
-  shared_examples 'handoff_selfie_required_with_ipp_option' do
-    it 'displays selfie version of handoff page header' do
-      expect(page).to have_current_path(idv_hybrid_handoff_path)
-      expect(page).to have_selector(
-                        'h1',
-                        text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                        )
-    end
-    it 'displays IPP option section' do
-      expect(page).to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-      expect(page).to have_link(
-                        t('in_person_proofing.headings.prepare'),
-                        href: idv_document_capture_path(step: :hybrid_handoff),
-                        )
-    end
-
-    it 'goes to document capture when selected IPP and comes back from document capture when click back button' do
-
-      click_on t('in_person_proofing.headings.prepare')
-      expect(page).to have_current_path(idv_document_capture_path({ step: 'hybrid_handoff' }))
-      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.find_a_post_office'))
-      expect(page).to have_content(t('headings.verify'))
-      click_on t('forms.buttons.back')
-      expect(page).to have_current_path(idv_hybrid_handoff_path)
-    end
+  def verify_handoff_page_selfie_version_content(page)
+    expect(page).to have_current_path(idv_hybrid_handoff_path)
+    expect(page).to have_selector(
+      'h1',
+      text: t('doc_auth.headings.hybrid_handoff_selfie'),
+    )
   end
+
+  def verify_handoff_page_non_selfie_version_content(page)
+    expect(page).to have_current_path(idv_hybrid_handoff_path)
+    expect(page).to_not have_selector(
+      'h1',
+      text: t('doc_auth.headings.hybrid_handoff_selfie'),
+    )
+    expect(page).to have_selector(
+      'h1',
+      text: t('doc_auth.headings.hybrid_handoff'),
+    )
+  end
+
+  def verify_handoff_page_no_ipp_option_shown(page)
+    expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
+    expect(page).to_not have_link(
+      t('in_person_proofing.headings.prepare'),
+      href: idv_document_capture_path(step: :hybrid_handoff),
+    )
+  end
+
+  def verify_handoff_page_ipp_section_and_link(page)
+    expect(page).to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
+    expect(page).to have_link(
+      t('in_person_proofing.headings.prepare'),
+      href: idv_document_capture_path(step: :hybrid_handoff),
+    )
+    click_on t('in_person_proofing.headings.prepare')
+    expect(page).to have_current_path(idv_document_capture_path({ step: 'hybrid_handoff' }))
+    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.find_a_post_office'))
+    expect(page).to have_content(t('headings.verify'))
+    click_on t('forms.buttons.back')
+    expect(page).to have_current_path(idv_hybrid_handoff_path)
+  end
+
+  def verify_upload_photos_section_and_link(page)
+    expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
+    click_on t('forms.buttons.upload_photos')
+    expect(page).to have_current_path(idv_document_capture_url)
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+    click_link t('links.cancel')
+    expect(page).to have_content(t('idv.cancel.headings.prompt.standard'))
+    expect(current_path).to eq(idv_cancel_path)
+  end
+
+  def verify_no_upload_photos_section_and_link(page)
+    expect(page).to_not have_content(t('doc_auth.headings.upload_from_computer'))
+  end
+
   context 'on a desktop device with various ipp and selfie configuration' do
     let(:in_person_proofing_enabled) { true }
     let(:sp_ipp_enabled) { true }
@@ -319,10 +350,8 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
     let(:user) { user_with_2fa }
     let(:service_provider) do
       if sp_ipp_enabled
-        Rails.logger.debug 'create ipp'
         create(:service_provider, :active, :in_person_proofing_enabled)
       else
-        Rails.logger.debug 'create sp without ipp'
         sp = create(:service_provider, :active, :in_person_proofing_enabled)
         sp.in_person_proofing_enabled = false
         sp.save!
@@ -356,77 +385,35 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
         context 'when sp ipp is available' do
           before do
             expect(page).to have_current_path(idv_how_to_verify_path)
-            choose 'Most Common'
+            choose t('doc_auth.tips.most_common')
             sleep(1)
-            click_on 'Continue'
+            click_on t('doc_auth.buttons.continue')
           end
           context 'when selfie is enabled system wide' do
             describe 'when selfie is required by sp' do
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                click_on t('in_person_proofing.headings.prepare')
-                expect(page).to have_current_path(idv_document_capture_path({ step: 'hybrid_handoff' }))
-                expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.find_a_post_office'))
-                expect(page).to have_content(t('headings.verify'))
-                click_on t('forms.buttons.back')
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
+              it 'shows selfie version of top content and ipp option section' do
+                verify_handoff_page_selfie_version_content(page)
+                verify_handoff_page_ipp_section_and_link(page)
               end
             end
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff'),
-                )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
           context 'when selfie is disabled system wide' do
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff'),
-                )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -437,25 +424,11 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             let(:doc_auth_selfie_capture_enabled) { false }
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff'),
-                )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -463,41 +436,20 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             let(:doc_auth_selfie_capture_enabled) { true }
             describe 'when selfie is required by sp' do
               let(:biometric_comparison_required) { true }
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                sleep(5)
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).not_to have_content(t('doc_auth.headings.upload_from_computer'))
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
+              it 'shows selfie version of top content, no ipp option section,
+                  no upload section' do
+                verify_handoff_page_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_no_upload_photos_section_and_link(page)
               end
             end
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                sleep(5)
-                expect(page).to_not have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -512,25 +464,11 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             let(:doc_auth_selfie_capture_enabled) { false }
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff'),
-                )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -539,46 +477,20 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             let(:doc_auth_selfie_capture_enabled) { true }
             describe 'when selfie is required by sp' do
               let(:biometric_comparison_required) { true }
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).not_to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).not_to have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).not_to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.upload_from_computer'),
-                )
+              it 'shows selfie version of top content, no upload section,
+                  no ipp option section' do
+                verify_handoff_page_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_no_upload_photos_section_and_link(page)
               end
             end
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                sleep(5)
-                expect(page).to_not have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).not_to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).not_to have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff'),
-                )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -589,26 +501,11 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             let(:doc_auth_selfie_capture_enabled) { false }
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                  t('in_person_proofing.headings.prepare'),
-                  href: idv_document_capture_path(step: :hybrid_handoff),
-                )
-                expect(page).to have_selector(
-                  'h1',
-                  text: t('doc_auth.headings.hybrid_handoff'),
-                )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                sleep(10)
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -619,47 +516,27 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
     context 'when ipp is not available system wide' do
       let(:in_person_proofing_enabled) { false }
       context 'when ipp opt in is enabled' do
-        let(:in_person_proofing_opt_in_enabled) {true}
+        let(:in_person_proofing_opt_in_enabled) { true }
         context 'when sp ipp is available' do
           let(:sp_ipp_enabled) { true }
           context 'when selfie is enabled system wide' do
             let(:doc_auth_selfie_capture_enabled) { true }
             describe 'when selfie is required by sp' do
               let(:biometric_comparison_required) { true }
-              it 'works' do #case 3
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                  )
-                expect(page).not_to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                                  t('in_person_proofing.headings.prepare'),
-                                  href: idv_document_capture_path(step: :hybrid_handoff),
-                                  )
+              it 'shows selfie version of top content, no upload section,
+                  no ipp option section' do
+                verify_handoff_page_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_no_upload_photos_section_and_link(page)
               end
             end
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'works' do #case 3
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                      )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff'),
-                                  )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -667,154 +544,75 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             let(:doc_auth_selfie_capture_enabled) { false }
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                      )
-                expect(page).not_to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).not_to have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff'),
-                                  )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content with upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
         end
         context 'when sp ipp is not available' do
-          let(:sp_ipp_enabled) {false }
+          let(:sp_ipp_enabled) { false }
           context 'when selfie is disabled system wide' do
-            let(:doc_auth_selfie_capture_enabled) {false}
+            let(:doc_auth_selfie_capture_enabled) { false }
             describe 'when selfie is not required by sp' do
-              let(:biometric_comparison_required) {false}
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                      )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff'),
-                                  )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              let(:biometric_comparison_required) { false }
+              it 'shows non selfie version of top content with upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
           context 'when selfie is enabled system wide' do
-            let(:doc_auth_selfie_capture_enabled) {true}
+            let(:doc_auth_selfie_capture_enabled) { true }
             describe 'when selfie is required by sp' do
-              let(:biometric_comparison_required) {true}
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                sleep(10)
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                  )
-                expect(page).not_to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).not_to have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).not_to have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.upload_from_computer'),
-                                      )
-                sleep(5)
+              let(:biometric_comparison_required) { true }
+              it 'shows selfie version of top content, no upload section,
+                  no ipp option section' do
+                verify_handoff_page_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_no_upload_photos_section_and_link(page)
               end
             end
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                      )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff'),
-                                  )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
-          end
+        end
       end
 
       context 'when ipp opt in is disabled' do
-        let(:in_person_proofing_opt_in_enabled) {false }
+        let(:in_person_proofing_opt_in_enabled) { false }
         context 'when sp ipp is enabled' do
           let(:sp_ipp_enabled) { true }
           context 'when selfie is enabled system wide' do
             let(:doc_auth_selfie_capture_enabled) { true }
             describe 'when selfie is required by sp' do
               let(:biometric_comparison_required) { true }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                  )
-                expect(page).not_to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).not_to have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).not_to have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.upload_from_computer'),
-                                      )
+              it 'shows selfie version of top content, no upload section,
+                  no ipp option section' do
+                verify_handoff_page_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_no_upload_photos_section_and_link(page)
               end
             end
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                      )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff'),
-                                  )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -822,25 +620,11 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             let(:doc_auth_selfie_capture_enabled) { true }
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                      )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff'),
-                                  )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
@@ -848,74 +632,35 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
         context 'when sp ipp is not enabled' do
           let(:sp_ipp_enabled) { false }
           context 'when selfie is enabled system wide' do
-            let(:doc_auth_selfie_capture_enabled) {true}
+            let(:doc_auth_selfie_capture_enabled) { true }
             describe 'when selfie required by sp' do
               let(:biometric_comparison_required) { true }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                  )
-                expect(page).not_to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).not_to have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).not_to have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.upload_from_computer'),
-                                      )
+              it 'shows selfie version of top content, no upload section,
+                  no ipp option section' do
+                verify_handoff_page_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_no_upload_photos_section_and_link(page)
               end
             end
             describe 'when selfie not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                      )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff'),
-                                  )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end
           context 'when selfie is disabled system wide' do
-            let(:doc_auth_selfie_capture_enabled) {false}
+            let(:doc_auth_selfie_capture_enabled) { false }
             describe 'when selfie not required by sp' do
               let(:biometric_comparison_required) { false }
-              it 'works' do
-                expect(page).to have_current_path(idv_hybrid_handoff_path)
-                expect(page).to_not have_selector(
-                                      'h1',
-                                      text: t('doc_auth.headings.hybrid_handoff_selfie'),
-                                      )
-                expect(page).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-                expect(page).to_not have_link(
-                                      t('in_person_proofing.headings.prepare'),
-                                      href: idv_document_capture_path(step: :hybrid_handoff),
-                                      )
-                expect(page).to have_selector(
-                                  'h1',
-                                  text: t('doc_auth.headings.hybrid_handoff'),
-                                  )
-                expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-                click_on t('forms.buttons.upload_photos')
-                expect(page).to have_current_path(idv_document_capture_url)
-                expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+              it 'shows non selfie version of top content and upload section,
+                  no ipp option section' do
+                verify_handoff_page_non_selfie_version_content(page)
+                verify_handoff_page_no_ipp_option_shown(page)
+                verify_upload_photos_section_and_link(page)
               end
             end
           end

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -354,13 +354,15 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
     context 'when ipp is available system wide' do
       context 'when in person proofing opt in enabled' do
         context 'when sp ipp is available' do
+          before do
+            expect(page).to have_current_path(idv_how_to_verify_path)
+            choose 'Most Common'
+            sleep(1)
+            click_on 'Continue'
+          end
           context 'when selfie is enabled system wide' do
             describe 'when selfie is required by sp' do
               it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_how_to_verify_path)
-                choose 'Most Common'
-                sleep(1)
-                click_on 'Continue'
                 expect(page).to have_current_path(idv_hybrid_handoff_path)
                 expect(page).to have_selector(
                   'h1',
@@ -382,10 +384,6 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
               it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_how_to_verify_path)
-                choose 'Most Common'
-                sleep(1)
-                click_on 'Continue'
                 expect(page).to have_current_path(idv_hybrid_handoff_path)
                 expect(page).to_not have_selector(
                   'h1',
@@ -411,10 +409,6 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
             describe 'when selfie is not required by sp' do
               let(:biometric_comparison_required) { false }
               it 'continues from handoff by choosing IPP and comes back' do
-                expect(page).to have_current_path(idv_how_to_verify_path)
-                choose 'Most Common'
-                sleep(1)
-                click_on 'Continue'
                 expect(page).to have_current_path(idv_hybrid_handoff_path)
                 expect(page).to_not have_selector(
                   'h1',

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -393,6 +393,7 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
               it 'shows selfie version of top content and ipp option section' do
                 verify_handoff_page_selfie_version_content(page)
                 verify_handoff_page_ipp_section_and_link(page)
+                verify_no_upload_photos_section_and_link(page)
               end
             end
             describe 'when selfie is not required by sp' do

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -348,18 +348,13 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
     let(:doc_auth_selfie_capture_enabled) { true }
     let(:biometric_comparison_required) { true }
     let(:user) { user_with_2fa }
-    let(:service_provider) do
-      if sp_ipp_enabled
-        create(:service_provider, :active, :in_person_proofing_enabled)
-      else
-        sp = create(:service_provider, :active, :in_person_proofing_enabled)
-        sp.in_person_proofing_enabled = false
-        sp.save!
-        sp
-      end
-    end
 
     before do
+      service_provider = create(:service_provider, :active, :in_person_proofing_enabled)
+      unless sp_ipp_enabled
+        service_provider.in_person_proofing_enabled = false
+        service_provider.save!
+      end
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).and_return(false)
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(
         in_person_proofing_enabled,

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -386,7 +386,6 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
           before do
             expect(page).to have_current_path(idv_how_to_verify_path)
             choose t('doc_auth.tips.most_common')
-            sleep(1)
             click_on t('doc_auth.buttons.continue')
           end
           context 'when selfie is enabled system wide' do

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -230,6 +230,40 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
         expect(mobile_form).to have_name(t('forms.buttons.send_link'))
         expect(page).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff_selfie'))
       end
+      context 'on a desktop choose ipp', js: true do
+        let(:in_person_doc_auth_button_enabled) { true }
+        let(:sp_ipp_enabled) { true }
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_doc_auth_button_enabled).
+            and_return(in_person_doc_auth_button_enabled)
+          allow(Idv::InPersonConfig).to receive(:enabled_for_issuer?).with(anything).
+            and_return(sp_ipp_enabled)
+          complete_doc_auth_steps_before_hybrid_handoff_step
+        end
+
+        context 'when ipp is enabled' do
+          it 'proceeds to ipp if selected and can go back' do
+            expect(page).to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
+            click_on t('in_person_proofing.headings.prepare')
+            expect(page).to have_current_path(idv_document_capture_path({ step: 'hybrid_handoff' }))
+            click_on t('forms.buttons.back')
+            expect(page).to have_current_path(idv_hybrid_handoff_path)
+          end
+        end
+
+        context 'when ipp is disabled' do
+          let(:in_person_doc_auth_button_enabled) { false }
+          let(:sp_ipp_enabled) { false }
+          it 'has no ipp option can be selected' do
+            expect(page).to_not have_content(
+              strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')),
+            )
+            expect(page).to_not have_content(
+              t('in_person_proofing.headings.prepare'),
+            )
+          end
+        end
+      end
     end
 
     describe 'when selfie is not required by sp' do
@@ -240,40 +274,6 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
 
         expect(mobile_form).to have_name(t('forms.buttons.send_link'))
         expect(desktop_form).to have_name(t('forms.buttons.upload_photos'))
-      end
-    end
-  end
-  context 'on a desktop choose ipp', js: true do
-    let(:in_person_doc_auth_button_enabled) { true }
-    let(:sp_ipp_enabled) { true }
-    before do
-      allow(IdentityConfig.store).to receive(:in_person_doc_auth_button_enabled).
-        and_return(in_person_doc_auth_button_enabled)
-      allow(Idv::InPersonConfig).to receive(:enabled_for_issuer?).with(anything).
-        and_return(sp_ipp_enabled)
-      complete_doc_auth_steps_before_hybrid_handoff_step
-    end
-
-    context 'when ipp is enabled' do
-      it 'proceeds to ipp if selected and can go back' do
-        expect(page).to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
-        click_on t('in_person_proofing.headings.prepare')
-        expect(page).to have_current_path(idv_document_capture_path({ step: 'hybrid_handoff' }))
-        click_on t('forms.buttons.back')
-        expect(page).to have_current_path(idv_hybrid_handoff_path)
-      end
-    end
-
-    context 'when ipp is disabled' do
-      let(:in_person_doc_auth_button_enabled) { false }
-      let(:sp_ipp_enabled) { false }
-      it 'has no ipp option can be selected' do
-        expect(page).to_not have_content(
-          strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')),
-        )
-        expect(page).to_not have_content(
-          t('in_person_proofing.headings.prepare'),
-        )
       end
     end
   end

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
 
     describe 'when ipp is enabled' do
       before do
-        @opt_in_ipp_enabled = true
+        @direct_ipp_with_selfie_enabled = true
       end
       it 'displays content and link for choose ipp' do
         expect(rendered).to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
@@ -72,7 +72,7 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
 
     describe 'when ipp is not enabled' do
       before do
-        @opt_in_ipp_enabled = false
+        @direct_ipp_with_selfie_enabled = false
       end
       it 'displays content and link for choose ipp' do
         expect(rendered).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
       expect(rendered).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff'))
       expect(rendered).to have_selector('h2', text: t('doc_auth.headings.upload_from_phone'))
     end
+
+    it 'does not display IPP related content' do
+      expect(rendered).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
+      expect(rendered).to_not have_link(
+        t('in_person_proofing.headings.prepare'),
+        href: idv_document_capture_path(step: :hybrid_handoff),
+      )
+    end
   end
   context 'when selfie is required' do
     before do
@@ -47,6 +55,32 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
     end
     it 'displays the expected headings from the "a" case' do
       expect(rendered).to have_selector('h1', text: t('doc_auth.headings.hybrid_handoff_selfie'))
+    end
+
+    describe 'when ipp is enabled' do
+      before do
+        @opt_in_ipp_enabled = true
+      end
+      it 'displays content and link for choose ipp' do
+        expect(rendered).to have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
+        expect(rendered).to have_link(
+          t('in_person_proofing.headings.prepare'),
+          href: idv_document_capture_path(step: :hybrid_handoff),
+        )
+      end
+    end
+
+    describe 'when ipp is not enabled' do
+      before do
+        @opt_in_ipp_enabled = false
+      end
+      it 'displays content and link for choose ipp' do
+        expect(rendered).to_not have_content(strip_tags(t('doc_auth.info.hybrid_handoff_ipp_html')))
+        expect(rendered).to_not have_link(
+          t('in_person_proofing.headings.prepare'),
+          href: idv_document_capture_path(step: :hybrid_handoff),
+        )
+      end
     end
   end
 end

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
 
   let(:acuant_version) { '1.3.3.7' }
   let(:skip_doc_auth) { false }
+  let(:skip_doc_auth_from_handoff) { false }
   let(:opted_in_to_in_person_proofing) { false }
 
   before do
@@ -47,6 +48,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       acuant_version: acuant_version,
       doc_auth_selfie_capture: selfie_capture_enabled,
       skip_doc_auth: skip_doc_auth,
+      skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
     }
   end
@@ -102,6 +104,13 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       render_partial
       expect(rendered).to have_css(
         "#document-capture-form[data-doc-auth-selfie-capture='false']",
+      )
+    end
+
+    it 'sends skip_doc_auth_from_handoff to in the frontend' do
+      render_partial
+      expect(rendered).to have_css(
+        "#document-capture-form[data-skip-doc-auth-from-handoff='false']",
       )
     end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12631](https://cm-jira.usa.gov/browse/LG-12631)

Previous PR with wrong branch name: https://github.com/18F/identity-idp/pull/10260

## 🛠 Summary of changes

IPP options on hybrid handoff page when IPP is available. User can select IPP and start document capture from handoff page on desktop.

A new `skip_doc_auth_from_handoff` flag is added for idv_session, simlar to `skip_doc_auth` which works with the optin page.

[Test cases](https://docs.google.com/spreadsheets/d/1ncGqc8X2hh77PC3E5fPT3aL5bqV_xVLOkpca4poU7kQ/edit?usp=sharing) for configuration items combination: 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

Please refer the test cases spreadsheet, it may not be realistic to test all combinations in staging environment.



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<!--
<summary>Before:</summary>
</details>
-->
<details>
<summary>After:</summary>

### IPP available and selfie required

| English      | Spanish  |  French  |
| ----------- | ----------- | ----------- |
|  ![En](https://github.com/18F/identity-idp/assets/130466753/99766a22-df2d-4443-9391-577b43e95066) | ![Es](https://github.com/18F/identity-idp/assets/130466753/cdf42d8b-cf6c-499a-9f5a-33e3cb22822f) | ![Fr](https://github.com/18F/identity-idp/assets/130466753/bca448d4-b267-40b3-b95d-cb7718dc7ab0)|






### IPP available and NO selfie required
| English      | Spanish  |  French  |
| ----------- | ----------- | ----------- |
| ![En-Ipp-NonSelfie](https://github.com/18F/identity-idp/assets/130466753/a983108a-c9dd-498f-9482-cbf07fa59be1) | ![ES-Ipp-Nonselfie](https://github.com/18F/identity-idp/assets/130466753/e3d9a47f-c0e5-4280-a7ca-f25fe21e81f8) | ![Fr-Ipp-NonSelfie](https://github.com/18F/identity-idp/assets/130466753/def6f7d0-f6eb-4376-927c-e945c23ba0c0) |

### IPP NOT available and Selfie required

| English      | Spanish  |  French  |
| ----------- | ----------- | ----------- |
|![EN-NonIpp-Selfie](https://github.com/18F/identity-idp/assets/130466753/288e2008-f0f0-4d72-82e7-7d411a8d75f5) | ![ES-NonIpp-Selfie](https://github.com/18F/identity-idp/assets/130466753/26b7be5f-cc1e-4607-9806-56eee7264840) | ![Fr-NonIpp-Selfie](https://github.com/18F/identity-idp/assets/130466753/e2354095-292e-4a47-8ca8-635a8ce03921) |

### IPP NOT available and NO Selfie required
| English      | Spanish  |  French  |
| ----------- | ----------- | ----------- |
| ![EN-Noipp-NonSelfie](https://github.com/18F/identity-idp/assets/130466753/31542b9a-acde-4d35-9c14-dfe1fb2e147e) | ![ES-Nonipp-NonSelfie](https://github.com/18F/identity-idp/assets/130466753/9bf65466-4fc6-4b01-8fd0-9142ee6f7cbd) | ![Fr-NonIpp-NonSelfie](https://github.com/18F/identity-idp/assets/130466753/7f58dfac-842f-4c70-8ef8-6575671c0783) |


</details>
