### PR TITLE
Remove Rack::ContentLength from being loaded outside of Rails

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -8,5 +8,4 @@ STDOUT.sync = true
 
 require ::File.expand_path('../config/environment', __FILE__)
 
-use Rack::ContentLength
 run Rails.application


### PR DESCRIPTION
## 🛠 Summary of changes

This fix is tied to the issues in #10304 / #10318. `RequestStore` depends on `Rack::BodyProxy`, which depends on the [close method being called](https://github.com/rack/rack/blob/main/lib/rack/body_proxy.rb#L31-L35) on the body so it can run the callbacks. Mysteriously, this wasn't happening, which caused `RequestStore` to not clean up after a request.

After digging a bit and removing as many Rack middlewares as possible and seeing what might causes the change in behavior, the culprit seems to be `use Rack::ContentLength` being called outside the Rails application. In testing this change, Content-Length is returned regardless due to the web server rather than application server handling it, and there should be no impact. I tested `RequestStore` a bit and it seemed to behave as expected with this change.

The issue was present when using both Puma and WEBrick since they both rely on being able to call `close` on the body ([Puma](https://github.com/puma/puma/blob/dfd33df/lib/puma/request.rb#L137), [WEBrick](https://github.com/rack/rackup/blob/482635c6216b7236013cba03c9d5c1dedd31b010/lib/rackup/handler/webrick.rb#L155)). I couldn't validate Passenger locally due to https://github.com/phusion/passenger/issues/2508, but I suspect the result would be [similar](https://github.com/phusion/passenger/blob/dd6b01e1029a377653450005156b1c36705ecb98/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb#L153).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
