### PR TITLE
Remove Lint Exceptions: Name the Component Returned from with-props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -114,12 +114,6 @@
       }
     },
     {
-      "files": ["app/javascript/packages/document-capture/higher-order/with-props.jsx"],
-      "rules": {
-        "react/display-name": "off"
-      }
-    },
-    {
       "files": [
         "app/javascript/packages/form-steps/form-steps.spec.tsx",
         "spec/javascript/spec_helper.js"

--- a/app/javascript/packages/document-capture/higher-order/with-props.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-props.jsx
@@ -1,5 +1,0 @@
-function withProps(boundProps) {
-  return (Component) => (props) => <Component {...boundProps} {...props} />;
-}
-
-export default withProps;

--- a/app/javascript/packages/document-capture/higher-order/with-props.tsx
+++ b/app/javascript/packages/document-capture/higher-order/with-props.tsx
@@ -1,3 +1,7 @@
+function getDisplayName(ComponentWithBoundProps) {
+  return ComponentWithBoundProps.displayName || ComponentWithBoundProps.name || 'Component';
+}
+
 // withProps returns a function that accepts a JSX component and binds
 // some new props to that JSX component, then returns it.
 function withProps(boundProps) {
@@ -5,6 +9,7 @@ function withProps(boundProps) {
     function ComponentWithBoundProps(props) {
       return <Component {...boundProps} {...props} />;
     }
+    ComponentWithBoundProps.displayName = getDisplayName(Component);
     return ComponentWithBoundProps;
   }
   return (Component) => bindProps(Component);

--- a/app/javascript/packages/document-capture/higher-order/with-props.tsx
+++ b/app/javascript/packages/document-capture/higher-order/with-props.tsx
@@ -1,7 +1,3 @@
-function getDisplayName(ComponentWithBoundProps) {
-  return ComponentWithBoundProps.displayName || ComponentWithBoundProps.name || 'Component';
-}
-
 // withProps returns a function that accepts a JSX component and binds
 // some new props to that JSX component, then returns it.
 function withProps(boundProps) {
@@ -9,7 +5,7 @@ function withProps(boundProps) {
     function ComponentWithBoundProps(props) {
       return <Component {...boundProps} {...props} />;
     }
-    ComponentWithBoundProps.displayName = getDisplayName(Component);
+    ComponentWithBoundProps.displayName = Component.displayName;
     return ComponentWithBoundProps;
   }
   return (Component) => bindProps(Component);

--- a/app/javascript/packages/document-capture/higher-order/with-props.tsx
+++ b/app/javascript/packages/document-capture/higher-order/with-props.tsx
@@ -1,0 +1,13 @@
+// withProps returns a function that accepts a JSX component and binds
+// some new props to that JSX component, then returns it.
+function withProps(boundProps) {
+  function bindProps(Component) {
+    function ComponentWithBoundProps(props) {
+      return <Component {...boundProps} {...props} />;
+    }
+    return ComponentWithBoundProps;
+  }
+  return (Component) => bindProps(Component);
+}
+
+export default withProps;

--- a/spec/javascript/packages/document-capture/higher-order/with-props-spec.jsx
+++ b/spec/javascript/packages/document-capture/higher-order/with-props-spec.jsx
@@ -12,5 +12,13 @@ describe('document-capture/higher-order/with-props', () => {
 
       expect(getByText('test2')).to.be.ok();
     });
+    it('has a WithProps(Component) displayName', () => {
+      const TestComponent = ({ test = 'test' }) => test;
+      const displayName = `WithProps(TestComponentName)`;
+      TestComponent.displayName = displayName;
+      const WithPropComponent = withProps({ test: 'testProp' })(TestComponent);
+
+      expect(WithPropComponent.displayName).to.equal(displayName);
+    });
   });
 });


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->


## 🛠 Summary of changes

This removes a lint exception by reworking the with-props function to name the component it returns. I think the code change is of dubious value, but the idea behind this react rule is that it makes sure there aren't any anonymous components, so that might be worth it down the line.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
