### PR TITLE
LG-13037 Remove `mfa_expiration_interval` from sp session

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -53,28 +53,29 @@ module RememberDeviceConcern
     )
   end
 
-  private
-
-  def sp_aal
-    decorated_sp_session.sp_aal
-  end
-
-  def sp_ial
-    decorated_sp_session.sp_ial
-  end
-
-  def resolved_authn_context_result
-    decorated_sp_session.resolved_authn_context_result
-  end
-
   def mfa_expiration_interval
     aal_1_expiration = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
     aal_2_expiration = IdentityConfig.store.remember_device_expiration_minutes_aal_2.minutes
+
     return aal_2_expiration if sp_aal > 1
     return aal_2_expiration if sp_ial > 1
     return aal_2_expiration if resolved_authn_context_result.aal2?
 
     aal_1_expiration
+  end
+
+  private
+
+  def sp_aal
+    decorated_sp_session&.sp_aal || 1
+  end
+
+  def sp_ial
+    current_sp&.ial || 1
+  end
+
+  def resolved_authn_context_result
+    decorated_sp_session.resolved_authn_context_result
   end
 
   def expired_for_interval?(user, interval)

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -74,14 +74,6 @@ module RememberDeviceConcern
     current_sp&.ial || 1
   end
 
-  # def resolved_authn_context_result
-  #   @resolved_authn_context_result ||= AuthnContextResolver.new(
-  #     service_provider: current_sp,
-  #     vtr: decorated_sp_session.sp_session[:vtr],
-  #     acr_values: decorated_sp_session.sp_session[:acr_values],
-  #   ).resolve
-  # end
-
   def expired_for_interval?(user, interval)
     return false unless has_remember_device_auth_event?
     remember_cookie = remember_device_cookie

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -19,7 +19,7 @@ module RememberDeviceConcern
     return unless UserSessionContext.authentication_context?(context)
     return if remember_device_cookie.nil?
 
