### PR TITLE
Remove support for ?biometric_comparison_required

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -63,8 +63,7 @@ module OpenidConnect
     end
 
     def biometric_comparison_requested?
-      @authorize_form.parsed_vector_of_trust&.biometric_comparison? ||
-        params['biometric_comparison_required'] == 'true'
+      @authorize_form.parsed_vector_of_trust&.biometric_comparison?
     end
 
     def check_sp_active

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -23,7 +23,6 @@ class OpenidConnectAuthorizeForm
     :vtr,
     :scope,
     :verified_within,
-    :biometric_comparison_required,
     *SIMPLE_ATTRS,
   ].freeze
 
@@ -66,7 +65,6 @@ class OpenidConnectAuthorizeForm
     @prompt ||= 'select_account'
     @scope = parse_to_values(params[:scope], scopes)
     @unauthorized_scope = check_for_unauthorized_scope(params)
-    @biometric_comparison_required = params[:biometric_comparison_required].to_s == 'true'
 
     if verified_within_allowed?
       @duration_parser = DurationParser.new(params[:verified_within])
@@ -157,7 +155,7 @@ class OpenidConnectAuthorizeForm
                  :ial2_requested?
 
   def biometric_comparison_required?
-    @biometric_comparison_required
+    parsed_vector_of_trust&.biometric_comparison?
   end
 
   def parsed_vector_of_trust

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -36,17 +36,13 @@ class StoreSpMetadataInSession
     @sp_request ||= ServiceProviderRequestProxy.from_uuid(request_id)
   end
 
-  def biometric_comparison_required_value
-    parsed_vot&.biometric_comparison? || sp_request&.biometric_comparison_required
-  end
-
   def update_session
     session[:sp] = {
       issuer: sp_request.issuer,
       request_url: sp_request.url,
       request_id: sp_request.uuid,
       requested_attributes: sp_request.requested_attributes,
-      biometric_comparison_required: biometric_comparison_required_value,
+      biometric_comparison_required: parsed_vot&.biometric_comparison?,
       acr_values: sp_request.acr_values,
       vtr: sp_request.vtr,
     }

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -417,18 +417,18 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               end
 
               context 'selfie check was not performed' do
-                it 'redirects to have the user verify their account' do
+                it 'does not redirect to have the user verify their account' do
                   action
-                  expect(controller).to redirect_to(idv_url)
+                  expect(controller).not_to redirect_to(idv_url)
                 end
               end
 
               context 'selfie capture not enabled, biometric_comparison_required requested by sp' do
                 let(:selfie_capture_enabled) { false }
-                it 'returns status not_acceptable' do
+                it 'does not returnstatus not_acceptable' do
                   action
 
-                  expect(response.status).to eq(406)
+                  expect(response.status).not_to eq(406)
                 end
               end
 
@@ -551,12 +551,12 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                   params[:biometric_comparison_required] = 'true'
                 end
 
-                it 'redirects to gpo enter code page' do
+                it 'does not redirect to gpo enter code page' do
                   create(:profile, :verify_by_mail_pending, idv_level: :unsupervised_with_selfie, user: user)
 
                   action
 
-                  expect(controller).to redirect_to(idv_verify_by_mail_enter_code_url)
+                  expect(controller).not_to redirect_to(idv_verify_by_mail_enter_code_url)
                 end
               end
 
@@ -1325,8 +1325,8 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             context 'because the environment is not set to "prod"' do
               let(:env) { 'test' }
 
-              it 'sets the session :biometric_comparison_required value to true' do
-                expect(session[:sp][:biometric_comparison_required]).to eq(true)
+              it 'does not set the session :biometric_comparison_required value to true' do
+                expect(session[:sp][:biometric_comparison_required]).not_to be_truthy
               end
             end
           end
@@ -1337,12 +1337,12 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
           context 'in production' do
             let(:env) { 'prod' }
 
-            it 'does not set the :sp value' do
-              expect(session).not_to include(:sp)
+            it 'sets the :sp value' do
+              expect(session).to include(:sp)
             end
 
-            it 'renders the unacceptable page' do
-              expect(controller).to render_template('pages/not_acceptable')
+            it 'does not render the unacceptable page' do
+              expect(controller).not_to render_template('pages/not_acceptable')
             end
           end
         end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -389,60 +389,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               expect(sp_return_log.ial).to eq(2)
             end
 
