### PR TITLE
Return a `Pii::StateId` object from `pii_from_doc` on the mock proofer

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -95,8 +95,8 @@ module Idv
       end
 
       response.extra.merge!(extra_attributes)
-      response.extra[:state] = response.pii_from_doc[:state]
-      response.extra[:state_id_type] = response.pii_from_doc[:state_id_type]
+      response.extra[:state] = response.pii_from_doc.to_h[:state]
+      response.extra[:state_id_type] = response.pii_from_doc.to_h[:state_id_type]
 
       update_analytics(
         client_response: response,
@@ -119,7 +119,7 @@ module Idv
 
     def validate_pii_from_doc(client_response)
       response = Idv::DocPiiForm.new(
-        pii: client_response.pii_from_doc,
+        pii: client_response.pii_from_doc.to_h,
         attention_with_barcode: client_response.attention_with_barcode?,
       ).submit
       response.extra.merge!(extra_attributes)
@@ -452,7 +452,7 @@ module Idv
     end
 
     def track_event(response)
-      pii_from_doc = response.pii_from_doc || {}
+      pii_from_doc = response.pii_from_doc.to_h || {}
       stored_image_result = store_encrypted_images_if_required
 
       irs_attempts_api_tracker.idv_document_upload_submitted(

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -16,7 +16,7 @@ class DocumentCaptureSession < ApplicationRecord
       id: generate_result_id,
     )
     session_result.success = doc_auth_response.success?
-    session_result.pii = doc_auth_response.pii_from_doc
+    session_result.pii = doc_auth_response.pii_from_doc.to_h
     session_result.captured_at = Time.zone.now
     session_result.attention_with_barcode = doc_auth_response.attention_with_barcode?
     session_result.doc_auth_success = doc_auth_response.doc_auth_success?

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -82,7 +82,7 @@ class ImageUploadResponsePresenter
   def ocr_pii
     return unless success?
     return unless attention_with_barcode? && @form_response.respond_to?(:pii_from_doc)
-    @form_response.pii_from_doc&.slice(:first_name, :last_name, :dob)
+    @form_response.pii_from_doc.to_h.slice(:first_name, :last_name, :dob)
   end
 
   def doc_type_supported?

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -82,7 +82,7 @@ module DocAuth
         if parsed_data_from_uploaded_file.present?
           parsed_pii_from_doc
         else
-          Idp::Constants::MOCK_IDV_APPLICANT
+          Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
         end
       end
 
@@ -132,11 +132,11 @@ module DocAuth
 
       def parsed_pii_from_doc
         if parsed_data_from_uploaded_file.has_key?('document')
-          Idp::Constants::MOCK_IDV_APPLICANT.merge(
-            parsed_data_from_uploaded_file['document'].symbolize_keys,
+          Pii::StateId.new(
+            **Idp::Constants::MOCK_IDV_APPLICANT.merge(
+              parsed_data_from_uploaded_file['document'].symbolize_keys,
+            ).slice(*Pii::StateId.members),
           )
-        else
-          {}
         end
       end
 

--- a/app/services/pii/state_id.rb
+++ b/app/services/pii/state_id.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/MutableConstant
+module Pii
+  StateId = RedactedData.define(
+    :first_name,
+    :last_name,
+    :middle_name,
+    :address1,
+    :address2,
+    :city,
+    :state,
+    :dob,
+    :state_id_expiration,
+    :state_id_issued,
+    :state_id_jurisdiction,
+    :state_id_number,
+    :state_id_type,
+    :zipcode,
+    :issuing_country_code,
+  )
+end
+# rubocop:enable Style/MutableConstant

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
         expect(response.selfie_status).to eq(:not_processed)
         expect(response.errors).to eq({})
         expect(response.attention_with_barcode?).to eq(false)
-        expect(response.pii_from_doc).to eq(Idp::Constants::MOCK_IDV_APPLICANT)
+        expect(response.pii_from_doc).to eq(Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT))
       end
 
       context 'when liveness check is required' do
@@ -422,7 +422,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
           },
         )
         expect(response.attention_with_barcode?).to eq(false)
-        expect(response.pii_from_doc).to eq({})
+        expect(response.pii_from_doc.to_h).to eq({})
       end
     end
 
@@ -453,7 +453,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
         expect(response.success?).to eq(true)
         expect(response.errors).to eq({})
         expect(response.attention_with_barcode?).to eq(false)