-    expiration_time = decorated_sp_session.mfa_expiration_interval
+    expiration_time = mfa_expiration_interval
     return unless remember_device_cookie.valid_for_user?(
       user: current_user,
       expiration_interval: expiration_time,
@@ -39,7 +39,7 @@ module RememberDeviceConcern
   def remember_device_expired_for_sp?
     expired_for_interval?(
       current_user,
-      decorated_sp_session.mfa_expiration_interval,
+      mfa_expiration_interval,
     )
   end
 
@@ -54,6 +54,10 @@ module RememberDeviceConcern
   end
 
   private
+
+  def mfa_expiration_interval
+    decorated_sp_session.mfa_expiration_interval
+  end
 
   def expired_for_interval?(user, interval)
     return false unless has_remember_device_auth_event?

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -56,7 +56,13 @@ module RememberDeviceConcern
   private
 
   def mfa_expiration_interval
-    decorated_sp_session.mfa_expiration_interval
+    aal_1_expiration = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
+    aal_2_expiration = IdentityConfig.store.remember_device_expiration_minutes_aal_2.minutes
+    return aal_2_expiration if decorated_sp_session.sp_aal > 1
+    return aal_2_expiration if decorated_sp_session.sp_ial > 1
+    return aal_2_expiration if decorated_sp_session.resolved_authn_context_result.aal2?
+
+    aal_1_expiration
   end
 
   def expired_for_interval?(user, interval)

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -55,12 +55,24 @@ module RememberDeviceConcern
 
   private
 
+  def sp_aal
+    decorated_sp_session.sp_aal
+  end
+
+  def sp_ial
+    decorated_sp_session.sp_ial
+  end
+
+  def resolved_authn_context_result
+    decorated_sp_session.resolved_authn_context_result
+  end
+
   def mfa_expiration_interval
     aal_1_expiration = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
     aal_2_expiration = IdentityConfig.store.remember_device_expiration_minutes_aal_2.minutes
-    return aal_2_expiration if decorated_sp_session.sp_aal > 1
-    return aal_2_expiration if decorated_sp_session.sp_ial > 1
-    return aal_2_expiration if decorated_sp_session.resolved_authn_context_result.aal2?
+    return aal_2_expiration if sp_aal > 1
+    return aal_2_expiration if sp_ial > 1
+    return aal_2_expiration if resolved_authn_context_result.aal2?
 
     aal_1_expiration
   end

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -59,7 +59,7 @@ module RememberDeviceConcern
 
     return aal_2_expiration if sp_aal > 1
     return aal_2_expiration if sp_ial > 1
-    return aal_2_expiration if resolved_authn_context_result.aal2?
+    return aal_2_expiration if resolved_authn_context_result&.aal2?
 
     aal_1_expiration
   end
@@ -74,13 +74,13 @@ module RememberDeviceConcern
     current_sp&.ial || 1
   end
 
-  def resolved_authn_context_result
-    @resolved_authn_context_result ||= AuthnContextResolver.new(
-      service_provider: decorated_sp_session.sp,
-      vtr: decorated_sp_session.sp_session[:vtr],
-      acr_values: decorated_sp_session.sp_session[:acr_values],
-    ).resolve
-  end
+  # def resolved_authn_context_result
+  #   @resolved_authn_context_result ||= AuthnContextResolver.new(
+  #     service_provider: current_sp,
+  #     vtr: decorated_sp_session.sp_session[:vtr],
+  #     acr_values: decorated_sp_session.sp_session[:acr_values],
+  #   ).resolve
+  # end
 
   def expired_for_interval?(user, interval)
     return false unless has_remember_device_auth_event?

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -75,7 +75,11 @@ module RememberDeviceConcern
   end
 
   def resolved_authn_context_result
-    decorated_sp_session.resolved_authn_context_result
+    @resolved_authn_context_result ||= AuthnContextResolver.new(
+      service_provider: decorated_sp_session.sp,
+      vtr: decorated_sp_session.sp_session[:vtr],
+      acr_values: decorated_sp_session.sp_session[:acr_values],
+    ).resolve
   end
 
   def expired_for_interval?(user, interval)

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -67,7 +67,7 @@ module RememberDeviceConcern
   private
 
   def sp_aal
-    decorated_sp_session&.sp_aal || 1
+    current_sp&.default_aal || 1
   end
 
   def sp_ial

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -55,10 +55,6 @@ class NullServiceProviderSession
     1
   end
 
-  def sp_ial
-    1
-  end
-
   def resolved_authn_context_result
     AuthnContextResolver.new(
       service_provider: 'null sp',

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -17,10 +17,6 @@ class NullServiceProviderSession
     view_context.root_url
   end
 
-  def mfa_expiration_interval
-    IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
-  end
-
   def remember_device_default
     true
   end

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -55,6 +55,22 @@ class NullServiceProviderSession
     view_context&.current_user
   end
 
+  def sp_aal
+    1
+  end
+
+  def sp_ial
+    1
+  end
+
+  def resolved_authn_context_result
+    AuthnContextResolver.new(
+      service_provider: 'null sp',
+      vtr: ['C1'],
+      acr_values: Vot::LegacyComponentValues::LOA1,
+    ).resolve
+  end
+
   private
 
   attr_reader :view_context

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -51,18 +51,6 @@ class NullServiceProviderSession
     view_context&.current_user
   end
 
-  def sp_aal
-    1
-  end
-
-  def resolved_authn_context_result
-    AuthnContextResolver.new(
-      service_provider: 'null sp',
-      vtr: ['C1'],
-      acr_values: Vot::LegacyComponentValues::LOA1,
-    ).resolve
-  end
-
   private
 
   attr_reader :view_context

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -122,10 +122,6 @@ class ServiceProviderSession
     view_context&.current_user
   end
 
-  def sp_aal
-    sp&.default_aal || 1
-  end
-
   def resolved_authn_context_result
     @resolved_authn_context_result ||= AuthnContextResolver.new(
       service_provider: sp,
@@ -139,6 +135,10 @@ class ServiceProviderSession
   private
 
   attr_reader :view_context, :service_provider_request
+
+  def sp_aal
+    sp&.default_aal || 1
+  end
 
   def request_url
     sp_session[:request_url] || service_provider_request.url

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -134,9 +134,11 @@ class ServiceProviderSession
     ).resolve
   end
 
+  attr_reader :sp, :sp_session
+
   private
 
-  attr_reader :sp, :view_context, :sp_session, :service_provider_request
+  attr_reader :view_context, :service_provider_request
 
   def request_url
     sp_session[:request_url] || service_provider_request.url

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -90,16 +90,6 @@ class ServiceProviderSession
     end
   end
 
-  def mfa_expiration_interval
-    aal_1_expiration = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
-    aal_2_expiration = IdentityConfig.store.remember_device_expiration_minutes_aal_2.minutes
-    return aal_2_expiration if sp_aal > 1
-    return aal_2_expiration if sp_ial > 1
-    return aal_2_expiration if resolved_authn_context_result.aal2?
-
-    aal_1_expiration
-  end
-
   def requested_more_recent_verification?
     unless IdentityConfig.store.allowed_verified_within_providers.include?(sp_issuer)
       return false

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -132,9 +132,13 @@ class ServiceProviderSession
     view_context&.current_user
   end
 
-  private
+  def sp_aal
+    sp.default_aal || 1
+  end
 
-  attr_reader :sp, :view_context, :sp_session, :service_provider_request
+  def sp_ial
+    sp.ial || 1
+  end
 
   def resolved_authn_context_result
     @resolved_authn_context_result ||= AuthnContextResolver.new(
@@ -144,13 +148,9 @@ class ServiceProviderSession
     ).resolve
   end
 
-  def sp_aal
-    sp.default_aal || 1
-  end
+  private
 
-  def sp_ial
-    sp.ial || 1
-  end
+  attr_reader :sp, :view_context, :sp_session, :service_provider_request
 
   def request_url
     sp_session[:request_url] || service_provider_request.url

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -122,14 +122,6 @@ class ServiceProviderSession
     view_context&.current_user
   end
 
-  def resolved_authn_context_result
-    @resolved_authn_context_result ||= AuthnContextResolver.new(
-      service_provider: sp,
-      vtr: sp_session[:vtr],
-      acr_values: sp_session[:acr_values],
-    ).resolve
-  end
-
   attr_reader :sp, :sp_session
 
   private

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -123,11 +123,7 @@ class ServiceProviderSession
   end
 
   def sp_aal
-    sp.default_aal || 1
-  end
-
-  def sp_ial
-    sp.ial || 1
+    sp&.default_aal || 1
   end
 
   def resolved_authn_context_result

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -1,34 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe RememberDeviceConcern do
-  let(:sp) { build(:service_provider) }
+  let(:sp) { nil }
   let(:raw_session) { {} }
-  let(:request) do
-    double(
-      'request',
+
+  subject(:test_controller) do
+    test_controller_class =
+      Class.new(ApplicationController) do
+        include(RememberDeviceConcern)
+
+        attr_reader :sp, :raw_session, :request
+        alias :sp_from_sp_session :sp
+        alias :sp_session :raw_session
+
+        def initialize(sp, raw_session, request)
+          @sp = sp
+          @raw_session = raw_session
+          @request = request
+        end
+      end
+
+    test_request = double(
+      'test_request',
       session: raw_session,
       parameters: {},
       filtered_parameters: {},
     )
+
+    test_controller_class.new(sp, raw_session, test_request)
   end
-
-  let(:test_class) do
-    Class.new(ApplicationController) do
-      include(RememberDeviceConcern)
-
-      attr_reader :sp, :raw_session, :request
-      alias :sp_from_sp_session :sp
-      alias :sp_session :raw_session
-
-      def initialize(sp, raw_session, request)
-        @sp = sp
-        @raw_session = raw_session
-        @request = request
-      end
-    end
-  end
-
-  subject(:test_instance) { test_class.new(sp, raw_session, request) }
 
   describe '#mfa_expiration_interval' do
     let(:expected_aal_1_expiration) { 720.hours }
@@ -37,19 +37,19 @@ RSpec.describe RememberDeviceConcern do
     context 'with no sp' do
       let(:sp) { nil }
 
-      it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_1_expiration) }
+      it { expect(test_controller.mfa_expiration_interval).to eq(expected_aal_1_expiration) }
     end
 
     context 'with an AAL2 sp' do
       let(:sp) { build(:service_provider, default_aal: 2) }
 
-      it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+      it { expect(test_controller.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
     end
 
     context 'with an IAL2 sp' do
       let(:sp) { build(:service_provider, ial: 2) }
 
-      it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+      it { expect(test_controller.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
     end
 
     context 'with an sp that is not AAL2 or IAL2' do
@@ -59,13 +59,13 @@ RSpec.describe RememberDeviceConcern do
         context 'with vtr' do
           let(:raw_session) { { vtr: ['C1'] } }
 
-          it { expect(test_instance.mfa_expiration_interval).to eq(30.days) }
+          it { expect(test_controller.mfa_expiration_interval).to eq(30.days) }
         end
 
         context 'with legacy acr' do
           let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF } }
 
-          it { expect(test_instance.mfa_expiration_interval).to eq(30.days) }
+          it { expect(test_controller.mfa_expiration_interval).to eq(30.days) }
         end
       end
 
@@ -73,13 +73,13 @@ RSpec.describe RememberDeviceConcern do
         context 'with vtr' do
           let(:raw_session) { { vtr: ['C2'] } }
 
-          it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+          it { expect(test_controller.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
         end
 
         context 'with legacy acr' do
           let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF } }
 
-          it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+          it { expect(test_controller.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
         end
       end
     end

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -24,15 +24,6 @@ RSpec.describe RememberDeviceConcern do
         @request = request
       end
 
-      def decorated_sp_session
-        ServiceProviderSession.new(
-          sp: @sp,
-          view_context: {},
-          sp_session: @raw_session,
-          service_provider_request: {},
-        )
-      end
-
       def sp_from_sp_session
         @sp
       end

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -16,20 +16,14 @@ RSpec.describe RememberDeviceConcern do
     Class.new(ApplicationController) do
       include(RememberDeviceConcern)
 
-      attr_reader :raw_session, :request
+      attr_reader :sp, :raw_session, :request
+      alias :sp_from_sp_session :sp
+      alias :sp_session :raw_session
 
       def initialize(sp, raw_session, request)
         @sp = sp
         @raw_session = raw_session
         @request = request
-      end
-
-      def sp_from_sp_session
-        @sp
-      end
-
-      def sp_session
-        @raw_session
       end
     end
   end

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe RememberDeviceConcern do
+  let(:sp) { build(:service_provider) }
+  let(:raw_session) { { vtr: ['C1'] } }
+
+  let(:test_class) do
+    Class.new(self.class) do
+      include(RememberDeviceConcern)
+
+      def current_sp
+        sp
+      end
+
+      def decorated_sp_session
+        ServiceProviderSession.new(
+          sp: sp,
+          view_context: {},
+          sp_session: raw_session,
+          service_provider_request: {},
+        )
+      end
+    end
+  end
+
+  subject(:test_instance) { test_class.new }
+
+  describe '#mfa_expiration_interval' do
+    let(:expected_aal_1_expiration) { 720.hours }
+    let(:expected_aal_2_expiration) { 0.hours }
+
+    context 'with no sp' do
+      let(:sp) { nil }
+
+      it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_1_expiration) }
+    end
+
+    context 'with an AAL2 sp' do
+      let(:sp) { build(:service_provider, default_aal: 2) }
+
+      it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+    end
+
+    context 'with an IAL2 sp' do
+      let(:sp) { build(:service_provider, ial: 2) }
+
+      it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+    end
+
+    context 'with an sp that is not AAL2 or IAL2 and AAL1 requested' do
+      let(:sp) { build(:service_provider) }
+
+      context 'with vtr' do
+        it { expect(test_instance.mfa_expiration_interval).to eq(30.days) }
+      end
+
+      context 'with legacy acr' do
+        let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF } }
+
+        it { expect(test_instance.mfa_expiration_interval).to eq(30.days) }
+      end
+    end
+
+    context 'with an sp that is not AAL2 or IAL2 and AAL2 requested' do
+      let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF } }
+
+      it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+    end
+  end
+end

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -9,21 +9,12 @@ RSpec.describe RememberDeviceConcern do
     Class.new(ApplicationController) do
       include(RememberDeviceConcern)
 
