### PR TITLE
Change the default value of `use_vot_in_sp_requests` to true

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -350,7 +350,7 @@ version_headers_enabled: false
 vtm_url: 'https://developer.login.gov/vot-trust-framework'
 use_dashboard_service_providers: false
 use_kms: false
-use_vot_in_sp_requests: false
+use_vot_in_sp_requests: true
 usps_auth_token_refresh_job_enabled: false
 usps_confirmation_max_days: 30
 usps_ipp_password: ''
@@ -506,7 +506,6 @@ production:
   state_tracking_enabled: false
   telephony_adapter: pinpoint
   use_kms: true
-  use_vot_in_sp_requests: false
   usps_auth_token_refresh_job_enabled: true
   usps_confirmation_max_days: 30
   usps_upload_sftp_directory: ''
@@ -601,7 +600,6 @@ test:
   verify_gpo_key_max_attempts: 2
   verify_personal_key_attempt_window_in_minutes: 3
   verify_personal_key_max_attempts: 2
-  use_vot_in_sp_requests: true
   usps_ipp_root_url: 'http://localhost:1000'
   usps_upload_sftp_directory: "/directory"
   usps_upload_sftp_host: example.com


### PR DESCRIPTION
We have approval to enable VTRs and we will be preferring them over the old ACR values in most envs. This commit changes the default config to reflect that in the config.
