### PR TITLE
Refactor component values into constant

### DIFF
--- a/app/services/vot/legacy_component_values.rb
+++ b/app/services/vot/legacy_component_values.rb
@@ -76,11 +76,13 @@ module Vot
       requirements: [:aal2, :hspd12],
     )
 
+    NAME_HASH = constants.map do |constant|
+      component_value = const_get(constant)
+      [component_value.name, component_value]
+    end.to_h
+
     def self.by_name
-      @by_name ||= constants.map do |constant|
-        component_value = const_get(constant)
-        [component_value.name, component_value]
-      end.to_h
+      NAME_HASH
     end
   end
 end

--- a/app/services/vot/supported_component_values.rb
+++ b/app/services/vot/supported_component_values.rb
@@ -37,11 +37,13 @@ module Vot
       requirements: [:biometric_comparison],
     )
 
+    NAME_HASH = constants.map do |constant|
+      component_value = const_get(constant)
+      [component_value.name, component_value]
+    end.to_h
+
     def self.by_name
-      @by_name ||= constants.map do |constant|
-        component_value = const_get(constant)
-        [component_value.name, component_value]
-      end.to_h
+      NAME_HASH
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

To get closer to being thread-safer, this PR refactors the VoT component values out of a class instance variable into a constant. This value is only written once with what should be the same value, so the current implementation is probably safe, but this is more of moving to best practices around thread-safety.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
