### PR TITLE
LG-12064 Update "Didn't get your letter?" screen

### DIFF
--- a/app/views/idv/by_mail/enter_code/_did_not_receive_letter.html.erb
+++ b/app/views/idv/by_mail/enter_code/_did_not_receive_letter.html.erb
@@ -10,43 +10,49 @@
   <% end %>
 <% end %>
 
-<%= render AlertComponent.new(type: :info, class: 'margin-bottom-4', text_tag: 'div') do %>
-  <p>
-    <%= t('idv.gpo.alert_info') %>
-    <br>
-    <%= render 'shared/address', address: @gpo_verify_form.pii %>
-  </p>
-  <p>
-    <%= t('idv.gpo.wrong_address') %>
-    <%= link_to t('idv.gpo.clear_and_start_over'), idv_confirm_start_over_path %>
-  </p>
-<% end %>
-
 <%= render PageHeadingComponent.new.with_content(t('idv.gpo.did_not_receive_letter.title')) %>
 
-<% if @can_request_another_letter %>
+<p>
   <%= t(
-        'idv.gpo.did_not_receive_letter.intro.request_new_letter_prompt_html',
-        request_new_letter_link: link_to(
-          t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
-          idv_request_letter_path,
+        'idv.gpo.did_not_receive_letter.intro_html',
+        date_letter_was_sent: I18n.l(
+          @last_date_letter_was_sent,
+          format: :event_date,
         ),
       ) %>
+</p>
+
+<%= render AccordionComponent.new(class: 'margin-bottom-4') do |c| %>
+  <% c.with_header { t('idv.gpo.address_accordion.title') } %>
+  <p><%= t('idv.gpo.address_accordion.body') %></p>
+  <p><%= render 'shared/address', address: @gpo_verify_form.pii %></p>
+  <p>
+    <%= t(
+          'idv.gpo.address_accordion.cta_html',
+          cta_link_html: link_to(
+            t('idv.gpo.address_accordion.cta_link'),
+            idv_confirm_start_over_path,
+          ),
+        ) %>
+  </p>
 <% end %>
-<%= t('idv.gpo.did_not_receive_letter.intro.be_patient_html') %>
+
+<p>
+  <%= t('idv.gpo.did_not_receive_letter.request_a_new_letter_html') %>
+</p>
+
+<% if @can_request_another_letter %>
+  <%= link_to t('idv.messages.gpo.resend'), idv_request_letter_path, class: 'display-block margin-top-4' %>
+<% end %>
 
 <hr class="margin-y-4" />
 
-<h2><%= t('idv.gpo.form.title') %></h2>
+<h2><%= t('idv.gpo.title') %></h2>
 
-<p class="margin-bottom-1">
-  <%= t('idv.gpo.did_not_receive_letter.form.instructions') %>
-</p>
+<p><%= t('idv.gpo.did_not_receive_letter.form.instructions') %></p>
 
 <%= render 'form' %>
 
-<%= link_to t('idv.gpo.return_to_profile'), account_path %>
+<hr class="margin-y-4" />
 
-<div class="margin-top-2 padding-top-2 border-top border-primary-light">
-  <%= link_to t('idv.messages.clear_and_start_over'), idv_confirm_start_over_path %>
-</div>
+<%= link_to t('idv.gpo.return_to_profile'), account_path %>

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -179,25 +179,21 @@ en:
         cta_html: Not the right address? %{cta_link_html}
         cta_link: Clear your information and start over.
         title: Where was my letter sent?
-      alert_info: 'We sent a letter with your verification code to:'
       alert_rate_limit_warning_html: You can’t request more letters right now. Your
         previous letter request was on <strong>%{date_letter_was_sent}</strong>.
-      clear_and_start_over: Clear your information and start over
       did_not_receive_letter:
         form:
           instructions: If you have your letter, enter the 10-character code from the
             letter you received.
-        intro:
-          be_patient_html: Please note that letters take up to <strong>10 days</strong> to
-            arrive. Thank you for your patience.
-          request_new_letter_link: request a new letter
-          request_new_letter_prompt_html: If you haven’t received your letter, you may
-            <span>%{request_new_letter_link}</span>.
+        intro_html: You last requested a letter on
+          <strong>%{date_letter_was_sent}</strong>.
+        request_a_new_letter_html: Request a new letter if it’s been over <strong>10
+          days</strong> since you last requested a letter or if your
+          verification code has expired.
         title: Didn’t get your letter?
       form:
         otp_label: Verification code
         submit: Submit
-        title: Confirm your account
       intro: Welcome back. Enter the 10-character code from the letter you received.
       last_letter_request_message_html: You last requested a letter on
         <strong>%{date_letter_was_sent}</strong>. If your letter hasn’t arrived
@@ -212,14 +208,12 @@ en:
         title: Request another letter?
       return_to_profile: Return to your profile
       title: Enter your verification code
-      wrong_address: Not the right address?
     images:
       come_back_later: Letter with a check mark
     messages:
       activated_html: Your identity has been verified. If you need to change your
         verified information, please %{link_html}.
       activated_link: contact us
-      clear_and_start_over: Clear my information and start over
       come_back_later_html: <p>Letters take <strong>5 to 10 days</strong> to arrive
         via USPS First-Class Mail.</p> <p>Once your letter arrives, sign in to
         %{app_name}, and enter your verification code when prompted.</p>

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -186,26 +186,22 @@ es:
         cta_html: ¿La dirección es incorrecta? %{cta_link_html}
         cta_link: Borre su información y comience nuevamente.
         title: ¿A dónde enviaron mi carta?
-      alert_info: 'Enviamos una carta con su código de verificación a:'
-      alert_rate_limit_warning_html: No puede solicitar más cartas por ahora. La fecha
-        de su solicitud de carta anterior es el
+      alert_rate_limit_warning_html: No puede solicitar más cartas ahora mismo. Su
+        solicitud de carta anterior la hizo el
         <strong>%{date_letter_was_sent}</strong>.
-      clear_and_start_over: Borre su información y empiece de nuevo
       did_not_receive_letter:
         form:
           instructions: Si ya tiene su carta, introduzca el código de 10 caracteres de la
             carta que recibió.
-        intro:
-          be_patient_html: Recuerde que las cartas tardan hasta <strong>10 días</strong>
-            en llegar. Gracias por su paciencia.
-          request_new_letter_link: solicitar una carta nueva
-          request_new_letter_prompt_html: Si no ha recibido su carta, puede
-            <span>%{request_new_letter_link}</span>.
-        title: '¿No recibió su carta?'
+        intro_html: La última vez que solicitó una carta fue el
+          <strong>%{date_letter_was_sent}</strong>.
+        request_a_new_letter_html: Solicite una nueva carta si han pasado más de
+          <strong>10 días</strong> desde la última vez que la solicitó o si su
+          código de verificación ha caducado.
+        title: ¿No recibió su carta?
       form:
         otp_label: Código de verificación
         submit: Enviar
-        title: Confirme su cuenta
       intro: Bienvenido de nuevo. Introduzca el código de 10 caracteres de la carta
         que recibió.
       last_letter_request_message_html: Usted solicitó una carta el
@@ -222,14 +218,12 @@ es:
         title: '¿Solicitar otra carta?'
       return_to_profile: Vuelva a su perfil
       title: Introduzca su código de verificación
-      wrong_address: '¿No es la dirección correcta?'
     images:
       come_back_later: Carta con una marca de verificación
     messages:
       activated_html: Se verificó su identidad. Si necesita cambiar la información
         verificada, %{link_html}.
       activated_link: contáctenos
-      clear_and_start_over: Borrar mi información y empezar de nuevo
       come_back_later_html: '<p>Las cartas tardan de <strong>5 a 10 días</strong> en
         llegar por First-Class Mail del Servicio Postal de los EE. UU.
         (USPS).</p> <p>Una vez que reciba su carta, inicie sesión en %{app_name}

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -196,26 +196,22 @@ fr:
         cta_html: Ce n’est pas la bonne adresse? %{cta_link_html}
         cta_link: Effacez vos renseignements et recommencez.
         title: Où ma lettre a-t-elle été envoyée?
-      alert_info: 'Nous avons envoyé une lettre avec votre code de vérification à :'
       alert_rate_limit_warning_html: Vous ne pouvez pas demander d’autres lettres pour
         le moment. Votre demande de lettre précédente a été effectuée le
         <strong>%{date_letter_was_sent}</strong>.
-      clear_and_start_over: Effacez vos renseignements et recommencez
       did_not_receive_letter:
         form:
-          instructions: Si vous avez disposez de votre lettre, veuillez entrer le code à
-            10 caractères qu’elle contient.
-        intro:
-          be_patient_html: Veuillez noter que les lettres mettent jusqu’à <strong>10
-            jours</strong> pour arriver. Nous vous remercions de votre patience.
-          request_new_letter_link: demander une nouvelle lettre
-          request_new_letter_prompt_html: Si votre lettre n’est pas encore arrivée, vous
-            pouvez <span>%{request_new_letter_link}</span>.
+          instructions: Si vous avez votre lettre, veuillez saisir le code à 10 caractères
+            qu’elle contient.
+        intro_html: Vous avez demandé pour la dernière fois de recevoir un courrier le
+          <strong>%{date_letter_was_sent}</strong>.
+        request_a_new_letter_html: Demandez à recevoir un nouveau courrier si plus de
+          <strong>10 jours</strong> se sont écoulés depuis la dernière fois que
+          vous en avez demandé un ou si votre code de vérification a expiré.
         title: Vous n’avez pas reçu votre lettre ?
       form:
         otp_label: Code de vérification
         submit: Valider
-        title: Confirmez votre compte
       intro: Bienvenue à nouveau. Saisissez le code à 10 caractères contenu dans le
         courrier que vous avez reçu.
       last_letter_request_message_html: Vous avez demandé pour la dernière fois de
@@ -233,14 +229,12 @@ fr:
         title: Vous voulez demander une autre lettre ?
       return_to_profile: Retourner à votre profil
       title: Saisir votre code de vérification
-      wrong_address: Pas la bonne adresse ?
     images:
       come_back_later: Lettre avec une coche
     messages:
       activated_html: Votre identité a été vérifiée. Si vous souhaitez modifier les
         informations qui ont été vérifiées, veuillez %{link_html}.
       activated_link: nous contacter
-      clear_and_start_over: Effacer mes renseignements et recommencer
       come_back_later_html: '<p>Les lettres mettent <strong>5 à 10 jours</strong> pour
         arriver par courrier prioritaire via USPS.</p> <p>Une fois votre lettre
         arrivée, connectez-vous à %{app_name} et saisissez votre code de

--- a/config/locales/idv/zh.yml
+++ b/config/locales/idv/zh.yml
@@ -150,21 +150,16 @@ zh:
         cta_html: 地址不对？%{cta_link_html}
         cta_link: 清除我的信息并重新开始。
         title: 我的信寄发到哪里了？
-      alert_info: '我们把带有你验证码的信件寄到了：'
       alert_rate_limit_warning_html: 你现在不能再要求发信了。你此前曾在<strong>%{date_letter_was_sent}</strong> 要求过信件。
-      clear_and_start_over: 清除你的信息并重新开始。
       did_not_receive_letter:
         form:
           instructions: 如果你收到了信，请输入信中由 10 个字符组成的代码。
-        intro:
-          be_patient_html: 请注意信件最多需要<strong> 10 天</strong>才能送到。感谢你的耐心。
-          request_new_letter_link: 要求再发一封信
-          request_new_letter_prompt_html: 如果你尚未收到信，可以 <span>%{request_new_letter_link}</span>。
+        intro_html: 你最近一次要求我们发信是<strong>%{date_letter_was_sent}</strong>.
+        request_a_new_letter_html: 如果从你最近一次要求信件后 <strong>10 天</strong>已经过去了，或者你的验证代码已失效，请重新要求一封信。
         title: 没收到信？
       form:
         otp_label: 验证码
         submit: 提交
-        title: 确认你的账户
       intro: 欢迎回来输入你收到信中的由 10 个字符组成的代码。
       last_letter_request_message_html:
         你最近一次要求我们发信是<strong>%{date_letter_was_sent}</strong>。如果你的信件还没到，请耐心一点，因为信件有可能需要<strong>10
@@ -176,13 +171,11 @@ zh:
         title: 要求再发一封信？
       return_to_profile: 返回你的用户资料
       title: 输入你的验证代码
-      wrong_address: 地址不对？
     images:
       come_back_later: 带有打勾符的信件
     messages:
       activated_html: 你的身份已经验证。如要更改已验证过的你的信息，请 %{link_html}。
       activated_link: 联系我们
-      clear_and_start_over: 清除我的信息并重新开始。
       come_back_later_html: <p> 美国邮局平信一般需要 <strong> 5 到 10 天</strong> 送达。</p> <p>
         你的信件到达后，请登录 %{app_name}，并按照提示输入你的验证码 </p>。
       come_back_later_no_sp_html: 你目前可以返回你的<strong>%{app_name} 账户</strong> 了。

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -179,12 +179,19 @@ RSpec.feature 'idv enter letter code step', allowed_extra_analytics: [:*] do
       sign_in_live_with_2fa(user)
 
       expect(current_path).to eq idv_verify_by_mail_enter_code_path
-      expect(page).to have_content t('idv.gpo.alert_info')
-      expect(page).to have_content t('idv.gpo.wrong_address')
+      expect(page).to have_content t('idv.gpo.intro')
+      expect(page).to have_content(
+        strip_tags(
+          t(
+            'idv.gpo.address_accordion.cta_html',
+            cta_link_html: t('idv.gpo.address_accordion.cta_link'),
+          ),
+        ),
+      )
       expect(page).to have_content Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:address1]
       verify_no_rate_limit_banner
 
