### PR TITLE
Return a `Pii::StateId` object from `idv_session.pii_from_doc`

### DIFF
--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -49,11 +49,11 @@ module Idv
 
     def address_from_document
       Pii::Address.new(
-        address1: idv_session.pii_from_doc[:address1],
-        address2: idv_session.pii_from_doc[:address2],
-        city: idv_session.pii_from_doc[:city],
-        state: idv_session.pii_from_doc[:state],
-        zipcode: idv_session.pii_from_doc[:zipcode],
+        address1: idv_session.pii_from_doc.address1,
+        address2: idv_session.pii_from_doc.address2,
+        city: idv_session.pii_from_doc.city,
+        state: idv_session.pii_from_doc.state,
+        zipcode: idv_session.pii_from_doc.zipcode,
       )
     end
 

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -75,7 +75,7 @@ module Idv
     private
 
     def next_url
-      if idv_session.pii_from_doc[:state] == 'PR' && !ssn_presenter.updating_ssn?
+      if idv_session.pii_from_doc.state == 'PR' && !ssn_presenter.updating_ssn?
         idv_address_url
       else
         idv_verify_info_url

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -79,7 +79,9 @@ module Idv
     end
 
     def pii
-      idv_session.pii_from_doc.merge(idv_session.updated_user_address.to_h)
+      idv_session.pii_from_doc.to_h.merge(
+        idv_session.updated_user_address.to_h,
+      ).with_indifferent_access
     end
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -19,7 +19,6 @@ module Idv
       personal_key
       personal_key_acknowledged
       phone_for_mobile_flow
-      pii_from_doc
       previous_phone_step_params
       profile_id
       redo_document_capture
@@ -169,9 +168,25 @@ module Idv
       session[:failed_phone_step_params] ||= []
     end
 
+    def pii_from_doc=(new_pii_from_doc)
+      if new_pii_from_doc.blank?
+        session[:pii_from_doc] = nil
+      else
+        session[:pii_from_doc] = new_pii_from_doc.to_h
+      end
+    end
+
+    def pii_from_doc
+      return nil if session[:pii_from_doc].blank?
+      Pii::StateId.new(**session[:pii_from_doc].slice(*Pii::StateId.members))
+    end
+
     def updated_user_address=(updated_user_address)
-      session[:updated_user_address] = nil if updated_user_address.nil?
-      session[:updated_user_address] = updated_user_address.to_h
+      if updated_user_address.blank?
+        session[:updated_user_address] = nil
+      else
+        session[:updated_user_address] = updated_user_address.to_h
+      end
     end
 
     def updated_user_address
@@ -198,7 +213,7 @@ module Idv
     end
 
     def remote_document_capture_complete?
-      pii_from_doc
+      pii_from_doc.present?
     end
 
     def ipp_document_capture_complete?

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'IdvStepConcern' do
 
     context 'document capture complete' do
       before do
-        idv_session.pii_from_doc = { first_name: 'Susan' }
+        idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
       end
 
       it 'allows the back button and stays on page' do

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Idv::AddressController do
   let(:user) { create(:user) }
 
-  let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.stringify_keys }
+  let(:pii_from_doc) { Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT) }
 
   before do
     stub_sign_in(user)

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Idv::EnterPasswordController, allowed_extra_analytics: [:*] do
     subject.idv_session.welcome_visited = true
     subject.idv_session.idv_consent_given = true
     subject.idv_session.flow_path = 'standard'
-    subject.idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT
+    subject.idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
     subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn]
     subject.idv_session.resolution_successful = true
     subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Idv::LinkSentController do
 
       context 'with pii in idv_session' do
         it 'allows the back button and does not redirect' do
-          subject.idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT
+          subject.idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
           get :show
 
           expect(response).to render_template :show

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Idv::OtpVerificationController,
     subject.idv_session.welcome_visited = true
     subject.idv_session.idv_consent_given = true
     subject.idv_session.flow_path = 'standard'
-    subject.idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT
+    subject.idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
     subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn]
     subject.idv_session.resolution_successful = true
     subject.idv_session.applicant[:phone] = phone

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Idv::PhoneErrorsController,
       subject.idv_session.welcome_visited = true
       subject.idv_session.idv_consent_given = true
       subject.idv_session.flow_path = 'standard'
-      subject.idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT
+      subject.idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
       subject.idv_session.ssn = '123-45-6789'
       subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
       subject.idv_session.resolution_successful = true

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Idv::SsnController do
 
       context 'with a Puerto Rico address and pii_from_doc in idv_session' do
         it 'redirects to address controller after user enters their SSN' do
-          subject.idv_session.pii_from_doc[:state] = 'PR'
+          subject.idv_session.pii_from_doc = subject.idv_session.pii_from_doc.with(state: 'PR')
 
           put :update, params: params
 
@@ -155,7 +155,7 @@ RSpec.describe Idv::SsnController do
 
         it 'redirects to the verify info controller if a user is updating their SSN' do
           subject.idv_session.ssn = ssn
-          subject.idv_session.pii_from_doc[:state] = 'PR'
+          subject.idv_session.pii_from_doc = subject.idv_session.pii_from_doc.with(state: 'PR')
 
           put :update, params: params
 

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -82,14 +82,14 @@ RSpec.describe Idv::VerifyInfoController, allowed_extra_analytics: [:*] do
       render_views
 
       it 'With address2 in PII, shows address line 2 input' do
-        subject.idv_session.pii_from_doc[:address2] = 'APT 3E'
+        subject.idv_session.pii_from_doc = subject.idv_session.pii_from_doc.with(address2: 'APT 3E')
         get :show
 
         expect(response.body).to have_content(t('idv.form.address2'))
       end
 
       it 'No address2 in PII, still shows address line 2 input' do
-        subject.idv_session.pii_from_doc[:address2] = nil
+        subject.idv_session.pii_from_doc = subject.idv_session.pii_from_doc.with(address2: nil)
 
         get :show
 

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Idv::WelcomeController, allowed_extra_analytics: [:*] do
       context 'and verify info already completed' do
         before do
           subject.idv_session.flow_path = 'standard'
-          subject.idv_session.pii_from_doc = { first_name: 'Susan' }
+          subject.idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
           subject.idv_session.ssn = '123-45-6789'
           subject.idv_session.resolution_successful = true
         end

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Idv::FlowPolicy' do
         idv_session.flow_path = 'standard'
         idv_session.phone_for_mobile_flow = '201-555-1212'
 
-        idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT
+        idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
         idv_session.had_barcode_read_failure = true
         idv_session.had_barcode_attention_error = true
 

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -19,9 +19,9 @@ module FlowPolicyHelper
       idv_session.flow_path = 'standard'
     when :link_sent
       idv_session.flow_path = 'hybrid'
-      idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT.dup
+      idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
     when :document_capture
-      idv_session.pii_from_doc = Idp::Constants::MOCK_IDV_APPLICANT.dup
+      idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
     when :ssn
       idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
     when :ipp_ssn


### PR DESCRIPTION
Previous commits added the `Pii::StateId` data class. This is intended to hold the data that is read from the state ID. This has several advantages over the old approach (holding this data in a Hash):

1. It is immutable so it will error if you try to add data not from the state ID
2. It has defined attributes that are all required so you know what data will be present

This commit takes the next step in integrating this tool which is modifying `idv_session#pii_from_doc` to serialize the PII before it is written to the session and then deserialize it into `Pii::StateId` on read.
