### PR TITLE
LG-13139: Fix race condition with token verifier expired validity

### DIFF
--- a/app/controllers/openid_connect/user_info_controller.rb
+++ b/app/controllers/openid_connect/user_info_controller.rb
@@ -17,11 +17,11 @@ module OpenidConnect
 
     def authenticate_identity_via_bearer_token
       verifier = AccessTokenVerifier.new(request.env['HTTP_AUTHORIZATION'])
-      response = verifier.submit
+      response, identity = verifier.submit
       analytics.openid_connect_bearer_token(**response.to_h)
 
       if response.success?
-        @current_identity = verifier.identity
+        @current_identity = identity
       else
         render json: { error: verifier.errors[:access_token].join(' ') },
                status: :unauthorized

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -13,9 +13,11 @@ class AccessTokenVerifier
 
   # @return [Array(FormResponse, ServiceProviderIdentity), Array(FormResponse, nil)]
   def submit
+    success = valid?
+
     response = FormResponse.new(
-      success: valid?,
-      errors: errors,
+      success:,
+      errors:,
       extra: {
         client_id: @identity&.service_provider,
         ial: @identity&.ial,

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -12,26 +12,21 @@ class AccessTokenVerifier
   end
 
   def submit
-    FormResponse.new(
-      success: valid?, errors: errors, extra: {
-        client_id: identity&.service_provider,
-        ial: identity&.ial,
-      }
+    response = FormResponse.new(
+      success: valid?,
+      errors: errors,
+      extra: {
+        client_id: @identity&.service_provider,
+        ial: @identity&.ial,
+      },
     )
-  end
 
-  def identity
-    valid? ? @identity : nil
+    [response, @identity]
   end
 
   private
 
   attr_reader :http_authorization_header
-
-  def valid?
-    return @valid if defined?(@valid)
-    @valid = super
-  end
 
   def validate_access_token
     access_token = extract_access_token(http_authorization_header)

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -28,6 +28,11 @@ class AccessTokenVerifier
 
   attr_reader :http_authorization_header
 
+  def valid?
+    return @valid if defined?(@valid)
+    @valid = super
+  end
+
   def validate_access_token
     access_token = extract_access_token(http_authorization_header)
     load_identity(access_token) if access_token

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -11,6 +11,7 @@ class AccessTokenVerifier
     @identity = nil
   end
 
+  # @return [Array(FormResponse, ServiceProviderIdentity), Array(FormResponse, nil)]
   def submit
     response = FormResponse.new(
       success: valid?,


### PR DESCRIPTION
## 🎫 Ticket

[LG-13139](https://cm-jira.usa.gov/browse/LG-13139)

## 🛠 Summary of changes

Fixes an issue where a token may become invalid between the time [it's initially validated](https://github.com/18F/identity-idp/blob/712c0ec191dd9746c3cf0f522143567ac59cecb1/app/controllers/openid_connect/user_info_controller.rb#L20) and when the [identity is referenced](https://github.com/18F/identity-idp/blob/712c0ec191dd9746c3cf0f522143567ac59cecb1/app/controllers/openid_connect/user_info_controller.rb#L24), since [each independently triggers validation to run](https://github.com/18F/identity-idp/blob/712c0ec191dd9746c3cf0f522143567ac59cecb1/app/services/access_token_verifier.rb#L14-L25).

~The proposed solution is to memoize the validity result, since the submission is not parameterized, so the result on an instance would not be expected to change after the initial validation call.~ **Edit:** After 93edf8f, updated to use the second of the two "Alternative solution"s presented below ([see discussion](https://github.com/18F/identity-idp/pull/10481#discussion_r1576334514)).

Alternative solution could include: (I'm open to any of these)

- Removing the call to `valid?` within the `identity` method, since `UserInfoController` is the only place this class is used, and it's guaranteed by the controller code that `identity` would only be referenced on a valid result.
- Returning `identity` as part of the submission "result", i.e. `FormResponse#extra`, or as a tuple result `[response, identity]`

## 📜 Testing Plan

Validate that specs pass:

```rb
spec/controllers/openid_connect/user_info_controller_spec.rb
```

For good measure, sign-in end-to-end using the [OIDC sample application](https://github.com/18f/identity-oidc-sinatra).