### PR TITLE
LG-12706: Include user_id in piv_cac_login event

### DIFF
--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -46,7 +46,6 @@ module Users
 
     def process_piv_cac_login
       result = piv_cac_login_form.submit
-      analytics.piv_cac_login(**result.to_h)
       clear_piv_cac_information
       clear_piv_cac_nonce
       if result.success?
@@ -54,6 +53,7 @@ module Users
       else
         process_invalid_submission
       end
+      analytics.piv_cac_login(**result.to_h)
     end
 
     def piv_cac_login_form

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Users::PivCacLoginController do
       end
 
       context 'with a valid token' do
+        let(:user) {}
         let(:service_provider) { create(:service_provider) }
         let(:sp_session) { { ial: 1, issuer: service_provider.issuer, vtr: vtr } }
         let(:nonce) { SecureRandom.base64(20) }
@@ -65,6 +66,7 @@ RSpec.describe Users::PivCacLoginController do
           subject.session[:sp] = sp_session
 
           allow(PivCacService).to receive(:decode_token).with(token) { data }
+          stub_analytics(user:)
           get :new, params: { token: token }
         end
 

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -1,14 +1,17 @@
 module AnalyticsHelper
   def stub_analytics(user: nil)
-    @analytics = FakeAnalytics.new
+    analytics = FakeAnalytics.new
 
-    allow(controller).to receive(:analytics).and_wrap_original do |_original|
-      expect(controller.analytics_user).to eq(user) if user
-      allow(controller).to receive(:analytics).and_call_original
-      controller.analytics = @analytics
+    if user
+      allow(controller).to receive(:analytics) do
+        expect(controller.analytics_user).to eq(user)
+        analytics
+      end
+    else
+      controller.analytics = analytics
     end
 
-    @analytics
+    @analytics = analytics
   end
 
   def unstub_analytics

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -1,7 +1,14 @@
 module AnalyticsHelper
-  def stub_analytics
-    controller.analytics = FakeAnalytics.new
-    @analytics = controller.analytics
+  def stub_analytics(user: nil)
+    @analytics = FakeAnalytics.new
+
+    allow(controller).to receive(:analytics).and_wrap_original do |_original|
+      expect(controller.analytics_user).to eq(user) if user
+      allow(controller).to receive(:analytics).and_call_original
+      controller.analytics = @analytics
+    end
+
+    @analytics
   end
 
   def unstub_analytics


### PR DESCRIPTION
## 🎫 Ticket

[LG-12706](https://cm-jira.usa.gov/browse/LG-12706)

## 🛠 Summary of changes

Updates logging of `piv_cac_login` to ensure that a non-`nil` `user_id` is included in the logged result.

## 📜 Testing Plan

1. Run `EVENT_NAME=piv_cac_login make watch_events` in a separate terminal process to the IdP
2. Go to http://localhost:3000
3. Click "Sign in with your government employee ID"
4. Sign in with PIV
5. Observe log entry "piv_cac_login" has a `user_id` for the user which logged in