### PR TITLE
LG-12376 state id update - check ssn

### DIFF
--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -130,7 +130,7 @@ module Idv
       end
 
       def updating_state_id?
-        pii_from_user.has_key?(:first_name)
+        pii_from_user.has_key?(:first_name) && !user_session[:idv][:ssn].nil?
       end
 
       def parsed_dob

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -22,16 +22,17 @@ module Idv
 
         pii_from_user = flow_session[:pii_from_user]
         initial_state_of_same_address_as_id = pii_from_user[:same_address_as_id]
-        Idv::StateIdForm::ATTRIBUTES.each do |attr|
-          pii_from_user[attr] = flow_params[attr]
-        end
+
         form_result = form.submit(flow_params)
 
-        analytics.idv_in_person_proofing_state_id_submitted(
-          **analytics_arguments.merge(**form_result.to_h),
-        )
-
         if form_result.success?
+          Idv::StateIdForm::ATTRIBUTES.each do |attr|
+            pii_from_user[attr] = flow_params[attr]
+          end
+
+          analytics.idv_in_person_proofing_state_id_submitted(
+            **analytics_arguments.merge(**form_result.to_h),
+          )
           # Accept Date of Birth from both memorable date and input date components
           formatted_dob = MemorableDateComponent.extract_date_param flow_params&.[](:dob)
           pii_from_user[:dob] = formatted_dob if formatted_dob
@@ -130,7 +131,7 @@ module Idv
       end
 
       def updating_state_id?
-        pii_from_user.has_key?(:first_name) && user_session.dig(:idv, :ssn).present?
+        user_session.dig(:idv, :ssn).present?
       end
 
       def parsed_dob

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -130,7 +130,7 @@ module Idv
       end
 
       def updating_state_id?
-        pii_from_user.has_key?(:first_name) && !user_session[:idv][:ssn].nil?
+        pii_from_user.has_key?(:first_name) && user_session.dig(:idv, :ssn).present?
       end
 
       def parsed_dob


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12376](https://cm-jira.usa.gov/browse/LG-12376)


## 🛠 Summary of changes

This pr fixes a bug introduced into the 1st pr addressing the update route for the state id controller. We are now also checking that there is an ssn for the user as a means to determine if the user is updating their id information. Previously we did not check the ssn value and so if a user had entered their name on the page but validation failed the page would change to show the appropriate view for someone who is now updating the page. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Turn on flag for state id controller
- [x] Go through the ipp flow and arrive at the state id page
- [x] Enter inputs that will fail for name and address
- [x] Click continue
- [x] Verify that validation errors are present
- [x] Verify that page view is still of someone first arriving at state id page, NOT of someone updating the page


