### PR TITLE
Revert cssbundling-rails upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'caxlsx', require: false
 gem 'concurrent-ruby'
 gem 'connection_pool'
 gem 'csv'
-gem 'cssbundling-rails'
+gem 'cssbundling-rails', '1.0.0'
 gem 'devise', '~> 4.8'
 gem 'dotiw', '>= 4.0.1'
 gem 'faraday', '~> 2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
-    cssbundling-rails (1.4.0)
+    cssbundling-rails (1.0.0)
       railties (>= 6.0.0)
     csv (3.2.8)
     date (3.3.4)
@@ -764,7 +764,7 @@ DEPENDENCIES
   caxlsx
   concurrent-ruby
   connection_pool
-  cssbundling-rails
+  cssbundling-rails (= 1.0.0)
   csv
   derailed_benchmarks
   devise (~> 4.8)


### PR DESCRIPTION
## 🛠 Summary of changes

This PR reverts the upgrade of `cssbundling-rails` due to issues we ran into in deployed environments. That patch is here: https://github.com/18F/identity-devops/pull/7263.

The upgrade can be re-applied once the above PR is merged.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
