### PR TITLE
LG-12268: Use Department of State translations for Face Match Fail

### DIFF
--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -39,7 +39,8 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
-        selfie_not_live: 'Try taking your photos again. Make sure all of your photos are clear and in focus.'
+        selfie_not_live: 'Try taking your photos again. Make sure all of your photos are
+          clear and in focus.'
         selfie_poor_quality: 'Try taking a photo of yourself again. Make sure your whole
           face is clear and visible in the photo.'
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -39,8 +39,7 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
-        selfie_not_live: 'Try taking a photo of yourself again. Make sure your whole
-          face is clear and visible in the photo.'
+        selfie_not_live: 'Try taking your photos again. Make sure all of your photos are clear and in focus.'
         selfie_poor_quality: 'Try taking a photo of yourself again. Make sure your whole
           face is clear and visible in the photo.'
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -49,8 +49,7 @@ es:
           identidad. Intente tomar nuevas fotos.
         ref_control_number_check: No pudimos leer el código de barras del número de
           control. Intente tomar nuevas fotografías.
-        selfie_not_live: 'Intente tomar de nuevo una foto de usted. Asegúrese de que su
-          rostro se vea claramente en la foto.'
+        selfie_not_live: 'Intente tomar de nuevo sus fotos. Asegúrese de que sus fotos estén claras y enfocadas.'
         selfie_poor_quality: 'Intente tomar de nuevo una foto de usted. Asegúrese de que
           su rostro se vea claramente en la foto.'
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -49,7 +49,8 @@ es:
           identidad. Intente tomar nuevas fotos.
         ref_control_number_check: No pudimos leer el código de barras del número de
           control. Intente tomar nuevas fotografías.
-        selfie_not_live: 'Intente tomar de nuevo sus fotos. Asegúrese de que sus fotos estén claras y enfocadas.'
+        selfie_not_live: 'Intente tomar de nuevo sus fotos. Asegúrese de que sus fotos
+          estén claras y enfocadas.'
         selfie_poor_quality: 'Intente tomar de nuevo una foto de usted. Asegúrese de que
           su rostro se vea claramente en la foto.'
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -52,8 +52,8 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
         ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro de
           contrôle. Essayez de prendre de nouvelles photos.
-        selfie_not_live: 'Essayez de prendre de nouvelles photos de vous-même. Veillez à ce que toutes vos photos soient claires
-          et nettes.'
+        selfie_not_live: 'Essayez de prendre de nouvelles photos de vous-même. Veillez à
+          ce que toutes vos photos soient claires et nettes.'
         selfie_poor_quality: 'Essayez de prendre une nouvelle photo de vous-même.
           Assurez-vous que l’ensemble de votre visage soit clair et visible sur
           la photo.'

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -52,9 +52,8 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
         ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro de
           contrôle. Essayez de prendre de nouvelles photos.
-        selfie_not_live: 'Essayez de prendre une nouvelle photo de vous-même.
-          Assurez-vous que l’ensemble de votre visage soit clair et visible sur
-          la photo.'
+        selfie_not_live: 'Essayez de prendre de nouvelles photos de vous-même. Veillez à ce que toutes vos photos soient claires
+          et nettes.'
         selfie_poor_quality: 'Essayez de prendre une nouvelle photo de vous-même.
           Assurez-vous que l’ensemble de votre visage soit clair et visible sur
           la photo.'

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -36,7 +36,7 @@ es:
       rate_limited_text_html: 'Por su seguridad, limitamos el número de veces que
         puede intentar verificar un documento en línea. <strong>Inténtelo de
         nuevo en %{timeout}.</strong>'
-      selfie_fail_heading: No pudimos cotejar tu foto con tu identificación
+      selfie_fail_heading: No hemos podido cotejar su foto con su identificación.
       selfie_not_live_or_poor_quality_heading: No pudimos verificar su foto
       send_link_limited: Ha intentado demasiadas veces, por favor, inténtelo de nuevo
         en %{timeout}. También puede retroceder y elegir utilizar su computadora

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -40,8 +40,7 @@ fr:
       rate_limited_text_html: 'Pour votre sécurité, nous limitons le nombre de fois où
         vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
         réessayer dans %{timeout}.</strong>'
-      selfie_fail_heading: Nous n’avons pas pu faire correspondre votre photo à votre
-        pièce d’identité
+      selfie_fail_heading: Nous n'avons pas pu faire correspondre votre photo à celle figurant sur votre pièce d'identité.
       selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
       send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans
         %{timeout}. Vous pouvez également revenir en arrière et choisir

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -40,7 +40,8 @@ fr:
       rate_limited_text_html: 'Pour votre sécurité, nous limitons le nombre de fois où
         vous pouvez tenter de vérifier un document en ligne. <strong>Veuillez
         réessayer dans %{timeout}.</strong>'
-      selfie_fail_heading: Nous n'avons pas pu faire correspondre votre photo à celle figurant sur votre pièce d'identité.
+      selfie_fail_heading: Nous n’avons pas pu faire correspondre votre photo à celle
+        figurant sur votre pièce d’identité.
       selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
       send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans
         %{timeout}. Vous pouvez également revenir en arrière et choisir

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -421,7 +421,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               submit_images
               message = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
               expect(page).to have_content(message)
-              detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_poor_quality'))
+              detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live'))
               security_message = strip_tags(
                 t(
                   'idv.warning.attempts_html',


### PR DESCRIPTION
## 🎫 Ticket

[LG-12268: Implement Department of State translation for in-line error message for FaceMatchResult: Fail](https://cm-jira.usa.gov/browse/LG-12268)


## 🛠 Summary of changes
1. Update Spanish and French headings for scenario where the FaceMatchResult is Fail.
2. Update English, Spanish, and French body text for scenario where the FaceMatchResult is Fail.
3. For related context, see PR #10042, which implemented Gengo translations.


## 📜 Testing Plan
To test on desktop...
- [ ] In your local `application.yml`, set the below variables
```
  doc_auth_selfie_capture_enabled: true
  doc_auth_selfie_desktop_test_mode: true
```
- [ ] Be sure to follow the below steps for English, French, and Spanish
- [ ] Login with biometric comparison required at `/test/oidc/login`
- [ ] Navigate to document capture
- [ ] Upload the file `test_selfie_with_face_match_fail.yml` in all three (front/back/selfie) fields
- [ ] After you click "submit," ensure that the heading text and body text match what is shown in the screenshots below.



## 👀 Screenshots


<details>
<summary>English:</summary>

![12268FaceMatchFailEnglish](https://github.com/18F/identity-idp/assets/80347702/074e9404-0303-4c71-8054-824f99ca5722)

</details>

<details>
<summary>Spanish:</summary>

![12268FaceMatchFailSpanish](https://github.com/18F/identity-idp/assets/80347702/7d46ce12-b4db-4d57-9126-6cd0de885744)

</details>

<details>
<summary>French:</summary>

![12268FaceMatchFailFrench](https://github.com/18F/identity-idp/assets/80347702/766f128a-104d-4b8a-8365-85470abe98aa)

</details>


