### PR TITLE
Rename UpdateUser to focus on phone attributes

### DIFF
--- a/app/controllers/concerns/idv/phone_otp_rate_limitable.rb
+++ b/app/controllers/concerns/idv/phone_otp_rate_limitable.rb
@@ -19,13 +19,10 @@ module Idv
     def reset_attempt_count_if_user_no_longer_locked_out
       return unless current_user.no_longer_locked_out?
 
-      UpdateUser.new(
-        user: current_user,
-        attributes: {
-          second_factor_attempts_count: 0,
-          second_factor_locked_at: nil,
-        },
-      ).call
+      current_user.update!(
+        second_factor_attempts_count: 0,
+        second_factor_locked_at: nil,
+      )
     end
 
     def handle_too_many_otp_sends

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -48,10 +48,9 @@ module RememberDeviceConcern
   end
 
   def revoke_remember_device(user)
-    UpdateUser.new(
-      user: user,
-      attributes: { remember_device_revoked_at: Time.zone.now },
-    ).call
+    user.update!(
+      remember_device_revoked_at: Time.zone.now
+    )
   end
 
   private

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -49,7 +49,7 @@ module RememberDeviceConcern
 
   def revoke_remember_device(user)
     user.update!(
-      remember_device_revoked_at: Time.zone.now
+      remember_device_revoked_at: Time.zone.now,
     )
   end
 

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -102,13 +102,10 @@ module TwoFactorAuthenticatableMethods
   def reset_attempt_count_if_user_no_longer_locked_out
     return unless current_user.no_longer_locked_out?
 
-    UpdateUser.new(
-      user: current_user,
-      attributes: {
-        second_factor_attempts_count: 0,
-        second_factor_locked_at: nil,
-      },
-    ).call
+    current_user.update!(
+      second_factor_attempts_count: 0,
+      second_factor_locked_at: nil,
+    )
   end
 
   def handle_remember_device_preference(remember_device_preference)
@@ -184,7 +181,7 @@ module TwoFactorAuthenticatableMethods
   end
 
   def reset_second_factor_attempts_count
-    UpdateUser.new(user: current_user, attributes: { second_factor_attempts_count: 0 }).call
+    current_user.update!(second_factor_attempts_count: 0)
   end
 
   def mark_user_session_authenticated(auth_method:, authentication_type:)

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -56,10 +56,10 @@ module SignUp
     def process_successful_password_creation
       password = permitted_params[:password]
       now = Time.zone.now
-      UpdateUser.new(
-        user: @user,
-        attributes: { password: password, confirmed_at: now },
-      ).call
+      @user.update!(
+        password: password,
+        confirmed_at: now,
+      )
       @user.email_addresses.take.update(confirmed_at: now)
 
       sign_in_and_redirect_user

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -223,13 +223,13 @@ module TwoFactorAuthentication
     end
 
     def update_phone_attributes
-      UpdateUser.new(
+      UpdateUserPhoneConfiguration.update!(
         user: current_user,
         attributes: { phone_id: user_session[:phone_id],
                       phone: user_session[:unconfirmed_phone],
                       phone_confirmed_at: Time.zone.now,
                       otp_make_default_number: selected_otp_make_default_number },
-      ).call
+      )
     end
 
     def phone_changed

--- a/app/controllers/users/piv_cac_recommended_controller.rb
+++ b/app/controllers/users/piv_cac_recommended_controller.rb
@@ -16,20 +16,14 @@ module Users
     end
 
     def confirm
-      UpdateUser.new(
-        user: current_user,
-        attributes: { piv_cac_recommended_dismissed_at: Time.zone.now },
-      ).call
+      curret_user.update!(piv_cac_recommended_dismissed_at: Time.zone.now)
       analytics.piv_cac_recommended(action: :accepted)
       set_mfa_selections(['piv_cac'])
       redirect_to first_mfa_selection_path
     end
 
     def skip
-      UpdateUser.new(
-        user: current_user,
-        attributes: { piv_cac_recommended_dismissed_at: Time.zone.now },
-      ).call
+      current_user.update!(piv_cac_recommended_dismissed_at: Time.zone.now)
       analytics.piv_cac_recommended(action: :skipped)
       redirect_to after_sign_in_path_for(current_user)
     end

