### PR TITLE
stylelint-config: Resolve nested selectors with selector-class-pattern

### DIFF
--- a/app/javascript/packages/stylelint-config/CHANGELOG.md
+++ b/app/javascript/packages/stylelint-config/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.1.0
+
+### Improvements
+
+- The `selector-class-pattern` configuration now specifies [`resolveNestedSelectors: true`](https://stylelint.io/user-guide/rules/selector-class-pattern/#resolvenestedselectors-true--false-default-false) to resolve nested selectors using `&` interpolation.
+
 ## 4.0.0
 
 ### Breaking Changes

--- a/app/javascript/packages/stylelint-config/index.js
+++ b/app/javascript/packages/stylelint-config/index.js
@@ -12,6 +12,7 @@ module.exports = {
       {
         message:
           'Class selectors should be named using "Two Dashes Style" BEM format. See: https://en.bem.info/methodology/naming-convention/#two-dashes-style',
+        resolveNestedSelectors: true,
       },
     ],
   },

--- a/app/javascript/packages/stylelint-config/package.json
+++ b/app/javascript/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-stylelint-config",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": false,
   "description": "Stylelint shareable configuration for Login.gov CSS/SASS standards",
   "exports": {


### PR DESCRIPTION
## 🎫 Ticket

Partially addresses #10545 (cc @anselmbradford)

## 🛠 Summary of changes

Updates Stylelint configuration to specify [optional `resolveNestedSelectors` property](https://stylelint.io/user-guide/rules/selector-class-pattern/#resolvenestedselectors-true--false-default-false) of the configured `selector-class-pattern` rule.

## 📜 Testing Plan

Verify `yarn lint:css` passes.

Optional: Validate that interpolated selector names consistently enforce the selector name validation:

Example:

```diff
diff --git a/app/javascript/packages/document-capture/components/_file-input.scss b/app/javascript/packages/document-capture/components/_file-input.scss
index 8967e4e1f9..8dcafd7c8e 100644
--- a/app/javascript/packages/document-capture/components/_file-input.scss
+++ b/app/javascript/packages/document-capture/components/_file-input.scss
@@ -10,2 +10,10 @@
   outline-offset: 2px;
+
+  &--foo {
+    color: red;
+  }
+
+  &__foo {
+    color: red;
+  }
 }
```

```
$ yarn lint:css
yarn run v1.22.22
$ stylelint 'app/assets/stylesheets/**/*.scss' 'app/javascript/**/*.scss' 'app/components/*.scss'

app/javascript/packages/document-capture/components/_file-input.scss
 16:3  ✖  Class selectors should be named using "Two Dashes Style" BEM format. See:                                 selector-class-pattern
          https://en.bem.info/methodology/naming-convention/#two-dashes-style
```