### PR TITLE
Proof-of-concept: reCAPTCHA at sign-in

### DIFF
--- a/app/components/captcha_submit_button_component.html.erb
+++ b/app/components/captcha_submit_button_component.html.erb
@@ -25,7 +25,7 @@
       </div>
     <% end %>
   <% else %>
-    <%= f.input(:recaptcha_token, as: :hidden) %>
+    <%= f.input(:recaptcha_token, as: :hidden, input_html: { value: '' }) %>
   <% end %>
   <%= render SpinnerButtonComponent.new(
         action_message: t('components.captcha_submit_button.action_message'),

--- a/app/components/captcha_submit_button_component.html.erb
+++ b/app/components/captcha_submit_button_component.html.erb
@@ -32,6 +32,7 @@
         type: :submit,
         big: true,
         wide: true,
+        **button_options,
       ).with_content(content) %>
   <% if recaptcha_script_src.present? %>
     <%= content_tag(:script, '', src: recaptcha_script_src, async: true) %>

--- a/app/components/captcha_submit_button_component.rb
+++ b/app/components/captcha_submit_button_component.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class CaptchaSubmitButtonComponent < BaseComponent
-  attr_reader :form, :action, :tag_options
+  attr_reader :form, :action, :button_options, :tag_options
 
   alias_method :f, :form
 
   # @param [String] action https://developers.google.com/recaptcha/docs/v3#actions
-  def initialize(form:, action:, **tag_options)
+  def initialize(form:, action:, button_options:, **tag_options)
     @form = form
     @action = action
+    @button_options = button_options
     @tag_options = tag_options
   end
 

--- a/app/forms/sign_in_recaptcha_form.rb
+++ b/app/forms/sign_in_recaptcha_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class SignInRecaptchaForm
+  RECAPTCHA_ACTION = 'sign_in'
+
+  attr_reader :form_class, :form_args
+
+  delegate :submit, :errors, to: :form
+
+  def initialize(form_class: RecaptchaForm, **form_args)
+    @form_class = form_class
+    @form_args = form_args
+  end
+
+  private
+
+  def form
+    @form ||= form_class.new(
+      score_threshold: IdentityConfig.store.sign_in_recaptcha_score_threshold,
+      recaptcha_action: RECAPTCHA_ACTION,
+      **form_args,
+    )
+  end
+end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -48,7 +48,12 @@
         },
       ) %>
   <%= hidden_field_tag :platform_authenticator_available, id: 'platform_authenticator_available' %>
-  <%= f.submit t('links.sign_in'), full_width: true, wide: false %>
+
+  <%= render CaptchaSubmitButtonComponent.new(
+        form: f,
+        action: SignInRecaptchaForm::RECAPTCHA_ACTION,
+        button_options: { full_width: true },
+      ).with_content(t('links.sign_in')) %>
 <% end %>
 <% if desktop_device? %>
   <div class='margin-x-neg-1 margin-top-205'>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -316,6 +316,7 @@ session_timeout_in_minutes: 15
 session_timeout_warning_seconds: 150
 session_total_duration_timeout_in_minutes: 720
 ses_configuration_set_name: ''
+sign_in_recaptcha_score_threshold: 0.0
 sp_handoff_bounce_max_seconds: 2
 show_unsupported_passkey_platform_authentication_setup: false
 show_user_attribute_deprecation_warnings: false
@@ -431,6 +432,7 @@ development:
   secret_key_base: development_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   show_unsupported_passkey_platform_authentication_setup: true
+  sign_in_recaptcha_score_threshold: 0.3
   skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"]'
   state_tracking_enabled: true
   telephony_adapter: test

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -20,10 +20,12 @@ production:
   redis_url: ['env', 'REDIS_URL']
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
+  phone_recaptcha_mock_validator: true
   piv_cac_service_url: ['env', 'PIV_CAC_SERVICE_URL']
   piv_cac_verify_token_secret: "a6ed2fb16320ae85a7a8e48f4b0eeb6afca5f1ac64af2a05a0c486df1c20b693987832a11f0910729f199b3ce5c7609fe6d580bed428d035ea8460990e38a382"
   piv_cac_verify_token_url: ['env', 'PIV_CAC_VERIFY_TOKEN_URL']
   secret_key_base: development_secret_key_base
+  sign_in_recaptcha_score_threshold: 0.3
   domain_name: ['env', 'DOMAIN_NAME']
   use_kms: false
   email_from: no-reply@identitysandbox.gov

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -385,6 +385,7 @@ module IdentityConfig
     config.add(:show_user_attribute_deprecation_warnings, type: :boolean)
     config.add(:short_term_phone_otp_max_attempts, type: :integer)
     config.add(:short_term_phone_otp_max_attempt_window_in_seconds, type: :integer)
+    config.add(:sign_in_recaptcha_score_threshold, type: :float)
     config.add(:skip_encryption_allowed_list, type: :json)
     config.add(:sp_handoff_bounce_max_seconds, type: :integer)
     config.add(:sp_issuer_user_counts_report_configs, type: :json)


### PR DESCRIPTION
## 🛠 Summary of changes

Implements a proof-of-concept reCAPTCHA validation at sign-in.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Enter email and password
3. (Optional) Customize "reCAPTCHA score" in the mock debugger tool
4. Click "Sign in"
5. Observe:
   - If you have already signed in on this device, you are allowed to proceed regardless of the score entered in Step 3
   - If you haven't already signed in on this device and you enter a score at or above 0.3, you are allowed to proceed
   - Otherwise, you are presented with an error message

## 👀 Screenshots

![image](https://github.com/18F/identity-idp/assets/1779930/b765bf08-ee85-4474-b96c-deafa997c0e5)
