### PR TITLE
LG-12294: Send single aggregated email notification for new device sign-in

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -165,7 +165,11 @@ module TwoFactorAuthenticatableMethods
 
   def handle_valid_verification_for_authentication_context(auth_method:)
     mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa)
-    create_user_event(:sign_in_after_2fa)
+    create_user_event_with_disavowal(:sign_in_after_2fa)
+
+    if IdentityConfig.store.feature_new_device_alert_aggregation_enabled
+      UserAlerts::AlertUserAboutNewDevice.send_alert(current_user)
+    end
 
     reset_second_factor_attempts_count
   end

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -12,11 +12,15 @@ module TwoFactorAuthenticatableMethods
 
   def handle_valid_verification_for_authentication_context(auth_method:)
     mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa)
-    create_user_event_with_disavowal(:sign_in_after_2fa)
+    disavowal_event, disavowal_token = create_user_event_with_disavowal(:sign_in_after_2fa)
 
     if IdentityConfig.store.feature_new_device_alert_aggregation_enabled &&
        current_user.sign_in_new_device_at
-      UserAlerts::AlertUserAboutNewDevice.send_alert(current_user)
+      UserAlerts::AlertUserAboutNewDevice.send_alert(
+        user: current_user,
+        disavowal_event:,
+        disavowal_token:,
+      )
     end
 
     reset_second_factor_attempts_count

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -14,8 +14,9 @@ module TwoFactorAuthenticatableMethods
     mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa)
     disavowal_event, disavowal_token = create_user_event_with_disavowal(:sign_in_after_2fa)
 
-    if IdentityConfig.store.feature_new_device_alert_aggregation_enabled
-      if current_user.sign_in_new_device_at.blank? && user_session[:new_device]
+    if IdentityConfig.store.feature_new_device_alert_aggregation_enabled &&
+       user_session[:new_device]
+      if current_user.sign_in_new_device_at.blank?
         current_user.update(sign_in_new_device_at: disavowal_event.created_at)
       end
 

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -15,7 +15,7 @@ module TwoFactorAuthenticatableMethods
     disavowal_event, disavowal_token = create_user_event_with_disavowal(:sign_in_after_2fa)
 
     if IdentityConfig.store.feature_new_device_alert_aggregation_enabled
-      if current_user.sign_in_new_device_at.blank?
+      if current_user.sign_in_new_device_at.blank? && user_session[:new_device]
         current_user.update(sign_in_new_device_at: disavowal_event.created_at)
       end
 

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -14,8 +14,11 @@ module TwoFactorAuthenticatableMethods
     mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa)
     disavowal_event, disavowal_token = create_user_event_with_disavowal(:sign_in_after_2fa)
 
-    if IdentityConfig.store.feature_new_device_alert_aggregation_enabled &&
-       current_user.sign_in_new_device_at
+    if IdentityConfig.store.feature_new_device_alert_aggregation_enabled
+      if current_user.sign_in_new_device_at.blank?
+        current_user.update(sign_in_new_device_at: disavowal_event.created_at)
+      end
+
       UserAlerts::AlertUserAboutNewDevice.send_alert(
         user: current_user,
         disavowal_event:,

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -15,7 +15,7 @@ module TwoFactorAuthenticatableMethods
     disavowal_event, disavowal_token = create_user_event_with_disavowal(:sign_in_after_2fa)
 
     if IdentityConfig.store.feature_new_device_alert_aggregation_enabled &&
-       user_session[:new_device]
+       user_session[:new_device] != false
       if current_user.sign_in_new_device_at.blank?
         current_user.update(sign_in_new_device_at: disavowal_event.created_at)
       end

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -74,6 +74,7 @@ module Users
         presented: true,
       )
 
+      user_session[:new_device] = current_user.new_device?(cookie_uuid: cookies[:device])
       handle_valid_verification_for_authentication_context(
         auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,6 +28,7 @@ class Event < ApplicationRecord
     phone_added: 21,
     password_invalidated: 22,
     sign_in_unsuccessful_2fa: 23,
+    sign_in_notification_window_lapsed: 24,
   }
 
   validates :event_type, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,7 +28,7 @@ class Event < ApplicationRecord
     phone_added: 21,
     password_invalidated: 22,
     sign_in_unsuccessful_2fa: 23,
-    sign_in_notification_window_lapsed: 24,
+    sign_in_notification_timeframe_expired: 24,
   }
 
   validates :event_type, presence: true

--- a/app/services/create_new_device_alert.rb
+++ b/app/services/create_new_device_alert.rb
@@ -9,7 +9,7 @@ class CreateNewDeviceAlert < ApplicationJob
       sql_query_for_users_with_new_device,
       tvalue: now - IdentityConfig.store.new_device_alert_delay_in_minutes.minutes,
     ).each do |user|
-      emails_sent += 1 if clear_new_device_and_send_email(user)
+      emails_sent += 1 if UserAlerts::AlertUserAboutNewDevice.send_alert(user)
     end
 
     emails_sent
@@ -22,11 +22,5 @@ class CreateNewDeviceAlert < ApplicationJob
       sign_in_new_device_at IS NOT NULL AND
       sign_in_new_device_at < :tvalue
     SQL
