### PR TITLE
Add the ability to render an expanded `AccordionComponent`

### DIFF
--- a/app/components/accordion_component.html.erb
+++ b/app/components/accordion_component.html.erb
@@ -3,7 +3,7 @@
     <button
       type="button"
       class="usa-accordion__button"
-      aria-expanded="false"
+      aria-expanded=<%= expanded? ? 'true' : 'false' %>
       aria-controls="accordion-<%= unique_id %>"
     >
       <%= header %>

--- a/app/components/accordion_component.rb
+++ b/app/components/accordion_component.rb
@@ -3,8 +3,9 @@ class AccordionComponent < BaseComponent
 
   attr_reader :bordered, :tag_options
 
-  def initialize(bordered: true, **tag_options)
+  def initialize(bordered: true, expanded: false, **tag_options)
     @bordered = bordered
+    @expanded = expanded
     @tag_options = tag_options
   end
 
@@ -12,5 +13,9 @@ class AccordionComponent < BaseComponent
     classes = ['usa-accordion', *tag_options[:class]]
     classes << 'usa-accordion--bordered' if bordered
     classes
+  end
+
+  def expanded?
+    @expanded
   end
 end

--- a/spec/components/accordion_component_spec.rb
+++ b/spec/components/accordion_component_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe AccordionComponent, type: :component do
   let(:bordered) { nil }
+  let(:expanded) { nil }
   let(:tag_options) { {} }
-  let(:options) { { bordered:, **tag_options }.compact }
+  let(:options) { { bordered:, expanded:, **tag_options }.compact }
 
   subject(:rendered) do
     render_inline(described_class.new(**options)) do |c|
@@ -14,6 +15,7 @@ RSpec.describe AccordionComponent, type: :component do
 
   it 'renders an accordion' do
     expect(rendered).to have_css('.usa-accordion.usa-accordion--bordered')
+    expect(rendered).to have_css('button.usa-accordion__button[aria-expanded="false"]')
     expect(rendered).to have_css('.usa-accordion__heading', text: 'heading')
     expect(rendered).to have_css('.usa-accordion__content', text: 'content')
   end
@@ -34,6 +36,14 @@ RSpec.describe AccordionComponent, type: :component do
 
     it 'renders without bordered modifier' do
       expect(rendered).to have_css('.usa-accordion:not(.usa-accordion--bordered)')
+    end
+  end
+
+  context 'expanded' do
+    let(:expanded) { true }
+
+    it 'renders with expanded set to true' do
+      expect(rendered).to have_css('button.usa-accordion__button[aria-expanded="true"]')
     end
   end
 


### PR DESCRIPTION
In [LG-12064](https://cm-jira.usa.gov/browse/LG-12064) we have a change to render an accordion that is expanded by default on screen. Currently `AccordionComponent` does not support being rendered in this way.

The USWDS suggests that the underlying component can be [rendered open by default by setting the `aria-exapnded` attribute](https://designsystem.digital.gov/components/accordion/#using-the-accordion-component-2):

> Add the `aria-expanded="true"` attribute to any `usa-accordion__button` to have that section open by default at page load. When the accordion is initialized, the JavaScript will automatically add `aria-expanded="false"` attribute to all other accordion buttons.

This commit adds an `expanded` option to `AccordionComponent` and renders the component with `aria-expanded="true”` if it is set to true. The default value is false to maintain existing behavior.
