### PR TITLE
LG-12873: Annotate reCAPTCHA assessments with MFA results

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -58,7 +58,6 @@ module TwoFactorAuthentication
       return if assessment_id.blank?
       RecaptchaAnnotator.new(assessment_id:, analytics:).annotate(
         reason: RecaptchaAnnotator::AnnotationReasons::PASSED_TWO_FACTOR,
-        annotation: RecaptchaAnnotator::Annotations::LEGITIMATE,
       )
     end
 

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -73,30 +73,27 @@ module Users
 
     def handle_create_success(phone)
       if MfaContext.new(current_user).phone_configurations.map(&:phone).index(phone).nil?
-        prompt_to_confirm_phone(
-          id: nil,
-          phone: @new_phone_form.phone,
-          selected_delivery_method: @new_phone_form.otp_delivery_preference,
-          phone_type: @new_phone_form.phone_info&.type,
-          selected_default_number: @new_phone_form.otp_make_default_number,
-        )
+        prompt_to_confirm_phone
       else
         flash[:error] = t('errors.messages.phone_duplicate')
         redirect_to phone_setup_url
       end
     end
 
-    def prompt_to_confirm_phone(id:, phone:, selected_delivery_method: nil,
-                                selected_default_number: nil, phone_type: nil)
-
-      user_session[:unconfirmed_phone] = phone
+    def prompt_to_confirm_phone
+      user_session[:unconfirmed_phone] = @new_phone_form.phone
       user_session[:context] = 'confirmation'
-      user_session[:phone_type] = phone_type.to_s
+      user_session[:phone_type] = @new_phone_form.phone_info&.type.to_s
+      user_session[:phone_recaptcha_assessment_id] = @new_phone_form.recaptcha_assessment_id
 
       redirect_to otp_send_url(
         otp_delivery_selection_form: {
-          otp_delivery_preference: otp_delivery_method(id, phone, selected_delivery_method),
-          otp_make_default_number: selected_default_number,
+          otp_delivery_preference: otp_delivery_method(
+            nil,
+            @new_phone_form.phone,
+            @new_phone_form.otp_delivery_preference,
+          ),
+          otp_make_default_number: @new_phone_form.otp_make_default_number,
         },
       )
     end

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -309,11 +309,21 @@ module Users
         },
       }
 
+      annotate_recaptcha_phone_assessment
+
       if UserSessionContext.authentication_or_reauthentication_context?(context)
         Telephony.send_authentication_otp(**otp_params)
       else
         Telephony.send_confirmation_otp(**otp_params)
       end
+    end
+
+    def annotate_recaptcha_phone_assessment
+      assessment_id = user_session[:phone_recaptcha_assessment_id]
+      return if assessment_id.blank?
+      RecaptchaAnnotator.new(assessment_id:, analytics:).annotate(
+        reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+      )
     end
 
     def user_selected_default_number

--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -24,7 +24,8 @@ class NewPhoneForm
               :otp_make_default_number,
               :setup_voice_preference,
               :recaptcha_token,
-              :recaptcha_mock_score
+              :recaptcha_mock_score,
+              :recaptcha_assessment_id
 
   alias_method :setup_voice_preference?, :setup_voice_preference
 
@@ -131,7 +132,8 @@ class NewPhoneForm
 
   def validate_recaptcha_token
     return if !validate_recaptcha_token?
-    recaptcha_form.submit(recaptcha_token)
+    _response, assessment_id = recaptcha_form.submit(recaptcha_token)
+    @recaptcha_assessment_id = assessment_id
     errors.merge!(recaptcha_form)
   end
 

