### PR TITLE
Refactor reCAPTCHA validator as form model

### DIFF
--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -130,12 +130,9 @@ class NewPhoneForm
   end
 
   def validate_recaptcha_token
-    return if !validate_recaptcha_token? || recaptcha_validator.valid?(recaptcha_token)
-    errors.add(
-      :recaptcha_token,
-      I18n.t('errors.messages.invalid_recaptcha_token'),
-      type: :invalid_recaptcha_token,
-    )
+    return if !validate_recaptcha_token?
+    recaptcha_validator.submit(recaptcha_token)
+    errors.merge!(recaptcha_validator)
   end
 
   def recaptcha_validator

--- a/app/services/phone_recaptcha_validator.rb
+++ b/app/services/phone_recaptcha_validator.rb
@@ -5,7 +5,7 @@ class PhoneRecaptchaValidator
 
   attr_reader :parsed_phone, :validator_class, :validator_args
 
-  delegate :valid?, :exempt?, to: :validator
+  delegate :submit, :errors, to: :validator
 
   def initialize(parsed_phone:, validator_class: RecaptchaValidator, **validator_args)
     @parsed_phone = parsed_phone

--- a/app/services/recaptcha_enterprise_validator.rb
+++ b/app/services/recaptcha_enterprise_validator.rb
@@ -16,7 +16,7 @@ class RecaptchaEnterpriseValidator < RecaptchaValidator
     )
   end
 
