### PR TITLE
Return default values for missing fields in `DocAuth::Mock::ResultsResponse#pii_from_doc`

### DIFF
--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -80,8 +80,7 @@ module DocAuth
 
       def pii_from_doc
         if parsed_data_from_uploaded_file.present?
-          raw_pii = parsed_data_from_uploaded_file['document']
-          raw_pii&.symbolize_keys || {}
+          parsed_pii_from_doc
         else
           Idp::Constants::MOCK_IDV_APPLICANT
         end
@@ -129,6 +128,16 @@ module DocAuth
 
       def parsed_alerts
         parsed_data_from_uploaded_file&.dig('failed_alerts')
+      end
+
+      def parsed_pii_from_doc
+        if parsed_data_from_uploaded_file.has_key?('document')
+          Idp::Constants::MOCK_IDV_APPLICANT.merge(
+            parsed_data_from_uploaded_file['document'].symbolize_keys,
+          )
+        else
+          {}
+        end
       end
 
       def parsed_data_from_uploaded_file

--- a/spec/fixtures/ial2_test_credential_barcode_attention_no_address.yml
+++ b/spec/fixtures/ial2_test_credential_barcode_attention_no_address.yml
@@ -9,6 +9,11 @@ document:
   phone: +1 314-555-1212
   state_id_jurisdiction: 'NY'
   state_id_number: 'S59397998'
+  address1: null
+  address2: null
+  city: null
+  state: null
+  zipcode: null
 failed_alerts:
   - name: 2D Barcode Read
     result: Attention

--- a/spec/fixtures/ial2_test_credential_no_address.yml
+++ b/spec/fixtures/ial2_test_credential_no_address.yml
@@ -8,3 +8,8 @@ document:
   dob: 10/06/1938
   phone: +1 314-555-1212
   state_id_jurisdiction: 'ND'
+  address1: null
+  address2: null
+  city: null
+  state: null
+  zipcode: null

--- a/spec/fixtures/ial2_test_credential_no_dob.yml
+++ b/spec/fixtures/ial2_test_credential_no_dob.yml
@@ -10,3 +10,4 @@ document:
   phone: +1 314-555-1212
   state_id_jurisdiction: 'NY'
   state_id_number: 'S59397998'
+  dob: null

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -57,6 +57,9 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
         state_id_number: '111111111'
         state_id_jurisdiction: ND
         state_id_type: drivers_license
+        state_id_expiration: '2089-12-31'
+        state_id_issued: '2009-12-31'
+        issuing_country_code: 'CA'
       classification_info:
           Front:
             ClassName: Tribal Identification
@@ -87,6 +90,50 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
       state_id_number: '111111111',
       state_id_jurisdiction: 'ND',
       state_id_type: 'drivers_license',
+      state_id_expiration: '2089-12-31',
+      state_id_issued: '2009-12-31',
+      issuing_country_code: 'CA',
+    )
+    expect(get_results_response.attention_with_barcode?).to eq(false)
+  end
+
+  it 'if the document is a YAML file that does not include all PII attributes returns defaults' do
+    yaml = <<~YAML
+      document:
+        first_name: Susan
+      classification_info:
+          Front:
+            ClassName: Tribal Identification
+    YAML
+
+    client.post_front_image(
+      instance_id: instance_id,
+      image: yaml,
+    )
+    client.post_back_image(
+      instance_id: instance_id,
+      image: yaml,
+    )
+    get_results_response = client.get_results(
+      instance_id: instance_id,
+    )
+
+    expect(get_results_response.pii_from_doc).to eq(
+      first_name: 'Susan',
+      middle_name: nil,
+      last_name: 'MCFAKERSON',
+      address1: '1 FAKE RD',
+      address2: nil,
+      city: 'GREAT FALLS',
+      state: 'MT',
+      zipcode: '59010',
+      dob: '1938-10-06',
+      state_id_number: '1111111111111',
+      state_id_jurisdiction: 'ND',
+      state_id_type: 'drivers_license',
+      state_id_expiration: '2099-12-31',
+      state_id_issued: '2019-12-31',
+      issuing_country_code: 'US',
     )
     expect(get_results_response.attention_with_barcode?).to eq(false)
   end

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -305,7 +305,6 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         zipcode: '11364',
         dob: '1938-10-06',
         state_id_type: 'drivers_license',
-        type: 'license',
         state_id_expiration: '2089-12-31',
         state_id_issued: '2009-12-31',
         issuing_country_code: 'CA',


### PR DESCRIPTION
The `pii_from_doc` method in `DocAuth::Mock::ResultsResponse` is intended to mock the behavior of the `pii_from_doc` method on the LexisNexis TrueID client. That method uses [`DocAuth::LexisNexis::DocPiiReader`](https://github.com/18F/identity-idp/blob/a2b3cfcf78b127f6d8a7d8b5fbd27141add52159/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb) to construct its response. As a result the response will always contain the same keys.

The `pii_from_doc` method in the mock client returns a set of default PII described by [`Idp::Constants::MOCK_IDV_APPLICANT`](https://github.com/18F/identity-idp/blob/a2b3cfcf78b127f6d8a7d8b5fbd27141add52159/lib/idp/constants.rb#L94) if an image is uploaded. If a user uploads a YAML file, however, the YAML can dictate what PII is returned. This commit makes changes to the behavior when a YAML file is uploaded.

Previously when a YAML file had a `document` key the hash under that `document` key would be returned from `pii_from_doc`. This leads to issues with missing or extra values being present in this hash. This is especially problematic when the YAML file is used for testing since it does not properly simulate the behavior of a deployed environment.

Now, when a `document` key is provided the values from the hash under that `document` key are merged into the default values. This addresses the issue of missing keys. Extraneous keys will be addressed in a follow-up.

### Returning a nil value from `pii_from_doc`

It should be noted that prior to this commit when no `document` key was present the `pii_from_doc` method returned `nil`. This allowed testing error conditions where there would be no PII. For example, if a document cannot be read then `pii_from_doc` is expected to return `nil` since the PII from the document could not be read. This commit preservers that behavior.

### Returning a nil value for specific attributes

There are testing scenarios where it is desirable for a specific PII field to be nil. For example, if we are testing the validation that a zipcode is included we need to simulate a scenario where `pii_from_doc` returns a nil zipcode. Previously those scenarios could be tested by simply not providing a zipcode. Now a default value will be in the place of the absent zipcode. This testing scenario can be covered by explicitly providing a nil value in the YAML file e.g.

```yaml
document:
  zipcode: null
```
