### PR TITLE
Configure Dependabot for security updates, major Stylelint releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,28 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      - dependency-name: '@18f/identity-design-system'
-      - dependency-name: libphonenumber-js
+    groups:
+      sync-all-versions:
+        applies-to: version-updates
+        allow:
+          - dependency-name: '@18f/identity-design-system'
+          - dependency-name: libphonenumber-js
+      sync-major-versions:
+        applies-to: version-updates
+        allow:
+          - dependency-name: stylelint
+        update-types:
+          - major
+      security:
+        applies-to: security-updates
   - package-ecosystem: bundler
     directory: /
     schedule:
       interval: daily
-    allow:
-      - dependency-name: phonelib
+    groups:
+      sync-all-versions:
+        applies-to: version-updates
+        allow:
+          - dependency-name: phonelib
+      security:
+        applies-to: security-updates


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `dependabot.yml` to try to improve automated updates beyond current configuration:

- Update Stylelint major releases based on comment at https://github.com/18F/identity-idp/issues/10545#issuecomment-2098900814, and to avoid delays in publishing new versions of `@18f/identity-stylelint-config` as raised in #10124
- Include security updates. It was discovered that configuring `dependabot.yml` to update specific dependencies results in the default security updates not applying. This wasn't considered a blocker since we have [security update linting](https://github.com/18F/identity-idp/blob/659f2bf553449c7f2cc919e7444064960d7c9408/Makefile#L78-L82) and GitHub's "Security" tab to fall back on, but it would be nice to automate the updates themselves, and this can account for differences in auditing between `bundle-audit`, `yarn audit`, and Dependabot's auditing.
   - It was previously thought this was not possible to support in Dependabot, though I'm hoping that based on my read of how [`groups`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) is documented to work, this can serve our needs. This seems to be a somewhat-new feature ([announced in August 2023](https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/)), so perhaps this addresses the previous shortcoming in Dependabot?

## 📜 Testing Plan

(TBD if we can test this prior to merging)