### PR TITLE
LG-12294: Fix asynchronous email delivery for aggregated sign-in email

### DIFF
--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -33,7 +33,7 @@ module UserAlerts
           'sign_in_unsuccessful_2fa',
           'sign_in_after_2fa',
         ],
-      ).order(:created_at).includes(:device)
+      ).order(:created_at).includes(:device).to_a
 
       user.confirmed_email_addresses.each do |email_address|
         mailer = UserMailer.with(user:, email_address:)

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ReportMailer, type: :mailer do
       )
     end
 
-    it_behaves_like 'a system email'
+    it_behaves_like 'a system email', synchronous_only: true
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
-  let(:user) { build(:user) }
+  let(:user) { create(:user) }
   let(:email_address) { user.email_addresses.first }
   let(:banned_email) { 'banned_email+123abc@gmail.com' }
   let(:banned_email_address) { create(:email_address, email: banned_email, user: user) }
@@ -203,6 +203,32 @@ RSpec.describe UserMailer, type: :mailer do
       )
       expect_email_body_to_have_help_and_contact_links
     end
+  end
+
+  describe '#new_device_sign_in_before_2fa' do
+    let(:event) { create(:event, event_type: :sign_in_before_2fa, user:, device: create(:device)) }
+    subject(:mail) do
+      UserMailer.with(user:, email_address:).new_device_sign_in_before_2fa(
+        events: user.events.where(event_type: 'sign_in_before_2fa').includes(:device).to_a,
+        disavowal_token: 'token',
+      )
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+  end
+
+  describe '#new_device_sign_in_after_2fa' do
+    let(:event) { create(:event, event_type: :sign_in_after_2fa, user:, device: create(:device)) }
+    subject(:mail) do
+      UserMailer.with(user:, email_address:).new_device_sign_in_after_2fa(
+        events: user.events.where(event_type: 'sign_in_after_2fa').includes(:device).to_a,
+        disavowal_token: 'token',
+      )
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
   end
 
   describe '#personal_key_regenerated' do

--- a/spec/support/shared_examples_for_mailer.rb
+++ b/spec/support/shared_examples_for_mailer.rb
@@ -10,6 +10,10 @@ RSpec.shared_examples 'a system email' do
     # https://www.caniemail.com/features/image-svg/
     expect(body).not_to have_css('img[src$=".svg"]')
   end
+
+  it 'does not error when delivered asynchronously' do
+    mail.deliver_later
+  end
 end
 
 # expects there to be a let(:user) in scope

--- a/spec/support/shared_examples_for_mailer.rb
+++ b/spec/support/shared_examples_for_mailer.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'a system email' do |synchronous_only:|
+RSpec.shared_examples 'a system email' do |synchronous_only: false|
   it 'is from the default email' do
     expect(mail.from).to eq [IdentityConfig.store.email_from]
     expect(mail[:from].display_names).to eq [IdentityConfig.store.email_from_display_name]

--- a/spec/support/shared_examples_for_mailer.rb
+++ b/spec/support/shared_examples_for_mailer.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'a system email' do
+RSpec.shared_examples 'a system email' do |synchronous_only:|
   it 'is from the default email' do
     expect(mail.from).to eq [IdentityConfig.store.email_from]
     expect(mail[:from].display_names).to eq [IdentityConfig.store.email_from_display_name]
@@ -11,7 +11,7 @@ RSpec.shared_examples 'a system email' do
     expect(body).not_to have_css('img[src$=".svg"]')
   end
 
-  it 'does not error when delivered asynchronously' do
+  it 'does not error when delivered asynchronously', unless: synchronous_only do
     mail.deliver_later
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Supplemental fix for [LG-12294](https://cm-jira.usa.gov/browse/LG-12294)

## 🛠 Summary of changes

Fixes an issue where asynchronous delivery of aggregated new device sign-in email notifications raises an error, due to non-serializable arguments.

```
     ActiveJob::SerializationError:
       Unsupported argument type: ActiveRecord::AssociationRelation
```

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1712932922568999

## 📜 Testing Plan

1. Add `deliver_mail_async: true` to `config/application.yml`
2. In a private browsing window (Incognito), go to http://localhost:3000
3. Sign in and MFA
4. Observe no errors after fully authenticated