### PR TITLE
LG-11753 Update Enter Code (formerly, Welcome Back) Screen

### DIFF
--- a/app/views/idv/by_mail/enter_code/_enter_code.html.erb
+++ b/app/views/idv/by_mail/enter_code/_enter_code.html.erb
@@ -10,38 +10,43 @@
   <% end %>
 <% end %>
 
-<%= render AlertComponent.new(type: :info, class: 'margin-bottom-4', text_tag: 'div') do %>
-  <p>
-    <%= t('idv.gpo.alert_info') %>
-    <br>
-    <%= render 'shared/address', address: @gpo_verify_form.pii %>
-  </p>
-  <p>
-    <%= t('idv.gpo.wrong_address') %>
-    <%= link_to t('idv.gpo.clear_and_start_over'), idv_confirm_start_over_path %>
-  </p>
-<% end %>
-
 <%= render PageHeadingComponent.new.with_content(t('idv.gpo.title')) %>
 
-<%= t('idv.gpo.intro_html') %>
-
-<hr class="margin-y-4" />
-
-<h2><%= t('idv.gpo.form.title') %></h2>
-
-<p class="margin-bottom-1">
-  <%= t('idv.gpo.form.instructions') %>
-</p>
+<p><%= t('idv.gpo.intro') %></p>
 
 <%= render 'form' %>
 
-<% if @can_request_another_letter %>
-  <%= link_to t('idv.messages.gpo.resend'), idv_request_letter_path, class: 'display-block margin-bottom-2' %>
+<hr class="margin-y-4" />
+
+<%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
+  <% c.with_header { t('idv.gpo.address_accordion.title') } %>
+  <p><%= t('idv.gpo.address_accordion.body') %></p>
+  <p><%= render 'shared/address', address: @gpo_verify_form.pii %></p>
+  <p>
+    <%= t(
+          'idv.gpo.address_accordion.cta_html',
+          cta_link_html: link_to(
+            t('idv.gpo.address_accordion.cta_link'),
+            idv_confirm_start_over_path,
+          ),
+        ) %>
+  </p>
 <% end %>
 
-<%= link_to t('idv.gpo.return_to_profile'), account_path %>
+<p>
+  <%= t(
+        'idv.gpo.last_letter_request_message_html',
+        date_letter_was_sent: I18n.l(
+          @last_date_letter_was_sent,
+          format: :event_date,
+        ),
+      ) %>
+</p>
 
-<div class="margin-top-2 padding-top-2 border-top border-primary-light">
-  <%= link_to t('idv.messages.clear_and_start_over'), idv_confirm_start_over_path %>
-</div>
+<% if @can_request_another_letter %>
+  <%= link_to t('idv.messages.gpo.resend'), idv_request_letter_path, class: 'display-block margin-top-4' %>
+<% end %>
+
+<hr class="margin-y-4" />
+
+<%= link_to t('idv.gpo.return_to_profile'), account_path %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -174,6 +174,11 @@ en:
       state: State
       zipcode: ZIP Code
     gpo:
+      address_accordion:
+        body: 'We sent a letter with your verification code to:'
+        cta_html: Not the right address? %{cta_link_html}
+        cta_link: Clear your information and start over.
+        title: Where was my letter sent?
       alert_info: 'We sent a letter with your verification code to:'
       alert_rate_limit_warning_html: You can’t request more letters right now. Your
         previous letter request was on <strong>%{date_letter_was_sent}</strong>.
@@ -190,14 +195,14 @@ en:
             <span>%{request_new_letter_link}</span>.
         title: Didn’t get your letter?
       form:
-        instructions: Enter the 10-character code from the letter you received.
         otp_label: Verification code
-        submit: Confirm account
+        submit: Submit
         title: Confirm your account
-      intro_html: '<p>If you have received your letter, please enter your verification
-        code below. </p><p>If your letter hasn’t arrived yet, please be patient
-        as letters take up to <strong>10 days</strong> to arrive. Thank you for
-        your patience.</p>'
+      intro: Welcome back. Enter the 10-character code from the letter you received.
+      last_letter_request_message_html: You last requested a letter on
+        <strong>%{date_letter_was_sent}</strong>. If your letter hasn’t arrived
+        yet, please be patient as letters take up to <strong>10 days</strong> to
+        arrive. Thank you for your patience.
       request_another_letter:
         button: Request another letter
         instructions_html: Request a new letter if you have issues with your current
@@ -206,7 +211,7 @@ en:
         learn_more_link: Learn more about verifying your address by mail
         title: Request another letter?
       return_to_profile: Return to your profile
-      title: Welcome back
+      title: Enter your verification code
       wrong_address: Not the right address?
     images:
       come_back_later: Letter with a check mark

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -181,6 +181,11 @@ es:
       state: Estado
       zipcode: Código postal
     gpo:
