### PR TITLE
LG-13038 Add user context to the `​​AuthnContextResolver`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,6 +111,7 @@ class ApplicationController < ActionController::Base
       @resolved_authn_context_result = Vot::Parser::Result.no_sp_result
     else
       @resolved_authn_context_result = AuthnContextResolver.new(
+        user: current_user,
         service_provider: service_provider,
         vtr: sp_session[:vtr],
         acr_values: sp_session[:acr_values],

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -65,7 +65,7 @@ module OpenidConnect
     end
 
     def biometric_comparison_requested?
-      @authorize_form.parsed_vector_of_trust&.biometric_comparison?
+      @authorize_form.biometric_comparison_requested?
     end
 
     def check_sp_active

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -48,4 +48,12 @@ class AnonymousUser
   def locked_out?
     second_factor_locked_at.present? && !lockout_period_expired?
   end
+
+  def identity_verified_with_biometric_comparison?
+    false
+  end
+
+  def identity_verified?
+    false
+  end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -45,9 +45,12 @@ class OpenidConnectUserInfoPresenter
   private
 
   def vot_values
-    vot = JSON.parse(identity.vtr).first
-    parsed_vot = Vot::Parser.new(vector_of_trust: vot).parse
-    parsed_vot.expanded_component_values
+    AuthnContextResolver.new(
+      user: identity.user,
+      vtr: JSON.parse(identity.vtr),
+      service_provider: identity&.service_provider_record,
+      acr_values: nil,
+    ).resolve.expanded_component_values
   end
 
   def uuid_from_sp_identity(identity)
@@ -140,6 +143,7 @@ class OpenidConnectUserInfoPresenter
 
   def resolved_authn_context_result
     @resolved_authn_context_result ||= AuthnContextResolver.new(
+      user: identity.user,
       service_provider: identity&.service_provider_record,
       vtr: identity.vtr.presence && JSON.parse(identity.vtr),
       acr_values: identity.acr_values,

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -128,6 +128,7 @@ class Analytics
     service_provider = ServiceProvider.find_by(issuer: sp)
 
     @resolved_authn_context_result = AuthnContextResolver.new(
+      user: user,
       service_provider:,
       vtr: session[:sp][:vtr],
       acr_values: session[:sp][:acr_values],

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -71,6 +71,7 @@ class AttributeAsserter
     @resolved_authn_context_result ||= begin
       saml = FederatedProtocols::Saml.new(authn_request)
       AuthnContextResolver.new(
+        user: user,
         service_provider: service_provider,
         vtr: saml.vtr,
         acr_values: saml.acr_values,

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class AuthnContextResolver
-  attr_reader :service_provider, :vtr, :acr_values
+  attr_reader :user, :service_provider, :vtr, :acr_values
 
-  def initialize(service_provider:, vtr:, acr_values:)
+  def initialize(user:, service_provider:, vtr:, acr_values:)
+    @user = user
     @service_provider = service_provider
     @vtr = vtr
     @acr_values = acr_values
@@ -11,7 +12,7 @@ class AuthnContextResolver
 
   def resolve
     if vtr.present?
-      vot_parser_result
+      selected_vtr_parser_result_from_vtr_list
     else
       acr_result_with_sp_defaults
     end
@@ -19,19 +20,50 @@ class AuthnContextResolver
 
   private
 
-  def vot_parser_result
-    @vot_result = Vot::Parser.new(
-      vector_of_trust: vtr&.first,
-      acr_values: acr_values,
-    ).parse
+  def selected_vtr_parser_result_from_vtr_list
+    if biometric_proofing_vot.present? && user&.identity_verified_with_biometric_comparison?
+      biometric_proofing_vot
+    elsif non_biometric_identity_proofing_vot.present? && user&.identity_verified?
+      non_biometric_identity_proofing_vot
+    elsif no_identity_proofing_vot.present?
+      no_identity_proofing_vot
+    else
+      parsed_vectors_of_trust.first
+    end
+  end
+
+  def parsed_vectors_of_trust
+    @parsed_vectors_of_trust ||= vtr.map do |vot|
+      Vot::Parser.new(vector_of_trust: vot).parse
+    end
+  end
+
+  def biometric_proofing_vot
+    parsed_vectors_of_trust.find(&:biometric_comparison?)
+  end
+
+  def non_biometric_identity_proofing_vot
+    parsed_vectors_of_trust.find do |vot_parser_result|
+      vot_parser_result.identity_proofing? && !vot_parser_result.biometric_comparison?
+    end
+  end
+
+  def no_identity_proofing_vot
+    parsed_vectors_of_trust.find do |vot_parser_result|
+      !vot_parser_result.identity_proofing?
+    end
   end
 
   def acr_result_with_sp_defaults
     result_with_sp_aal_defaults(
       result_with_sp_ial_defaults(
-        vot_parser_result,
+        acr_result_without_sp_defaults,
       ),
     )
+  end
+
+  def acr_result_without_sp_defaults
+    @acr_result_without_sp_defaults ||= Vot::Parser.new(acr_values: acr_values).parse
   end
 
   def result_with_sp_aal_defaults(result)
@@ -57,14 +89,14 @@ class AuthnContextResolver
   end
 
   def acr_aal_component_values
-    vot_parser_result.component_values.filter do |component_value|
+    acr_result_without_sp_defaults.component_values.filter do |component_value|
       component_value.name.include?('aal') ||
         component_value.name == Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
     end
   end
 
   def acr_ial_component_values
-    vot_parser_result.component_values.filter do |component_value|
+    acr_result_without_sp_defaults.component_values.filter do |component_value|
       component_value.name.include?('ial') || component_value.name.include?('loa')
     end
   end

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -93,6 +93,7 @@ class IdTokenBuilder
 
   def resolved_authn_context_result
     @resolved_authn_context_result ||= AuthnContextResolver.new(
+      user: identity.user,
       service_provider: identity.service_provider_record,
       vtr: parsed_vtr_value,
       acr_values: identity.acr_values,

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -3,20 +3,22 @@ require 'rails_helper'
 RSpec.describe RememberDeviceConcern do
   let(:sp) { nil }
   let(:raw_session) { {} }
+  let(:current_user) { build(:user) }
 
   subject(:test_controller) do
     test_controller_class =
       Class.new(ApplicationController) do
         include(RememberDeviceConcern)
 
-        attr_reader :sp, :raw_session, :request
+        attr_reader :sp, :raw_session, :request, :current_user
         alias :sp_from_sp_session :sp
         alias :sp_session :raw_session
 
-        def initialize(sp, raw_session, request)
+        def initialize(sp, raw_session, request, current_user)
           @sp = sp
           @raw_session = raw_session
           @request = request
+          @current_user = current_user
         end
       end
 
@@ -27,7 +29,7 @@ RSpec.describe RememberDeviceConcern do
       filtered_parameters: {},
     )
 
-    test_controller_class.new(sp, raw_session, test_request)
+    test_controller_class.new(sp, raw_session, test_request, current_user)
   end
 
   describe '#mfa_expiration_interval' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -197,6 +197,21 @@ FactoryBot.define do
       end
     end
 
+    trait :proofed_with_selfie do
+      fully_registered
+
+      after :build do |user|
+        create(
+          :profile,
+          :active,
+          :verified,
+          :with_pii,
+          idv_level: :unsupervised_with_selfie,
+          user: user,
+        )
+      end
+    end
+
     trait :with_pending_in_person_enrollment do
       after :build do |user|
         profile = create(:profile, :with_pii, :in_person_verification_pending, user: user)

--- a/spec/features/sign_in/multiple_vot_spec.rb
+++ b/spec/features/sign_in/multiple_vot_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.feature 'Sign in with multiple vectors of trust', allowed_extra_analytics: [:*] do
+  include OidcAuthHelper
+  include IdvHelper
+  include DocAuthHelper
+
+  before do
+    allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+  end
+
+  context 'biometric and non-biometric proofing is acceptable' do
+    scenario 'identity proofing is not required if user is proofed with biometric' do
+      user = create(:user, :proofed_with_selfie)
+
+      visit_idp_from_oidc_sp_with_vtr(vtr: ['C1.C2.P1.Pb', 'C1.C2.P1'])
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq(sign_up_completed_path)
+      click_agree_and_continue
+
+      user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
+
+      expect(user_info[:given_name]).to be_present
+      expect(user_info[:vot]).to eq('C1.C2.P1.Pb')
+    end
+
+    scenario 'identity proofing is not required if user is proofed without biometric' do
+      user = create(:user, :proofed)
+
+      visit_idp_from_oidc_sp_with_vtr(vtr: ['C1.C2.P1.Pb', 'C1.C2.P1'])
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq(sign_up_completed_path)
+      click_agree_and_continue
+
+      user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
+
+      expect(user_info[:given_name]).to be_present
+      expect(user_info[:vot]).to eq('C1.C2.P1')
+    end
+
+    scenario 'identity proofing with biometric is required if user is not proofed', :js do
+      user = create(:user, :fully_registered)
+
+      visit_idp_from_oidc_sp_with_vtr(vtr: ['C1.C2.P1.Pb', 'C1.C2.P1'])
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq(idv_welcome_path)
+      complete_all_doc_auth_steps_before_password_step(with_selfie: true)
+      fill_in 'Password', with: user.password
+      click_continue
+      acknowledge_and_confirm_personal_key
+
+      expect(current_path).to eq(sign_up_completed_path)
+      click_agree_and_continue
+
+      user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
+
+      expect(user_info[:given_name]).to be_present
+      expect(user_info[:vot]).to eq('C1.C2.P1.Pb')
+    end
+  end
+
+  context 'proofing or no proofing is acceptable (IALMAX)' do
+    scenario 'identity proofing is not required if the user is not proofed' do
+      user = create(:user, :fully_registered)
+
+      visit_idp_from_oidc_sp_with_vtr(
+        vtr: ['C1.C2.P1', 'C1.C2'],
+        scope: 'openid email profile:name',
+      )
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq(sign_up_completed_path)
+      click_agree_and_continue
+
+      user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
+
+      expect(user_info[:given_name]).to_not be_present
+      expect(user_info[:vot]).to eq('C1.C2')
+    end
+
+    scenario 'attributes are shared if the user is proofed' do
+      user = create(:user, :proofed)
+
+      visit_idp_from_oidc_sp_with_vtr(
+        vtr: ['C1.C2.P1', 'C1.C2'],
+        scope: 'openid email profile:name',
+      )
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq(sign_up_completed_path)
+      click_agree_and_continue
+
+      user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
+
+      expect(user_info[:given_name]).to be_present
+      expect(user_info[:vot]).to eq('C1.C2.P1')
+    end
+
+    scenario 'identity proofing is not required if proofed user resets password' do
+      user = create(:user, :proofed)
+
+      visit_idp_from_oidc_sp_with_vtr(
+        vtr: ['C1.C2.P1', 'C1.C2'],
+        scope: 'openid email profile:name',
+      )
+      trigger_reset_password_and_click_email_link(user.email)
+      reset_password(user, 'new even better password')
+      user.password = 'new even better password'
+      sign_in_live_with_2fa(user)
+
+      expect(current_path).to eq(sign_up_completed_path)
+      click_agree_and_continue
+
+      user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
+
+      expect(user_info[:given_name]).to_not be_present
+      expect(user_info[:vot]).to eq('C1.C2')
+    end
+  end
+end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -672,9 +672,9 @@ RSpec.describe OpenidConnectAuthorizeForm do
     end
   end
 
-  describe '#biometric_comparison_required?' do
+  describe '#biometric_comparison_requested?' do
     it 'returns false by default' do
-      expect(subject.biometric_comparison_required?).to eql(false)
+      expect(subject.biometric_comparison_requested?).to eql(false)
     end
 
     context 'biometric requested via VTR' do
@@ -682,7 +682,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
       let(:vtr) { ['C1.P1.Pb'].to_json }
 
       it 'returns true' do
-        expect(subject.biometric_comparison_required?).to eql(true)
+        expect(subject.biometric_comparison_requested?).to eql(true)
       end
     end
 
@@ -691,7 +691,16 @@ RSpec.describe OpenidConnectAuthorizeForm do
       let(:vtr) { ['C1.P1'].to_json }
 
       it 'returns false' do
-        expect(subject.biometric_comparison_required?).to eql(false)
+        expect(subject.biometric_comparison_requested?).to eql(false)
+      end
+    end
+
+    context 'multiple VTR including biometric comparison' do
+      let(:acr_values) { nil }
+      let(:vtr) { ['C1.P1', 'C1.P1.Pb'].to_json }
+
+      it 'returns false' do
+        expect(subject.biometric_comparison_requested?).to eql(true)
       end
     end
   end

--- a/spec/policies/pending_profile_policy_spec.rb
+++ b/spec/policies/pending_profile_policy_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe PendingProfilePolicy do
   let(:user) { create(:user) }
   let(:resolved_authn_context_result) do
     AuthnContextResolver.new(
+      user: user,
       service_provider: nil,
       vtr: vtr,
       acr_values: acr_values,


### PR DESCRIPTION
The `AuthnContextResolver#resolve` takes the ACR values and VTR param for a request and returns an `Vot::Parser::Result` object. This object has predicate methods such as `aal2?` and `#identity_proofing?` which describe the requirements for the given service provider request. This is necessary because these requirements are a function of the service provider settings that are stored in the database and the request from the service provider.

When using vectors of trust a service provider is able to make a request with multiple valid vectors. Prior to this commit we used the first vector in the list for the service provider request. This commit makes a change to show the following preference:

1. If a SP requests biometric comparison and the user has completed proofing with biometric comparison we select the biometric comparison vector
2. If a SP requests identity proofing without biometric comparison and the user completed proofing we select the vector for identity proofing without biometric comparison
3. If neither of the above is true then we continue to select the first vector.

This change requires passing the current user into the `AuthnContextResolver` initializer so it has access to the user context once the user signs in.

The arrangement allows us to use the following vector combinations to satisfy the following use cases

- `C1.C2.P1.Pb,C1.C2.P1`: Existing proofed users do not need to proof again but unproofed users need to proof with a biometric
- `C1.C2.P1,C1.C2`: Users who have proofed have their attributes shared but unproofed users do not need to go through proofing i.e. IALMax
