### PR TITLE
Increase strictness and improve ability to keep internationalization tests up-to-date

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -34,22 +34,14 @@ module I18n
         { key: /^countries/ }, # Some countries have the same name across languages
         { key: 'datetime.dotiw.minutes.one' }, # "minute is minute" in French and English
         { key: 'datetime.dotiw.minutes.other' }, # "minute is minute" in French and English
-        { key: 'doc_auth.headings.photo', locales: %i[fr] }, # "Photo" is "Photo" in French
-        { key: 'doc_auth.headings.selfie', locales: %i[fr] }, # "Photo" is "Photo" in French
         { key: /^i18n\.locale\./ }, # Show locale options translated as that language
-        { key: /^i18n\.transliterate\./ }, # Approximate non-ASCII characters in ASCII
         { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
         { key: 'mailer.logo' }, # "logo is logo" in English, French and Spanish
         { key: 'saml_idp.auth.error.title', locales: %i[es] }, # "Error" is "Error" in Spanish
         { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
-        { key: 'simple_form.required.html' }, # No text content
-        { key: 'simple_form.required.mark' }, # No text content
         { key: 'time.am' }, # "AM" is "AM" in French and Spanish
         { key: 'time.formats.sms_date' }, # for us date format
         { key: 'time.pm' }, # "PM" is "PM" in French and Spanish
-        { key: 'datetime.dotiw.minutes.one' }, # "minute is minute" in French and English
-        { key: 'datetime.dotiw.minutes.other' }, # "minute is minute" in French and English
-        { key: 'mailer.logo' }, # "logo is logo" in English, French and Spanish
         { key: 'datetime.dotiw.words_connector' }, # " , " is only punctuation and not translated
       ].freeze
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -107,9 +107,8 @@ RSpec.describe 'I18n' do
       "untranslated i18n keys: #{untranslated_keys}",
     )
 
-    unused_allowed_untranslated_keys = I18n::Tasks::BaseTask::ALLOWED_UNTRANSLATED_KEYS.filter do |x|
-      !x[:used]
-    end
+    unused_allowed_untranslated_keys =
+      I18n::Tasks::BaseTask::ALLOWED_UNTRANSLATED_KEYS.reject { |key| key[:used] }
     expect(unused_allowed_untranslated_keys).to(
       be_empty,
       "unused allowed untranslated i18n keys: #{unused_allowed_untranslated_keys}",


### PR DESCRIPTION
## 🛠 Summary of changes

While working on #10291, I was working on some improvements to the i18n tests and pulled them out here to make them easier to review. This PR makes a few changes:

- Check whether keys in ALLOWED_UNTRANSLATED_KEYS are used in untranslated keys test. It's kind of goofy to mutate the hashes in the constant and check it in the same test, but it was straightforward. I'm very open to suggestions here.
- Similar to above, check whether ALLOWED_INTERPOLATION_MISMATCH_KEYS are all used

The above will hopefully help in keeping the list of exceptions up-to-date.

I've also made some smaller changes to the checks in `allowed_untranslated_key?` so that we don't use a Regexp unless it is explicitly one, and otherwise use strict equality.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
