### PR TITLE
Remove unused usa-form styles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ lint_asset_bundle_size: ## Lints JavaScript and CSS compiled bundle size
 	@# and you have no options to split that from the common bundles. If you need to increase this
 	@# budget and accept the fact that this will force end-users to endure longer load times, you
 	@# should set the new budget to within a few thousand bytes of the production-compiled size.
-	find app/assets/builds/application.css -size -190000c | grep .
+	find app/assets/builds/application.css -size -185000c | grep .
 	find public/packs/js/application-*.digested.js -size -5000c | grep .
 
 lint_migrations:

--- a/app/assets/stylesheets/_uswds.scss
+++ b/app/assets/stylesheets/_uswds.scss
@@ -6,7 +6,6 @@
 @forward 'usa-alert';
 @forward 'usa-banner';
 @forward 'usa-button';
-@forward 'usa-form';
 @forward 'usa-layout-grid';
 @forward 'usa-link';
 @forward 'usa-list';


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused styles for the `usa-form` USWDS form component.

Despite having many forms, we never use the `usa-form` class. We do use `usa-form-group` styles, but these are [included separately](https://github.com/18F/identity-idp/blob/f354510e253243d71712a5d91a8a1f19b6e2537b/app/assets/stylesheets/_uswds-form-controls.scss#L4).

**Performance Impact:**

```
NODE_ENV=production yarn build:css && brotli-size app/assets/builds/application.css
```

**Before:** 18.7 kB
**After** 18.4 kB
**Diff:** -0.3 kB (-1.6%)

## 📜 Testing Plan

Verify there are no instances of `usa-form` class use in the codebase.