-  end
-
-  def clear_new_device_and_send_email(user)
-    UserAlerts::AlertUserAboutNewDevice.send_alert(user)
-
-    true
   end
 end

--- a/app/services/create_new_device_alert.rb
+++ b/app/services/create_new_device_alert.rb
@@ -9,7 +9,7 @@ class CreateNewDeviceAlert < ApplicationJob
       sql_query_for_users_with_new_device,
       tvalue: now - IdentityConfig.store.new_device_alert_delay_in_minutes.minutes,
     ).each do |user|
-      emails_sent += 1 if UserAlerts::AlertUserAboutNewDevice.send_alert(user)
+      emails_sent += 1 if lapse_sign_in_notification_window_and_send_alert(user)
     end
 
     emails_sent
@@ -22,5 +22,12 @@ class CreateNewDeviceAlert < ApplicationJob
       sign_in_new_device_at IS NOT NULL AND
       sign_in_new_device_at < :tvalue
     SQL
+  end
+
+  def lapse_sign_in_notification_window_and_send_alert(user)
+    disavowal_event, disavowal_token = UserEventCreator.new(current_user: user).
+      create_out_of_band_user_event_with_disavowal(:sign_in_notification_window_lapsed)
+
+    UserAlerts::AlertUserAboutNewDevice.send_alert(user:, disavowal_event:, disavowal_token:)
   end
 end

--- a/app/services/create_new_device_alert.rb
+++ b/app/services/create_new_device_alert.rb
@@ -9,7 +9,7 @@ class CreateNewDeviceAlert < ApplicationJob
       sql_query_for_users_with_new_device,
       tvalue: now - IdentityConfig.store.new_device_alert_delay_in_minutes.minutes,
     ).each do |user|
-      emails_sent += 1 if lapse_sign_in_notification_window_and_send_alert(user)
+      emails_sent += 1 if expire_sign_in_notification_timeframe_and_send_alert(user)
     end
 
     emails_sent
@@ -24,9 +24,9 @@ class CreateNewDeviceAlert < ApplicationJob
     SQL
   end
 
-  def lapse_sign_in_notification_window_and_send_alert(user)
+  def expire_sign_in_notification_timeframe_and_send_alert(user)
     disavowal_event, disavowal_token = UserEventCreator.new(current_user: user).
-      create_out_of_band_user_event_with_disavowal(:sign_in_notification_window_lapsed)
+      create_out_of_band_user_event_with_disavowal(:sign_in_notification_timeframe_expired)
 
     UserAlerts::AlertUserAboutNewDevice.send_alert(user:, disavowal_event:, disavowal_token:)
   end

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -24,6 +24,8 @@ module UserAlerts
     end
 
     def self.send_alert(user)
+      return false unless user.sign_in_new_device_at
+
       events = user.events.where(
         created_at: user.sign_in_new_device_at..,
         event_type: [

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -34,6 +34,7 @@ module UserAlerts
       ).order(:created_at)
 
       disavowal_event = events.reverse_each.find(&:disavowal_token_fingerprint)
+      return false unless disavowal_event
       disavowal_token = disavowal_event.disavowal_token_fingerprint
 
       user.confirmed_email_addresses.each do |email_address|
@@ -48,6 +49,7 @@ module UserAlerts
       end
 
       user.update(sign_in_new_device_at: nil)
+      true
     end
   end
 end

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -2,12 +2,11 @@
 
 module UserAlerts
   class AlertUserAboutNewDevice
-    def self.call(event:, disavowal_token:)
+    def self.call(event:, device:, disavowal_token:)
       if IdentityConfig.store.feature_new_device_alert_aggregation_enabled
         event.user.sign_in_new_device_at ||= event.created_at
         event.user.save
       else
-        device = event.device
         device_decorator = DeviceDecorator.new(device)
         login_location = device_decorator.last_sign_in_location_and_ip
         device_name = device_decorator.nice_name

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -23,7 +23,7 @@ module UserAlerts
       end
     end
 
-    def self.send_alert(user)
+    def self.send_alert(user:, disavowal_event:, disavowal_token:)
       return false unless user.sign_in_new_device_at
 
       events = user.events.where(
@@ -35,14 +35,10 @@ module UserAlerts
         ],
       ).order(:created_at)
 
-      disavowal_event = events.reverse_each.find(&:disavowal_token_fingerprint)
-      return false unless disavowal_event
-      disavowal_token = disavowal_event.disavowal_token_fingerprint
-
       user.confirmed_email_addresses.each do |email_address|
         mailer = UserMailer.with(user:, email_address:)
         mail = case disavowal_event.event_type
-        when 'sign_in_before_2fa'
+        when 'sign_in_notification_window_lapsed'
           mailer.new_device_sign_in_before_2fa(events:, disavowal_token:)
         when 'sign_in_after_2fa'
           mailer.new_device_sign_in_after_2fa(events:, disavowal_token:)

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -2,12 +2,13 @@
 
 module UserAlerts
   class AlertUserAboutNewDevice
-    def self.call(event:)
+    def self.call(event:, disavowal_token:)
       if IdentityConfig.store.feature_new_device_alert_aggregation_enabled
         event.user.sign_in_new_device_at ||= event.created_at
         event.user.save
       else