-      attr_reader :raw_session
+      attr_reader :raw_session, :request
 
-      def initialize(sp, raw_session)
+      def initialize(sp, raw_session, request)
         @sp = sp
         @raw_session = raw_session
-      end
-
-      def resolved_authn_context_result
-        return nil unless raw_session[:vtr] || raw_session[:acr_values]
-
-        AuthnContextResolver.new(
-          service_provider: @sp,
-          vtr: @raw_session[:vtr],
-          acr_values: @raw_session[:acr_values],
-        ).resolve
+        @request = request
       end
 
       def decorated_sp_session
@@ -38,10 +29,18 @@ RSpec.describe RememberDeviceConcern do
       def current_sp
         @sp
       end
+
+      def sp_from_sp_session
+        @sp
+      end
+
+      def sp_session
+        @raw_session
+      end
     end
   end
 
-  subject(:test_instance) { test_class.new(sp, raw_session) }
+  subject(:test_instance) { test_class.new(sp, raw_session, request) }
 
   describe '#mfa_expiration_interval' do
     let(:expected_aal_1_expiration) { 720.hours }

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -2,14 +2,20 @@ require 'rails_helper'
 
 RSpec.describe RememberDeviceConcern do
   let(:sp) { build(:service_provider) }
-  let(:raw_session) { { vtr: ['C1'] } }
+  let(:raw_session) { {} }
 
   let(:test_class) do
     Class.new(self.class) do
       include(RememberDeviceConcern)
 
