### PR TITLE
Add internationalization test against leading and trailing whitespace

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -933,9 +933,9 @@ help_text.requested_attributes.full_name: Full name
 help_text.requested_attributes.ial1_consent_reminder_html: You must consent each year to share your information with <strong>%{sp}</strong>. We’ll share your information with <strong>%{sp}</strong> to connect your account.
 help_text.requested_attributes.ial1_intro_html: We’ll share your information with <strong>%{sp}</strong> to connect your account.
 help_text.requested_attributes.ial2_consent_reminder_html: "<strong>%{sp}</stro\
-  ng> needs to know who you are to connect to your account. You must consent each year to share your verified information with <strong>%{sp}</strong>. We’ll share this information: "
-help_text.requested_attributes.ial2_intro_html: '<strong>%{sp}</strong> needs to know who you are to connect your account. We’ll share this information with %{sp}: '
-help_text.requested_attributes.ial2_reverified_consent_info: 'Because you verified your identity again, we need your permission to share this information with %{sp}: '
+  ng> needs to know who you are to connect to your account. You must consent each year to share your verified information with <strong>%{sp}</strong>. We’ll share this information:"
+help_text.requested_attributes.ial2_intro_html: '<strong>%{sp}</strong> needs to know who you are to connect your account. We’ll share this information with %{sp}:'
+help_text.requested_attributes.ial2_reverified_consent_info: 'Because you verified your identity again, we need your permission to share this information with %{sp}:'
 help_text.requested_attributes.phone: Phone number
 help_text.requested_attributes.social_security_number: Social Security number
 help_text.requested_attributes.verified_at: Updated on
@@ -1133,9 +1133,7 @@ idv.warning.attempts_html.one: For security reasons, you have <strong>one attemp
 idv.warning.attempts_html.other: For security reasons, you have <strong>%{count} attempts</strong> remaining.
 idv.warning.sessions.heading: We couldn’t find records matching your personal information
 idv.warning.state_id.cancel_button: Exit %{app_name}
-idv.warning.state_id.explanation: |
-  Unfortunately, we’re experiencing technical difficulties
-  with IDs from your state and are currently unable to verify your information.
+idv.warning.state_id.explanation: Unfortunately, we’re experiencing technical difficulties with IDs from your state and are currently unable to verify your information.
 idv.warning.state_id.heading: We are working to resolve an error
 idv.warning.state_id.next_steps.items_html:
   - Try again now <strong>or</strong>
@@ -1309,7 +1307,7 @@ instructions.password.strength.1: Weak
 instructions.password.strength.2: Average
 instructions.password.strength.3: Good
 instructions.password.strength.4: Great
-instructions.password.strength.intro: 'Password strength: '
+instructions.password.strength.intro: 'Password strength:'
 instructions.sp_handoff_bounced: Your sign in was successful, but %{sp_name} sent you back to %{app_name}. Please contact %{sp_link} for help.
 instructions.sp_handoff_bounced_with_no_sp: your service provider
 links.account.reactivate.with_key: I have my key

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -932,9 +932,9 @@ help_text.requested_attributes.email: Dirección de correo electrónico
 help_text.requested_attributes.full_name: Nombre completo
 help_text.requested_attributes.ial1_consent_reminder_html: Debe dar su consentimiento cada año para divulgar su información a <strong>%{sp}</strong>. Divulgaremos su información a <strong>%{sp}</strong> para conectar su cuenta.
 help_text.requested_attributes.ial1_intro_html: Divulgaremos su información a <strong>%{sp}</strong> para conectar su cuenta.