-            context 'SP requests biometric_comparison_required' do
-              let(:selfie_capture_enabled) { true }
-              let(:biometric_comparison_required) { 'true' }
-
-              before do
-                params[:biometric_comparison_required] = biometric_comparison_required.to_s
-                expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
-                  and_return(selfie_capture_enabled)
-                allow(IdentityConfig.store).to receive(:openid_connect_redirect).
-                  and_return('server_side')
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
-                user.identities.last.update!(
-                  verified_attributes: %w[given_name family_name birthdate verified_at],
-                )
-                allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
-              end
-
-              context 'selfie check was performed' do
-                it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
-                  user.active_profile.idv_level = :unsupervised_with_selfie
-
-                  action
-
-                  expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
-                end
-              end
-
-              context 'selfie check was not performed' do
-                it 'does not redirect to have the user verify their account' do
-                  action
-                  expect(controller).not_to redirect_to(idv_url)
-                end
-              end
-
-              context 'selfie capture not enabled, biometric_comparison_required requested by sp' do
-                let(:selfie_capture_enabled) { false }
-                it 'does not returnstatus not_acceptable' do
-                  action
-
-                  expect(response.status).not_to eq(406)
-                end
-              end
-
-              context 'selfie capture not enabled, biometric_comparison_required param is false' do
-                let(:selfie_capture_enabled) { false }
-                let(:biometric_comparison_required) { 'false' }
-
-                it 'redirects to the service provider' do
-                  action
-                  expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
-                end
-              end
-            end
-
             context 'SP has a vector of trust that includes a biometric comparison' do
               let(:selfie_capture_enabled) { true }
               before do
@@ -544,34 +490,15 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               before do
                 expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
                   and_return(selfie_capture_enabled)
+                params[:vtr] = ['C1.C2.P1.Pb'].to_json
               end
 
-              context 'with biometric_comparison_required param' do
-                before do
-                  params[:biometric_comparison_required] = 'true'
-                end
+              it 'redirects to gpo enter code page' do
+                create(:profile, :verify_by_mail_pending, idv_level: :unsupervised_with_selfie, user: user)
 
-                it 'does not redirect to gpo enter code page' do
-                  create(:profile, :verify_by_mail_pending, idv_level: :unsupervised_with_selfie, user: user)
+                action
 
-                  action
-
-                  expect(controller).not_to redirect_to(idv_verify_by_mail_enter_code_url)
-                end
-              end
-
-              context 'with vectors of trust' do
-                before do
-                  params[:vtr] = ['C1.C2.P1.Pb'].to_json
-                end
-
-                it 'redirects to gpo enter code page' do
-                  create(:profile, :verify_by_mail_pending, idv_level: :unsupervised_with_selfie, user: user)
-
-                  action
-
-                  expect(controller).to redirect_to(idv_verify_by_mail_enter_code_url)
-                end
+                expect(controller).to redirect_to(idv_verify_by_mail_enter_code_url)
               end
             end
           end
@@ -1307,70 +1234,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
           biometric_comparison_required: false,
           vtr: nil,
         )
-      end
-
-      describe 'handling the :biometric_comparison_required parameter' do
-        before do
-          allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
-          allow(Identity::Hostdata).to receive(:env).and_return(env)
-        end
-
-        context 'when the param value :biometric_comparison_required is "true"' do
-          before do
-            params[:biometric_comparison_required] = 'true'
-            action
-          end
-
-          context 'and we are not in production' do
-            context 'because the environment is not set to "prod"' do
-              let(:env) { 'test' }
-
-              it 'does not set the session :biometric_comparison_required value to true' do
-                expect(session[:sp][:biometric_comparison_required]).not_to be_truthy
-              end
-            end
-          end
-
-          # Temporary barrier to public presentation. Update or remove
-          # when we are ready to accept :biometric_comparison_required
-          # in production. See LG-11962.
-          context 'in production' do
-            let(:env) { 'prod' }
-
-            it 'sets the :sp value' do
-              expect(session).to include(:sp)
-            end
-
-            it 'does not render the unacceptable page' do
-              expect(controller).not_to render_template('pages/not_acceptable')
-            end
-          end
-        end
-
-        context 'when the param value :biometric_comparison_required is not set' do
-          before do
-            # Should be a no-op, but let's be paranoid.
-            params.delete(:biometric_comparison_required)
-
-            action
-          end
-
-          context 'in production' do
-            let(:env) { 'prod' }
-
-            it 'sets the session :biometric_comparison_required value to false' do
-              expect(session[:sp][:biometric_comparison_required]).to eq(false)
-            end
-          end
-
-          context 'not in production' do
-            let(:env) { 'test' }
-
-            it 'sets the session :biometric_comparison_required value to false' do
-              expect(session[:sp][:biometric_comparison_required]).to eq(false)
-            end
-          end
-        end
       end
     end
   end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -211,7 +211,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
     before do
       expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
         and_return(selfie_check_enabled)