--- a/app/forms/recaptcha_enterprise_form.rb
+++ b/app/forms/recaptcha_enterprise_form.rb
@@ -36,6 +36,7 @@ class RecaptchaEnterpriseForm < RecaptchaForm
       RecaptchaResult.new(
         success: response.body.dig('tokenProperties', 'valid') == true &&
           response.body.dig('tokenProperties', 'action') == recaptcha_action,
+        assessment_id: response.body.dig('name'),
         score: response.body.dig('riskAnalysis', 'score'),
         reasons: [
           *response.body.dig('riskAnalysis', 'reasons').to_a,

--- a/app/forms/recaptcha_form.rb
+++ b/app/forms/recaptcha_form.rb
@@ -57,7 +57,8 @@ class RecaptchaForm
     [response, @recaptcha_result&.assessment_id]
   rescue Faraday::Error => error
     log_analytics(error:)
-    FormResponse.new(success: true, serialize_error_details_only: true)
+    response = FormResponse.new(success: true, serialize_error_details_only: true)
+    [response, nil]
   end
 
   private

--- a/app/forms/recaptcha_mock_form.rb
+++ b/app/forms/recaptcha_mock_form.rb
@@ -11,6 +11,6 @@ class RecaptchaMockForm < RecaptchaForm
   private
 
   def recaptcha_result
-    RecaptchaResult.new(success: true, score:)
+    RecaptchaResult.new(success: true, assessment_id: SecureRandom.uuid, score:)
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3771,12 +3771,14 @@ module AnalyticsEvents
 
   # Tracks when the the user has added the MFA method phone to their account
   # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
-  def multi_factor_auth_added_phone(enabled_mfa_methods_count:, **extra)
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
+  def multi_factor_auth_added_phone(enabled_mfa_methods_count:, recaptcha_annotation:, **extra)
     track_event(
       'Multi-Factor Authentication: Added phone',
       {
         method_name: :phone,
         enabled_mfa_methods_count: enabled_mfa_methods_count,
+        recaptcha_annotation:,
         **extra,
       }.compact,
     )
@@ -5079,6 +5081,7 @@ module AnalyticsEvents
   # @param [Hash] telephony_response
   # @param [:test, :pinpoint] adapter which adapter the OTP was delivered with
   # @param [Boolean] success
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # A phone one-time password send was attempted
   def telephony_otp_sent(
     area_code:,
@@ -5090,6 +5093,7 @@ module AnalyticsEvents
     telephony_response:,
     adapter:,
     success:,
+    recaptcha_annotation: nil,
     **extra
   )
     track_event(
@@ -5104,6 +5108,7 @@ module AnalyticsEvents
         telephony_response: telephony_response,
         adapter: adapter,
         success: success,
+        recaptcha_annotation:,
         **extra,
       },
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4637,14 +4637,6 @@ module AnalyticsEvents
     track_event('Reactivate Account Visited')
   end
 
-  # A previous reCAPTCHA assessment was annotated
-  # @param [String] assessment_id Assessment reference identifier
-  # @param [String] reason Reason for annotating the assessment
-  # @param [String] annotation Type of annotation
-  def recaptcha_assessment_annotated(assessment_id:, reason:, annotation:, **extra)
-    track_event(:recaptcha_assessment_annotated, assessment_id:, reason:, annotation:, **extra)
-  end
-
   # The result of a reCAPTCHA verification request was received
   # @param [Hash] recaptcha_result Full reCAPTCHA response body
   # @param [Float] score_threshold Minimum value for considering passing result

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4635,6 +4635,14 @@ module AnalyticsEvents
     track_event('Reactivate Account Visited')
   end
 
+  # A previous reCAPTCHA assessment was annotated
+  # @param [String] assessment_id Assessment reference identifier
+  # @param [String] reason Reason for annotating the assessment
+  # @param [String] annotation Type of annotation
+  def recaptcha_assessment_annotated(assessment_id:, reason:, annotation:, **extra)
+    track_event(:recaptcha_assessment_annotated, assessment_id:, reason:, annotation:, **extra)
+  end
+
   # The result of a reCAPTCHA verification request was received
   # @param [Hash] recaptcha_result Full reCAPTCHA response body
   # @param [Float] score_threshold Minimum value for considering passing result

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -33,6 +33,8 @@ class RecaptchaAnnotator
       faraday.post(annotation_url(assessment_id:), request_body) do |request|
         request.options.context = { service_name: 'recaptcha_annotate' }
       end
+    rescue Faraday::Error => error
+      NewRelic::Agent.notice_error(error)
     end
 
     def faraday

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class RecaptchaAnnotator
+  attr_reader :assessment_id, :analytics
+
+  # See: https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.assessments/annotate#reason
+  module AnnotationReasons
+    INITIATED_TWO_FACTOR = :INITIATED_TWO_FACTOR
+    PASSED_TWO_FACTOR = :PASSED_TWO_FACTOR
+  end
+
+  # See: https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.assessments/annotate#annotation
+  module Annotations
+    LEGITIMATE = :LEGITIMATE
+    FRAUDULENT = :FRAUDULENT
+  end
+
+  def initialize(assessment_id:, analytics:)
+    @assessment_id = assessment_id
+    @analytics = analytics
+  end
+
+  def annotate(reason: nil, annotation: nil)
+    submit_annotation(reason:, annotation:) if !IdentityConfig.store.phone_recaptcha_mock_validator
+    log_analytics(reason:, annotation:)
+  end
+
+  private
+
+  BASE_ENDPOINT = 'https://recaptchaenterprise.googleapis.com/v1/projects'
+
+  def submit_annotation(reason:, annotation:)
+    request_body = { reason:, annotation: }.compact
+    faraday.post(annotation_url, request_body) do |request|
+      request.options.context = { service_name: 'recaptcha_annotate' }
+    end
+  end
+
+  def faraday
+    Faraday.new do |conn|
+      conn.request :instrumentation, name: 'request_log.faraday'
+      conn.request :json
+      conn.response :json
+    end
+  end
+
+  def annotation_url
+    UriService.add_params(
+      format(
+        '%{base_endpoint}/%{project_id}/assessments/%{assessment_id}:annotate',
+        base_endpoint: BASE_ENDPOINT,
+        project_id: IdentityConfig.store.recaptcha_enterprise_project_id,
+        assessment_id:,
+      ),
+      key: IdentityConfig.store.recaptcha_enterprise_api_key,
+    )
+  end
+
+  def log_analytics(reason:, annotation:)
+    analytics&.recaptcha_assessment_annotated(assessment_id:, reason:, annotation:)
+  end
+end

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -30,8 +30,7 @@ class RecaptchaAnnotator
   BASE_ENDPOINT = 'https://recaptchaenterprise.googleapis.com/v1'
 
   def submit_annotation(reason:, annotation:)
-    request_body = { annotation: }.compact
-    request_body[:reasons] = [reason] if reason
+    request_body = { annotation:, reasons: reason && [reason] }.compact
     faraday.post(annotation_url, request_body) do |request|
       request.options.context = { service_name: 'recaptcha_annotate' }
     end

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -27,10 +27,11 @@ class RecaptchaAnnotator
 
   private
 
-  BASE_ENDPOINT = 'https://recaptchaenterprise.googleapis.com/v1/projects'
+  BASE_ENDPOINT = 'https://recaptchaenterprise.googleapis.com/v1'
 
   def submit_annotation(reason:, annotation:)
-    request_body = { reason:, annotation: }.compact
+    request_body = { annotation: }.compact
+    request_body[:reasons] = [reason] if reason
     faraday.post(annotation_url, request_body) do |request|
       request.options.context = { service_name: 'recaptcha_annotate' }
     end
@@ -47,7 +48,7 @@ class RecaptchaAnnotator
   def annotation_url
     UriService.add_params(
       format(
-        '%{base_endpoint}/%{project_id}/assessments/%{assessment_id}:annotate',
+        '%{base_endpoint}/%{assessment_id}:annotate',
         base_endpoint: BASE_ENDPOINT,
         project_id: IdentityConfig.store.recaptcha_enterprise_project_id,
         assessment_id:,

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -21,7 +21,7 @@ class RecaptchaAnnotator
   end
 
   def annotate(reason: nil, annotation: nil)
-    submit_annotation(reason:, annotation:) if !IdentityConfig.store.phone_recaptcha_mock_validator
+    submit_annotation(reason:, annotation:) if FeatureManagement.recaptcha_enterprise?
     log_analytics(reason:, annotation:)
   end
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -707,7 +707,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
           end
 
           it 'annotates with passed 2fa and resets a recaptcha assessment' do
-            assessment_id = 'assessment-id'
+            assessment_id = 'projects/project-id/assessments/assessment-id'
 
             controller.user_session[:phone_recaptcha_assessment_id] = assessment_id
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -714,7 +714,6 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
             annotator = instance_double(RecaptchaAnnotator)
             expect(annotator).to receive(:annotate).once.with(
               reason: RecaptchaAnnotator::AnnotationReasons::PASSED_TWO_FACTOR,
-              annotation: RecaptchaAnnotator::Annotations::LEGITIMATE,
             )
 
             allow(RecaptchaAnnotator).to receive(:new).

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
       before do
         @user = create(:user, :with_phone)
         sign_in_before_2fa(@user)
-        @old_otp = subject.current_user.direct_otp
+        @old_otp = controller.current_user.direct_otp
         allow(Telephony).to receive(:send_authentication_otp).and_call_original
       end
 
@@ -391,6 +391,37 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
           end
 
           expect(@user.reload.second_factor_locked_at).to eq Time.zone.now
+        end
+      end
+
+      context 'with recaptcha phone assessment id in session' do
+        let(:assessment_id) { 'assessment-id' }
+
+        subject(:response) do
+          get :send_code, params: {
+            otp_delivery_selection_form: {
+              **otp_preference_sms,
+              otp_make_default_number: nil,
+            },
+          }
+        end
+
+        before do
+          stub_analytics
+          controller.user_session[:phone_recaptcha_assessment_id] = assessment_id
+        end
+
+        it 'annotates recaptcha assessment with initiated 2fa' do
+          annotator = instance_double(RecaptchaAnnotator)
+          expect(annotator).to receive(:annotate).once.with(
+            reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+          )
+
+          allow(RecaptchaAnnotator).to receive(:new).
+            with(assessment_id:, analytics: @analytics).
+            and_return(annotator)
+
+          response
         end
       end
 

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -412,16 +412,20 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
         end
 
         it 'annotates recaptcha assessment with initiated 2fa' do
-          annotator = instance_double(RecaptchaAnnotator)
-          expect(annotator).to receive(:annotate).once.with(
+          recaptcha_annotation = {
+            assessment_id:,
             reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
-          )
-
-          allow(RecaptchaAnnotator).to receive(:new).
-            with(assessment_id:, analytics: @analytics).
-            and_return(annotator)
+          }
+          expect(RecaptchaAnnotator).to receive(:annotate).once.
+            with(**recaptcha_annotation).
+            and_return(recaptcha_annotation)
 
           response
+
+          expect(@analytics).to have_logged_event(
+            'Telephony: OTP sent',
+            hash_including(recaptcha_annotation:),
+          )
         end
       end
 

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
       end
 
       context 'with recaptcha phone assessment id in session' do
-        let(:assessment_id) { 'assessment-id' }
+        let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
 
         subject(:response) do
           get :send_code, params: {

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -222,17 +222,17 @@ RSpec.describe 'Add a new phone number', allowed_extra_analytics: [:*] do
     expect(page).to have_content(t('errors.messages.invalid_recaptcha_token'))
     expect(fake_analytics).to have_logged_event(
       'reCAPTCHA verify result received',
-      hash_including(
-        recaptcha_result: {
-          success: true,
-          score: 0.5,
-          errors: [],
-          reasons: [],
-        },
-        evaluated_as_valid: false,
-        score_threshold: 0.6,
-        phone_country_code: 'AU',
-      ),
+      recaptcha_result: {
+        assessment_id: kind_of(String),
+        success: true,
+        score: 0.5,
+        errors: [],
+        reasons: [],
+      },
+      evaluated_as_valid: false,
+      score_threshold: 0.6,
+      phone_country_code: 'AU',
+      form_class: 'RecaptchaMockForm',
     )
 
     # Passing international should display OTP confirmation

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe NewPhoneForm do
       let(:international_code) { 'CA' }
       let(:params) { super().merge(recaptcha_token:) }
       let(:recaptcha_form_response) { FormResponse.new(success: true) }
-      let(:recaptcha_assessment_id) { 'assessment-id' }
+      let(:recaptcha_assessment_id) { 'projects/project-id/assessments/assessment-id' }
 
       subject(:result) { form.submit(params) }
 

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -354,6 +354,10 @@ RSpec.describe NewPhoneForm do
           and_return(score_threshold)
       end
 
+      it 'assigns recaptcha_assessment_id value' do
+        expect { result }.to change { form.recaptcha_assessment_id }.from(nil).to kind_of(String)
+      end
+
       context 'with invalid captcha score' do
         let(:recaptcha_mock_score) { score_threshold - 0.1 }
 
@@ -380,20 +384,32 @@ RSpec.describe NewPhoneForm do
       let(:phone) { '3065550100' }
       let(:international_code) { 'CA' }
       let(:params) { super().merge(recaptcha_token:) }
+      let(:recaptcha_form_response) { FormResponse.new(success: true) }
+      let(:recaptcha_assessment_id) { 'assessment-id' }
 
       subject(:result) { form.submit(params) }
 
       before do
         allow(FeatureManagement).to receive(:phone_recaptcha_enabled?).and_return(true)
-        allow(recaptcha_form).to receive(:submit).with(recaptcha_token)
+        allow(recaptcha_form).to receive(:submit).with(recaptcha_token).
+          and_return([recaptcha_form_response, recaptcha_assessment_id])
         allow(recaptcha_form).to receive(:errors).and_return(errors)
         allow(form).to receive(:recaptcha_form).and_return(recaptcha_form)
       end
 
       context 'with valid recaptcha result' do
+        let(:recaptcha_form_response) { FormResponse.new(success: true) }
+
         it 'is valid' do
           expect(result.success?).to eq(true)
           expect(result.errors).to be_blank
+        end
+
+        it 'assigns recaptcha_assessment_id value' do
+          expect { result }.
+            to change { form.recaptcha_assessment_id }.
+            from(nil).
+            to(recaptcha_assessment_id)
         end
 
         context 'with recaptcha enterprise' do

--- a/spec/forms/recaptcha_enterprise_form_spec.rb
+++ b/spec/forms/recaptcha_enterprise_form_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe RecaptchaEnterpriseForm do
 
     context 'with unsuccessful response from validation service' do
       let(:token) { 'token' }
-      let(:name) { 'assessment-id' }
+      let(:name) { 'projects/project-id/assessments/assessment-id' }
 
       before do
         stub_recaptcha_response(
@@ -227,7 +227,7 @@ RSpec.describe RecaptchaEnterpriseForm do
 
     context 'with failing score from validation service' do
       let(:token) { 'token' }
-      let(:name) { 'assessment-id' }
+      let(:name) { 'projects/project-id/assessments/assessment-id' }
       let(:score) { score_threshold - 0.1 }
 
       before do
@@ -274,7 +274,7 @@ RSpec.describe RecaptchaEnterpriseForm do
 
     context 'with successful score from validation service' do
       let(:token) { 'token' }
-      let(:name) { 'assessment-id' }
+      let(:name) { 'projects/project-id/assessments/assessment-id' }
       let(:score) { score_threshold + 0.1 }
 
       around do |example|
@@ -318,7 +318,7 @@ RSpec.describe RecaptchaEnterpriseForm do
       end
 
       context 'with action mismatch' do
-        let(:name) { 'assessment-id' }
+        let(:name) { 'projects/project-id/assessments/assessment-id' }
 
         before do
           stub_recaptcha_response(

--- a/spec/forms/recaptcha_enterprise_form_spec.rb
+++ b/spec/forms/recaptcha_enterprise_form_spec.rb
@@ -53,19 +53,22 @@ RSpec.describe RecaptchaEnterpriseForm do
 
   describe '#submit' do
     let(:token) { nil }
-    subject(:response) { form.submit(token) }
+    subject(:result) { form.submit(token) }
 
     context 'with exemption' do
       before do
         allow(form).to receive(:exempt?).and_return(true)
       end
 
-      it 'is successful' do
+      it 'is successful without assessment id' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(success: true)
+        expect(assessment_id).to be_nil
       end
 
       it 'does not log analytics' do
-        response
+        result
 
         expect(analytics).not_to have_logged_event('reCAPTCHA verify result received')
       end
@@ -74,15 +77,18 @@ RSpec.describe RecaptchaEnterpriseForm do
     context 'with missing token' do
       let(:token) { nil }
 
-      it 'is unsuccessful with error for blank token' do
+      it 'is unsuccessful with nil assessment id and error for blank token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { blank: true } },
         )
+        expect(assessment_id).to be_nil
       end
 
       it 'does not log analytics' do
-        response
+        result
 
         expect(analytics).not_to have_logged_event('reCAPTCHA verify result received')
       end
@@ -91,15 +97,18 @@ RSpec.describe RecaptchaEnterpriseForm do
     context 'with blank token' do
       let(:token) { '' }
 
-      it 'is unsuccessful with error for blank token' do
+      it 'is unsuccessful with nil assessment id and error for blank token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { blank: true } },
         )
+        expect(assessment_id).to be_nil
       end
 
       it 'does not log analytics' do
-        response
+        result
 
         expect(analytics).not_to have_logged_event('reCAPTCHA verify result received')
       end
@@ -107,27 +116,32 @@ RSpec.describe RecaptchaEnterpriseForm do
 
     context 'with unsuccessful response from validation service' do
       let(:token) { 'token' }
+      let(:name) { 'assessment-id' }
 
       before do
         stub_recaptcha_response(
           body: {
             tokenProperties: { valid: false, action:, invalidReason: 'EXPIRED' },
             event: {},
+            name:,
           },
           action:,
           token:,
         )
       end
 
-      it 'is unsuccessful with error for invalid token' do
+      it 'is unsuccessful with assessment id and error for invalid token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { invalid: true } },
         )
+        expect(assessment_id).to eq(name)
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
@@ -136,6 +150,7 @@ RSpec.describe RecaptchaEnterpriseForm do
             score: nil,
             errors: [],
             reasons: ['EXPIRED'],
+            assessment_id: name,
           },
           evaluated_as_valid: false,
           score_threshold: score_threshold,
@@ -157,17 +172,21 @@ RSpec.describe RecaptchaEnterpriseForm do
         )
       end
 
-      it 'is successful' do
+      it 'is successful with nil assessment id' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(success: true)
+        expect(assessment_id).to be_nil
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
           recaptcha_result: {
             success: false,
+            assessment_id: nil,
             score: nil,
             errors: ['INVALID_ARGUMENT'],
             reasons: [],
@@ -186,12 +205,15 @@ RSpec.describe RecaptchaEnterpriseForm do
         stub_request(:post, assessment_url).to_timeout
       end
 
-      it 'is successful' do
+      it 'is successful with nil assessment id' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(success: true)
+        expect(assessment_id).to be_nil
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
@@ -205,6 +227,7 @@ RSpec.describe RecaptchaEnterpriseForm do
 
     context 'with failing score from validation service' do
       let(:token) { 'token' }
+      let(:name) { 'assessment-id' }
       let(:score) { score_threshold - 0.1 }
 
       before do
@@ -213,21 +236,25 @@ RSpec.describe RecaptchaEnterpriseForm do
             tokenProperties: { valid: true, action: },
             riskAnalysis: { score:, reasons: ['AUTOMATION'] },
             event: {},
+            name:,
           },
           action:,
           token:,
         )
       end
 
-      it 'is unsuccessful with error for invalid token' do
+      it 'is unsuccessful with assesment id and error for invalid token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { invalid: true } },
         )
