### PR TITLE
Update ButtonComponent usage to use url/method abstraction

### DIFF
--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -13,7 +13,6 @@ class ButtonComponent < BaseComponent
               :tag_options
 
   def initialize(
-    action: nil,
     url: nil,
     method: nil,
     icon: nil,
@@ -25,7 +24,6 @@ class ButtonComponent < BaseComponent
     danger: false,
     **tag_options
   )
-    @action = action
     @url = url
     @method = method
     @icon = icon
@@ -66,6 +64,8 @@ class ButtonComponent < BaseComponent
       original_content
     end
   end
+
+  private
 
   def action
     @action ||= begin

--- a/app/components/download_button_component.rb
+++ b/app/components/download_button_component.rb
@@ -6,14 +6,8 @@ class DownloadButtonComponent < ButtonComponent
   def initialize(file_data:, file_name:, **tag_options)
     super(
       icon: :file_download,
-      action: ->(**tag_options, &block) do
-        link_to(
-          "data:text/plain;charset=utf-8,#{ERB::Util.url_encode(file_data)}",
-          download: file_name,
-          **tag_options,
-          &block
-        )
-      end,
+      url: "data:text/plain;charset=utf-8,#{ERB::Util.url_encode(file_data)}",
+      download: file_name,
       **tag_options,
     )
 

--- a/app/components/manageable_authenticator_component.html.erb
+++ b/app/components/manageable_authenticator_component.html.erb
@@ -91,7 +91,7 @@
     <div class="manageable-authenticator__name manageable-authenticator__summary-name"><%= configuration.name %></div>
     <div class="manageable-authenticator__actions">
       <%= render ButtonComponent.new(
-            action: ->(**tag_options, &block) { link_to(manage_url, **tag_options, &block) },
+            url: manage_url,
             type: :button,
             unstyled: true,
             class: 'no-js',

--- a/app/components/tab_navigation_component.html.erb
+++ b/app/components/tab_navigation_component.html.erb
@@ -3,7 +3,7 @@
     <% routes.each do |route| %>
       <li class="usa-button-group__item">
         <%= render ButtonComponent.new(
-              action: ->(**tag_options, &block) { link_to(route[:path], **tag_options, &block) },
+              url: route[:path],
               big: true,
               outline: !is_current_path?(route[:path]),
               aria: { current: is_current_path?(route[:path]) ? 'page' : nil },

--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -21,9 +21,7 @@
 
 <% if current_user.auth_app_configurations.count < IdentityConfig.store.max_auth_apps_per_account %>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          link_to(authenticator_setup_url, **tag_options, &block)
-        end,
+        url: authenticator_setup_url,
         icon: :add,
         class: 'usa-button usa-button--outline margin-top-2',
       ).with_content(t('account.index.auth_app_add')) %>

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -32,7 +32,7 @@
 </div>
 <% if EmailPolicy.new(current_user).can_add_email? %>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) { link_to(add_email_path, **tag_options, &block) },
+        url: add_email_path,
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -25,7 +25,7 @@
 </div>
 <% if current_user.phone_configurations.count < IdentityConfig.store.max_phone_numbers_per_account %>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) { link_to(phone_setup_path, **tag_options, &block) },
+        url: phone_setup_path,
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -2,7 +2,7 @@
   <%= t('headings.account.federal_employee_id') %>
 </h2>
 