-      complete_doc_auth_steps_before_document_capture_step
+      allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
     end
 
     context 'when a selfie is not requested by SP' do
@@ -243,12 +243,6 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
     end
 
     context 'when a selfie is required by the SP' do
-      before do
-        allow_any_instance_of(FederatedProtocols::Oidc).
-          to receive(:biometric_comparison_required?).
-          and_return(true)
-      end
-
       context 'on mobile platform', allow_browser_log: true do
         before do
           # mock mobile device as cameraCapable, this allows us to process
@@ -293,10 +287,6 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
         context 'selfie with error is uploaded' do
           before do
             allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(99)
-
-            allow_any_instance_of(FederatedProtocols::Oidc).
-              to receive(:biometric_comparison_required?).
-              and_return(true)
             perform_in_browser(:mobile) do
               visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
               sign_in_and_2fa_user(@user)
@@ -751,7 +741,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
         end
         context 'with Attention with Barcode' do
           it 'try again and page show selfie fail inline error message' do
-            visit_idp_from_oidc_sp_with_ial2
+            visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
             sign_in_and_2fa_user(@user)
             complete_doc_auth_steps_before_document_capture_step
             attach_images(

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -244,10 +244,9 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
           and_return(true)
-        allow_any_instance_of(FederatedProtocols::Oidc).
-          to receive(:biometric_comparison_required?).and_return(true)
+        allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
         allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:fail)
-        start_idv_from_sp
+        start_idv_from_sp(biometric_comparison_required: true)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_success_face_match_fail
@@ -269,10 +268,9 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
           and_return(true)
-        allow_any_instance_of(FederatedProtocols::Oidc).
-          to receive(:biometric_comparison_required?).and_return(true)
+        allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
 
-        start_idv_from_sp
+        start_idv_from_sp(biometric_comparison_required: true)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_success_face_match_fail
@@ -318,10 +316,9 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
           and_return(true)
-        allow_any_instance_of(FederatedProtocols::Oidc).
-          to receive(:biometric_comparison_required?).and_return(true)
+        allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
 
-        start_idv_from_sp
+        start_idv_from_sp(biometric_comparison_required: true)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_failure_face_match_pass
@@ -366,10 +363,9 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
           and_return(true)
-        allow_any_instance_of(FederatedProtocols::Oidc).
-          to receive(:biometric_comparison_required?).and_return(true)
+        allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
         allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:fail)
-        start_idv_from_sp
+        start_idv_from_sp(biometric_comparison_required: true)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_success_face_match_fail
@@ -387,13 +383,12 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).
           and_return(true)
-        allow_any_instance_of(FederatedProtocols::Oidc).
-          to receive(:biometric_comparison_required?).and_return(true)
+        allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
         pii = Idp::Constants::MOCK_IDV_APPLICANT.dup
         pii[:address1] = nil
         allow_any_instance_of(DocAuth::LexisNexis::Responses::TrueIdResponse).
           to receive(:pii_from_doc).and_return(Pii::StateId.new(**pii))
-        start_idv_from_sp
+        start_idv_from_sp(biometric_comparison_required: true)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_pass_face_match_pass_no_address1

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
 
   before do
     allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
+    allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
   end
 
   before do
@@ -336,12 +337,11 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
 
   it 'prefills the phone number used on the phone step if the user has no MFA phone', :js do
     expect(FeatureManagement).to receive(:idv_allow_selfie_check?).at_least(:once).and_return(true)
-    allow_any_instance_of(FederatedProtocols::Oidc).
-      to receive(:biometric_comparison_required?).and_return(true)
+
     user = create(:user, :with_authentication_app)
 
     perform_in_browser(:desktop) do
-      start_idv_from_sp
+      start_idv_from_sp(biometric_comparison_required: true)
       sign_in_and_2fa_user(user)
 
       complete_doc_auth_steps_before_hybrid_handoff_step

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -130,6 +130,7 @@ RSpec.feature 'OIDC Authorization Confirmation', allowed_extra_analytics: [:*] d
   context 'when asked for selfie verification in production' do
     before do
       allow(Rails.env).to receive(:production?).and_return(true)
+      allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
       visit visit_idp_from_ial2_oidc_sp(biometric_comparison_required: true)
     end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -864,4 +864,28 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
   end
