### PR TITLE
LG-12061: All step indicator steps are shown completed on Personal Key page

### DIFF
--- a/app/components/step_indicator_component.rb
+++ b/app/components/step_indicator_component.rb
@@ -1,6 +1,8 @@
 class StepIndicatorComponent < BaseComponent
   attr_reader :current_step, :locale_scope, :tag_options
 
+  ALL_STEPS_COMPLETE = :all_steps_complete
+
   def initialize(steps:, current_step:, locale_scope: nil, **tag_options)
     @steps = steps
     @current_step = current_step
@@ -19,6 +21,8 @@ class StepIndicatorComponent < BaseComponent
   private
 
   def step_status(step)
+    return :complete if current_step == ALL_STEPS_COMPLETE
+
     if step[:name] == current_step
       :current
     elsif step_index(step[:name]) < step_index(current_step)

--- a/app/views/idv/personal_key/show.html.erb
+++ b/app/views/idv/personal_key/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: step_indicator_steps,
-        current_step: :secure_account,
+        current_step: StepIndicatorComponent::ALL_STEPS_COMPLETE,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
       ) %>

--- a/spec/components/step_indicator_component_spec.rb
+++ b/spec/components/step_indicator_component_spec.rb
@@ -115,6 +115,29 @@ RSpec.describe StepIndicatorComponent, type: :component do
         )
       end
     end
+
+    context 'all steps complete' do
+      let(:current_step) { StepIndicatorComponent::ALL_STEPS_COMPLETE }
+
+      it 'renders current step' do
+        expect(rendered).not_to have_css('.step-indicator__step--current')
+      end
+
+      it 'renders all steps completed' do
+        expect(rendered).to have_css(
+          '.step-indicator__step--complete',
+          text: t('step_indicator.flows.example.one'),
+        )
+        expect(rendered).to have_css(
+          '.step-indicator__step--complete',
+          text: t('step_indicator.flows.example.two'),
+        )
+        expect(rendered).to have_css(
+          '.step-indicator__step--complete',
+          text: t('step_indicator.flows.example.three'),
+        )
+      end
+    end
   end
 
   describe 'locale_scope' do

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -340,11 +340,15 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
     expect(page).to have_content(t('forms.personal_key_partial.acknowledgement.text'))
     expect(page).to have_content(t('forms.personal_key_partial.acknowledgement.help_link_text'))
     expect(page).to have_content(t('idv.messages.confirm'))
-    expect_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
     expect(page).to have_css(
       '.step-indicator__step--complete',
       text: t('step_indicator.flows.idv.verify_phone_or_address'),
     )
+    expect(page).to have_css(
+      '.step-indicator__step--complete',
+      text: t('step_indicator.flows.idv.secure_account'),
+    )
+    expect(page).not_to have_css('.step-indicator__step--current', wait: 5)
     expect(page).not_to have_content(t('step_indicator.flows.idv.get_a_letter'))
 
     # Refreshing shows same page (BUT with new personal key, we should warn the user)

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
       '.step-indicator__step--complete',
       text: t('step_indicator.flows.idv.secure_account'),
     )
-    expect(page).not_to have_css('.step-indicator__step--current', wait: 5)
+    expect(page).not_to have_css('.step-indicator__step--current')
     expect(page).not_to have_content(t('step_indicator.flows.idv.get_a_letter'))
 
     # Refreshing shows same page (BUT with new personal key, we should warn the user)

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     complete_enter_password_step(user)
 
     # personal key page
-    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
+    expect_in_person_step_indicator
+    expect(page).not_to have_css('.step-indicator__step--current')
     expect(page).to have_content(t('titles.idv.personal_key'))
     deadline = nil
     freeze_time do
@@ -292,7 +293,8 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
       click_button t('idv.gpo.form.submit')
 
       # personal key
-      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
+      expect_in_person_step_indicator
+      expect(page).not_to have_css('.step-indicator__step--current')
       expect(page).to have_content(t('titles.idv.personal_key'))
       acknowledge_and_confirm_personal_key
 
@@ -502,7 +504,8 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
       complete_enter_password_step(user)
 
       # personal key page
-      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
+      expect_in_person_step_indicator
+      expect(page).not_to have_css('.step-indicator__step--current')
       expect(page).to have_content(t('titles.idv.personal_key'))
       deadline = nil
       freeze_time do

--- a/spec/features/idv/in_person_threatmetrix_spec.rb
+++ b/spec/features/idv/in_person_threatmetrix_spec.rb
@@ -129,7 +129,8 @@ RSpec.describe 'In Person Proofing Threatmetrix', js: true, allowed_extra_analyt
       complete_enter_password_step(user)
 
       # personal key page
-      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
+      expect_in_person_step_indicator
+      expect(page).not_to have_css('.step-indicator__step--current')
       expect(page).to have_content(t('titles.idv.personal_key'))
       deadline = nil
       freeze_time do

--- a/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
+++ b/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true, allowed_extra_analy
         complete_enter_password_step(user)
 
         # personal key page
-        expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
+        expect_in_person_step_indicator
+        expect(page).not_to have_css('.step-indicator__step--current')
         expect(page).to have_content(t('titles.idv.personal_key'))
         deadline = nil
         freeze_time do
@@ -222,7 +223,8 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true, allowed_extra_analy
       complete_enter_password_step(user)
 
       # personal key page
-      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
+      expect_in_person_step_indicator
+      expect(page).not_to have_css('.step-indicator__step--current')
       expect(page).to have_content(t('titles.idv.personal_key'))
       deadline = nil
       freeze_time do
@@ -380,7 +382,8 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true, allowed_extra_analy
       complete_enter_password_step(user)
 
       # personal key page
-      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
+      expect_in_person_step_indicator
+      expect(page).not_to have_css('.step-indicator__step--current')
       expect(page).to have_content(t('titles.idv.personal_key'))
       deadline = nil
       freeze_time do

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -179,6 +179,11 @@ module InPersonHelper
   end
 
   def expect_in_person_step_indicator_current_step(text)
+    expect_in_person_step_indicator
+    expect_step_indicator_current_step(text)
+  end
+
+  def expect_in_person_step_indicator
     # Normally we're only concerned with the "current" step, but since some steps are shared between
     # flows, we also want to make sure that at least one of the in-person-specific steps exists in
     # the step indicator.
@@ -186,8 +191,6 @@ module InPersonHelper
       '.step-indicator__step',
       text: t('step_indicator.flows.idv.find_a_post_office'),
     )
-
-    expect_step_indicator_current_step(text)
   end
 
   def expect_in_person_gpo_step_indicator_current_step(text)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12061](https://cm-jira.usa.gov/browse/LG-12061)

## 🛠 Summary of changes

In #10280 we reworded the `secure_account` step to "Re-enter your password" so it no longer makes sense to have the final step be current once the user has re-entered their password.

The PR adds a new current_step of `ALL_STEPS_COMPLETED` which can be used to force all steps to render as completed.


## 👀 Screenshots

<details>
<summary>Before:</summary>

<img width="632" alt="lg-12061-before" src="https://github.com/18F/identity-idp/assets/2583060/20fe5b16-2fee-4b54-b3cd-c11a141f3f11">

</details>

<details>
<summary>After:</summary>

<img width="632" alt="lg-12061-after" src="https://github.com/18F/identity-idp/assets/2583060/9b23e3fc-7e41-434d-920e-62a2fbaaa266">

</details>
