### PR TITLE
Fix issue where the “Did not receive letter” UI appears after incorrect submission

### DIFF
--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -144,7 +144,7 @@ module Idv
       # GPO reminder emails include an "I did not receive my letter!" link that results in
       # slightly different copy on this screen.
       def user_did_not_receive_letter?
-        !!params[:did_not_receive_letter].present?
+        params[:did_not_receive_letter].present?
       end
 
       def user_can_request_another_letter?

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -80,7 +80,7 @@ module Idv
       end
 
       def note_if_user_did_not_receive_letter
-        if !current_user && params[:did_not_receive_letter]
+        if !current_user && user_can_request_another_letter?
           # Stash that the user didn't receive their letter.
           # Once the authentication process completes, they'll be redirected to complete their
           # GPO verification...
@@ -144,7 +144,7 @@ module Idv
       # GPO reminder emails include an "I did not receive my letter!" link that results in
       # slightly different copy on this screen.
       def user_did_not_receive_letter?
-        !!params[:did_not_receive_letter]
+        !!params[:did_not_receive_letter].present?
       end
 
       def user_can_request_another_letter?

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -144,7 +144,7 @@ module Idv
       # GPO reminder emails include an "I did not receive my letter!" link that results in
       # slightly different copy on this screen.
       def user_did_not_receive_letter?
-        params[:did_not_receive_letter].present?
+        !!params[:did_not_receive_letter].present?
       end
 
       def user_can_request_another_letter?

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -80,7 +80,7 @@ module Idv
       end
 
       def note_if_user_did_not_receive_letter
-        if !current_user && user_can_request_another_letter?
+        if !current_user && user_did_not_receive_letter?
           # Stash that the user didn't receive their letter.
           # Once the authentication process completes, they'll be redirected to complete their
           # GPO verification...
@@ -144,7 +144,7 @@ module Idv
       # GPO reminder emails include an "I did not receive my letter!" link that results in
       # slightly different copy on this screen.
       def user_did_not_receive_letter?
-        !!params[:did_not_receive_letter].present?
+        params[:did_not_receive_letter].present?
       end
 
       def user_can_request_another_letter?

--- a/app/views/idv/by_mail/enter_code/_form.html.erb
+++ b/app/views/idv/by_mail/enter_code/_form.html.erb
@@ -13,7 +13,7 @@
             autofocus: true,
             label: t('idv.gpo.form.otp_label'),
           ) %>
-      <%= hidden_field_tag :did_not_receive_letter, @did_not_receive_letter %>
+      <%= hidden_field_tag :did_not_receive_letter, @user_did_not_receive_letter ? '1' : nil %>
       <%= f.submit t('idv.gpo.form.submit'), full_width: true, wide: false, class: 'display-block margin-top-5' %>
     </div>
   </div>

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -83,6 +83,23 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
     end
   end
 
+  it 'renders an error with the enter code ui if an incorrect code is entered' do
+    fill_in_credentials_and_submit(user.email, user.password)
+    continue_as(user.email, user.password)
+    uncheck(t('forms.messages.remember_device'))
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+
+    expect(current_path).to eq idv_verify_by_mail_enter_code_path
+    expect(page).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
+
+    fill_in t('idv.gpo.form.otp_label'), with: 'incorrect1'
+    click_button t('idv.gpo.form.submit')
+
+    expect(page).to have_css('h1', text: t('idv.gpo.intro_html'))
+    expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))
+  end
+
   context 'coming from an "I did not receive my letter" link in a reminder email' do
     it 'renders an alternate ui that remains after failed submission', :js do
       visit idv_verify_by_mail_enter_code_url(did_not_receive_letter: 1)

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -84,6 +84,7 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
   end
 
   it 'renders an error with the enter code ui if an incorrect code is entered' do
+    visit new_user_session_path
     fill_in_credentials_and_submit(user.email, user.password)
     continue_as(user.email, user.password)
     uncheck(t('forms.messages.remember_device'))
@@ -91,12 +92,12 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
     click_submit_default
 
     expect(current_path).to eq idv_verify_by_mail_enter_code_path
-    expect(page).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
+    expect(page).to have_css('h1', text: t('idv.gpo.title'))
 
     fill_in t('idv.gpo.form.otp_label'), with: 'incorrect1'
     click_button t('idv.gpo.form.submit')
 
-    expect(page).to have_css('h1', text: t('idv.gpo.intro_html'))
+    expect(page).to have_css('h1', text: t('idv.gpo.title'))
     expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))
   end
 


### PR DESCRIPTION
The verify-by-mail flow’s enter code screen has a hidden field for the “did_not_receive_letter” param. This allowed the “Did not receive letter” UI to be applied after a failed submission by inspecting the param like so:

```ruby
# GPO reminder emails include an "I did not receive my letter!" link that results in
# slightly different copy on this screen.
def user_did_not_receive_letter?
  !!params[:did_not_receive_letter]
end
```

However, the hidden input submits an empty string when the `@user_did_not_receive_letter` ivar is set to false. The empty string is truthy which made the UI revert to the “Did not receive letter” experience.

This commit fixes the issue by calling `present?` on the param.
