### PR TITLE
Refactor ScriptHelper class to be thread-safe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'rack-timeout', require: false
 gem 'redacted_struct'
 gem 'redis', '>= 3.2.0'
 gem 'redis-session-store', github: '18F/redis-session-store', tag: 'v1.0.1-18f'
+gem 'request_store', '~> 1.0'
 gem 'retries'
 gem 'rotp', '~> 6.1'
 gem 'rqrcode'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -835,6 +835,7 @@ DEPENDENCIES
   redacted_struct
   redis (>= 3.2.0)
   redis-session-store!
+  request_store (~> 1.0)
   retries
   rotp (~> 6.1)
   rqrcode

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Rails/HelperInstanceVariable
 module ScriptHelper
   def javascript_packs_tag_once(*names, **attributes)
     scripts = RequestStore.store[:scripts]
@@ -72,4 +71,3 @@ module ScriptHelper
     end
   end
 end
-# rubocop:enable Rails/HelperInstanceVariable

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -3,7 +3,12 @@
 # rubocop:disable Rails/HelperInstanceVariable
 module ScriptHelper
   def javascript_packs_tag_once(*names, **attributes)
-    @scripts = @scripts.to_h.merge(names.index_with(attributes))
+    scripts = RequestStore.store[:scripts]
+    if scripts
+      RequestStore.store[:scripts].merge!(names.index_with(attributes))
+    else
+      RequestStore.store[:scripts] = names.index_with(attributes)
+    end
     nil
   end
 
@@ -12,9 +17,9 @@ module ScriptHelper
   def render_javascript_pack_once_tags(...)
     capture do
       javascript_packs_tag_once(...)
-      return if @scripts.blank?
+      return if RequestStore.store[:scripts].blank?
       concat javascript_assets_tag
-      @scripts.each do |name, attributes|
+      RequestStore.store[:scripts].each do |name, attributes|
         asset_sources.get_sources(name).each do |source|
           concat javascript_include_tag(
             source,
@@ -42,7 +47,7 @@ module ScriptHelper
   end
 
   def javascript_assets_tag
-    assets = asset_sources.get_assets(*@scripts.keys)
+    assets = asset_sources.get_assets(*RequestStore.store[:scripts].keys)
 
     if assets.present?
       asset_map = assets.index_with { |path| asset_path(path, host: asset_host(path)) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,6 +121,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
+    RequestStore.clear!
     Rails.cache.clear
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Builds on #10301 to make `ScriptHelper` explicitly thread-safe as well using `RequestStore`. The current usage is not necessarily thread-unsafe, but this refactors it to use the thread-safe `RequestStore` to protect against future changes that may not be.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
