### PR TITLE
Use CSV.parse_line for config CSV parse

### DIFF
--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -30,7 +30,7 @@ class IdentityConfig
     end,
     symbol: proc { |value| value.to_sym },
     comma_separated_string_list: proc do |value|
-      value.parse_csv.to_a
+      CSV.parse_line(value).to_a
     end,
     integer: proc do |value|
       Integer(value)


### PR DESCRIPTION
## 🛠 Summary of changes

Swaps `String#parse_csv` monkeypatch with more explicit `CSV.parse_line`, as suggested at https://github.com/18F/identity-idp/pull/10354#discussion_r1550099351 .

## 📜 Testing Plan

```
rspec spec/lib/identity_config_spec.rb
```