### PR TITLE
LG-12268: Fix bug in face match failure result copy

### DIFF
--- a/app/services/doc_auth/error_generator.rb
+++ b/app/services/doc_auth/error_generator.rb
@@ -116,7 +116,7 @@ module DocAuth
 
     SELFIE_GENERAL_FAILURE_ERROR =
       {
-        general: [Errors::SELFIE_NOT_LIVE],
+        general: [Errors::SELFIE_FAILURE],
         front: [Errors::MULTIPLE_FRONT_ID_FAILURES],
         back: [Errors::MULTIPLE_BACK_ID_FAILURES],
         selfie: [Errors::SELFIE_FAILURE],

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -39,8 +39,8 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
-        selfie_not_live: 'Try taking your photos again. Make sure all of your photos are
-          clear and in focus.'
+        selfie_not_live: Try taking a photo of yourself again. Make sure your whole face
+          is clear and visible in the photo.
         selfie_poor_quality: 'Try taking a photo of yourself again. Make sure your whole
           face is clear and visible in the photo.'
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
@@ -85,7 +85,8 @@ en:
         network_error: We are having technical difficulties on our end. Please try to
           submit your images again later.
         no_liveness: Try taking new pictures.
-        selfie_failure: We couldn’t verify the photo of yourself. Try taking a new picture.
+        selfie_failure: Try taking your photos again. Make sure all of your photos are
+          clear and in focus.
       glare:
         failed_short: Image has glare, please try again.
         top_msg: We couldn’t read your ID. Your photo may have glare. Make sure that the

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -49,8 +49,8 @@ es:
           identidad. Intente tomar nuevas fotos.
         ref_control_number_check: No pudimos leer el código de barras del número de
           control. Intente tomar nuevas fotografías.
-        selfie_not_live: 'Intente tomar de nuevo sus fotos. Asegúrese de que sus fotos
-          estén claras y enfocadas.'
+        selfie_not_live: Intente tomar de nuevo una foto de usted. Asegúrese de que su
+          rostro se vea claramente en la foto.
         selfie_poor_quality: 'Intente tomar de nuevo una foto de usted. Asegúrese de que
           su rostro se vea claramente en la foto.'
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar
@@ -108,7 +108,8 @@ es:
         network_error: Estamos teniendo problemas técnicos por nuestra parte. Intente
           enviar sus imágenes de nuevo más tarde.
         no_liveness: Intente tomar nuevas fotografías.
-        selfie_failure: No pudimos verificar su foto. Intente tomar una nueva foto.
+        selfie_failure: Intente tomar de nuevo sus fotos. Asegúrese de que sus fotos
+          estén claras y enfocadas.
       glare:
         failed_short: Hay reflejos en la imagen, por favor inténtelo de nuevo.
         top_msg: No pudimos leer su identificación. Es posible que su foto tenga

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -52,8 +52,9 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
         ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro de
           contrôle. Essayez de prendre de nouvelles photos.
-        selfie_not_live: 'Essayez de prendre de nouvelles photos de vous-même. Veillez à
-          ce que toutes vos photos soient claires et nettes.'
+        selfie_not_live: Essayez de prendre une nouvelle photo de vous-même.
+          Assurez-vous que l’ensemble de votre visage soit clair et visible sur
+          la photo.
         selfie_poor_quality: 'Essayez de prendre une nouvelle photo de vous-même.
           Assurez-vous que l’ensemble de votre visage soit clair et visible sur
           la photo.'
@@ -114,8 +115,8 @@ fr:
         network_error: Nous avons des difficultés techniques de notre côté. Veuillez
           essayer de soumettre à nouveau vos images plus tard.
         no_liveness: Essayez de prendre de nouvelles photos.
-        selfie_failure: Nous n’avons pas pu vérifier votre photo. Essayez de prendre une
-          nouvelle photo.
+        selfie_failure: Essayez de prendre de nouvelles photos de vous-même. Veillez à
+          ce que toutes vos photos soient claires et nettes.
       glare:
         failed_short: L’image a des reflets, veuillez réessayer.
         top_msg: Nous n’avons pas pu lire votre pièce d’identité. Votre photo peut avoir

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -325,7 +325,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               expect(page).to have_current_path(idv_phone_url)
             end
           end
-          context 'selfie with no liveness or poor quality is uploaded',
+          context 'selfie with error is uploaded',
                   allow_browser_log: true do
             it 'try again and page show no liveness inline error message' do
               visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
@@ -421,7 +421,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               submit_images
               message = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
               expect(page).to have_content(message)
-              detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live'))
+              detail_message = strip_tags(t('doc_auth.errors.general.selfie_failure'))
               security_message = strip_tags(
                 t(
                   'idv.warning.attempts_html',


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12268](https://cm-jira.usa.gov/browse/LG-12268)



## 🛠 Summary of changes
- This is an attempt to fix the bug @kellular surfaced in [this slack thread.](https://gsa-tts.slack.com/archives/C05HSH9RQ57/p1711482907389469) (Hat tip to @amirbey for suggesting the fix during the afternoon group work session!)



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Run automated tests
- [ ] Manual QA with the file `spec/fixtures/ial2_test_portrait_match_failure.yml` for the front, back, and selfie image



## 👀 Screenshots

I know the bug we found wasn't affecting inline error messages, but I am including a screenshot of inline error messages for thoroughness's sake.

<details>
<summary>English errors (body copy):</summary>

![12268BugFixEnglish](https://github.com/18F/identity-idp/assets/80347702/18d8d00c-b0d5-4ad4-9ea9-f828235d16ae)

</details>

<details>
<summary>English errors (inline errors):</summary>

![12268BugFixEnglishInlineErrors](https://github.com/18F/identity-idp/assets/80347702/92c4af6c-e2ad-4465-9b52-5774a602d3de)

</details>


<details>
<summary>Spanish errors (body copy):</summary>

![12268BugFixSpanish](https://github.com/18F/identity-idp/assets/80347702/081934f4-0a15-451d-a2d6-1f6e04a535c1)
</details>

<details>
<summary>Spanish errors (inline errors):</summary>

![12268BugFixSpanishInlineErrors](https://github.com/18F/identity-idp/assets/80347702/701764c5-403f-4d98-8718-49a2649b0bfe)


</details>

<details>
<summary>French errors (body copy):</summary>

![12268BugFixFrench](https://github.com/18F/identity-idp/assets/80347702/babab0a2-7b01-4fd3-8709-efe19dc51d94)

</details>

<details>
<summary>French errors (inline errors):</summary>

![12268BugFixFrenchInlineErrors](https://github.com/18F/identity-idp/assets/80347702/9fc5093e-22f2-4368-988b-3ccc0dbcaf33)

</details>
