### PR TITLE
LG-13106: Post-LQA Content Error Fix | Step-up user GS in Spanish

### DIFF
--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -245,7 +245,8 @@ es:
         too_many_faces: Demasiados rostros
       ssn: Necesitamos su número de Seguro Social para verificar su nombre, fecha de
         nacimiento y dirección.
-      stepping_up_html: Verifique su identidad de nuevo para acceder a este servicio. %{link_html}
+      stepping_up_html: Verifique su identidad de nuevo para acceder a este servicio.
+        %{link_html}
       tag: Recomendado
       upload_from_computer: '¿No tiene un teléfono? Cargue fotos de su identificación
         desde esta computadora.'

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -245,7 +245,7 @@ es:
         too_many_faces: Demasiados rostros
       ssn: Necesitamos su número de Seguro Social para verificar su nombre, fecha de
         nacimiento y dirección.
-      stepping_up_html: Verifica su identidad de nuevo para acceder a este servicio. %{link_html}
+      stepping_up_html: Verifique su identidad de nuevo para acceder a este servicio. %{link_html}
       tag: Recomendado
       upload_from_computer: '¿No tiene un teléfono? Cargue fotos de su identificación
         desde esta computadora.'


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13106](https://cm-jira.usa.gov/browse/LG-13106)

## 🛠 Summary of changes

Fixing one word in the translation.

## 📜 Testing Plan

In your local testing environment, add the following to your `application.yml`:
```
  doc_auth_selfie_capture_enabled: true
  proofing_device_profiling: enabled
```
then restart your server and do the following:

- [ ] Go to `/test/oidc/login`
- [ ] Click on [Sign in with IAL2](http://localhost:3000/test/oidc/auth_request?ial=2)
- [ ] Create an account and go through IdV
- [ ] Go to `/test/oidc/login`
- [ ] Click on [Sign in with Biometric](http://localhost:3000/test/oidc/auth_request?ial=biometric-comparison-required)
- [ ] Confirm that you are on the `/verify/welcome` page
- [ ] Change the language to Spanish
- [ ] Confirm that the first word in the top paragraph is `Verifique`

## 👀 Screenshots

The resulting screen:
<img width="775" alt="Screen Shot 2024-05-03 at 14 02 38" src="https://github.com/18F/identity-idp/assets/2583060/37077113-f613-4187-8ea7-1f97f28fa17a">