-      def current_sp
-        sp
+      def resolved_authn_context_result
+        return nil unless raw_session[:vtr] || raw_session[:acr_values]
+
+        AuthnContextResolver.new(
+          service_provider: sp,
+          vtr: raw_session[:vtr],
+          acr_values: raw_session[:acr_values],
+        ).resolve
       end
 
       def decorated_sp_session
@@ -19,6 +25,10 @@ RSpec.describe RememberDeviceConcern do
           sp_session: raw_session,
           service_provider_request: {},
         )
+      end
+
+      def current_sp
+        sp
       end
     end
   end
@@ -47,24 +57,36 @@ RSpec.describe RememberDeviceConcern do
       it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
     end
 
-    context 'with an sp that is not AAL2 or IAL2 and AAL1 requested' do
+    context 'with an sp that is not AAL2 or IAL2' do
       let(:sp) { build(:service_provider) }
 
-      context 'with vtr' do
-        it { expect(test_instance.mfa_expiration_interval).to eq(30.days) }
+      context 'and AAL1 requested' do
+        context 'with vtr' do
+          let(:raw_session) { { vtr: ['C1'] } }
+
+          it { expect(test_instance.mfa_expiration_interval).to eq(30.days) }
+        end
+
+        context 'with legacy acr' do
+          let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF } }
+
+          it { expect(test_instance.mfa_expiration_interval).to eq(30.days) }
+        end
       end
 
