### PR TITLE
Improve PIV CSP test assertion for order independence

### DIFF
--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -15,8 +15,8 @@ RSpec.feature 'PIV/CAC Management', allowed_extra_analytics: [:*] do
       visit account_two_factor_authentication_path
       click_link t('account.index.piv_cac_add'), href: setup_piv_cac_url
 
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include("form-action https://*.pivcac.test.example.com 'self';"))
+      expect(page.response_headers['Content-Security-Policy'].split(';').map(&:strip)).
+        to(include("form-action https://*.pivcac.test.example.com 'self'"))
 
       nonce = piv_cac_nonce_from_form_action
 


### PR DESCRIPTION
## 🛠 Summary of changes

Improve PIV CSP test assertion for order independence, to resolve a flakey test.

Example: https://gitlab.login.gov/lg/identity-idp/-/jobs/1114999

The issue is that the previous assertion assumed that the `form-action` directive would never occur last and therefore always be suffixed with `;`. This doesn't appear to always be deterministic. The solution is to split the directives by the semi-colon joiner, which also preserves the expectation that the `form-action` value _only_ includes the asserted text.

## 📜 Testing Plan

```
rspec spec/features/users/piv_cac_management_spec.rb:18
```