### PR TITLE
Bug fix: Hide the selfie hint box when there's no text.

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -25,8 +25,10 @@ function AcuantSelfieCaptureCanvas({ imageCaptureText, onSelfieCaptureClosed }) 
     <>
       {!isReady && <LoadingSpinner />}
       <div id={acuantCaptureContainerId} />
-      <p aria-live="assertive" className="document-capture-selfie-feedback">
-        {imageCaptureText}
+      <p aria-live="assertive">
+        {imageCaptureText && (
+          <span className="document-capture-selfie-feedback">{imageCaptureText}</span>
+        )}
       </p>
       <button type="button" onClick={onSelfieCaptureClosed} className="usa-sr-only">
         {t('doc_auth.buttons.close')}

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
@@ -7,7 +7,6 @@
   top: 10%;
   position: fixed;
   transform: translateX(-50%);
-  padding: 0 5px 0 5px;
-  opacity: 100%;
+  padding: 0 5px;
   z-index: 11;
 }

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
@@ -11,3 +11,7 @@
   padding: 10px;
   z-index: 11;
 }
+
+.document-capture-selfie-feedback:empty {
+  display: none;
+}

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
@@ -2,11 +2,12 @@
 
 .document-capture-selfie-feedback {
   color: color('white');
-  background: color('black');
+  background: rgba(0, 0, 0, .5);
   left: 50%;
   top: 10%;
   position: fixed;
   transform: translateX(-50%);
-  border-radius: 5px;
+  padding: 0 5px 0 5px;
+  opacity: 100%;
   z-index: 11;
 }

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
@@ -2,7 +2,7 @@
 
 .document-capture-selfie-feedback {
   color: color('white');
-  background: rgba(0, 0, 0, .5);
+  background: color('black');
   left: 50%;
   top: 10%;
   position: fixed;

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.scss
@@ -8,10 +8,5 @@
   position: fixed;
   transform: translateX(-50%);
   border-radius: 5px;
-  padding: 10px;
   z-index: 11;
-}
-
-.document-capture-selfie-feedback:empty {
-  display: none;
 }


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Slack thread bug report is [here](https://gsa-tts.slack.com/archives/C05HSH9RQ57/p1710973400493459).


## 🛠 Summary of changes

This PR adds a few lines of CSS to hide an odd black dot that was appearing when the selfie hint text was empty. What was happening is that we style the `<p>` element with the class `.document-capture-selfie-feedback`. But because that styling was always applied, we were essentially getting a black background `<p>` element with padding. This change hides the `<p>` using CSS when it has no text inside it.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go to the front/back/selfie page.
- [ ] Open selfie capture
- [ ] The hint text should change
- [ ] You shouldn't see the black dot in the "before" screeenshots.


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

![before-black-dot](https://github.com/18F/identity-idp/assets/6818839/d994a288-e8a1-40af-bfbd-f65d6960d332)

</details>

<details>
<summary>After with padding</summary>

![after-no-black-dot](https://github.com/18F/identity-idp/assets/6818839/8f6df952-54db-4bd3-956d-7e4da6e4648f)

</details>

<details>
<summary>After, no padding</summary>

![after-no-padding-black-dot](https://github.com/18F/identity-idp/assets/6818839/d5387b0d-89a5-4e26-8b43-ca7d0f1f4215)

</details>