-      context 'with legacy acr' do
-        let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF } }
+      context 'and AAL2 requested' do
+        context 'with vtr' do
+          let(:raw_session) { { vtr: ['C2'] } }
 
-        it { expect(test_instance.mfa_expiration_interval).to eq(30.days) }
+          it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+        end
+
+        context 'with legacy acr' do
+          let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF } }
+
+          it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+        end
       end
-    end
-
-    context 'with an sp that is not AAL2 or IAL2 and AAL2 requested' do
-      let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF } }
-
-      it { expect(test_instance.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
     end
   end
 end

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 RSpec.describe RememberDeviceConcern do
   let(:sp) { build(:service_provider) }
   let(:raw_session) { {} }
-  let(:request) { double('request', session: raw_session) }
+  let(:request) do
+    double(
+      'request',
+      session: raw_session,
+      parameters: {},
+      filtered_parameters: {},
+    )
+  end
 
   let(:test_class) do
     Class.new(ApplicationController) do
@@ -24,10 +31,6 @@ RSpec.describe RememberDeviceConcern do
           sp_session: @raw_session,
           service_provider_request: {},
         )
-      end
-
-      def current_sp
-        @sp
       end
 
       def sp_from_sp_session

--- a/spec/decorators/null_service_provider_session_spec.rb
+++ b/spec/decorators/null_service_provider_session_spec.rb
@@ -39,12 +39,6 @@ RSpec.describe NullServiceProviderSession do
     end
   end
 
-  describe '#mfa_expiration_interval' do
-    it 'returns the AAL1 expiration interval' do
-      expect(subject.mfa_expiration_interval).to eq(30.days)
-    end
-  end
-
   describe '#requested_more_recent_verification' do
     it 'is false' do
       expect(subject.requested_more_recent_verification?).to eq(false)

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe ServiceProviderSession do
     end
   end
 
-  describe '#mfa_expiration_interval' do
+  xdescribe '#mfa_expiration_interval' do
     context 'with an AAL2 sp' do
       before do
         allow(sp).to receive(:default_aal).and_return(2)

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -240,33 +240,6 @@ RSpec.describe ServiceProviderSession do
     end
   end
 
-  xdescribe '#mfa_expiration_interval' do
-    context 'with an AAL2 sp' do
-      before do
-        allow(sp).to receive(:default_aal).and_return(2)
-      end
-
-      it { expect(subject.mfa_expiration_interval).to eq(0.hours) }
-    end
-
-    context 'with an IAL2 sp' do
-      before do
-        allow(sp).to receive(:ial).and_return(2)
-      end
-
-      it { expect(subject.mfa_expiration_interval).to eq(0.hours) }
-    end
-
-    context 'with an sp that is not AAL2 or IAL2 and AAL1 requested' do
-      it { expect(subject.mfa_expiration_interval).to eq(30.days) }
-    end
-
-    context 'with an sp that is not AAL2 or IAL2 and AAL2 requested' do
-      let(:sp_session) { { acr_values: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF } }
-      it { expect(subject.mfa_expiration_interval).to eq(0.hours) }
-    end
-  end
-
   describe '#requested_more_recent_verification?' do
     let(:verified_within) { nil }
     let(:user) { create(:user) }


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13037](https://cm-jira.usa.gov/browse/LG-13037)

## 🛠 Summary of changes

Moved `ServiceProviderSession#mfa_expiration_interval` to `RememberDeviceConcern#mfa_expiration_interval`
Added a spec for it in the concern.
Removed as much associated plumbing from sp_session as was obvious.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Ensure by inspection the the new `service_provider_session_spec.rb` correctly cover the necessary cases for `mfa_expiration_interval`
- [ ] Ensure by inspection that the changes to `service_provider_session_spec.rb` and `null_service_provider_spec.rb` only relate to the removed `mfa_expiration_interval` method.
- [ ] Ensure that all specs pass without changes other than the ones noted above.