### PR TITLE
Update disavowed event lookup to load one record

### DIFF
--- a/app/services/event_disavowal/find_disavowed_event.rb
+++ b/app/services/event_disavowal/find_disavowed_event.rb
@@ -15,7 +15,8 @@ module EventDisavowal
     private
 
     def event
-      @event ||= Event.find_by(disavowal_token_fingerprint: disavowal_token_fingerprints)
+      return @event if defined?(@event)
+      @event = Event.find_by(disavowal_token_fingerprint: disavowal_token_fingerprints)
     end
 
     def disavowal_token_fingerprints

--- a/app/services/event_disavowal/find_disavowed_event.rb
+++ b/app/services/event_disavowal/find_disavowed_event.rb
@@ -15,11 +15,7 @@ module EventDisavowal
     private
 
     def event
-      # Use `#all` here instead of `#first` to avoid setting a 'LIMIT 1' to the
-      # postgres query which causes it to run slowly.
-      @event ||= Event.where(
-        disavowal_token_fingerprint: disavowal_token_fingerprints,
-      ).all[0]
+      @event ||= Event.find_by(disavowal_token_fingerprint: disavowal_token_fingerprints)
     end
 
     def disavowal_token_fingerprints


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `EventDisavowal::FindDisavowedEvent#event` to avoid loading all events matching token fingerprints.

This is the result of a discussion with @jmhooper stemming from surprise around performance characteristics noted in #2855. While `#first` would still be advisable to avoid here due to built-in ordering (["if no order is defined it will order by primary key"](https://api.rubyonrails.org/v7.1.3.2/classes/ActiveRecord/FinderMethods.html#method-i-first)), `#find_by` will locate at most one record without imposing any order. `#take` would have also worked.

The previous implementation was likely fine enough since the logic producing fingerprints would likely only ever produce 0 or 1 database results, but these revisions are simpler and more semantic, and should hopefully avoid future confusion around unoptimized `LIMIT 1` queries.

## 📜 Testing Plan

Existing tests provide coverage for (a) missing, (b) matched, (c) matched old key. Verify they pass:

```
rspec spec/services/event_disavowal/find_disavowed_event_spec.rb
```