### PR TITLE
Fix flash of accordion content during page load

### DIFF
--- a/app/components/accordion_component.html.erb
+++ b/app/components/accordion_component.html.erb
@@ -9,9 +9,7 @@
       <%= header %>
     </button>
   </div>
-  <div id="accordion-<%= unique_id %>" class="usa-accordion__container">
-    <div class="usa-accordion__content">
-      <%= content %>
-    </div>
+  <div id="accordion-<%= unique_id %>" class="usa-accordion__content">
+    <%= content %>
   </div>
 <% end %>

--- a/spec/components/accordion_component_spec.rb
+++ b/spec/components/accordion_component_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe AccordionComponent, type: :component do
   it 'assigns a unique id' do
     second_rendered = render_inline(described_class.new)
 
-    rendered_id = rendered.css('.usa-accordion__container').first['id']
-    second_rendered_id = second_rendered.css('.usa-accordion__container').first['id']
+    rendered_id = rendered.css('.usa-accordion__content').first['id']
+    second_rendered_id = second_rendered.css('.usa-accordion__content').first['id']
 
     expect(rendered_id).to be_present
     expect(second_rendered_id).to be_present


### PR DESCRIPTION
## 🛠 Summary of changes

This updates Accordion component markup, removing invalid `usa-accordion__container` wrapper element, in order to allow the intended improvement from [`@18f/identity-design-system@9.1.0`](https://github.com/18F/identity-design-system/releases/tag/v9.1.0) to prevent flashing content during page load.

This follows a similar change from the introduction of that enhancement in https://github.com/18F/identity-design-system/pull/434 to alter the documented component markup, "[removing] an unnecessary and useless `usa-accordion__container` container element which is not standard to USWDS and would make the JavaScript hiding behavior ineffective".

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create an account
3. At password entry screen, refresh the page with cache disabled
4. Observe no flash of open accordion content for "Password safety tips"

## 👀 Screenshots

Screen recordings emulating slower page loads with "Fast 3G" preset in Chrome network simulation..

**Before:**

https://github.com/18F/identity-idp/assets/1779930/0bb88c7e-5b5c-41e3-82b9-a4b23ad90aa3

**After:**

https://github.com/18F/identity-idp/assets/1779930/3d8516c9-120d-4bbe-a240-2c621cfdcfd5