### PR TITLE
Use version 0.19.3-18f of saml-idp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.19.2-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.19.3-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,10 +34,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 4c858dab80cfe32081a7e6bd7cd76c43cc3ec778
-  tag: 0.19.2-18f
+  revision: 95369fdd9336773b9983c8de71eb35a8c92e9683
+  tag: 0.19.3-18f
   specs:
-    saml_idp (0.19.2.pre.18f)
+    saml_idp (0.19.3.pre.18f)
       activesupport
       builder
       faraday


### PR DESCRIPTION
This fixes log writing failures of the form
'log writing failed. "\xB5" from ASCII-8BIT to UTF-8'.

