### PR TITLE
LG-12176: register and emit idv_sdk_selfie_image_taken event.

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -54,6 +54,7 @@ class FrontendLogController < ApplicationController
     idv_sdk_selfie_image_capture_failed
     idv_sdk_selfie_image_capture_opened
     idv_sdk_selfie_image_re_taken
+    idv_sdk_selfie_image_taken
     idv_selfie_image_added
     idv_selfie_image_clicked
     phone_input_country_changed

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -713,6 +713,10 @@ function AcuantCapture(
 
   function onSelfieTaken() {
     selfieAttempts.current += 1;
+    trackEvent('idv_sdk_selfie_image_taken', {
+      captureAttempts,
+      selfie_attempts: selfieAttempts.current,
+    });
   }
 
   return (

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3316,7 +3316,7 @@ module AnalyticsEvents
       captureAttempts: captureAttempts,
       selfie_attempts: selfie_attempts,
       **extra,
-      )
+    )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3299,6 +3299,25 @@ module AnalyticsEvents
       **extra,
     )
   end
+
+  # User opened the SDK to take a selfie
+  # @param [String] acuant_version
+  # @param [Integer] captureAttempts number of attempts to capture / upload an image
+  # @param [Integer] selfie_attempts number of selfie captured by SDK
+  def idv_sdk_selfie_image_taken(
+    acuant_version:,
+    captureAttempts: nil,
+    selfie_attempts: nil,
+    **extra
+  )
+    track_event(
+      :idv_sdk_selfie_image_taken,
+      acuant_version: acuant_version,
+      captureAttempts: captureAttempts,
+      selfie_attempts: selfie_attempts,
+      **extra,
+      )
+  end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName
 
   # User took a selfie image with the SDK, or uploaded a selfie using the file picker

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -1234,7 +1234,6 @@ describe('document-capture/components/acuant-capture', () => {
       // This allows us to test everything about that callback -except- the Acuant SDK parts.
       initialize({
         selfieStart: sinon.stub().callsFake((callbacks) => {
-          callbacks.onPhotoTaken();
           callbacks.onPhotoRetake();
         }),
       });
@@ -1243,6 +1242,28 @@ describe('document-capture/components/acuant-capture', () => {
       expect(trackEvent).to.be.calledWith('IdV: Acuant SDK loaded');
       expect(trackEvent).to.be.calledWith(
         'idv_sdk_selfie_image_re_taken',
+        sinon.match({
+          captureAttempts: sinon.match.number,
+          selfie_attempts: sinon.match.number,
+        }),
+      );
+    });
+
+    it('calls trackEvent from onSelfieTake', () => {
+      // In real use the `start` method opens the Acuant SDK full screen selfie capture window.
+      // Because we can't do that in test (AcuantSDK does not allow), this doesn't attempt to load
+      // the SDK. Instead, it simply calls the callback that happens when a photo is captured.
+      // This allows us to test everything about that callback -except- the Acuant SDK parts.
+      initialize({
+        selfieStart: sinon.stub().callsFake((callbacks) => {
+          callbacks.onPhotoTaken();
+        }),
+      });
+
+      expect(trackEvent).to.be.calledWith('idv_selfie_image_clicked');
+      expect(trackEvent).to.be.calledWith('IdV: Acuant SDK loaded');
+      expect(trackEvent).to.be.calledWith(
+        'idv_sdk_selfie_image_taken',
         sinon.match({
           captureAttempts: sinon.match.number,
           selfie_attempts: sinon.match.number,


### PR DESCRIPTION
changelog: Internal, Doc Auth, Analytics event for selfie image taken.

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12176](https://cm-jira.usa.gov/browse/LG-12176)



## 🛠 Summary of changes

Analytics event `idv_sdk_selfie_image_taken`.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1: Selfie capture flow
- [ ] Step 2: On doc capture screen
- [ ] Step 3: Add selfie
- [ ] Step 4: Verify event logged with `captureAttempts`, `selfie_attempts` props.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
