### PR TITLE
Allow form submission when reCAPTCHA fails to load

### DIFF
--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -136,6 +136,27 @@ describe('CaptchaSubmitButtonElement', () => {
           });
         });
       });
+
+      context('when recaptcha fails to load', () => {
+        beforeEach(() => {
+          delete (global as any).grecaptcha;
+        });
+
+        it('does not prevent default form submission', async () => {
+          const button = screen.getByRole('button', { name: 'Submit' });
+          const form = document.querySelector('form')!;
+
+          let didSubmit = false;
+          form.addEventListener('submit', (event) => {
+            expect(event.defaultPrevented).to.equal(false);
+            event.preventDefault();
+            didSubmit = true;
+          });
+
+          await userEvent.click(button);
+          await waitFor(() => expect(didSubmit).to.be.true());
+        });
+      });
     });
   });
 });

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -31,12 +31,12 @@ class CaptchaSubmitButtonElement extends HTMLElement {
     return this.getAttribute('recaptcha-enterprise') === 'true';
   }
 
-  get recaptchaClient(): ReCaptchaV2.ReCaptcha {
+  get recaptchaClient(): ReCaptchaV2.ReCaptcha | undefined {
     if (this.isRecaptchaEnterprise) {
-      return grecaptcha.enterprise;
+      return globalThis.grecaptcha?.enterprise;
     }
 
-    return grecaptcha;
+    return globalThis.grecaptcha;
   }
 
   submit() {
@@ -44,16 +44,16 @@ class CaptchaSubmitButtonElement extends HTMLElement {
   }
 
   invokeChallenge() {
-    this.recaptchaClient.ready(async () => {
+    this.recaptchaClient!.ready(async () => {
       const { recaptchaSiteKey: siteKey, recaptchaAction: action } = this;
-      const token = await this.recaptchaClient.execute(siteKey!, { action });
+      const token = await this.recaptchaClient!.execute(siteKey!, { action });
       this.tokenInput.value = token;
       this.submit();
     });
   }
 
   shouldInvokeChallenge(): boolean {
-    return !!this.recaptchaSiteKey;
+    return !!(this.recaptchaSiteKey && this.recaptchaClient);
   }
 
   handleFormSubmit = (event: SubmitEvent) => {


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `CaptchaSubmitButtonElement` to avoid preventing submission in case reCAPTCHA is unable to load.

This should typically never happen, but error logs indicate that there are a low number of cases where reCAPTCHA is unavailable at the time that it's meant to be executed. It is likely these are caused by ad blockers or other script blockers, but it could also be due to any number of network interruptions.

Regardless the cause, since #10408 removed exceptions to the client-side reCAPTCHA call, it is important that this does not become a blocker to someone's ability to submit the page, particularly if they would be exempt from the backend assessment result validation.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1713294014865199

## 📜 Testing Plan

This is hard to simulate, but absent some ability to block the network request, you could manually try changing [the script source](https://github.com/18F/identity-idp/blob/90256569bb5ad8ed5d0c52db8b419977bbd1d549/app/components/captcha_submit_button_component.rb#L25-L26) to something which will fail to load.

Then, follow the Testing Plan from #10408 and verify that you're always permitted to submit the phone setup page. You should see the reCAPTCHA checkbox error fallback page "Protecting against spam" if the reCAPTCHA verification token is required for the phone number (international numbers).