### PR TITLE
Always initialize geocoder if geolocation data file exists

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -11,7 +11,7 @@ end
 
 GEO_DATA_FILEPATH = Rails.root.join(IdentityConfig.store.geo_data_file_path).freeze
 
-if Rails.env.production? && File.exist?(GEO_DATA_FILEPATH)
+if File.exist?(GEO_DATA_FILEPATH)
   Geocoder.configure(
     ip_lookup: :geoip2,
     geoip2: {


### PR DESCRIPTION
## 🛠 Summary of changes

Updates geocoder initializer to always load the geocoder file if it exists, regardless of environment.

This is to avoid future confusion like I experienced when following our [instructions to set up geolocation](https://github.com/18F/identity-idp/blob/main/docs/local-development.md#setting-up-geolocation) and it not working as instructed.

## 📜 Testing Plan

1. Follow the instructions to set up geolocation
   1. Alternatively, download live database from S3
3. Verify geocoder produces real data
   1. `rails c`
   2. `Geocoder.search(Faker::Internet.ip_v4_address).first`
   4. Verify output is something other than the [fake default](https://github.com/18F/identity-idp/blob/bf24298d61fd53f0ade05f4d048946e1a6c95647/config/initializers/geocoder.rb#L26)
