### PR TITLE
Fix manifest cache for local JavaScript feature tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,9 +75,13 @@ RSpec.configure do |config|
       # rubocop:enable Style/GlobalVars
       # rubocop:disable Rails/Output
       print '                       Bundling JavaScript and stylesheets... '
-      system 'WEBPACK_PORT= yarn concurrently "yarn:build:*" > /dev/null 2>&1'
+      system 'yarn concurrently "yarn:build:*" > /dev/null 2>&1'
       puts '✨ Done!'
       # rubocop:enable Rails/Output
+
+      # The JavaScript assets manifest is cached by the application. Since the preceding build will
+      # write a new manifest, instruct the application to refresh the cache from disk.
+      Rails.application.config.asset_sources.load_manifest
     end
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Ensures that the JavaScript build which runs when executing a test using the JavaScript driver in tests will invalidate the cached assets manifest.

This resolves an issue where running JavaScript feature specs locally could result in Content-Security-Policy errors in trying to load scripts from http://localhost:3035/ (the Webpack dev server).

This may have been made more prevalent by recent changes in #10301 to eagerly cache the manifest, though likely existed prior.

As outlined in the included inline code comment, the problem is that the application will cache whatever manifest exists at startup, but the JavaScript build happens on-demand. Therefore, the application may try to load incorrect URLs if the on-demand build would produce a different manifest.

## 📜 Testing Plan

1. Run `make run`. This will generate `public/packs/manifest.json` with http://localhost:3035/ URLs for the Webpack dev server
2. Run `rspec ./spec/features/accessibility/idv_pages_spec.rb:20`

**Before:** You would see CSP errors, because the application starts up and caches the manifest produced by Step 1 .

Example:

```
       Unexpected browser console logging:
     
       http://127.0.0.1:60993/account - Refused to load the script 'http://localhost:3035/packs/js/navigation.js' because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-eval' 'nonce-e586d9c7c882eb04f2ac42658d7c9d43'". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.

[...]
```

**After:** The test will pass, because the cached manifest will be reloaded using the manifest generated by the on-demand JavaScript build.