--- a/app/controllers/users/piv_cac_recommended_controller.rb
+++ b/app/controllers/users/piv_cac_recommended_controller.rb
@@ -16,7 +16,7 @@ module Users
     end
 
     def confirm
-      curret_user.update!(piv_cac_recommended_dismissed_at: Time.zone.now)
+      current_user.update!(piv_cac_recommended_dismissed_at: Time.zone.now)
       analytics.piv_cac_recommended(action: :accepted)
       set_mfa_selections(['piv_cac'])
       redirect_to first_mfa_selection_path

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -221,10 +221,7 @@ module Users
     end
 
     def update_user_password_compromised_checked_at
-      UpdateUser.new(
-        user: current_user,
-        attributes: { password_compromised_checked_at: Time.zone.now },
-      ).call
+      current_user.update!(password_compromised_checked_at: Time.zone.now)
     end
 
     def randomize_check_password?

--- a/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
+++ b/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
@@ -28,8 +28,7 @@ module EventDisavowal
     end
 
     def update_user
-      attributes = { password: password }
-      UpdateUser.new(user: user, attributes: attributes).call
+      user.update!(password: password)
     end
 
     def mark_profile_inactive

--- a/app/forms/idv/phone_confirmation_otp_verification_form.rb
+++ b/app/forms/idv/phone_confirmation_otp_verification_form.rb
@@ -29,7 +29,7 @@ module Idv
     end
 
     def clear_second_factor_attempts
-      UpdateUser.new(user: user, attributes: { second_factor_attempts_count: 0 }).call
+      user.update!(second_factor_attempts_count: 0)
     end
 
     def increment_second_factor_attempts

--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -35,8 +35,7 @@ class OtpDeliverySelectionForm
   attr_reader :success, :user
 
   def change_otp_delivery_preference_to_sms
-    user_attributes = { otp_delivery_preference: 'sms' }
-    UpdateUser.new(user: user, attributes: user_attributes).call
+    user.update!(otp_delivery_preference: 'sms')
   end
 
   def extra_analytics_attributes

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -57,7 +57,7 @@ class ResetPasswordForm
       end
     end
 
-    UpdateUser.new(user: user, attributes: attributes).call
+    user.update!(attributes)
   end
 
   def mark_profile_inactive

--- a/app/forms/rules_of_use_form.rb
+++ b/app/forms/rules_of_use_form.rb
@@ -35,6 +35,6 @@ class RulesOfUseForm
 
   def process_successful_submission
     self.success = true
-    UpdateUser.new(user: user, attributes: { accepted_terms_at: Time.zone.now }).call
+    user.update!(accepted_terms_at: Time.zone.now)
   end
 end

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -51,9 +51,9 @@ class TwoFactorOptionsForm
   end
 
   def update_otp_delivery_preference_for_user
-    user_attributes = { otp_delivery_preference:
-      selection.find { |element| %w[voice sms].include?(element) } }
-    UpdateUser.new(user: user, attributes: user_attributes).call
+    user.update!(
+      otp_delivery_preference: selection.find { |element| %w[voice sms].include?(element) },
+    )
   end
 
   def phone_selected?

--- a/app/forms/update_email_language_form.rb
+++ b/app/forms/update_email_language_form.rb
@@ -14,7 +14,7 @@ class UpdateEmailLanguageForm
   def submit(params)
     @email_language = params[:email_language]
 