+        expect(assessment_id).to eq(name)
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
@@ -236,6 +263,7 @@ RSpec.describe RecaptchaEnterpriseForm do
             score:,
             reasons: ['AUTOMATION'],
             errors: [],
+            assessment_id: name,
           },
           evaluated_as_valid: false,
           score_threshold: score_threshold,
@@ -246,6 +274,7 @@ RSpec.describe RecaptchaEnterpriseForm do
 
     context 'with successful score from validation service' do
       let(:token) { 'token' }
+      let(:name) { 'assessment-id' }
       let(:score) { score_threshold + 0.1 }
 
       around do |example|
@@ -254,6 +283,7 @@ RSpec.describe RecaptchaEnterpriseForm do
             tokenProperties: { valid: true, action: },
             riskAnalysis: { score:, reasons: ['LOW_CONFIDENCE'] },
             event: {},
+            name:,
           },
           action:,
           token:,
@@ -262,12 +292,15 @@ RSpec.describe RecaptchaEnterpriseForm do
         expect(stubbed_request).to have_been_made.once
       end
 
-      it 'is successful' do
+      it 'is successful with assessment id' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(success: true)
+        expect(assessment_id).to eq(name)
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
@@ -276,6 +309,7 @@ RSpec.describe RecaptchaEnterpriseForm do
             score:,
             reasons: ['LOW_CONFIDENCE'],
             errors: [],
