### PR TITLE
Replace GET form with link for regenerating backup codes

### DIFF
--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -1,10 +1,21 @@
 # frozen_string_literal: true
 
 class ButtonComponent < BaseComponent
-  attr_reader :action, :icon, :big, :wide, :full_width, :outline, :unstyled, :danger, :tag_options
+  attr_reader :url,
+              :method,
+              :icon,
+              :big,
+              :wide,
+              :full_width,
+              :outline,
+              :unstyled,
+              :danger,
+              :tag_options
 
   def initialize(
-    action: ->(**tag_options, &block) { button_tag(**tag_options, &block) },
+    action: nil,
+    url: nil,
+    method: nil,
     icon: nil,
     big: false,
     wide: false,
@@ -15,6 +26,8 @@ class ButtonComponent < BaseComponent
     **tag_options
   )
     @action = action
+    @url = url
+    @method = method
     @icon = icon
     @big = big
     @wide = wide
@@ -51,6 +64,20 @@ class ButtonComponent < BaseComponent
       trimmed_content
     else
       original_content
+    end
+  end
+
+  def action
+    @action ||= begin
+      if url
+        if method && method != :get
+          ->(**tag_options, &block) { button_to(url, method:, **tag_options, &block) }
+        else
+          ->(**tag_options, &block) { link_to(url, **tag_options, &block) }
+        end
+      else
+        ->(**tag_options, &block) { button_tag(**tag_options, &block) }
+      end
     end
   end
 end