-<div role="list"> 
+<div role="list">
   <% MfaContext.new(current_user).piv_cac_configurations.each do |configuration| %>
     <%= render ManageableAuthenticatorComponent.new(
           configuration:,
@@ -21,9 +21,7 @@
 
 <% if current_user.piv_cac_configurations.count < IdentityConfig.store.max_piv_cac_per_account %>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          link_to(setup_piv_cac_url, **tag_options, &block)
-        end,
+        url: setup_piv_cac_url,
         icon: :add,
         outline: true,
         class: 'margin-top-2',

--- a/app/views/accounts/_webauthn_platform.html.erb
+++ b/app/views/accounts/_webauthn_platform.html.erb
@@ -20,9 +20,7 @@
 </div>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        link_to(webauthn_setup_path(platform: true), **tag_options, &block)
-      end,
+      url: webauthn_setup_path(platform: true),
       icon: :add,
       outline: true,
       class: 'margin-top-2',

--- a/app/views/accounts/_webauthn_roaming.html.erb
+++ b/app/views/accounts/_webauthn_roaming.html.erb
@@ -25,9 +25,7 @@
 </div>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        link_to(webauthn_setup_path, **tag_options, &block)
-      end,
+      url: webauthn_setup_path,
       icon: :add,
       outline: true,
       class: 'margin-top-2',

--- a/app/views/accounts/actions/_generate_backup_codes.html.erb
+++ b/app/views/accounts/actions/_generate_backup_codes.html.erb
@@ -1,7 +1,5 @@
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        link_to(backup_code_create_path, **tag_options, &block)
-      end,
+      url: backup_code_create_path,
       icon: :add,
       class: 'usa-button usa-button--outline margin-top-2',
     ).with_content(t('forms.backup_code.generate')) %>

--- a/app/views/accounts/actions/_regenerate_backup_codes.html.erb
+++ b/app/views/accounts/actions/_regenerate_backup_codes.html.erb
@@ -1,7 +1,5 @@
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        link_to(backup_code_regenerate_path, **tag_options, &block)
-      end,
+      url: backup_code_regenerate_path,
       icon: :add,
       outline: true,
       class: 'margin-top-2',

--- a/app/views/idv/forgot_password/new.html.erb
+++ b/app/views/idv/forgot_password/new.html.erb
@@ -10,15 +10,12 @@
   </ul>
 
   <% c.with_action_button(
-       action: ->(**tag_options, &block) do
-         link_to(idv_enter_password_path, **tag_options, &block)
-       end,
+       url: idv_enter_password_path,
      ) { t('idv.forgot_password.try_again') } %>
 
   <% c.with_action_button(
-       action: ->(**tag_options, &block) do
-         button_to(idv_forgot_password_path, method: :post, **tag_options, &block)
-       end,
+       url: idv_forgot_password_path,
+       method: :post,
        outline: true,
      ) { t('idv.forgot_password.reset_password') } %>
 <% end %>

