### PR TITLE
Remove nondeterministic DB migration code

### DIFF
--- a/db/primary_migrate/20210614145845_add_email_name_id_format_to_service_providers.rb
+++ b/db/primary_migrate/20210614145845_add_email_name_id_format_to_service_providers.rb
@@ -2,21 +2,5 @@ class AddEmailNameIdFormatToServiceProviders < ActiveRecord::Migration[6.1]
   def change
     add_column :service_providers, :email_nameid_format_allowed, :boolean
     change_column_default :service_providers, :email_nameid_format_allowed, from: nil, to: false
-
-    reversible do |dir|
-      dir.up do
-        if IdentityConfig.store.respond_to?(:issuers_with_email_nameid_format)
-          issuers = IdentityConfig.store.issuers_with_email_nameid_format
-          unless issuers.empty?
-            query = <<~SQL
-              UPDATE service_providers
-              SET email_nameid_format_allowed = 't'
-              WHERE issuer in (#{issuers.map { |i| "'#{i}'" }.join(', ')})
-            SQL
-            ActiveRecord::Base.connection.execute(query)
-          end
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
**Why**: Config values change over time, but migrations should be deterministic. This old migration ran what we would now run as an explicit backfill, based on live data.

Since the config that it depends on is no longer around, we can remove this block of code entirely