### PR TITLE
Remove Doc Auth AB Test Fallbacks

### DIFF
--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -199,18 +199,11 @@ module DocAuthRouter
   def self.doc_auth_vendor(discriminator: nil, analytics: nil)
     case AbTests::DOC_AUTH_VENDOR.bucket(discriminator)
     when :alternate_vendor
-      vendor = IdentityConfig.store.doc_auth_vendor_randomize_alternate_vendor
+      IdentityConfig.store.doc_auth_vendor_randomize_alternate_vendor
     else
       analytics&.idv_doc_auth_randomizer_defaulted if discriminator.blank?
 
-      vendor = IdentityConfig.store.doc_auth_vendor
+      IdentityConfig.store.doc_auth_vendor
     end
-
-    # if vendor is not set to mock and selfie enabled use lexisnexis
-    if FeatureManagement.idv_allow_selfie_check? &&
-       vendor != Idp::Constants::Vendors::MOCK
-      vendor = Idp::Constants::Vendors::LEXIS_NEXIS
-    end
-    vendor
   end
 end

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -72,32 +72,6 @@ RSpec.describe DocAuthRouter, allowed_extra_analytics: [:*] do
 
         expect(result).to eq(doc_auth_vendor)
       end
-
-      context 'when selfie is enabled' do
-        before do
-          expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-            and_return(true)
-        end
-        context 'when vendor is not set to mock' do
-          it 'chose lexisnexis' do
-            result = DocAuthRouter.doc_auth_vendor(
-              discriminator: discriminator,
-              analytics: analytics,
-            )
-            expect(result).to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
-          end
-        end
-        context 'when vendor is set to mock' do
-          let(:doc_auth_vendor) { Idp::Constants::Vendors::MOCK }
-          it 'stays with the mock' do
-            result = DocAuthRouter.doc_auth_vendor(
-              discriminator: discriminator,
-              analytics: analytics,
-            )
-            expect(result).to eq(Idp::Constants::Vendors::MOCK)
-          end
-        end
-      end
     end
 
     context 'with a discriminator that hashes inside the test group' do
@@ -110,25 +84,6 @@ RSpec.describe DocAuthRouter, allowed_extra_analytics: [:*] do
       it 'is the alternate vendor' do
         expect(DocAuthRouter.doc_auth_vendor(discriminator: discriminator)).
           to eq(doc_auth_vendor_randomize_alternate_vendor)
-      end
-
-      context 'with selfie enabled' do
-        before do
-          expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-            and_return(true)
-        end
-        it 'is the lexisnexis vendor' do
-          expect(DocAuthRouter.doc_auth_vendor(discriminator: discriminator)).
-            to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
-        end
-
-        context 'when alternate is set to mock' do
-          let(:doc_auth_vendor_randomize_alternate_vendor) { Idp::Constants::Vendors::MOCK }
-          it 'stays with the mock vendor' do
-            expect(DocAuthRouter.doc_auth_vendor(discriminator: discriminator)).
-              to eq(Idp::Constants::Vendors::MOCK)
-          end
-        end
       end
 
       context 'with randomize false' do


### PR DESCRIPTION
## 🛠 Summary of changes

A followup to https://github.com/18F/identity-idp/pull/9561 where fallback logic was added to handle vendors and selfies. With only two vendors remaining after https://github.com/18F/identity-idp/pull/10198, this fallback logic no longer seems to be necessary.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