-        expect(response.pii_from_doc).to eq(Idp::Constants::MOCK_IDV_APPLICANT)
+        expect(response.pii_from_doc).to eq(Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT))
       end
     end
 

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -24,21 +24,23 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
 
     expect(get_results_response.success?).to eq(true)
     expect(get_results_response.pii_from_doc).to eq(
-      first_name: 'FAKEY',
-      middle_name: nil,
-      last_name: 'MCFAKERSON',
-      address1: '1 FAKE RD',
-      address2: nil,
-      city: 'GREAT FALLS',
-      state: 'MT',
-      zipcode: '59010',
-      dob: '1938-10-06',
-      state_id_number: '1111111111111',
-      state_id_jurisdiction: 'ND',
-      state_id_type: 'drivers_license',
-      state_id_expiration: '2099-12-31',
-      state_id_issued: '2019-12-31',
-      issuing_country_code: 'US',
+      Pii::StateId.new(
+        first_name: 'FAKEY',
+        middle_name: nil,
+        last_name: 'MCFAKERSON',
+        address1: '1 FAKE RD',
+        address2: nil,
+        city: 'GREAT FALLS',
+        state: 'MT',
+        zipcode: '59010',
+        dob: '1938-10-06',
+        state_id_number: '1111111111111',
+        state_id_jurisdiction: 'ND',
+        state_id_type: 'drivers_license',
+        state_id_expiration: '2099-12-31',
+        state_id_issued: '2019-12-31',
+        issuing_country_code: 'US',
+      ),
     )
   end
 
@@ -78,21 +80,23 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
     )
 
     expect(get_results_response.pii_from_doc).to eq(
-      first_name: 'Susan',
-      middle_name: 'Q',
-      last_name: 'Smith',
-      address1: '1 Microsoft Way',
-      address2: 'Apt 3',
-      city: 'Bayside',
-      state: 'NY',
-      zipcode: '11364',
-      dob: '1938-10-06',
-      state_id_number: '111111111',
-      state_id_jurisdiction: 'ND',
-      state_id_type: 'drivers_license',
-      state_id_expiration: '2089-12-31',
-      state_id_issued: '2009-12-31',
-      issuing_country_code: 'CA',
+      Pii::StateId.new(
+        first_name: 'Susan',
+        middle_name: 'Q',
+        last_name: 'Smith',
+        address1: '1 Microsoft Way',
+        address2: 'Apt 3',
+        city: 'Bayside',
+        state: 'NY',
+        zipcode: '11364',
+        dob: '1938-10-06',
+        state_id_number: '111111111',
+        state_id_jurisdiction: 'ND',
+        state_id_type: 'drivers_license',
+        state_id_expiration: '2089-12-31',
+        state_id_issued: '2009-12-31',
+        issuing_country_code: 'CA',
+      ),
     )
     expect(get_results_response.attention_with_barcode?).to eq(false)
   end
@@ -119,21 +123,23 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
     )
 
     expect(get_results_response.pii_from_doc).to eq(
-      first_name: 'Susan',
-      middle_name: nil,
-      last_name: 'MCFAKERSON',
-      address1: '1 FAKE RD',
-      address2: nil,
-      city: 'GREAT FALLS',
-      state: 'MT',
-      zipcode: '59010',
-      dob: '1938-10-06',
-      state_id_number: '1111111111111',
-      state_id_jurisdiction: 'ND',
-      state_id_type: 'drivers_license',
-      state_id_expiration: '2099-12-31',
-      state_id_issued: '2019-12-31',
-      issuing_country_code: 'US',
+      Pii::StateId.new(
+        first_name: 'Susan',
+        middle_name: nil,
+        last_name: 'MCFAKERSON',
+        address1: '1 FAKE RD',
+        address2: nil,
+        city: 'GREAT FALLS',
+        state: 'MT',
+        zipcode: '59010',
+        dob: '1938-10-06',
+        state_id_number: '1111111111111',
+        state_id_jurisdiction: 'ND',
+        state_id_type: 'drivers_license',
+        state_id_expiration: '2099-12-31',
+        state_id_issued: '2019-12-31',
+        issuing_country_code: 'US',
+      ),
     )
     expect(get_results_response.attention_with_barcode?).to eq(false)
   end

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.success?).to eq(true)
       expect(response.errors).to eq({})
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).
+      expect(response.pii_from_doc.to_h).
         to eq(Idp::Constants::MOCK_IDV_APPLICANT)
       expect(response.attention_with_barcode?).to eq(false)
       expect(response.selfie_status).to eq(:success)