+
+  describe '#biometric_comparison_required?' do
+    it 'returns false by default' do
+      expect(subject.biometric_comparison_required?).to eql(false)
+    end
+
+    context 'biometric requested via VTR' do
+      let(:acr_values) { nil }
+      let(:vtr) { ['C1.P1.Pb'].to_json }
+
+      it 'returns true' do
+        expect(subject.biometric_comparison_required?).to eql(true)
+      end
+    end
+
+    context 'VTR used but biometric not requested' do
+      let(:acr_values) { nil }
+      let(:vtr) { ['C1.P1'].to_json }
+
+      it 'returns false' do
+        expect(subject.biometric_comparison_required?).to eql(false)
+      end
+    end
+  end
 end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
       code_challenge: code_challenge,
       code_challenge_method: code_challenge_method,
       verified_within: verified_within,
-      biometric_comparison_required: biometric_comparison_required,
     )
   end
 
@@ -31,7 +30,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
   let(:code_challenge) { nil }
   let(:code_challenge_method) { nil }
   let(:verified_within) { nil }
-  let(:biometric_comparison_required) { nil }
 
   before do
     allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -96,28 +96,6 @@ RSpec.describe StoreSpMetadataInSession do
         end
       end
 
-      context 'when biometric comparison is requested with ACRs' do
-        let(:request_acr) do
-          [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-           Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF].join(' ')
-        end
-        let(:biometric_comparison_required) { true }
-
-        it 'sets the session[:sp] hash correctly' do
-          expect(app_session[:sp]).to eq(
-            {
-              issuer: issuer,
-              acr_values: request_acr,
-              request_url: request_url,
-              request_id: request_id,
-              requested_attributes: requested_attributes,
-              biometric_comparison_required: false,
-              vtr: request_vtr,
-            },
-          )
-        end
-      end
-
       context 'when MFA is requested using a VTR' do
         let(:request_vtr) { ['C1'] }
 

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -22,13 +22,11 @@ RSpec.describe StoreSpMetadataInSession do
       let(:requested_attributes) { %w[email] }
       let(:request_acr) { nil }
       let(:request_vtr) { nil }
-      let(:biometric_comparison_required) { false }
       let(:sp_request) do
         ServiceProviderRequestProxy.find_or_create_by(uuid: request_id) do |sp_request|
           sp_request.issuer = issuer
           sp_request.url = request_url
           sp_request.requested_attributes = requested_attributes
-          sp_request.biometric_comparison_required = biometric_comparison_required
           sp_request.acr_values = request_acr
           sp_request.vtr = request_vtr
         end
@@ -113,7 +111,7 @@ RSpec.describe StoreSpMetadataInSession do
               request_url: request_url,
               request_id: request_id,
               requested_attributes: requested_attributes,
-              biometric_comparison_required: true,
+              biometric_comparison_required: false,
               vtr: request_vtr,
             },
           )

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -144,18 +144,24 @@ module IdvHelper
     verified_within: nil,
     biometric_comparison_required: nil
   )
-    visit openid_connect_authorize_path(
-      client_id: client_id,
+    params = {
+      client_id:,
       response_type: 'code',
-      acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
       scope: 'openid email profile:name phone social_security_number',
       redirect_uri: sp_oidc_redirect_uri,
-      state: state,
+      state:,
       prompt: 'select_account',
-      nonce: nonce,
-      verified_within: verified_within,
-      biometric_comparison_required: biometric_comparison_required,
-    )
+      nonce:,
+      verified_within:,
+    }
+
+    if biometric_comparison_required
+      params[:vtr] = ['C1.P1.Pb'].to_json
+    else
+      params[:acr_values] = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+    end
+
+    visit openid_connect_authorize_path(params)
   end
 
   def visit_idp_from_oidc_sp_with_loa3

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -13,9 +13,9 @@ module IdvStepHelper
     end
   end
 
-  def start_idv_from_sp(sp = :oidc)
+  def start_idv_from_sp(sp = :oidc, biometric_comparison_required: nil)
     if sp.present?
-      visit_idp_from_sp_with_ial2(sp)
+      visit_idp_from_sp_with_ial2(sp, biometric_comparison_required:)
     else
       visit root_path
     end

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -92,16 +92,19 @@ module OidcAuthHelper
     ial2_params = {
       client_id: client_id,
       response_type: 'code',
-      acr_values: acr_values,
       scope: 'openid email profile:name social_security_number',
       redirect_uri: 'http://localhost:7654/auth/result',
       state: state,
       nonce: nonce,
     }
     ial2_params[:prompt] = prompt if prompt
+
     if biometric_comparison_required
-      ial2_params[:biometric_comparison_required] = 'true'
+      ial2_params[:vtr] = ['C1.P1.Pb'].to_json
+    else
+      ial2_params[:acr_values] = acr_values
     end
+
     ial2_params
   end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-12576](https://cm-jira.usa.gov/browse/LG-12576)

## 🛠 Summary of changes

Removes support for passing `?biometric_comparison_required=1` in the OIDC flow in favor of using a vector of trust including `Pb`.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
