### PR TITLE
Rm ImageMagick files from download script

### DIFF
--- a/scripts/download_acuant_sdk.sh
+++ b/scripts/download_acuant_sdk.sh
@@ -58,7 +58,6 @@ cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/*.wasm "$PUBLIC_DIR/"
 cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/*.json "$PUBLIC_DIR/"
 cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/tiny_face_detector* "$PUBLIC_DIR/"
 cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/face_landmark* "$PUBLIC_DIR/"
-cp "$TEMP_DIR"/Acuant-JavascriptWebSDKV11-*/webSdk/imageMagick* "$PUBLIC_DIR/"
 
 echo "Done! You can commit the files in ${PUBLIC_DIR}."
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-12342](https://cm-jira.usa.gov/browse/LG-12342)

## 🛠 Summary of changes

[See details on the reason for this change in this PR](https://github.com/18F/identity-idp/pull/10283).

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Make sure you don't have `public/acuant/11.9.3` (delete it if you do)
- [x] Run `make download_acuant_sdk`
- [x] Make sure now:
    - [x] you have `public/acuant/11.9.3`
    - [x] `public/acuant/11.9.3` DOES NOT contain `imageMagick.mjs` and `imageMagick.umd.js`.