### PR TITLE
Parse config CSV values as CSV

### DIFF
--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 class IdentityConfig
   GIT_SHA = `git rev-parse --short=8 HEAD`.chomp
   GIT_TAG = `git tag --points-at HEAD`.chomp.split("\n").first
@@ -28,7 +30,7 @@ class IdentityConfig
     end,
     symbol: proc { |value| value.to_sym },
     comma_separated_string_list: proc do |value|
-      value.split(',')
+      value.parse_csv.to_a
     end,
     integer: proc do |value|
       Integer(value)

--- a/spec/lib/identity_config_spec.rb
+++ b/spec/lib/identity_config_spec.rb
@@ -30,6 +30,24 @@ RSpec.describe IdentityConfig do
     end
   end
 
+  describe '::CONVERTERS' do
+    describe 'comma_separated_string_list' do
+      it 'respects double-quotes for embedded commas' do
+        config = IdentityConfig.new({ csv_value: 'one,two,"three,four"' })
+        config.add(:csv_value, type: :comma_separated_string_list)
+
+        expect(config.written_env).to eq(csv_value: ['one', 'two', 'three,four'])
+      end
+
+      it 'parses empty value as empty array' do
+        config = IdentityConfig.new({ csv_value: '' })
+        config.add(:csv_value, type: :comma_separated_string_list)
+
+        expect(config.written_env).to eq(csv_value: [])
+      end
+    end
+  end
+
   describe 'idv_contact_phone_number' do
     it 'has config value for contact phone number' do
       contact_number = IdentityConfig.store.idv_contact_phone_number


### PR DESCRIPTION
## 🛠 Summary of changes

Improves `IdentityConfig` converter for `comma_separated_string_list` to support CSV values embedding commas within double-quoted segments.

This is in response to a [recent discovery that this was unsupported](https://gsa-tts.slack.com/archives/C5QUGUANN/p1711990069167089?thread_ts=1710534224.779029&cid=C5QUGUANN), which led to delays implementing a fix, and required a workaround in #10346 and patch deploy of [RC 367.1](https://github.com/18F/identity-idp/releases/tag/2024-04-01T191527). The changes included here could have avoided the need for that.

## 📜 Testing Plan

```
rspec spec/lib/identity_config_spec.rb
```

Validate compatibility of remaining uses of `comma_separated_list_value`:

* `requests_per_ip_cidr_allowlist`
* `requests_per_ip_path_prefixes_allowlist`
* `test_ssn_allowed_list`