### PR TITLE
Remove `add_cost` and `add_costs` method from `Idv::Steps::DocAuthBaseStep`

### DIFF
--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -58,17 +58,6 @@ module Idv
         current_user ? current_user.id : user_id_from_token
       end
 
-      def add_cost(token, transaction_id: nil)
-        Db::SpCost::AddSpCost.call(current_sp, 2, token, transaction_id: transaction_id)
-      end
-
-      def add_costs(result)
-        Db::AddDocumentVerificationAndSelfieCosts.
-          new(user_id: user_id,
-              service_provider: current_sp).
-          call(result)
-      end
-
       def sp_session
         session.fetch(:sp, {})
       end


### PR DESCRIPTION
The `add_cost` and `add_costs` methods both create `SpCost` records for `FlowStateMachine` steps that inherit from `Idv::Steps::DocAuthBaseStep`.

We [removed the `FlowStateMachine`](https://github.com/18F/identity-idp/pull/8705) from all paths that lead to the creation of an `SpCost` record about a year ago. The [`FlowStateMachine`](https://github.com/18F/identity-idp/blob/main/app/services/flow/flow_state_machine.rb) and associated [`Idv::Steps::DocAuthBaseStep`](https://github.com/18F/identity-idp/blob/main/app/services/idv/steps/doc_auth_base_step.rb) remain, however, to support the in-person flow. The in-person flow does not create `SpCost` records in the `FlowStateMachine`.

These methods, like many methods in `FlowStateMachine` relics, are unused. We left these unused methods because it was assumed that the `FlowStateMachine` would be entirely removed from the in-person flow shortly after it was removed from the unsupervised flow. That has not been the case so this commit does some cleanup to remove them.
