### PR TITLE
Fix typo "exceeded" for maximum sign-in error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -737,7 +737,7 @@ errors.messages.wrong_length.one: is the wrong length (should be 1 character)
 errors.messages.wrong_length.other: is the wrong length (should be %{count} characters)
 errors.piv_cac_setup.unique_name: That name is already taken. Please choose a different name.
 errors.registration.terms: Before you can continue, you must give us permission. Please check the box below and then click continue.
-errors.sign_in.bad_password_limit: You have exceeeded the maximum sign in attempts.
+errors.sign_in.bad_password_limit: You have exceeded the maximum sign in attempts.
 errors.two_factor_auth_setup.must_select_additional_option: Select an additional authentication method.
 errors.two_factor_auth_setup.must_select_option: Select an authentication method.
 errors.verify_personal_key.rate_limited: You tried too many times, please try again in %{timeout}.


### PR DESCRIPTION
## 🛠 Summary of changes

Fixeees an typo with an excess "e" in the word "exceeded".

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Fail sign-in more than the configured maximum ([5 attempts](https://github.com/18F/identity-idp/blob/236075767aa531add5dfd865773d0d6a6a7667a3/config/application.yml.default#L209) in [60 seconds](https://github.com/18F/identity-idp/blob/236075767aa531add5dfd865773d0d6a6a7667a3/config/application.yml.default#L210))
3. Observe error message does not include a typo

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/1c2385d1-23cc-4b26-b308-647f618a4775)|![image](https://github.com/18F/identity-idp/assets/1779930/cf65a7f9-dd65-49b9-82da-5987e6701708)
