### PR TITLE
Fix Sass compilation rebuild after error

### DIFF
--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add support for verbose CLI output using `--verbose` flag (`-v` shorthand), which currently outputs files being built.
 
+### Bug Fixes
+
+- Fix rebuild after error when using `--watch` mode.
+
 ## 3.0.0
 
 ### Breaking Changes

--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### New Features
+
+- Add support for verbose CLI output using `--verbose` flag (`-v` shorthand), which currently outputs files being built.
+
 ## 3.0.0
 
 ### Breaking Changes

--- a/app/javascript/packages/build-sass/README.md
+++ b/app/javascript/packages/build-sass/README.md
@@ -31,6 +31,7 @@ Flags:
 - `--out-dir`: The output directory
 - `--watch`: Run in watch mode, recompiling files on change
 - `--load-path`: Include additional path in Sass path resolution
+- `--verbose` (`-v`): Output verbose debugging details
 
 ### API
 

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -14,6 +14,8 @@ import getErrorSassStackPaths from './get-error-sass-stack-paths.js';
 /** @typedef {import('sass-embedded').Options<'sync'>} SyncSassOptions */
 /** @typedef {import('sass-embedded').Exception} SassException */
 /** @typedef {import('./').BuildOptions} BuildOptions */
+/** @typedef {import('node:child_process').ChildProcess} ChildProcess */
+/** @typedef {import('sass-embedded').AsyncCompiler & { process: ChildProcess}} SassAsyncCompiler */
 
 const env = process.env.NODE_ENV || process.env.RAILS_ENV || 'development';
 const isProduction = env === 'production';
@@ -80,7 +82,8 @@ function build(files) {
       console.error(error);
 
       if (isWatching && isSassException(error)) {
-        watchOnce(getErrorSassStackPaths(error.sassStack), () => build(files));
+        const { spawnfile } = /** @type {SassAsyncCompiler} */ (sassCompiler).process;
+        watchOnce(getErrorSassStackPaths(error.sassStack, spawnfile), () => build(files));
       } else {
         throw error;
       }

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -24,10 +24,11 @@ const { values: flags, positionals: fileArgs } = parseArgs({
     watch: { type: 'boolean' },
     'out-dir': { type: 'string' },
     'load-path': { type: 'string', multiple: true, default: [] },
+    verbose: { type: 'boolean', short: 'v' },
   },
 });
 
-const { watch: isWatching, 'out-dir': outDir, 'load-path': loadPaths = [] } = flags;
+const { watch: isWatching, 'out-dir': outDir, 'load-path': loadPaths = [], verbose } = flags;
 loadPaths.push(...getDefaultLoadPaths());
 
 const sassCompiler = await initAsyncSassCompiler();
