### PR TITLE
Remove unused remember_created_at user column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  # To be dropped in: https://github.com/18F/identity-idp/pull/10429
-  self.ignored_columns = [:remember_created_at]
-
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer

--- a/db/primary_migrate/20240415125124_drop_remember_created_at_from_users.rb
+++ b/db/primary_migrate/20240415125124_drop_remember_created_at_from_users.rb
@@ -1,0 +1,7 @@
+class DropRememberCreatedAtFromUsers < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :users, :remember_created_at, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_11_163520) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_15_125124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -588,7 +588,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_163520) do
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "reset_password_token", limit: 255
     t.datetime "reset_password_sent_at", precision: nil
-    t.datetime "remember_created_at", precision: nil
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.datetime "confirmed_at", precision: nil


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the `remember_created_at` column from the `users` table.

This field is not currently used, and as best I can tell has never been referenced as far back as #1.

## 📜 Testing Plan

Verify migration runs cleanly:

```
rails db:migrate
```

Verify no lingering references to the removed column.