### PR TITLE
Analytics-related spec updates

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2557,8 +2557,10 @@ module AnalyticsEvents
   # @param [Boolean] fraud_review_pending Profile is under review for fraud
   # @param [Boolean] fraud_rejection Profile is rejected due to fraud
   # @param [Boolean] in_person_verification_pending Profile is pending in-person verification
+  # @param [String] address_verification_method "phone" or "gpo"
   # User submitted IDV personal key page
   def idv_personal_key_submitted(
+    address_verification_method:,
     fraud_review_pending:,
     fraud_rejection:,
     in_person_verification_pending:,
@@ -2568,6 +2570,7 @@ module AnalyticsEvents
   )
     track_event(
       'IdV: personal key submitted',
+      address_verification_method: address_verification_method,
       in_person_verification_pending: in_person_verification_pending,
       deactivation_reason: deactivation_reason,
       fraud_review_pending: fraud_review_pending,
@@ -2578,11 +2581,23 @@ module AnalyticsEvents
   end
 
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [String] address_verification_method "phone" or "gpo"
+  # @param [Boolean,nil] in_person_verification_pending
+  # @param [Boolean] encrypted_profiles_missing True if user's session had no encrypted pii
   # User visited IDV personal key page
-  def idv_personal_key_visited(proofing_components: nil, **extra)
+  def idv_personal_key_visited(
+    proofing_components: nil,
+    address_verification_method: nil,
+    in_person_verification_pending: nil,
+    encrypted_profiles_missing: nil,
+    **extra
+  )
     track_event(
       'IdV: personal key visited',
       proofing_components: proofing_components,
+      address_verification_method: address_verification_method,
+      in_person_verification_pending: in_person_verification_pending,
+      encrypted_profiles_missing: encrypted_profiles_missing,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3048,10 +3048,16 @@ module AnalyticsEvents
   # @param [String] step
   # @param [String] location
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [boolean,nil] cancelled_enrollment Whether the user's IPP enrollment has been canceled
+  # @param [String,nil] enrollment_code IPP enrollment code
+  # @param [Integer,nil] enrollment_id ID of the associated IPP enrollment record
   # User started over idv
   def idv_start_over(
     step:,
     location:,
+    cancelled_enrollment: nil,
+    enrollment_code: nil,
+    enrollment_id: nil,
     proofing_components: nil,
     **extra
   )
@@ -3060,6 +3066,9 @@ module AnalyticsEvents
       step: step,
       location: location,
       proofing_components: proofing_components,
+      cancelled_enrollment: cancelled_enrollment,
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -820,12 +820,25 @@ module AnalyticsEvents
 
   # @param [String] step the step that the user was on when they clicked cancel
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
+  # @param [boolean,nil] cancelled_enrollment Whether the user's IPP enrollment has been canceled
+  # @param [String,nil] enrollment_code IPP enrollment code
+  # @param [Integer,nil] enrollment_id ID of the associated IPP enrollment record
   # The user chose to go back instead of cancel IDV
-  def idv_cancellation_go_back(step:, proofing_components: nil, **extra)
+  def idv_cancellation_go_back(
+    step:,
+    proofing_components: nil,
+    cancelled_enrollment: nil,
+    enrollment_code: nil,
+    enrollment_id: nil,
+    **extra
+  )
     track_event(
       'IdV: cancellation go back',
       step: step,
       proofing_components: proofing_components,
+      cancelled_enrollment: cancelled_enrollment,
+      enrollment_code: enrollment_code,
+      enrollment_id: enrollment_id,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2646,6 +2646,7 @@ module AnalyticsEvents
   # @param [String] area_code area code of phone number
   # @param [Boolean] rate_limit_exceeded whether or not the rate limit was exceeded by this attempt
   # @param [Hash] telephony_response response from Telephony gem
+  # @param [String] phone_fingerprint Fingerprint string identifying phone number
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # The user resent an OTP during the IDV phone step
   def idv_phone_confirmation_otp_resent(
@@ -2656,6 +2657,7 @@ module AnalyticsEvents
     area_code:,
     rate_limit_exceeded:,
     telephony_response:,
+    phone_fingerprint:,
     proofing_components: nil,
     **extra
   )
@@ -2668,6 +2670,7 @@ module AnalyticsEvents
       area_code: area_code,
       rate_limit_exceeded: rate_limit_exceeded,
       telephony_response: telephony_response,
+      phone_fingerprint: phone_fingerprint,
       proofing_components: proofing_components,
       **extra,
     )
@@ -3854,12 +3857,14 @@ module AnalyticsEvents
   # Tracks if otp phone validation failed
   # @identity.idp.previous_event_name Twilio Phone Validation Failed
   # @param [String] error
+  # @param [string] message
   # @param [String] context
   # @param [String] country
-  def otp_phone_validation_failed(error:, context:, country:, **extra)
+  def otp_phone_validation_failed(error:, message:, context:, country:, **extra)
     track_event(
       'Vendor Phone Validation failed',
       error: error,
+      message: message,
       context: context,
       country: country,
       **extra,

--- a/spec/controllers/concerns/idv/phone_otp_rate_limitable_spec.rb
+++ b/spec/controllers/concerns/idv/phone_otp_rate_limitable_spec.rb
@@ -13,17 +13,13 @@ RSpec.describe Idv::PhoneOtpRateLimitable, type: :controller do
     before do
       stub_analytics
       stub_attempts_tracker
-      allow(@analytics).to receive(:track_event)
       allow(@irs_attempts_api_tracker).to receive(:track_event)
     end
 
     it 'calls analytics tracking event' do
       subject.handle_too_many_otp_sends
 
-      expect(@analytics).to have_received(:track_event).with(
-        'Idv: Phone OTP sends rate limited',
-        proofing_components: nil,
-      )
+      expect(@analytics).to have_logged_event('Idv: Phone OTP sends rate limited')
     end
 
     it 'calls irs tracking event idv_phone_otp_sent_rate_limited' do

--- a/spec/controllers/idv/by_mail/letter_enqueued_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/letter_enqueued_controller_spec.rb
@@ -11,16 +11,19 @@ RSpec.describe Idv::ByMail::LetterEnqueuedController do
   end
 
   context 'user needs USPS address verification' do
-    it 'renders the show template' do
+    it 'logs an analytics event' do
       stub_analytics
-
-      expect(@analytics).to receive(:track_event).with(
-        'IdV: letter enqueued visited',
-        proofing_components: nil,
-      )
 
       get :show
 
+      expect(@analytics).to have_logged_event(
+        'IdV: letter enqueued visited',
+        proofing_components: nil,
+      )
+    end
+
+    it 'renders the show template' do
+      get :show
       expect(response).to render_template :show
     end
   end

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe Idv::ByMail::RequestLetterController, allowed_extra_analytics: [:*] do
+RSpec.describe Idv::ByMail::RequestLetterController,
+               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
   let(:user) { create(:user) }
 
   let(:ab_test_args) do

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe Idv::CancellationsController do
       stub_sign_in
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with(
+      get :new
+
+      expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
         request_came_from: 'no referer',
         step: nil,
         proofing_components: nil,
       )
-
-      get :new
     end
 
     it 'tracks the event in analytics when referer is present' do
@@ -33,28 +33,28 @@ RSpec.describe Idv::CancellationsController do
       stub_analytics
       request.env['HTTP_REFERER'] = 'http://example.com/'
 
-      expect(@analytics).to receive(:track_event).with(
+      get :new
+
+      expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
         request_came_from: 'users/sessions#new',
         step: nil,
         proofing_components: nil,
       )
-
-      get :new
     end
 
     it 'tracks the event in analytics when step param is present' do
       stub_sign_in
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with(
+      get :new, params: { step: 'first' }
+
+      expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
         request_came_from: 'no referer',
         step: 'first',
         proofing_components: nil,
       )
-
-      get :new, params: { step: 'first' }
     end
 
     context 'when no session' do
@@ -104,7 +104,6 @@ RSpec.describe Idv::CancellationsController do
 
   describe '#update' do
     let(:user) { create(:user) }
-    let(:enrollment) { create(:in_person_enrollment, :pending, user: user) }
 
     before do
       stub_sign_in(user)
@@ -112,32 +111,39 @@ RSpec.describe Idv::CancellationsController do
     end
 
     it 'logs cancellation go back' do
-      expect(@analytics).to receive(:track_event).with(
+      put :update, params: { step: 'first', cancel: 'true' }
+
+      expect(@analytics).to have_logged_event(
         'IdV: cancellation go back',
         step: 'first',
         proofing_components: nil,
+        cancelled_enrollment: nil,
+        enrollment_code: nil,
+        enrollment_id: nil,
       )
-
-      put :update, params: { step: 'first', cancel: 'true' }
-    end
-
-    it 'logs cancellation go back with extra analytics attributes for barcode step' do
-      expect(@analytics).to receive(:track_event).with(
-        'IdV: cancellation go back',
-        step: 'barcode',
-        proofing_components: nil,
-        cancelled_enrollment: false,
-        enrollment_code: enrollment.enrollment_code,
-        enrollment_id: enrollment.id,
-      )
-
-      put :update, params: { step: 'barcode', cancel: 'true' }
     end
 
     it 'redirects to idv_path' do
       put :update, params: { cancel: 'true' }
 
       expect(response).to redirect_to idv_url
+    end
+
+    context 'in-person proofing' do
+      let!(:enrollment) { create(:in_person_enrollment, :pending, user: user) }
+
+      it 'logs cancellation go back with extra analytics attributes for barcode step' do
+        put :update, params: { step: 'barcode', cancel: 'true' }
+
+        expect(@analytics).to have_logged_event(
+          'IdV: cancellation go back',
+          step: 'barcode',
+          proofing_components: nil,
+          cancelled_enrollment: false,
+          enrollment_code: enrollment.enrollment_code,
+          enrollment_id: enrollment.id,
+        )
+      end
     end
 
     context 'with go back path stored in session' do
@@ -162,13 +168,13 @@ RSpec.describe Idv::CancellationsController do
       stub_sign_in
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with(
+      delete :destroy, params: { step: 'first' }
+
+      expect(@analytics).to have_logged_event(
         'IdV: cancellation confirmed',
         step: 'first',
         proofing_components: nil,
       )
-
-      delete :destroy, params: { step: 'first' }
     end
 
     context 'when no session' do

--- a/spec/controllers/idv/forgot_password_controller_spec.rb
+++ b/spec/controllers/idv/forgot_password_controller_spec.rb
@@ -11,17 +11,12 @@ RSpec.describe Idv::ForgotPasswordController do
     before do
       stub_sign_in
       stub_analytics
-
-      allow(@analytics).to receive(:track_event)
     end
 
     it 'tracks the event in analytics when referer is nil' do
       get :new
 
-      expect(@analytics).to have_received(:track_event).with(
-        'IdV: forgot password visited',
-        proofing_components: nil,
-      )
+      expect(@analytics).to have_logged_event('IdV: forgot password visited')
     end
   end
 
@@ -32,7 +27,6 @@ RSpec.describe Idv::ForgotPasswordController do
       stub_sign_in(user)
       stub_analytics
       stub_attempts_tracker
-      allow(@analytics).to receive(:track_event)
     end
 
     it 'tracks appropriate events' do
@@ -42,10 +36,7 @@ RSpec.describe Idv::ForgotPasswordController do
 
       post :update
 
-      expect(@analytics).to have_received(:track_event).with(
-        'IdV: forgot password confirmed',
-        proofing_components: nil,
-      )
+      expect(@analytics).to have_logged_event('IdV: forgot password confirmed')
     end
   end
 end

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe Idv::OtpVerificationController do
+RSpec.describe Idv::OtpVerificationController,
+               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
   let(:user) { create(:user) }
 
   let(:phone) { '2255555000' }
@@ -28,7 +29,6 @@ RSpec.describe Idv::OtpVerificationController do
   before do
     stub_analytics
     stub_attempts_tracker
-    allow(@analytics).to receive(:track_event)
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
 
     sign_in(user)
@@ -81,7 +81,7 @@ RSpec.describe Idv::OtpVerificationController do
     it 'tracks an analytics event' do
       get :show
 
-      expect(@analytics).to have_received(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'IdV: phone confirmation otp visited',
         proofing_components: nil,
       )
@@ -184,7 +184,7 @@ RSpec.describe Idv::OtpVerificationController do
         **ab_test_args,
       }
 
-      expect(@analytics).to have_received(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'IdV: phone confirmation otp submitted',
         expected_result,
       )

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::PersonalKeyController, allowed_extra_analytics: [:*] do
+RSpec.describe Idv::PersonalKeyController do
   include FlowPolicyHelper
   include SamlAuthHelper
   include PersonalKeyValidator

--- a/spec/controllers/idv/please_call_controller_spec.rb
+++ b/spec/controllers/idv/please_call_controller_spec.rb
@@ -34,14 +34,18 @@ RSpec.describe Idv::PleaseCallController do
     expect(response).to redirect_to(idv_not_verified_url)
   end
 
-  it 'renders the show template' do
+  it 'logs an analytics event' do
     stub_analytics
 
-    expect(@analytics).to receive(:track_event).with(
+    get :show
+
+    expect(@analytics).to have_logged_event(
       'IdV: Verify please call visited',
       proofing_components: nil,
     )
+  end
 
+  it 'renders the show template' do
     get :show
 
     expect(response).to render_template :show

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Idv::ResendOtpController do
 
   before do
     stub_analytics
-    allow(@analytics).to receive(:track_event)
 
     sign_in(user)
     stub_verify_steps_one_and_two(user)
@@ -64,7 +63,7 @@ RSpec.describe Idv::ResendOtpController do
         proofing_components: nil,
       }
 
-      expect(@analytics).to have_received(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'IdV: phone confirmation otp resent',
         expected_result,
       )
@@ -91,23 +90,22 @@ RSpec.describe Idv::ResendOtpController do
       end
 
       before do
-        stub_analytics
         allow(Telephony).to receive(:send_confirmation_otp).and_return(telephony_response)
       end
 
       it 'tracks an analytics events' do
-        expect(@analytics).to receive(:track_event).ordered.with(
+        post :create
+
+        expect(@analytics).to have_logged_event(
           'IdV: phone confirmation otp resent',
           hash_including(
             success: false,
             telephony_response: telephony_response,
           ),
         )
-        expect(@analytics).to receive(:track_event).ordered.with(
+        expect(@analytics).to have_logged_event(
           'Vendor Phone Validation failed', telephony_error_analytics_hash
         )
-
-        post :create
       end
     end
   end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Idv::SessionsController do
   let(:user) { build(:user) }
-  let(:enrollment) { create(:in_person_enrollment, :pending, user: user) }
 
   before do
     stub_sign_in(user)
@@ -47,21 +46,28 @@ RSpec.describe Idv::SessionsController do
         'IdV: start over',
         location: 'get_help',
         proofing_components: nil,
+        cancelled_enrollment: nil,
+        enrollment_code: nil,
+        enrollment_id: nil,
         step: 'first',
       )
     end
 
-    it 'logs idv_start_over event with extra analytics attributes for barcode step' do
-      expect(@analytics).to receive(:track_event).with(
-        'IdV: start over',
-        location: '',
-        proofing_components: nil,
-        step: 'barcode',
-        cancelled_enrollment: true,
-        enrollment_code: enrollment.enrollment_code,
-        enrollment_id: enrollment.id,
-      )
-      delete :destroy, params: { step: 'barcode', location: '' }
+    context 'with in person enrollment' do
+      let(:user) { build(:user, :with_pending_in_person_enrollment) }
+
+      it 'logs idv_start_over event with extra analytics attributes for barcode step' do
+        delete :destroy, params: { step: 'barcode', location: '' }
+        expect(@analytics).to have_logged_event(
+          'IdV: start over',
+          location: '',
+          proofing_components: nil,
+          step: 'barcode',
+          cancelled_enrollment: true,
+          enrollment_code: user.pending_in_person_enrollment.enrollment_code,
+          enrollment_id: user.pending_in_person_enrollment.id,
+        )
+      end
     end
 
     it 'redirect occurs to the start of identity verification' do
@@ -88,6 +94,9 @@ RSpec.describe Idv::SessionsController do
           'IdV: start over',
           location: 'clear_and_start_over',
           proofing_components: nil,
+          cancelled_enrollment: nil,
+          enrollment_code: nil,
+          enrollment_id: nil,
           step: 'gpo_verify',
         )
       end

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -124,8 +124,10 @@ RSpec.describe 'cancel IdV', allowed_extra_analytics: [:*] do
 
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation go back',
-        step: 'ssn',
-        proofing_components: { document_check: 'mock', document_type: 'state_id' },
+        hash_including(
+          proofing_components: { document_check: 'mock', document_type: 'state_id' },
+          step: 'ssn',
+        ),
       )
 
       click_link t('links.cancel')
@@ -133,9 +135,10 @@ RSpec.describe 'cancel IdV', allowed_extra_analytics: [:*] do
 
       expect(fake_analytics).to have_logged_event(
         'IdV: start over',
-        location: nil,
-        proofing_components: { document_check: 'mock', document_type: 'state_id' },
-        step: 'ssn',
+        hash_including(
+          proofing_components: { document_check: 'mock', document_type: 'state_id' },
+          step: 'ssn',
+        ),
       )
 
       complete_doc_auth_steps_before_ssn_step
@@ -145,8 +148,10 @@ RSpec.describe 'cancel IdV', allowed_extra_analytics: [:*] do
 
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation confirmed',
-        step: 'ssn',
-        proofing_components: { document_check: 'mock', document_type: 'state_id' },
+        hash_including(
+          step: 'ssn',
+          proofing_components: { document_check: 'mock', document_type: 'state_id' },
+        ),
       )
     end
   end


### PR DESCRIPTION
Previously: #10258 

This PR:

* Updates several specs to use `have_logged_event` instead of `expect(@analytics).to receive(:track_event)`. 
* Removes `allowed_extra_analytics: [:*]` from a couple of specs and documents the parameters found

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