-        device_decorator = DeviceDecorator.new(event.device)
+        device = event.device
+        device_decorator = DeviceDecorator.new(device)
         login_location = device_decorator.last_sign_in_location_and_ip
         device_name = device_decorator.nice_name
 
@@ -17,7 +18,7 @@ module UserAlerts
               strftime('%B %-d, %Y %H:%M Eastern Time'),
             location: login_location,
             device_name: device_name,
-            disavowal_token: event.disavowal_token,
+            disavowal_token: disavowal_token,
           ).deliver_now_or_later
         end
       end

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -33,7 +33,7 @@ module UserAlerts
           'sign_in_unsuccessful_2fa',
           'sign_in_after_2fa',
         ],
-      ).order(:created_at)
+      ).order(:created_at).includes(:device)
 
       user.confirmed_email_addresses.each do |email_address|
         mailer = UserMailer.with(user:, email_address:)

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -38,7 +38,7 @@ module UserAlerts
       user.confirmed_email_addresses.each do |email_address|
         mailer = UserMailer.with(user:, email_address:)
         mail = case disavowal_event.event_type
-        when 'sign_in_notification_window_lapsed'
+        when 'sign_in_notification_timeframe_expired'
           mailer.new_device_sign_in_before_2fa(events:, disavowal_token:)
         when 'sign_in_after_2fa'
           mailer.new_device_sign_in_after_2fa(events:, disavowal_token:)

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -79,18 +79,11 @@ class UserEventCreator
   # @return [Array(Event, String)] an (event, disavowal_token) tuple
   def create_event_for_new_device(event_type:, user:, disavowal_token:)
     if user.fully_registered? && user.has_devices? && disavowal_token.nil?
-      device, event, disavowal_token = Device.transaction do
+      event, disavowal_token = Device.transaction do
         device = create_device_for_user(user)
-        event, disavowal_token = create_user_event_with_disavowal(
-          event_type, user, device
-        )
-        [device, event, disavowal_token]
+        create_user_event_with_disavowal(event_type, user, device)
       end
-      send_new_device_notification(
-        user: user,
-        device: device,
-        disavowal_token: disavowal_token,
-      )
+      send_new_device_notification(event:)
       [event, disavowal_token]
     else
       Device.transaction do
@@ -123,8 +116,8 @@ class UserEventCreator
     cookies.permanent[:device] = device_cookie unless device_cookie == cookies[:device]
   end
 
-  def send_new_device_notification(user:, device:, disavowal_token:)
-    UserAlerts::AlertUserAboutNewDevice.call(user, device, disavowal_token)
+  def send_new_device_notification(event:)
+    UserAlerts::AlertUserAboutNewDevice.call(event:)
   end
 
   # @return [Array(Event, String)] an (event, disavowal_token) tuple

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -83,7 +83,7 @@ class UserEventCreator
         device = create_device_for_user(user)
         create_user_event_with_disavowal(event_type, user, device)
       end
-      send_new_device_notification(event:)
+      send_new_device_notification(event:, disavowal_token:)
       [event, disavowal_token]
     else
       Device.transaction do
@@ -116,8 +116,8 @@ class UserEventCreator
     cookies.permanent[:device] = device_cookie unless device_cookie == cookies[:device]
   end
 
-  def send_new_device_notification(event:)
-    UserAlerts::AlertUserAboutNewDevice.call(event:)
+  def send_new_device_notification(event:, disavowal_token:)
+    UserAlerts::AlertUserAboutNewDevice.call(event:, disavowal_token:)
   end
 
   # @return [Array(Event, String)] an (event, disavowal_token) tuple

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -24,7 +24,7 @@ en:
     piv_cac_enabled: PIV/CAC card associated
     sign_in_after_2fa: Signed in with second factor
     sign_in_before_2fa: Signed in with password
-    sign_in_notification_window_lapsed: Sign in notification window expired
+    sign_in_notification_timeframe_expired: Expired notification timeframe for sign-in from new device
     sign_in_unsuccessful_2fa: Failed to authenticate
     webauthn_key_added: Hardware security key added
     webauthn_key_removed: Hardware security key removed

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -24,7 +24,7 @@ en:
     piv_cac_enabled: PIV/CAC card associated
     sign_in_after_2fa: Signed in with second factor
     sign_in_before_2fa: Signed in with password
-    sign_in_unsuccessful_2fa: Failed to authenticate
     sign_in_notification_window_lapsed: Sign in notification window expired
+    sign_in_unsuccessful_2fa: Failed to authenticate
     webauthn_key_added: Hardware security key added
     webauthn_key_removed: Hardware security key removed

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -25,5 +25,6 @@ en:
     sign_in_after_2fa: Signed in with second factor
     sign_in_before_2fa: Signed in with password
     sign_in_unsuccessful_2fa: Failed to authenticate
+    sign_in_notification_window_lapsed: Sign in notification window expired
     webauthn_key_added: Hardware security key added
     webauthn_key_removed: Hardware security key removed

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -24,6 +24,8 @@ es:
     piv_cac_enabled: Tarjeta PIV/CAC asociada
     sign_in_after_2fa: Inicia sesión con segundo factor
     sign_in_before_2fa: Inicia sesión con contraseña
