### PR TITLE
LG-13057: Remove Hardcoded Prod Prevention for Selfie (It's still turned off via feature flag)

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -23,8 +23,7 @@ module SamlIdpAuthConcern
   private
 
   def block_biometric_requests_in_production
-    if @saml_request_validator.parsed_vector_of_trust&.biometric_comparison? &&
-       !FeatureManagement.idv_allow_selfie_check?
+    if @saml_request_validator.parsed_vector_of_trust&.biometric_comparison?
       render_not_acceptable
     end
   end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -56,8 +56,7 @@ module OpenidConnect
     end
 
     def block_biometric_requests_in_production
-      if biometric_comparison_requested? &&
-         !FeatureManagement.idv_allow_selfie_check?
+      if biometric_comparison_requested?
         render_not_acceptable
       end
     end

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -73,8 +73,7 @@ class ServiceProviderSession
   end
 
   def biometric_comparison_required?
-    !!(FeatureManagement.idv_allow_selfie_check? &&
-      sp_session[:biometric_comparison_required])
+    sp_session[:biometric_comparison_required]
   end
 
   def cancel_link_url

--- a/app/policies/pending_profile_policy.rb
+++ b/app/policies/pending_profile_policy.rb
@@ -26,7 +26,6 @@ class PendingProfilePolicy
   end
 
   def biometric_comparison_requested?
-    return false if !FeatureManagement.idv_allow_selfie_check?
     resolved_authn_context_result.biometric_comparison? || biometric_comparison_requested
   end
 

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -102,8 +102,7 @@ module DocAuth
         end
 
         def include_liveness?
-          FeatureManagement.idv_allow_selfie_check? &&
-            liveness_checking_required
+          liveness_checking_required
         end
       end
     end

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -54,7 +54,7 @@ module Idv
         else
           :legacy_in_person
         end
-      elsif FeatureManagement.idv_allow_selfie_check? && selfie_check_performed
+      elsif selfie_check_performed
         :unsupervised_with_selfie
       else
         :legacy_unsupervised

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,7 @@
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: us_states_territories,
-      doc_auth_selfie_capture: FeatureManagement.idv_allow_selfie_check? && doc_auth_selfie_capture,
+      doc_auth_selfie_capture: doc_auth_selfie_capture,
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
       skip_doc_auth: skip_doc_auth,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -151,8 +151,4 @@ class FeatureManagement
       outage_status.any_phone_vendor_outage? ||
       outage_status.phone_finder_outage?
   end
-
-  def self.idv_allow_selfie_check?
-    !(Identity::Hostdata.env == 'prod') && IdentityConfig.store.doc_auth_selfie_capture_enabled
-  end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -395,8 +395,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
 
               before do
                 params[:biometric_comparison_required] = biometric_comparison_required.to_s
-                expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-                  and_return(selfie_capture_enabled)
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
                 IdentityLinker.new(user, service_provider).link_identity(ial: 3)
@@ -448,8 +446,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               before do
                 params[:acr_values] = nil
                 params[:vtr] = ['C1.C2.P1.Pb'].to_json
-                expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-                  and_return(selfie_capture_enabled)
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
                 allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
@@ -513,11 +509,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               let(:selfie_capture_enabled) { true }
               let(:user) { create(:profile, :active, :verified).user }
 
-              before do
-                expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-                  and_return(selfie_capture_enabled)
-              end
-
               it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
                 create(:profile, :verify_by_mail_pending, :with_pii, idv_level: :unsupervised_with_selfie, user: user)
                 user.active_profile.idv_level = :legacy_unsupervised
@@ -540,11 +531,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             context 'sp requests biometrics' do
               let(:selfie_capture_enabled) { true }
               let(:user) { create(:profile, :active, :verified).user }
-
-              before do
-                expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-                  and_return(selfie_capture_enabled)
-              end
 
               context 'with biometric_comparison_required param' do
                 before do

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -180,11 +180,6 @@ RSpec.describe ServiceProviderSession do
   end
 
   describe '#selfie_required' do
-    before do
-      expect(FeatureManagement).to receive(:idv_allow_selfie_check?).
-        and_return(selfie_capture_enabled)
-    end
-
     context 'doc_auth_selfie_capture_enabled is true' do
       let(:selfie_capture_enabled) { true }
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -932,8 +932,6 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
 
   context 'Happy selfie path' do
     before do
-      expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-        and_return(true)
       allow_any_instance_of(FederatedProtocols::Oidc).
         to receive(:biometric_comparison_required?).
         and_return(true)

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -209,8 +209,6 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
   context 'selfie check' do
     let(:selfie_check_enabled) { true }
     before do
-      expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-        and_return(selfie_check_enabled)
       complete_doc_auth_steps_before_document_capture_step
     end
 

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -242,8 +242,6 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
   context 'when selfie is enabled' do
     context 'error due to data issue with 2xx status code', allow_browser_log: true do
       before do
-        expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-          and_return(true)
         allow_any_instance_of(FederatedProtocols::Oidc).
           to receive(:biometric_comparison_required?).and_return(true)
         allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:fail)
@@ -267,8 +265,6 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
 
     context 'when doc auth is success and portrait match fails', allow_browser_log: true do
       before do
