### PR TITLE
Use patterns syntax for Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,13 @@ updates:
     groups:
       sync-all-versions:
         applies-to: version-updates
-        allow:
-          - dependency-name: '@18f/identity-design-system'
-          - dependency-name: libphonenumber-js
+        patterns:
+          - '@18f/identity-design-system'
+          - libphonenumber-js
       sync-major-versions:
         applies-to: version-updates
-        allow:
-          - dependency-name: stylelint
+        patterns:
+          - stylelint
         update-types:
           - major
       security:
@@ -25,7 +25,7 @@ updates:
     groups:
       sync-all-versions:
         applies-to: version-updates
-        allow:
-          - dependency-name: phonelib
+        patterns:
+          - phonelib
       security:
         applies-to: security-updates


### PR DESCRIPTION
## 🛠 Summary of changes

Attempts to fix Dependabot configuration issues introduced in #10576:

```
The property '#/updates/0/groups/sync-all-versions' contains additional properties ["allow"] outside of the schema when none are allowed
The property '#/updates/0/groups/sync-all-versions' of type object did not match one or more of the required schemas
The property '#/updates/0/groups/sync-major-versions' contains additional properties ["allow"] outside of the schema when none are allowed
The property '#/updates/0/groups/security' of type object did not match one or more of the required schemas
The property '#/updates/1/groups/sync-all-versions' contains additional properties ["allow"] outside of the schema when none are allowed
The property '#/updates/1/groups/sync-all-versions' of type object did not match one or more of the required schemas
The property '#/updates/1/groups/security' of type object did not match one or more of the required schemas
```

https://github.com/18F/identity-idp/runs/24823024757

Reference documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

## 📜 Testing Plan

Check run after merge.