### PR TITLE
LG-13022 Allow in-person proofing to satisfy biometric comparison requirement

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   MAX_RECENT_EVENTS = 5
   MAX_RECENT_DEVICES = 5
 
-  BIOMETRIC_COMPARISON_IDV_LEVELS = %w[unsupervised_with_selfie in_person].freeze
+  BIOMETRIC_COMPARISON_IDV_LEVELS = %w[unsupervised_with_selfie in_person].to_set.freeze
 
   enum otp_delivery_preference: { sms: 0, voice: 1 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -365,7 +365,8 @@ class User < ApplicationRecord
   end
 
   def identity_verified_with_selfie?
-    active_profile&.idv_level == 'unsupervised_with_selfie'
+    biometric_comparison_idv_levels = ['unsupervised_with_selfie', 'in_person']
+    biometric_comparison_idv_levels.include?(active_profile&.idv_level)
   end
 
   def reproof_for_irs?(service_provider:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,8 @@ class User < ApplicationRecord
   MAX_RECENT_EVENTS = 5
   MAX_RECENT_DEVICES = 5
 
+  BIOMETRIC_COMPARISON_IDV_LEVELS = %w[unsupervised_with_selfie, in_person].freeze
+
   enum otp_delivery_preference: { sms: 0, voice: 1 }
 
   # rubocop:disable Rails/HasManyOrHasOneDependent
@@ -365,8 +367,7 @@ class User < ApplicationRecord
   end
 
   def identity_verified_with_selfie?
-    biometric_comparison_idv_levels = ['unsupervised_with_selfie', 'in_person']
-    biometric_comparison_idv_levels.include?(active_profile&.idv_level)
+    BIOMETRIC_COMPARISON_IDV_LEVELS.include?(active_profile&.idv_level)
   end
 
   def reproof_for_irs?(service_provider:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   MAX_RECENT_EVENTS = 5
   MAX_RECENT_DEVICES = 5
 
-  BIOMETRIC_COMPARISON_IDV_LEVELS = %w[unsupervised_with_selfie, in_person].freeze
+  BIOMETRIC_COMPARISON_IDV_LEVELS = %w[unsupervised_with_selfie in_person].freeze
 
   enum otp_delivery_preference: { sms: 0, voice: 1 }
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -477,6 +477,16 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 end
               end
 
+              context 'bioemtric comparison was performed in-person' do
+                it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
+                  user.active_profile.idv_level = :in_person
+
+                  action
+
+                  expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+                end
+              end
+
               context 'selfie capture not enabled, biometric_comparison_check requested by sp' do
                 let(:selfie_capture_enabled) { false }
                 it 'returns status not_acceptable' do

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 end
               end
 
-              context 'bioemtric comparison was performed in-person' do
+              context 'biometric comparison was performed in-person' do
                 it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
                   user.active_profile.idv_level = :in_person
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -658,9 +658,21 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
           end
         end
 
-        context 'the user has proofed with a biometric check' do
+        context 'the user has proofed with a biometric check remotely' do
           before do
             user.active_profile.update!(idv_level: :unsupervised_with_selfie)
+          end
+
+          it 'does not redirect to proofing' do
+            saml_get_auth(vtr_settings)
+            expect(response).to redirect_to(sign_up_completed_url)
+            expect(controller.session[:sp][:vtr]).to eq(['C1.C2.P1.Pb'])
+          end
+        end
+
+        context 'the user has proofed with a biometric check in-person' do
+          before do
+            user.active_profile.update!(idv_level: :in_person)
           end
 
           it 'does not redirect to proofing' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1435,6 +1435,12 @@ RSpec.describe User do
       expect(user.identity_verified_with_selfie?).to eq false
     end
 
+    it 'return true if user has an active in-person profile' do
+      active_profile.idv_level = :in_person
+      active_profile.save
+      expect(user.identity_verified_with_selfie?).to eq true
+    end
+
     context 'user does not have active profile' do
       let(:active_profile) { nil }
       it 'returns false' do


### PR DESCRIPTION
When a user proofs in-person they satisfy the biometric comparison requirement since that is done when they present their document. This was not recognized as satisfying the biometric requirement in the code. This commit makes adjustments so that it does.