-        expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-          and_return(true)
         allow_any_instance_of(FederatedProtocols::Oidc).
           to receive(:biometric_comparison_required?).and_return(true)
 
@@ -316,8 +312,6 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
 
     context 'when doc auth fails and portrait match pass', allow_browser_log: true do
       before do
-        expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-          and_return(true)
         allow_any_instance_of(FederatedProtocols::Oidc).
           to receive(:biometric_comparison_required?).and_return(true)
 
@@ -364,8 +358,6 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
 
     context 'when doc auth and portrait match fail', allow_browser_log: true do
       before do
-        expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-          and_return(true)
         allow_any_instance_of(FederatedProtocols::Oidc).
           to receive(:biometric_comparison_required?).and_return(true)
         allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:fail)
@@ -385,8 +377,6 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
 
     context 'when pii validation fails', allow_browser_log: true do
       before do
-        expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-          and_return(true)
         allow_any_instance_of(FederatedProtocols::Oidc).
           to receive(:biometric_comparison_required?).and_return(true)
         pii = Idp::Constants::MOCK_IDV_APPLICANT.dup

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -264,8 +264,6 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
 
   context 'barcode read error on desktop, redo document capture on mobile' do
     before do
-      expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-        and_return(false)
       allow_any_instance_of(FederatedProtocols::Oidc).
         to receive(:biometric_comparison_required?).and_return(true)
     end
@@ -335,7 +333,6 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
   end
 
   it 'prefills the phone number used on the phone step if the user has no MFA phone', :js do
-    expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).and_return(true)
     allow_any_instance_of(FederatedProtocols::Oidc).
       to receive(:biometric_comparison_required?).and_return(true)
     user = create(:user, :with_authentication_app)

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -492,37 +492,4 @@ RSpec.describe 'FeatureManagement' do
       end
     end
   end
-
-  describe '#idv_allow_selfie_check?' do
-    before do
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).
-        and_return(selfie_capture_enabled)
-    end
-
-    context 'selfies are disabled' do
-      let(:selfie_capture_enabled) { false }
-
-      it 'says to block biometric requests' do
-        expect(FeatureManagement.idv_allow_selfie_check?).to eq(false)
-      end
-    end
-
-    context 'selfies are enabled' do
-      let(:selfie_capture_enabled) { true }
-
-      it 'says to allow biometric requests' do
-        expect(FeatureManagement.idv_allow_selfie_check?).to eq(true)
-      end
-
-      context 'in production' do
-        before do
-          allow(Identity::Hostdata).to receive(:env).and_return('prod')
-        end
-
-        it 'says to block biometric requests' do
-          expect(FeatureManagement.idv_allow_selfie_check?).to eq(false)
-        end
-      end
-    end
-  end
 end

--- a/spec/policies/pending_profile_policy_spec.rb
+++ b/spec/policies/pending_profile_policy_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe PendingProfilePolicy do
       before do
         create(:profile, :active, :verified, idv_level: :legacy_unsupervised, user: user)
         create(:profile, :verify_by_mail_pending, idv_level: idv_level, user: user)
-        allow(FeatureManagement).to receive(:idv_allow_selfie_check?).and_return(true)
       end
 
       context 'with resolved authn context result' do

--- a/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
@@ -116,9 +116,6 @@ RSpec.describe DocAuth::LexisNexis::LexisNexisClient do
   context 'with selfie check enabled' do
     ## enable feature
     let(:workflow) { 'LIVENESS.CROPPING.WORKFLOW' }
-    before do
-      allow(FeatureManagement).to receive(:idv_allow_selfie_check?).and_return(true)
-    end
     describe 'when success response returned' do
       before do
         stub_request(:post, image_upload_url).to_return(

--- a/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/true_id_request_spec.rb
@@ -108,8 +108,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
     end
 
     def include_liveness_expected
-      FeatureManagement.idv_allow_selfie_check? &&
-        liveness_checking_required
+      liveness_checking_required
     end
   end
 
@@ -166,10 +165,6 @@ RSpec.describe DocAuth::LexisNexis::Requests::TrueIdRequest do
 
   context 'with liveness_checking_enabled as true' do
     let(:selfie_check_allowed) { true }
-    before do
-      expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-        and_return(selfie_check_allowed)
-    end
 
     context 'when liveness checking is NOT required' do
       let(:liveness_checking_required) { false }

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -242,11 +242,6 @@ RSpec.describe Idv::ProfileMaker do
       context 'unsupervised with selfie' do
         let(:selfie_check_performed) { true }
 
-        before do
-          expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-            and_return(true)
-        end
-
         it 'creates an active profile' do
           expect(profile.activated_at).to be_nil
           expect(profile.active).to eq(false)

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -115,10 +115,6 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
     end
 
     context 'when selfie FF enabled' do
-      before do
-        expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-          and_return(selfie_capture_enabled)
-      end
       it 'does send doc_auth_selfie_capture to the FE' do
         render_partial
         expect(rendered).to have_css(


### PR DESCRIPTION

## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-13057

## 🛠 Summary of changes

We currently have a method that guarantees that the selfie code will never run in prod. As we approach release, we want to remove that method so we can turn on selfie by changing the feature flag.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
