### PR TITLE
LG-12617: Add additional profile-related fields to enhanced Idv events

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -808,12 +808,22 @@ module AnalyticsEvents
 
   # @param [String] step the step that the user was on when they clicked cancel
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user confirmed their choice to cancel going through IDV
-  def idv_cancellation_confirmed(step:, proofing_components: nil, **extra)
+  def idv_cancellation_confirmed(
+    step:,
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: cancellation confirmed',
       step: step,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -823,6 +833,8 @@ module AnalyticsEvents
   # @param [boolean,nil] cancelled_enrollment Whether the user's IPP enrollment has been canceled
   # @param [String,nil] enrollment_code IPP enrollment code
   # @param [Integer,nil] enrollment_id ID of the associated IPP enrollment record
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user chose to go back instead of cancel IDV
   def idv_cancellation_go_back(
     step:,
@@ -830,6 +842,8 @@ module AnalyticsEvents
     cancelled_enrollment: nil,
     enrollment_code: nil,
     enrollment_id: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -839,6 +853,8 @@ module AnalyticsEvents
       cancelled_enrollment: cancelled_enrollment,
       enrollment_code: enrollment_code,
       enrollment_id: enrollment_id,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -847,11 +863,15 @@ module AnalyticsEvents
   # @param [String] request_came_from the controller and action from the
   #   source such as "users/sessions#new"
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user clicked cancel during IDV (presented with an option to go back or confirm)
   def idv_cancellation_visited(
     step:,
     request_came_from:,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -859,6 +879,8 @@ module AnalyticsEvents
       step: step,
       request_came_from: request_came_from,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -1240,6 +1262,8 @@ module AnalyticsEvents
   # @param [Boolean] in_person_verification_pending
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # @identity.idp.previous_event_name  IdV: review info visited
   def idv_enter_password_submitted(
     success:,
@@ -1249,6 +1273,8 @@ module AnalyticsEvents
     in_person_verification_pending:,
     deactivation_reason: nil,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -1260,6 +1286,8 @@ module AnalyticsEvents
       in_person_verification_pending: in_person_verification_pending,
       fraud_rejection: fraud_rejection,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -1267,18 +1295,24 @@ module AnalyticsEvents
   # @param [Idv::ProofingComponentsLogging] proofing_components User's
   #        current proofing components
   # @param [String] address_verification_method The method (phone or gpo) being
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   #        used to verify the user's identity
   # User visited IDV password confirm page
   # @identity.idp.previous_event_name  IdV: review info visited
   def idv_enter_password_visited(
     proofing_components: nil,
     address_verification_method: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
       :idv_enter_password_visited,
       address_verification_method: address_verification_method,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -1315,6 +1349,9 @@ module AnalyticsEvents
   # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verificaiton
   # @param [Boolean] in_person_verification_pending Profile is awaiting in person verificaiton
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Array,nil] profile_history Array of user's profiles (oldest to newest).
   # @see Reporting::IdentityVerificationReport#query This event is used by the identity verification
   #       report. Changes here should be reflected there.
   # Tracks the last step of IDV, indicates the user successfully proofed
@@ -1326,6 +1363,9 @@ module AnalyticsEvents
     in_person_verification_pending:,
     deactivation_reason: nil,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    profile_history: nil,
     **extra
   )
     track_event(
@@ -1337,26 +1377,47 @@ module AnalyticsEvents
       in_person_verification_pending: in_person_verification_pending,
       deactivation_reason: deactivation_reason,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
+      profile_history: profile_history,
       **extra,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User visited forgot password page
-  def idv_forgot_password(proofing_components: nil, **extra)
+  def idv_forgot_password(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: forgot password visited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User confirmed forgot password
-  def idv_forgot_password_confirmed(proofing_components: nil, **extra)
+  def idv_forgot_password_confirmed(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: forgot password confirmed',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -1486,6 +1547,8 @@ module AnalyticsEvents
   #                  and now in hours
   # @param [Integer] phone_step_attempts Number of attempts at phone step before requesting letter
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # GPO letter was enqueued and the time at which it was enqueued
   def idv_gpo_address_letter_enqueued(
     enqueued_at:,
@@ -1494,6 +1557,8 @@ module AnalyticsEvents
     hours_since_first_letter:,
     phone_step_attempts:,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -1504,6 +1569,8 @@ module AnalyticsEvents
       hours_since_first_letter: hours_since_first_letter,
       phone_step_attempts: phone_step_attempts,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -1514,6 +1581,8 @@ module AnalyticsEvents
   #                  and now in hours
   # @param [Integer] phone_step_attempts Number of attempts at phone step before requesting letter
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # GPO letter was requested
   def idv_gpo_address_letter_requested(
     resend:,
@@ -1521,6 +1590,8 @@ module AnalyticsEvents
     hours_since_first_letter:,
     phone_step_attempts:,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -1530,6 +1601,8 @@ module AnalyticsEvents
       hours_since_first_letter:,
       phone_step_attempts:,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -1975,12 +2048,18 @@ module AnalyticsEvents
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user visited the "ready to verify" page for the in person proofing flow
   def idv_in_person_ready_to_verify_visit(proofing_components: nil,
+                                          active_profile_idv_level: nil,
+                                          pending_profile_idv_level: nil,
                                           **extra)
     track_event(
       'IdV: in person ready to verify visited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2415,8 +2494,25 @@ module AnalyticsEvents
   end
 
   # User visits IdV
-  def idv_intro_visit(**extra)
-    track_event('IdV: intro visited', **extra)
+  # @param [Hash,nil] proofing_components User's proofing components.
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Array,nil] profile_history Array of user's profiles (oldest to newest).
+  def idv_intro_visit(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    profile_history: nil,
+    **extra
+  )
+    track_event(
+      'IdV: intro visited',
+      proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
+      profile_history: profile_history,
+      **extra,
+    )
   end
 
   # @param [String] enrollment_id
@@ -2434,11 +2530,20 @@ module AnalyticsEvents
 
   # The user visited the "letter enqueued" page shown during the verify by mail flow
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # @identity.idp.previous_event_name IdV: come back later visited
-  def idv_letter_enqueued_visit(proofing_components: nil, **extra)
+  def idv_letter_enqueued_visit(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: letter enqueued visited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2531,12 +2636,22 @@ module AnalyticsEvents
   # key creation
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # @param [boolean] checked whether the user checked or un-checked
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   #                  the box with this click
-  def idv_personal_key_acknowledgment_toggled(checked:, proofing_components:, **extra)
+  def idv_personal_key_acknowledgment_toggled(
+    checked:,
+    proofing_components:,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: personal key acknowledgment toggled',
       checked: checked,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2544,10 +2659,19 @@ module AnalyticsEvents
   # A user has downloaded their personal key. This event is no longer emitted.
   # @identity.idp.previous_event_name IdV: download personal key
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
-  def idv_personal_key_downloaded(proofing_components: nil, **extra)
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  def idv_personal_key_downloaded(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: personal key downloaded',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2558,6 +2682,8 @@ module AnalyticsEvents
   # @param [Boolean] fraud_rejection Profile is rejected due to fraud
   # @param [Boolean] in_person_verification_pending Profile is pending in-person verification
   # @param [String] address_verification_method "phone" or "gpo"
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User submitted IDV personal key page
   def idv_personal_key_submitted(
     address_verification_method:,
@@ -2566,6 +2692,8 @@ module AnalyticsEvents
     in_person_verification_pending:,
     proofing_components: nil,
     deactivation_reason: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2576,6 +2704,8 @@ module AnalyticsEvents
       fraud_review_pending: fraud_review_pending,
       fraud_rejection: fraud_rejection,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2584,12 +2714,16 @@ module AnalyticsEvents
   # @param [String] address_verification_method "phone" or "gpo"
   # @param [Boolean,nil] in_person_verification_pending
   # @param [Boolean] encrypted_profiles_missing True if user's session had no encrypted pii
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User visited IDV personal key page
   def idv_personal_key_visited(
     proofing_components: nil,
     address_verification_method: nil,
     in_person_verification_pending: nil,
     encrypted_profiles_missing: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2598,6 +2732,8 @@ module AnalyticsEvents
       address_verification_method: address_verification_method,
       in_person_verification_pending: in_person_verification_pending,
       encrypted_profiles_missing: encrypted_profiles_missing,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2606,12 +2742,16 @@ module AnalyticsEvents
   # @param [Hash] errors
   # @param ["sms", "voice"] otp_delivery_preference
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user submitted their phone on the phone confirmation page
   def idv_phone_confirmation_form_submitted(
     success:,
     otp_delivery_preference:,
     errors:,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2620,36 +2760,65 @@ module AnalyticsEvents
       errors: errors,
       otp_delivery_preference: otp_delivery_preference,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user was rate limited for submitting too many OTPs during the IDV phone step
-  def idv_phone_confirmation_otp_rate_limit_attempts(proofing_components: nil, **extra)
+  def idv_phone_confirmation_otp_rate_limit_attempts(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'Idv: Phone OTP attempts rate limited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user was locked out for hitting the phone OTP rate limit during IDV
-  def idv_phone_confirmation_otp_rate_limit_locked_out(proofing_components: nil, **extra)
+  def idv_phone_confirmation_otp_rate_limit_locked_out(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'Idv: Phone OTP rate limited user',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user was rate limited for requesting too many OTPs during the IDV phone step
-  def idv_phone_confirmation_otp_rate_limit_sends(proofing_components: nil, **extra)
+  def idv_phone_confirmation_otp_rate_limit_sends(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'Idv: Phone OTP sends rate limited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2663,6 +2832,8 @@ module AnalyticsEvents
   # @param [Hash] telephony_response response from Telephony gem
   # @param [String] phone_fingerprint Fingerprint string identifying phone number
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user resent an OTP during the IDV phone step
   def idv_phone_confirmation_otp_resent(
     success:,
@@ -2674,6 +2845,8 @@ module AnalyticsEvents
     telephony_response:,
     phone_fingerprint:,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2687,6 +2860,8 @@ module AnalyticsEvents
       telephony_response: telephony_response,
       phone_fingerprint: phone_fingerprint,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2701,6 +2876,8 @@ module AnalyticsEvents
   # @param [Hash] telephony_response response from Telephony gem
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # @param [:test, :pinpoint] adapter which adapter the OTP was delivered with
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The user requested an OTP to confirm their phone during the IDV phone step
   def idv_phone_confirmation_otp_sent(
     success:,
@@ -2713,6 +2890,8 @@ module AnalyticsEvents
     telephony_response:,
     adapter:,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2727,6 +2906,8 @@ module AnalyticsEvents
       telephony_response: telephony_response,
       adapter: adapter,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2738,6 +2919,8 @@ module AnalyticsEvents
   # @param [Integer] second_factor_attempts_count number of attempts to confirm this phone
   # @param [Time, nil] second_factor_locked_at timestamp when the phone was locked out
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # When a user attempts to confirm posession of a new phone number during the IDV process
   def idv_phone_confirmation_otp_submitted(
     success:,
@@ -2747,6 +2930,8 @@ module AnalyticsEvents
     second_factor_attempts_count:,
     second_factor_locked_at:,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2758,16 +2943,27 @@ module AnalyticsEvents
       second_factor_attempts_count: second_factor_attempts_count,
       second_factor_locked_at: second_factor_locked_at,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # When a user visits the page to confirm posession of a new phone number during the IDV process
-  def idv_phone_confirmation_otp_visit(proofing_components: nil, **extra)
+  def idv_phone_confirmation_otp_visit(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: phone confirmation otp visited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2775,11 +2971,15 @@ module AnalyticsEvents
   # @param [Boolean] success
   # @param [Hash] errors
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The vendor finished the process of confirming the users phone
   def idv_phone_confirmation_vendor_submitted(
     success:,
     errors:,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2787,6 +2987,8 @@ module AnalyticsEvents
       success: success,
       errors: errors,
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2796,12 +2998,16 @@ module AnalyticsEvents
   # @param [Integer] remaining_submit_attempts number of submit attempts remaining
   #                  (previously called "remaining_attempts")
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # When a user gets an error during the phone finder flow of IDV
   def idv_phone_error_visited(
     type:,
     proofing_components: nil,
     limiter_expires_at: nil,
     remaining_submit_attempts: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2813,15 +3019,26 @@ module AnalyticsEvents
         remaining_submit_attempts: remaining_submit_attempts,
         **extra,
       }.compact,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User visited idv phone of record
-  def idv_phone_of_record_visited(proofing_components: nil, **extra)
+  def idv_phone_of_record_visited(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: phone of record visited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2831,12 +3048,16 @@ module AnalyticsEvents
   # @param [Hash] errors
   # @param [Hash] error_details
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   def idv_phone_otp_delivery_selection_submitted(
     success:,
     otp_delivery_preference:,
     proofing_components: nil,
     errors: nil,
     error_details: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **extra
   )
     track_event(
@@ -2849,15 +3070,26 @@ module AnalyticsEvents
         proofing_components: proofing_components,
         **extra,
       }.compact,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User visited idv phone OTP delivery selection
-  def idv_phone_otp_delivery_selection_visit(proofing_components: nil, **extra)
+  def idv_phone_otp_delivery_selection_visit(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: Phone OTP delivery Selection Visited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -2876,21 +3108,42 @@ module AnalyticsEvents
 
   # @identity.idp.previous_event_name IdV: Verify setup errors visited
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Array,nil] profile_history Array of user's profiles (oldest to newest).
   # Tracks when the user reaches the verify please call page after failing proofing
-  def idv_please_call_visited(proofing_components: nil, **extra)
+  def idv_please_call_visited(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    profile_history: nil,
+    **extra
+  )
     track_event(
       'IdV: Verify please call visited',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
+      profile_history: profile_history,
       **extra,
     )
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # The system encountered an error and the proofing results are missing
-  def idv_proofing_resolution_result_missing(proofing_components: nil, **extra)
+  def idv_proofing_resolution_result_missing(
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: proofing resolution result missing',
       proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
       **extra,
     )
   end
@@ -3024,6 +3277,9 @@ module AnalyticsEvents
   # @param [String] source
   # @param [String] use_alternate_sdk
   # @param [Boolean] liveness_checking_required
+  # @param [Hash,nil] proofing_components User's proofing components.
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   def idv_selfie_image_clicked(
     acuant_sdk_upgrade_a_b_testing_enabled:,
     acuant_version:,
@@ -3032,6 +3288,9 @@ module AnalyticsEvents
     source:,
     use_alternate_sdk:,
     liveness_checking_required: nil,
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
     **_extra
   )
     track_event(
@@ -3043,6 +3302,9 @@ module AnalyticsEvents
       source: source,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      proofing_components: proofing_components,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
@@ -3069,6 +3331,9 @@ module AnalyticsEvents
   # @param [boolean,nil] cancelled_enrollment Whether the user's IPP enrollment has been canceled
   # @param [String,nil] enrollment_code IPP enrollment code
   # @param [Integer,nil] enrollment_id ID of the associated IPP enrollment record
+  # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
+  # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Array,nil] profile_history Array of user's profiles (oldest to newest).
   # User started over idv
   def idv_start_over(
     step:,
@@ -3077,6 +3342,9 @@ module AnalyticsEvents
     enrollment_code: nil,
     enrollment_id: nil,
     proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    profile_history: nil,
     **extra
   )
     track_event(
@@ -3087,6 +3355,9 @@ module AnalyticsEvents
       cancelled_enrollment: cancelled_enrollment,
       enrollment_code: enrollment_code,
       enrollment_id: enrollment_id,
+      active_profile_idv_level: active_profile_idv_level,
+      pending_profile_idv_level: pending_profile_idv_level,
+      profile_history: profile_history,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3017,10 +3017,10 @@ module AnalyticsEvents
         proofing_components: proofing_components,
         limiter_expires_at: limiter_expires_at,
         remaining_submit_attempts: remaining_submit_attempts,
+        active_profile_idv_level: active_profile_idv_level,
+        pending_profile_idv_level: pending_profile_idv_level,
         **extra,
       }.compact,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
     )
   end
 

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -136,6 +136,7 @@ module Idv
         proofing_components: proofing_components,
         active_profile_idv_level: active_profile&.idv_level,
         pending_profile_idv_level: pending_profile&.idv_level,
+        profile_history: profile_history,
       }.compact
     end
 
@@ -147,6 +148,15 @@ module Idv
     def pending_profile
       return if !user&.respond_to?(:pending_profile) || !user.pending_profile
       user.pending_profile
+    end
+
+    def profile_history
+      return if !user&.respond_to?(:profiles)
+
+      (user&.profiles || []).
+        sort_by { |profile| profile.created_at }.
+        map { |profile| ProfileLogging.new(profile) }.
+        presence
     end
 
     def proofing_components

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -84,7 +84,6 @@ module Idv
       idv_in_person_usps_proofing_results_job_unexpected_response
       idv_in_person_usps_proofing_results_job_user_sent_to_fraud_review
       idv_in_person_usps_request_enroll_exception
-      idv_intro_visit
       idv_ipp_deactivated_for_never_visiting_post_office
       idv_link_sent_capture_doc_polling_complete
       idv_link_sent_capture_doc_polling_started
@@ -109,6 +108,20 @@ module Idv
       idv_warning_shown
     ].to_set.freeze
 
+    STANDARD_ARGUMENTS = %i[
+      proofing_components
+      active_profile_idv_level
+      pending_profile_idv_level
+    ].freeze
+
+    METHODS_WITH_PROFILE_HISTORY = %i[
+      idv_doc_auth_verify_proofing_results
+      idv_intro_visit
+      idv_final
+      idv_please_call_visited
+      idv_start_over
+    ].to_set.freeze
+
     def self.included(_mod)
       raise 'this mixin is intended to be prepended, not included'
     end
@@ -117,7 +130,7 @@ module Idv
       mod.instance_methods.each do |method_name|
         if should_enhance_method?(method_name)
           mod.define_method method_name do |**kwargs|
-            super(**kwargs, **common_analytics_attributes)
+            super(**kwargs, **analytics_attributes(method_name))
           end
         end
       end
@@ -125,19 +138,32 @@ module Idv
 
     def self.should_enhance_method?(method_name)
       return false if IGNORED_METHODS.include?(method_name)
-
       method_name.start_with?('idv_')
+    end
+
+    def self.extra_args_for_method(method_name)
+      return [] unless should_enhance_method?(method_name)
+
+      args = STANDARD_ARGUMENTS
+
+      if METHODS_WITH_PROFILE_HISTORY.include?(method_name)
+        args = [
+          *args,
+          :profile_history,
+        ]
+      end
+
+      args
     end
 
     private
 
-    def common_analytics_attributes
-      {
-        proofing_components: proofing_components,
-        active_profile_idv_level: active_profile_idv_level.presence,
-        pending_profile_idv_level: pending_profile_idv_level.presence,
-        profile_history: profile_history,
-      }.compact
+    def analytics_attributes(method_name)
+      AnalyticsEventsEnhancer.extra_args_for_method(method_name).
+        index_with do |arg_name|
+          send(arg_name.to_s).presence
+        end.
+        compact
     end
 
     def active_profile_idv_level
@@ -153,8 +179,7 @@ module Idv
 
       (user&.profiles || []).
         sort_by { |profile| profile.created_at }.
-        map { |profile| ProfileLogging.new(profile) }.
-        presence
+        map { |profile| ProfileLogging.new(profile) }
     end
 
     def proofing_components

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -134,7 +134,19 @@ module Idv
     def common_analytics_attributes
       {
         proofing_components: proofing_components,
+        active_profile_idv_level: active_profile&.idv_level,
+        pending_profile_idv_level: pending_profile&.idv_level,
       }.compact
+    end
+
+    def active_profile
+      return if !user&.respond_to?(:active_profile) || !user.active_profile
+      user.active_profile
+    end
+
+    def pending_profile
+      return if !user&.respond_to?(:pending_profile) || !user.pending_profile
+      user.pending_profile
     end
 
     def proofing_components

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -134,20 +134,18 @@ module Idv
     def common_analytics_attributes
       {
         proofing_components: proofing_components,
-        active_profile_idv_level: active_profile&.idv_level,
-        pending_profile_idv_level: pending_profile&.idv_level,
+        active_profile_idv_level: active_profile_idv_level.presence,
+        pending_profile_idv_level: pending_profile_idv_level.presence,
         profile_history: profile_history,
       }.compact
     end
 
-    def active_profile
-      return if !user&.respond_to?(:active_profile) || !user.active_profile
-      user.active_profile
+    def active_profile_idv_level
+      user&.respond_to?(:active_profile) && user&.active_profile&.idv_level
     end
 
-    def pending_profile
-      return if !user&.respond_to?(:pending_profile) || !user.pending_profile
-      user.pending_profile
+    def pending_profile_idv_level
+      user&.respond_to?(:pending_profile) && user&.pending_profile&.idv_level
     end
 
     def profile_history

--- a/app/services/idv/profile_logging.rb
+++ b/app/services/idv/profile_logging.rb
@@ -1,0 +1,22 @@
+module Idv
+  ProfileLogging = Struct.new(:profile) do
+    def as_json
+      profile.slice(
+        %i[
+          id
+          active
+          idv_level
+          created_at
+          verified_at
+          activated_at
+          in_person_verification_pending_at
+          gpo_verification_pending_at
+          fraud_review_pending_at
+          fraud_rejection_at
+          fraud_pending_reason
+          deactivation_reason
+        ],
+      ).compact
+    end
+  end
+end

--- a/spec/controllers/idv/by_mail/letter_enqueued_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/letter_enqueued_controller_spec.rb
@@ -16,10 +16,7 @@ RSpec.describe Idv::ByMail::LetterEnqueuedController do
 
       get :show
 
-      expect(@analytics).to have_logged_event(
-        'IdV: letter enqueued visited',
-        proofing_components: nil,
-      )
+      expect(@analytics).to have_logged_event('IdV: letter enqueued visited')
     end
 
     it 'renders the show template' do

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -166,12 +166,13 @@ RSpec.describe Idv::ByMail::RequestLetterController,
 
         expect(@analytics).to have_logged_event(
           'IdV: USPS address letter requested',
-          resend: false,
-          phone_step_attempts: 1,
-          first_letter_requested_at: nil,
-          hours_since_first_letter: 0,
-          proofing_components: nil,
-          **ab_test_args,
+          hash_including(
+            resend: false,
+            phone_step_attempts: 1,
+            first_letter_requested_at: nil,
+            hours_since_first_letter: 0,
+            **ab_test_args,
+          ),
         )
       end
 
@@ -222,23 +223,26 @@ RSpec.describe Idv::ByMail::RequestLetterController,
 
         expect(@analytics).to have_logged_event(
           'IdV: USPS address letter requested',
-          resend: true,
-          phone_step_attempts: 1,
-          first_letter_requested_at: pending_profile.gpo_verification_pending_at,
-          hours_since_first_letter: 24,
-          proofing_components: nil,
-          **ab_test_args,
+          hash_including(
+            resend: true,
+            phone_step_attempts: 1,
+            first_letter_requested_at: pending_profile.gpo_verification_pending_at,
+            hours_since_first_letter: 24,
+            **ab_test_args,
+          ),
         )
 
         expect(@analytics).to have_logged_event(
           'IdV: USPS address letter enqueued',
-          resend: true,
-          first_letter_requested_at: pending_profile.gpo_verification_pending_at,
-          hours_since_first_letter: 24,
-          enqueued_at: Time.zone.now,
-          phone_step_attempts: 1,
-          proofing_components: nil,
-          **ab_test_args,
+          hash_including(
+            resend: true,
+            first_letter_requested_at: pending_profile.gpo_verification_pending_at,
+            hours_since_first_letter: 24,
+            enqueued_at: Time.zone.now,
+            phone_step_attempts: 1,
+            proofing_components: nil,
+            **ab_test_args,
+          ),
         )
       end
 

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
-        request_came_from: 'no referer',
-        step: nil,
-        proofing_components: nil,
+        hash_including(
+          request_came_from: 'no referer',
+          step: nil,
+        ),
       )
     end
 
@@ -37,9 +38,10 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
-        request_came_from: 'users/sessions#new',
-        step: nil,
-        proofing_components: nil,
+        hash_including(
+          request_came_from: 'users/sessions#new',
+          step: nil,
+        ),
       )
     end
 
@@ -51,9 +53,10 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
-        request_came_from: 'no referer',
-        step: 'first',
-        proofing_components: nil,
+        hash_including(
+          request_came_from: 'no referer',
+          step: 'first',
+        ),
       )
     end
 
@@ -115,11 +118,9 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation go back',
-        step: 'first',
-        proofing_components: nil,
-        cancelled_enrollment: nil,
-        enrollment_code: nil,
-        enrollment_id: nil,
+        hash_including(
+          step: 'first',
+        ),
       )
     end
 
@@ -137,11 +138,12 @@ RSpec.describe Idv::CancellationsController do
 
         expect(@analytics).to have_logged_event(
           'IdV: cancellation go back',
-          step: 'barcode',
-          proofing_components: nil,
-          cancelled_enrollment: false,
-          enrollment_code: enrollment.enrollment_code,
-          enrollment_id: enrollment.id,
+          hash_including(
+            step: 'barcode',
+            cancelled_enrollment: false,
+            enrollment_code: enrollment.enrollment_code,
+            enrollment_id: enrollment.id,
+          ),
         )
       end
     end
@@ -172,8 +174,7 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation confirmed',
-        step: 'first',
-        proofing_components: nil,
+        hash_including(step: 'first'),
       )
     end
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -280,14 +280,15 @@ RSpec.describe Idv::EnterPasswordController, allowed_extra_analytics: [:*] do
 
         expect(@analytics).to have_logged_event(
           :idv_enter_password_submitted,
-          success: false,
-          fraud_review_pending: false,
-          fraud_rejection: false,
-          gpo_verification_pending: false,
-          in_person_verification_pending: false,
-          proofing_components: nil,
-          deactivation_reason: nil,
-          **ab_test_args,
+          hash_including(
+            success: false,
+            fraud_review_pending: false,
+            fraud_rejection: false,
+            gpo_verification_pending: false,
+            in_person_verification_pending: false,
+            deactivation_reason: nil,
+            **ab_test_args,
+          ),
         )
       end
     end
@@ -297,14 +298,15 @@ RSpec.describe Idv::EnterPasswordController, allowed_extra_analytics: [:*] do
 
       expect(@analytics).to have_logged_event(
         :idv_enter_password_submitted,
-        success: true,
-        fraud_review_pending: false,
-        fraud_rejection: false,
-        gpo_verification_pending: false,
-        in_person_verification_pending: false,
-        proofing_components: nil,
-        deactivation_reason: anything,
-        **ab_test_args,
+        hash_including(
+          success: true,
+          fraud_review_pending: false,
+          fraud_rejection: false,
+          gpo_verification_pending: false,
+          in_person_verification_pending: false,
+          deactivation_reason: anything,
+          **ab_test_args,
+        ),
       )
       expect(@analytics).to have_logged_event(
         'IdV: final resolution',
@@ -779,25 +781,27 @@ RSpec.describe Idv::EnterPasswordController, allowed_extra_analytics: [:*] do
                   put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
                   expect(@analytics).to have_logged_event(
                     :idv_enter_password_submitted,
-                    success: true,
-                    fraud_review_pending: fraud_review_pending?,
-                    fraud_rejection: false,
-                    gpo_verification_pending: false,
-                    in_person_verification_pending: false,
-                    proofing_components: nil,
-                    deactivation_reason: nil,
-                    **ab_test_args,
+                    hash_including(
+                      success: true,
+                      fraud_review_pending: fraud_review_pending?,
+                      fraud_rejection: false,
+                      gpo_verification_pending: false,
+                      in_person_verification_pending: false,
+                      deactivation_reason: nil,
+                      **ab_test_args,
+                    ),
                   )
                   expect(@analytics).to have_logged_event(
                     'IdV: final resolution',
-                    success: true,
-                    fraud_review_pending: fraud_review_pending?,
-                    fraud_rejection: false,
-                    gpo_verification_pending: false,
-                    in_person_verification_pending: false,
-                    proofing_components: nil,
-                    deactivation_reason: nil,
-                    **ab_test_args,
+                    hash_including(
+                      success: true,
+                      fraud_review_pending: fraud_review_pending?,
+                      fraud_rejection: false,
+                      gpo_verification_pending: false,
+                      in_person_verification_pending: false,
+                      deactivation_reason: nil,
+                      **ab_test_args,
+                    ),
                   )
                 end
 
@@ -847,13 +851,14 @@ RSpec.describe Idv::EnterPasswordController, allowed_extra_analytics: [:*] do
 
         expect(@analytics).to have_logged_event(
           'IdV: USPS address letter enqueued',
-          resend: false,
-          enqueued_at: Time.zone.now,
-          phone_step_attempts: 1,
-          first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
-          hours_since_first_letter: 0,
-          proofing_components: nil,
-          **ab_test_args,
+          hash_including(
+            resend: false,
+            enqueued_at: Time.zone.now,
+            phone_step_attempts: 1,
+            first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
+            hours_since_first_letter: 0,
+            **ab_test_args,
+          ),
         )
       end
 
@@ -866,13 +871,14 @@ RSpec.describe Idv::EnterPasswordController, allowed_extra_analytics: [:*] do
 
           expect(@analytics).to have_logged_event(
             'IdV: USPS address letter enqueued',
-            resend: false,
-            enqueued_at: Time.zone.now,
-            phone_step_attempts: RateLimiter.max_attempts(rate_limit_type),
-            first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
-            hours_since_first_letter: 0,
-            proofing_components: nil,
-            **ab_test_args,
+            hash_including(
+              resend: false,
+              enqueued_at: Time.zone.now,
+              phone_step_attempts: RateLimiter.max_attempts(rate_limit_type),
+              first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
+              hours_since_first_letter: 0,
+              **ab_test_args,
+            ),
           )
         end
       end

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -81,10 +81,7 @@ RSpec.describe Idv::OtpVerificationController,
     it 'tracks an analytics event' do
       get :show
 
-      expect(@analytics).to have_logged_event(
-        'IdV: phone confirmation otp visited',
-        proofing_components: nil,
-      )
+      expect(@analytics).to have_logged_event('IdV: phone confirmation otp visited')
     end
   end
 
@@ -180,13 +177,12 @@ RSpec.describe Idv::OtpVerificationController,
         code_matches: true,
         second_factor_attempts_count: 0,
         second_factor_locked_at: nil,
-        proofing_components: nil,
         **ab_test_args,
       }
 
       expect(@analytics).to have_logged_event(
         'IdV: phone confirmation otp submitted',
-        expected_result,
+        hash_including(expected_result),
       )
     end
 

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -442,12 +442,13 @@ RSpec.describe Idv::PersonalKeyController do
 
         expect(@analytics).to have_logged_event(
           'IdV: personal key submitted',
-          address_verification_method: 'phone',
-          fraud_review_pending: false,
-          fraud_rejection: false,
-          in_person_verification_pending: false,
-          deactivation_reason: nil,
-          proofing_components: nil,
+          hash_including(
+            address_verification_method: 'phone',
+            fraud_review_pending: false,
+            fraud_rejection: false,
+            in_person_verification_pending: false,
+            deactivation_reason: nil,
+          ),
         )
       end
     end
@@ -489,12 +490,13 @@ RSpec.describe Idv::PersonalKeyController do
 
         expect(@analytics).to have_logged_event(
           'IdV: personal key submitted',
-          address_verification_method: 'phone',
-          fraud_review_pending: false,
-          fraud_rejection: false,
-          deactivation_reason: nil,
-          in_person_verification_pending: false,
-          proofing_components: nil,
+          hash_including(
+            address_verification_method: 'phone',
+            fraud_review_pending: false,
+            fraud_rejection: false,
+            in_person_verification_pending: false,
+            proofing_components: nil,
+          ),
         )
       end
     end
@@ -517,12 +519,13 @@ RSpec.describe Idv::PersonalKeyController do
 
           expect(@analytics).to have_logged_event(
             'IdV: personal key submitted',
-            address_verification_method: 'phone',
-            fraud_review_pending: false,
-            fraud_rejection: false,
-            in_person_verification_pending: false,
-            deactivation_reason: nil,
-            proofing_components: nil,
+            hash_including(
+              address_verification_method: 'phone',
+              fraud_review_pending: false,
+              fraud_rejection: false,
+              in_person_verification_pending: false,
+              proofing_components: nil,
+            ),
           )
         end
       end
@@ -544,12 +547,13 @@ RSpec.describe Idv::PersonalKeyController do
 
           expect(@analytics).to have_logged_event(
             'IdV: personal key submitted',
-            fraud_review_pending: true,
-            fraud_rejection: false,
-            address_verification_method: 'phone',
-            in_person_verification_pending: false,
-            deactivation_reason: nil,
-            proofing_components: nil,
+            hash_including(
+              fraud_review_pending: true,
+              fraud_rejection: false,
+              address_verification_method: 'phone',
+              in_person_verification_pending: false,
+              deactivation_reason: nil,
+            ),
           )
         end
       end

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -316,11 +316,14 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
           phone_type: :mobile,
           otp_delivery_preference: '🎷',
           types: [],
-          proofing_components: nil,
           **ab_test_args,
         }
 
-        expect(@analytics).to have_logged_event('IdV: phone confirmation form', result)
+        expect(@analytics).to have_logged_event(
+          'IdV: phone confirmation form',
+          hash_including(result),
+        )
+
         expect(subject.idv_session.vendor_phone_confirmation).to be_falsy
       end
     end
@@ -362,11 +365,13 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
           phone_type: :mobile,
           otp_delivery_preference: 'sms',
           types: [:fixed_or_mobile],
-          proofing_components: nil,
           **ab_test_args,
         }
 
-        expect(@analytics).to have_logged_event('IdV: phone confirmation form', result)
+        expect(@analytics).to have_logged_event(
+          'IdV: phone confirmation form',
+          hash_including(result),
+        )
       end
 
       it 'updates the doc auth log for the user with verify_phone_submit step' do
@@ -460,13 +465,13 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
             transaction_id: 'address-mock-transaction-id-123',
             reference: '',
           },
-          proofing_components: nil,
         }
 
         put :create, params: { idv_phone_form: { phone: good_phone } }
 
         expect(@analytics).to have_logged_event(
-          'IdV: phone confirmation form', hash_including(:success)
+          'IdV: phone confirmation form',
+          hash_including(:success),
         )
 
         expect(response).to redirect_to idv_phone_path
@@ -474,7 +479,8 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
         get :new
 
         expect(@analytics).to have_logged_event(
-          'IdV: phone confirmation vendor', result
+          'IdV: phone confirmation vendor',
+          hash_including(result),
         )
       end
     end
@@ -486,13 +492,15 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
       expect(response).to redirect_to idv_phone_path
 
       expect(@analytics).to have_logged_event(
-        'IdV: phone confirmation form', hash_including(:success)
+        'IdV: phone confirmation form',
+        hash_including(:success),
       )
 
       get :new
 
       expect(@analytics).to have_logged_event(
-        'IdV: phone confirmation vendor', hash_including(hybrid_handoff_phone_used: true)
+        'IdV: phone confirmation vendor',
+        hash_including(hybrid_handoff_phone_used: true),
       )
     end
 
@@ -547,7 +555,8 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
         put :create, params: { idv_phone_form: { phone: bad_phone } }
 
         expect(@analytics).to have_logged_event(
-          'IdV: phone confirmation form', hash_including(:success)
+          'IdV: phone confirmation form',
+          hash_including(:success),
         )
 
         expect(response).to redirect_to idv_phone_path
@@ -555,7 +564,8 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
         get :new
 
         expect(@analytics).to have_logged_event(
-          'IdV: phone confirmation vendor', result
+          'IdV: phone confirmation vendor',
+          hash_including(result),
         )
       end
 
@@ -576,9 +586,7 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
         it 'tracks rate limited event' do
           expect(@analytics).to have_logged_event(
             'Rate Limit Reached',
-            {
-              limiter_type: :proof_address,
-            },
+            limiter_type: :proof_address,
           )
         end
       end

--- a/spec/controllers/idv/please_call_controller_spec.rb
+++ b/spec/controllers/idv/please_call_controller_spec.rb
@@ -39,10 +39,7 @@ RSpec.describe Idv::PleaseCallController do
 
     get :show
 
-    expect(@analytics).to have_logged_event(
-      'IdV: Verify please call visited',
-      proofing_components: nil,
-    )
+    expect(@analytics).to have_logged_event('IdV: Verify please call visited')
   end
 
   it 'renders the show template' do

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -60,12 +60,11 @@ RSpec.describe Idv::ResendOtpController do
         area_code: '225',
         rate_limit_exceeded: false,
         telephony_response: instance_of(Telephony::Response),
-        proofing_components: nil,
       }
 
       expect(@analytics).to have_logged_event(
         'IdV: phone confirmation otp resent',
-        expected_result,
+        hash_including(expected_result),
       )
     end
 

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -44,12 +44,13 @@ RSpec.describe Idv::SessionsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: start over',
-        location: 'get_help',
-        proofing_components: nil,
-        cancelled_enrollment: nil,
-        enrollment_code: nil,
-        enrollment_id: nil,
-        step: 'first',
+        hash_including(
+          location: 'get_help',
+          cancelled_enrollment: nil,
+          enrollment_code: nil,
+          enrollment_id: nil,
+          step: 'first',
+        ),
       )
     end
 
@@ -60,12 +61,13 @@ RSpec.describe Idv::SessionsController do
         delete :destroy, params: { step: 'barcode', location: '' }
         expect(@analytics).to have_logged_event(
           'IdV: start over',
-          location: '',
-          proofing_components: nil,
-          step: 'barcode',
-          cancelled_enrollment: true,
-          enrollment_code: user.pending_in_person_enrollment.enrollment_code,
-          enrollment_id: user.pending_in_person_enrollment.id,
+          hash_including(
+            location: '',
+            step: 'barcode',
+            cancelled_enrollment: true,
+            enrollment_code: user.pending_in_person_enrollment.enrollment_code,
+            enrollment_id: user.pending_in_person_enrollment.id,
+          ),
         )
       end
     end
@@ -90,14 +92,16 @@ RSpec.describe Idv::SessionsController do
         expect(cancel).to receive(:call)
 
         delete :destroy, params: { step: 'gpo_verify', location: 'clear_and_start_over' }
+
         expect(@analytics).to have_logged_event(
           'IdV: start over',
-          location: 'clear_and_start_over',
-          proofing_components: nil,
-          cancelled_enrollment: nil,
-          enrollment_code: nil,
-          enrollment_id: nil,
-          step: 'gpo_verify',
+          hash_including(
+            location: 'clear_and_start_over',
+            cancelled_enrollment: nil,
+            enrollment_code: nil,
+            enrollment_id: nil,
+            step: 'gpo_verify',
+          ),
         )
       end
     end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -37,7 +37,11 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
 
   let(:happy_path_events) do
     {
-      'IdV: intro visited' => {},
+      'IdV: intro visited' => {
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        profile_history: nil,
+        proofing_components: nil
+      },
       'IdV: doc auth welcome visited' => {
         step: 'welcome', analytics_id: 'Doc Auth', irs_reproofing: false, skip_hybrid_handoff: nil, lexisnexis_instant_verify_workflow_ab_test_bucket: :default
       },
@@ -96,49 +100,62 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: phone of record visited' => {
         acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: phone confirmation form' => {
         success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, otp_delivery_preference: 'sms',
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: phone confirmation vendor' => {
         success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, hybrid_handoff_phone_used: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp sent' => {
         success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202', adapter: :test, errors: {}, phone_fingerprint: anything, rate_limit_exceeded: false, telephony_response: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp visited' => {
-        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp submitted' => {
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
         address_verification_method: 'phone', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: final resolution' => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
+        profile_history: match_array(kind_of(Idv::ProfileLogging)),
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
         address_verification_method: 'phone', encrypted_profiles_missing: false, in_person_verification_pending: false,
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {
         checked: true,
-        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key submitted' => {
         address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
     }
@@ -146,7 +163,11 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
 
   let(:happy_hybrid_path_events) do
     {
-      'IdV: intro visited' => {},
+      'IdV: intro visited' => {
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        profile_history: nil,
+        proofing_components: nil
+      },
       'IdV: doc auth welcome visited' => {
         step: 'welcome', analytics_id: 'Doc Auth', irs_reproofing: false, skip_hybrid_handoff: nil, lexisnexis_instant_verify_workflow_ab_test_bucket: :default
       },
@@ -205,49 +226,62 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: phone of record visited' => {
         acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: phone confirmation form' => {
         success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, otp_delivery_preference: 'sms',
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: phone confirmation vendor' => {
         success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, hybrid_handoff_phone_used: true, area_code: '202', country_code: 'US', phone_fingerprint: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp sent' => {
         success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202', adapter: :test, errors: {}, phone_fingerprint: anything, rate_limit_exceeded: false, telephony_response: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp visited' => {
-        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp submitted' => {
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
         address_verification_method: 'phone', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: final resolution' => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
+        profile_history: match_array(kind_of(Idv::ProfileLogging)),
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
         address_verification_method: 'phone', encrypted_profiles_missing: false, in_person_verification_pending: false,
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {
         checked: true,
-        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key submitted' => {
         address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'legacy_unsupervised', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
     }
@@ -255,7 +289,11 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
 
   let(:gpo_path_events) do
     {
-      'IdV: intro visited' => {},
+      'IdV: intro visited' => {
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        profile_history: nil,
+        proofing_components: nil
+      },
       'IdV: doc auth welcome visited' => {
         step: 'welcome', analytics_id: 'Doc Auth', irs_reproofing: false, skip_hybrid_handoff: nil, lexisnexis_instant_verify_workflow_ab_test_bucket: :default
       },
@@ -311,10 +349,12 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: phone of record visited' => {
         acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: USPS address letter requested' => {
         resend: false, phone_step_attempts: 0, first_letter_requested_at: nil, hours_since_first_letter: 0, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: request letter visited' => {
@@ -322,22 +362,29 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       :idv_enter_password_visited => {
         address_verification_method: 'gpo', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
       'IdV: USPS address letter enqueued' => {
         enqueued_at: Time.zone.now.utc, resend: false, phone_step_attempts: 0, first_letter_requested_at: Time.zone.now.utc, hours_since_first_letter: 0, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
       :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: true, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
       'IdV: final resolution' => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: true, in_person_verification_pending: false, deactivation_reason: nil,
+        # NOTE: pending_profile_idv_level should be set here, a nil value is cached for current_user.pending_profile.
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        profile_history: match_array(kind_of(Idv::ProfileLogging)),
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
       'IdV: letter enqueued visited' => {
-        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' },
+        active_profile_idv_level: nil, pending_profile_idv_level: 'legacy_unsupervised',
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'gpo_letter' }
       },
     }
   end
@@ -420,51 +467,65 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: phone confirmation form' => {
         success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, otp_delivery_preference: 'sms',
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' }
       },
       'IdV: phone confirmation vendor' => {
         success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, hybrid_handoff_phone_used: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' }
       },
       'IdV: phone confirmation otp sent' => {
         success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202', adapter: :test, errors: {}, phone_fingerprint: anything, rate_limit_exceeded: false, telephony_response: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' }
       },
       'IdV: phone confirmation otp visited' => {
-        proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' },
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'aamva' }
       },
       'IdV: phone confirmation otp submitted' => {
         success: true, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {}, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
         acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, address_verification_method: 'phone',
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, deactivation_reason: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: final resolution' => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, deactivation_reason: nil,
+        # NOTE: pending_profile_idv_level should be set here, a nil value is cached for current_user.pending_profile.
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        profile_history: match_array(kind_of(Idv::ProfileLogging)),
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
         in_person_verification_pending: true,
         address_verification_method: 'phone',
         encrypted_profiles_missing: false,
-        proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: nil, pending_profile_idv_level: 'legacy_in_person',
+        proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {
         checked: true,
-        proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: nil, pending_profile_idv_level: 'legacy_in_person',
+        proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key submitted' => {
         address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, in_person_verification_pending: true, deactivation_reason: nil,
+        active_profile_idv_level: nil, pending_profile_idv_level: 'legacy_in_person',
         proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: in person ready to verify visited' => {
-        proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: nil, pending_profile_idv_level: 'legacy_in_person',
+        proofing_components: { document_check: 'usps', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: user clicked what to bring link on ready to verify page' => {},
       'IdV: user clicked sp link on ready to verify page' => {},
@@ -473,7 +534,11 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
 
   let(:happy_mobile_selfie_path_events) do
     {
-      'IdV: intro visited' => {},
+      'IdV: intro visited' => {
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        profile_history: nil,
+        proofing_components: nil
+      },
       'IdV: doc auth welcome visited' => {
         step: 'welcome', analytics_id: 'Doc Auth', irs_reproofing: false, skip_hybrid_handoff: anything, lexisnexis_instant_verify_workflow_ab_test_bucket: :default
       },
@@ -535,49 +600,62 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: phone of record visited' => {
         acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: phone confirmation form' => {
         success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: anything, otp_delivery_preference: 'sms',
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: phone confirmation vendor' => {
         success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, hybrid_handoff_phone_used: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp sent' => {
         success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202', adapter: :test, errors: {}, phone_fingerprint: anything, rate_limit_exceeded: false, telephony_response: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp visited' => {
-        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: phone confirmation otp submitted' => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: anything, code_expired: false, code_matches: true, second_factor_attempts_count: 0, second_factor_locked_at: nil, errors: {},
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
         address_verification_method: 'phone', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: anything,
+        active_profile_idv_level: nil, pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_submitted => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: anything, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'unsupervised_with_selfie', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: final resolution' => {
         success: true, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: anything, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'unsupervised_with_selfie', pending_profile_idv_level: nil,
+        profile_history: match_array(kind_of(Idv::ProfileLogging)),
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
         address_verification_method: 'phone', in_person_verification_pending: false, encrypted_profiles_missing: false,
+        active_profile_idv_level: 'unsupervised_with_selfie', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {
         checked: true,
-        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        active_profile_idv_level: 'unsupervised_with_selfie', pending_profile_idv_level: nil,
+        proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key submitted' => {
         address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, in_person_verification_pending: false, deactivation_reason: nil,
+        active_profile_idv_level: 'unsupervised_with_selfie', pending_profile_idv_level: nil,
         proofing_components: { document_check: 'mock', document_type: 'state_id', source_check: 'aamva', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
     }

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -109,9 +109,11 @@ RSpec.describe 'cancel IdV', allowed_extra_analytics: [:*] do
 
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation visited',
-        proofing_components: { document_check: 'mock', document_type: 'state_id' },
-        request_came_from: 'idv/ssn#show',
-        step: 'ssn',
+        hash_including(
+          proofing_components: { document_check: 'mock', document_type: 'state_id' },
+          request_came_from: 'idv/ssn#show',
+          step: 'ssn',
+        ),
       )
 
       expect(page).to have_unique_form_landmark_labels

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -140,6 +140,18 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
 
   describe 'profile_history' do
     let(:profiles) { nil }
+    let(:include_profile_history?) { true }
+
+    before do
+      if include_profile_history?
+        allow(
+          stub_const(
+            'Idv::AnalyticsEventsEnhancer::METHODS_WITH_PROFILE_HISTORY',
+            %i[idv_test_method],
+          ),
+        )
+      end
+    end
 
     context 'user has no profiles' do
       it 'logs an empty array' do
@@ -174,6 +186,15 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
           active_profile_idv_level: 'legacy_unsupervised',
           profile_history: all(be_instance_of(Idv::ProfileLogging)),
         )
+      end
+
+      context 'method is not opted into profile_history' do
+        let(:include_profile_history?) { false }
+
+        it 'does not log profile_history' do
+          analytics.idv_test_method(extra: true)
+          expect(analytics.called_kwargs).not_to include(:profile_history)
+        end
       end
     end
   end

--- a/spec/services/idv/analytics_events_enhancer_spec.rb
+++ b/spec/services/idv/analytics_events_enhancer_spec.rb
@@ -94,4 +94,47 @@ RSpec.describe Idv::AnalyticsEventsEnhancer do
       end
     end
   end
+
+  describe 'active_profile_idv_level' do
+    context 'without an active profile' do
+      it 'calls analytics method with original attributes but not active_profile_idv_level' do
+        analytics.idv_test_method(extra: true)
+        expect(analytics.called_kwargs).to match(extra: true)
+      end
+    end
+
+    context 'with an active profile' do
+      let(:user) { create(:user) }
+      let!(:profile) { create(:profile, :active, user: user) }
+
+      it 'calls analytics method with original attributes and active_profile_idv_level' do
+        analytics.idv_test_method(extra: true)
+        expect(analytics.called_kwargs).to include(
+          extra: true,
+          active_profile_idv_level: 'legacy_unsupervised',
+        )
+      end
+    end
+  end
+
+  describe 'pending_profile_idv_level' do
+    context 'without a pending profile' do
+      it 'calls analytics method with original attributes but not pending_profile_idv_level' do
+        analytics.idv_test_method(extra: true)
+        expect(analytics.called_kwargs).to match(extra: true)
+      end
+    end
+
+    context 'with a pending profile' do
+      let(:user) { create(:user) }
+      let!(:profile) { create(:profile, :verify_by_mail_pending, user: user) }
+
+      it 'calls analytics method with original attributes and pending_profile_idv_level' do
+        analytics.idv_test_method(extra: true)
+        expect(analytics.called_kwargs).to include(
+          pending_profile_idv_level: 'legacy_unsupervised',
+        )
+      end
+    end
+  end
 end

--- a/spec/services/idv/profile_logging_spec.rb
+++ b/spec/services/idv/profile_logging_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Idv::ProfileLogging do
+  describe '#as_json' do
+    context 'active profile' do
+      let(:profile) { create(:profile, :active) }
+
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(%i[id active activated_at created_at idv_level verified_at]),
+        )
+      end
+    end
+
+    context 'gpo pending profile' do
+      let(:profile) { create(:profile, :verify_by_mail_pending) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level
+               gpo_verification_pending_at],
+          ),
+        )
+      end
+    end
+
+    context 'in person pending profile' do
+      let(:profile) { create(:profile, :in_person_verification_pending) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level
+               in_person_verification_pending_at],
+          ),
+        )
+      end
+    end
+
+    context 'fraud review pending' do
+      let(:profile) { create(:profile, :fraud_review_pending) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level
+               fraud_pending_reason fraud_review_pending_at],
+          ),
+        )
+      end
+    end
+
+    context 'fraud rejection' do
+      let(:profile) { create(:profile, :fraud_rejection) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level fraud_pending_reason fraud_rejection_at],
+          ),
+        )
+      end
+    end
+
+    context 'password reset profile' do
+      let(:profile) { create(:profile, :password_reset) }
+      it 'returns relevant attributes with nil values omitted' do
+        expect(described_class.new(profile).as_json).to eql(
+          profile.slice(
+            %i[id active created_at idv_level deactivation_reason],
+          ),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12617](https://cm-jira.usa.gov/browse/LG-12617)

## 🛠 Summary of changes

This PR updates the `Idv::AnalyticsEventsEnhancer` to add more fields to covered Idv-related events. Previously, we were only adding `proofing_components`. With this update we will add:

* `pending_profile_idv_level`: The verification level associated with the user's pending profile
* `active_profile_idv_level`: The verification level associated with the user's active profile

Additionally, a subset of events will have a new `profile_history` argument added. This argument is an array. Each item is a hash including the following fields:

  * `id`
  * `active`
  * `idv_level`
  * `created_at`
  * `verified_at`
  * `activated_at`
  * `in_person_verification_pending_at`
  * `gpo_verification_pending_at`
  * `fraud_review_pending_at`
  * `fraud_rejection_at`
  * `fraud_pending_reason`
  * `deactivation_reason`
