### PR TITLE
Render incorrect verify-by-mail OTP error inline

### DIFF
--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -11,36 +11,21 @@ module Idv
       before_action :confirm_verification_needed
 
       def index
-        # GPO reminder emails include an "I did not receive my letter!" link that results in
-        # slightly different copy on this screen.
-        @user_did_not_receive_letter = !!params[:did_not_receive_letter]
-
-        gpo_mail = Idv::GpoMail.new(current_user)
-        @can_request_another_letter =
-          FeatureManagement.gpo_verification_enabled? &&
-          !gpo_mail.rate_limited? &&
-          !gpo_mail.profile_too_old?
-
         analytics.idv_verify_by_mail_enter_code_visited(
-          source: if @user_did_not_receive_letter then 'gpo_reminder_email' end,
+          source: user_did_not_receive_letter? ? 'gpo_reminder_email' : nil,
           otp_rate_limited: rate_limiter.limited?,
-          user_can_request_another_letter: @can_request_another_letter,
+          user_can_request_another_letter: user_can_request_another_letter?,
         )
 
         if rate_limiter.limited?
-          redirect_to idv_enter_code_rate_limited_url
-          return
+          return redirect_to idv_enter_code_rate_limited_url
+        elsif pii_locked?
+          return redirect_to capture_password_url
         end
 
-        @last_date_letter_was_sent = last_date_letter_was_sent
-        @gpo_verify_form = GpoVerifyForm.new(user: current_user, pii: pii)
-        @code = session[:last_gpo_confirmation_code] if FeatureManagement.reveal_gpo_code?
-
-        if pii_locked?
-          redirect_to capture_password_url
-        else
-          render :index
-        end
+        prefilled_code = session[:last_gpo_confirmation_code] if FeatureManagement.reveal_gpo_code?
+        @gpo_verify_form = GpoVerifyForm.new(user: current_user, pii: pii, otp: prefilled_code)
+        render_enter_code_form
       end
 
       def pii
@@ -68,18 +53,22 @@ module Idv
           if rate_limiter.limited?
             redirect_to idv_enter_code_rate_limited_url
           else
-            flash[:error] = @gpo_verify_form.errors.first.message if !rate_limiter.limited?
-            redirect_to idv_verify_by_mail_enter_code_url
+            render_enter_code_form
           end
-          return
+        else
+          prepare_for_personal_key
+          redirect_to idv_personal_key_url
         end
-
-        prepare_for_personal_key
-
-        redirect_to idv_personal_key_url
       end
 
       private
+
+      def render_enter_code_form
+        @can_request_another_letter = user_can_request_another_letter?
+        @user_did_not_receive_letter = user_did_not_receive_letter?
+        @last_date_letter_was_sent = last_date_letter_was_sent
+        render :index
+      end
 
       def pending_in_person_enrollment?
         return false unless IdentityConfig.store.in_person_proofing_enabled
@@ -152,9 +141,29 @@ module Idv
         !Pii::Cacher.new(current_user, user_session).exists_in_session?
       end
 
+      # GPO reminder emails include an "I did not receive my letter!" link that results in
+      # slightly different copy on this screen.
+      def user_did_not_receive_letter?
+        !!params[:did_not_receive_letter]
+      end
+
+      def user_can_request_another_letter?
+        return @user_can_request_another_letter if defined?(@user_can_request_another_letter)
+        gpo_mail = Idv::GpoMail.new(current_user)
+        @user_can_request_another_letter =
+          FeatureManagement.gpo_verification_enabled? &&
+          !gpo_mail.rate_limited? &&
+          !gpo_mail.profile_too_old?
+      end
+
       def last_date_letter_was_sent
-        current_user.gpo_verification_pending_profile&.gpo_confirmation_codes&.
-          pluck(:updated_at)&.max
+        return @last_date_letter_was_sent if defined?(@last_date_letter_was_sent)
+
+        @last_date_letter_was_sent = current_user.
+          gpo_verification_pending_profile&.
+          gpo_confirmation_codes&.
+          pluck(:updated_at)&.
+          max
       end
     end
   end

--- a/app/views/idv/by_mail/enter_code/_form.html.erb
+++ b/app/views/idv/by_mail/enter_code/_form.html.erb
@@ -11,9 +11,6 @@
             maxlength: 10,
             required: true,
             autofocus: true,
-            input_html: {
-              value: @code,
-            },
             label: t('idv.gpo.form.otp_label'),
           ) %>
       <%= f.submit t('idv.gpo.form.submit'), full_width: true, wide: false, class: 'display-block margin-top-5' %>

--- a/app/views/idv/by_mail/enter_code/_form.html.erb
+++ b/app/views/idv/by_mail/enter_code/_form.html.erb
@@ -13,6 +13,7 @@
             autofocus: true,
             label: t('idv.gpo.form.otp_label'),
           ) %>
+      <%= hidden_field_tag :did_not_receive_letter, @did_not_receive_letter %>
       <%= f.submit t('idv.gpo.form.submit'), full_width: true, wide: false, class: 'display-block margin-top-5' %>
     </div>
   </div>

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -53,9 +53,7 @@ en:
       already_confirmed: was already confirmed, please try signing in
       blank: Please fill in this field.
       blank_cert_element_req: We cannot detect a certificate in your request.
