### PR TITLE
LG-12758 reorder metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,8 +69,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-# gem 'saml_idp', github: '18F/saml_idp', tag: '0.19.1-18f'
-gem 'saml_idp', path: "../saml_idp"
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.19.2-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,8 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.19.1-18f'
+# gem 'saml_idp', github: '18F/saml_idp', tag: '0.19.1-18f'
+gem 'saml_idp', path: "../saml_idp"
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,18 +33,6 @@ GIT
       redis (>= 4.3, < 6)
 
 GIT
-  remote: https://github.com/18F/saml_idp.git
-  revision: f7dd59de0c860e9d78ab4f05e8365153a2a9b25a
-  tag: 0.19.1-18f
-  specs:
-    saml_idp (0.19.1.pre.18f)
-      activesupport
-      builder
-      faraday
-      nokogiri (>= 1.10.2)
-      pkcs11
-
-GIT
   remote: https://github.com/hallelujah/valid_email.git
   revision: 486b860fb40281d1ba99ec7621505abc5c9ad5bb
   ref: 486b860
@@ -74,6 +62,16 @@ GIT
   specs:
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
+
+PATH
+  remote: ../saml_idp
+  specs:
+    saml_idp (0.19.2.pre.18f)
+      activesupport
+      builder
+      faraday
+      nokogiri (>= 1.10.2)
+      pkcs11
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,18 @@ GIT
       redis (>= 4.3, < 6)
 
 GIT
+  remote: https://github.com/18F/saml_idp.git
+  revision: 4c858dab80cfe32081a7e6bd7cd76c43cc3ec778
+  tag: 0.19.2-18f
+  specs:
+    saml_idp (0.19.2.pre.18f)
+      activesupport
+      builder
+      faraday
+      nokogiri (>= 1.10.2)
+      pkcs11
+
+GIT
   remote: https://github.com/hallelujah/valid_email.git
   revision: 486b860fb40281d1ba99ec7621505abc5c9ad5bb
   ref: 486b860
@@ -62,16 +74,6 @@ GIT
   specs:
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
-
-PATH
-  remote: ../saml_idp
-  specs:
-    saml_idp (0.19.2.pre.18f)
-      activesupport
-      builder
-      faraday
-      nokogiri (>= 1.10.2)
-      pkcs11
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION

## 🎫 Ticket
Link to the relevant ticket:
[LG-12758](https://cm-jira.usa.gov/browse/LG-12758)

## 🛠 Summary of changes
A partner wrote in https://logingov.zendesk.com/agent/tickets/8122 pointing out that the SAML metadata fails validation against the SAML metadata schema because a few elements are out of order. saml_idp was updated here: https://github.com/18F/saml_idp/pull/92/files#diff-5e1a3c3dbbdd1b6b38ccf8b3ee053f93487579e671c96d76f66be77731942990

This change updates the saml_idp version used so that the idp gets the reordered metadata

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
