### PR TITLE
Ensure that the pids directory is present for puma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,11 @@ Vagrantfile
 .yardoc
 /doc/
 
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids
+!/tmp/pids/.keep
+
 package-lock.json
 browsers.json
 Brewfile.lock.json


### PR DESCRIPTION
Uses the same strategy that a `rails new project` would employ.
