### PR TITLE
Split print styles to separate stylesheet

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -4,4 +4,3 @@
 @forward 'design-system-waiting-room';
 @forward 'components';
 @forward 'utilities';
-@forward 'print';

--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -1,0 +1,7 @@
+nav,
+footer,
+.usa-button,
+.usa-radio__input--bordered,
+.usa-checkbox__input--bordered {
+  display: none;
+}

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,9 +1,0 @@
-@media only print {
-  nav,
-  footer,
-  .usa-button,
-  .usa-radio__input--bordered,
-  .usa-checkbox__input--bordered {
-    display: none;
-  }
-}

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -19,7 +19,8 @@
   <%= preload_link_tag font_url('public-sans/PublicSans-Bold.woff2') %>
   <%= preload_link_tag font_url('public-sans/PublicSans-Regular.woff2') %>
   <%= render_stylesheet_once_tags %>
-  <%= stylesheet_link_tag 'application', media: 'all' %>
+  <%= stylesheet_link_tag 'application' %>
+  <%= stylesheet_link_tag 'print', media: :print, preload_links_header: false %>
   <%= csrf_meta_tags %>
 
   <%= favicon_link_tag(


### PR DESCRIPTION
## 🛠 Summary of changes

Splits print styles to separate stylesheet, so that it's only loaded when printing.

**Why?**

- Reduce size of stylesheet for users browsing the web version of the site

**Performance Impact:**

```
NODE_ENV=production yarn build:css && brotli-size app/assets/builds/application.css
```

_Before:_ 18.4 kB
_After:_ 18.3 kB
_Diff:_ -0.1 kB (-0.5%)

## 📜 Testing Plan

Verify that print styles are preserved:

1. Go to http://localhost:3000
2. Press <kbd>Cmd+P</kbd>
3. Observe that the preview does not include the "Submit" button

Verify that the print stylesheet is not preloaded:

1. In a separate Terminal process, run: `curl -I --silent http://localhost:3000 | grep 'link:'`
2. Verify that the output does not include `print.css`