-help_text.requested_attributes.ial2_consent_reminder_html: 'Para conectar su cuenta, <strong>%{sp}</strong> necesita saber quién es usted. Debe dar su consentimiento cada año para divulgar su información verificada a <strong>%{sp}</strong>. Divulgaremos esta información: '
-help_text.requested_attributes.ial2_intro_html: 'Para conectar su cuenta, <strong>%{sp}</strong> necesita saber quién es usted. Divulgaremos esta información a %{sp}: '
-help_text.requested_attributes.ial2_reverified_consent_info: 'Como volvió a verificar su identidad, necesitamos su permiso para divulgar esta información a %{sp}: '
+help_text.requested_attributes.ial2_consent_reminder_html: 'Para conectar su cuenta, <strong>%{sp}</strong> necesita saber quién es usted. Debe dar su consentimiento cada año para divulgar su información verificada a <strong>%{sp}</strong>. Divulgaremos esta información:'
+help_text.requested_attributes.ial2_intro_html: 'Para conectar su cuenta, <strong>%{sp}</strong> necesita saber quién es usted. Divulgaremos esta información a %{sp}:'
+help_text.requested_attributes.ial2_reverified_consent_info: 'Como volvió a verificar su identidad, necesitamos su permiso para divulgar esta información a %{sp}:'
 help_text.requested_attributes.phone: Número de teléfono
 help_text.requested_attributes.social_security_number: Número de Seguro Social
 help_text.requested_attributes.verified_at: Actualizado en
@@ -1306,7 +1306,7 @@ instructions.password.strength.1: Débil
 instructions.password.strength.2: Promedio
 instructions.password.strength.3: Buena
 instructions.password.strength.4: Muy buena
-instructions.password.strength.intro: 'Seguridad de la contraseña: '
+instructions.password.strength.intro: 'Seguridad de la contraseña:'
 instructions.sp_handoff_bounced: Logró iniciar sesión, pero %{sp_name} lo envió de nuevo a %{app_name}. Contacte con %{sp_link} para obtener ayuda.
 instructions.sp_handoff_bounced_with_no_sp: su proveedor de servicios
 links.account.reactivate.with_key: Tengo mi clave

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1133,10 +1133,7 @@ idv.warning.attempts_html.one: Pour des raisons de sécurité, il vous reste <st
 idv.warning.attempts_html.other: Pour des raisons de sécurité, il vous reste <strong>%{count} tentatives</strong>.
 idv.warning.sessions.heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations personnelles
 idv.warning.state_id.cancel_button: Quitter %{app_name}
-idv.warning.state_id.explanation:
-  'Malheureusement, nous rencontrons des difficultés techniques avec les pièces d’identité de votre État et ne sommes pas en mesure de vérifier vos informations pour le moment.
-
-  '
+idv.warning.state_id.explanation: Malheureusement, nous rencontrons des difficultés techniques avec les pièces d’identité de votre État et ne sommes pas en mesure de vérifier vos informations pour le moment.
 idv.warning.state_id.heading: Nous travaillons à la résolution d’une erreur
 idv.warning.state_id.next_steps.items_html:
   - Réessayer maintenant <strong>ou</strong>
@@ -1310,7 +1307,7 @@ instructions.password.strength.1: Faible
 instructions.password.strength.2: Moyen
 instructions.password.strength.3: Bonne
 instructions.password.strength.4: Excellente
-instructions.password.strength.intro: 'Force du mot de passe : '
+instructions.password.strength.intro: 'Force du mot de passe :'
 instructions.sp_handoff_bounced: Votre connexion a réussi, mais %{sp_name} vous a renvoyé à %{app_name}. Veuillez contacter %{sp_link} pour obtenir de l’aide.
 instructions.sp_handoff_bounced_with_no_sp: votre fournisseur de service
 links.account.reactivate.with_key: J’ai ma clé

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -937,10 +937,9 @@ help_text.requested_attributes.full_name: 姓名
 help_text.requested_attributes.ial1_consent_reminder_html: 你每年都必须授权同意与 <strong>%{sp}</strong> 分享信息。我们将与 <strong>%{sp}</strong> 分享你的信息来连接你账户。
 help_text.requested_attributes.ial1_intro_html: 我们将与 <strong>%{sp}</strong> 分享你的信息来连接你账户。
 help_text.requested_attributes.ial2_consent_reminder_html: "<strong>%{sp}</stro\
-  ng> 需要知道你是谁才能连接你的账户。你每年都必须授权同意与 <strong>%{sp}</strong> 分享已验证过的你的信息。我们会分享这些信息：
-  "
-help_text.requested_attributes.ial2_intro_html: '<strong>%{sp}</strong> 需要知道你是谁才能连接你的账户。我们会与 %{sp} 分享这些信息： '
-help_text.requested_attributes.ial2_reverified_consent_info: '因为你重新验证了身份，我们需要得到你的许可才能与 %{sp} 分享该信息。 '
+  ng> 需要知道你是谁才能连接你的账户。你每年都必须授权同意与 <strong>%{sp}</strong> 分享已验证过的你的信息。我们会分享这些信息："
+help_text.requested_attributes.ial2_intro_html: '<strong>%{sp}</strong> 需要知道你是谁才能连接你的账户。我们会与 %{sp} 分享这些信息：'
+help_text.requested_attributes.ial2_reverified_consent_info: '因为你重新验证了身份，我们需要得到你的许可才能与 %{sp} 分享该信息。'
 help_text.requested_attributes.phone: 电话号码
 help_text.requested_attributes.social_security_number: 社会保障号码
 help_text.requested_attributes.verified_at: 更新是在
