### PR TITLE
LG-13009 [AC-1]: unexpected face error message

### DIFF
--- a/app/services/doc_auth/error_generator.rb
+++ b/app/services/doc_auth/error_generator.rb
@@ -139,10 +139,6 @@ module DocAuth
         return nil
       end
 
-      # Error when the image on the id does not match the selfie image, but the image was acceptable
-      if error_is_success(face_match_error)
-        return Errors::SELFIE_FAILURE
-      end
       # Error when the image on the id is poor quality
       if error_is_poor_quality(face_match_error)
         return Errors::SELFIE_POOR_QUALITY

--- a/app/services/doc_auth/selfie_concern.rb
+++ b/app/services/doc_auth/selfie_concern.rb
@@ -5,18 +5,14 @@ module DocAuth
     extend ActiveSupport::Concern
     def selfie_live?
       portrait_error = get_portrait_error(portrait_match_results)
-      return true if portrait_error.nil? || portrait_error.blank?
+      return true if portrait_error.blank?
       !error_is_not_live(portrait_error)
     end
 
     def selfie_quality_good?
       portrait_error = get_portrait_error(portrait_match_results)
-      return true if portrait_error.nil? || portrait_error.blank?
+      return true if portrait_error.blank?
       !error_is_poor_quality(portrait_error)
-    end
-
-    def error_is_success(error_message)
-      error_message == ERROR_TEXTS[:success]
     end
 
     def error_is_not_live(error_message)
@@ -31,7 +27,7 @@ module DocAuth
       SELFIE_PERFORMED_STATUSES.include?(selfie_status)
     end
 
-  private
+    private
 
     SELFIE_PERFORMED_STATUSES = %i[success fail].freeze
 
@@ -45,5 +41,5 @@ module DocAuth
     def get_portrait_error(portrait_match_results)
       portrait_match_results&.with_indifferent_access&.dig(:FaceErrorMessage)
     end
-end
+  end
 end

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -61,7 +61,8 @@ module DocAuthRouter
     # i18n-tasks-use t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
     DocAuth::Errors::SELFIE_NOT_LIVE => 'doc_auth.errors.alerts.selfie_not_live_or_poor_quality',
     # i18n-tasks-use t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
-    DocAuth::Errors::SELFIE_POOR_QUALITY => 'doc_auth.errors.alerts.selfie_not_live_or_poor_quality',
+    DocAuth::Errors::SELFIE_POOR_QUALITY =>
+      'doc_auth.errors.alerts.selfie_not_live_or_poor_quality',
     # i18n-tasks-use t('doc_auth.errors.alerts.sex_check')
     DocAuth::Errors::SEX_CHECK => 'doc_auth.errors.alerts.sex_check',
     # i18n-tasks-use t('doc_auth.errors.alerts.visible_color_check')

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -58,10 +58,10 @@ module DocAuthRouter
       'doc_auth.errors.alerts.ref_control_number_check',
     # i18n-tasks-use t('doc_auth.errors.general.selfie_failure')
     DocAuth::Errors::SELFIE_FAILURE => 'doc_auth.errors.general.selfie_failure',
-    # i18n-tasks-use t('doc_auth.errors.alerts.selfie_not_live')
-    DocAuth::Errors::SELFIE_NOT_LIVE => 'doc_auth.errors.alerts.selfie_not_live',
-    # i18n-tasks-use t('doc_auth.errors.alerts.selfie_poor_quality')
-    DocAuth::Errors::SELFIE_POOR_QUALITY => 'doc_auth.errors.alerts.selfie_poor_quality',
+    # i18n-tasks-use t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
+    DocAuth::Errors::SELFIE_NOT_LIVE => 'doc_auth.errors.alerts.selfie_not_live_or_poor_quality',
+    # i18n-tasks-use t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
+    DocAuth::Errors::SELFIE_POOR_QUALITY => 'doc_auth.errors.alerts.selfie_not_live_or_poor_quality',
     # i18n-tasks-use t('doc_auth.errors.alerts.sex_check')
     DocAuth::Errors::SEX_CHECK => 'doc_auth.errors.alerts.sex_check',
     # i18n-tasks-use t('doc_auth.errors.alerts.visible_color_check')

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -39,9 +39,9 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
-        selfie_not_live_or_poor_quality: Try taking a photo of yourself again. Make sure your whole face
-          is clear and visible in the photo.
         selfie_not_live_help_link_text: Review more tips for taking a clear photo of yourself