+    sign_in_notification_timeframe_expired: Plazo de notificación expirado para el
+      inicio de sesión desde un nuevo dispositivo
     sign_in_unsuccessful_2fa: Error al autenticar
     webauthn_key_added: Clave de seguridad de hardware añadido
     webauthn_key_removed: Clave de seguridad de hardware eliminada

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -24,6 +24,8 @@ fr:
     piv_cac_enabled: Carte PIV/CAC associée
     sign_in_after_2fa: Signé avec deuxième facteur
     sign_in_before_2fa: Connecté avec mot de passe
+    sign_in_notification_timeframe_expired: Délai de notification pour la connexion
+      à partir d’un nouveau dispositif expiré
     sign_in_unsuccessful_2fa: Échec de l’authentification
     webauthn_key_added: Clé de sécurité ajoutée
     webauthn_key_removed: Clé de sécurité retirée

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -236,12 +236,12 @@ en:
       new_sign_in_from: New sign-in potentially located in %{location}
     new_device_sign_in_before_2fa:
       info_p1_html:
-        zero: Your %{app_name} email and password were used to sign in from a new device
-          but <strong>failed to authenticate</strong>.
         one: Your %{app_name} email and password were used to sign in from a new device
           but <strong>failed to authenticate</strong>.
         other: Your %{app_name} email and password were used to sign in from a new
           device but <strong>failed to authenticate %{count} times</strong>.
+        zero: Your %{app_name} email and password were used to sign in from a new device
+          but <strong>failed to authenticate</strong>.
       info_p2: If you recognize this activity, you don’t need to do anything.
       info_p3_html: Two-factor authentication protects your account from unauthorized
         access. If this wasn’t you, %{reset_password_link_html} immediately.

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -236,6 +236,8 @@ en:
       new_sign_in_from: New sign-in potentially located in %{location}
     new_device_sign_in_before_2fa:
       info_p1_html:
+        zero: Your %{app_name} email and password were used to sign in from a new device
+          but <strong>failed to authenticate</strong>.
         one: Your %{app_name} email and password were used to sign in from a new device
           but <strong>failed to authenticate</strong>.
         other: Your %{app_name} email and password were used to sign in from a new

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -239,7 +239,7 @@ en:
         one: Your %{app_name} email and password were used to sign in from a new device
           but <strong>failed to authenticate</strong>.
         other: Your %{app_name} email and password were used to sign in from a new
-          device but <strong>failed to authenticate %{count} times</strong>
+          device but <strong>failed to authenticate %{count} times</strong>.
       info_p2: If you recognize this activity, you don’t need to do anything.
       info_p3_html: Two-factor authentication protects your account from unauthorized
         access. If this wasn’t you, %{reset_password_link_html} immediately.

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -254,7 +254,7 @@ es:
           error</strong>.
         other: Su correo electrónico y su contraseña de %{app_name} se usaron para
           ingresar desde un nuevo dispositivo, pero <strong>error al autenticar
-          %{count} veces</strong>
+          %{count} veces</strong>.
       info_p2: Si reconoce esta actividad, no tiene que hacer nada.
       info_p3_html: La autenticación de dos factores protege su cuenta de accesos no
         autorizados. Si no fue usted, %{reset_password_link_html}

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -249,6 +249,9 @@ es:
       new_sign_in_from: Nuevo inicio de sesión potencialmente ubicado en %{location}
     new_device_sign_in_before_2fa:
       info_p1_html:
+        zero: Su correo electrónico y su contraseña de %{app_name} se usaron para
+          ingresar desde un nuevo dispositivo, pero <strong>la autenticación dio
+          error</strong>.
         one: Su correo electrónico y su contraseña de %{app_name} se usaron para
           ingresar desde un nuevo dispositivo, pero <strong>la autenticación dio
           error</strong>.

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -249,15 +249,15 @@ es:
       new_sign_in_from: Nuevo inicio de sesión potencialmente ubicado en %{location}
     new_device_sign_in_before_2fa:
       info_p1_html:
-        zero: Su correo electrónico y su contraseña de %{app_name} se usaron para
-          ingresar desde un nuevo dispositivo, pero <strong>la autenticación dio
-          error</strong>.
         one: Su correo electrónico y su contraseña de %{app_name} se usaron para
           ingresar desde un nuevo dispositivo, pero <strong>la autenticación dio
           error</strong>.
         other: Su correo electrónico y su contraseña de %{app_name} se usaron para
           ingresar desde un nuevo dispositivo, pero <strong>error al autenticar
           %{count} veces</strong>.
+        zero: Su correo electrónico y su contraseña de %{app_name} se usaron para
+          ingresar desde un nuevo dispositivo, pero <strong>la autenticación dio
+          error</strong>.
       info_p2: Si reconoce esta actividad, no tiene que hacer nada.
       info_p3_html: La autenticación de dos factores protege su cuenta de accesos no
         autorizados. Si no fue usted, %{reset_password_link_html}

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -255,6 +255,9 @@ fr:
       new_sign_in_from: Nouvelle connexion potentiellement située à %{location}
     new_device_sign_in_before_2fa:
       info_p1_html:
+        zero: Votre adresse électronique et votre mot de passe %{app_name} ont été
+          utilisés pour vous connecter à partir d’un nouvel appareil, mais
+          <strong>l’authentification a échoué</strong>.
         one: Votre adresse électronique et votre mot de passe %{app_name} ont été
           utilisés pour vous connecter à partir d’un nouvel appareil, mais
           <strong>l’authentification a échoué</strong>.

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -255,15 +255,15 @@ fr:
       new_sign_in_from: Nouvelle connexion potentiellement située à %{location}
     new_device_sign_in_before_2fa:
       info_p1_html:
