### PR TITLE
Log event for new device alert job emails sent

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -334,6 +334,12 @@ module AnalyticsEvents
     )
   end
 
+  # New device sign-in alerts sent after expired notification timeframe
+  # @param [Integer] Number of emails sent
+  def create_new_device_alert_job_emails_sent(count:, **extra)
+    track_event(:create_new_device_alert_job_emails_sent, count:, **extra)
+  end
+
   # @param [String] message the warning
   # Logged when there is a non-user-facing error in the doc auth process, such as an unrecognized
   # field from a vendor

--- a/app/services/create_new_device_alert.rb
+++ b/app/services/create_new_device_alert.rb
@@ -12,10 +12,16 @@ class CreateNewDeviceAlert < ApplicationJob
       emails_sent += 1 if expire_sign_in_notification_timeframe_and_send_alert(user)
     end
 
+    analytics.create_new_device_alert_job_emails_sent(count: emails_sent)
+
     emails_sent
   end
 
   private
+
+  def analytics
+    @analytics ||= Analytics.new(user: AnonymousUser.new, request: nil, sp: nil, session: {})
+  end
 
   def sql_query_for_users_with_new_device
     <<~SQL

--- a/spec/services/create_new_device_alert_spec.rb
+++ b/spec/services/create_new_device_alert_spec.rb
@@ -3,10 +3,12 @@ require 'rails_helper'
 RSpec.describe CreateNewDeviceAlert do
   let(:user) { create(:user) }
   let(:now) { Time.zone.now }
+
   before do
     user.update! sign_in_new_device_at:
       now - 1 - IdentityConfig.store.new_device_alert_delay_in_minutes.minutes
   end
+
   describe '#perform' do
     it 'sends an email for matching user' do
       emails_sent = CreateNewDeviceAlert.new.perform(now)
@@ -24,6 +26,16 @@ RSpec.describe CreateNewDeviceAlert do
       user.update! sign_in_new_device_at: nil
       emails_sent = CreateNewDeviceAlert.new.perform(now)
       expect(emails_sent).to eq(0)
+    end
+
+    it 'logs analytics with number of emails sent' do
+      analytics = FakeAnalytics.new
+      alert = CreateNewDeviceAlert.new
+      allow(alert).to receive(:analytics).and_return(analytics)
+
+      alert.perform(now)
+
+      expect(analytics).to have_logged_event(:create_new_device_alert_job_emails_sent, count: 1)
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds logging to the worker job responsible for sending emails in response to expired sign-in attempts.

**Why?**

- For debuggability
- For parity with other similar jobs, e.g. [account reset emails sent](https://github.com/18F/identity-idp/blob/1d769f76fc396cfd2fca72a53b3cdbce956da5e1/app/services/account_reset/grant_requests_and_send_emails.rb#L16)

## 📜 Testing Plan

Verify tests pass:

1. `rspec spec/services/create_new_device_alert_spec.rb`

Verify event logged in local development when job runs:

1. Run `make watch_events` in parallel to `make run`
2. (Optional) Visit http://localhost:3000 and sign-in before MFA
3. When job runs (every 5 minutes), observe logged event in terminal process with `make watch_events` with count of emails which were sent