+            assessment_id: name,
           },
           evaluated_as_valid: true,
           score_threshold: score_threshold,
@@ -284,23 +318,29 @@ RSpec.describe RecaptchaEnterpriseForm do
       end
 
       context 'with action mismatch' do
+        let(:name) { 'assessment-id' }
+
         before do
           stub_recaptcha_response(
             body: {
               tokenProperties: { valid: true, action: 'wrong' },
               riskAnalysis: { score:, reasons: ['LOW_CONFIDENCE'] },
               event: {},
+              name:,
             },
             action:,
             token:,
           )
         end
 
-        it 'is unsuccessful with error for invalid token' do
+        it 'is unsuccessful with assessment id and error for invalid token' do
+          response, assessment_id = result
+
           expect(response.to_h).to eq(
             success: false,
             error_details: { recaptcha_token: { invalid: true } },
           )
+          expect(assessment_id).to eq(name)
         end
       end
 
@@ -308,7 +348,7 @@ RSpec.describe RecaptchaEnterpriseForm do
         let(:extra_analytics_properties) { { extra: true } }
 
         it 'logs analytics of the body' do
-          response
+          result
 
           expect(analytics).to have_logged_event(
             'reCAPTCHA verify result received',
@@ -317,6 +357,7 @@ RSpec.describe RecaptchaEnterpriseForm do
               score:,
               reasons: ['LOW_CONFIDENCE'],
               errors: [],
+              assessment_id: name,
             },
             evaluated_as_valid: true,
             score_threshold: score_threshold,
