### PR TITLE
Consolidate identity verification accessibility tests to improve test speed

### DIFF
--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -9,14 +9,6 @@ RSpec.feature 'Accessibility on IDV pages', :js, allowed_extra_analytics: [:*] d
       create(:service_provider, :active, :in_person_proofing_enabled)
     end
 
-    scenario 'home page' do
-      sign_in_and_2fa_user
-
-      visit idv_path
-
-      expect_page_to_have_no_accessibility_violations(page)
-    end
-
     scenario 'how to verify page' do
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
       allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
@@ -32,47 +24,15 @@ RSpec.feature 'Accessibility on IDV pages', :js, allowed_extra_analytics: [:*] d
       expect_page_to_have_no_accessibility_violations(page)
     end
 
-    scenario 'cancel idv' do
+    scenario 'doc auth steps accessibility' do
       sign_in_and_2fa_user
 
       visit idv_cancel_path
-
       expect(current_path).to eq idv_cancel_path
       expect_page_to_have_no_accessibility_violations(page)
-    end
 
-    scenario 'phone info' do
-      sign_in_and_2fa_user
       visit idv_path
-      complete_all_doc_auth_steps
-
-      expect(current_path).to eq idv_phone_path
       expect_page_to_have_no_accessibility_violations(page)
-    end
-
-    scenario 'review page' do
-      sign_in_and_2fa_user
-      visit idv_path
-      complete_all_doc_auth_steps_before_password_step
-
-      expect(page).to have_current_path(idv_enter_password_path)
-      expect_page_to_have_no_accessibility_violations(page)
-    end
-
-    scenario 'personal key / confirmation page' do
-      sign_in_and_2fa_user
-      visit idv_path
-      complete_all_doc_auth_steps_before_password_step
-      fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
-      click_continue
-
-      expect(current_path).to eq idv_personal_key_path
-      expect_page_to_have_no_accessibility_violations(page)
-    end
-
-    scenario 'doc auth steps accessibility' do
-      sign_in_and_2fa_user
-      visit idv_path
       complete_all_doc_auth_steps_before_password_step(expect_accessible: true)
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue


### PR DESCRIPTION
## 🛠 Summary of changes

I did some testing to ensure that the same pages are tested for accessibility, this should only be a reduction in duplicative tests. This is intended to be a speed improvement on #4000 and the intervening changes since then.

I added a small patch to keep track of which pages the test file was running accessibility checks on to be more sure we aren't losing accessibility coverage. We'd expect to see some duplication since the mobile test shares many of the same pages. The results don't suggest that we've lost any coverage, so this change should be a reduction in time spent without any reduction in test coverage.

Before:
```
# ~45 seconds locally
[["/verify/agreement", 2], ["/verify/cancel", 1], ["/verify/document_capture", 2], ["/verify/enter_password", 3], ["/verify/how_to_verify", 1], ["/verify/hybrid_handoff", 1], ["/verify/personal_key", 3], ["/verify/phone", 3], ["/verify/ssn", 2], ["/verify/verify_info", 2], ["/verify/welcome", 3]]
```

After:
```
# ~25 seconds locally
[["/verify/agreement", 2], ["/verify/cancel", 1], ["/verify/document_capture", 2], ["/verify/enter_password", 2], ["/verify/how_to_verify", 1], ["/verify/hybrid_handoff", 1], ["/verify/personal_key", 2], ["/verify/phone", 2], ["/verify/ssn", 2], ["/verify/verify_info", 2], ["/verify/welcome", 3]]
```

<details>
<summary>Patch</summary>


```
 require 'rails_helper'
 require 'axe-rspec'
+ACCESSIBLE_PAGES = {}

 RSpec.feature 'Accessibility on IDV pages', :js, allowed_extra_analytics: [:*] do
   describe 'IDV pages' do
@@ -9,6 +10,10 @@ RSpec.feature 'Accessibility on IDV pages', :js, allowed_extra_analytics: [:*] d
       create(:service_provider, :active, :in_person_proofing_enabled)
     end

+    after(:all) do
+      puts ACCESSIBLE_PAGES.sort.inspect
+    end
+
     scenario 'how to verify page' do
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
       allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
diff --git a/spec/support/matchers/accessibility.rb b/spec/support/matchers/accessibility.rb
index b9e295ecc6..379183baad 100644
--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -310,6 +310,9 @@ class AccessibleName
 end

 def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
+  ACCESSIBLE_PAGES[page.current_path] ||= 0
+  ACCESSIBLE_PAGES[page.current_path] += 1
+
   expect(page).to be_axe_clean.according_to(
     :section508, :"best-practice",
     :wcag21aa
--
```

</details>

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
