### PR TITLE
Cleanup `DocPiiReader#read_pii`

### DIFF
--- a/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb
+++ b/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb
@@ -21,60 +21,42 @@ module DocAuth
 
       # @return [Pii::StateId, nil]
       def read_pii(true_id_product)
-        return nil unless true_id_product&.dig(:IDAUTH_FIELD_DATA).present?
-        pii = {}
-        PII_INCLUDES.each do |true_id_key, idp_key|
-          pii[idp_key] = true_id_product[:IDAUTH_FIELD_DATA][true_id_key]
-        end
-        pii[:state_id_type] = DocAuth::Response::ID_TYPE_SLUGS[pii[:state_id_type]]
+        id_auth_field_data = true_id_product&.dig(:IDAUTH_FIELD_DATA)
+        return nil unless id_auth_field_data.present?
 
-        dob = parse_date(
-          year: pii.delete(:dob_year),
-          month: pii.delete(:dob_month),
-          day: pii.delete(:dob_day),
+        state_id_type_slug = id_auth_field_data['Fields_DocumentClassName']
+        state_id_type = DocAuth::Response::ID_TYPE_SLUGS[state_id_type_slug]
+
+        Pii::StateId.new(
+          first_name: id_auth_field_data['Fields_FirstName'],
+          last_name: id_auth_field_data['Fields_Surname'],
+          middle_name: id_auth_field_data['Fields_MiddleName'],
+          address1: id_auth_field_data['Fields_AddressLine1'],
+          address2: id_auth_field_data['Fields_AddressLine2'],
+          city: id_auth_field_data['Fields_City'],
+          state: id_auth_field_data['Fields_State'],
+          zipcode: id_auth_field_data['Fields_PostalCode'],
+          dob: parse_date(
+            year: id_auth_field_data['Fields_DOB_Year'],
+            month: id_auth_field_data['Fields_DOB_Month'],
+            day: id_auth_field_data['Fields_DOB_Day'],
+          ),
+          state_id_expiration: parse_date(
+            year: id_auth_field_data['Fields_ExpirationDate_Year'],
+            month: id_auth_field_data['Fields_ExpirationDate_Month'],
+            day: id_auth_field_data['Fields_xpirationDate_Day'], # this is NOT a typo
+          ),
+          state_id_issued: parse_date(
+            year: id_auth_field_data['Fields_IssueDate_Year'],
+            month: id_auth_field_data['Fields_IssueDate_Month'],
+            day: id_auth_field_data['Fields_IssueDate_Day'],
+          ),
+          state_id_jurisdiction: id_auth_field_data['Fields_IssuingStateCode'],
+          state_id_number: id_auth_field_data['Fields_DocumentNumber'],
+          state_id_type: state_id_type,
+          issuing_country_code: id_auth_field_data['Fields_CountryCode'],
         )
-        pii[:dob] = dob
-
-        exp_date = parse_date(
-          year: pii.delete(:state_id_expiration_year),
-          month: pii.delete(:state_id_expiration_month),
-          day: pii.delete(:state_id_expiration_day),
-        )
-        pii[:state_id_expiration] = exp_date
-
-        issued_date = parse_date(
-          year: pii.delete(:state_id_issued_year),
-          month: pii.delete(:state_id_issued_month),
-          day: pii.delete(:state_id_issued_day),
-        )
-        pii[:state_id_issued] = issued_date
-
-        Pii::StateId.new(**pii)
       end
-
-      PII_INCLUDES = {
-        'Fields_FirstName' => :first_name,
-        'Fields_MiddleName' => :middle_name,
-        'Fields_Surname' => :last_name,
-        'Fields_AddressLine1' => :address1,
-        'Fields_AddressLine2' => :address2,
-        'Fields_City' => :city,
-        'Fields_State' => :state,
-        'Fields_PostalCode' => :zipcode,
-        'Fields_DOB_Year' => :dob_year,
-        'Fields_DOB_Month' => :dob_month,
-        'Fields_DOB_Day' => :dob_day,
-        'Fields_DocumentNumber' => :state_id_number,
-        'Fields_IssuingStateCode' => :state_id_jurisdiction,
-        'Fields_xpirationDate_Day' => :state_id_expiration_day, # this is NOT a typo
-        'Fields_ExpirationDate_Month' => :state_id_expiration_month,
-        'Fields_ExpirationDate_Year' => :state_id_expiration_year,
-        'Fields_IssueDate_Day' => :state_id_issued_day,
-        'Fields_IssueDate_Month' => :state_id_issued_month,
-        'Fields_IssueDate_Year' => :state_id_issued_year,
-        'Fields_DocumentClassName' => :state_id_type,
-        'Fields_CountryCode' => :issuing_country_code,
-      }.freeze
 
       def parse_date(year:, month:, day:)
         Date.new(year.to_i, month.to_i, day.to_i).to_s if year.to_i.positive?


### PR DESCRIPTION
This commit is in response to feedback on #10498 [ref](https://github.com/18F/identity-idp/pull/10498#discussion_r1578427544).

This method rebuilds the `#read_pii` method so it no longer maintains a map of keys to values and instead reads everything in-line where it can. I am hopeful this makes it a bit more succinct and readable.
