### PR TITLE
changelog: internal, in-person-proofing, add new skip_doc_auth name

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -27,6 +27,7 @@ module Idv
       selfie_check_required
       skip_doc_auth
       skip_doc_auth_from_handoff
+      skip_doc_auth_from_how_to_verify
       skip_hybrid_handoff
       ssn
       threatmetrix_review_status


### PR DESCRIPTION
[LG-13006](https://cm-jira.usa.gov/browse/LG-13006)

## 🛠 Summary of changes
Adding a new property for session.rb for the eventual renaming `skip_doc_auth` to `skip_doc_auth_from_how_to_verify`.

This is the first step in getting the renamed property into session.rb.