+      address_accordion:
+        body: 'Le enviamos una carta con su código de verificación a:'
+        cta_html: ¿La dirección es incorrecta? %{cta_link_html}
+        cta_link: Borre su información y comience nuevamente.
+        title: ¿A dónde enviaron mi carta?
       alert_info: 'Enviamos una carta con su código de verificación a:'
       alert_rate_limit_warning_html: No puede solicitar más cartas por ahora. La fecha
         de su solicitud de carta anterior es el
@@ -198,14 +203,15 @@ es:
             <span>%{request_new_letter_link}</span>.
         title: '¿No recibió su carta?'
       form:
-        instructions: Introduzca el código de 10 caracteres de la carta que recibió.
         otp_label: Código de verificación
-        submit: Confirmar cuenta
+        submit: Enviar
         title: Confirme su cuenta
-      intro_html: '<p>Si ya recibió su carta, introduzca su código de verificación a
-        continuación. </p><p>Si su carta aún no ha llegado, tenga paciencia, ya
-        que las cartas tardan hasta <strong>10 días</strong> en llegar. Gracias
-        por su paciencia.</p>'
+      intro: Bienvenido de nuevo. Introduzca el código de 10 caracteres de la carta
+        que recibió.
+      last_letter_request_message_html: Usted solicitó una carta el
+        <strong>%{date_letter_was_sent}</strong>. Si aún no ha llegado, tenga
+        paciencia, ya que las cartas tardan hasta <strong>10 días</strong> en
+        llegar. Gracias por su paciencia.
       request_another_letter:
         button: Solicitar otra carta
         instructions_html: Solicite otra carta si tiene problemas con la carta actual o
@@ -215,7 +221,7 @@ es:
           por correo
         title: '¿Solicitar otra carta?'
       return_to_profile: Vuelva a su perfil
-      title: Bienvenido de nuevo
+      title: Introduzca su código de verificación
       wrong_address: '¿No es la dirección correcta?'
     images:
       come_back_later: Carta con una marca de verificación

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -257,7 +257,7 @@ es:
         learn_more_verify_by_mail: Obtenga más información sobre la verificación de su
           dirección por correo
         letter_on_the_way: Le enviaremos una carta
-        resend: Envíeme otra carta
+        resend: Envíenme otra carta
         start_over_html: Si esta no es la dirección correcta, tendrá que
           %{start_over_link_html}.
         start_over_link_text: empezar de nuevo y verificar con su nueva dirección

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -191,7 +191,12 @@ fr:
       state: État
       zipcode: Code postal
     gpo:
-      alert_info: 'Nous avons envoyé une lettre avec votre code de vérification à :'
+      address_accordion:
+        body: 'Nous avons envoyé une lettre avec votre code de vérification à :'
+        cta_html: Ce n’est pas la bonne adresse? %{cta_link_html}
+        cta_link: Effacez vos renseignements et recommencez.
+        title: Où ma lettre a-t-elle été envoyée?
+      alert_info: 'Nous avons envoyé une lettre avec votre code de vérification à :'
       alert_rate_limit_warning_html: Vous ne pouvez pas demander d’autres lettres pour
         le moment. Votre demande de lettre précédente a été effectuée le
         <strong>%{date_letter_was_sent}</strong>.
@@ -208,15 +213,16 @@ fr:
             pouvez <span>%{request_new_letter_link}</span>.
         title: Vous n’avez pas reçu votre lettre ?
       form:
-        instructions: Saisissez le code à 10 caractères que contient la lettre.
         otp_label: Code de vérification
-        submit: Confirmer le compte
+        submit: Valider
         title: Confirmez votre compte
-      intro_html: '<p>Si vous avez reçu votre lettre, veuillez saisir votre code de
-        vérification ci-dessous.</p><p>Les lettres mettent jusqu’à <strong>10
-        jours</strong> pour arriver. Par conséquent, si votre lettre ne vous est
-        pas encore parvenue, veuillez patienter. Nous vous remercions de votre
-        patience.</p>'
+      intro: Bienvenue à nouveau. Saisissez le code à 10 caractères contenu dans le
+        courrier que vous avez reçu.
+      last_letter_request_message_html: Vous avez demandé pour la dernière fois de
+        recevoir un courrier le <strong>%{date_letter_was_sent}</strong>. Si
+        votre lettre n’est pas encore arrivée, veuillez patienter car elle peut
+        mettre jusqu’à <strong>10 jours</strong>. Nous vous remercions de votre
+        patience.
       request_another_letter:
         button: Demander une autre lettre
         instructions_html: Vous pouvez demander une nouvelle lettre si vous avez des
