### PR TITLE
Start reading from `idv_session.updated_user_address`

### DIFF
--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -11,15 +11,15 @@ module Idv
     def new
       analytics.idv_address_visit
 
-      @address_form = Idv::AddressForm.new(idv_session.pii_from_doc)
+      @address_form = build_address_form
       @presenter = AddressPresenter.new
     end
 
     def update
       clear_future_steps!
-      @address_form = Idv::AddressForm.new(idv_session.pii_from_doc)
+      @address_form = build_address_form
       form_result = @address_form.submit(profile_params)
-      analytics.idv_address_submitted(**form_result.to_h)
+      track_submit_event(form_result)
       capture_address_edited(form_result)
       if form_result.success?
         success
@@ -41,11 +41,24 @@ module Idv
 
     private
 
-    def idv_form
-      Idv::AddressForm.new(idv_session.pii_from_doc)
+    def build_address_form
+      Idv::AddressForm.new(
+        idv_session.updated_user_address || address_from_document,
+      )
+    end
+
+    def address_from_document
+      Pii::Address.new(
+        address1: idv_session.pii_from_doc[:address1],
+        address2: idv_session.pii_from_doc[:address2],
+        city: idv_session.pii_from_doc[:city],
+        state: idv_session.pii_from_doc[:state],
+        zipcode: idv_session.pii_from_doc[:zipcode],
+      )
     end
 
     def success
+      idv_session.address_edited = address_edited?
       idv_session.pii_from_doc = idv_session.pii_from_doc.merge(
         address1: @address_form.address1,
         address2: @address_form.address2,
@@ -53,7 +66,7 @@ module Idv
         state: @address_form.state,
         zipcode: @address_form.zipcode,
       )
-      idv_session.updated_user_address = address_from_form
+      idv_session.updated_user_address = @address_form.updated_user_address
       redirect_to idv_verify_info_url
     end
 
@@ -62,14 +75,13 @@ module Idv
       render :new
     end
 
-    def address_from_form
-      Pii::Address.new(
-        address1: @address_form.address1,
-        address2: @address_form.address2,
-        city: @address_form.city,
-        state: @address_form.state,
-        zipcode: @address_form.zipcode,
-      )
+    def track_submit_event(form_result)
+      address_edited = form_result.success? && address_edited?
+      analytics.idv_address_submitted(**form_result.to_h.merge(address_edited:))
+    end
+
+    def address_edited?
+      address_from_document != @address_form.updated_user_address
     end
 
     def profile_params

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -79,7 +79,7 @@ module Idv
     end
 
     def pii
-      idv_session.pii_from_doc
+      idv_session.pii_from_doc.merge(idv_session.updated_user_address.to_h)
     end
   end
 end

--- a/app/forms/idv/address_form.rb
+++ b/app/forms/idv/address_form.rb
@@ -13,46 +13,41 @@ module Idv
       ActiveModel::Name.new(self, nil, 'IdvForm')
     end
 
-    def initialize(pii)
-      set_ivars_with_pii(pii)
-      @address_edited = false
+    def initialize(initial_address)
+      consume_attributes_from_address(initial_address.to_h)
     end
 
     def submit(params)
-      consume_params(params)
+      consume_attributes_from_address(params.to_h)
 
       FormResponse.new(
         success: valid?,
         errors: errors,
         extra: {
-          address_edited: @address_edited,
           pii_like_keypaths: [[:errors, :zipcode], [:error_details, :zipcode]],
         },
       )
     end
 
+    def updated_user_address
+      Pii::Address.new(
+        address1: address1,
+        address2: address2,
+        city: city,
+        state: state,
+        zipcode: zipcode,
+      )
+    end
+
     private
 
