### PR TITLE
LG-12829: add conditional links for selfie help center articles

### DIFF
--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -83,9 +83,19 @@ function UnknownError({
     );
   }
   if ((isFailedSelfieLivenessOrQuality || isFailedSelfie) && err) {
+    let selfieHelpCenterLink = helpCenterLink;
+    let selfieHelpCenterLinkText = t('doc_auth.errors.general.selfie_failure_help_link_text');
+    if (isFailedSelfieLivenessOrQuality) {
+      selfieHelpCenterLink += '#anchor'
+      selfieHelpCenterLinkText = t('doc_auth.errors.alerts.selfie_not_live_help_link_text');
+    }
     return (
       <>
-        <p>{err.message}</p>
+        <p>{err.message}{' '}{altIsFailedSelfieDontIncludeAttempts && (
+          <Link isExternal isNewTab href={selfieHelpCenterLink}>
+            {selfieHelpCenterLinkText}
+          </Link>
+        )}</p>
         <p>
           {!altIsFailedSelfieDontIncludeAttempts && (
             <HtmlTextWithStrongNoWrap

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -84,18 +84,21 @@ function UnknownError({
   }
   if ((isFailedSelfieLivenessOrQuality || isFailedSelfie) && err) {
     let selfieHelpCenterLinkText = t('doc_auth.errors.general.selfie_failure_help_link_text');
-    const helpCenterURL = new URL(helpCenterLink)
+    const helpCenterURL = new URL(helpCenterLink);
     if (isFailedSelfieLivenessOrQuality) {
-      helpCenterURL.hash = 'how-to-add-a-photo-of-your-face-to-help-verify-your-id'
+      helpCenterURL.hash = 'how-to-add-a-photo-of-your-face-to-help-verify-your-id';
       selfieHelpCenterLinkText = t('doc_auth.errors.alerts.selfie_not_live_help_link_text');
     }
     return (
       <>
-        <p>{err.message}{' '}{altIsFailedSelfieDontIncludeAttempts && (
-          <Link isExternal isNewTab href={helpCenterURL.toString()}>
-            {selfieHelpCenterLinkText}
-          </Link>
-        )}</p>
+        <p>
+          {err.message}{' '}
+          {altIsFailedSelfieDontIncludeAttempts && (
+            <Link isExternal isNewTab href={helpCenterURL.toString()}>
+              {selfieHelpCenterLinkText}
+            </Link>
+          )}
+        </p>
         <p>
           {!altIsFailedSelfieDontIncludeAttempts && (
             <HtmlTextWithStrongNoWrap

--- a/app/javascript/packages/document-capture/components/unknown-error.tsx
+++ b/app/javascript/packages/document-capture/components/unknown-error.tsx
@@ -83,16 +83,16 @@ function UnknownError({
     );
   }
   if ((isFailedSelfieLivenessOrQuality || isFailedSelfie) && err) {
-    let selfieHelpCenterLink = helpCenterLink;
     let selfieHelpCenterLinkText = t('doc_auth.errors.general.selfie_failure_help_link_text');
+    const helpCenterURL = new URL(helpCenterLink)
     if (isFailedSelfieLivenessOrQuality) {
-      selfieHelpCenterLink += '#anchor'
+      helpCenterURL.hash = 'how-to-add-a-photo-of-your-face-to-help-verify-your-id'
       selfieHelpCenterLinkText = t('doc_auth.errors.alerts.selfie_not_live_help_link_text');
     }
     return (
       <>
         <p>{err.message}{' '}{altIsFailedSelfieDontIncludeAttempts && (
-          <Link isExternal isNewTab href={selfieHelpCenterLink}>
+          <Link isExternal isNewTab href={helpCenterURL.toString()}>
             {selfieHelpCenterLinkText}
           </Link>
         )}</p>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -41,6 +41,7 @@ en:
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
         selfie_not_live: Try taking a photo of yourself again. Make sure your whole face
           is clear and visible in the photo.
+        selfie_not_live_help_link_text: Review more tips for taking a clear photo of yourself
         selfie_poor_quality: 'Try taking a photo of yourself again. Make sure your whole
           face is clear and visible in the photo.'
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
@@ -87,6 +88,7 @@ en:
         no_liveness: Try taking new pictures.
         selfie_failure: Try taking your photos again. Make sure all of your photos are
           clear and in focus.
+        selfie_failure_help_link_text: Review more tips for taking clear photos
       glare:
         failed_short: Image has glare, please try again.
         top_msg: We couldn’t read your ID. Your photo may have glare. Make sure that the

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -51,6 +51,7 @@ es:
           control. Intente tomar nuevas fotografías.
         selfie_not_live: Intente tomar de nuevo una foto de usted. Asegúrese de que su
           rostro se vea claramente en la foto.
+        selfie_not_live_help_link_text: Consulte más consejos para tomar una foto clara de su rostro
         selfie_poor_quality: 'Intente tomar de nuevo una foto de usted. Asegúrese de que
           su rostro se vea claramente en la foto.'
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar
@@ -110,6 +111,7 @@ es:
         no_liveness: Intente tomar nuevas fotografías.
         selfie_failure: Intente tomar de nuevo sus fotos. Asegúrese de que sus fotos
           estén claras y enfocadas.
+        selfie_failure_help_link_text: Consulte más consejos para tomar fotos claras
       glare:
         failed_short: Hay reflejos en la imagen, por favor inténtelo de nuevo.
         top_msg: No pudimos leer su identificación. Es posible que su foto tenga

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -55,6 +55,7 @@ fr:
         selfie_not_live: Essayez de prendre une nouvelle photo de vous-même.
           Assurez-vous que l’ensemble de votre visage soit clair et visible sur
           la photo.
+        selfie_not_live_help_link_text: Consultez plus de conseils pour prendre une photo claire de vous-même
         selfie_poor_quality: 'Essayez de prendre une nouvelle photo de vous-même.
           Assurez-vous que l’ensemble de votre visage soit clair et visible sur
           la photo.'
@@ -117,6 +118,7 @@ fr:
         no_liveness: Essayez de prendre de nouvelles photos.
         selfie_failure: Essayez de prendre de nouvelles photos de vous-même. Veillez à
           ce que toutes vos photos soient claires et nettes.
+        selfie_failure_help_link_text: Consultez plus de conseils pour prendre des photos claires
       glare:
         failed_short: L’image a des reflets, veuillez réessayer.
         top_msg: Nous n’avons pas pu lire votre pièce d’identité. Votre photo peut avoir


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12829](https://cm-jira.usa.gov/browse/LG-12829)

## 🛠 Summary of changes
Add a link to the error message that directs the user to the help center when selfie match fails.

## 📜 Testing Plan

- [ ] Fail doc auth with selfie due to a liveness failure in the portrait match and observe the link routes to the Doc Auth content in the help center and the destination link contains the anchor (Note: the anchored content will not be deployed to login.gov help center until selfie go live)
- [ ] Fail doc auth with selfie due to a portrait match failure and observe the link routes to the Doc Auth content in the help center

## 👀 Screenshots
<details>
<summary>Liveness:</summary>

<img width="515" alt="LG-12903-liveness-en" src="https://github.com/18F/identity-idp/assets/1261794/011cbb74-11a9-4598-9d86-91f9aec3b44d">

<img width="588" alt="LG-12903-liveness-es" src="https://github.com/18F/identity-idp/assets/1261794/e78291d8-7fc0-463a-ba87-eeb651deda3f">

<img width="583" alt="LG-12903-liveness-fr" src="https://github.com/18F/identity-idp/assets/1261794/8eb2e75c-4ffc-4c38-8854-d826d0bbb297">

</details>

<details>
<summary>FaceMatch:</summary>

<img width="507" alt="LG-12903-pm-fail-en" src="https://github.com/18F/identity-idp/assets/1261794/f33139a7-dbc6-4ea4-a5a2-0db5e3dbe34a">

<img width="523" alt="LG-12903-pm-fail-es" src="https://github.com/18F/identity-idp/assets/1261794/7868c226-0834-43a8-a318-c6e63bc3c665">

<img width="562" alt="LG-12903-pm-fail-fr" src="https://github.com/18F/identity-idp/assets/1261794/ea4beeed-60a4-440f-bc08-692a22b4531a">

</details>