@@ -226,7 +232,7 @@ fr:
         learn_more_link: En savoir plus sur la vérification de votre adresse par courrier
         title: Vous voulez demander une autre lettre ?
       return_to_profile: Retourner à votre profil
-      title: Bienvenue de nouveau
+      title: Saisir votre code de vérification
       wrong_address: Pas la bonne adresse ?
     images:
       come_back_later: Lettre avec une coche

--- a/config/locales/idv/zh.yml
+++ b/config/locales/idv/zh.yml
@@ -145,6 +145,11 @@ zh:
       state: 州
       zipcode: 邮编
     gpo:
+      address_accordion:
+        body: '我们把带有你验证代码的信寄发到了：'
+        cta_html: 地址不对？%{cta_link_html}
+        cta_link: 清除我的信息并重新开始。
+        title: 我的信寄发到哪里了？
       alert_info: '我们把带有你验证码的信件寄到了：'
       alert_rate_limit_warning_html: 你现在不能再要求发信了。你此前曾在<strong>%{date_letter_was_sent}</strong> 要求过信件。
       clear_and_start_over: 清除你的信息并重新开始。
@@ -157,20 +162,20 @@ zh:
           request_new_letter_prompt_html: 如果你尚未收到信，可以 <span>%{request_new_letter_link}</span>。
         title: 没收到信？
       form:
-        instructions: 输入你收到信中的由 10 个字符组成的代码。
         otp_label: 验证码
-        submit: 确认账户
+        submit: 提交
         title: 确认你的账户
-      intro_html:
-        '<p>如果你收到了信件，请在下面输入你的一次性代码 。</p><p>如果你的信件还没到，请耐心等待，因为信件最多需要
-        <strong>10 天</strong>才能送到。感谢你的耐心。</p>'
+      intro: 欢迎回来输入你收到信中的由 10 个字符组成的代码。
+      last_letter_request_message_html:
+        你最近一次要求我们发信是<strong>%{date_letter_was_sent}</strong>。如果你的信件还没到，请耐心一点，因为信件有可能需要<strong>10
+        days</strong>才能送到。感谢你的耐心。
       request_another_letter:
         button: 要求再发一封信
         instructions_html: 如果你目前的信有问题或者从未收到，请再要求发一封信。信件需要<strong>5 到 10 天</strong>到达。
         learn_more_link: 对通过邮件验证你地址获得更多了解
         title: 要求再发一封信？
       return_to_profile: 返回你的用户资料
-      title: 欢迎回来
+      title: 输入你的验证代码
       wrong_address: 地址不对？
     images:
       come_back_later: 带有打勾符的信件

--- a/spec/features/idv/confirm_start_over_spec.rb
+++ b/spec/features/idv/confirm_start_over_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'idv gpo confirm start over', js: true, allowed_extra_analytics: [
       gpo_verification_pending_at: 1.day.ago,
     )
   end
