### PR TITLE
Fix Dependabot security group schema

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
           - major
       security:
         applies-to: security-updates
+        patterns:
+          - '*'
   - package-ecosystem: bundler
     directory: /
     schedule:
@@ -29,3 +31,5 @@ updates:
           - phonelib
       security:
         applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
## 🛠 Summary of changes

Continues to attempt to fix Dependabot configuration issues introduced in https://github.com/18F/identity-idp/pull/10576:

```
The property '#/updates/0/groups/security' of type object did not match one or more of the required schemas
The property '#/updates/1/groups/security' of type object did not match one or more of the required schemas
```

https://github.com/18F/identity-idp/runs/24825325838

Reference documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

>You must use the `patterns`, `exclude-patterns`, `dependency-type`, or `update-types` options to define the group, or any combination thereof.

## 📜 Testing Plan

As before, it's not possible to test prior to merge (see https://github.com/dependabot/dependabot-core/issues/4605).

At some point, I may abandon this and revert back to the configuration prior to #10576 if issues continue.