### PR TITLE
LG-12756 Spell canceled consistently

### DIFF
--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -72,7 +72,7 @@ module Idv
     def render_document_capture_cancelled
       redirect_to idv_hybrid_handoff_url
       idv_session.flow_path = nil
-      failure(I18n.t('errors.doc_auth.document_capture_cancelled'))
+      failure(I18n.t('errors.doc_auth.document_capture_canceled'))
     end
 
     def render_step_incomplete_error

--- a/app/views/account_reset/pending/cancel.html.erb
+++ b/app/views/account_reset/pending/cancel.html.erb
@@ -1,6 +1,6 @@
-<% self.title = t('account_reset.pending.cancelled') %>
+<% self.title = t('account_reset.pending.canceled') %>
 
-<%= render PageHeadingComponent.new.with_content(t('account_reset.pending.cancelled')) %>
+<%= render PageHeadingComponent.new.with_content(t('account_reset.pending.canceled')) %>
 
 <%= link_to(
       t('links.continue_sign_in'),

--- a/app/views/idv/cancellations/destroy.html.erb
+++ b/app/views/idv/cancellations/destroy.html.erb
@@ -1,4 +1,4 @@
-<% self.title = t('titles.idv.cancelled') %>
+<% self.title = t('titles.idv.canceled') %>
 
 <%= render StatusPageComponent.new(status: :error) do |c| %>
   <% c.with_header { t('idv.cancel.headings.confirmation.hybrid') } %>

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -29,7 +29,7 @@ en:
       title: Deleting your account should be your last resort
     pending:
       cancel_request: Cancel request
-      cancelled: We have cancelled your request to delete your account.
+      cancelled: We have canceled your request to delete your account.
       confirm: If you cancel now, you must create a new request and wait another
         %{interval} to delete your account.
       header: You requested to delete your account

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -29,7 +29,7 @@ en:
       title: Deleting your account should be your last resort
     pending:
       cancel_request: Cancel request
-      cancelled: We have canceled your request to delete your account.
+      canceled: We have canceled your request to delete your account.
       confirm: If you cancel now, you must create a new request and wait another
         %{interval} to delete your account.
       header: You requested to delete your account

--- a/config/locales/account_reset/es.yml
+++ b/config/locales/account_reset/es.yml
@@ -30,7 +30,7 @@ es:
       title: Eliminar tu cuenta debería ser tu último recurso
     pending:
       cancel_request: Cancelar petición
-      cancelled: Hemos cancelado su solicitud para eliminar su cuenta.
+      canceled: Hemos cancelado su solicitud para eliminar su cuenta.
       confirm: Si cancela ahora, debe crear una nueva solicitud y esperar otras
         %{interval} para eliminar su cuenta.
       header: Solicitaste eliminar tu cuenta

--- a/config/locales/account_reset/fr.yml
+++ b/config/locales/account_reset/fr.yml
@@ -30,7 +30,7 @@ fr:
       title: La suppression de votre compte devrait être votre dernier recours
     pending:
       cancel_request: Demande d’annulation
-      cancelled: Nous avons annulé votre demande de suppression de votre compte.
+      canceled: Nous avons annulé votre demande de suppression de votre compte.
       confirm: Si vous annulez maintenant, vous devez créer une nouvelle demande et
         attendre encore %{interval} pour supprimer votre compte.
       header: Vous avez demandé de supprimer votre compte

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -25,7 +25,7 @@ en:
       consent_form: Before you can continue, you must give us permission. Please check
         the box below and then click continue.
       doc_type_not_supported_heading: We only accept a driver’s license or a state ID
-      document_capture_cancelled: You have cancelled uploading photos of your ID on your phone.
+      document_capture_cancelled: You have canceled uploading photos of your ID on your phone.
       how_to_verify_form: Select a way to verify your identity.
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -25,7 +25,7 @@ en:
       consent_form: Before you can continue, you must give us permission. Please check
         the box below and then click continue.
       doc_type_not_supported_heading: We only accept a driver’s license or a state ID
-      document_capture_cancelled: You have canceled uploading photos of your ID on your phone.
+      document_capture_canceled: You have canceled uploading photos of your ID on your phone.
       how_to_verify_form: Select a way to verify your identity.
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -27,7 +27,7 @@ es:
         continuación y luego haga clic en continuar.
       doc_type_not_supported_heading: Solo aceptamos una licencia de conducir o un
         documento de identidad estatal
-      document_capture_cancelled: Ha cancelado la carga de fotos de su identificación en este teléfono.
+      document_capture_canceled: Ha cancelado la carga de fotos de su identificación en este teléfono.
       how_to_verify_form: Seleccione una forma de verificar su identidad.
       phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
         antes de continuar. Te enviamos un enlace con instrucciones.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -29,7 +29,7 @@ fr:
         Veuillez cocher la case ci-dessous puis cliquez sur continuer.
       doc_type_not_supported_heading: Nous n’acceptons que les permis de conduire ou
         les cartes d’identité délivrées par l’État
-      document_capture_cancelled: Vous avez annulé le téléchargement de vos photos
+      document_capture_canceled: Vous avez annulé le téléchargement de vos photos
         d’identité sur votre téléphone.
       how_to_verify_form: Sélectionnez un moyen de vérifier votre identité.
       phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -43,7 +43,7 @@ en:
         start_over: If you start over, you will restart this process from the beginning.
       headings:
         confirmation:
-          hybrid: You have cancelled uploading photos of your ID on this phone
+          hybrid: You have canceled uploading photos of your ID on this phone
         exit:
           with_sp: Exit %{app_name} and return to %{sp_name}
           without_sp: Exit identity verification and go to your account page

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -2,7 +2,7 @@
 en:
   telephony:
     account_deleted_notice: This text message confirms you have deleted your %{app_name} account.
-    account_reset_cancellation_notice: Your request to delete your %{app_name} account has been cancelled.
+    account_reset_cancellation_notice: Your request to delete your %{app_name} account has been canceled.
     account_reset_notice: As requested, your %{app_name} account will be deleted in
       %{interval}. Don't want to delete your account? Sign in to your
       %{app_name} account to cancel.

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -31,8 +31,8 @@ en:
       phone_verification: Phone number not verified
     forget_all_browsers: Forget all browsers
     idv:
+      canceled: Identity verification is canceled
       cancellation_prompt: Cancel identity verification
-      cancelled: Identity verification is canceled
       come_back_soon: Come back soon
       enter_one_time_code: Enter your one-time code
       enter_password: Re-enter your password

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -32,7 +32,7 @@ en:
     forget_all_browsers: Forget all browsers
     idv:
       cancellation_prompt: Cancel identity verification
-      cancelled: Identity verification is cancelled
+      cancelled: Identity verification is canceled
       come_back_soon: Come back soon
       enter_one_time_code: Enter your one-time code
       enter_password: Re-enter your password

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -31,8 +31,8 @@ es:
       phone_verification: Número telefónico no verificado
     forget_all_browsers: Olvídate de todos los navegadores
     idv:
+      canceled: Se canceló la verificación de identidad
       cancellation_prompt: Cancela la verificación de identidad
-      cancelled: Se canceló la verificación de identidad
       come_back_soon: Vuelve pronto
       enter_one_time_code: Introduzca su código único
       enter_password: Vuelve a ingresar tu contraseña

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -31,8 +31,8 @@ fr:
       phone_verification: Numéro de téléphone non vérifié
     forget_all_browsers: Oubliez tous les navigateurs
     idv:
+      canceled: La vérification d’identité est annulée
       cancellation_prompt: Annulez la vérification d’identité
-      cancelled: La vérification d’identité est annulée
       come_back_soon: Revenez bientôt
       enter_one_time_code: Entrez votre code à usage unique
       enter_password: Saisissez à nouveau votre mot de passe

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -14,7 +14,7 @@ en:
         %{interval} from the time you made the request to complete the process.
         Please check back later.
       successful_cancel: Thank you. Your request to delete your %{app_name} account
-        has been cancelled.
+        has been canceled.
       text_html: If you can’t use any of the authentication methods above, you can
         reset your preferences by %{link_html}.
     attempt_remaining_warning_html:

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -10,7 +10,7 @@ en:
         agency whose service you are trying to access.
       subject: We couldn’t verify your identity
     account_reset_cancel:
-      intro_html: This email confirms you have cancelled your request to delete your
+      intro_html: This email confirms you have canceled your request to delete your
         %{app_name_html} account.
       subject: Request canceled
     account_reset_complete:

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Idv::LinkSentController do
 
       context 'document capture session canceled' do
         let(:session_canceled_at) { Time.zone.now }
-        let(:error_message) { t('errors.doc_auth.document_capture_cancelled') }
+        let(:error_message) { t('errors.doc_auth.document_capture_canceled') }
 
         before do
           expect(FormResponse).to receive(:new).with(

--- a/spec/features/account_reset/pending_request_spec.rb
+++ b/spec/features/account_reset/pending_request_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Pending account reset request sign in', allowed_extra_analytics: 
 
     click_on t('account_reset.pending.cancel_request')
     click_on t('forms.buttons.continue')
-    expect(page).to have_content(t('account_reset.pending.cancelled'))
+    expect(page).to have_content(t('account_reset.pending.canceled'))
 
     click_on t('links.continue_sign_in')
     expect(page).to have_content(t('two_factor_authentication.header_text'))

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -17,6 +17,14 @@ LOCALE_SPECIFIC_CONTENT = {
   es: /¿|ó/,
 }.freeze
 
+# Regex patterns for commonly misspelled words by locale. Match on word boundaries ignoring case.
+# The current design should be adequate for a small number of words in each language.
+# If we encounter false positives we should come up with a scheme to ignore those cases.
+# Add additional words using the regex union operator '|'.
+COMMONLY_MISSPELLED_WORDS = {
+  en: /\b(cancelled|occured|seperated?)\b/i,
+}
+
 module I18n
   module Tasks
     class BaseTask
@@ -211,6 +219,15 @@ RSpec.describe 'I18n' do
             expect(value).not_to match(
               Regexp.union(*LOCALE_SPECIFIC_CONTENT.slice(*other_locales).values),
             )
+          end
+        end
+
+        it 'does not contain commonly misspelled words' do
+          flattened_yaml_data.each do |key, value|
+            locale = key.split('.', 2).first.to_sym
+            if COMMONLY_MISSPELLED_WORDS.key?(locale)
+              expect(value).not_to match(COMMONLY_MISSPELLED_WORDS[locale])
+            end
           end
         end
       end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -23,7 +23,7 @@ LOCALE_SPECIFIC_CONTENT = {
 # Add additional words using the regex union operator '|'.
 COMMONLY_MISSPELLED_WORDS = {
   en: /\b(cancelled|occured|seperated?)\b/i,
-}
+}.freeze
 
 module I18n
   module Tasks
@@ -170,6 +170,7 @@ RSpec.describe 'I18n' do
 
     Dir["#{group_path}/*.yml"].each do |full_path|
       i18n_file = full_path.sub("#{root_dir}/", '')
+      locale = File.basename(full_path, '.yml').to_sym
 
       describe i18n_file do
         let(:flattened_yaml_data) { flatten_hash(YAML.load_file(full_path)) }
@@ -214,7 +215,6 @@ RSpec.describe 'I18n' do
 
         it 'does not contain content from another language' do
           flattened_yaml_data.each do |key, value|
-            locale = key.split('.', 2).first.to_sym
             other_locales = LOCALE_SPECIFIC_CONTENT.keys - [locale]
             expect(value).not_to match(
               Regexp.union(*LOCALE_SPECIFIC_CONTENT.slice(*other_locales).values),
@@ -222,12 +222,9 @@ RSpec.describe 'I18n' do
           end
         end
 
-        it 'does not contain commonly misspelled words' do
+        it 'does not contain common misspellings', if: COMMONLY_MISSPELLED_WORDS.key?(locale) do
           flattened_yaml_data.each do |key, value|
-            locale = key.split('.', 2).first.to_sym
-            if COMMONLY_MISSPELLED_WORDS.key?(locale)
-              expect(value).not_to match(COMMONLY_MISSPELLED_WORDS[locale])
-            end
+            expect(value).not_to match(COMMONLY_MISSPELLED_WORDS[locale])
           end
         end
       end


### PR DESCRIPTION
**Why**:
- Use the standard TTS practice of American English spelling everywhere.

**How**:
- Change only the user-facing text in this commit.

changelog: User-Facing Improvements, Messages, Use the American spelling of canceled consistently

=
## 🎫 Ticket

[LG-12756](https://cm-jira.usa.gov/browse/LG-12756)

