### PR TITLE
Remove deprecated GPO routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -425,10 +425,6 @@ Rails.application.routes.draw do
       if FeatureManagement.gpo_verification_enabled?
         get '/by_mail/request_letter' => 'by_mail/request_letter#index', as: :request_letter
         put '/by_mail/request_letter' => 'by_mail/request_letter#create'
-
-        # Temporary routes + redirects supporting GPO route renaming
-        get '/usps' => redirect('/verify/by_mail/request_letter')
-        put '/usps' => 'by_mail/request_letter#create'
       end
 
       get '/by_mail/letter_enqueued' => 'by_mail/letter_enqueued#show', as: :letter_enqueued

--- a/spec/routing/gpo_verification_routing_spec.rb
+++ b/spec/routing/gpo_verification_routing_spec.rb
@@ -3,19 +3,13 @@ require 'rails_helper'
 RSpec.describe 'GPO verification routes' do
   let(:get_routes) do
     %w[
-      verify/usps
-    ]
-  end
-
-  let(:create_routes) do
-    %w[
-      verify/usps
+      verify/by_mail/request_letter
     ]
   end
 
   let(:put_routes) do
     %w[
-      verify/usps
+      verify/by_mail/request_letter
     ]
   end
 
@@ -38,11 +32,6 @@ RSpec.describe 'GPO verification routes' do
           to route_to(controller: 'pages', action: 'page_not_found', path: route)
       end
 
-      create_routes.each do |route|
-        expect(post: route).
-          to route_to(controller: 'pages', action: 'page_not_found', path: route)
-      end
-
       put_routes.each do |route|
         expect(put: route).
           to route_to(controller: 'pages', action: 'page_not_found', path: route)
@@ -59,15 +48,11 @@ RSpec.describe 'GPO verification routes' do
 
     it 'routes to endpoints controlled by feature flag' do
       get_routes.each do |route|
-        expect(get: route).to be_routable
-      end
-
-      create_routes.each do |route|
-        expect(post: route).to be_routable
+        expect(get: route).to route_to(controller: 'idv/by_mail/request_letter', action: 'index')
       end
 
       put_routes.each do |route|
-        expect(put: route).to be_routable
+        expect(put: route).to route_to(controller: 'idv/by_mail/request_letter', action: 'create')
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes temporary GPO routes which were added for transition to new routes in #9184.

Related Slack discussion: https://github.com/18F/identity-idp/pull/9184#discussion_r1412469520

Verified `production.log` includes no requests for `filter path = '/verify/usps'` in the past two weeks.

## 📜 Testing Plan

Verify route removed:

1. Visit http://localhost:3000/verify/usps
2. See 404

Verify tests pass:

1. `rspec spec/routing/gpo_verification_routing_spec.rb`