### PR TITLE
Fix Pinpoint Maintenance Script

### DIFF
--- a/lib/pinpoint_supported_countries.rb
+++ b/lib/pinpoint_supported_countries.rb
@@ -196,7 +196,7 @@ class PinpointSupportedCountries
       table = doc.xpath('//table').first
 
       headings = []
-      table.xpath('//thead/tr').each do |row|
+      table.xpath('thead/tr').each do |row|
         row.xpath('th').each do |cell|
           headings << cell.text
         end


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where we get an error running `make lint_country_dialing_codes`. It looks like the `Sender ID support` section was updated to be a table, and our xpath query was a little too permissive and was getting the columns for all tables.

Stacktrace:

```
/builds/lg/identity-idp/lib/pinpoint_supported_countries.rb:116:in `block in load_country_dialing_codes': no phone_data for '', maybe it needs to be remapped? (RuntimeError)
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
