### PR TITLE
LG-12342 setup: Download files needed for selfie capture

### DIFF
--- a/docs/sdk-upgrade.md
+++ b/docs/sdk-upgrade.md
@@ -48,7 +48,12 @@ Steps:
 
 8. After you have photographed the front and back of your card, you have tested the SDK locally. You do not need to submit the images. If you have both an Android and an iPhone, test the SDK with both of them. (Or, pair with someone who has the other type of phone.)
 
-9. Open a pull request for the modified SDK files. The next process &mdash; A/B testing the new version &mdash; can only take place after the files are accepted into the main branch.
+9. If you are running into errors testing locally, you can try:
+    - making sure the new files in `public/acuant/11.N.N` match what's in the `webSdk` directory [in Acuant's repo](https://github.com/Acuant/JavascriptWebSDKV11/tree/master/webSdk) for the new version
+        - if they don't match, try looking at our [`download_acuant_sdk` script](../scripts/download_acuant_sdk.sh) and see if more files need to be copied over
+        - there may be some we don't need (as of 3/20/2024 we don't need `AcuantCamera.js`, for instance)
+
+10. Open a pull request for the modified SDK files. The next process &mdash; A/B testing the new version &mdash; can only take place after the files are accepted into the main branch.
 
 ## Turn on A/B testing
 

--- a/scripts/download_acuant_sdk.sh
+++ b/scripts/download_acuant_sdk.sh
@@ -55,6 +55,10 @@ echo "Copying SDK files to '${PUBLIC_DIR}'..."
 mkdir -p "$PUBLIC_DIR"
 cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/*.min.js "$PUBLIC_DIR/"
 cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/*.wasm "$PUBLIC_DIR/"
+cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/*.json "$PUBLIC_DIR/"
+cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/tiny_face_detector* "$PUBLIC_DIR/"
+cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/face_landmark* "$PUBLIC_DIR/"
+cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/imageMagick* "$PUBLIC_DIR/"
 
 echo "Done! You can commit the files in ${PUBLIC_DIR}."
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-12342](https://cm-jira.usa.gov/browse/LG-12342)

## 🛠 Summary of changes

When testing the new Acuant SDK v11.9.3, I found parts of the selfie functionality didn't work.

After research, I realized that was because we had missing files. Our `download_acuant_sdk` script only copied over `.min.js` and `.wasm` files.

We found after talking with Matt Hinz that this was because previously we only needed the document capture files.

With this change, we should get everything that's needed - there is currently one file we aren't downloading - and that's the `AcuantCamera.js`. There are two reasons I chose not to download that.

1. the same code is already in place and used in `AcuantCamera.min.js`.
2. it seems like it'd be easier to just download everything, but we do want to be mindful of not including more files than we need.

There is a chance that this may come up again in a future upgrade, but that is why I am updating our `docs/sdk-upgrade.md` as well.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Make sure you don't have `public/acuant/11.9.3` (delete it if you do)
- [x] Run `make download_acuant_sdk`
- [x] Make sure now:
    - [x] you have `public/acuant/11.9.3`
    - [x] `public/acuant/11.9.3` contains `[tiny_face_detector_model-shard1](https://github.com/Acuant/JavascriptWebSDKV11/blob/master/webSdk/tiny_face_detector_model-shard1)`

Co-authored-by: Eileen McFarland <eileen.mcfarland@gsa.gov>