@@ -54,21 +54,23 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.errors).to eq({})
       expect(response.exception).to eq(nil)
       expect(response.pii_from_doc).to eq(
-        first_name: 'Susan',
-        middle_name: 'Q',
-        last_name: 'Smith',
-        address1: '1 Microsoft Way',
-        address2: 'Apt 3',
-        city: 'Bayside',
-        state: 'NY',
-        zipcode: '11364',
-        dob: '1938-10-06',
-        state_id_number: '111111111',
-        state_id_jurisdiction: 'ND',
-        state_id_type: 'drivers_license',
-        state_id_expiration: '2089-12-31',
-        state_id_issued: '2009-12-31',
-        issuing_country_code: 'CA',
+        Pii::StateId.new(
+          first_name: 'Susan',
+          middle_name: 'Q',
+          last_name: 'Smith',
+          address1: '1 Microsoft Way',
+          address2: 'Apt 3',
+          city: 'Bayside',
+          state: 'NY',
+          zipcode: '11364',
+          dob: '1938-10-06',
+          state_id_number: '111111111',
+          state_id_jurisdiction: 'ND',
+          state_id_type: 'drivers_license',
+          state_id_expiration: '2089-12-31',
+          state_id_issued: '2009-12-31',
+          issuing_country_code: 'CA',
+        ),
       )
       expect(response.attention_with_barcode?).to eq(false)
     end
@@ -97,7 +99,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.success?).to eq(true)
       expect(response.errors).to eq({})
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to include(dob: '1938-10-06')
+      expect(response.pii_from_doc.dob).to eq('1938-10-06')
       expect(response.attention_with_barcode?).to eq(false)
     end
   end
@@ -121,7 +123,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         hints: true,
       )
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to eq({})
+      expect(response.pii_from_doc).to eq(nil)
       expect(response.attention_with_barcode?).to eq(false)
     end
   end
@@ -142,7 +144,8 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.success?).to eq(true)
       expect(response.errors).to eq({})
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to include(first_name: 'Susan', last_name: nil)
+      expect(response.pii_from_doc.first_name).to eq('Susan')
+      expect(response.pii_from_doc.last_name).to eq(nil)
       expect(response.attention_with_barcode?).to eq(true)
     end
   end
@@ -180,7 +183,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         hints: false,
       )
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to eq({})
+      expect(response.pii_from_doc).to eq(nil)
       expect(response.attention_with_barcode?).to eq(false)
     end
   end
@@ -196,7 +199,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.success?).to eq(true)
       expect(response.errors).to eq({})
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).
+      expect(response.pii_from_doc.to_h).
         to eq(Idp::Constants::MOCK_IDV_APPLICANT)
       expect(response.attention_with_barcode?).to eq(false)
     end
@@ -213,7 +216,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.success?).to eq(false)
       expect(response.errors).to eq(general: ['parsed URI, but scheme was https (expected data)'])
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to eq({})
+      expect(response.pii_from_doc).to eq(nil)
       expect(response.attention_with_barcode?).to eq(false)
     end
   end
@@ -229,7 +232,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.success?).to eq(false)
       expect(response.errors).to eq(general: ['YAML data should have been a hash, got String'])
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to eq({})
+      expect(response.pii_from_doc).to eq(nil)
       expect(response.attention_with_barcode?).to eq(false)
     end
   end
@@ -248,7 +251,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.success?).to eq(false)
       expect(response.errors).to eq(general: ['invalid YAML file'])
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to eq({})
+      expect(response.pii_from_doc).to eq(nil)
       expect(response.attention_with_barcode?).to eq(false)
     end
   end