@@ -330,7 +371,7 @@ RSpec.describe RecaptchaEnterpriseForm do
         let(:analytics) { nil }
 
         it 'validates gracefully without analytics logging' do
-          response
+          result
         end
       end
     end

--- a/spec/forms/recaptcha_form_spec.rb
+++ b/spec/forms/recaptcha_form_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RecaptchaForm do
 
   describe '#submit' do
     let(:token) { nil }
-    subject(:response) { form.submit(token) }
+    subject(:result) { form.submit(token) }
 
     context 'with exemption' do
       before do
@@ -41,11 +41,14 @@ RSpec.describe RecaptchaForm do
       end
 
       it 'is successful' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(success: true)
+        expect(assessment_id).to be_nil
       end
 
       it 'does not log analytics' do
-        response
+        result
 
         expect(analytics).not_to have_logged_event('reCAPTCHA verify result received')
       end
@@ -55,14 +58,17 @@ RSpec.describe RecaptchaForm do
       let(:token) { nil }
 
       it 'is unsuccessful with error for blank token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { blank: true } },
         )
+        expect(assessment_id).to be_nil
       end
 
       it 'does not log analytics' do
-        response
+        result
 
         expect(analytics).not_to have_logged_event('reCAPTCHA verify result received')
       end
@@ -72,14 +78,17 @@ RSpec.describe RecaptchaForm do
       let(:token) { '' }
 
       it 'is unsuccessful with error for blank token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { blank: true } },
         )
