### PR TITLE
Revert "Ensure that the pids directory is present for puma"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,11 +77,6 @@ Vagrantfile
 .yardoc
 /doc/
 
-# Ignore pidfiles, but keep the directory.
-/tmp/pids/*
-!/tmp/pids
-!/tmp/pids/.keep
-
 package-lock.json
 browsers.json
 Brewfile.lock.json


### PR DESCRIPTION
Reverts 18F/identity-idp#10308

This is causing issues in deployed environments due to some weird things we do around symbolic links, so I'm reverting this until we can fix that.