### PR TITLE
Fix failed_alerts key in test yml files

### DIFF
--- a/spec/fixtures/ial2_test_credential_classification_info_no_name.yml
+++ b/spec/fixtures/ial2_test_credential_classification_info_no_name.yml
@@ -8,7 +8,7 @@ document:
   phone: +1 314-555-1212
   state_id_jurisdiction: 'ND'
 doc_auth_result: Passed
-failed_alert: []
+failed_alerts: []
 classification_info:
   Front:
     ClassName: Drivers License

--- a/spec/fixtures/ial2_test_portrait_match_success.yml
+++ b/spec/fixtures/ial2_test_portrait_match_success.yml
@@ -12,6 +12,6 @@ document:
   state_id_type: 'drivers_license'
   zipcode: '59010'
 doc_auth_result: Passed
-failed_alert: []
+failed_alerts: []
 portrait_match_results:
   FaceMatchResult: Pass


### PR DESCRIPTION
## 🛠 Summary of changes

This does not cause an issue because these failures are empty. But
when copying from them to create new yml files I discovered the
key is wrong and should be fixed.

[skip changelog]