### PR TITLE
LG-12871: Remove exceptions for client-side reCAPTCHA execute

### DIFF
--- a/app/components/phone_input_component.html.erb
+++ b/app/components/phone_input_component.html.erb
@@ -4,7 +4,6 @@
       data: {
         delivery_methods:,
         translated_country_code_names:,
-        captcha_exempt_countries:,
       },
     ) do %>
   <%= content_tag(

--- a/app/components/phone_input_component.rb
+++ b/app/components/phone_input_component.rb
@@ -6,7 +6,6 @@ class PhoneInputComponent < BaseComponent
               :required,
               :allowed_countries,
               :delivery_methods,
-              :captcha_exempt_countries,
               :tag_options
 
   alias_method :f, :form
@@ -17,7 +16,6 @@ class PhoneInputComponent < BaseComponent
     allowed_countries: nil,
     delivery_methods: [:sms, :voice],
     required: false,
-    captcha_exempt_countries: nil,
     **tag_options
   )
     @allowed_countries = allowed_countries
@@ -25,7 +23,6 @@ class PhoneInputComponent < BaseComponent
     @form = form
     @required = required
     @delivery_methods = delivery_methods
-    @captcha_exempt_countries = captcha_exempt_countries
     @tag_options = tag_options
   end
 

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { screen, waitFor, fireEvent } from '@testing-library/dom';
 import { useSandbox, useDefineProperty } from '@18f/identity-test-helpers';
 import '@18f/identity-spinner-button/spinner-button-element';
