### PR TITLE
LG-12571 Specify "hints" for WebAuthn security key enrollment

### DIFF
--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -134,12 +134,14 @@ describe('enrollWebauthnDevice', () => {
           challenge,
           excludeCredentials,
           authenticatorAttachment: 'platform',
+          publicKeyCredentialHints: 'security-key',
         });
 
         expect(navigator.credentials.create).to.have.been.calledWithMatch({
           publicKey: {
             authenticatorSelection: {
               authenticatorAttachment: 'platform',
+              publicKeyCredentialHints: 'client-device',
             },
           },
         });

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -134,7 +134,7 @@ describe('enrollWebauthnDevice', () => {
           challenge,
           excludeCredentials,
           authenticatorAttachment: 'platform',
-          publicKeyCredentialHints: 'security-key',
+          publicKeyCredentialHints: 'client-device',
         });
 
         expect(navigator.credentials.create).to.have.been.calledWithMatch({

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -62,6 +62,7 @@ describe('enrollWebauthnDevice', () => {
         challenge,
         excludeCredentials,
         authenticatorAttachment: 'cross-platform',
+        publicKeyCredentialHints: 'security-key',
       });
 
       expect(navigator.credentials.create).to.have.been.calledWith({
@@ -85,8 +86,9 @@ describe('enrollWebauthnDevice', () => {
           timeout: 800000,
           attestation: 'none',
           authenticatorSelection: {
-            authenticatorAttachment: 'cross-platform',
             userVerification: 'discouraged',
+            authenticatorAttachment: 'cross-platform',
+            publicKeyCredentialHints: 'security-key',
           },
           excludeCredentials: [
             {

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -62,7 +62,7 @@ describe('enrollWebauthnDevice', () => {
         challenge,
         excludeCredentials,
         authenticatorAttachment: 'cross-platform',
-        publicKeyCredentialHints: 'security-key',
+        hints: ['security-key'],
       });
 
       expect(navigator.credentials.create).to.have.been.calledWith({
@@ -88,7 +88,7 @@ describe('enrollWebauthnDevice', () => {
           authenticatorSelection: {
             userVerification: 'discouraged',
             authenticatorAttachment: 'cross-platform',
-            publicKeyCredentialHints: 'security-key',
+            hints: ['security-key'],
           },
           excludeCredentials: [
             {
@@ -134,14 +134,14 @@ describe('enrollWebauthnDevice', () => {
           challenge,
           excludeCredentials,
           authenticatorAttachment: 'platform',
-          publicKeyCredentialHints: 'client-device',
+          hints: ['client-device'],
         });
 
         expect(navigator.credentials.create).to.have.been.calledWithMatch({
           publicKey: {
             authenticatorSelection: {
               authenticatorAttachment: 'platform',
-              publicKeyCredentialHints: 'client-device',
+              hints: ['client-device'],
             },
           },
         });

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -15,6 +15,8 @@ interface AuthenticatorAttestationResponseBrowserSupport
   getAuthenticatorData: AuthenticatorAttestationResponse['getAuthenticatorData'] | undefined;
 }
 
+type PublicKeyCredentialHintType = 'client-device' | 'security-key' | 'hybrid';
+
 interface EnrollOptions {
   user: PublicKeyCredentialUserEntity;
 
@@ -24,7 +26,7 @@ interface EnrollOptions {
 
   authenticatorAttachment?: AuthenticatorAttachment;
 
-  publicKeyCredentialHints?: 'client-device' | 'security-key';
+  hints?: Array<PublicKeyCredentialHintType>;
 }
 
 interface EnrollResult {
@@ -40,7 +42,7 @@ interface EnrollResult {
 }
 
 interface AuthenticatorSelectionCriteriaWithHints extends AuthenticatorSelectionCriteria {
-  publicKeyCredentialHints?: 'client-device' | 'security-key';
+  hints?: Array<PublicKeyCredentialHintType>;
 }
 
 /**
@@ -82,7 +84,7 @@ async function enrollWebauthnDevice({
   challenge,
   excludeCredentials,
   authenticatorAttachment,
-  publicKeyCredentialHints,
+  hints,
 }: EnrollOptions): Promise<EnrollResult> {
   const credential = (await navigator.credentials.create({
     publicKey: {
@@ -96,7 +98,7 @@ async function enrollWebauthnDevice({
         // Prevents user from needing to use PIN with Security Key
         userVerification: 'discouraged',
         authenticatorAttachment,
-        publicKeyCredentialHints,
+        hints,
       } as AuthenticatorSelectionCriteriaWithHints,
       excludeCredentials,
     },

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -40,7 +40,7 @@ interface EnrollResult {
 }
 
 interface AuthenticatorSelectionCriteriaWithHints extends AuthenticatorSelectionCriteria {
-  publicKeyCredentialHints?: 'client' | 'security-key';
+  publicKeyCredentialHints?: 'client-device' | 'security-key';
 }
 
 /**

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -39,7 +39,7 @@ interface EnrollResult {
   transports?: string[];
 }
 
-interface AuthenticatorSelectionCriteria {
+interface AuthenticatorSelectionCriteriaWithHints {
   authenticatorAttachment?: 'platform' | 'cross-platform' | undefined;
   requireResidentKey?: boolean | undefined;
   userVerification?: 'required' | 'preferred' | 'discouraged' | undefined;
@@ -100,7 +100,7 @@ async function enrollWebauthnDevice({
         userVerification: 'discouraged',
         authenticatorAttachment,
         publicKeyCredentialHints,
-      } as AuthenticatorSelectionCriteria,
+      } as AuthenticatorSelectionCriteriaWithHints,
       excludeCredentials,
     },
   })) as PublicKeyCredential;

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -23,6 +23,8 @@ interface EnrollOptions {
   excludeCredentials: PublicKeyCredentialDescriptor[];
 
   authenticatorAttachment?: AuthenticatorAttachment;
+
+  publicKeyCredentialHints?: string;
 }
 
 interface EnrollResult {
@@ -35,6 +37,13 @@ interface EnrollResult {
   authenticatorDataFlagsValue?: number;
 
   transports?: string[];
+}
+
+interface AuthenticatorSelectionCriteria {
+  authenticatorAttachment?: 'platform' | 'cross-platform' | undefined;
+  requireResidentKey?: boolean | undefined;
+  userVerification?: 'required' | 'preferred' | 'discouraged' | undefined;
+  publicKeyCredentialHints?: 'client' | 'security-key';
 }
 
 /**
@@ -76,6 +85,7 @@ async function enrollWebauthnDevice({
   challenge,
   excludeCredentials,
   authenticatorAttachment,
+  publicKeyCredentialHints,
 }: EnrollOptions): Promise<EnrollResult> {
   const credential = (await navigator.credentials.create({
     publicKey: {
@@ -89,7 +99,8 @@ async function enrollWebauthnDevice({
         // Prevents user from needing to use PIN with Security Key
         userVerification: 'discouraged',
         authenticatorAttachment,
-      },
+        publicKeyCredentialHints,
+      } as AuthenticatorSelectionCriteria,
       excludeCredentials,
     },
   })) as PublicKeyCredential;

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -24,7 +24,7 @@ interface EnrollOptions {
 
   authenticatorAttachment?: AuthenticatorAttachment;
 
-  publicKeyCredentialHints?: string;
+  publicKeyCredentialHints?: 'client-device' | 'security-key';
 }
 
 interface EnrollResult {

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -39,10 +39,7 @@ interface EnrollResult {
   transports?: string[];
 }
 
-interface AuthenticatorSelectionCriteriaWithHints {
-  authenticatorAttachment?: 'platform' | 'cross-platform' | undefined;
-  requireResidentKey?: boolean | undefined;
-  userVerification?: 'required' | 'preferred' | 'discouraged' | undefined;
+interface AuthenticatorSelectionCriteriaWithHints extends AuthenticatorSelectionCriteria {
   publicKeyCredentialHints?: 'client' | 'security-key';
 }
 

--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -56,7 +56,7 @@ function webauthn() {
           .filter(Boolean),
       ),
       authenticatorAttachment: platformAuthenticator ? 'platform' : 'cross-platform',
-      publicKeyCredentialHints: platformAuthenticator ? 'client-device' : 'security-key',
+      hints: platformAuthenticator ? ['client-device', 'hybrid'] : ['security-key'],
     })
       .then((result) => {
         (document.getElementById('webauthn_id') as HTMLInputElement).value = result.webauthnId;

--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -56,6 +56,7 @@ function webauthn() {
           .filter(Boolean),
       ),
       authenticatorAttachment: platformAuthenticator ? 'platform' : 'cross-platform',
+      publicKeyCredentialHints: platformAuthenticator ? 'client-device' : 'security-key',
     })
       .then((result) => {
         (document.getElementById('webauthn_id') as HTMLInputElement).value = result.webauthnId;


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-12571](https://cm-jira.usa.gov/browse/LG-12571)



## 🛠 Summary of changes

When enrolling a non-platform webauthn device it passes the value 'security-key' with the `authenticatorSelection` object.
Platform devices will have 'client-device' added.
https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialhints-client-device


## 📜 Testing Plan

Test for enroll-webauthn-device should pass.
Setup should work as before without any issues.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
