### PR TITLE
Stop adding updated address to `idv_session.pii_from_doc`

### DIFF
--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -59,13 +59,6 @@ module Idv
 
     def success
       idv_session.address_edited = address_edited?
-      idv_session.pii_from_doc = idv_session.pii_from_doc.merge(
-        address1: @address_form.address1,
-        address2: @address_form.address2,
-        city: @address_form.city,
-        state: @address_form.state,
-        zipcode: @address_form.zipcode,
-      )
       idv_session.updated_user_address = @address_form.updated_user_address
       redirect_to idv_verify_info_url
     end

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -63,24 +63,6 @@ RSpec.describe Idv::AddressController do
       end.to change { subject.idv_session.address_edited }.from(nil).to eql(true)
     end
 
-    it 'updates pii_from_doc in idv_session' do
-      expect do
-        put :update, params: params
-      end.to change { subject.idv_session.pii_from_doc }
-
-      expect(subject.idv_session.pii_from_doc).to eql(
-        pii_from_doc.merge(
-          {
-            'address1' => '1234 Main St',
-            'address2' => 'Apt B',
-            'city' => 'Beverly Hills',
-            'state' => 'CA',
-            'zipcode' => '90210',
-          },
-        ),
-      )
-    end
-
     it 'adds updated_user_data to idv_session' do
       expect do
         put :update, params: params
@@ -127,7 +109,7 @@ RSpec.describe Idv::AddressController do
       end
     end
 
-    xit 'has the correct `address_edited` value when submitted twice with the same data' do
+    it 'has the correct `address_edited` value when submitted twice with the same data' do
       put :update, params: params
       expect(subject.idv_session.address_edited).to eq(true)
       put :update, params: params


### PR DESCRIPTION
In #10390 we started using the new `idv_session.updated_user_address` value to represent the user address if it is present. This allows us to stop overwriting the user address that was on the document in `pii_from_doc`. We were not able to actually take this step because of the 50/50 state issues related to session updates.

This commit stops overwriting the PII from the document in `pii_from_doc` when a new address is provided in `Idv::AddressController`
