### PR TITLE
Stop writing proofing stages into the proofing result

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -304,27 +304,27 @@ module Idv
     end
 
     def add_proofing_costs(results)
-      results[:context][:stages].each do |stage, hash|
-        if stage == :resolution
-          # transaction_id comes from ConversationId
-          add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
-        elsif stage == :residential_address
-          next if pii[:same_address_as_id] == 'true'
-          next if hash[:vendor_name] == 'ResidentialAddressNotRequired'
-          add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
-        elsif stage == :state_id
-          next if hash[:exception].present?
-          next if hash[:vendor_name] == 'UnsupportedJurisdiction'
-          # transaction_id comes from TransactionLocatorId
-          add_cost(:aamva, transaction_id: hash[:transaction_id])
-          track_aamva
-        elsif stage == :threatmetrix
-          # transaction_id comes from request_id
-          tmx_id = hash[:transaction_id]
-          log_irs_tmx_fraud_check_event(hash, current_user) if tmx_id
-          add_cost(:threatmetrix, transaction_id: tmx_id) if tmx_id
-        end
-      end
+      # results[:context][:stages].each do |stage, hash|
+      #   if stage == :resolution
+      #     # transaction_id comes from ConversationId
+      #     add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
+      #   elsif stage == :residential_address
+      #     next if pii[:same_address_as_id] == 'true'
+      #     next if hash[:vendor_name] == 'ResidentialAddressNotRequired'
+      #     add_cost(:lexis_nexis_resolution, transaction_id: hash[:transaction_id])
+      #   elsif stage == :state_id
+      #     next if hash[:exception].present?
+      #     next if hash[:vendor_name] == 'UnsupportedJurisdiction'
+      #     # transaction_id comes from TransactionLocatorId
+      #     add_cost(:aamva, transaction_id: hash[:transaction_id])
+      #     track_aamva
+      #   elsif stage == :threatmetrix
+      #     # transaction_id comes from request_id
+      #     tmx_id = hash[:transaction_id]
+      #     log_irs_tmx_fraud_check_event(hash, current_user) if tmx_id
+      #     add_cost(:threatmetrix, transaction_id: tmx_id) if tmx_id
+      #   end
+      # end
     end
 
     def track_aamva

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -39,12 +39,12 @@ module Proofing
               device_profiling_adjudication_reason: device_profiling_reason,
               resolution_adjudication_reason: resolution_reason,
               should_proof_state_id: should_proof_state_id?,
-              stages: {
-                resolution: resolution_result.to_h,
-                residential_address: residential_resolution_result.to_h,
-                state_id: state_id_result.to_h,
-                threatmetrix: device_profiling_result.to_h,
-              },
+              # stages: {
+              #   resolution: resolution_result.to_h,
+              #   residential_address: residential_resolution_result.to_h,
+              #   state_id: state_id_result.to_h,
+              #   threatmetrix: device_profiling_result.to_h,
+              # },
             },
           },
         )


### PR DESCRIPTION
This commit removes this code so we can see what all fails to identify what is dependent on these being present.