--- a/app/views/accounts/_pii.html.erb
+++ b/app/views/accounts/_pii.html.erb
@@ -5,9 +5,7 @@
         <div class="usa-alert__text">
           <%= t('account.re_verify.banner') %>
           <%= render ButtonComponent.new(
-                action: ->(**tag_options, &block) do
-                  button_to(account_reauthentication_path, **tag_options, &block)
-                end,
+                url: account_reauthentication_path,
                 method: :post,
                 class: 'usa-button usa-button--unstyled',
               ).with_content(t('account.re_verify.footer')) %>

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -57,9 +57,7 @@
 
     <div class="margin-top-4">
       <%= render SpinnerButtonComponent.new(
-            action: ->(**tag_options, &block) do
-              button_to(idv_cancel_path(step: params[:step], location: 'cancel'), **tag_options, &block)
-            end,
+            url: idv_cancel_path(step: params[:step], location: 'cancel'),
             method: :delete,
             big: true,
             wide: true,

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -28,9 +28,7 @@
 
     <div class="margin-top-4">
       <%= render ButtonComponent.new(
-            action: ->(**tag_options, &block) do
-              button_to(idv_session_path(step: params[:step]), **tag_options, &block)
-            end,
+            url: idv_session_path(step: params[:step]),
             method: :delete,
             big: true,
             wide: true,
@@ -39,9 +37,7 @@
       %>
       <div class="margin-top-2">
         <%= render ButtonComponent.new(
-              action: ->(**tag_options, &block) do
-                button_to(idv_cancel_path(step: params[:step]), **tag_options, &block)
-              end,
+              url: idv_cancel_path(step: params[:step]),
               method: :put,
               big: true,
               wide: true,

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -7,15 +7,11 @@
     <p><%= t('idv.cancel.description.hybrid') %></p>
 
     <% c.with_action_button(
-         action: ->(**tag_options, &block) do
-           button_to(idv_cancel_path(step: params[:step], location: 'cancel'), **tag_options, &block)
-         end,
+         url: idv_cancel_path(step: params[:step], location: 'cancel'),
          method: :delete,
        ).with_content(t('forms.buttons.cancel')) %>
     <% c.with_action_button(
-         action: ->(**tag_options, &block) do
-           button_to(idv_cancel_path(step: params[:step]), **tag_options, &block)
-         end,
+         url: idv_cancel_path(step: params[:step]),
          method: :put,
          outline: true,
        ).with_content(t('links.go_back')) %>

--- a/app/views/idv/confirm_start_over/before_letter.html.erb
+++ b/app/views/idv/confirm_start_over/before_letter.html.erb
@@ -13,9 +13,7 @@
 
   <div class="margin-y-5">
     <%= render ButtonComponent.new(
-          action: ->(**tag_options, &block) do
-            button_to(idv_session_path(step: :request_letter), **tag_options, &block)
-          end,
+          url: idv_session_path(step: :request_letter),
           method: :delete,
           big: true,
           wide: true,

--- a/app/views/idv/confirm_start_over/index.html.erb
+++ b/app/views/idv/confirm_start_over/index.html.erb
@@ -17,9 +17,7 @@
 
   <div class="margin-y-5">
     <%= render ButtonComponent.new(
-          action: ->(**tag_options, &block) do
-            button_to(idv_session_path(step: :gpo_verify), **tag_options, &block)
-          end,
+          url: idv_session_path(step: :gpo_verify),
           method: :delete,
           big: true,
           wide: true,

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -142,9 +142,7 @@ locals:
   </div>
   <div class="margin-top-5">
       <%= render SpinnerButtonComponent.new(
-            action: ->(**tag_options, &block) do
-              button_to(idv_in_person_verify_info_path, **tag_options, &block)
-            end,
+            url: idv_in_person_verify_info_path,
             big: true,
             wide: true,
             action_message: t('idv.messages.verifying'),

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -119,9 +119,7 @@ locals:
   </div>
   <div class="margin-top-5">
       <%= render SpinnerButtonComponent.new(
-            action: ->(**tag_options, &block) do
-              button_to(idv_verify_info_path, **tag_options, &block)
-            end,
+            url: idv_verify_info_path,
             big: true,
             wide: true,
             action_message: t('idv.messages.verifying'),

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -49,9 +49,7 @@
         t('continue', scope: modal_presenter.translation_scope),
       ) %>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          button_to(logout_path, **tag_options, &block)
-        end,
+        url: logout_path,
         method: :delete,
         big: true,
         full_width: true,

--- a/app/views/users/auth_app/edit.html.erb
+++ b/app/views/users/auth_app/edit.html.erb
@@ -22,15 +22,9 @@
 <% end %>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        button_to(
-          auth_app_path(id: @form.configuration.id),
-          form: { aria: { label: t('two_factor_authentication.auth_app.delete') } },
-          **tag_options,
-          &block
-        )
-      end,
+      url: auth_app_path(id: @form.configuration.id),
       method: :delete,
+      form: { aria: { label: t('two_factor_authentication.auth_app.delete') } },
       big: true,
       wide: true,
       danger: true,

--- a/app/views/users/authorization_confirmation/new.html.erb
+++ b/app/views/users/authorization_confirmation/new.html.erb
@@ -20,9 +20,8 @@
 
 <div class="margin-top-4 text-center">
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          button_to(user_authorization_confirmation_path, method: :post, **tag_options, &block)
-        end,
+        url: user_authorization_confirmation_path,
+        method: :post,
         big: true,
         wide: true,
       ).with_content(t('user_authorization_confirmation.continue')) %>
@@ -30,9 +29,8 @@
     <%= t('user_authorization_confirmation.or') %>
   </div>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          button_to(reset_user_authorization_path, method: :delete, **tag_options, &block)
-        end,
+        url: reset_user_authorization_path,
+        method: :delete,
         big: true,
         wide: true,
       ).with_content(t('user_authorization_confirmation.sign_in')) %>

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -8,10 +8,16 @@
   <%= t('forms.backup_code_regenerate.caution') %>
 </p>
 
-<%= form_tag(backup_code_setup_path, method: :get, class: 'margin-top-5') do %>
-  <%= button_tag t('account.index.backup_code_confirm_regenerate'), type: 'submit',
-                                                                    class: 'usa-button usa-button--big usa-button--wide margin-bottom-2' %>
-<% end %>
+<%= render ButtonComponent.new(
+      url: backup_code_setup_path,
+      big: true,
+      wide: true,
+      class: 'margin-top-3 margin-bottom-2',
+    ).with_content(t('account.index.backup_code_confirm_regenerate')) %>
 
-<%= link_to t('links.cancel'), account_path,
-            class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>
+<%= render ButtonComponent.new(
+      url: account_path,
+      big: true,
+      wide: true,
+      outline: true,
+    ).with_content(t('links.cancel')) %>

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -1,23 +1,21 @@
 <% self.title = t('forms.backup_code_regenerate.confirm') %>
 
-<%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-4') %>
+<%= render StatusPageComponent.new(status: :warning) do |c| %>
+  <% c.with_header { t('forms.backup_code_regenerate.confirm') } %>
 
-<%= render PageHeadingComponent.new.with_content(t('forms.backup_code_regenerate.confirm')) %>
+  <p><%= t('forms.backup_code_regenerate.caution') %></p>
 
-<p>
-  <%= t('forms.backup_code_regenerate.caution') %>
-</p>
+  <%= render ButtonComponent.new(
+        url: backup_code_setup_path,
+        big: true,
+        wide: true,
+        class: 'margin-top-3 margin-bottom-2',
+      ).with_content(t('account.index.backup_code_confirm_regenerate')) %>
 
-<%= render ButtonComponent.new(
-      url: backup_code_setup_path,
-      big: true,
-      wide: true,
-      class: 'margin-top-3 margin-bottom-2',
-    ).with_content(t('account.index.backup_code_confirm_regenerate')) %>
-
-<%= render ButtonComponent.new(
-      url: account_path,
-      big: true,
-      wide: true,
-      outline: true,
-    ).with_content(t('links.cancel')) %>
+  <%= render ButtonComponent.new(
+        url: account_path,
+        big: true,
+        wide: true,
+        outline: true,
+      ).with_content(t('links.cancel')) %>
+<% end %>

--- a/app/views/users/piv_cac/edit.html.erb
+++ b/app/views/users/piv_cac/edit.html.erb
@@ -21,15 +21,9 @@
 <% end %>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        button_to(
-          piv_cac_path(id: @form.configuration.id),
-          form: { aria: { label: @presenter.delete_button_label } },
-          **tag_options,
-          &block
-        )
-      end,
+      url: piv_cac_path(id: @form.configuration.id),
       method: :delete,
+      form: { aria: { label: @presenter.delete_button_label } },
       big: true,
       wide: true,
       danger: true,

--- a/app/views/users/webauthn/edit.html.erb
+++ b/app/views/users/webauthn/edit.html.erb
@@ -19,15 +19,9 @@
 <% end %>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        button_to(
-          webauthn_path(id: @form.configuration.id),
-          form: { aria: { label: @presenter.delete_button_label } },
-          **tag_options,
-          &block
-        )
-      end,
+      url: webauthn_path(id: @form.configuration.id),
       method: :delete,
+      form: { aria: { label: @presenter.delete_button_label } },
       big: true,
       wide: true,
       danger: true,

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,19 +3,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "406a2c5ea3d852268958d2db11c146841491b6e87cee9c583dd35f5f41898fb7",
+      "fingerprint": "0550ef2573eae747e7e4bb6f31851ed77713409b74f7abe48c15a6a82801babb",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/idv/cancellations/new.html.erb",
-      "line": 43,
+      "line": 31,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => ButtonComponent.new(:action => (lambda do\n button_to(idv_cancel_path(:step => params[:step]), { **tag_options }, &block)\n end), :method => :put, :big => true, :wide => true, :outline => true, :form => ({ :\"aria-label\" => t(\"idv.cancel.actions.keep_going\") })).with_content(t(\"idv.cancel.actions.keep_going\")), {})",
+      "code": "render(action => ButtonComponent.new(:url => idv_session_path(:step => params[:step]), :method => :delete, :big => true, :wide => true, :form => ({ :\"aria-label\" => t(\"idv.cancel.actions.start_over\") })).with_content(t(\"idv.cancel.actions.start_over\")), {})",
       "render_path": [
         {
           "type": "controller",
           "class": "Idv::CancellationsController",
           "method": "new",
-          "line": 13,
+          "line": 16,
           "file": "app/controllers/idv/cancellations_controller.rb",
           "rendered": {
             "name": "idv/cancellations/new",
@@ -37,19 +37,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "8b51f403181f74421f5681ada1096371e1f55fb03d0127db01b5e5da7dda3c51",
+      "fingerprint": "278d16995e8a645908c9a043314cfeebd8cb094bce766ad5101c62ff08853de6",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/idv/cancellations/new.html.erb",
-      "line": 32,
+      "line": 60,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => ButtonComponent.new(:action => (lambda do\n button_to(idv_session_path(:step => params[:step]), { **tag_options }, &block)\n end), :method => :delete, :big => true, :wide => true, :form => ({ :\"aria-label\" => t(\"idv.cancel.actions.start_over\") })).with_content(t(\"idv.cancel.actions.start_over\")), {})",
+      "code": "render(action => SpinnerButtonComponent.new(:url => idv_cancel_path(:step => params[:step], :location => \"cancel\"), :method => :delete, :big => true, :wide => true, :outline => true, :form => ({ :\"aria-label\" => CancellationsPresenter.new(:sp_name => decorated_sp_session.sp_name, :url_options => url_options).exit_action_text, :data => ({ :form_steps_wait => \"\" }) })).with_content(CancellationsPresenter.new(:sp_name => decorated_sp_session.sp_name, :url_options => url_options).exit_action_text), {})",
       "render_path": [
         {
           "type": "controller",
           "class": "Idv::CancellationsController",
           "method": "new",
-          "line": 13,
+          "line": 16,
           "file": "app/controllers/idv/cancellations_controller.rb",
           "rendered": {
             "name": "idv/cancellations/new",
@@ -71,19 +71,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "f7d01c6318e6ce369f9fe9bf59b6a3a323034b4b826e2a52a9a87b581d468598",
+      "fingerprint": "341d99a0fdaf75dff50ea66c9da1b973cb36fc1aac2221480deff6e30d11540a",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/idv/cancellations/new.html.erb",
-      "line": 65,
+      "line": 40,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => SpinnerButtonComponent.new(:action => (lambda do\n button_to(idv_cancel_path(:step => params[:step], :location => \"cancel\"), { **tag_options }, &block)\n end), :method => :delete, :big => true, :wide => true, :outline => true, :form => ({ :\"aria-label\" => CancellationsPresenter.new(:sp_name => decorated_sp_session.sp_name, :url_options => url_options).exit_action_text, :data => ({ :form_steps_wait => \"\" }) })).with_content(CancellationsPresenter.new(:sp_name => decorated_sp_session.sp_name, :url_options => url_options).exit_action_text), {})",
+      "code": "render(action => ButtonComponent.new(:url => idv_cancel_path(:step => params[:step]), :method => :put, :big => true, :wide => true, :outline => true, :form => ({ :\"aria-label\" => t(\"idv.cancel.actions.keep_going\") })).with_content(t(\"idv.cancel.actions.keep_going\")), {})",
       "render_path": [
         {
           "type": "controller",
           "class": "Idv::CancellationsController",
           "method": "new",
-          "line": 13,
+          "line": 16,
           "file": "app/controllers/idv/cancellations_controller.rb",
           "rendered": {
             "name": "idv/cancellations/new",
@@ -103,6 +103,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-11-02 09:34:28 -0400",
-  "brakeman_version": "6.0.1"
+  "updated": "2024-04-19 08:20:16 -0400",
+  "brakeman_version": "6.1.0"
 }

--- a/spec/components/button_component_spec.rb
+++ b/spec/components/button_component_spec.rb
@@ -131,4 +131,33 @@ RSpec.describe ButtonComponent, type: :component do
       )
     end
   end
+
+  context 'with url' do
+    let(:url) { '/' }
+    let(:options) { { url: } }
+
+    it 'renders link to url' do
+      expect(rendered).to have_link(content, href: url)
+    end
+
+    context 'with method' do
+      let(:method) { :put }
+      let(:options) { super().merge(method:) }
+
+      it 'renders button to url' do
+        expect(subject).to have_selector("form[action='#{url}']")
+        expect(subject).to have_selector("input[name='_method'][value='#{method}']", visible: :all)
+        expect(subject).to have_selector("button[type='submit']")
+        expect(subject).to have_text(content)
+      end
+
+      context 'with get method' do
+        let(:method) { :get }
+
+        it 'renders link to url' do
+          expect(rendered).to have_link(content, href: url)
+        end
+      end
+    end
+  end
 end

--- a/spec/components/button_component_spec.rb
+++ b/spec/components/button_component_spec.rb
@@ -145,10 +145,10 @@ RSpec.describe ButtonComponent, type: :component do
       let(:options) { super().merge(method:) }
 
       it 'renders button to url' do
-        expect(subject).to have_selector("form[action='#{url}']")
-        expect(subject).to have_selector("input[name='_method'][value='#{method}']", visible: :all)
-        expect(subject).to have_selector("button[type='submit']")
-        expect(subject).to have_text(content)
+        expect(rendered).to have_selector("form[action='#{url}']")
+        expect(rendered).to have_selector("input[name='_method'][value='#{method}']", visible: :all)
+        expect(rendered).to have_selector("button[type='submit']")
+        expect(rendered).to have_text(content)
       end
 
       context 'with get method' do

--- a/spec/views/users/backup_code_setup/edit.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/edit.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'users/backup_code_setup/edit.html.erb' do
+  subject(:rendered) { render }
+
+  it 'has a link to confirm and proceed to setup' do
+    expect(rendered).to have_link(
+      t('account.index.backup_code_confirm_regenerate'),
+      href: backup_code_setup_path,
+    )
+  end
+
+  it 'has a link to cancel and return to account page' do
+    expect(rendered).to have_link(t('links.cancel'), href: account_path)
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-12716](https://cm-jira.usa.gov/browse/LG-12716)

## 🛠 Summary of changes

Updates the backup codes regenerate confirmation screen primary button to use a link (`<a href="...">`) in place of a `<form action="..." method="get"><button>`.

This is related to the comment at https://github.com/18F/identity-idp/pull/10088#discussion_r1570623056, where it's theorized there may be misbehaving browser versions which incorrectly handle the form submission. By using an anchor tag link, it's hoped this resolves the unexpected requests we're seeing to the route planned for removal in #10088.

Related Slack thread: https://gsa-tts.slack.com/archives/C05MGJ72GU9/p1713455028604359

This also includes minor refactoring to use common conventions for rendering buttons and status pages.

## 📜 Testing Plan

Verify there is no regression in the behavior of regenerating backup codes.

1. Go to http://localhost:3000
2. Sign in
3. From account dashboard, click "Get codes" if you don't already have backup codes
4. Once you have backup codes, click "Get new codes" from the account dashboard
5. Observe you still see the confirmation screen with primary "Yes, regenerate codes" primary and "Cancel" secondary buttons
6. Click either/both buttons and verify you're redirected as expected

## 👀 Screenshots

There's no visual changes expected.

Screenshot for reference:

![Screenshot 2024-04-18 at 3 49 05 PM](https://github.com/18F/identity-idp/assets/1779930/de524495-b90d-4e2a-abbb-25f8099f94de)