-        zero: Votre adresse électronique et votre mot de passe %{app_name} ont été
-          utilisés pour vous connecter à partir d’un nouvel appareil, mais
-          <strong>l’authentification a échoué</strong>.
         one: Votre adresse électronique et votre mot de passe %{app_name} ont été
           utilisés pour vous connecter à partir d’un nouvel appareil, mais
           <strong>l’authentification a échoué</strong>.
         other: Votre adresse électronique et votre mot de passe %{app_name} ont été
           utilisés pour vous connecter à partir d’un nouvel appareil, mais
           <strong>l’authentification a échoué %{count} reprises</strong>.
+        zero: Votre adresse électronique et votre mot de passe %{app_name} ont été
+          utilisés pour vous connecter à partir d’un nouvel appareil, mais
+          <strong>l’authentification a échoué</strong>.
       info_p2: Si vous reconnaissez cette activité, vous n’avez rien à faire.
       info_p3_html: L’authentification à deux facteurs protège votre compte contre
         tout accès non autorisé. Si ce n’est pas vous,

--- a/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
+++ b/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe TwoFactorAuthenticatableMethods, type: :controller do
+  controller ApplicationController do
+    include TwoFactorAuthenticatableMethods
+  end
+
+  describe '#handle_valid_verification_for_authentication_context' do
+    let(:user) { create(:user) }
+    let(:auth_method) { TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE }
+
+    subject(:result) do
+      controller.handle_valid_verification_for_authentication_context(auth_method:)
+    end
+
+    before do
+      stub_sign_in_before_2fa(user)
+    end
+
+    it 'tracks authentication event' do
+      stub_analytics
+
+      result
+
+      expect(@analytics).to have_logged_event(
+        'User marked authenticated',
+        authentication_type: :valid_2fa,
+      )
+    end
+
+    it 'authenticates user session auth methods' do
+      expect(controller.auth_methods_session).to receive(:authenticate!).with(auth_method)
+
+      result
+    end
+
+    it 'creates a new user event with disavowal' do
+      expect { result }.to change { user.reload.events.count }.from(0).to(1)
+      expect(user.events.last.event_type).to eq('sign_in_after_2fa')
+      expect(user.events.last.disavowal_token_fingerprint).to be_present
+    end
+
+    context 'when authenticating without new device sign in' do
+      let(:user) { create(:user) }
+
+      it 'does not send an alert' do
+        expect(UserAlerts::AlertUserAboutNewDevice).to_not receive(:send_alert)
+
+        result
+      end
+    end
+
+    context 'when authenticating with new device sign in' do
+      let(:user) { create(:user, sign_in_new_device_at: Time.zone.now) }
+
+      context 'when alert aggregation feature is disabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:feature_new_device_alert_aggregation_enabled).
+            and_return(false)
+        end
+
+        it 'does not send an alert' do
+          expect(UserAlerts::AlertUserAboutNewDevice).to_not receive(:send_alert)
+
+          result
+        end
+      end
+
+      context 'when alert aggregation feature is enabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:feature_new_device_alert_aggregation_enabled).
+            and_return(true)
+        end
+
+        it 'sends the new device alert' do
+          expect(UserAlerts::AlertUserAboutNewDevice).to receive(:send_alert).with(user)
+
+          result
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
+++ b/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe TwoFactorAuthenticatableMethods, type: :controller do
         end
 
         it 'sends the new device alert' do
-          expect(UserAlerts::AlertUserAboutNewDevice).to receive(:send_alert).with(user)
+          expect(UserAlerts::AlertUserAboutNewDevice).to receive(:send_alert).
+            with(user:, disavowal_event: kind_of(Event), disavowal_token: kind_of(String))
 
           result
         end

--- a/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
+++ b/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe TwoFactorAuthenticatableMethods, type: :controller do
 
         it 'sends the new device alert using 2fa event date' do
           expect(UserAlerts::AlertUserAboutNewDevice).to receive(:send_alert) do |**args|
-            expect(user.reload.sign_in_new_device_at).to eq(args[:disavowal_event].created_at)
+            expect(user.reload.sign_in_new_device_at.change(usec: 0)).to eq(
+              args[:disavowal_event].created_at.change(usec: 0),
+            )
             expect(args[:user]).to eq(user)
             expect(args[:disavowal_event]).to be_kind_of(Event)
             expect(args[:disavowal_token]).to be_kind_of(String)

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
           expect(@irs_attempts_api_tracker).to receive(:track_event).
             with(:mfa_login_backup_code, success: true)
 
+          expect(controller).to receive(:handle_valid_verification_for_authentication_context).
+            with(auth_method: TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE).
+            and_call_original
+
           post :create, params: payload
 
           expect(subject.user_session[:auth_events]).to eq(

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -307,6 +307,10 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_submitted).
           with(reauthentication: false, success: true)
 