-    UpdateUser.new(user: user, attributes: { email_language: email_language }).call if valid?
+    user.update!(email_language: email_language) if valid?
 
     FormResponse.new(
       success: valid?,

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -25,13 +25,8 @@ class UpdateUserPasswordForm
   attr_reader :user, :user_session
 
   def process_valid_submission
-    update_user_password
+    user.update!(password: password)
     encrypt_user_profiles
-  end
-
-  def update_user_password
-    attributes = { password: password }
-    UpdateUser.new(user: user, attributes: attributes).call
   end
 
   def encrypt_user_profiles

--- a/app/services/forget_all_browsers.rb
+++ b/app/services/forget_all_browsers.rb
@@ -9,11 +9,6 @@ class ForgetAllBrowsers
   end
 
   def call
-    UpdateUser.new(
-      user: user,
-      attributes: {
-        remember_device_revoked_at: remember_device_revoked_at,
-      },
-    ).call
+    user.update!(remember_device_revoked_at: remember_device_revoked_at)
   end
 end

--- a/app/services/otp_preference_updater.rb
+++ b/app/services/otp_preference_updater.rb
@@ -11,10 +11,14 @@ class OtpPreferenceUpdater
   def call
     return false unless user
     return false unless phone_configuration_changed?
-    user_attributes = { otp_delivery_preference: preference,
-                        phone_id: phone_id,
-                        otp_make_default_number: default }
-    UpdateUser.new(user: user, attributes: user_attributes).call
+    UpdateUserPhoneConfiguration.update!(
+      user: user,
+      attributes: {
+        otp_delivery_preference: preference,
+        phone_id: phone_id,
+        otp_make_default_number: default,
+      },
+    )
   end
 
   private

--- a/app/services/otp_rate_limiter.rb
+++ b/app/services/otp_rate_limiter.rb
@@ -29,7 +29,7 @@ class OtpRateLimiter
   end
 
   def lock_out_user
-    UpdateUser.new(user: user, attributes: { second_factor_locked_at: Time.zone.now }).call
+    user.update!(second_factor_locked_at: Time.zone.now)
   end
 
   def increment

--- a/app/services/update_user_phone_configuration.rb
+++ b/app/services/update_user_phone_configuration.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-class UpdateUser
+# Updates user phone attributes and creates associated events
+class UpdateUserPhoneConfiguration
+  # Shorthand for .new.call, easier to stub in tests
+  def self.update!(user:, attributes:)
+    new(user:, attributes:).call
+  end
+
   def initialize(user:, attributes:)
     @user = user
     @attributes = attributes

--- a/config/initializers/session_limitable.rb
+++ b/config/initializers/session_limitable.rb
@@ -8,7 +8,7 @@ Warden::Manager.after_set_user(except: :fetch) do |record, warden, options|
   if warden.authenticated?(options[:scope])
     unique_session_id = Devise.friendly_token
     warden.session(options[:scope])['unique_session_id'] = unique_session_id
-    UpdateUser.new(user: record, attributes: { unique_session_id: unique_session_id }).call
+    record.update!(unique_session_id: unique_session_id)
   end
 end
 

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -89,10 +89,7 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
       end
 
       it 'resets the second_factor_attempts_count' do
-        UpdateUser.new(
-          user: subject.current_user,
-          attributes: { second_factor_attempts_count: 1 },
-        ).call
+        subject.current_user.update!(second_factor_attempts_count: 1)
 
         get :show, params: { token: 'good-token' }
 

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -35,10 +35,7 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
       end
 
       it 'resets the second_factor_attempts_count' do
-        UpdateUser.new(
-          user: subject.current_user,
-          attributes: { second_factor_attempts_count: 1 },
-        ).call
+        subject.current_user.update!(second_factor_attempts_count: 1)
 
         post :create, params: { code: generate_totp_code(@secret) }
 

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -270,7 +270,7 @@ RSpec.feature 'Password Recovery', allowed_extra_analytics: [:*] do
     raw_reset_token, db_confirmation_token =
       Devise.token_generator.generate(User, :reset_password_token)
 
-    UpdateUser.new(user: user, attributes: { reset_password_token: db_confirmation_token }).call
+    user.update!(reset_password_token: db_confirmation_token)
 
     visit edit_user_password_path(reset_password_token: raw_reset_token)
 

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -71,21 +71,16 @@ RSpec.describe OtpDeliverySelectionForm do
 
     context 'with voice preference and unsupported phone' do
       it 'changes the otp_delivery_preference to sms' do
-        user = build_stubbed(:user, otp_delivery_preference: 'voice')
+        user = build(:user, otp_delivery_preference: 'voice')
         form = OtpDeliverySelectionForm.new(
           user,
           '+12423270143',
           'authentication',
         )
-        attributes = { otp_delivery_preference: 'sms' }
 
-        updated_user = instance_double(UpdateUser)
-        allow(UpdateUser).to receive(:new).
-          with(user: user, attributes: attributes).and_return(updated_user)
-
-        expect(updated_user).to receive(:call)
-
-        form.submit(otp_delivery_preference: 'voice')
+        expect do
+          form.submit(otp_delivery_preference: 'voice')
+        end.to(change { user.otp_delivery_preference }.to('sms'))
       end
     end
 
@@ -98,9 +93,9 @@ RSpec.describe OtpDeliverySelectionForm do
           'authentication',
         )
 
