### PR TITLE
LG-10790 Delete Deprecated Residential Address URL

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,14 +389,6 @@ Rails.application.routes.draw do
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
 
-      # DEPRECATION NOTICE
-      # Usage of the /in_person_proofing/address routes is deprecated.
-      # Use the /in_person/address routes instead.
-      #
-      # These have been left in temporarily to prevent any impact to users
-      # during the deprecation process.
-      get '/in_person_proofing/address' => redirect('/verify/in_person/address', status: 307)
-      put '/in_person_proofing/address' => redirect('/verify/in_person/address', status: 307)
       get '/in_person_proofing/state_id' => 'in_person/state_id#show'
 
       get '/in_person' => 'in_person#index'


### PR DESCRIPTION
## 🎫 Ticket

[LG-10790](https://cm-jira.usa.gov/browse/LG-10790) FSM/Residential Address - Change url - Part 2- Clean Up

## 🛠 Summary of changes

- In [PR# 10790](https://github.com/18F/identity-idp/pull/10435), the residential address url route was renamed and the`/in_person_proofing/address` route was deprecated
- This pull request is just cleaning up the deprecated routes now that the new route was merged into production on 04/23
- There should be no user facing changes/impacts

## 📜 Testing Plan

Check 1:
- [ ]  Complete in-person proofing up to state id step, pick No, I live at a different address, click Continue
- [ ]  Verify that URL ends with /verify/in_person/address
- [ ]  Complete form with a different address and submit address form
- [ ]  Complete and submit ssn form
- [ ]  Verify that address you typed is what appears on the Verify Info page
- [ ]  Click Update for section Current residential address on the Verify Info page
- [ ]  Verify that URL ends with /verify/in_person/address
- [ ]  Submit address form
- [ ]  Verify that address you typed is what appears on the Verify Info page
- [ ]  Continue through the flow to confirm you get a barcode

Check 2:
- [ ]  Complete in-person proofing up to state id step, pick same address as ID on state id form, click Continue
- [ ]  Complete and submit ssn form
- [ ]  Verify that address you typed is what appears on the Verify Info page
- [ ]  Click Update for section Current residential address on the Verify Info page
- [ ]  Verify that URL ends with /verify/in_person/address
- [ ]  Submit address form
- [ ]  Verify that address you typed is what appears on the Verify Info page
- [ ]  Continue through the flow to confirm you get a barcode

Check 3:
- [ ] Once on the /verify/in_person/address page, if you manually change the url by typing  /verify/in_person_proofing/address in the url, you are not directed anywhere and the url remains /verify/in_person/address


