### PR TITLE
Drop unused bounced_at column from GpoConfirmationCode

### DIFF
--- a/app/models/gpo_confirmation_code.rb
+++ b/app/models/gpo_confirmation_code.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class GpoConfirmationCode < ApplicationRecord
-  self.ignored_columns = [:bounced_at]
-
   self.table_name = 'usps_confirmation_codes'
 
   belongs_to :profile

--- a/db/primary_migrate/20240502192930_drop_bounced_at_column_from_usps_confirmation_code.rb
+++ b/db/primary_migrate/20240502192930_drop_bounced_at_column_from_usps_confirmation_code.rb
@@ -1,0 +1,7 @@
+class DropBouncedAtColumnFromUspsConfirmationCode < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :usps_confirmation_codes, :bounced_at, :datetime, precision: nil
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_16_165602) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_02_192930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -627,7 +627,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_16_165602) do
     t.datetime "code_sent_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.datetime "bounced_at", precision: nil
     t.datetime "reminder_sent_at", precision: nil
     t.index ["otp_fingerprint"], name: "index_usps_confirmation_codes_on_otp_fingerprint"
     t.index ["profile_id"], name: "index_usps_confirmation_codes_on_profile_id"


### PR DESCRIPTION
## 🛠 Summary of changes

Drops the `bounced_at` column from the `usps_confirmation_codes` (`GpoConfirmationCode`) table.

Follow-up to #6775, which ignored the column, but it was never removed.

## 📜 Testing Plan

Verify build passes.

Verify migration applies cleanly:

```
rails db:migrate:primary
```