-        expect(UpdateUser).to_not receive(:new)
-
-        form.submit(otp_delivery_preference: 'voice')
+        expect do
+          form.submit(otp_delivery_preference: 'voice')
+        end.to_not(change { user.otp_delivery_preference })
       end
     end
   end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -83,17 +83,16 @@ RSpec.describe ResetPasswordForm, type: :model do
 
         form = ResetPasswordForm.new(user)
         password = 'valid password'
-        user_updater = instance_double(UpdateUser)
-        allow(UpdateUser).to receive(:new).
-          with(user: user, attributes: { password: password }).and_return(user_updater)
 
-        expect(user_updater).to receive(:call)
-        expect(
-          form.submit(
+        result = nil
+        expect do
+          result = form.submit(
             password: password,
             password_confirmation: password,
-          ).to_h,
-        ).to eq(
+          ).to_h
+        end.to(change { user.reload.encrypted_password_digest })
+
+        expect(result).to eq(
           success: true,
           errors: {},
           user_id: '123',

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -64,33 +64,31 @@ RSpec.describe TwoFactorOptionsForm do
 
     context "when the selection is different from the user's otp_delivery_preference" do
       it "updates the user's otp_delivery_preference if they have an alternate method selected" do
-        user_updater = instance_double(UpdateUser)
-        allow(UpdateUser).
-          to receive(:new).
-          with(
-            user: user,
-            attributes: { otp_delivery_preference: 'voice' },
-          ).
-          and_return(user_updater)
-        expect(user_updater).to receive(:call)
+        user.save!
 
-        subject.submit(selection: ['voice', 'backup_code'])
+        expect do
+          subject.submit(selection: ['voice', 'backup_code'])
+        end.to(change { user.reload.otp_delivery_preference }.to('voice'))
       end
     end
 
     context "when the selection is the same as the user's otp_delivery_preference" do
       it "does not update the user's otp_delivery_preference" do
-        expect(UpdateUser).to_not receive(:new)
+        user.save!
 
-        subject.submit(selection: ['sms'])
+        expect do
+          subject.submit(selection: ['sms'])
+        end.to_not(change { user.reload.otp_delivery_preference })
       end
     end
 
     context 'when the selection is not voice or sms' do
       it "does not update the user's otp_delivery_preference" do
-        expect(UpdateUser).to_not receive(:new)
+        user.save!
 
-        subject.submit(selection: ['auth_app'])
+        expect do
+          subject.submit(selection: ['auth_app'])
+        end.to_not(change { user.reload.otp_delivery_preference })
       end
     end
 

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
           )],
         }
 
-        expect(UpdateUser).not_to receive(:new)
+        expect(UpdateUserPhoneConfiguration).not_to receive(:update!)
         expect(UserProfilesEncryptor).not_to receive(:new)
         expect(subject.submit(params).to_h).to include(
           success: false,
@@ -54,16 +54,12 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
         )
       end
 
-      it 'updates the user' do
-        user_updater = instance_double(UpdateUser)
-        allow(UpdateUser).to receive(:new).
-          with(user: user, attributes: { password: 'salty new password' }).
-          and_return(user_updater)
-        allow(user_updater).to receive(:call)
+      it 'updates the user password' do
+        user.save!
 
-        subject.submit(params)
-
-        expect(user_updater).to have_received(:call)
+        expect do
+          subject.submit(params)
+        end.to(change { user.reload.encrypted_password_digest })
       end
     end
 

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -33,9 +33,15 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
           )],
         }
 
-        expect(UpdateUserPhoneConfiguration).not_to receive(:update!)
         expect(UserProfilesEncryptor).not_to receive(:new)
-        expect(subject.submit(params).to_h).to include(
+        user.save!
+
+        result = nil
+        expect do
+          result = subject.submit(params).to_h
+        end.to_not(change { user.reload.encrypted_password_digest })
+
+        expect(result).to include(
           success: false,
           errors: errors,
           error_details: hash_including(:password, :password_confirmation),

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -963,7 +963,7 @@ RSpec.describe User do
       context 'user is not already suspended' do
         let(:mock_session_id) { SecureRandom.uuid }
         before do
-          UpdateUser.new(user: user, attributes: { unique_session_id: mock_session_id }).call
+          user.update!(unique_session_id: mock_session_id)
         end
 
         it 'creates SuspendedEmail records for each email address' do

--- a/spec/services/otp_preference_updater_spec.rb
+++ b/spec/services/otp_preference_updater_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe OtpPreferenceUpdater do
                                   delivery_preference: 'sms'
           )
           updater = OtpPreferenceUpdater.new(user: user, preference: 'sms', phone_id: phone.id)
-          expect(UpdateUser).to_not receive(:new)
+          expect(UpdateUserPhoneConfiguration).to_not receive(:update!)
           updater.call
         end
       end
@@ -37,11 +37,8 @@ RSpec.describe OtpPreferenceUpdater do
                          otp_make_default_number: nil,
                          phone_id: 1 }
 
