### PR TITLE
Revert "Revert cssbundling-rails upgrade"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'caxlsx', require: false
 gem 'concurrent-ruby'
 gem 'connection_pool'
 gem 'csv'
-gem 'cssbundling-rails', '1.0.0'
+gem 'cssbundling-rails'
 gem 'devise', '~> 4.8'
 gem 'dotiw', '>= 4.0.1'
 gem 'faraday', '~> 2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
-    cssbundling-rails (1.0.0)
+    cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
     csv (3.2.8)
     date (3.3.4)
@@ -764,7 +764,7 @@ DEPENDENCIES
   caxlsx
   concurrent-ruby
   connection_pool
-  cssbundling-rails (= 1.0.0)
+  cssbundling-rails
   csv
   derailed_benchmarks
   devise (~> 4.8)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `cssbundling-rails` gem dependency to the latest version, from 1.0.0 to 1.4.0.

This reverts #10417, effectively unreverting #10412, now that required infrastructure changes are deployed.

## 📜 Testing Plan

1. Run `SKIP_YARN_INSTALL=true rails assets:precompile`
2. Verify that the first command you see is `yarn run` and not `yarn install`