### PR TITLE
Avoid initializing geocoder in test environments

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -13,7 +13,7 @@ end
 
 GEO_DATA_FILEPATH = Rails.root.join(IdentityConfig.store.geo_data_file_path).freeze
 
-if File.exist?(GEO_DATA_FILEPATH)
+if File.exist?(GEO_DATA_FILEPATH) && !Rails.env.test?
   Geocoder.configure(
     ip_lookup: :geoip2,
     geoip2: {


### PR DESCRIPTION
## 🛠 Summary of changes

Updates geocoder initializer to avoid loading the geocoder file in test environments.

This is a partial reversal of #10319, while still allowing the geocoder to be initialized for local development.

This resolves an issue where tests may fail when trying to geocode an IP address.

## 📜 Testing Plan

1. Follow the instructions to set up geolocation
   1. Alternatively, download live database from S3
2. Run: `rspec spec/controllers/users/piv_cac_login_controller_spec.rb`
3. Observe all tests pass

Previous failure example:

```
      Failure/Error: @geocoded_location ||= Geocoder.search(ip).first
      
      ActionView::Template::Error:
        unknown stub request 0.0.0.0
      # ./app/services/ip_geocoder.rb:42:in `geocoded_location'
```