-      click_on t('idv.gpo.clear_and_start_over')
+      click_on t('idv.gpo.address_accordion.cta_link')
 
       expect(current_path).to eq idv_confirm_start_over_path
 

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -153,14 +153,14 @@ RSpec.feature 'idv request letter step', allowed_extra_analytics: [:*] do
     def confirm_rate_limited
       expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
       expect(page).not_to have_link(
-        t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
+        t('idv.messages.gpo.resend'),
       )
       # does not allow the user to go to the resend page manually
       visit idv_request_letter_path
 
       expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
       expect(page).not_to have_link(
-        t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
+        t('idv.messages.gpo.resend'),
       )
     end
   end

--- a/spec/views/idv/by_mail/enter_code/index.html.erb_spec.rb
+++ b/spec/views/idv/by_mail/enter_code/index.html.erb_spec.rb
@@ -51,24 +51,26 @@ RSpec.describe 'idv/by_mail/enter_code/index.html.erb' do
       expect(rendered).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
     end
 
-    it 'has a special intro paragraph' do
+    it 'has a special body text' do
       expect(rendered).to have_content(
         strip_tags(
           t(
-            'idv.gpo.did_not_receive_letter.intro.request_new_letter_prompt_html',
-            request_new_letter_link:
-              t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
+            'idv.gpo.did_not_receive_letter.intro_html',
+            date_letter_was_sent: I18n.l(
+              last_date_letter_was_sent,
+              format: :event_date,
+            ),
           ),
         ),
       )
       expect(rendered).to have_content(
-        strip_tags(t('idv.gpo.did_not_receive_letter.intro.be_patient_html')),
+        strip_tags(t('idv.gpo.did_not_receive_letter.request_a_new_letter_html')),
       )
     end
 
     it 'links to requesting a new letter' do
       expect(rendered).to have_link(
-        t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
+        t('idv.messages.gpo.resend'),
         href: idv_request_letter_path,
       )
     end
