### PR TITLE
Create tmp/pids directory in make setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -74,6 +74,6 @@ Dir.chdir APP_ROOT do
   run "make clobber_logs"
 
   puts "\n== Restarting application server =="
-  run "mkdir -p tmp"
+  run "mkdir -p tmp/pids"
   run "touch tmp/restart.txt"
 end


### PR DESCRIPTION
Creating this directory manually helps make sure that `make run` can run without issue (instead of throwing errors because the `pids` directory does not exist)

Redo of #10308, which had issues with file permissions when deployed and had to be reverted