@@ -1096,7 +1095,7 @@ idv.messages.gpo.start_over_html: 如果该地址不对，你需要%{start_over_
 idv.messages.gpo.start_over_link_text: 重新开始并用你新地址进行验证。
 idv.messages.gpo.timeframe_html: 你会在<strong> 5 到 10 天</strong> 里收到带有<strong>验证码</strong> 的信。
 idv.messages.otp_delivery_method_description: 如果你在上面输入的是座机电话，请在下边选择“接听电话”。
-idv.messages.phone.alert_html: '<strong>输入一个这样的电话号码：</strong> '
+idv.messages.phone.alert_html: '<strong>输入一个这样的电话号码：</strong>'
 idv.messages.phone.description: 我们会将该号码与记录核对并给你发个一次性代码。这是为了帮助你验证身份。
 idv.messages.phone.failed_number.alert_text: 我们无法将你与该号码匹配。
 idv.messages.phone.failed_number.gpo_alert_html: 试试 <strong>另一个</strong> 号码或者%{link_html}。
@@ -1313,7 +1312,7 @@ instructions.password.strength.1: 弱
 instructions.password.strength.2: 一般
 instructions.password.strength.3: 好
 instructions.password.strength.4: 棒！
-instructions.password.strength.intro: '密码强度： '
+instructions.password.strength.intro: '密码强度：'
 instructions.sp_handoff_bounced: 你登录成功了，但 %{sp_name} 将你送回到 %{app_name}。请联系 %{sp_link} 寻求帮助。
 instructions.sp_handoff_bounced_with_no_sp: 你的服务提供商
 links.account.reactivate.with_key: 我有密钥

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -236,24 +236,29 @@ module I18n
       end
 
       def inconsistent_leading_or_ending_whitespace?(key)
-        values = self.locales.map do |current_locale|
+        values_list = self.locales.map do |current_locale|
           value = data[current_locale].first.children[key]&.value
           if value.is_a?(String)
-            value
+            [value]
+          elsif value.is_a?(Array)
+            value.compact
           end
         end.compact
 
-        return false if values.empty?
+        return false if values_list.empty?
+        values_list = values_list.transpose
 
-        consistent_leading_whitespace = values.map do |value|
-          value.match?(/^\s/) && value[0]
-        end.compact.uniq.count == 1
+        values_list.all? do |values|
+          consistent_leading_whitespace = values.map do |value|
+            value.match?(/^\s/) && value[0]
+          end.compact.uniq.count == 1
 
-        consistent_ending_whitespace = values.map do |value|
-          value.match?(/\s$/) && value[-1]
-        end.compact.uniq.count == 1
+          consistent_ending_whitespace = values.map do |value|
+            value.match?(/\s$/) && value[-1]
+          end.compact.uniq.count == 1
 
-        !consistent_leading_whitespace || !consistent_ending_whitespace
+          !consistent_leading_whitespace || !consistent_ending_whitespace
+        end
       end
 
       def untranslated_keys


### PR DESCRIPTION
## 🛠 Summary of changes

With a few exceptions, we are rendering content in HTML where whitespace is not significant and won't be displayed. This PR adds a test to alert when we include such whitespace. Cases where we concatenate content like the following is a case where removal of whitespace would cause a change in the display, and will be validated prior to merging.

```ruby
"#{t('content1')}#{t('content2')}"
```
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Validate that the content changed does not join content to make the whitespace significant

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
