### PR TITLE
Implement modal component as native dialog element

### DIFF
--- a/app/assets/stylesheets/_uswds.scss
+++ b/app/assets/stylesheets/_uswds.scss
@@ -12,7 +12,6 @@
 @forward 'usa-link';
 @forward 'usa-list';
 @forward 'usa-media-block';
-@forward 'usa-modal';
 @forward 'usa-process-list';
 @forward 'usa-skipnav';
 @forward 'usa-tag';

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -12,7 +12,6 @@
 @forward 'full-screen';
 @forward 'hr';
 @forward 'language-picker';
-@forward 'modal';
 @forward 'header';
 @forward 'page-heading';
 @forward 'profile-section';

--- a/app/assets/stylesheets/variables/_app.scss
+++ b/app/assets/stylesheets/variables/_app.scss
@@ -16,7 +16,5 @@ $sm-h6: 0.75rem !default;
 
 $border-radius-md: 6px !default;
 $border-radius-xl: 16px !default;
-$border-radius-xxl: 24px !default;
 
 $container-skinny-width: 620px !default;
-$container-xskinny-width: 416px !default;

--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -1,11 +1,12 @@
 <%= content_tag(:'lg-modal', **tag_options) do %>
-  <%= tag.dialog(
+  <%= content_tag(
+        :dialog,
+        content,
         aria: {
           describedby: description_id,
           labelledby: label_id,
         },
         class: 'modal__content',
-      ) do %>
-    <%= content %>
+      ) %>
   <% end %>
 <% end %>

--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -8,5 +8,4 @@
         },
         class: 'modal__content',
       ) %>
-  <% end %>
 <% end %>