@@ -79,25 +81,29 @@ RSpec.describe 'idv/by_mail/enter_code/index.html.erb' do
       )
     end
 
-    it 'does not link to requesting a new letter at the bottom of the page' do
-      expect(rendered).not_to have_link(
-        t('idv.messages.gpo.resend'),
-        href: idv_request_letter_path,
-      )
-    end
-
     context 'user is NOT allowed to request another GPO letter' do
       let(:can_request_another_letter) { false }
 
-      it 'still has a special intro' do
+      it 'still has a special body text' do
         expect(rendered).to have_content(
-          strip_tags(t('idv.gpo.did_not_receive_letter.intro.be_patient_html')),
+          strip_tags(
+            t(
+              'idv.gpo.did_not_receive_letter.intro_html',
+              date_letter_was_sent: I18n.l(
+                last_date_letter_was_sent,
+                format: :event_date,
+              ),
+            ),
+          ),
+        )
+        expect(rendered).to have_content(
+          strip_tags(t('idv.gpo.did_not_receive_letter.request_a_new_letter_html')),
         )
       end
 
       it 'does not link to requesting a new letter' do
-        expect(rendered).not_to have_link(
-          t('idv.gpo.did_not_receive_letter.intro.request_new_letter_link'),
+        expect(rendered).to_not have_link(
+          t('idv.messages.gpo.resend'),
           href: idv_request_letter_path,
         )
       end


### PR DESCRIPTION
This commit makes changes to the "Didn't get your letter" screen in the welcome back flow. It updates the address and “Clear my information and start over” link to be in an accordion, makes content updates, and rearranges some of the elements.
