### PR TITLE
Fix Missing Hint Text on Android - Move the hint text inside the capture div

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -24,12 +24,13 @@ function AcuantSelfieCaptureCanvas({ imageCaptureText, onSelfieCaptureClosed }) 
   return (
     <>
       {!isReady && <LoadingSpinner />}
-      <div id={acuantCaptureContainerId} />
-      <p aria-live="assertive">
-        {imageCaptureText && (
-          <span className="document-capture-selfie-feedback">{imageCaptureText}</span>
-        )}
-      </p>
+      <div id={acuantCaptureContainerId}>
+        <p aria-live="assertive">
+          {imageCaptureText && (
+            <span className="document-capture-selfie-feedback">{imageCaptureText}</span>
+          )}
+        </p>
+      </div>
       <button type="button" onClick={onSelfieCaptureClosed} className="usa-sr-only">
         {t('doc_auth.buttons.close')}
       </button>


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

This PR fixes an issue where the hint text was not showing on Android/Chrome by moving the hint text inside the div that the Acuant SDK binds to. Before this PR the hint text would not show up on Android/Chrome most of the time.

I've tested that the hint text appears with this PR for:
- Android/Chrome
- iOS/Chrome
- iOS/Safari

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
