### PR TITLE
Add `Pii::Address` and use it store address in `Idv::AddressController`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -560,7 +560,7 @@ GEM
       ffi (~> 1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    redacted_struct (1.1.0)
+    redacted_struct (2.0.0)
     redcarpet (3.6.0)
     redis (5.0.6)
       redis-client (>= 0.9.0)

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -35,7 +35,7 @@ module Idv
         action: :new,
         next_steps: [:verify_info],
         preconditions: ->(idv_session:, user:) { idv_session.remote_document_capture_complete? },
-        undo_step: ->(idv_session:, user:) {},
+        undo_step: ->(idv_session:, user:) { idv_session.updated_user_address = nil },
       )
     end
 
@@ -53,12 +53,23 @@ module Idv
         state: @address_form.state,
         zipcode: @address_form.zipcode,
       )
+      idv_session.updated_user_address = address_from_form
       redirect_to idv_verify_info_url
     end
 
     def failure
       @presenter = AddressPresenter.new
       render :new
+    end
+
+    def address_from_form
+      Pii::Address.new(
+        address1: @address_form.address1,
+        address2: @address_form.address2,
+        city: @address_form.city,
+        state: @address_form.state,
+        zipcode: @address_form.zipcode,
+      )
     end
 
     def profile_params

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -169,6 +169,16 @@ module Idv
       session[:failed_phone_step_params] ||= []
     end
 
+    def updated_user_address=(updated_user_address)
+      session[:updated_user_address] = nil if updated_user_address.nil?
+      session[:updated_user_address] = updated_user_address.to_h
+    end
+
+    def updated_user_address
+      return nil if session[:updated_user_address].blank?
+      Pii::Address.new(**session[:updated_user_address])
+    end
+
     def add_failed_phone_step_number(phone)
       parsed_phone = Phonelib.parse(phone)
       phone_e164 = parsed_phone.e164

--- a/app/services/pii/address.rb
+++ b/app/services/pii/address.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/MutableConstant
+module Pii
+  Address = RedactedData.define(:state, :zipcode, :city, :address1, :address2)
+end
+# rubocop:enable Style/MutableConstant

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe Idv::AddressController do
       )
     end
 
+    it 'adds updated_user_data to idv_session' do
+      expect do
+        put :update, params: params
+      end.to change { subject.idv_session.updated_user_address }
+
+      expect(subject.idv_session.updated_user_address).to eql(
+        Pii::Address.new(
+          address1: '1234 Main St',
+          address2: 'Apt B',
+          city: 'Beverly Hills',
+          state: 'CA',
+          zipcode: '90210',
+        ),
+      )
+    end
+
     it 'invalidates future steps' do
       expect(subject).to receive(:clear_future_steps!)
 
@@ -109,6 +125,13 @@ RSpec.describe Idv::AddressController do
         expect(response).to render_template(:new)
         expect(response.body).to include(t('idv.errors.pattern_mismatch.zipcode'))
       end
+    end
+
+    xit 'has the correct `address_edited` value when submitted twice with the same data' do
+      put :update, params: params
+      expect(subject.idv_session.address_edited).to eq(true)
+      put :update, params: params
+      expect(subject.idv_session.address_edited).to eq(true)
     end
   end
 end


### PR DESCRIPTION
Currently `Idv::AddressController` collects an updated address from the user and merges it into `pii_from_doc` in `idv_session`. This results in the address that was read from the doc being overwritten. This approach leads to a few issues:

1. It necessitates a `address_edited` property on `Idv::Session` and custom code to maintain the value of that column. This code also has a tricky bug where it does not track address edits if the same data is submitted twice.
2. It differs from the in-person workflow where the document address and the user address are maintained separately for use in double address verification

This commit introduces a new pattern where the PII collected from the user is stored in an immutable object in the `Idv::Session`. This lets us be confident that the PII we have in the session is in fact what the user entered and operate on it as such.

This commit makes changes to the session so it will require a follow-up change to read this data once this has been deployed. All of that will need to be followed by a change to stop writing the data using the old approach.
