### PR TITLE
Improve failure message for unused allowed untranslated keys test

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe 'I18n' do
       <<~EOS,
         ALLOWED_UNTRANSLATED_KEYS contains unused allowed untranslated i18n keys.
         The following keys can be removed from ALLOWED_UNTRANSLATED_KEYS:
-        #{unused_allowed_untranslated_keys}
+        #{unused_allowed_untranslated_keys.pretty_inspect}
       EOS
     )
   end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -292,11 +292,11 @@ RSpec.describe 'I18n' do
       I18n::Tasks::BaseTask::ALLOWED_UNTRANSLATED_KEYS.reject { |key| key[:used] }
     expect(unused_allowed_untranslated_keys).to(
       be_empty,
-      """
-      ALLOWED_UNTRANSLATED_KEYS contains unused allowed untranslated i18n keys.
-      The following keys can be removed from ALLOWED_UNTRANSLATED_KEYS:
-      #{unused_allowed_untranslated_keys}
-      """,
+      <<~EOS,
+        ALLOWED_UNTRANSLATED_KEYS contains unused allowed untranslated i18n keys.
+        The following keys can be removed from ALLOWED_UNTRANSLATED_KEYS:
+        #{unused_allowed_untranslated_keys}
+      EOS
     )
   end
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -292,7 +292,11 @@ RSpec.describe 'I18n' do
       I18n::Tasks::BaseTask::ALLOWED_UNTRANSLATED_KEYS.reject { |key| key[:used] }
     expect(unused_allowed_untranslated_keys).to(
       be_empty,
-      "unused allowed untranslated i18n keys: #{unused_allowed_untranslated_keys}",
+      """
+      ALLOWED_UNTRANSLATED_KEYS contains unused allowed untranslated i18n keys.
+      The following keys can be removed from ALLOWED_UNTRANSLATED_KEYS:
+      #{unused_allowed_untranslated_keys}
+      """,
     )
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

This PR makes a small proposed change to the error message around unused allowed untranslated keys from #10508 to give clearer instructions on the source of the failure and how to resolve it.

Old message:
```
     Failure/Error:
       expect(unused_allowed_untranslated_keys).to(
         be_empty,
         "unused allowed untranslated i18n keys: #{unused_allowed_untranslated_keys}",
       )

       unused allowed untranslated i18n keys: [{:key=>"titles.piv_cac_setup.upsell", :locales=>[:fr]}, {:key=>"titles.piv_cac_setup.upsell", :locales=>[:es]}]
```

Proposed message:

```
     Failure/Error:
           expect(unused_allowed_untranslated_keys).to(
             be_empty,
             <<~EOS,
               ALLOWED_UNTRANSLATED_KEYS contains unused allowed untranslated i18n keys.
               The following keys can be removed from ALLOWED_UNTRANSLATED_KEYS:
               #{unused_allowed_untranslated_keys.pretty_inspect}
             EOS
           )

       ALLOWED_UNTRANSLATED_KEYS contains unused allowed untranslated i18n keys.
       The following keys can be removed from ALLOWED_UNTRANSLATED_KEYS:
       [{:key=>"titles.piv_cac_setup.upsell", :locales=>[:fr]},
        {:key=>"titles.piv_cac_setup.upsell", :locales=>[:es]}]
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
