### PR TITLE
Fix bug with mismatched parameters in 50/50 state in UserMailer

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -58,7 +58,7 @@ class UserMailer < ActionMailer::Base
     )
   end
 
-  def email_confirmation_instructions(token, request_id:)
+  def email_confirmation_instructions(token, request_id:, instructions: nil)
     with_user_locale(user) do
       presenter = ConfirmationEmailPresenter.new(user, view_context)
       @first_sentence = presenter.first_sentence
@@ -69,6 +69,21 @@ class UserMailer < ActionMailer::Base
       mail(
         to: email_address.email,
         subject: t('user_mailer.email_confirmation_instructions.subject'),
+      )
+    end
+  end
+
+  def unconfirmed_email_instructions(token, request_id:, instructions:)
+    with_user_locale(user) do
+      presenter = ConfirmationEmailPresenter.new(user, view_context)
+      @first_sentence = instructions || presenter.first_sentence
+      @confirmation_period = presenter.confirmation_period
+      @request_id = request_id
+      @locale = locale_url_param
+      @token = token
+      mail(
+        to: email_address.email,
+        subject: t('user_mailer.email_confirmation_instructions.email_not_found'),
       )
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Emails can be sent asynchronously, and their arguments must be backwards compatible between deploys. This PR is a followup to #10434 to make it safely backwards compatible.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
