### PR TITLE
Remove temporary redirect route for email resend

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -300,7 +300,6 @@ Rails.application.routes.draw do
         as: :sign_up_create_email_confirmation
     get '/sign_up/enter_email' => 'sign_up/registrations#new', as: :sign_up_email
     post '/sign_up/enter_email' => 'sign_up/registrations#create', as: :sign_up_register
-    get '/sign_up/enter_email/resend' => redirect('/sign_up/enter_email')
     get '/sign_up/enter_password' => 'sign_up/passwords#new'
     get '/sign_up/verify_email' => 'sign_up/emails#show', as: :sign_up_verify_email
     get '/sign_up/completed' => 'sign_up/completions#show', as: :sign_up_completed


### PR DESCRIPTION
## 🎫 Ticket

Follow-up task for [LG-13033](https://cm-jira.usa.gov/browse/LG-13033)

## 🛠 Summary of changes

Removes a temporary redirect route added in #10404 for transitionary period during and after deploy.

Since this has been live for a week, it's safe to drop. I've confirmed drop-off in logs in CloudWatch.

## 📜 Testing Plan

1. Go to http://localhost:3000/sign_up/enter_email/resend
2. Observe 404 error