+        expect(controller).to receive(:handle_valid_verification_for_authentication_context).
+          with(auth_method: TwoFactorAuthenticatable::AuthMethod::SMS).
+          and_call_original
+
         freeze_time do
           post :create, params: {
             code: subject.current_user.reload.direct_otp,

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController,
         expect(@analytics).to receive(:track_event).
           with('User marked authenticated', authentication_type: :valid_2fa)
 
+        expect(controller).to receive(:handle_valid_verification_for_authentication_context).
+          with(auth_method: TwoFactorAuthenticatable::AuthMethod::PERSONAL_KEY).
+          and_call_original
+
         freeze_time do
           post :create, params: payload
 

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -134,6 +134,10 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
         expect(@analytics).to receive(:track_event).
           with('User marked authenticated', authentication_type: :valid_2fa)
 
+        expect(controller).to receive(:handle_valid_verification_for_authentication_context).
+          with(auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC).
+          and_call_original
+
         get :show, params: { token: 'good-token' }
       end
 

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -62,6 +62,9 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
           with('User marked authenticated', authentication_type: :valid_2fa)
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_login_totp, success: true)
+        expect(controller).to receive(:handle_valid_verification_for_authentication_context).
+          with(auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP).
+          and_call_original
 
         post :create, params: { code: generate_totp_code(@secret) }
       end

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -158,6 +158,9 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
             :mfa_login_webauthn_roaming,
             success: true,
           )
+          expect(controller).to receive(:handle_valid_verification_for_authentication_context).
+            with(auth_method: TwoFactorAuthenticatable::AuthMethod::WEBAUTHN).
+            and_call_original
 
           freeze_time do
             patch :confirm, params: params

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe Users::PivCacLoginController do
           end
 
           it 'sets the session correctly' do
+            expect(controller.user_session[:new_device]).to eq(true)
             expect(controller.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).
               to eq false
 
@@ -150,6 +151,16 @@ RSpec.describe Users::PivCacLoginController do
               presented: true,
             }
             expect(controller.user_session[:decrypted_x509]).to eq session_info.to_json
+          end
+
+          context 'from existing device' do
+            before do
+              allow(user).to receive(:new_device?).and_return(false)
+            end
+
+            it 'sets the session correctly' do
+              expect(controller.user_session[:new_device]).to eq(true)
+            end
           end
 
           context 'when the user has not accepted the most recent terms of use' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -182,7 +182,6 @@ FactoryBot.define do
 
       after :create do |user, evaluator|
         user.create_registration_log(registered_at: evaluator.registered_at)
-        user.devices << create(:device)
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -182,6 +182,7 @@ FactoryBot.define do
 
       after :create do |user, evaluator|
         user.create_registration_log(registered_at: evaluator.registered_at)
+        user.devices << create(:device)
       end
     end
 

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -35,14 +35,16 @@ RSpec.feature 'disavowing an action', allowed_extra_analytics: [:*] do
 
       CreateNewDeviceAlert.new.perform(Time.zone.now)
 
-      fill_in_code_with_last_phone_otp
-      click_submit_default
-
-      expect_delivered_email_count(2)
+      expect_delivered_email_count(1)
       expect_delivered_email(
         to: [user.email_addresses.first.email],
         subject: t('user_mailer.new_device_sign_in_before_2fa.subject', app_name: APP_NAME),
       )
+
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect_delivered_email_count(2)
       expect_delivered_email(
         to: [user.email_addresses.first.email],
         subject: t('user_mailer.new_device_sign_in_after_2fa.subject', app_name: APP_NAME),

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'disavowing an action', allowed_extra_analytics: [:*] do
     before do
       allow(IdentityConfig.store).to receive(:feature_new_device_alert_aggregation_enabled).
         and_return(true)
+      user.devices << create(:device)
     end
 
     scenario 'disavowing a sign-in after 2fa' do

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -20,10 +20,14 @@ RSpec.feature 'Signing in via one-time use personal key', allowed_extra_analytic
     expect(last_message.body).to eq t('telephony.personal_key_sign_in_notice', app_name: APP_NAME)
     expect(last_message.to).to eq user.phone_configurations.take.phone
 
-    expect_delivered_email_count(1)
+    expect_delivered_email_count(2)
     expect_delivered_email(
       to: [user.email_addresses.first.email],
       subject: t('user_mailer.personal_key_sign_in.subject'),
+    )
+    expect_delivered_email(
+      to: [user.email_addresses.first.email],
+      subject: t('user_mailer.new_device_sign_in_after_2fa.subject', app_name: APP_NAME),
     )
   end
 

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe UserAlerts::AlertUserAboutNewDevice do
   describe '#call' do
     let(:user) { create(:user, :fully_registered) }
+    let(:event) { create(:event, user:) }
     let(:disavowal_token) { 'the_disavowal_token' }
     let(:device) { create(:device, user: user) }
 
@@ -12,24 +13,27 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
           :feature_new_device_alert_aggregation_enabled,
         ).and_return(true)
       end
-      it 'sets the user sign_in_new_device_at value to current datetime' do
-        described_class.call(user, device, disavowal_token)
-        expect(user.sign_in_new_device_at).not_to be_nil
+
+      it 'sets the user sign_in_new_device_at value to time of the given event' do
+        described_class.call(event:, device:, disavowal_token:)
+
+        expect(user.sign_in_new_device_at).to be_present.and eq(event.created_at)
       end
     end
 
