### PR TITLE
Don't use stale document capture user ids for effective_user

### DIFF
--- a/app/controllers/concerns/effective_user.rb
+++ b/app/controllers/concerns/effective_user.rb
@@ -1,7 +1,15 @@
 module EffectiveUser
   def effective_user
     return current_user if effective_user_id == current_user&.id
-    return User.find_by(id: effective_user_id) if effective_user_id
+
+    user = User.find_by(id: effective_user_id) if effective_user_id
+
+    if user.nil?
+      session.delete(:doc_capture_user_id)
+      return current_user
+    end
+
+    user
   end
 
   private

--- a/spec/controllers/concerns/effective_user_spec.rb
+++ b/spec/controllers/concerns/effective_user_spec.rb
@@ -78,8 +78,7 @@ RSpec.describe EffectiveUser, type: :controller do
         end
 
         it 'deletes the session key' do
-          subject
-          expect(session).not_to include(:doc_capture_user_id)
+          expect { subject }.to(change { session[:doc_capture_user_id] }.to(nil))
         end
       end
     end

--- a/spec/controllers/concerns/effective_user_spec.rb
+++ b/spec/controllers/concerns/effective_user_spec.rb
@@ -14,21 +14,36 @@ RSpec.describe EffectiveUser, type: :controller do
       it 'returns nil' do
         expect(subject).to be_nil
       end
+
+      context 'with valid doc capture session user id' do
+        before do
+          session[:doc_capture_user_id] = user.id
+        end
+
+        it 'returns session user id' do
+          expect(subject).to eq user
+        end
+      end
+
+      context 'with invalid doc capture session user id' do
+        before do
+          session[:doc_capture_user_id] = -1
+        end
+
+        it 'returns session user id' do
+          expect(subject).to be_nil
+        end
+
+        it 'deletes the session key' do
+          subject
+          expect(session).not_to include(:doc_capture_user_id)
+        end
+      end
     end
 
     context 'non-existent user' do
       it 'returns session user id' do
         expect(subject).to be_nil
-      end
-    end
-
-    context 'logged out with doc capture session user id' do
-      before do
-        session[:doc_capture_user_id] = user.id
-      end
-
-      it 'returns session user id' do
-        expect(subject).to eq user
       end
     end
 
@@ -39,6 +54,33 @@ RSpec.describe EffectiveUser, type: :controller do
 
       it 'returns session user id' do
         expect(subject).to eq user
+      end
+
+      context 'with valid doc capture session user id that is not the logged-in user' do
+        let(:doc_capture_user) { create(:user) }
+
+        before do
+          session[:doc_capture_user_id] = doc_capture_user.id
+        end
+
+        it 'returns doc capture user id' do
+          expect(subject).to eq(doc_capture_user)
+        end
+      end
+
+      context 'with invalid doc capture session user id' do
+        before do
+          session[:doc_capture_user_id] = -1
+        end
+
+        it 'returns logged in user' do
+          expect(subject).to eql(user)
+        end
+
+        it 'deletes the session key' do
+          subject
+          expect(session).not_to include(:doc_capture_user_id)
+        end
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12793](https://cm-jira.usa.gov/browse/LG-12793)

## 🛠 Summary of changes

If the user deletes their account, it is possible that the user id stored in the session for document capture will not be valid. This results in analytics events being improperly attributed to `anonymous-uuid`.

