### PR TITLE
Remove harcoded "Login.gov" and switch to interpolation

### DIFF
--- a/app/views/idv/mail_only_warning/show.html.erb
+++ b/app/views/idv/mail_only_warning/show.html.erb
@@ -17,7 +17,7 @@
   </p>
   <span><%= t('vendor_outage.alerts.pinpoint.idv.options_prompt') %></span>
   <ul class="margin-bottom-5">
-    <% t('vendor_outage.alerts.pinpoint.idv.options_html', status_page_url: StatusPage.base_url).each do | option | %>
+    <% t('vendor_outage.alerts.pinpoint.idv.options_html', app_name: APP_NAME).each do |option| %>
       <li>
         <%= option %>
       </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1905,7 +1905,7 @@ vendor_outage.alerts.pinpoint.idv.header: We are working to resolve an error
 vendor_outage.alerts.pinpoint.idv.message_html: '%{sp_name_html} needs to make sure you are you — not someone pretending to be you.'
 vendor_outage.alerts.pinpoint.idv.options_html:
   - Continue now and verify by mail, which takes <strong>5 to 10 days</strong>.
-  - Exit Login.gov and try again later.
+  - Exit %{app_name} and try again later.
 vendor_outage.alerts.pinpoint.idv.options_prompt: 'You can:'
 vendor_outage.alerts.pinpoint.idv.status_page_html: Unfortunately, we’re having technical difficulties right now. %{link_html} to learn when the error is resolved.
 vendor_outage.alerts.pinpoint.idv.status_page_link: Get updates on our status page

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1902,7 +1902,7 @@ vendor_outage.alerts.pinpoint.idv.header: Estamos trabajando para corregir un er
 vendor_outage.alerts.pinpoint.idv.message_html: '%{sp_name_html} necesita asegurarse de que se trata de usted y no de alguien que se hace pasar por usted.'
 vendor_outage.alerts.pinpoint.idv.options_html:
   - Continuar ahora y verificar por correo, lo cual tarda entre <strong>5 y 10 días</strong>.
-  - Salir de Login.gov e inténtelo de nuevo más tarde.
+  - Salir de %{app_name} e inténtelo de nuevo más tarde.
 vendor_outage.alerts.pinpoint.idv.options_prompt: 'Usted puede:'
 vendor_outage.alerts.pinpoint.idv.status_page_html: Lamentablemente, estamos teniendo problemas técnicos. %{link_html} para saber cuando se haya resuelto el error.
 vendor_outage.alerts.pinpoint.idv.status_page_link: Obtenga las actualizaciones en nuestra página de estado

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1906,7 +1906,7 @@ vendor_outage.alerts.pinpoint.idv.header: Nous travaillons à la résolution d�
 vendor_outage.alerts.pinpoint.idv.message_html: '%{sp_name_html} doit s’assurer qu’il s’agit bien de vous, et non de quelqu’un qui se fait passer pour vous.'
 vendor_outage.alerts.pinpoint.idv.options_html:
   - Continuer maintenant et effectuer la vérification par courrier, qui nécessite <strong>5 à 10 jours</strong>.
-  - Quitter Login.gov.
+  - Quitter %{app_name}.
 vendor_outage.alerts.pinpoint.idv.options_prompt: 'Vous pouvez :'
 vendor_outage.alerts.pinpoint.idv.status_page_html: Malheureusement, nous rencontrons actuellement des difficultés techniques. %{link_html} pour savoir quand l’erreur est résolue.
 vendor_outage.alerts.pinpoint.idv.status_page_link: Obtenir les dernières informations sur notre page d’état des systèmes.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1909,7 +1909,7 @@ vendor_outage.alerts.pinpoint.idv.header: 我们正在争取解决错误。
 vendor_outage.alerts.pinpoint.idv.message_html: '%{sp_name_html}需要确保你是你，而不是别人冒充你。'
 vendor_outage.alerts.pinpoint.idv.options_html:
   - 现在继续并通过普通邮件验证，这需要<strong>5 到 10 天</strong>。
-  - 退出 Login.gov，稍后再试。
+  - 退出 %{app_name}，稍后再试。
 vendor_outage.alerts.pinpoint.idv.options_prompt: 你可以：
 vendor_outage.alerts.pinpoint.idv.status_page_html: 遗憾的是，我们目前遇到技术困难。到 %{link_html} 了解错误何时能解决。
 vendor_outage.alerts.pinpoint.idv.status_page_link: 在我们的状态页面获得最新信息。

--- a/spec/views/idv/mail_only_warning/show.html.erb_spec.rb
+++ b/spec/views/idv/mail_only_warning/show.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/mail_only_warning/show.html.erb' do
+  before do
+    allow(view).to receive(:step_indicator_steps).and_return([])
+    allow(view).to receive(:current_sp).and_return(nil)
+
+    allow(view).to receive(:exit_url).and_return('/exit_url')
+  end
+
+  it 'lists options with correct interpolation' do
+    render
+
+    expect(rendered).to include(APP_NAME)
+  end
+end


### PR DESCRIPTION
I caught a hardcoded `Login.gov` in the translation YMLs which we should have caught with a lint. So this fixes that, and updates the corresponding linter too.

- Updates i18n_spec to correctly iterate over arrays
- Updates i18n_spec to handle new flatter files