+        selfie_not_live_or_poor_quality: Try taking a photo of yourself again. Make sure
+          your whole face is clear and visible in the photo.
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
         visible_color_check: We couldn’t verify your ID. It might have moved when you
           took the picture, or the picture is too dark. Try taking new pictures

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -39,11 +39,9 @@ en:
           the picture. Try taking new pictures.
         issue_date_checks: We couldn’t read the issue date on your ID. Try taking new pictures.
         ref_control_number_check: We couldn’t read the control number barcode. Try taking new pictures.
-        selfie_not_live: Try taking a photo of yourself again. Make sure your whole face
+        selfie_not_live_or_poor_quality: Try taking a photo of yourself again. Make sure your whole face
           is clear and visible in the photo.
         selfie_not_live_help_link_text: Review more tips for taking a clear photo of yourself
-        selfie_poor_quality: 'Try taking a photo of yourself again. Make sure your whole
-          face is clear and visible in the photo.'
         sex_check: We couldn’t read the sex on your ID. Try taking new pictures.
         visible_color_check: We couldn’t verify your ID. It might have moved when you
           took the picture, or the picture is too dark. Try taking new pictures

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -49,11 +49,9 @@ es:
           identidad. Intente tomar nuevas fotos.
         ref_control_number_check: No pudimos leer el código de barras del número de
           control. Intente tomar nuevas fotografías.
-        selfie_not_live: Intente tomar de nuevo una foto de usted. Asegúrese de que su
+        selfie_not_live_or_poor_quality: Intente tomar de nuevo una foto de usted. Asegúrese de que su
           rostro se vea claramente en la foto.
         selfie_not_live_help_link_text: Consulte más consejos para tomar una foto clara de su rostro
-        selfie_poor_quality: 'Intente tomar de nuevo una foto de usted. Asegúrese de que
-          su rostro se vea claramente en la foto.'
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar
           nuevas fotos.
         visible_color_check: No pudimos verificar su documento de identidad. Puede que

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -49,9 +49,9 @@ es:
           identidad. Intente tomar nuevas fotos.
         ref_control_number_check: No pudimos leer el código de barras del número de
           control. Intente tomar nuevas fotografías.
-        selfie_not_live_or_poor_quality: Intente tomar de nuevo una foto de usted. Asegúrese de que su
-          rostro se vea claramente en la foto.
         selfie_not_live_help_link_text: Consulte más consejos para tomar una foto clara de su rostro
+        selfie_not_live_or_poor_quality: Intente tomar de nuevo una foto de usted.
+          Asegúrese de que su rostro se vea claramente en la foto.
         sex_check: No pudimos leer el sexo en su documento de identidad. Intente tomar
           nuevas fotos.
         visible_color_check: No pudimos verificar su documento de identidad. Puede que

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -52,10 +52,10 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
         ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro de
           contrôle. Essayez de prendre de nouvelles photos.
-        selfie_not_live_or_poor_quality: Essayez de prendre une nouvelle photo de vous-même.
-          Assurez-vous que l’ensemble de votre visage soit clair et visible sur
-          la photo.
         selfie_not_live_help_link_text: Consultez plus de conseils pour prendre une photo claire de vous-même
+        selfie_not_live_or_poor_quality: Essayez de prendre une nouvelle photo de
+          vous-même. Assurez-vous que l’ensemble de votre visage soit clair et
+          visible sur la photo.
         sex_check: Nous n’avons pas pu lire le sexe sur votre pièce d’identité. Essayez
           de prendre de nouvelles photos.
         visible_color_check: Nous n’avons pas pu vérifier votre pièce d’identité. Elle a

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -52,13 +52,10 @@ fr:
           d’identité. Essayez de prendre de nouvelles photos.
         ref_control_number_check: Nous n’avons pas pu lire le code-barres du numéro de
           contrôle. Essayez de prendre de nouvelles photos.
-        selfie_not_live: Essayez de prendre une nouvelle photo de vous-même.
+        selfie_not_live_or_poor_quality: Essayez de prendre une nouvelle photo de vous-même.
           Assurez-vous que l’ensemble de votre visage soit clair et visible sur
           la photo.
         selfie_not_live_help_link_text: Consultez plus de conseils pour prendre une photo claire de vous-même
