### PR TITLE
Don't send GPO reminders to users with active profiles

### DIFF
--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -7,6 +7,7 @@ class GpoReminderSender
     reminder_eligible_range =
       IdentityConfig.store.usps_confirmation_max_days.days.ago..for_letters_sent_before
     profiles_due_for_reminder(for_letters_sent_before).each do |profile|
+      next if profile.user.active_profile
       profile.gpo_confirmation_codes.all.each do |gpo_code|
         next if gpo_code.reminder_sent_at
         next unless reminder_eligible_range.cover?(gpo_code.created_at)

--- a/spec/jobs/gpo_reminder_job_spec.rb
+++ b/spec/jobs/gpo_reminder_job_spec.rb
@@ -62,5 +62,15 @@ RSpec.describe GpoReminderJob do
         user_id: due_for_reminder_user.uuid,
       )
     end
+
+    context 'when the user has another active profile' do
+      let!(:active_profile) do
+        create(:profile, :active, user: due_for_reminder_user)
+      end
+
+      it 'does not send an email' do
+        expect { perform }.not_to change { ActionMailer::Base.deliveries.count }
+      end
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13167](https://cm-jira.usa.gov/browse/LG-13167)

## 🛠 Summary of changes

Fixes an issue in production where we get a NoMethodError when sending GPO reminder emails because we currently have a user with both a GPO pending profile and an active profile.
