### PR TITLE
Disable retries gem sleep in all specs

### DIFF
--- a/spec/lib/pwned_password_downloader_spec.rb
+++ b/spec/lib/pwned_password_downloader_spec.rb
@@ -12,12 +12,9 @@ RSpec.describe PwnedPasswordDownloader do
   end
 
   around do |example|
-    original_retries_sleep_enabled = Retries.sleep_enabled
-    Retries.sleep_enabled = false
     Dir.mktmpdir('pwned_passwords') do |destination|
       @destination = destination
       example.run
-      Retries.sleep_enabled = original_retries_sleep_enabled
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,9 @@ RSpec.configure do |config|
   config.profile_examples = RSPEC_RUNNING_IN_PARALLEL ? 10 : 0
 end
 
+require 'retries'
+Retries.sleep_enabled = false
+
 require 'webmock/rspec'
 WebMock.disable_net_connect!(
   allow: [


### PR DESCRIPTION
**Why:** so that the test suite runs faster

When tracking down some spec failures in https://github.com/18F/identity-idp/pull/10491, I found that one spec was very slow! This likely affects other files too.

**Before**
```
Proofing::Aamva::Request::SecurityTokenRequest ....... (1.61s)
```

**After**
```
Proofing::Aamva::Request::SecurityTokenRequest ....... (0.17s)
```
(to get this formatting, I installed the [fivemat gem](https://github.com/tpope/fivemat) locally and ran it with `FIVEMAT_PROFILE=1`)