### PR TITLE
Configure reCAPTCHA score threshold for local development

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -417,6 +417,7 @@ development:
   newrelic_license_key: ''
   otp_delivery_blocklist_findtime: 5
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
+  phone_recaptcha_score_threshold: 0.5
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   push_notifications_enabled: true
   rails_mailer_previews_enabled: true


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a default score threshold for reCAPTCHA assessments in local development, to avoid having to require reviewers to specify this manually in `application.yml` in order to test related work (e.g. see Testing Plan in #10540).

## 📜 Testing Plan

1. Go to http://localhost:3000/
2. Create an account
3. When prompted to select MFA, choose phone
4. Enter an international phone number, e.g. +610491570006
5. In the reCAPTCHA score debugger tool, enter a value between 0.0 and 1.0
6. Click "Send code"
7. Observe that you are blocked if the score you entered was less than 0.5