-    def set_ivars_with_pii(pii)
-      pii = pii.symbolize_keys
-      @address1 = pii[:address1]
-      @address2 = pii[:address2]
-      @city = pii[:city]
-      @state = pii[:state]
-      @zipcode = pii[:zipcode]
-    end
-
-    def consume_params(params)
-      ATTRIBUTES.each do |attribute_name|
-        if send(attribute_name).to_s != params[attribute_name].to_s
-          @address_edited = true
-        end
-        send(:"#{attribute_name}=", params[attribute_name].to_s)
-      end
-    end
-
-    def raise_invalid_address_parameter_error(key)
-      raise ArgumentError, "#{key} is an invalid address attribute"
+    def consume_attributes_from_address(address_hash)
+      address_hash = address_hash.symbolize_keys
+      @address1 = address_hash[:address1].to_s.strip
+      @address2 = address_hash[:address2].to_s.strip
+      @city = address_hash[:city].to_s.strip
+      @state = address_hash[:state].to_s.strip
+      @zipcode = address_hash[:zipcode].to_s.strip
     end
   end
 end

--- a/spec/forms/idv/address_form_spec.rb
+++ b/spec/forms/idv/address_form_spec.rb
@@ -1,16 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Idv::AddressForm do
-  let(:pii) do
-    {
-      first_name: 'Test',
-      last_name: 'McTesterson',
+  let(:initial_address) do
+    Pii::Address.new(
       address1: '123 Main St',
-      address2: nil,
+      address2: '',
       city: 'Testertown',
       state: 'TX',
       zipcode: '11111',
-    }
+    )
   end
 
   let(:params) do
@@ -24,9 +22,9 @@ RSpec.describe Idv::AddressForm do
   end
 
   it 'is initialized with values from the hash in the initializer' do
-    address_form = Idv::AddressForm.new(pii)
+    address_form = Idv::AddressForm.new(initial_address)
     expect(address_form.address1).to eq('123 Main St')
-    expect(address_form.address2).to eq(nil)
+    expect(address_form.address2).to eq('')
     expect(address_form.city).to eq('Testertown')
     expect(address_form.state).to eq('TX')
     expect(address_form.zipcode).to eq('11111')
@@ -35,10 +33,9 @@ RSpec.describe Idv::AddressForm do
   describe '#submit' do
     context 'with valid params' do
       it 'returns a successful result' do
-        result = Idv::AddressForm.new(pii).submit(params)
+        result = Idv::AddressForm.new(initial_address).submit(params)
 
         expect(result.success?).to eq(true)
-        expect(result.extra[:address_edited]).to eq(true)
       end
     end
 
@@ -46,7 +43,7 @@ RSpec.describe Idv::AddressForm do
       it 'returns an error result' do
         params[:zipcode] = 'this is not a valid zipcde'
 
-        result = Idv::AddressForm.new(pii).submit(params)
+        result = Idv::AddressForm.new(initial_address).submit(params)
 
         expect(result.success?).to eq(false)
         expect(result.errors[:zipcode]).to be_present
@@ -57,21 +54,10 @@ RSpec.describe Idv::AddressForm do
       it 'returns an error result' do
         params.delete(:zipcode)
 
-        result = Idv::AddressForm.new(pii).submit(params)
+        result = Idv::AddressForm.new(initial_address).submit(params)
 
         expect(result.success?).to eq(false)
         expect(result.errors[:zipcode]).to be_present
-      end
-    end
-
-    context 'the user submits the same address that is in the pii' do
-      it 'does not set `address_edited` to true' do
-        params = pii.slice(:address1, :address2, :city, :state, :zipcode)
-
-        result = Idv::AddressForm.new(pii).submit(params)
-
-        expect(result.success?).to eq(true)
-        expect(result.extra[:address_edited]).to eq(false)
       end
     end
   end


### PR DESCRIPTION
In #10385 we started writing the address the user provides in the `Idv::AddressController` to `idv_session.updated_user_address`. This commit starts reading the address from there so that we can eventually stop overwriting the address in `pii_from_doc`.