-      confirmation_code_incorrect: Incorrect verification code. Did you type it in correctly?
-      confirmation_invalid_token: Invalid confirmation link. Either the link expired
-        or you already confirmed your account.
+      confirmation_code_incorrect: Incorrect verification code
       confirmation_period_expired: Expired confirmation link. You can click “Resend
         confirmation instructions” to get another one.
       expired: has expired, please request a new one

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -54,6 +54,8 @@ en:
       blank: Please fill in this field.
       blank_cert_element_req: We cannot detect a certificate in your request.
       confirmation_code_incorrect: Incorrect verification code
+      confirmation_invalid_token: Invalid confirmation link. Either the link expired
+        or you already confirmed your account.
       confirmation_period_expired: Expired confirmation link. You can click “Resend
         confirmation instructions” to get another one.
       expired: has expired, please request a new one

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -57,7 +57,7 @@ es:
       already_confirmed: ya estaba confirmado, por favor intente iniciar una sesión
       blank: Por favor, rellenar este campo.
       blank_cert_element_req: No podemos detectar un certificado en su solicitud.
-      confirmation_code_incorrect: Código de verificación incorrecto. ¿Lo escribió correctamente?
+      confirmation_code_incorrect: Código de verificación incorrecto
       confirmation_invalid_token: El enlace de confirmación no es válido. El enlace
         expiró o usted ya ha confirmado su cuenta.
       confirmation_period_expired: El enlace de confirmación expiró. Puede hacer clic

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -63,7 +63,7 @@ fr:
       already_confirmed: a déjà été confirmé, veuillez essayer de vous connecter
       blank: Veuillez remplir ce champ.
       blank_cert_element_req: Nous ne pouvons pas détecter un certificat sur votre demande.
-      confirmation_code_incorrect: Code de vérification incorrect. L’avez-vous saisi correctement ?
+      confirmation_code_incorrect: Code de vérification incorrect
       confirmation_invalid_token: Lien de confirmation non valide. Le lien est expiré
         ou vous avez déjà confirmé votre compte.
       confirmation_period_expired: Lien de confirmation expiré. Vous pouvez cliquer

--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe Idv::ByMail::EnterCodeController, allowed_extra_analytics: [:*] d
 
       let(:user) { create(:user, :with_pending_gpo_profile, created_at: 2.days.ago) }
 
-      it 'redirects to the index page to show errors' do
+      it 'renders to the index page to show errors' do
         action
 
         expect(@irs_attempts_api_tracker).to have_received(:idv_gpo_verification_submitted).
@@ -382,7 +382,7 @@ RSpec.describe Idv::ByMail::EnterCodeController, allowed_extra_analytics: [:*] d
           submit_attempts: 1,
           error_details: { otp: { confirmation_code_incorrect: true } },
         )
-        expect(response).to redirect_to(idv_verify_by_mail_enter_code_url)
+        expect(response).to render_template(:index)
       end
 
       it 'does not 500 with missing form keys' do

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
   end
 
   context 'coming from an "I did not receive my letter" link in a reminder email' do
-    it 'renders an alternate ui', :js do
+    it 'renders an alternate ui that remains after failed submission', :js do
       visit idv_verify_by_mail_enter_code_url(did_not_receive_letter: 1)
       verify_no_rate_limit_banner
       expect(current_path).to eql(new_user_session_path)
@@ -97,6 +97,13 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
 
       expect(current_path).to eq idv_verify_by_mail_enter_code_path
       expect(page).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
+
+      fill_in t('idv.gpo.form.otp_label'), with: 'incorrect1'
+      click_button t('idv.gpo.form.submit')
+
+      expect(current_path).to eq idv_verify_by_mail_enter_code_path
+      expect(page).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
+      expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))
     end
   end
 


### PR DESCRIPTION
Prior to this commit the verify-by-mail OTP submission would add errors to the flash and redirect to the OTP entry path. This lead to a couple problems:

1. The error for the OTP appeared in the flash instead of on the OTP field
2. The `did_not_receive_letter` param was not sticky i.e. when a user submitted the OTP it would switch back to the “Welcome back” UI. This was because the param was not present on the redirected URL.

This commit changes the implementation to closer match what we would expect from a controller using the [Form Object Pattern](https://dev.to/drbragg/rails-design-patterns-form-object-4d47). Specifically the `#create` action no longer redirects, but renders the `index` template with the `GpoVerifyForm` that was used for submission and thus has all of the errors and context for the submission.

One wrinkle with this approach is I had to set the `@can_request_another_letter`, `@user_did_not_receive_letter`, and `@last_date_letter_was_sent` ivars in the create action and in the index action. I opted to add a `#render_enter_code_form` method which handles setting up these ivars and rendering the index template.

I also had to add a hidden input to the form with the `did_not_receive_letter` param so it appears in the params on submission.

Here is what the form looked like before:

![image](https://github.com/18F/identity-idp/assets/963654/40f0256e-4ead-42c4-88d4-dc4f8d8fa8d5)

Here is what it looks like now:

![image](https://github.com/18F/identity-idp/assets/963654/f71a354c-cb2c-45cf-ade4-691dd72c6627)
