### PR TITLE
Remove unused method verification_method_choice

### DIFF
--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -9,10 +9,6 @@ class NullServiceProviderSession
     I18n.t('headings.sign_in_without_sp')
   end
 
-  def verification_method_choice
-    I18n.t('idv.messages.select_verification_without_sp')
-  end
-
   def cancel_link_url
     view_context.root_url
   end

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -52,10 +52,6 @@ class ServiceProviderSession
     I18n.t('headings.sign_in_with_sp', sp: sp_name)
   end
 
-  def verification_method_choice
-    I18n.t('idv.messages.select_verification_with_sp', sp_name: sp_name)
-  end
-
   def requested_attributes
     (sp_session[:requested_attributes] || service_provider_request.requested_attributes).sort
   end

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -259,10 +259,6 @@ en:
           - Based in the United States (including U.S. territories)
           - Your primary number (the one you use the most often)
       return_to_profile: '‹ Return to your %{app_name} profile'
-      select_verification_with_sp: To protect you from identity fraud, we will contact
-        you to confirm that this %{sp_name} account is legitimate.
-      select_verification_without_sp: To protect you from identity fraud, we will
-        contact you to confirm that this account is legitimate.
       sessions:
         enter_password_message: When you re-enter your password, %{app_name} will
           protect the information you’ve given us, so that only you can access

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -272,11 +272,6 @@ es:
           - Con base en Estados Unidos (incluidos los territorios de EE.UU.)
           - Su número principal (el que utiliza con más frecuencia)
       return_to_profile: '‹ Vuelva a su perfil de %{app_name}'
-      select_verification_with_sp: Para protegerle contra el fraude de identidad,
-        contactaremos con usted para confirmar que esta cuenta de %{sp_name} es
-        legítima.
-      select_verification_without_sp: Para protegerle contra el fraude de identidad,
-        contactaremos con usted para confirmar que esta cuenta es legítima.
       sessions:
         enter_password_message: Cuando vuelva a ingresar su contraseña, %{app_name}
           protegerá la información que nos dio, para que solo usted pueda

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -283,12 +283,6 @@ fr:
           - Basé aux Etats-Unis (y compris les territoires américains)
           - Votre numéro principal (celui que vous utilisez le plus souvent)
       return_to_profile: '‹ Revenir à votre profil %{app_name}'
-      select_verification_with_sp: Afin de vous protéger contre l’usurpation
-        d’identité, nous vous contacterons pour confirmer que ce compte
-        %{sp_name} est légitime.
-      select_verification_without_sp: Afin de vous protéger contre l’usurpation
-        d’identité, nous vous contacterons pour confirmer que ce compte est
-        légitime.
       sessions:
         enter_password_message: Lorsque vous ressaisirez votre mot de passe, %{app_name}
           protégera les informations que vous nous aurez données pour que vous

--- a/config/locales/idv/zh.yml
+++ b/config/locales/idv/zh.yml
@@ -211,8 +211,6 @@ zh:
           - 美国的（包括美国属地）
           - 你的主要号码（你最常用的）
       return_to_profile: '‹ 返回你的 %{app_name} 用户资料'
-      select_verification_with_sp: 为了保护你不受身份欺诈，我们会联系你确认该 %{sp_name} 账户是真实的。
-      select_verification_without_sp: 为了保护你不受身份欺诈，我们会联系你确认该账户是真实的。
       sessions:
         enter_password_message: 你重新输入密码时， %{app_name} 会保护你给我们的信息，这样只有你能访问这些信息。
         no_pii: 测试站点 - 请勿使用真实个人信息（仅为演示目的） - 测试站点

--- a/spec/decorators/null_service_provider_session_spec.rb
+++ b/spec/decorators/null_service_provider_session_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe NullServiceProviderSession do
     end
   end
 
-  describe '#verification_method_choice' do
-    it 'returns the correct string' do
-      expect(subject.verification_method_choice).to eq(
-        I18n.t('idv.messages.select_verification_without_sp'),
-      )
-    end
-  end
-
   describe '#sp_logo' do
     it 'returns nil' do
       expect(subject.sp_logo).to be_nil

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -35,14 +35,6 @@ RSpec.describe ServiceProviderSession do
     end
   end
 
-  describe '#verification_method_choice' do
-    it 'returns the correct string' do
-      expect(subject.verification_method_choice).to eq(
-        I18n.t('idv.messages.select_verification_with_sp', sp_name: sp_name),
-      )
-    end
-  end
-
   describe '#sp_alert' do
     context 'sp has custom alert' do
       it 'uses the custom template' do


### PR DESCRIPTION
## 🛠 Summary of changes

Removes an unused method `SerivceProvider#verification_method_choice`

Added in #1227, and last reference removed in #2206.

## 📜 Testing Plan

Verify build passes.