### PR TITLE
Tweak error message for have_logged_event

### DIFF
--- a/spec/support/have_logged_event_matcher.rb
+++ b/spec/support/have_logged_event_matcher.rb
@@ -136,6 +136,9 @@ class HaveLoggedEventMatcher
   end
 
   def ignored_attributes_description(actual_attributes)
+    using_matcher = !expected_attributes.nil? && !expected_attributes.instance_of?(Hash)
+    return if !using_matcher
+
     ignored_attributes = actual_attributes.except(*expected_attributes_hash.keys)
     return if ignored_attributes.empty?
 

--- a/spec/support/have_logged_event_matcher.rb
+++ b/spec/support/have_logged_event_matcher.rb
@@ -136,7 +136,7 @@ class HaveLoggedEventMatcher
   end
 
   def ignored_attributes_description(actual_attributes)
-    using_matcher = !expected_attributes.nil? && !expected_attributes.instance_of?(Hash)
+    using_matcher = expected_attributes && !expected_attributes.instance_of?(Hash)
     return if !using_matcher
 
     ignored_attributes = actual_attributes.except(*expected_attributes_hash.keys)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

I made a bunch of changes to how `have_logged_event` works in #10334, but I just found an issue where an error message is slightly weird in cases where an event is logged with extra, unexpected arguments. This PR tweaks the error message and adds a spec to cover the "extra arguments" case.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
