### PR TITLE
Queue GpoReminderJob as long_running

### DIFF
--- a/app/jobs/gpo_reminder_job.rb
+++ b/app/jobs/gpo_reminder_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class GpoReminderJob < ApplicationJob
-  queue_as :low
+  queue_as :long_running
 
   # Send email reminders to people with USPS proofing letters whose
   # letters were sent a while ago, and haven't yet entered their code


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

This job pretty regularly takes more than 50s to run, which causes it to trigger the [worker perform time alarm](https://gsa-tts.slack.com/archives/C06M08T8LE5/p1714003668307909). Queuing it as `:long_running` will make it not trigger that alarm.

The job execution time scales with the number of reminder emails it needs to send. Average time / email over the last month or so is 0.3s. It may be possible to optimize this, but there are some basic I/O constrains (email sending and analytics logging) that will make that challenging.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