+        expect(assessment_id).to be_nil
       end
 
       it 'does not log analytics' do
-        response
+        result
 
         expect(analytics).not_to have_logged_event('reCAPTCHA verify result received')
       end
@@ -96,18 +105,22 @@ RSpec.describe RecaptchaForm do
       end
 
       it 'is unsuccessful with error for invalid token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { invalid: true } },
         )
+        expect(assessment_id).to be_nil
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
           recaptcha_result: {
+            assessment_id: nil,
             success: false,
             score: nil,
             reasons: ['timeout-or-duplicate'],
@@ -129,15 +142,19 @@ RSpec.describe RecaptchaForm do
           end
 
           it 'is successful' do
+            response, assessment_id = result
+
             expect(response.to_h).to eq(success: true)
+            expect(assessment_id).to be_nil
           end
 
           it 'logs analytics of the body' do
-            response
+            result
 
             expect(analytics).to have_logged_event(
               'reCAPTCHA verify result received',
               recaptcha_result: {
+                assessment_id: nil,
                 success: false,
                 score: nil,
                 errors: ['missing-input-secret'],
@@ -159,15 +176,19 @@ RSpec.describe RecaptchaForm do
           end
 
           it 'is successful' do
+            response, assessment_id = result
+
             expect(response.to_h).to eq(success: true)
+            expect(assessment_id).to be_nil
           end
 
           it 'logs analytics of the body' do
-            response
+            result
 
             expect(analytics).to have_logged_event(
               'reCAPTCHA verify result received',
               recaptcha_result: {
+                assessment_id: nil,
                 success: false,
                 score: nil,
                 errors: ['invalid-input-secret'],
@@ -190,11 +211,14 @@ RSpec.describe RecaptchaForm do
       end
 
       it 'is successful' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(success: true)
+        expect(assessment_id).to be_nil
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
@@ -215,18 +239,22 @@ RSpec.describe RecaptchaForm do
       end
 
       it 'is unsuccessful with error for invalid token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { invalid: true } },
         )
+        expect(assessment_id).to be_nil
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
           recaptcha_result: {
+            assessment_id: nil,
             success: true,
             score:,
             errors: [],
@@ -250,15 +278,19 @@ RSpec.describe RecaptchaForm do
       end
 
       it 'is successful' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(success: true)
+        expect(assessment_id).to be_nil
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
           recaptcha_result: {
+            assessment_id: nil,
             success: true,
             score:,
             errors: [],
@@ -274,11 +306,12 @@ RSpec.describe RecaptchaForm do
         let(:extra_analytics_properties) { { extra: true } }
 
         it 'logs analytics of the body' do
-          response
+          result
 
           expect(analytics).to have_logged_event(
             'reCAPTCHA verify result received',
             recaptcha_result: {
+              assessment_id: nil,
               success: true,
               score:,
               errors: [],
@@ -296,7 +329,7 @@ RSpec.describe RecaptchaForm do
         let(:analytics) { nil }
 
         it 'validates gracefully without analytics logging' do
-          response
+          result
         end
       end
     end

--- a/spec/forms/recaptcha_mock_form_spec.rb
+++ b/spec/forms/recaptcha_mock_form_spec.rb
@@ -14,24 +14,28 @@ RSpec.describe RecaptchaMockForm do
 
   describe '#submit' do
     let(:token) { 'token' }
-    subject(:response) { form.submit(token) }
+    subject(:result) { form.submit(token) }
 
     context 'with failing score from validation service' do
       let(:score) { score_threshold - 0.1 }
 
       it 'is unsuccessful with error for invalid token' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(
           success: false,
           error_details: { recaptcha_token: { invalid: true } },
         )
+        expect(assessment_id).to be_kind_of(String)
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
           recaptcha_result: {
+            assessment_id: kind_of(String),
             success: true,
             score:,
             errors: [],
@@ -49,15 +53,19 @@ RSpec.describe RecaptchaMockForm do
       let(:score) { score_threshold + 0.1 }
 
       it 'is successful' do
+        response, assessment_id = result
+
         expect(response.to_h).to eq(success: true)
+        expect(assessment_id).to be_kind_of(String)
       end
 
       it 'logs analytics of the body' do
-        response
+        result
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
           recaptcha_result: {
+            assessment_id: kind_of(String),
             success: true,
             score:,
             errors: [],
@@ -73,7 +81,7 @@ RSpec.describe RecaptchaMockForm do
         let(:analytics) { nil }
 
         it 'validates gracefully without analytics logging' do
-          response
+          result
         end
       end
     end

--- a/spec/services/recaptcha_annotator_spec.rb
+++ b/spec/services/recaptcha_annotator_spec.rb
@@ -3,13 +3,12 @@ require 'rails_helper'
 RSpec.describe RecaptchaAnnotator do
   let(:recaptcha_enterprise_api_key) { 'recaptcha_enterprise_api_key' }
   let(:recaptcha_enterprise_project_id) { 'project_id' }
-  let(:assessment_id) { 'assessment-id' }
+  let(:assessment_id) { "projects/#{recaptcha_enterprise_project_id}/assessments/assessment-id" }
   let(:analytics) { FakeAnalytics.new }
   let(:annotation_url) do
     format(
-      '%{base_endpoint}/%{project_id}/assessments/%{assessment_id}:annotate?key=%{api_key}',
+      '%{base_endpoint}/%{assessment_id}:annotate?key=%{api_key}',
       base_endpoint: RecaptchaAnnotator::BASE_ENDPOINT,
-      project_id: recaptcha_enterprise_project_id,
       assessment_id:,
       api_key: recaptcha_enterprise_api_key,
     )
@@ -52,7 +51,14 @@ RSpec.describe RecaptchaAnnotator do
         allow(IdentityConfig.store).to receive(:recaptcha_enterprise_api_key).
           and_return(recaptcha_enterprise_api_key)
         stub_request(:post, annotation_url).
-          to_return(headers: { 'Content-Type': 'application/json' }, body: '')
+          with do |req|
+            parsed_body = JSON.parse(req.body)
+            next if reason && parsed_body['reasons'] != [reason.to_s]
+            next if !reason && parsed_body.key?('reasons')
+            next if annotation && parsed_body['annotation'] != annotation.to_s
+            true
+          end.
+          to_return(headers: { 'Content-Type': 'application/json' }, body: '{}')
       end
 
       it 'submits annotation' do
@@ -73,12 +79,14 @@ RSpec.describe RecaptchaAnnotator do
       end
 
       context 'with an optional argument omitted' do
+        let(:annotation) { nil }
         subject(:annotate) { annotator.annotate(reason:) }
 
         it 'submits and logs only what is provided' do
           annotate
 
-          expect(WebMock).to have_requested(:post, annotation_url).with(body: { reason: }.to_json)
+          expect(WebMock).to have_requested(:post, annotation_url).
+            with(body: { reasons: [reason] }.to_json)
 
           expect(analytics).to have_logged_event(
             :recaptcha_assessment_annotated,

--- a/spec/services/recaptcha_annotator_spec.rb
+++ b/spec/services/recaptcha_annotator_spec.rb
@@ -110,6 +110,22 @@ RSpec.describe RecaptchaAnnotator do
 
         it { expect(annotate).to be_nil }
       end
+
+      context 'with connection error' do
+        before do
+          stub_request(:post, annotation_url).to_timeout
+        end
+
+        it 'fails gracefully' do
+          annotate
+        end
+
+        it 'notices the error to NewRelic' do
+          expect(NewRelic::Agent).to receive(:notice_error).with(Faraday::Error)
+
+          annotate
+        end
+      end
     end
   end
 end

--- a/spec/services/recaptcha_annotator_spec.rb
+++ b/spec/services/recaptcha_annotator_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe RecaptchaAnnotator do
+  let(:recaptcha_enterprise_api_key) { 'recaptcha_enterprise_api_key' }
+  let(:recaptcha_enterprise_project_id) { 'project_id' }
+  let(:assessment_id) { 'assessment-id' }
+  let(:analytics) { FakeAnalytics.new }
+  let(:annotation_url) do
+    format(
+      '%{base_endpoint}/%{project_id}/assessments/%{assessment_id}:annotate?key=%{api_key}',
+      base_endpoint: RecaptchaAnnotator::BASE_ENDPOINT,
+      project_id: recaptcha_enterprise_project_id,
+      assessment_id:,
+      api_key: recaptcha_enterprise_api_key,
+    )
+  end
+  subject(:annotator) { RecaptchaAnnotator.new(assessment_id:, analytics:) }
+
+  describe '#annotate' do
+    let(:reason) { RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR }
+    let(:annotation) { RecaptchaAnnotator::Annotations::LEGITIMATE }
+    subject(:annotate) { annotator.annotate(reason:, annotation:) }
+
+    context 'without recaptcha enterprise' do
+      before do
+        allow(FeatureManagement).to receive(:recaptcha_enterprise?).and_return(false)
+      end
+
+      it 'does not submit annotation' do
+        annotate
+
+        expect(WebMock).not_to have_requested(:post, annotation_url)
+      end
+
+      it 'logs analytics' do
+        annotate
+
+        expect(analytics).to have_logged_event(
+          :recaptcha_assessment_annotated,
+          assessment_id:,
+          reason:,
+          annotation:,
+        )
+      end
+    end
+
+    context 'with recaptcha enterprise' do
+      before do
+        allow(FeatureManagement).to receive(:recaptcha_enterprise?).and_return(true)
+        allow(IdentityConfig.store).to receive(:recaptcha_enterprise_project_id).
+          and_return(recaptcha_enterprise_project_id)
+        allow(IdentityConfig.store).to receive(:recaptcha_enterprise_api_key).
+          and_return(recaptcha_enterprise_api_key)
+        stub_request(:post, annotation_url).
+          to_return(headers: { 'Content-Type': 'application/json' }, body: '')
+      end
+
+      it 'submits annotation' do
+        annotate
+
+        expect(WebMock).to have_requested(:post, annotation_url)
+      end
+
+      it 'logs analytics' do
+        annotate
+
+        expect(analytics).to have_logged_event(
+          :recaptcha_assessment_annotated,
+          assessment_id:,
+          reason:,
+          annotation:,
+        )
+      end
+
+      context 'with an optional argument omitted' do
+        subject(:annotate) { annotator.annotate(reason:) }
+
+        it 'submits and logs only what is provided' do
+          annotate
+
+          expect(WebMock).to have_requested(:post, annotation_url).with(body: { reason: }.to_json)
+
+          expect(analytics).to have_logged_event(
+            :recaptcha_assessment_annotated,
+            assessment_id:,
+            annotation: nil,
+            reason:,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-12873](https://cm-jira.usa.gov/browse/LG-12873)

## 🛠 Summary of changes

Updates phone setup flow to annotate a reCAPTCHA assessment after the user initiates and completes phone setup.

Related resources:

- https://cloud.google.com/recaptcha-enterprise/docs/annotate-assessment

## 📜 Testing Plan

Verify that you see events for annotating an assessment upon initiating and completing phone setup:

1. Have `make run` and `make watch_events` running in parallel in two separate terminal processes
2. Visit http://localhost:3000
3. Sign in or create an account
4. When possible, add a phone to your account (clicking "Add phone number" at the account dashboard if signing in, or choosing "Text or voice message" at the MFA selection screen during account creation)
5. Enter an international phone number, e.g. `+610491570006`
6. Click "Send code"
7. Observe ~an event `recaptcha_assessment_annotated`~ _that the `Telephony: OTP sent` event includes an `recaptcha_annotation`_ with non-null `assessment_id` and a `reason` of `'INITIATED_TWO_FACTOR'`
8. Click "Submit" to submit the one-time code
9. Observe ~an event `recaptcha_assessment_annotated`~ _that the `Multi-factor authentication: Phone added` event includes an `recaptcha_annotation`_ with non-null `assessment_id`, a `reason` of `'PASSED_TWO_FACTOR'`, and a `annotation` of `'LEGITIMATE'`