### PR TITLE
update assurance level for testing on joy

### DIFF
--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -51,7 +51,7 @@ module UspsInPersonProofing
         state: applicant.state,
         zipCode: applicant.zip_code,
         emailAddress: applicant.email,
-        IPPAssuranceLevel: '1.5',
+        IPPAssuranceLevel: '2.0',
       }
 
       res = faraday.post(url, body, dynamic_headers) do |req|


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12821](https://cm-jira.usa.gov/browse/LG-12821)
 
## 🛠 Summary of changes

Changing IPPAssurance level to 2.0 for EIPP testing in Joy.