### PR TITLE
Update browser gem to 6.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     brakeman (6.1.0)
-    browser (5.3.1)
+    browser (6.0.0)
     builder (3.2.4)
     bullet (7.1.4)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `browser` gem to v6.0.0.

This adds support for a `chromium_based?` method which could be useful for our browser support detection. I requested this via https://github.com/fnando/browser/issues/541 with the intention of using it, though I can't recall exactly what I had planned to use it for.

Regardless, there seems to be some nice potential performance optimizations here that we could take advantage of in the meantime.

Notable code improvements are:

- [Using `instance_of?` vs. creating new instances when detecting browsers](https://my.diffend.io/gems/browser/5.3.1/6.0.0#d2h-913577)
- [Short-circuit return of relevant matcher in initialization](https://my.diffend.io/gems/browser/5.3.1/6.0.0#d2h-251020)

## 📜 Testing Plan

Build should pass.