### PR TITLE
Remove short_term_phone_otp_rate_limiter_enabled configuration key

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -275,7 +275,6 @@ module Users
     end
 
     def exceeded_short_term_otp_rate_limit?
-      return false unless IdentityConfig.store.short_term_phone_otp_rate_limiter_enabled
       short_term_otp_rate_limiter.increment!
       short_term_otp_rate_limiter.limited?
     end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -234,7 +234,6 @@ personal_key_retired: true
 phone_carrier_registration_blocklist_array: '[]'
 short_term_phone_otp_max_attempt_window_in_seconds: 10
 short_term_phone_otp_max_attempts: 2
-short_term_phone_otp_rate_limiter_enabled: true
 phone_confirmation_max_attempts: 20
 phone_confirmation_max_attempt_window_in_minutes: 1_440
 phone_service_check: true
@@ -490,7 +489,6 @@ production:
   phone_recaptcha_mock_validator: false
   piv_cac_verify_token_secret:
   session_encryptor_alert_enabled: true
-  short_term_phone_otp_rate_limiter_enabled: false
   redis_throttle_url: redis://redis.login.gov.internal:6379/1
   redis_url: redis://redis.login.gov.internal:6379
   report_timeout: 1_000_000
@@ -586,7 +584,6 @@ test:
   scrypt_cost: 800$8$1$
   secret_key_base: test_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
-  short_term_phone_otp_rate_limiter_enabled: false
   skip_encryption_allowed_list: '[]'
   state_tracking_enabled: true
   team_ada_email: 'ada@example.com'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -584,6 +584,7 @@ test:
   scrypt_cost: 800$8$1$
   secret_key_base: test_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
+  short_term_phone_otp_max_attempts: 100
   skip_encryption_allowed_list: '[]'
   state_tracking_enabled: true
   team_ada_email: 'ada@example.com'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -460,7 +460,6 @@ class IdentityConfig
     config.add(:show_user_attribute_deprecation_warnings, type: :boolean)
     config.add(:short_term_phone_otp_max_attempts, type: :integer)
     config.add(:short_term_phone_otp_max_attempt_window_in_seconds, type: :integer)
-    config.add(:short_term_phone_otp_rate_limiter_enabled, type: :boolean)
     config.add(:skip_encryption_allowed_list, type: :json)
     config.add(:sp_handoff_bounce_max_seconds, type: :integer)
     config.add(:sp_issuer_user_counts_report_configs, type: :json)

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -609,8 +609,6 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
         stub_analytics
         sign_in_before_2fa(@user)
         subject.user_session[:context] = 'confirmation'
-        allow(IdentityConfig.store).to receive(:short_term_phone_otp_rate_limiter_enabled).
-          and_return(true)
         allow(IdentityConfig.store).to receive(:short_term_phone_otp_max_attempts).and_return(2)
         allow(IdentityConfig.store).to receive(:short_term_phone_otp_max_attempt_window_in_seconds).
           and_return(5)


### PR DESCRIPTION
## 🛠 Summary of changes

Related to #10360. This has been tested and can be enabled everywhere.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