-          updated_user = instance_double(UpdateUser)
-          allow(UpdateUser).to receive(:new).
-            with(user: user, attributes: attributes).and_return(updated_user)
-
-          expect(updated_user).to receive(:call)
+          expect(UpdateUserPhoneConfiguration).to receive(:update!).
+            with(user: user, attributes: attributes)
 
           updater.call
         end
@@ -56,7 +53,7 @@ RSpec.describe OtpPreferenceUpdater do
           phone_id: 1,
         )
 
-        expect(UpdateUser).to_not receive(:new)
+        expect(UpdateUserPhoneConfiguration).to_not receive(:update!)
 
         updater.call
       end

--- a/spec/services/update_user_phone_configuration_spec.rb
+++ b/spec/services/update_user_phone_configuration_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe UpdateUser do
+RSpec.describe UpdateUserPhoneConfiguration do
   describe '#call' do
     it 'updates the user with the passed in attributes' do
       user = build(:user, otp_delivery_preference: 'sms')
       attributes = { otp_delivery_preference: 'voice' }
-      updater = UpdateUser.new(user: user, attributes: attributes)
+      updater = UpdateUserPhoneConfiguration.new(user: user, attributes: attributes)
 
       updater.call
 
@@ -18,7 +18,7 @@ RSpec.describe UpdateUser do
 
       it 'does not delete the phone configuration' do
         attributes = { phone: nil }
-        updater = UpdateUser.new(user: user, attributes: attributes)
+        updater = UpdateUserPhoneConfiguration.new(user: user, attributes: attributes)
         updater.call
         expect(user.phone_configurations.reload).to_not be_empty
       end
@@ -33,7 +33,7 @@ RSpec.describe UpdateUser do
           phone: '+1 222 333-4444',
           phone_confirmed_at: confirmed_at,
         }
-        updater = UpdateUser.new(user: user, attributes: attributes)
+        updater = UpdateUserPhoneConfiguration.new(user: user, attributes: attributes)
         updater.call
         phone_configuration = user.phone_configurations.reload.first
         expect(phone_configuration.delivery_preference).to eq 'voice'
@@ -50,7 +50,7 @@ RSpec.describe UpdateUser do
           phone: '+1 222 333-4444',
           phone_confirmed_at: confirmed_at,
         }
-        updater = UpdateUser.new(user: user, attributes: attributes)
+        updater = UpdateUserPhoneConfiguration.new(user: user, attributes: attributes)
         updater.call
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe UpdateUser do
       context 'when phone is set as default' do
         it 'updates made_default_at timestamp with current date and time' do
           attributes[:otp_make_default_number] = true
-          UpdateUser.new(user: user, attributes: attributes).call
+          UpdateUserPhoneConfiguration.new(user: user, attributes: attributes).call
           phone_configuration = user.phone_configurations.reload.first
           expect(phone_configuration.made_default_at).to be_within(1.second).of Time.zone.now
         end
@@ -78,7 +78,7 @@ RSpec.describe UpdateUser do
       context 'when phone is not set as default' do
         it 'updates made_default_at with nil value' do
           attributes[:otp_make_default_number] = nil
-          UpdateUser.new(user: user, attributes: attributes).call
+          UpdateUserPhoneConfiguration.new(user: user, attributes: attributes).call
           phone_configuration = user.phone_configurations.reload.first
           expect(phone_configuration.made_default_at).to eq nil
         end
@@ -87,7 +87,7 @@ RSpec.describe UpdateUser do
       context 'when phone is not set as default' do
         it 'updates made_default_at with nil value' do
           attributes[:otp_make_default_number] = 'false'
-          UpdateUser.new(user: user, attributes: attributes).call
+          UpdateUserPhoneConfiguration.new(user: user, attributes: attributes).call
           phone_configuration = user.phone_configurations.reload.first
           expect(phone_configuration.made_default_at).to eq nil
         end