-    context 'aggregated new device alerts disenabled' do
+    context 'aggregated new device alerts disabled' do
       before do
         allow(IdentityConfig.store).to receive(
           :feature_new_device_alert_aggregation_enabled,
         ).and_return(false)
       end
+
       it 'sends an email to all confirmed email addresses' do
         user.email_addresses.destroy_all
         confirmed_email_addresses = create_list(:email_address, 2, user: user)
         create(:email_address, user: user, confirmed_at: nil)
 
-        described_class.call(user, device, disavowal_token)
+        described_class.call(event:, device:, disavowal_token:)
 
         expect_delivered_email_count(2)
         expect_delivered_email(

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
       it 'sets the user sign_in_new_device_at value to time of the given event' do
         described_class.call(event:, device:, disavowal_token:)
 
-        expect(user.sign_in_new_device_at).to be_present.and eq(event.created_at)
+        expect(user.sign_in_new_device_at.change(usec: 0)).to be_present.
+          and eq(event.created_at.change(usec: 0))
       end
     end
 
@@ -66,8 +67,8 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
     end
 
     it 'unsets sign_in_new_device_at on the user' do
-      expect { result }.to change { user.reload.sign_in_new_device_at }.
-        from(sign_in_new_device_at).
+      expect { result }.to change { user.reload.sign_in_new_device_at&.change(usec: 0) }.
+        from(sign_in_new_device_at.change(usec: 0)).
         to(nil)
     end
 

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe UserAlerts::AlertUserAboutNewDevice do
-  describe '#call' do
-    let(:user) { create(:user, :fully_registered) }
-    let(:event) { create(:event, user:) }
-    let(:disavowal_token) { 'the_disavowal_token' }
-    let(:device) { create(:device, user: user) }
+  let(:user) { create(:user, :fully_registered) }
+  let(:event) { create(:event, user:) }
+  let(:disavowal_token) { 'the_disavowal_token' }
+  let(:device) { create(:device, user: user) }
 
+  describe '.call' do
     context 'aggregated new device alerts enabled' do
       before do
         allow(IdentityConfig.store).to receive(
@@ -46,6 +46,139 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
           subject: t('user_mailer.new_device_sign_in.subject', app_name: APP_NAME),
           body: [disavowal_token],
         )
+      end
+    end
+  end
+
+  describe '.send_alert' do
+    let(:sign_in_new_device_at) { 10.minutes.ago }
+    let(:user) { create(:user, :fully_registered, sign_in_new_device_at:) }
+    let(:disavowal_event) do
+      create(:event, user:, event_type: :sign_in_after_2fa, created_at: 5.minutes.ago)
+    end
+
+    subject(:result) do
+      UserAlerts::AlertUserAboutNewDevice.send_alert(user:, disavowal_event:, disavowal_token:)
+    end
+
+    it 'returns true' do
+      expect(result).to eq(true)
+    end
+
+    it 'unsets sign_in_new_device_at on the user' do
+      expect { result }.to change { user.reload.sign_in_new_device_at }.
+        from(sign_in_new_device_at).
+        to(nil)
+    end
+
+    context 'with sign in notification lapsed disavowal event' do
+      let(:disavowal_event) do
+        create(
+          :event,
+          user:,
+          event_type: :sign_in_notification_window_lapsed,
+          created_at: 5.minutes.ago,
+        )
+      end
+
+      it 'sends mailer for authentication events within the time window' do
+        # 1. Exclude events outside the timeframe, e.g. previous sign-in
+        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 11.minutes.ago)
+
+        # 2. Include authentication events inside the timeframe, inclusive
+
+        # 2.1 Include sign-in before 2FA
+        sign_in_before_2fa_event = create(
+          :event,
+          user:,
+          event_type: :sign_in_before_2fa,
+          created_at: sign_in_new_device_at,
+        )
+
+        # 2.2 Include sign-in unsuccessful 2FA
+        sign_in_unsuccessful_2fa_event = create(
+          :event,
+          user:,
+          event_type: :sign_in_unsuccessful_2fa,
+          created_at: 8.minutes.ago,
+        )
+
+        # 3. Exclude sign in notification window lapsed event
+        disavowal_event
+
+        delivery = instance_double(ActionMailer::MessageDelivery)
+        expect(delivery).to receive(:deliver_now_or_later)
+        mailer = instance_double(UserMailer)
+        expect(UserMailer).to receive(:with).and_return(mailer)
+        expect(mailer).to receive(:new_device_sign_in_before_2fa).with(
+          events: [
+            sign_in_before_2fa_event,
+            sign_in_unsuccessful_2fa_event,
+          ],
+          disavowal_token:,
+        ).and_return(delivery)
+
+        result
+      end
+    end
+
+    context 'with sign in after 2fa disavowal event' do
+      let(:disavowal_event) do
+        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 5.minutes.ago)
+      end
+
+      it 'sends mailer for authentication events within the time window' do
+        # 1. Exclude events outside the timeframe, e.g. previous sign-in
+        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 11.minutes.ago)
+
+        # 2. Include authentication events inside the timeframe, inclusive
+
+        # 2.1 Include sign-in before 2FA
+        sign_in_before_2fa_event = create(
+          :event,
+          user:,
+          event_type: :sign_in_before_2fa,
+          created_at: sign_in_new_device_at,
+        )
+
+        # 2.2 Include sign-in unsuccessful 2FA
+        sign_in_unsuccessful_2fa_event = create(
+          :event,
+          user:,
+          event_type: :sign_in_unsuccessful_2fa,
+          created_at: 8.minutes.ago,
+        )
+
+        # 2.3 Include sign-in after 2FA
+        sign_in_after_2fa_event = disavowal_event
+
+        # 3. Exclude events not related to authentication, e.g. actions after sign-in
+        create(:event, user:, event_type: :password_changed, created_at: 4.minutes.ago)
+
+        delivery = instance_double(ActionMailer::MessageDelivery)
+        expect(delivery).to receive(:deliver_now_or_later)
+        mailer = instance_double(UserMailer)
+        expect(UserMailer).to receive(:with).and_return(mailer)
+        expect(mailer).to receive(:new_device_sign_in_after_2fa).with(
+          events: [
+            sign_in_before_2fa_event,
+            sign_in_unsuccessful_2fa_event,
+            sign_in_after_2fa_event,
+          ],
+          disavowal_token:,
+        ).and_return(delivery)
+
+        result
+      end
+    end
+
+    context 'without new device timestamp' do
+      let(:sign_in_new_device_at) { nil }
+
+      it 'returns false and does not send email' do
+        expect(UserMailer).not_to receive(:with)
+
+        expect(result).to eq(false)
       end
     end
   end

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
         to(nil)
     end
 
