### PR TITLE
Revert "Pre load scripts so they are cached"

### DIFF
--- a/app/javascript/packages/document-capture/context/acuant.tsx
+++ b/app/javascript/packages/document-capture/context/acuant.tsx
@@ -100,22 +100,6 @@ interface AcuantContextProviderProps {
    */
   passiveLivenessSrc: string | undefined;
   /**
-   * Loaded by AcuantPassiveLivness directly. We load it for caching purposes to speed up the AcuantSelfieCamera startup
-   */
-  faceLandmarkWeightsSrc: string | undefined;
-  /**
-   * Loaded by AcuantPassiveLivness directly. We load it for caching purposes to speed up the AcuantSelfieCamera startup
-   */
-  tinyFaceLandmarkWeightsSrc: string | undefined;
-  /**
-   * Loaded by AcuantPassiveLivness directly. We load it for caching purposes to speed up the AcuantSelfieCamera startup
-   */
-  faceLandmarkModelSrc: string | undefined;
-  /**
-   * Loaded by AcuantPassiveLivness directly. We load it for caching purposes to speed up the AcuantSelfieCamera startup
-   */
-  faceLandmarkShardSrc: string | undefined;
-  /**
    * SDK credentials.
    */
   credentials: string | null;
@@ -230,10 +214,6 @@ function AcuantContextProvider({
   cameraSrc,
   passiveLivenessOpenCVSrc,
   passiveLivenessSrc,
-  faceLandmarkWeightsSrc,
-  tinyFaceLandmarkWeightsSrc,
-  faceLandmarkModelSrc,
-  faceLandmarkShardSrc,
   credentials = null,
   endpoint = null,
   glareThreshold,
@@ -350,13 +330,6 @@ function AcuantContextProvider({
     const passiveLivenessScript = document.createElement('script');
     // Open CV script load. Open CV is required only for passive liveness
     const passiveLivenessOpenCVScript = document.createElement('script');
-    // The following four scripts are used interally by the AcuantPassiveLiveness script
-    // Load them here so they are cached, which greatly reduces the apparent
-    // startup time for the AcuantSelfieCamera on slow networks.
-    const tinyFaceLandmarkWeights = document.createElement('script');
-    const faceLandmarkWeights = document.createElement('script');
-    const faceLandmarkModel = document.createElement('script');
-    const faceLandmarkShard = document.createElement('script');
     if (passiveLivenessSrc) {
       passiveLivenessScript.async = true;
       passiveLivenessScript.src = passiveLivenessSrc;
@@ -364,33 +337,9 @@ function AcuantContextProvider({
       passiveLivenessOpenCVScript.async = true;
       passiveLivenessOpenCVScript.src = passiveLivenessOpenCVSrc;
       passiveLivenessOpenCVScript.onerror = () => setIsError(true);
-      if (tinyFaceLandmarkWeightsSrc) {
-        tinyFaceLandmarkWeights.async = true;
-        tinyFaceLandmarkWeights.src = tinyFaceLandmarkWeightsSrc;
-        tinyFaceLandmarkWeights.onerror = () => setIsError(true);
-      }
-      if (faceLandmarkWeightsSrc) {
-        faceLandmarkWeights.async = true;
-        faceLandmarkWeights.src = faceLandmarkWeightsSrc;
-        faceLandmarkWeights.onerror = () => setIsError(true);
-      }
-      if (faceLandmarkModelSrc) {
-        faceLandmarkModel.async = true;
-        faceLandmarkModel.src = faceLandmarkModelSrc;
-        faceLandmarkModel.onerror = () => setIsError(true);
-      }
-      if (faceLandmarkShardSrc) {
-        faceLandmarkShard.async = true;
-        faceLandmarkShard.src = faceLandmarkShardSrc;
-        faceLandmarkShard.onerror = () => setIsError(true);
-      }
     }
     document.body.appendChild(passiveLivenessScript);
     document.body.appendChild(passiveLivenessOpenCVScript);
-    document.body.appendChild(faceLandmarkWeights);
-    document.body.appendChild(tinyFaceLandmarkWeights);
-    document.body.appendChild(faceLandmarkModel);
-    document.body.appendChild(faceLandmarkShard);
 
     return () => {
       window.acuantConfig = originalAcuantConfig;
@@ -399,10 +348,6 @@ function AcuantContextProvider({
       document.body.removeChild(cameraScript);
       document.body.removeChild(passiveLivenessScript);
       document.body.removeChild(passiveLivenessOpenCVScript);
-      document.body.removeChild(faceLandmarkWeights);
-      document.body.removeChild(tinyFaceLandmarkWeights);
-      document.body.removeChild(faceLandmarkModel);
-      document.body.removeChild(faceLandmarkShard);
     };
   }, []);
 

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -151,19 +151,6 @@ const App = composeComponents(
       passiveLivenessSrc: getSelfieCaptureEnabled()
         ? acuantVersion && `/acuant/${acuantVersion}/AcuantPassiveLiveness.min.js`
         : undefined,
-      faceLandmarkWeightsSrc: getSelfieCaptureEnabled()
-        ? acuantVersion && `/acuant/${acuantVersion}/tiny_face_detector_model-weights_manifest.json`
-        : undefined,
-      tinyFaceLandmarkWeightsSrc: getSelfieCaptureEnabled()
-        ? acuantVersion &&
-          `/acuant/${acuantVersion}/face_landmark_68_tiny_model-weights_manifest.json`
-        : undefined,
-      faceLandmarkModelSrc: getSelfieCaptureEnabled()
-        ? acuantVersion && `/acuant/${acuantVersion}/face_landmark_68_tiny_model.bin`
-        : undefined,
-      faceLandmarkShardSrc: getSelfieCaptureEnabled()
-        ? acuantVersion && `/acuant/${acuantVersion}/tiny_face_detector_model-shard1`
-        : undefined,
       credentials: getMetaContent('acuant-sdk-initialization-creds'),
       endpoint: getMetaContent('acuant-sdk-initialization-endpoint'),
       glareThreshold,


### PR DESCRIPTION
Reverts 18F/identity-idp#10363 

There's been problems in dev after this PR merged, and the following appears in my console:
```
[Error] Refused to execute https://idp.dev.identitysandbox.gov/acuant/11.9.2/face_landmark_68_tiny_model-weights_manifest.json as script because "X-Content-Type-Options: nosniff" was given and its Content-Type is not a script MIME type.
[Error] Refused to execute https://idp.dev.identitysandbox.gov/acuant/11.9.2/tiny_face_detector_model-weights_manifest.json as script because "X-Content-Type-Options: nosniff" was given and its Content-Type is not a script MIME type.
```

This seems related to this PR so reverting it for now.