### PR TITLE
Remove unused javascript_include_tag_without_preload

### DIFF
--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -2,10 +2,6 @@
 
 # rubocop:disable Rails/HelperInstanceVariable
 module ScriptHelper
-  def javascript_include_tag_without_preload(...)
-    without_preload_links_header { javascript_include_tag(...) }
-  end
-
   def javascript_packs_tag_once(*names, **attributes)
     @scripts = @scripts.to_h.merge(names.index_with(attributes))
     nil
@@ -52,14 +48,6 @@ module ScriptHelper
         false,
       )
     end
-  end
-
-  def without_preload_links_header
-    original_preload_links_header = ActionView::Helpers::AssetTagHelper.preload_links_header
-    ActionView::Helpers::AssetTagHelper.preload_links_header = false
-    result = yield
-    ActionView::Helpers::AssetTagHelper.preload_links_header = original_preload_links_header
-    result
   end
 
   def asset_host(path)

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -1,15 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ScriptHelper do
-  describe '#javascript_include_tag_without_preload' do
-    it 'avoids modifying headers' do
-      output = javascript_include_tag_without_preload 'application'
-
-      expect(response.header['Link']).to be_nil
-      expect(output).to have_css('script', visible: :all)
-    end
-  end
-
   describe '#javascript_packs_tag_once' do
     it 'returns nil' do
       output = javascript_packs_tag_once('application')


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused `javascript_include_tag_without_preload`.

Last reference removed in #7563.

Removing may simplify upcoming work to refactor this module to be thread-safe.

## 📜 Testing Plan

There should be no user-facing impact of these changes, since the method is unused.