-    context 'with sign in notification lapsed disavowal event' do
+    context 'with sign in notification expired disavowal event' do
       let(:disavowal_event) do
         create(
           :event,
           user:,
-          event_type: :sign_in_notification_window_lapsed,
+          event_type: :sign_in_notification_timeframe_expired,
           created_at: 5.minutes.ago,
         )
       end
@@ -104,7 +104,7 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
           created_at: 8.minutes.ago,
         )
 
-        # 3. Exclude sign in notification window lapsed event
+        # 3. Exclude sign in notification timeframe expired event
         disavowal_event
 
         delivery = instance_double(ActionMailer::MessageDelivery)

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -65,8 +65,7 @@ RSpec.describe UserEventCreator do
         event, _disavowal_token = subject.create_user_event(event_type, user)
 
         expect(event).to be_a(Event)
-        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).
-          with(user, user.events.first.device, instance_of(String))
+        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).with(event:)
       end
     end
 
@@ -101,8 +100,7 @@ RSpec.describe UserEventCreator do
         event, _disavowal_token = subject.create_user_event(event_type, user)
 
         expect(event).to be_a(Event)
-        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).
-          with(user, user.events.first.device, instance_of(String))
+        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).with(event:)
       end
     end
   end

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -65,7 +65,11 @@ RSpec.describe UserEventCreator do
         event, _disavowal_token = subject.create_user_event(event_type, user)
 
         expect(event).to be_a(Event)
-        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).with(event:)
+        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).with(
+          event: user.events.first,
+          device: user.events.first.device,
+          disavowal_token: instance_of(String),
+        )
       end
     end
 
@@ -100,7 +104,11 @@ RSpec.describe UserEventCreator do
         event, _disavowal_token = subject.create_user_event(event_type, user)
 
         expect(event).to be_a(Event)
-        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).with(event:)
+        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).with(
+          event: user.events.first,
+          device: user.events.first.device,
+          disavowal_token: instance_of(String),
+        )
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-12294](https://cm-jira.usa.gov/browse/LG-12294)

## 🛠 Summary of changes

Implements the dispatching of a new aggregated email notification for sign-in, which happens 5 minutes after successful email and password submission, or immediately upon successful MFA, whichever occurs first.

This builds upon ("wires up") previous work in #10314 (email template) and #10317 (worker for delayed notification).

## 📜 Testing Plan

Verify that you are sent an email immediately upon full authentication:

1. In a private browsing session ("Incognito"), visit http://localhost:3000
2. Sign in with email and password
3. Complete MFA step
4. Observe you see an email notification immediately with listed events
   - Note that it's likely to show "unknown location" since events save `'::1'` as the IP address in local development

Verify that you are sent an email after delay upon partial authentication:

1. Optional: Change configured delay and/or worker frequency to avoid having to wait a full 5 minutes:
   - Set `new_device_alert_delay_in_minutes: 1` in `config/application.yml` (changes notification to send after 1 minute instead of after 5 minutes)
   - Set [`cron_5m` in `job_configurations.rb`](https://github.com/18F/identity-idp/blob/0e68f0919d9168f43a5c18fa9b5c355501212ad5/config/initializers/job_configurations.rb#L3) to `'0/1 * * * *'` (changes jobs to run every 1 minute instead of every 5 minutes)
2. In a private browsing session ("Incognito"), visit http://localhost:3000
3. Sign in with email and password
4. Wait until the next worker run after the delay specified in configuration
5. Observe you see an email notification with listed events
   - Note that it's likely to show "unknown location" since events save `'::1'` as the IP address in local development

## 👀 Screenshots

Partial Authentication|Full Authentication
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/6652aa6b-e657-46b6-af4b-0754c7b30169)|![image](https://github.com/18F/identity-idp/assets/1779930/25e55e7e-6b09-47c1-bc09-0e417951fdcf)

