### PR TITLE
Fixing spec issues related to How to Verify page changes

### DIFF
--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
         it 'goes to direct IPP if selected and can come back' do
           expect(page).to have_current_path(idv_how_to_verify_path)
           expect(page).to have_content(t('doc_auth.headings.how_to_verify'))
-          complete_how_to_verify_step(remote: false)
+          click_on t('forms.buttons.continue_ipp')
           expect(page).to have_current_path(idv_document_capture_path)
           expect_in_person_step_indicator_current_step(
             t('step_indicator.flows.idv.find_a_post_office'),

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -380,8 +380,7 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true,
         context 'when sp ipp is available' do
           before do
             expect(page).to have_current_path(idv_how_to_verify_path)
-            choose t('doc_auth.tips.most_common')
-            click_on t('doc_auth.buttons.continue')
+            click_on t('forms.buttons.continue_remote')
           end
           context 'when selfie is enabled system wide' do
             describe 'when selfie is required by sp' do


### PR DESCRIPTION
## 🎫 Ticket

No ticket. Noticed a few failing specs and realized they were related to some changes done to the How To Verify page and supporting specs. This pr should get the specs back to green.