-  let(:gpo_confirmation_code) do
+  let!(:gpo_confirmation_code) do
     create(
       :gpo_confirmation_code,
       profile: profile,
@@ -52,7 +52,8 @@ RSpec.feature 'idv gpo confirm start over', js: true, allowed_extra_analytics: [
     it 'can cancel from confirmation screen' do
       expect(current_path).to eq idv_verify_by_mail_enter_code_path
 
-      click_on t('idv.messages.clear_and_start_over')
+      click_on t('idv.gpo.address_accordion.title')
+      click_on t('idv.gpo.address_accordion.cta_link')
 
       expect(current_path).to eq idv_confirm_start_over_path
       expect(page).to have_content(t('idv.cancel.description.gpo.start_over'))
@@ -65,7 +66,8 @@ RSpec.feature 'idv gpo confirm start over', js: true, allowed_extra_analytics: [
     end
 
     it 'can return back to verify screen from confirm screen' do
-      click_on t('idv.messages.clear_and_start_over')
+      click_on t('idv.gpo.address_accordion.title')
+      click_on t('idv.gpo.address_accordion.cta_link')
       click_on t('forms.buttons.back')
 
       expect(fake_analytics).to have_logged_event('IdV: gpo confirm start over visited')

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -314,7 +314,8 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
       complete_enter_password_step
       click_idv_continue
       click_on t('account.index.verification.reactivate_button')
-      click_on t('idv.messages.clear_and_start_over')
+      click_on t('idv.gpo.address_accordion.title')
+      click_on t('idv.gpo.address_accordion.cta_link')
       click_idv_continue
 
       expect(page).to have_current_path(idv_welcome_path)

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -12,11 +12,13 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
       :with_pii,
     )
   end
-  let(:gpo_confirmation_code) do
+  let!(:gpo_confirmation_code) do
     create(
       :gpo_confirmation_code,
       profile: profile,
       otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
+      created_at: 2.days.ago,
+      updated_at: 2.days.ago,
     )
   end
   let(:user) { profile.user }
@@ -165,7 +167,6 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
         expect(page).to have_content t('idv.messages.gpo.resend')
 
         verify_no_rate_limit_banner
-        gpo_confirmation_code
         fill_in t('idv.gpo.form.otp_label'), with: otp
         click_button t('idv.gpo.form.submit')
 
@@ -193,8 +194,7 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
     end
   end
 
-  it 'allows a user to cancel and start over in the footer' do
-    gpo_confirmation_code
+  it 'allows a user to cancel and start over in the accordion' do
     another_gpo_confirmation_code = create(
       :gpo_confirmation_code,
       profile: profile,
@@ -205,7 +205,7 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
     expect(current_path).to eq idv_verify_by_mail_enter_code_path
     verify_rate_limit_banner_present(another_gpo_confirmation_code.updated_at)
 
-    click_on t('idv.messages.clear_and_start_over')
+    click_on t('idv.gpo.address_accordion.cta_link')
 
     expect(current_path).to eq idv_confirm_start_over_path
 
@@ -238,7 +238,8 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
 
       sign_in_live_with_2fa(user)
 
-      click_on t('idv.messages.clear_and_start_over')
+      click_on t('idv.gpo.address_accordion.title')
+      click_on t('idv.gpo.address_accordion.cta_link')
       expect(current_path).to eq idv_confirm_start_over_path
       click_idv_continue
 

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -112,6 +112,7 @@ RSpec.feature 'idv request letter step', allowed_extra_analytics: [:*] do
     context 'logged in with PIV/CAC and no password' do
       it 'does not 500' do
         create(:profile, :with_pii, user: user, gpo_verification_pending_at: 1.day.ago)
+        create(:gpo_confirmation_code, profile: user.pending_profile)
         create(:piv_cac_configuration, user: user, x509_dn_uuid: 'helloworld', name: 'My PIV Card')
 
         signin_with_piv(user)
@@ -204,7 +205,7 @@ RSpec.feature 'idv request letter step', allowed_extra_analytics: [:*] do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(page).to have_content(t('idv.gpo.form.instructions'))
+      expect(page).to have_content(t('idv.gpo.intro'))
     end
   end
 end

--- a/spec/support/idv_examples/clearing_and_restarting.rb
+++ b/spec/support/idv_examples/clearing_and_restarting.rb
@@ -1,6 +1,7 @@
 RSpec.shared_examples 'clearing and restarting idv' do
   it 'allows the user to retry verification with phone', js: true do
-    click_on t('idv.messages.clear_and_start_over')
+    click_on t('idv.gpo.address_accordion.title')
+    click_on t('idv.gpo.address_accordion.cta_link')
     click_idv_continue
 
     expect(user.reload.pending_profile?).to eq(false)
@@ -15,7 +16,8 @@ RSpec.shared_examples 'clearing and restarting idv' do
   end
 
   it 'allows the user to retry verification with gpo', js: true do
-    click_on t('idv.messages.clear_and_start_over')
+    click_on t('idv.gpo.address_accordion.title')
+    click_on t('idv.gpo.address_accordion.cta_link')
     click_idv_continue
 
     expect(user.reload.pending_profile?).to eq(false)
@@ -40,7 +42,8 @@ RSpec.shared_examples 'clearing and restarting idv' do
   end
 
   it 'deletes decrypted PII from the session and does not display it on the account page' do
-    click_on t('idv.messages.clear_and_start_over')
+    click_on t('idv.gpo.address_accordion.title')
+    click_on t('idv.gpo.address_accordion.cta_link')
     click_idv_continue
 
     visit account_path

--- a/spec/support/idv_examples/verification_code_entry.rb
+++ b/spec/support/idv_examples/verification_code_entry.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples 'verification code entry' do
     sign_in_live_with_2fa(user)
 
     expect(GpoConfirmation.count).to eq(0)
-    expect(GpoConfirmationCode.count).to eq(0)
+    expect(GpoConfirmationCode.count).to eq(1)
     click_on t('idv.messages.gpo.resend')
 
     expect_step_indicator_current_step(t('step_indicator.flows.idv.get_a_letter'))
@@ -58,7 +58,7 @@ RSpec.shared_examples 'verification code entry' do
     click_on t('idv.gpo.request_another_letter.button')
 
     expect(GpoConfirmation.count).to eq(1)
-    expect(GpoConfirmationCode.count).to eq(1)
+    expect(GpoConfirmationCode.count).to eq(2)
     expect(current_path).to eq idv_letter_enqueued_path
 
     confirmation_code = GpoConfirmationCode.first


### PR DESCRIPTION
This commit makes changes to the Enter Code screen in the welcome back flow. It updates the address and “Clear my information and start over” link to be in an accordion, makes content updates, and rearranges some of the elements.
