### PR TITLE
LG-12365 Log rate limit status on verify-by-mail enter-code controller

### DIFF
--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Idv::ByMail::EnterCodeController, allowed_extra_analytics: [:*] d
         expect(@analytics).to have_logged_event(
           'IdV: enter verify by mail code visited',
           source: nil,
+          otp_rate_limited: false,
+          user_can_request_another_letter: true,
         )
         expect(response).to render_template('idv/by_mail/enter_code/index')
       end
@@ -74,6 +76,8 @@ RSpec.describe Idv::ByMail::EnterCodeController, allowed_extra_analytics: [:*] d
           expect(@analytics).to have_logged_event(
             'IdV: enter verify by mail code visited',
             source: nil,
+            user_can_request_another_letter: true,
+            otp_rate_limited: true,
           )
         end
       end
@@ -84,6 +88,16 @@ RSpec.describe Idv::ByMail::EnterCodeController, allowed_extra_analytics: [:*] d
         it 'sets @can_request_another_letter to false' do
           action
           expect(assigns(:can_request_another_letter)).to eql(false)
+        end
+
+        it 'augments analytics event' do
+          action
+          expect(@analytics).to have_logged_event(
+            'IdV: enter verify by mail code visited',
+            source: nil,
+            user_can_request_another_letter: false,
+            otp_rate_limited: false,
+          )
         end
       end
 
@@ -100,6 +114,8 @@ RSpec.describe Idv::ByMail::EnterCodeController, allowed_extra_analytics: [:*] d
           expect(@analytics).to have_logged_event(
             'IdV: enter verify by mail code visited',
             source: 'gpo_reminder_email',
+            user_can_request_another_letter: true,
+            otp_rate_limited: false,
           )
         end
       end


### PR DESCRIPTION
We have several rate limits that are enforced when the user visits the verify-by-mail code entry screen:

1. _OTP Rate-Limit_: This limit applies to OTP entries. After the user has entered too many OTPs this is enforced and the user is redirected to an error screen.
2. _Letter request limit_: This limit applies to letter requests. After the user has requested too many letters or if the users profile is too old the user no longer sees the option to request a new letter.

The enter code screen enforced these limits but did not add any indicator to the logs that it was doing so. This commit adds properties to the analytics event for each of these cases so we can monitor how the app is behaving.