--- a/app/views/idv/mail_only_warning/show.html.erb
+++ b/app/views/idv/mail_only_warning/show.html.erb
@@ -24,17 +24,13 @@
     <% end %>
   </ul>
   <% c.with_action_button(
-       action: ->(**tag_options, &block) do
-         link_to(idv_url, **tag_options, &block)
-       end,
+       url: idv_url,
        big: true,
        wide: true,
        class: 'usa-button',
      ).with_content(t('doc_auth.buttons.continue')) %>
   <% c.with_action_button(
-       action: ->(**tag_options, &block) do
-         link_to(exit_url, **tag_options, &block)
-       end,
+       url: exit_url,
        big: true,
        wide: true,
        outline: true,

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -29,9 +29,8 @@
 <% end %>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        button_to(idv_resend_otp_path, method: :post, **tag_options, &block)
-      end,
+      url: idv_resend_otp_path,
+      method: :post,
       outline: true,
       icon: :loop,
       class: 'margin-bottom-4',

--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -34,7 +34,7 @@
       <% if @gpo_letter_available %>
         <div class="margin-y-5">
           <%= render ButtonComponent.new(
-                action: ->(**tag_options, &block) { link_to idv_request_letter_path, **tag_options, &block },
+                url: idv_request_letter_path,
                 big: true,
                 wide: true,
               ).with_content(t('idv.failure.phone.rate_limited.gpo.button')) %>

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -33,7 +33,7 @@
 
       <div class="margin-y-5">
         <%= render ButtonComponent.new(
-              action: ->(**tag_options, &block) { link_to idv_phone_path, **tag_options, &block },
+              url: idv_phone_path,
               big: true,
               wide: true,
             ).with_content(t('idv.failure.phone.warning.try_again_button')) %>
@@ -51,7 +51,7 @@
 
         <div class="margin-y-5">
           <%= render ButtonComponent.new(
-                action: ->(**tag_options, &block) { link_to idv_request_letter_path, **tag_options, &block },
+                url: idv_request_letter_path,
                 big: true,
                 wide: true,
                 outline: true,

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -16,7 +16,7 @@
   <p><%= t('idv.warning.attempts_html', count: @remaining_submit_attempts) %></p>
 
   <% c.with_action_button(
-       action: ->(**tag_options, &block) { link_to(@try_again_path, **tag_options, &block) },
+       url: @try_again_path,
        class: 'margin-bottom-2',
      ) { t('idv.forgot_password.try_again') } %>
 <% end %>

--- a/app/views/idv/unavailable/show.html.erb
+++ b/app/views/idv/unavailable/show.html.erb
@@ -28,13 +28,7 @@
   </p>
 
   <% c.with_action_button(
-       action: ->(**tag_options, &block) do
-         link_to(
-           return_to_sp_failure_to_proof_path(step: :unavailable, location: :unavailable),
-           **tag_options,
-           &block
-         )
-       end,
+       url: return_to_sp_failure_to_proof_path(step: :unavailable, location: :unavailable),
        big: true,
        wide: true,
      ).with_content(t('idv.unavailable.exit_button', app_name: APP_NAME)) %>

--- a/app/views/sign_up/cancellations/new.html.erb
+++ b/app/views/sign_up/cancellations/new.html.erb
@@ -15,15 +15,12 @@
   </ul>
 
   <% c.with_action_button(
-       action: ->(**tag_options, &block) do
-         button_to(sign_up_destroy_path, method: :delete, **tag_options, &block)
-       end,
+       url: sign_up_destroy_path,
+       method: :delete,
      ) { t('forms.buttons.cancel') } %>
 
   <% c.with_action_button(
-       action: ->(**tag_options, &block) do
-         link_to(@presenter.go_back_path, **tag_options, &block)
-       end,
+       url: @presenter.go_back_path,
        outline: true,
      ) { t('links.go_back') } %>
 <% end %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -43,18 +43,12 @@
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>
   <%= render ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          link_to(
-            otp_send_path(
-              otp_delivery_selection_form: {
-                otp_delivery_preference: @presenter.otp_delivery_preference,
-                resend: true,
-              },
-            ),
-            **tag_options,
-            &block
-          )
-        end,
+        url: otp_send_path(
+          otp_delivery_selection_form: {
+            otp_delivery_preference: @presenter.otp_delivery_preference,
+            resend: true,
+          },
+        ),
         outline: true,
         icon: :loop,
         class: 'margin-bottom-neg-1',

--- a/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
+++ b/app/views/two_factor_authentication/piv_cac_verification/show.html.erb
@@ -8,9 +8,7 @@
 
 <div class="margin-y-5">
   <%= render SpinnerButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          link_to(@presenter.piv_cac_service_link, **tag_options, &block)
-        end,
+        url: @presenter.piv_cac_service_link,
         big: true,
         wide: true,
       ).with_content(@presenter.piv_cac_capture_text) %>

--- a/app/views/users/backup_code_setup/confirm_backup_codes.html.erb
+++ b/app/views/users/backup_code_setup/confirm_backup_codes.html.erb
@@ -11,7 +11,7 @@
 </p>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) { link_to(authentication_methods_setup_path, **tag_options, &block) },
+      url: authentication_methods_setup_path,
       big: true,
       full_width: false,
       class: 'margin-top-3 margin-bottom-1',
@@ -24,5 +24,5 @@
         class: 'usa-button usa-button--unstyled',
       ) do %>
     <%= t('forms.buttons.continue') %>
-  <% end %> 
+  <% end %>
 <% end %>

--- a/app/views/users/piv_cac_login/new.html.erb
+++ b/app/views/users/piv_cac_login/new.html.erb
@@ -7,9 +7,7 @@
 </p>
 
 <%= render SpinnerButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        link_to(@presenter.piv_cac_service_link, **tag_options, &block)
-      end,
+      url: @presenter.piv_cac_service_link,
       big: true,
       wide: true,
     ).with_content(@presenter.piv_cac_capture_text) %>