@@ -292,22 +295,23 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.errors).to eq({})
       expect(response.exception).to eq(nil)
       expect(response.pii_from_doc).to eq(
-        first_name: 'Susan',
-        middle_name: 'Q',
-        last_name: 'Smith',
-        phone: '+1 314-555-1212',
-        address1: '1 Microsoft Way',
-        address2: 'Apt 3',
-        city: 'Bayside',
-        state: 'NY',
-        state_id_jurisdiction: 'NY',
-        state_id_number: '123456789',
-        zipcode: '11364',
-        dob: '1938-10-06',
-        state_id_type: 'drivers_license',
-        state_id_expiration: '2089-12-31',
-        state_id_issued: '2009-12-31',
-        issuing_country_code: 'CA',
+        Pii::StateId.new(
+          first_name: 'Susan',
+          middle_name: 'Q',
+          last_name: 'Smith',
+          address1: '1 Microsoft Way',
+          address2: 'Apt 3',
+          city: 'Bayside',
+          state: 'NY',
+          state_id_jurisdiction: 'NY',
+          state_id_number: '123456789',
+          zipcode: '11364',
+          dob: '1938-10-06',
+          state_id_type: 'drivers_license',
+          state_id_expiration: '2089-12-31',
+          state_id_issued: '2009-12-31',
+          issuing_country_code: 'CA',
+        ),
       )
       expect(response.attention_with_barcode?).to eq(false)
       expect(response.extra).to eq(
@@ -344,21 +348,23 @@ RSpec.describe DocAuth::Mock::ResultResponse do
     it 'returns default values for the missing fields' do
       expect(response.success?).to eq(true)
       expect(response.pii_from_doc).to eq(
-        first_name: 'Susan',
-        middle_name: nil,
-        last_name: 'MCFAKERSON',
-        address1: '1 FAKE RD',
-        address2: nil,
-        city: 'GREAT FALLS',
-        state: 'MT',
-        zipcode: '59010',
-        dob: '1938-10-06',
-        state_id_number: '1111111111111',
-        state_id_jurisdiction: 'ND',
-        state_id_type: 'drivers_license',
-        state_id_expiration: '2099-12-31',
-        state_id_issued: '2019-12-31',
-        issuing_country_code: 'US',
+        Pii::StateId.new(
+          first_name: 'Susan',
+          middle_name: nil,
+          last_name: 'MCFAKERSON',
+          address1: '1 FAKE RD',
+          address2: nil,
+          city: 'GREAT FALLS',
+          state: 'MT',
+          zipcode: '59010',
+          dob: '1938-10-06',
+          state_id_number: '1111111111111',
+          state_id_jurisdiction: 'ND',
+          state_id_type: 'drivers_license',
+          state_id_expiration: '2099-12-31',
+          state_id_issued: '2019-12-31',
+          issuing_country_code: 'US',
+        ),
       )
     end
   end
@@ -380,7 +386,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         hints: false,
       )
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to eq({})
+      expect(response.pii_from_doc).to eq(nil)
       expect(response.attention_with_barcode?).to eq(false)
       expect(response.extra).to eq(
         doc_auth_result: DocAuth::LexisNexis::ResultCodes::CAUTION.name,
@@ -407,7 +413,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         hints: true,
       )
       expect(response.exception).to eq(nil)
-      expect(response.pii_from_doc).to eq({})
+      expect(response.pii_from_doc).to eq(nil)
       expect(response.attention_with_barcode?).to eq(false)
       expect(response.extra).to eq(
         doc_auth_result: DocAuth::LexisNexis::ResultCodes::FAILED.name,
@@ -446,21 +452,23 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.errors).to eq({})
       expect(response.exception).to eq(nil)
       expect(response.pii_from_doc).to eq(
-        first_name: 'Susan',
-        middle_name: 'Q',
-        last_name: 'Smith',
-        address1: '1 Microsoft Way',
-        address2: 'Apt 3',
-        city: 'Bayside',
-        state: 'NY',
-        zipcode: '11364',
-        dob: '1938-10-06',
-        state_id_number: '111111111',
-        state_id_jurisdiction: 'ND',
-        state_id_type: 'drivers_license',
-        state_id_expiration: '2089-12-31',
-        state_id_issued: '2009-12-31',
-        issuing_country_code: 'CA',
+        Pii::StateId.new(
+          first_name: 'Susan',
+          middle_name: 'Q',
+          last_name: 'Smith',
+          address1: '1 Microsoft Way',
+          address2: 'Apt 3',
+          city: 'Bayside',
+          state: 'NY',
+          zipcode: '11364',
+          dob: '1938-10-06',
+          state_id_number: '111111111',
+          state_id_jurisdiction: 'ND',
+          state_id_type: 'drivers_license',
+          state_id_expiration: '2089-12-31',
+          state_id_issued: '2009-12-31',
+          issuing_country_code: 'CA',
+        ),
       )
       expect(response.attention_with_barcode?).to eq(false)
       expect(response.extra).to eq(
@@ -646,7 +654,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       YAML
     end
     it 'successfully extracts PII' do
-      expect(response.pii_from_doc.empty?).to eq(false)
+      expect(response.pii_from_doc).to_not be_blank
     end
   end
   context 'with a yaml file that includes classification info' do


### PR DESCRIPTION
In #10478 I modified the mock proofer to always return the full set of keys that the TrueID client returns from the `#pii_from_doc` method.

This commit continues on the work by introducing `Pii:StateId` to hold the data that is returned from `#pii_from_doc`. It is an immutable struct that holds the data and provides assurances about its shape by ensuring that data is present for every key.

In follow-up commits this data structure will be returned from the TrueID client and used to represent the PII from the document in `Idv::Session`.