@@ -110,7 +110,7 @@ RSpec.describe UpdateUser do
       context 'when phone is set as default' do
         it 'updates made_default_at timestamp with current date and time' do
           attributes[:otp_make_default_number] = true
-          UpdateUser.new(user: user, attributes: attributes).call
+          UpdateUserPhoneConfiguration.new(user: user, attributes: attributes).call
           phone_configuration.reload
           expect(phone_configuration.made_default_at).to be_within(1.second).of Time.zone.now
         end
@@ -121,7 +121,7 @@ RSpec.describe UpdateUser do
           attributes[:otp_make_default_number] = nil
           original_made_default_at = Time.zone.now - 2.days
           phone_configuration.update(made_default_at: original_made_default_at)
-          UpdateUser.new(user: user, attributes: attributes).call
+          UpdateUserPhoneConfiguration.new(user: user, attributes: attributes).call
           phone_configuration.reload
           expect(phone_configuration.made_default_at).
             to be_within(1.second).of original_made_default_at
@@ -133,7 +133,7 @@ RSpec.describe UpdateUser do
           other_phone = create(:phone_configuration)
           attributes[:phone_id] = other_phone.id
           expect do
-            UpdateUser.new(user: user, attributes: attributes).call
+            UpdateUserPhoneConfiguration.new(user: user, attributes: attributes).call
           end.to_not(change { other_phone.updated_at })
         end
       end

--- a/spec/support/shared_examples_for_otp_delivery_preference_validation.rb
+++ b/spec/support/shared_examples_for_otp_delivery_preference_validation.rb
@@ -10,8 +10,8 @@ RSpec.shared_examples 'an otp delivery preference form' do
 
   context 'voice' do
     it 'is valid when supported for the phone' do
-      expect(UpdateUserPhoneConfiguration).to receive(:update!)
-        .with(user: user, attributes: { otp_delivery_preference: 'voice' })
+      expect(UpdateUserPhoneConfiguration).to receive(:update!).
+        with(user: user, attributes: { otp_delivery_preference: 'voice' })
 
       capabilities = spy(PhoneNumberCapabilities)
       allow(PhoneNumberCapabilities).to receive(:new).with(phone).and_return(capabilities)

--- a/spec/support/shared_examples_for_otp_delivery_preference_validation.rb
+++ b/spec/support/shared_examples_for_otp_delivery_preference_validation.rb
@@ -10,11 +10,8 @@ RSpec.shared_examples 'an otp delivery preference form' do
 
   context 'voice' do
     it 'is valid when supported for the phone' do
-      update_user = instance_double(UpdateUser)
-      attributes = { otp_delivery_preference: 'voice' }
-      allow(UpdateUser).to receive(:new).with(user: user, attributes: attributes).
-        and_return(update_user)
-      expect(update_user).to receive(:call)
+      expect(UpdateUserPhoneConfiguration).to receive(:update!)
+        .with(user: user, attributes: { otp_delivery_preference: 'voice' })
 
       capabilities = spy(PhoneNumberCapabilities)
       allow(PhoneNumberCapabilities).to receive(:new).with(phone).and_return(capabilities)
@@ -26,11 +23,7 @@ RSpec.shared_examples 'an otp delivery preference form' do
     end
 
     it 'is invalid when unsupported for the phone' do
-      update_user = instance_double(UpdateUser)
-      attributes = { otp_delivery_preference: 'voice' }
-      allow(UpdateUser).to receive(:new).with(user: user, attributes: attributes).
-        and_return(update_user)
-      expect(update_user).to_not receive(:call)
+      expect(UpdateUserPhoneConfiguration).to_not receive(:update!)
 
       capabilities = spy(PhoneNumberCapabilities)
       allow(PhoneNumberCapabilities).to receive(:new).with(phone).and_return(capabilities)


### PR DESCRIPTION
- Inlines most use cases for UpdateUser
- Renames `UpdateUser` to `UpdateUserPhoneConfiguration` because that's where the bulk of the logic is

Possible future work: refactor `UpdateUserPhoneConfiguration` interface to be more specific about what side effects, such as having something like:
```
UpdateUserPhoneConfiguration.new(user).update_defaults(
  phone_id: ...
  otp_make_default_number: ...
)
```