-import { CAPTCHA_EVENT_NAME } from './captcha-submit-button-element';
+import './captcha-submit-button-element';
 
 describe('CaptchaSubmitButtonElement', () => {
   const sandbox = useSandbox();
@@ -109,29 +109,6 @@ describe('CaptchaSubmitButtonElement', () => {
         });
         expect(Object.fromEntries(new window.FormData(form))).to.deep.equal({
           recaptcha_token: RECAPTCHA_TOKEN_VALUE,
-        });
-      });
-
-      context('with cancellation of challenge event', () => {
-        beforeEach(() => {
-          const form = document.querySelector('form')!;
-          form.addEventListener(CAPTCHA_EVENT_NAME, (event) => event.preventDefault());
-        });
-
-        it('submits the form without challenge', async () => {
-          const button = screen.getByRole('button', { name: 'Submit' });
-          const form = document.querySelector('form')!;
-
-          let didSubmit = false;
-          form.addEventListener('submit', (event) => {
-            event.preventDefault();
-            didSubmit = true;
-          });
-
-          await userEvent.click(button);
-          await waitFor(() => expect(didSubmit).to.be.true());
-
-          expect(grecaptcha.ready).not.to.have.been.called();
         });
       });
 

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -1,5 +1,3 @@
-export const CAPTCHA_EVENT_NAME = 'lg:captcha-submit-button:challenge';
-
 class CaptchaSubmitButtonElement extends HTMLElement {
   form: HTMLFormElement | null;
 
@@ -55,13 +53,7 @@ class CaptchaSubmitButtonElement extends HTMLElement {
   }
 
   shouldInvokeChallenge(): boolean {
-    if (!this.recaptchaSiteKey) {
-      return false;
-    }
-
-    const event = new CustomEvent(CAPTCHA_EVENT_NAME, { bubbles: true, cancelable: true });
-    this.dispatchEvent(event);
-    return !event.defaultPrevented;
+    return !!this.recaptchaSiteKey;
   }
 
   handleFormSubmit = (event: SubmitEvent) => {

--- a/app/javascript/packages/phone-input/README.md
+++ b/app/javascript/packages/phone-input/README.md
@@ -13,7 +13,7 @@ import '@18f/identity-phone-input';
 The custom element will implement associatd behaviors, but all markup must already exist.
 
 ```html
-<lg-phone-input data-delivery-methods="[&quot;sms&quot;,&quot;voice&quot;]" data-translated-country-code-names="{&quot;us&quot;:&quot;United States&quot;}" data-captcha-exempt-countries="[&quot;US&quot;]">
+<lg-phone-input data-delivery-methods="[&quot;sms&quot;,&quot;voice&quot;]" data-translated-country-code-names="{&quot;us&quot;:&quot;United States&quot;}">
   <script type="application/json" class="phone-input__strings">{"country_code_label":"Country code","invalid_phone_us":"Enter a 10 digit phone number.","invalid_phone_international":"Enter a phone number with the correct number of digits.","unsupported_country":"We are unable to verify phone numbers from %{location}"}</script>
   <div class="phone-input__international-code-wrapper">
     <label for="international-code">Country code</label>

--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -4,7 +4,6 @@ import intlTelInput from 'intl-tel-input';
 import type { CountryCode } from 'libphonenumber-js';
 import type { Plugin as IntlTelInputPlugin, Options } from 'intl-tel-input';
 import { replaceVariables } from '@18f/identity-i18n';
-import { CAPTCHA_EVENT_NAME } from '@18f/identity-captcha-submit-button/captcha-submit-button-element';
 import { trackEvent } from '@18f/identity-analytics';
 
 interface PhoneInputStrings {
@@ -66,13 +65,8 @@ export class PhoneInputElement extends HTMLElement {
     this.textInput.addEventListener('input', () => this.validate());
     this.codeInput.addEventListener('change', () => this.formatTextInput());
     this.codeInput.addEventListener('change', () => this.validate());
-    this.ownerDocument.addEventListener(CAPTCHA_EVENT_NAME, this.handleCaptchaChallenge);
 
     this.validate();
-  }
-
-  disconnectedCallback() {
-    this.ownerDocument.removeEventListener(CAPTCHA_EVENT_NAME, this.handleCaptchaChallenge);
   }
 
   get selectedOption() {
@@ -114,14 +108,6 @@ export class PhoneInputElement extends HTMLElement {
 
   get hasDropdown(): boolean {
     return Boolean(this.supportedCountryCodes && this.supportedCountryCodes.length > 1);
-  }
-
-  get captchaExemptCountries(): string[] | boolean {
-    try {
-      return JSON.parse(this.dataset.captchaExemptCountries!);
-    } catch {
-      return true;
-    }
   }
 
   /**
@@ -267,18 +253,6 @@ export class PhoneInputElement extends HTMLElement {
   isSupportedCountry(): boolean {
     return this.deliveryMethods.some((delivery) => this.isDeliveryOptionSupported(delivery));
   }
-
-  handleCaptchaChallenge = (event: Event) => {
-    const countryCode = this.getSelectedCountryCode();
-    const isExempt =
-      typeof this.captchaExemptCountries === 'boolean'
-        ? this.captchaExemptCountries
-        : !countryCode || this.captchaExemptCountries.includes(countryCode);
-
-    if (isExempt) {
-      event.preventDefault();
-    }
-  };
 
   getSelectedCountryCode(): string | undefined {
     return (this.iti.getSelectedCountryData().iso2 as string | undefined)?.toUpperCase();

--- a/app/services/phone_recaptcha_validator.rb
+++ b/app/services/phone_recaptcha_validator.rb
@@ -13,10 +13,6 @@ class PhoneRecaptchaValidator
     @validator_args = validator_args
   end
 
-  def self.exempt_countries
-    country_score_overrides.select { |_key, value| !value.positive? }.keys
-  end
-
   def self.country_score_overrides
     IdentityConfig.store.phone_recaptcha_country_score_overrides
   end

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -24,7 +24,6 @@
         form: f,
         confirmed_phone: false,
         required: true,
-        captcha_exempt_countries: FeatureManagement.phone_recaptcha_enabled? ? PhoneRecaptchaValidator.exempt_countries : nil,
         class: 'margin-bottom-4',
       ) %>
 

--- a/spec/components/phone_input_component_spec.rb
+++ b/spec/components/phone_input_component_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe PhoneInputComponent, type: :component do
   let(:confirmed_phone) { true }
   let(:required) { nil }
   let(:delivery_methods) { nil }
-  let(:captcha_exempt_countries) { nil }
   let(:tag_options) { {} }
   let(:options) do
     {
@@ -22,7 +21,6 @@ RSpec.describe PhoneInputComponent, type: :component do
       confirmed_phone:,
       required:,
       delivery_methods:,
-      captcha_exempt_countries:,
       **tag_options,
     }.compact
   end
@@ -132,20 +130,6 @@ RSpec.describe PhoneInputComponent, type: :component do
         visible: false,
         text: t('two_factor_authentication.otp_delivery_preference.voice_unsupported'),
       )
-    end
-  end
-
-  describe '[data-captcha-exempt-countries] attribute' do
-    it 'is not assigned' do
-      expect(rendered).not_to have_css('[data-captcha-exempt-countries]')
-    end
-
-    context 'with captcha exempted countries' do
-      let(:captcha_exempt_countries) { [:US] }
-
-      it 'is assigned as a serialized array' do
-        expect(rendered).to have_css('[data-captcha-exempt-countries="[\"US\"]"]')
-      end
     end
   end
 

--- a/spec/services/phone_recaptcha_validator_spec.rb
+++ b/spec/services/phone_recaptcha_validator_spec.rb
@@ -70,22 +70,6 @@ RSpec.describe PhoneRecaptchaValidator do
     end
   end
 
-  describe '.exempt_countries' do
-    subject(:exempt_countries) { described_class.exempt_countries }
-
-    it 'returns an array of exempt countries' do
-      expect(exempt_countries).to eq([])
-    end
-
-    context 'with country overrides' do
-      let(:country_score_overrides_config) { { US: 0.0, CA: 0.1 } }
-
-      it 'returns an array of exempt countries' do
-        expect(exempt_countries).to eq([:US])
-      end
-    end
-  end
-
   describe '.country_score_overrides' do
     subject(:country_score_overrides) { described_class.country_score_overrides }
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-12871](https://cm-jira.usa.gov/browse/LG-12871)

## 🛠 Summary of changes

Updates client-side reCAPTCHA behavior to always invoke during client-side form submission, regardless of whether the user is exempted from backend validation.

This is based on a recommendation to improve the quality of assessments by avoiding bias toward certain subsets of users.

## 📜 Testing Plan

Prerequisite: You'll need valid reCAPTCHA keys for at least the invisible check. In local development, you can use keys generated yourself with the free version of reCAPTCHA:

1. Go to https://www.google.com/recaptcha/admin
2. Create keys for local development as a "Score based (v3)" type
3. Update configuration in `config/application.yml`, adding your v3 site and secret keys. v2 values need to be present, but they don't need to be valid keys.
    ```
    recaptcha_site_key_v2: 'any-value-doesnt-matter'
    recaptcha_site_key_v3: '[insert-v3-site-key]'
    recaptcha_secret_key_v2: 'any-value-doesnt-matter'
    recaptcha_secret_key_v3: '[insert-v3-secret-key]'
    ```

Validate that client-side reCAPTCHA runs for all numbers, but is only validated on the backend for international numbers:

1. Go to http://localhost:3000
2. Create an account
3. Continue account creation until MFA selection screen
4. Choose phone as MFA method and click "Continue"
5. Add a breakpoint here in your browser devtools: https://github.com/18F/identity-idp/blob/29ba13f3d4263b50694193be046d238908960b6d/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts#L51
6. Add a `binding.pry` breakpoint before this line: https://github.com/18F/identity-idp/blob/29ba13f3d4263b50694193be046d238908960b6d/app/services/recaptcha_validator.rb#L46
7. Enter a phone number
8. Click "Submit"
9. Observe that the breakpoint added in Step 5 is triggered, regardless of phone number
10. Allow breakpoint to continue ("Resume script execution" in Chrome Devtools debugger)
11. Observe in your terminal that that breakpoint added in Step 6 is triggered
12. Enter `exempt?` in your terminal breakpoint
13. Observe that the value is `false` if you submitted an international number, or `true` otherwise