-        selfie_poor_quality: 'Essayez de prendre une nouvelle photo de vous-même.
-          Assurez-vous que l’ensemble de votre visage soit clair et visible sur
-          la photo.'
         sex_check: Nous n’avons pas pu lire le sexe sur votre pièce d’identité. Essayez
           de prendre de nouvelles photos.
         visible_color_check: Nous n’avons pas pu vérifier votre pièce d’identité. Elle a

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -317,7 +317,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             submit_images
             message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
-            detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live'))
+            detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
               t(
                 'idv.warning.attempts_html',
@@ -354,7 +354,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             submit_images
             message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
-            detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_poor_quality'))
+            detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
               t(
                 'idv.warning.attempts_html',
@@ -431,7 +431,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             submit_images
             message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
-            detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live'))
+            detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
               t(
                 'idv.warning.attempts_html',

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -410,7 +410,46 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             inline_error = strip_tags(t('doc_auth.errors.general.selfie_failure'))
             expect(page).to have_content(inline_error)
           end
+
+          it 'try again and page show selfie fail inline error message' do
+            visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
+            sign_in_and_2fa_user(user)
+            complete_doc_auth_steps_before_document_capture_step
+            attach_images(
+              Rails.root.join(
+                'spec', 'fixtures',
+                'ial2_test_portrait_match_failure_unexpected_face_error_message.yml'
+              ),
+            )
+            attach_selfie(
+              Rails.root.join(
+                'spec', 'fixtures',
+                'ial2_test_portrait_match_failure_unexpected_face_error_message.yml'
+              ),
+            )
+            submit_images
+            message = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
+            expect(page).to have_content(message)
+            detail_message = strip_tags(t('doc_auth.errors.general.selfie_failure'))
+            security_message = strip_tags(
+              t(
+                'idv.warning.attempts_html',
+                count: IdentityConfig.store.doc_auth_max_attempts - 1,
+              ),
+            )
+            expect(page).to have_content(detail_message << "\n" << security_message)
+            review_issues_header = strip_tags(
+              t('errors.doc_auth.selfie_fail_heading'),
+            )
+            expect(page).to have_content(review_issues_header)
+            expect(page).to have_current_path(idv_document_capture_path)
+            click_try_again
+            expect(page).to have_current_path(idv_document_capture_path)
+            inline_error = strip_tags(t('doc_auth.errors.general.selfie_failure'))
+            expect(page).to have_content(inline_error)
+          end
         end
+
         context 'with Attention with Barcode' do
           it 'try again and page show selfie fail inline error message' do
             visit_idp_from_oidc_sp_with_ial2

--- a/spec/fixtures/ial2_test_portrait_match_failure_unexpected_face_error_message.yml
+++ b/spec/fixtures/ial2_test_portrait_match_failure_unexpected_face_error_message.yml
@@ -1,0 +1,17 @@
+document:
+  first_name: 'John'
+  last_name: 'Doe'
+  address1: 1800 F Street
+  address2: Apt 3
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  dob: 10/06/1938
+  phone: +1 314-555-1212
+  state_id_jurisdiction: 'ND'
+  state_id_number: '1111111111111'
+doc_auth_result: Passed
+failed_alert: []
+portrait_match_results:
+  FaceMatchResult: Fail
+  FaceErrorMessage: 'Ooops ... this is an unexpected face error messagfe'


### PR DESCRIPTION
## 🎫 Ticket
[LG-13009](https://cm-jira.usa.gov/browse/LG-13009) - AC 1

## 🛠 Summary of changes
- consolidate selfie_not_live and selfie_poor_quality i18n
- add test to cover an unexpected face error message

## 📜 Testing Plan
- submit doc auth w/ selfie images with a not live face error message and verify `Try taking a photo of yourself again. Make sure your whole face is clear and visible in the photo.` is displayed
- submit doc auth w/ selfie images with a poor quality face error message and verify `Try taking a photo of yourself again. Make sure your whole face is clear and visible in the photo.` is displayed
- submit doc auth w/ selfie images with an unknown face error message and verify general selfie failure message `Try taking your photos again. Make sure all of your photos are clear and in focus.` is displayed

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
