### PR TITLE
Order two_factor_enabled short-circuiting by usage

### DIFF
--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -81,10 +81,10 @@ class MfaContext
 
   def two_factor_enabled?
     return true if phone_configurations.any?(&:mfa_enabled?)
-    return true if piv_cac_configurations.any?(&:mfa_enabled?)
-    return true if auth_app_configurations.any?(&:mfa_enabled?)
-    return true if backup_code_configurations.any?(&:mfa_enabled?)
     return true if webauthn_configurations.any?(&:mfa_enabled?)
+    return true if backup_code_configurations.any?(&:mfa_enabled?)
+    return true if auth_app_configurations.any?(&:mfa_enabled?)
+    return true if piv_cac_configurations.any?(&:mfa_enabled?)
     return false
   end
 

--- a/spec/decorators/mfa_context_spec.rb
+++ b/spec/decorators/mfa_context_spec.rb
@@ -204,6 +204,22 @@ RSpec.describe MfaContext do
     end
   end
 
+  describe '#two_factor_enabled?' do
+    subject(:two_factor_enabled?) { mfa.two_factor_enabled? }
+
+    context 'when user has an associated mfa' do
+      let(:user) { create(:user, :with_phone) }
+
+      it { expect(two_factor_enabled?).to eq(true) }
+    end
+
+    context 'when user does not have any associated mfa' do
+      let(:user) { create(:user) }
+
+      it { expect(two_factor_enabled?).to eq(false) }
+    end
+  end
+
   describe '#enabled_mfa_methods_count' do
     context 'with 2 phones' do
       it 'returns 2' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,20 +99,6 @@ RSpec.describe User do
     end
   end
 
-  context '#two_factor_enabled?' do
-    it 'is true when user has a confirmed phone' do
-      user = create(:user, :with_phone)
-
-      expect(MfaPolicy.new(user).two_factor_enabled?).to eq true
-    end
-
-    it 'is false when user does not have a phone' do
-      user = create(:user)
-
-      expect(MfaPolicy.new(user).two_factor_enabled?).to eq false
-    end
-  end
-
   describe '#fully_registered?' do
     let(:user) { create(:user) }
     subject(:fully_registered?) { user.fully_registered? }


### PR DESCRIPTION
## 🛠 Summary of changes

Reorders checks in `MfaContext#two_factor_enabled?` to assure higher likelihood of short-circuiting, based on setup rates for common MFAs.

CloudWatch query:

```
filter name = 'Multi-Factor Authentication Setup'
| stats count(*) as method_count by properties.event_properties.multi_factor_auth_method
| sort method_count desc
```

## 📜 Testing Plan

This performs the same checks so it shouldn't have any notable effects.

Verify associated specs pass:

```
rspec spec/decorators/mfa_context_spec.rb
```