### PR TITLE
Fix typo "limitting" ➡️ "limiting"

### DIFF
--- a/knapsack_rspec_report.json
+++ b/knapsack_rspec_report.json
@@ -297,7 +297,7 @@
   "spec/features/phone/confirmation_spec.rb": 202.880041808,
   "spec/features/phone/default_phone_selection_spec.rb": 33.68962708,
   "spec/features/phone/edit_phone_spec.rb": 21.15221282,
-  "spec/features/phone/rate_limitting_spec.rb": 93.738608051,
+  "spec/features/phone/rate_limiting_spec.rb": 93.738608051,
   "spec/features/phone/remove_phone_spec.rb": 12.755412848,
   "spec/features/remember_device/cookie_expiration_spec.rb": 6.613393484,
   "spec/features/remember_device/phone_spec.rb": 58.912246182000004,

--- a/spec/features/phone/rate_limiting_spec.rb
+++ b/spec/features/phone/rate_limiting_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe 'phone rate limitting', allowed_extra_analytics: [:*] do
+RSpec.describe 'phone rate limiting', allowed_extra_analytics: [:*] do
   let(:phone) { '2025551234' }
 
   context 'on sign up' do
     let!(:user) { sign_up_and_set_password }
 
-    it_behaves_like 'phone rate limitting', :sms
-    it_behaves_like 'phone rate limitting', :voice
+    it_behaves_like 'phone rate limiting', :sms
+    it_behaves_like 'phone rate limiting', :voice
 
     def visit_otp_confirmation(delivery_method)
       select_2fa_option(:phone)
@@ -20,8 +20,8 @@ RSpec.describe 'phone rate limitting', allowed_extra_analytics: [:*] do
   context 'on add phone' do
     let(:user) { create(:user, :fully_registered) }
 
-    it_behaves_like 'phone rate limitting', :sms
-    it_behaves_like 'phone rate limitting', :voice
+    it_behaves_like 'phone rate limiting', :sms
+    it_behaves_like 'phone rate limiting', :voice
 
     def visit_otp_confirmation(delivery_method)
       sign_in_live_with_2fa(user)

--- a/spec/support/shared_examples/phone/rate_limiting.rb
+++ b/spec/support/shared_examples/phone/rate_limiting.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'phone rate limitting' do |delivery_method|
+RSpec.shared_examples 'phone rate limiting' do |delivery_method|
   let(:max_confirmation_attempts) { 4 }
   let(:max_otp_sends) { 2 }
   let(:min_attempts) { 2 }
@@ -20,7 +20,7 @@ RSpec.shared_examples 'phone rate limitting' do |delivery_method|
 
     expect(page).to have_content(t('two_factor_authentication.max_otp_requests_reached'))
     expect_user_to_be_rate_limitted
-    expect_rate_limitting_to_expire
+    expect_rate_limiting_to_expire
   end
 
   it 'limits the number of times a code can be sent to a phone across accounts' do
@@ -40,7 +40,7 @@ RSpec.shared_examples 'phone rate limitting' do |delivery_method|
     expect(page).to have_content(t('two_factor_authentication.max_otp_requests_reached'))
 
     expect_user_to_be_rate_limitted
-    expect_rate_limitting_to_expire
+    expect_rate_limiting_to_expire
   end
 
   it 'limits the number of times the user can enter an OTP' do
@@ -78,7 +78,7 @@ RSpec.shared_examples 'phone rate limitting' do |delivery_method|
 
     expect(page).to have_content(t('two_factor_authentication.max_otp_login_attempts_reached'))
     expect_user_to_be_rate_limitted
-    expect_rate_limitting_to_expire
+    expect_rate_limiting_to_expire
   end
 
   def expect_user_to_be_rate_limitted
@@ -94,7 +94,7 @@ RSpec.shared_examples 'phone rate limitting' do |delivery_method|
     expect(page).to have_content(t('two_factor_authentication.max_generic_login_attempts_reached'))
   end
 
-  def expect_rate_limitting_to_expire
+  def expect_rate_limiting_to_expire
     travel (IdentityConfig.store.lockout_period_in_minutes + 1).minutes do
       visit root_path
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a few occurrences of a typo of the word "limiting", misspelled as "limitting".

## 📜 Testing Plan

Verify build passes.