--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -1,14 +1,11 @@
-<%= content_tag(:'lg-modal', **tag_options, class: css_class, hidden: true) do %>
-  <%= tag.div(
-        role: 'dialog',
-        class: 'usa-modal-overlay',
+<%= content_tag(:'lg-modal', **tag_options) do %>
+  <%= tag.dialog(
         aria: {
           describedby: description_id,
           labelledby: label_id,
         },
+        class: 'modal__content',
       ) do %>
-    <div class="modal-content">
-      <%= content %>
-    </div>
+    <%= content %>
   <% end %>
 <% end %>

--- a/app/components/modal_component.rb
+++ b/app/components/modal_component.rb
@@ -7,10 +7,6 @@ class ModalComponent < BaseComponent
     @tag_options = tag_options
   end
 
-  def css_class
-    ['usa-modal-wrapper', *tag_options[:class]]
-  end
-
   def label_id
     "modal-label-#{unique_id}"
   end

--- a/app/components/modal_component.scss
+++ b/app/components/modal_component.scss
@@ -2,10 +2,6 @@
 
 @forward 'usa-modal/src/styles';
 
-::backdrop {
-  background: color('black-transparent-70');
-}
-
 lg-modal {
   text-align: left;
   display: flex;
@@ -27,6 +23,10 @@ lg-modal {
 
   @include at-media('tablet') {
     @include u-padding(6);
+  }
+
+  &::backdrop {
+    background: color('black-transparent-70');
   }
 
   hr {

--- a/app/components/modal_component.scss
+++ b/app/components/modal_component.scss
@@ -20,3 +20,7 @@
     width: 5rem;
   }
 }
+
+.usa-js-modal--active {
+  overflow: hidden;
+}

--- a/app/components/modal_component.scss
+++ b/app/components/modal_component.scss
@@ -1,7 +1,5 @@
 @use 'uswds-core' as *;
 
-@forward 'usa-modal/src/styles';
-
 lg-modal {
   text-align: left;
   display: flex;

--- a/app/components/modal_component.scss
+++ b/app/components/modal_component.scss
@@ -1,9 +1,12 @@
 @use 'uswds-core' as *;
-@use '../variables/app' as *;
 
-.usa-modal-overlay {
-  // Temporary styles to avoid inheriting too much of the USWDS opinionated modal styling until
-  // modal styles are settled in the Login.gov Design System.
+@forward 'usa-modal/src/styles';
+
+::backdrop {
+  background: color('black-transparent-70');
+}
+
+lg-modal {
   text-align: left;
   display: flex;
   align-items: start;
@@ -14,11 +17,13 @@
   }
 }
 
-.modal-content {
+.modal__content {
   @include u-padding(4);
   @include u-bg('white');
-  max-width: $container-xskinny-width;
-  border-radius: $border-radius-xxl;
+  width: 26rem;
+  max-width: 98%;
+  border-width: 0;
+  border-radius: units(1.5);
 
   @include at-media('tablet') {
     @include u-padding(6);

--- a/app/components/modal_component.scss
+++ b/app/components/modal_component.scss
@@ -1,16 +1,5 @@
 @use 'uswds-core' as *;
 
-lg-modal {
-  text-align: left;
-  display: flex;
-  align-items: start;
-  justify-content: center;
-
-  @include at-media('tablet') {
-    align-items: center;
-  }
-}
-
 .modal__content {
   @include u-padding(4);
   @include u-bg('white');

--- a/app/javascript/packages/modal/README.md
+++ b/app/javascript/packages/modal/README.md
@@ -15,15 +15,17 @@ The custom element will implement modal behavior, including focus trap and a pro
 However, all markup must already exist.
 
 ```html
-<lg-modal class="usa-modal-wrapper" hidden>
-  <div role="dialog" class="usa-modal-overlay" aria-describedby="modal-description-7ace89e6" aria-labelledby="modal-label-7ace89e6">
-    <div class="modal-content">
-      <h2 id="modal-label-7ace89e6">
-        Modal Heading
-      </h2>
-      Modal Content
-    </div>
-  </div>
+<lg-modal>
+  <dialog
+    class="modal__content"
+    aria-describedby="modal-description-7ace89e6"
+    aria-labelledby="modal-label-7ace89e6"
+  >
+    <h2 id="modal-label-7ace89e6">
+      Modal Heading
+    </h2>
+    Modal Content
+  </dialog>
 </lg-modal>
 ```
 

--- a/app/javascript/packages/modal/modal-element.spec.ts
+++ b/app/javascript/packages/modal/modal-element.spec.ts
@@ -1,33 +1,49 @@
 import sinon from 'sinon';
-import { screen, waitFor } from '@testing-library/dom';
+import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { useDefineProperty } from '@18f/identity-test-helpers';
 import './modal-element';
 
 describe('ModalElement', () => {
+  const defineProperty = useDefineProperty();
+
   let modal: HTMLElementTagNameMap['lg-modal'];
 
   beforeEach(() => {
+    // JSDOM does not currently implement HTMLDialogElement, so stub minimal implementation
+    // See: https://github.com/jsdom/jsdom/issues/3294
+    defineProperty(HTMLDialogElement.prototype, 'showModal', {
+      value(this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+      },
+      configurable: true,
+    });
+    defineProperty(HTMLDialogElement.prototype, 'close', {
+      value(this: HTMLDialogElement) {
+        this.removeAttribute('open');
+      },
+      configurable: true,
+    });
+
     document.body.innerHTML = `
-      <lg-modal class="usa-modal-wrapper" hidden>
-        <div role="dialog" class="usa-modal-overlay" aria-describedby="modal-description-7ace89e6" aria-labelledby="modal-label-7ace89e6">
-          <div class="modal-content">
-            <h2 id="modal-label-7ace89e6">
-              Modal Heading
-            </h2>
-            Modal Content
-            <button>First Button</button>
-            <button data-dismiss type="button">Dismiss</button>
-          </div>
-        </div>
+      <lg-modal>
+        <dialog
+          class="modal__content"
+          aria-describedby="modal-description-7ace89e6"
+          aria-labelledby="modal-label-7ace89e6"
+        >
+          <h2 id="modal-label-7ace89e6">
+            Modal Heading
+          </h2>
+          Modal Content
+          <button>First Button</button>
+          <button data-dismiss type="button">Dismiss</button>
+        </dialog>
       </lg-modal>
       <button>Outside Button</button>
     `;
 
     modal = document.querySelector('lg-modal')!;
-  });
-
-  afterEach(() => {
-    modal.hide();
   });
 
   it('toggles hidden when clicking dismiss button', async () => {
@@ -43,19 +59,9 @@ describe('ModalElement', () => {
     it('toggles visible', () => {
       modal.show();
 
-      expect(modal.hasAttribute('hidden')).to.be.false();
-      expect(modal.classList.contains('is-visible')).to.be.true();
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.hasAttribute('open')).to.be.true();
       expect(document.body.classList.contains('usa-js-modal--active')).to.be.true();
-    });
-
-    it('traps focus', async () => {
-      modal.show();
-
-      await waitFor(() => document.activeElement?.textContent === 'First Button');
-      await userEvent.tab();
-      await waitFor(() => document.activeElement?.textContent === 'Dismiss');
-      await userEvent.tab();
-      await waitFor(() => document.activeElement?.textContent === 'First Button');
     });
   });
 
@@ -64,18 +70,9 @@ describe('ModalElement', () => {
       modal.show();
       modal.hide();
 
-      expect(modal.hasAttribute('hidden')).to.be.true();
-      expect(modal.classList.contains('is-visible')).to.be.false();
+      const dialog = screen.getByRole('dialog', { hidden: true });
+      expect(dialog.hasAttribute('open')).to.be.false();
       expect(document.body.classList.contains('usa-js-modal--active')).to.be.false();
-    });
-
-    it('releases focus trap', async () => {
-      modal.show();
-      await waitFor(() => document.activeElement?.textContent === 'First Button');
-      modal.hide();
-
-      await userEvent.tab();
-      await waitFor(() => document.activeElement?.textContent === 'Outside Button');
     });
   });
 });

--- a/app/javascript/packages/modal/modal-element.ts
+++ b/app/javascript/packages/modal/modal-element.ts
@@ -1,11 +1,5 @@
-import { createFocusTrap } from 'focus-trap';
-import type { FocusTrap } from 'focus-trap';
-
 class ModalElement extends HTMLElement {
-  trap: FocusTrap;
-
   connectedCallback() {
-    this.trap = createFocusTrap(this, { escapeDeactivates: false });
     this.addEventListener('click', this.#handleDismiss);
   }
 
@@ -13,20 +7,20 @@ class ModalElement extends HTMLElement {
    * Shows the modal dialog.
    */
   show() {
-    this.removeAttribute('hidden');
-    this.classList.add('is-visible');
     this.ownerDocument.body.classList.add('usa-js-modal--active');
-    this.trap.activate();
+    this.#dialog.showModal();
   }
 
   /**
    * Hides the modal dialog.
    */
   hide() {
-    this.setAttribute('hidden', '');
-    this.classList.remove('is-visible');
     this.ownerDocument.body.classList.remove('usa-js-modal--active');
-    this.trap.deactivate();
+    this.#dialog.close();
+  }
+
+  get #dialog(): HTMLDialogElement {
+    return this.querySelector<HTMLDialogElement>('.modal__content')!;
   }
 
   #handleDismiss = (event: MouseEvent) => {

--- a/app/javascript/packages/modal/modal-element.ts
+++ b/app/javascript/packages/modal/modal-element.ts
@@ -22,7 +22,7 @@ class ModalElement extends HTMLElement {
   }
 
   get #dialog(): HTMLDialogElement {
-    return this.querySelector<HTMLDialogElement>('.modal__content')!;
+    return this.querySelector('dialog')!;
   }
 
   #handleDismiss = (event: MouseEvent) => {

--- a/app/javascript/packages/modal/modal-element.ts
+++ b/app/javascript/packages/modal/modal-element.ts
@@ -7,8 +7,10 @@ class ModalElement extends HTMLElement {
    * Shows the modal dialog.
    */
   show() {
-    this.ownerDocument.body.classList.add('usa-js-modal--active');
-    this.#dialog.showModal();
+    if (!this.#dialog.open) {
+      this.ownerDocument.body.classList.add('usa-js-modal--active');
+      this.#dialog.showModal();
+    }
   }
 
   /**

--- a/app/javascript/packages/modal/package.json
+++ b/app/javascript/packages/modal/package.json
@@ -2,9 +2,6 @@
   "name": "@18f/identity-modal",
   "version": "1.0.0",
   "private": true,
-  "dependencies": {
-    "focus-trap": "^6.7.1"
-  },
   "sideEffects": [
     "./modal-element.ts"
   ]

--- a/lib/extensions/capybara/node/simple.rb
+++ b/lib/extensions/capybara/node/simple.rb
@@ -1,0 +1,25 @@
+# Monkey-patch Capybara::Node::Simple#visible? to consider a dialog element without an open
+# attribute as hidden.
+#
+# >A `dialog` element without an `open` attribute specified should not be shown to the user.
+#
+# See: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-dialog-open
+# See: https://github.com/teamcapybara/capybara/blob/master/lib/capybara/node/simple.rb
+
+module Extensions
+  Capybara::Node::Simple.class_eval do
+    prepend(
+      Module.new do
+        def visible?(check_ancestors = true)
+          if check_ancestors
+            return false if find_xpath('boolean(./ancestor-or-self::dialog[not(@open)])')
+          elsif tag_name == 'dialog' && native[:open].nil?
+            return false
+          end
+
+          super(check_ancestors)
+        end
+      end,
+    )
+  end
+end

--- a/lib/extensions/capybara/node/simple.rb
+++ b/lib/extensions/capybara/node/simple.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Monkey-patch Capybara::Node::Simple#visible? to consider a dialog element without an open
 # attribute as hidden.
 #

--- a/spec/components/modal_component_spec.rb
+++ b/spec/components/modal_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ModalComponent, type: :component do
       ]
     end
 
-    dialog = rendered.css('[role="dialog"]').first
+    dialog = rendered.css('dialog').first
     labelledby_id = dialog['aria-labelledby']
     describedby_id = dialog['aria-describedby']
     heading_id = rendered.css('h1').first['id']

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,7 @@
 require 'capybara/rspec'
 require 'rack_session_access/capybara'
 require 'selenium/webdriver'
+require 'extensions/capybara/node/simple'
 
 # temporary fix for local development feature tests
 # remove when we get a new working version of Chromedriver

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe 'layouts/application.html.erb' do
       expect(rendered).to have_css('.page-header--basic')
       expect(rendered).to_not have_content(t('account.welcome'))
       expect(rendered).to_not have_button(t('links.sign_out'))
-      expect(rendered).to_not have_selector('form')
     end
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Reimplements `ModalComponent` as a [native `<dialog>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog).

**Why?**

- Using native functionality helps ensure consistent experience and avoid need for custom implementation of individual behaviors
   - Removing `focus-trap` removes a sizable dependency
   - Deletes substantial amount of modal styles in favor of browser defaults

**Behavior Differences:**

This should largely behave identically to previous, with a couple minor differences:

- Native `<dialog>` supports pressing <kbd>Escape</kbd> to close the modal, which is a [WAI recommended keyboard interaction](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction), but did not happen in our previous implementation
   - The only downside of this is that if a user presses <kbd>Escape</kbd> while viewing the session timeout modal, they will neither be signed out nor have their session extended. It could be possible to automatically extend their session in response to pressing <kbd>Escape</kbd>, but I didn't feel the need to implement that quite yet.
- Native `<dialog>` does constrain tab cycling similar to how `focus-trap` worked, but the browser will often include the address bar in the tab cycle, which did not occur previously since `focus-trap` operates within the context of the browser viewport

**Performance Impact:**

_application.css_:

`NODE_ENV=production yarn build:css && brotli-size app/assets/builds/application.css`

**Before:** 22.7 kb
**After:** 22.1 kB
**Diff:** -0.6 kB (-2.6%)

_modal_component.js_:

`NODE_ENV=production yarn build && brotli-size public/packs/js/modal_component-*.digested.js`

**Before:** 3.17 kB
**After:** 269 B
**Diff:** -2.90 kB (-91.5%)

## 📜 Testing Plan

Verify no regressions in modal usage for session timeout:

1. Optional: Set `session_timeout_warning_seconds: 900` and `session_check_delay: 0` in `config/application.yml` to trigger immediate dialog
2. Go to http://localhost:3000
3. Sign in
4. Wait for session timeout dialog to appear
11. Observe modal appears and behaves as it does on `main`, aside from "Behavior Differences" noted above

Verify no regressions in modal usage for reactivate account confirmation:

1. Prerequisite: Have verified account
5. Go to http://localhost:3000
6. Click "Forgot your password?"
7. Complete password reset
8. Sign in
9. Click "Reactivate your profile now"
10. Click "I don't have my key"
11. Observe modal appears and behaves as it does on `main`, aside from "Behavior Differences" noted above

## 👀 Screenshots

Tested across browsers:

Chrome|Safari|Firefox
---|---|---
![Screenshot 2024-03-22 at 11 37 10 AM](https://github.com/18F/identity-idp/assets/1779930/97d1997b-055c-41cc-8c22-f48a5f27c137)|![Screenshot 2024-03-22 at 11 37 37 AM](https://github.com/18F/identity-idp/assets/1779930/4361b129-1036-4090-87b9-300ae6285faf)|![Screenshot 2024-03-22 at 11 38 17 AM](https://github.com/18F/identity-idp/assets/1779930/e027d4d0-87e8-4793-8c22-896827f23eae)

Session timeout dialog:

![Screenshot 2024-03-22 at 11 45 12 AM](https://github.com/18F/identity-idp/assets/1779930/7291629e-f29f-4c4d-94cd-0bd02a67b6ce)

Screen reader experience:

https://github.com/18F/identity-idp/assets/1779930/c21e8a91-a90f-46d0-ac3e-82067c037cbe