### PR TITLE
Remove unused email argument and method

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -58,7 +58,7 @@ class UserMailer < ActionMailer::Base
     )
   end
 
-  def email_confirmation_instructions(token, request_id:, instructions: nil)
+  def email_confirmation_instructions(token, request_id:)
     with_user_locale(user) do
       presenter = ConfirmationEmailPresenter.new(user, view_context)
       @first_sentence = presenter.first_sentence
@@ -69,21 +69,6 @@ class UserMailer < ActionMailer::Base
       mail(
         to: email_address.email,
         subject: t('user_mailer.email_confirmation_instructions.subject'),
-      )
-    end
-  end
-
-  def unconfirmed_email_instructions(token, request_id:, instructions:)
-    with_user_locale(user) do
-      presenter = ConfirmationEmailPresenter.new(user, view_context)
-      @first_sentence = instructions || presenter.first_sentence
-      @confirmation_period = presenter.confirmation_period
-      @request_id = request_id
-      @locale = locale_url_param
-      @token = token
-      mail(
-        to: email_address.email,
-        subject: t('user_mailer.email_confirmation_instructions.email_not_found'),
       )
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Followup to #10440 to remove the methods/arguments that are no longer used. Should not be merged until #10440 is deployed. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
