### PR TITLE
Update IdvController spec to use have_logged_event

### DIFF
--- a/app/controllers/concerns/rate_limit_concern.rb
+++ b/app/controllers/concerns/rate_limit_concern.rb
@@ -43,14 +43,7 @@ module RateLimitConcern
 
   def track_rate_limited_event(rate_limit_type)
     analytics_args = { limiter_type: rate_limit_type }
-    limiter_context = 'single-session'
-
-    if rate_limit_type == :proof_address
-      analytics_args[:step_name] = :phone
-    elsif rate_limit_type == :proof_ssn
-      analytics_args[:step_name] = 'verify_info'
-      limiter_context = 'multi-session'
-    end
+    limiter_context = rate_limit_type == :proof_ssn ? 'multi-session' : 'single-session'
 
     irs_attempts_api_tracker.idv_verification_rate_limited(limiter_context: limiter_context)
     analytics.rate_limit_reached(**analytics_args)

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -578,7 +578,6 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:*] do
             'Rate Limit Reached',
             {
               limiter_type: :proof_address,
-              step_name: :phone,
             },
           )
         end

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe IdvController, allowed_extra_analytics: [:*] do
+RSpec.describe IdvController do
   before do
     stub_sign_in
   end
@@ -12,9 +12,8 @@ RSpec.describe IdvController, allowed_extra_analytics: [:*] do
     end
 
     it 'tracks page visit' do
-      expect(@analytics).to receive(:track_event).with(analytics_name)
-
       get :index
+      expect(@analytics).to have_logged_event(analytics_name)
     end
 
     it 'does not track page visit if profile is active' do
@@ -22,9 +21,9 @@ RSpec.describe IdvController, allowed_extra_analytics: [:*] do
 
       stub_sign_in(profile.user)
 
-      expect(@analytics).to_not receive(:track_event).with(analytics_name)
-
       get :index
+
+      expect(@analytics).not_to have_logged_event(analytics_name)
     end
 
     it 'redirects to please call page if fraud review is pending' do


### PR DESCRIPTION
Previously: #10258, #10309

This PR:

- Updates `IdvController` to use `have_logged_event` and removes `allowed_extra_analytics`