### PR TITLE
Add user remember_created_at as ignored column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  # To be dropped in: https://github.com/18F/identity-idp/pull/10429
+  self.ignored_columns = [:remember_created_at]
+
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer


### PR DESCRIPTION
## 🛠 Summary of changes

Marks `remember_created_at` on the User model as ignored, as a prerequisite to removing the column in #10429.

See: https://github.com/18F/identity-idp/pull/10429#pullrequestreview-2001135779

## 📜 Testing Plan

Verify that selecting all fields from a user does not produce a query including `remember_created_at`:

```
$ rails c
> User.first
# Observe that the logged SQL query does not include `remember_created_at`
```