@@ -62,6 +63,10 @@ const isSassException = (error) => 'span' in /** @type {SassException} */ (error
  * @return {Promise<void|void[]>}
  */
 function build(files) {
+  if (verbose) {
+    console.log('Building files', files);
+  }
+
   return Promise.all(
     files.map(async (file) => {
       const { loadedUrls } = await buildFile(file, options);

--- a/app/javascript/packages/build-sass/get-error-sass-stack-paths.js
+++ b/app/javascript/packages/build-sass/get-error-sass-stack-paths.js
@@ -1,32 +1,30 @@
+import { dirname, relative, resolve } from 'path';
+
 /**
  * Returns all file paths contained in the given Sass stack trace.
  *
  * @example
  * ```
  * getErrorSassStackPaths(
- *   'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
- *   'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
- *   'app/assets/stylesheets/components/_alert.scss 13:5                                     @import\n' +
- *   'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
- *   'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+ *   '../../../../app/assets/stylesheets/design-system-waiting-room.scss 31:2  @forward\n' +
+ *     '../../../../app/assets/stylesheets/application.css.scss 4:1              root stylesheet\n',
+ *   'node_modules/sass-embedded-darwin-arm64/dart-sass/src/dart',
  * );
  * // [
- * //   'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/_functions.scss',
- * //   'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/mixins/_icon.scss',
- * //   'app/assets/stylesheets/components/_alert.scss',
- * //   'app/assets/stylesheets/components/all.scss',
+ * //   'app/assets/stylesheets/design-system-waiting-room.scss',
  * //   'app/assets/stylesheets/application.css.scss',
  * // ]
  * ```
  *
  * @param {string} sassStack Sass stack trace (see example).
+ * @param {string} relativeFrom File from which to resolve relative paths from Sass stack trace.
  *
  * @return {string[]} Array of file paths.
  */
-const getErrorSassStackPaths = (sassStack) =>
+const getErrorSassStackPaths = (sassStack, relativeFrom) =>
   sassStack
     .split(/\.scss \d+:\d+\s+.+?\n/)
     .filter(Boolean)
-    .map((basename) => `${basename}.scss`);
+    .map((basename) => relative('.', resolve(dirname(relativeFrom), `${basename}.scss`)));
 
 export default getErrorSassStackPaths;

--- a/app/javascript/packages/build-sass/get-error-sass-stack-paths.spec.js
+++ b/app/javascript/packages/build-sass/get-error-sass-stack-paths.spec.js
@@ -1,39 +1,29 @@
 import getErrorSassStackPaths from './get-error-sass-stack-paths.js';
 
 describe('getErrorSassStackPaths', () => {
-  it('returns an array of paths from a sass stack message', () => {
+  it('returns an array of paths from a sass stack message resolved from relative file', () => {
     const stackPaths = getErrorSassStackPaths(
-      'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
-        'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
-        'app/assets/stylesheets/components/_alert.scss 13:5                                     @import\n' +
-        'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
-        'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+      '../../../../app/assets/stylesheets/design-system-waiting-room.scss 31:2  @forward\n' +
+        '../../../../app/assets/stylesheets/application.css.scss 4:1              root stylesheet\n',
+      'node_modules/sass-embedded-darwin-arm64/dart-sass/src/dart',
     );
 
     expect(stackPaths).to.deep.equal([
-      'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/_functions.scss',
-      'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/mixins/_icon.scss',
-      'app/assets/stylesheets/components/_alert.scss',
-      'app/assets/stylesheets/components/all.scss',
+      'app/assets/stylesheets/design-system-waiting-room.scss',
       'app/assets/stylesheets/application.css.scss',
     ]);
   });
 
   context('with a stack path containing a space', () => {
-    it('returns an array of paths from a sass stack message', () => {
+    it('returns an array of paths from a sass stack message resolved from relative file', () => {
       const stackPaths = getErrorSassStackPaths(
-        'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/_functions.scss 35:8     divide()\n' +
-          'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/mixins/_icon.scss 77:12  add-color-icon()\n' +
-          'app/assets/stylesheets/components/_alert example.scss 13:5                             @import\n' +
-          'app/assets/stylesheets/components/all.scss 3:9                                         @import\n' +
-          'app/assets/stylesheets/application.css.scss 7:9                                        root stylesheet\n',
+        '../../../../app/assets/stylesheets/design-system waiting-room.scss 31:2  @forward\n' +
+          '../../../../app/assets/stylesheets/application.css.scss 4:1              root stylesheet\n',
+        'node_modules/sass-embedded-darwin-arm64/dart-sass/src/dart',
       );
 
       expect(stackPaths).to.deep.equal([
-        'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/_functions.scss',
-        'node_modules/@18f/identity-design-system/dist/assets/scss/uswds/core/mixins/_icon.scss',
-        'app/assets/stylesheets/components/_alert example.scss',
-        'app/assets/stylesheets/components/all.scss',
+        'app/assets/stylesheets/design-system waiting-room.scss',
         'app/assets/stylesheets/application.css.scss',
       ]);
     });


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes `@18f/identity-build-sass` to rebuild stylesheets as expected after saving a file that had previously triggered an error.

This relied on parsing a stack trace produced by Sass. It appears that this stack trace was updated to produce paths relative from the compiler executable.

For future consideration:

- Open an issue to [`sass/embedded-host-node`](https://github.com/sass/embedded-host-node) to provide full compilation result in an error. This is related to https://github.com/sass/embedded-host-node/issues/190 . A failed compilation includes [`loadedUrls`](https://sass-lang.com/documentation/js-api/interfaces/compileresult/#loadedUrls), but there's no way to get at these since the failed result [raises an error without the full result object](https://github.com/sass/embedded-host-node/blob/eabbe379fe1224be32a1b8c36d7c0f3ca1913fe2/lib/src/compiler/utils.ts#L220-L221).
- Create end-to-end test for using CLI to compile and watch files, including this scenario

## 📜 Testing Plan

1. `yarn build-sass app/components/click_observer_component.scss --watch --verbose`
2. Edit and save `app/components/click_observer_component.scss` to cause an error, e.g. removing a curly brace
    ```diff
    - diff --git a/app/components/click_observer_component.scss b/app/components/click_observer_component.scss
    index 0d9671bba4..1c5c14cb44 100644
    --- a/app/components/click_observer_component.scss
    +++ b/app/components/click_observer_component.scss
    @@ -1,3 +1,2 @@
     lg-click-observer {
       display: contents;
    -}
    ```
3. Observe error in terminal
4. Edit and save `app/components/click_observer_component.scss` to fix error
5. Observe in terminal that rebuild occurs as expected
    ```
    Building files [ 'app/components/click_observer_component.scss' ]
    ```