### PR TITLE
LG-12294: Set maximum delay for aggregated email events

### DIFF
--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -27,7 +27,7 @@ module UserAlerts
       return false unless user.sign_in_new_device_at
 
       events = user.events.where(
-        created_at: user.sign_in_new_device_at..,
+        created_at: sign_in_events_start_time(user:)..,
         event_type: [
           'sign_in_before_2fa',
           'sign_in_unsuccessful_2fa',
@@ -48,6 +48,21 @@ module UserAlerts
 
       user.update(sign_in_new_device_at: nil)
       true
+    end
+
+    def self.sign_in_events_start_time(user:)
+      # Avoid scenarios where stale events may be reflected in the time since sign in:
+      #
+      # 1. The feature is enabled for a short time in a deployed environment before being disabled
+      # 2. In local development, the server is not always active and the job may not run until later
+      #
+      # Typically, it's guaranteed that even in the worst-case of a sign-in occurring immediately
+      # after a scheduled job run, it should take no longer than twice the scheduled delay. A small
+      # buffer is added to account for delays of the job run or within the job itself.
+      [
+        user.sign_in_new_device_at,
+        (IdentityConfig.store.new_device_alert_delay_in_minutes * 3).minutes.ago,
+      ].max
     end
   end
 end

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
   end
 
   describe '.send_alert' do
-    let(:sign_in_new_device_at) { 10.minutes.ago }
+    let(:sign_in_new_device_at) { 3.minutes.ago }
     let(:user) { create(:user, :fully_registered, sign_in_new_device_at:) }
     let(:disavowal_event) do
       create(:event, user:, event_type: :sign_in_after_2fa, created_at: 5.minutes.ago)
@@ -60,6 +60,10 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
 
     subject(:result) do
       UserAlerts::AlertUserAboutNewDevice.send_alert(user:, disavowal_event:, disavowal_token:)
+    end
+
+    before do
+      allow(IdentityConfig.store).to receive(:new_device_alert_delay_in_minutes).and_return(5)
     end
 
     it 'returns true' do
@@ -78,17 +82,20 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
           :event,
           user:,
           event_type: :sign_in_notification_timeframe_expired,
-          created_at: 5.minutes.ago,
+          created_at: Time.zone.now,
         )
       end
 
       it 'sends mailer for authentication events within the time window' do
-        # 1. Exclude events outside the timeframe, e.g. previous sign-in
-        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 11.minutes.ago)
+        # 1. Exclude events outside possible window of time of recurring job run
+        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 16.minutes.ago)
 
-        # 2. Include authentication events inside the timeframe, inclusive
+        # 2. Exclude events outside the timeframe, e.g. previous sign-in
+        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 4.minutes.ago)
 
-        # 2.1 Include sign-in before 2FA
+        # 3. Include authentication events inside the timeframe, inclusive
+
+        # 3.1 Include sign-in before 2FA
         sign_in_before_2fa_event = create(
           :event,
           user:,
@@ -96,15 +103,15 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
           created_at: sign_in_new_device_at,
         )
 
-        # 2.2 Include sign-in unsuccessful 2FA
+        # 3.2 Include sign-in unsuccessful 2FA
         sign_in_unsuccessful_2fa_event = create(
           :event,
           user:,
           event_type: :sign_in_unsuccessful_2fa,
-          created_at: 8.minutes.ago,
+          created_at: 2.minutes.ago,
         )
 
-        # 3. Exclude sign in notification timeframe expired event
+        # 4. Exclude sign in notification timeframe expired event
         disavowal_event
 
         delivery = instance_double(ActionMailer::MessageDelivery)
@@ -125,16 +132,19 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
 
     context 'with sign in after 2fa disavowal event' do
       let(:disavowal_event) do
-        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 5.minutes.ago)
+        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 1.minute.ago)
       end
 
       it 'sends mailer for authentication events within the time window' do
-        # 1. Exclude events outside the timeframe, e.g. previous sign-in
-        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 11.minutes.ago)
+        # 1. Exclude events outside possible window of time of recurring job run
+        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 16.minutes.ago)
 
-        # 2. Include authentication events inside the timeframe, inclusive
+        # 2. Exclude events outside the timeframe, e.g. previous sign-in
+        create(:event, user:, event_type: :sign_in_after_2fa, created_at: 4.minutes.ago)
 
-        # 2.1 Include sign-in before 2FA
+        # 3. Include authentication events inside the timeframe, inclusive
+
+        # 3.1 Include sign-in before 2FA
         sign_in_before_2fa_event = create(
           :event,
           user:,
@@ -142,19 +152,19 @@ RSpec.describe UserAlerts::AlertUserAboutNewDevice do
           created_at: sign_in_new_device_at,
         )
 
-        # 2.2 Include sign-in unsuccessful 2FA
+        # 3.2 Include sign-in unsuccessful 2FA
         sign_in_unsuccessful_2fa_event = create(
           :event,
           user:,
           event_type: :sign_in_unsuccessful_2fa,
-          created_at: 8.minutes.ago,
+          created_at: 2.minutes.ago,
         )
 
-        # 2.3 Include sign-in after 2FA
+        # 3.3 Include sign-in after 2FA
         sign_in_after_2fa_event = disavowal_event
 
-        # 3. Exclude events not related to authentication, e.g. actions after sign-in
-        create(:event, user:, event_type: :password_changed, created_at: 4.minutes.ago)
+        # 4. Exclude events not related to authentication, e.g. actions after sign-in
+        create(:event, user:, event_type: :password_changed, created_at: 30.seconds.ago)
 
         delivery = instance_double(ActionMailer::MessageDelivery)
         expect(delivery).to receive(:deliver_now_or_later)


### PR DESCRIPTION
## 🎫 Ticket

Supplemental improvement for [LG-12294](https://cm-jira.usa.gov/browse/LG-12294)

## 🛠 Summary of changes

Updates logic for aggregated email sign-in notification to prevent stale events from being included in the email.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1713191072377119?thread_ts=1712932922.568999&cid=C0NGESUN5

Examples:

- As discussed in the Slack thread above, enabling in sandbox environments and then quickly disabling to address #10421 produced stale events when re-enabling today
- As discussed in the Slack thread above, starting local development server today (Monday) prompted an email notification for sign-ins that occurred at the end of day Friday

## 📜 Testing Plan

Verify tests pass:

```
rspec spec/services/user_alerts/alert_user_about_new_device_spec.rb
```

Verify you don't get an email after a long delay:

1. Go to http://localhost:3000
2. Sign in with email and password (don't MFA)
3. Stop the local development server process
4. Wait 15 minutes
5. Start the local development server
6. Wait for the job to run
7. Observe that you don't receive an email notification about your sign-in