-  def recaptcha_result(recaptcha_token)
+  def recaptcha_result
     response = faraday.post(
       assessment_url,
       {

--- a/app/services/recaptcha_mock_validator.rb
+++ b/app/services/recaptcha_mock_validator.rb
@@ -10,7 +10,7 @@ class RecaptchaMockValidator < RecaptchaValidator
 
   private
 
-  def recaptcha_result(_recaptcha_token)
+  def recaptcha_result
     RecaptchaResult.new(success: true, score:)
   end
 end

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe NewPhoneForm do
     end
 
     context 'with recaptcha enabled' do
-      let(:valid) { nil }
+      let(:errors) { ActiveModel::Errors.new(RecaptchaValidator.new) }
       let(:validator) { PhoneRecaptchaValidator.new(parsed_phone: nil) }
       let(:recaptcha_token) { 'token' }
       let(:phone) { '3065550100' }
@@ -385,13 +385,12 @@ RSpec.describe NewPhoneForm do
 
       before do
         allow(FeatureManagement).to receive(:phone_recaptcha_enabled?).and_return(true)
-        allow(validator).to receive(:valid?).with(recaptcha_token).and_return(valid)
+        allow(validator).to receive(:submit).with(recaptcha_token)
+        allow(validator).to receive(:errors).and_return(errors)
         allow(form).to receive(:recaptcha_validator).and_return(validator)
       end
 
       context 'with valid recaptcha result' do
-        let(:valid) { true }
-
         it 'is valid' do
           expect(result.success?).to eq(true)
           expect(result.errors).to be_blank
@@ -417,7 +416,9 @@ RSpec.describe NewPhoneForm do
       end
 
       context 'with invalid recaptcha result' do
-        let(:valid) { false }
+        before do
+          errors.add(:recaptcha_token, :fail, message: 'fail')
+        end
 
         it 'is invalid' do
           expect(result.success?).to eq(false)

--- a/spec/services/phone_recaptcha_validator_spec.rb
+++ b/spec/services/phone_recaptcha_validator_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe PhoneRecaptchaValidator do
   end
 
   it 'passes instance variables to validator' do
-    recaptcha_validator = instance_double(RecaptchaValidator, valid?: true)
+    recaptcha_validator = instance_double(
+      RecaptchaValidator,
+      submit: FormResponse.new(success: true),
+    )
     expect(RecaptchaValidator).to receive(:new).
       with(
         score_threshold: score_threshold_config,
@@ -26,7 +29,7 @@ RSpec.describe PhoneRecaptchaValidator do
       ).
       and_return(recaptcha_validator)
 
-    validator.valid?('token')
+    validator.submit('token')
   end
 
   context 'with custom recaptcha validator class' do
@@ -39,31 +42,37 @@ RSpec.describe PhoneRecaptchaValidator do
     end
 
     it 'delegates to validator instance of the given class' do
-      recaptcha_validator = instance_double(RecaptchaMockValidator, valid?: true)
+      recaptcha_validator = instance_double(
+        RecaptchaValidator,
+        submit: FormResponse.new(success: true),
+      )
       expect(RecaptchaMockValidator).to receive(:new).and_return(recaptcha_validator)
-      expect(recaptcha_validator).to receive(:valid?)
+      expect(recaptcha_validator).to receive(:submit)
 
-      validator.valid?('token')
+      validator.submit('token')
     end
   end
 
-  describe '#valid?' do
+  describe '#submit' do
     it 'is delegated to recaptcha validator' do
-      recaptcha_validator = instance_double(RecaptchaValidator, valid?: true)
+      recaptcha_validator = instance_double(
+        RecaptchaValidator,
+        submit: FormResponse.new(success: true),
+      )
       expect(validator).to receive(:validator).and_return(recaptcha_validator)
-      expect(recaptcha_validator).to receive(:valid?)
+      expect(recaptcha_validator).to receive(:submit)
 
-      validator.valid?('token')
+      validator.submit('token')
     end
   end
 
-  describe '#exempt?' do
+  describe '#errors' do
     it 'is delegated to recaptcha validator' do
-      recaptcha_validator = instance_double(RecaptchaValidator, exempt?: true)
+      recaptcha_validator = instance_double(RecaptchaValidator, errors: ActiveModel::Errors.new({}))
       expect(validator).to receive(:validator).and_return(recaptcha_validator)
-      expect(recaptcha_validator).to receive(:exempt?)
+      expect(recaptcha_validator).to receive(:errors)
 
-      validator.exempt?
+      validator.errors
     end
   end
 

--- a/spec/services/recaptcha_mock_validator_spec.rb
+++ b/spec/services/recaptcha_mock_validator_spec.rb
@@ -12,17 +12,22 @@ RSpec.describe RecaptchaMockValidator do
     freeze_time { example.run }
   end
 
-  describe '#valid?' do
+  describe '#submit' do
     let(:token) { 'token' }
-    subject(:valid) { validator.valid?(token) }
+    subject(:response) { validator.submit(token) }
 
     context 'with failing score from validation service' do
       let(:score) { score_threshold - 0.1 }
 
-      it { expect(valid).to eq(false) }
+      it 'is unsuccessful with error for invalid token' do
+        expect(response.to_h).to eq(
+          success: false,
+          error_details: { recaptcha_token: { invalid: true } },
+        )
+      end
 
       it 'logs analytics of the body' do
-        valid
+        response
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
@@ -43,10 +48,12 @@ RSpec.describe RecaptchaMockValidator do
       let(:token) { 'token' }
       let(:score) { score_threshold + 0.1 }
 
-      it { expect(valid).to eq(true) }
+      it 'is successful' do
+        expect(response.to_h).to eq(success: true)
+      end
 
       it 'logs analytics of the body' do
-        valid
+        response
 
         expect(analytics).to have_logged_event(
           'reCAPTCHA verify result received',
@@ -66,7 +73,7 @@ RSpec.describe RecaptchaMockValidator do
         let(:analytics) { nil }
 
         it 'validates gracefully without analytics logging' do
-          valid
+          response
         end
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-12873](https://cm-jira.usa.gov/browse/LG-12873)

## 🛠 Summary of changes

Refactors reCAPTCHA validator classes to behave and validate as a [form class](https://github.com/18F/identity-idp/blob/main/docs/backend.md#forms-formresponse-analytics-and-controllers).

See previous discussion: https://github.com/18F/identity-idp/pull/10522#discussion_r1583611284

## 📜 Testing Plan

Validate that there are no regressions in the expected behavior of reCAPTCHA phone validation.

Configure reCAPTCHA score threshold in `config/application.yml`

```yml
phone_recaptcha_score_threshold: 0.5
```

1. Go to http://localhost:3000
2. Create an account
3. When prompted to select MFA, choose phone
4. Enter an international phone number, e.g. `+610491570006`
5. In the reCAPTCHA score debugger tool, enter a value between 0.0 and 1.0
6. Click "Send code"
7. Observe that you are blocked if the score you entered was less than 0.5