### PR TITLE
Allow Gitlab pages sites to access via CORS

### DIFF
--- a/lib/identity_cors.rb
+++ b/lib/identity_cors.rb
@@ -6,6 +6,7 @@ class IdentityCors
     'https://www.login.gov',
     'https://login.gov',
     'https://handbook.login.gov',
+    'https://lg-public.pages.production.gitlab.login.gov',
     FEDERALIST_REGEX,
   ].freeze
 

--- a/spec/requests/api_cors_spec.rb
+++ b/spec/requests/api_cors_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
       end
     end
 
+    context 'origin is gitlab pages' do
+      let(:http_origin) { 'https://lg-public.pages.production.gitlab.login.gov' }
+
+      it 'allows origin' do
+        aggregate_failures do
+          expect(response['Access-Control-Allow-Origin']).to eq(http_origin)
+          expect(response['Access-Control-Allow-Methods']).to eq('GET')
+        end
+      end
+    end
+
     context 'origin is local in development' do
       let(:http_origin) { 'http://127.0.0.1:4000' }
 


### PR DESCRIPTION
This allows us to recreate the [Analytics Events](https://handbook.login.gov/articles/analytics-events.html) article behind internal login