--- a/app/views/users/piv_cac_recommended/show.html.erb
+++ b/app/views/users/piv_cac_recommended/show.html.erb
@@ -9,25 +9,15 @@
 </p>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        button_to(
-          login_piv_cac_recommended_add_path,
-          **tag_options,
-          &block
-        )
-      end,
+      url: login_piv_cac_recommended_add_path,
+      method: :post,
       big: true,
       class: 'margin-top-5 margin-bottom-2',
     ).with_content(t('two_factor_authentication.piv_cac_upsell.add_piv')) %>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        button_to(
-          login_piv_cac_recommended_skip_path,
-          **tag_options,
-          &block
-        )
-      end,
+      url: login_piv_cac_recommended_skip_path,
+      method: :post,
       unstyled: true,
     ).with_content(@recommended_presenter.skip_text) %>
 

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
@@ -28,9 +28,8 @@
 <% end %>
 
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        button_to(login_add_piv_cac_prompt_path, **tag_options, method: :post, &block)
-      end,
+      url: login_add_piv_cac_prompt_path,
+      method: :post,
       big: true,
       wide: true,
       outline: true,

--- a/app/views/users/second_mfa_reminder/new.html.erb
+++ b/app/views/users/second_mfa_reminder/new.html.erb
@@ -8,22 +8,16 @@
   <div class="grid-row margin-top-5">
     <div class="tablet:grid-col-9">
       <%= render ButtonComponent.new(
-            action: ->(**tag_options, &block) do
-              button_to(
-                second_mfa_reminder_path,
-                **tag_options,
-                params: { add_method: true },
-                &block
-              )
-            end,
+            url: second_mfa_reminder_path,
+            method: :post,
+            params: { add_method: true },
             big: true,
             full_width: true,
             class: 'margin-bottom-2',
           ).with_content(t('users.second_mfa_reminder.add_method')) %>
       <%= render ButtonComponent.new(
-            action: ->(**tag_options, &block) do
-              button_to(second_mfa_reminder_path, **tag_options, &block)
-            end,
+            url: second_mfa_reminder_path,
+            method: :post,
             outline: true,
             big: true,
             full_width: true,

--- a/app/views/users/verify_personal_key/new.html.erb
+++ b/app/views/users/verify_personal_key/new.html.erb
@@ -21,9 +21,8 @@
 
 <%= t('forms.personal_key.alternative') %>
 <%= render ButtonComponent.new(
-      action: ->(**tag_options, &block) do
-        button_to(reactivate_account_path, method: :put, **tag_options, &block)
-      end,
+      url: reactivate_account_path,
+      method: :put,
       unstyled: true,
     ).with_content(t('links.reverify')) %>
 

--- a/spec/components/button_component_spec.rb
+++ b/spec/components/button_component_spec.rb
@@ -116,22 +116,6 @@ RSpec.describe ButtonComponent, type: :component do
     end
   end
 
-  context 'with custom button action' do
-    it 'calls the action with content and tag_options' do
-      rendered = render_inline ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          content_tag(:'lg-custom-button', **tag_options, data: { extra: '' }, &block)
-        end,
-        class: 'custom-class',
-      ).with_content(content)
-
-      expect(rendered).to have_css(
-        'lg-custom-button[data-extra].custom-class',
-        text: content,
-      )
-    end
-  end
-
   context 'with url' do
     let(:url) { '/' }
     let(:options) { { url: } }

--- a/spec/components/previews/button_component_preview.rb
+++ b/spec/components/previews/button_component_preview.rb
@@ -34,16 +34,6 @@ class ButtonComponentPreview < BaseComponentPreview
   def danger
     render(ButtonComponent.new(danger: true).with_content('Button'))
   end
-
-  def with_custom_action
-    render(
-      ButtonComponent.new(
-        action: ->(**tag_options, &block) do
-          content_tag(:'lg-custom-button', **tag_options, &block)
-        end,
-      ).with_content('Button'),
-    )
-  end
   # @!endgroup
 
   # rubocop:disable Layout/LineLength


### PR DESCRIPTION
## 🎫 Ticket

Refactoring after #10464, which supports [LG-12716](https://cm-jira.usa.gov/browse/LG-12716)

## 🛠 Summary of changes

Updates instances of `ButtonComponent` `action` to use the new `url` & `method` shorthand introduced in #10464.

Related comment: https://github.com/18F/identity-idp/pull/10464#discussion_r1571457278

## 📜 Testing Plan

Verify no regressions in the impacted buttons.