### PR TITLE
Shift header styles to navigation (account) stylesheet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ lint_asset_bundle_size: ## Lints JavaScript and CSS compiled bundle size
 	@# and you have no options to split that from the common bundles. If you need to increase this
 	@# budget and accept the fact that this will force end-users to endure longer load times, you
 	@# should set the new budget to within a few thousand bytes of the production-compiled size.
-	find app/assets/builds/application.css -size -220000c | grep .
+	find app/assets/builds/application.css -size -190000c | grep .
 	find public/packs/js/application-*.digested.js -size -5000c | grep .
 
 lint_migrations:

--- a/app/assets/stylesheets/_uswds.scss
+++ b/app/assets/stylesheets/_uswds.scss
@@ -7,7 +7,6 @@
 @forward 'usa-banner';
 @forward 'usa-button';
 @forward 'usa-form';
-@forward 'usa-header';
 @forward 'usa-layout-grid';
 @forward 'usa-link';
 @forward 'usa-list';

--- a/app/assets/stylesheets/navigation.css.scss
+++ b/app/assets/stylesheets/navigation.css.scss
@@ -1,5 +1,6 @@
 @use 'uswds-core' as *;
 
+@forward 'usa-header/src/styles/usa-header';
 @forward 'usa-nav/src/styles';
 @forward 'usa-sidenav/src/styles';
 

--- a/app/views/accounts/_nav_auth.html.erb
+++ b/app/views/accounts/_nav_auth.html.erb
@@ -1,3 +1,8 @@
+<div class="usa-overlay"></div>
+<div class="usa-header">
+  <%= render 'accounts/mobile_nav' %>
+</div>
+
 <div class="grid-container padding-x-0 tablet:padding-x-4">
   <div class="grid-row flex-justify tablet:padding-y-4">
     <div class="grid-col-auto display-flex flex-align-center padding-x-2 tablet:padding-x-0">
@@ -19,9 +24,10 @@
 
       <%= button_to t('links.sign_out'), logout_path, method: :delete, class: 'usa-button usa-button--unstyled' %>
 
-      <% if enable_mobile_nav %>
-        <button class="usa-menu-btn margin-left-2"><%= t('account.navigation.menu') %></button>
-      <% end %>
+      <button class="usa-menu-btn margin-left-2"><%= t('account.navigation.menu') %></button>
     </div>
   </div>
 </div>
+
+<%= stylesheet_tag_once('navigation') %>
+<%= javascript_packs_tag_once('navigation') %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:header) do %>
-  <%= render 'accounts/nav_auth', enable_mobile_nav: false, greeting: @presenter.header_personalization %>
+  <%= render 'accounts/nav_auth', greeting: @presenter.header_personalization %>
 <% end %>
 
 <% self.title = t('titles.account') %>

--- a/app/views/layouts/account_side_nav.html.erb
+++ b/app/views/layouts/account_side_nav.html.erb
@@ -1,13 +1,6 @@
 <% content_for(:header) do %>
-  <%= render 'accounts/nav_auth', enable_mobile_nav: true, greeting: @presenter.header_personalization %>
+  <%= render 'accounts/nav_auth', greeting: @presenter.header_personalization %>
 <% end %>
-
-<% content_for(:mobile_nav) do %>
-  <%= render 'accounts/mobile_nav' %>
-<% end %>
-
-<%= stylesheet_tag_once('navigation') %>
-<%= javascript_packs_tag_once('navigation') %>
 
 <%= extends_layout :application, body_class: 'site', disable_card: true, user_main_tag: false do %>
   <div class="grid-row grid-gap">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,12 +4,6 @@
 
 <%= extends_layout :base, body_class: local_assigns.fetch(:body_class, 'site tablet:bg-primary-lighter') do %>
   <%= link_to t('shared.skip_link'), '#main-content', class: 'usa-skipnav' %>
-  <div class="usa-overlay"></div>
-  <% if content_for?(:mobile_nav) %>
-    <div class="usa-header">
-      <%= yield(:mobile_nav) %>
-    </div>
-  <% end %>
   <%= render 'shared/banner' %>
   <%= content_tag(
         local_assigns[:user_main_tag] == false ? 'div' : 'main',

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -18,8 +18,8 @@
   <% end %>
   <%= preload_link_tag font_url('public-sans/PublicSans-Bold.woff2') %>
   <%= preload_link_tag font_url('public-sans/PublicSans-Regular.woff2') %>
-  <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= render_stylesheet_once_tags %>
+  <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= csrf_meta_tags %>
 
   <%= favicon_link_tag(

--- a/spec/views/accounts/_nav_auth.html.erb_spec.rb
+++ b/spec/views/accounts/_nav_auth.html.erb_spec.rb
@@ -7,36 +7,25 @@ RSpec.describe 'accounts/_nav_auth.html.erb' do
     @user = build_stubbed(:user, :with_backup_code)
     allow(view).to receive(:greeting).and_return(@user.email)
     allow(view).to receive(:current_user).and_return(@user)
+    render partial: 'accounts/nav_auth'
   end
 
-  context 'user is signed in' do
-    before do
-      render partial: 'accounts/nav_auth', locals: { enable_mobile_nav: false }
-    end
-
-    it 'contains welcome message' do
-      expect(rendered).to have_content "Welcome #{@user.email}", normalize_ws: true
-    end
-
-    it 'does not contain link to cancel the auth process' do
-      expect(rendered).not_to have_link(t('links.cancel'))
-    end
-
-    it 'contains sign out link' do
-      expect(rendered).to have_button(t('links.sign_out'))
-      expect(rendered).to have_selector('form') do |f|
-        expect(f['action']).to eq logout_path
-      end
-    end
+  it 'contains welcome message' do
+    expect(rendered).to have_content "Welcome #{@user.email}", normalize_ws: true
   end
 
-  context 'mobile nav is enabled' do
-    before do
-      render partial: 'accounts/nav_auth', locals: { enable_mobile_nav: true }
-    end
+  it 'does not contain link to cancel the auth process' do
+    expect(rendered).not_to have_link(t('links.cancel'))
+  end
 
-    it 'contains menu button' do
-      expect(rendered).to have_button t('account.navigation.menu')
+  it 'contains menu button' do
+    expect(rendered).to have_button t('account.navigation.menu')
+  end
+
+  it 'contains sign out link' do
+    expect(rendered).to have_button(t('links.sign_out'))
+    expect(rendered).to have_selector('form') do |f|
+      expect(f['action']).to eq logout_path
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Moves header styles out of the critical-path stylesheet (`application.css`) and into the dedicated stylesheet for the account page where the header is implemented (`navigation.css`).

**Why?**

- Reduces size of common application stylesheet
- Avoids bringing in additional unused styles (e.g. `usa-search`), since we only use [the base `usa-header` class](https://github.com/18F/identity-idp/blob/e578719946b2d3c965e7cd41924b6b9c284f1e17/app/views/layouts/application.html.erb#L9)

**Performance Impact:**

```
NODE_ENV=production yarn build:css
brotli-size app/assets/builds/application.css
brotli-size app/assets/builds/navigation.css
```

Stylesheet|Before|After|Net Diff|Percent Diff
---|---|---|---|---
`application.css`|21.3 kB|18.7 kB|-2.6 kB|-12.2%
`navigation.css`|2.27 kB|3.06 kB|+0.79 kB|+34.8%

## 📜 Testing Plan

Verify there are no visual regressions in the header layout of either the base layout (e.g. "Sign in" page) or the account section pages, including mobile navigation.