### PR TITLE
Apply autocomplete attribute consistently to all forms

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -9,8 +9,7 @@
 <%= simple_form_for(
       @reset_password_form,
       url: user_password_path,
-      html: { autocomplete: 'off',
-              method: :put },
+      method: :put,
     ) do |f| %>
   <%= f.input :reset_password_token, as: :hidden %>
   <%= f.full_error :reset_password_token %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -11,7 +11,6 @@
 <%= simple_form_for(
       @password_reset_email_form,
       url: user_password_path,
-      html: { autocomplete: 'off', method: :post },
     ) do |f| %>
   <%= render ValidatedFieldComponent.new(
         form: f,

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -27,7 +27,6 @@
       resource,
       as: resource_name,
       url: session_path(resource_name),
-      html: { autocomplete: 'off' },
     ) do |f|
 %>
   <%= render ValidatedFieldComponent.new(

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -5,8 +5,6 @@
 <%= simple_form_for(
       @password_reset_from_disavowal_form,
       url: events_disavowal_url,
-      html: { autocomplete: 'off',
-              method: :post },
     ) do |f| %>
     <%= f.input :disavowal_token, as: :hidden,
                                   input_html: { value: @disavowal_token, name: :disavowal_token } %>

--- a/app/views/forgot_password/show.html.erb
+++ b/app/views/forgot_password/show.html.erb
@@ -15,10 +15,11 @@
   <hr class="margin-y-4 border-width-05 border-info">
 </div>
 
-<%= simple_form_for @password_reset_email_form,
-                    html: { autocomplete: 'off', method: :post, class: 'margin-bottom-2' },
-                    url: user_password_path do |f| %>
-
+<%= simple_form_for(
+      @password_reset_email_form,
+      url: user_password_path,
+      html: { class: 'margin-bottom-2' },
+    ) do |f| %>
   <%= f.input :email, as: :hidden %>
   <%= f.input :resend, as: :hidden %>
   <p><%= t('notices.forgot_password.no_email_sent_explanation_start') %>

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -23,8 +23,7 @@
 <%= simple_form_for(
       @address_form,
       url: idv_address_path,
-      method: 'POST',
-      html: { autocomplete: 'off', class: 'margin-top-5' },
+      html: { class: 'margin-top-5' },
     ) do |f| %>
   <%= render ValidatedFieldComponent.new(
         form: f,

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -21,7 +21,7 @@
       as: :doc_auth,
       url: url_for,
       method: 'put',
-      html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
+      html: { class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
     ) do |f| %>
   <%= render ClickObserverComponent.new(event_name: 'IdV: consent checkbox toggled') do %>
     <%= render ValidatedFieldComponent.new(

--- a/app/views/idv/by_mail/enter_code/_form.html.erb
+++ b/app/views/idv/by_mail/enter_code/_form.html.erb
@@ -1,7 +1,6 @@
 <%= simple_form_for(
       @gpo_verify_form,
       url: idv_verify_by_mail_enter_code_path,
-      html: { autocomplete: 'off', method: :post },
     ) do |f| %>
   <div class="grid-row margin-top-neg-2 margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">

--- a/app/views/idv/enter_password/new.html.erb
+++ b/app/views/idv/enter_password/new.html.erb
@@ -18,7 +18,8 @@
 <%= simple_form_for(
       current_user,
       url: idv_enter_password_path,
-      html: { autocomplete: 'off', method: :put, class: 'margin-top-4' },
+      method: :put,
+      html: { class: 'margin-top-4' },
     ) do |f| %>
   <%= render PasswordToggleComponent.new(
         form: f,

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -17,7 +17,6 @@
     <%= simple_form_for(
           @idv_how_to_verify_form,
           html: {
-            autocomplete: 'off',
             id: nil,
             aria: { label: t('forms.buttons.continue_remote') },
           },
@@ -57,7 +56,6 @@
     <%= simple_form_for(
           @idv_how_to_verify_form,
           html: {
-            autocomplete: 'off',
             id: nil,
             aria: { label: t('forms.buttons.continue_ipp') },
           },

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -41,8 +41,10 @@
             as: :doc_auth,
             url: url_for(type: :mobile, combined: true),
             method: 'PUT',
-            html: { id: 'form-to-submit-photos-through-mobile' },
-            aria: { label: t('forms.buttons.send_link') },
+            html: {
+              id: 'form-to-submit-photos-through-mobile',
+              aria: { label: t('forms.buttons.send_link') },
+            },
           ) do |f| %>
         <%= render PhoneInputComponent.new(
               form: f,
@@ -75,8 +77,10 @@
           as: :doc_auth,
           url: url_for(type: :mobile, combined: true),
           method: 'PUT',
-          html: { id: 'form-to-submit-photos-through-mobile' },
-          aria: { label: t('forms.buttons.send_link') },
+          html: {
+            id: 'form-to-submit-photos-through-mobile',
+            aria: { label: t('forms.buttons.send_link') },
+          },
         ) do |f| %>
       <%= render PhoneInputComponent.new(
             form: f,
@@ -121,8 +125,10 @@
             url: url_for(type: :desktop),
             method: 'PUT',
             class: 'margin-bottom-4',
-            html: { id: 'form-to-submit-photos-through-desktop' },
-            aria: { label: t('forms.buttons.upload_photos') },
+            html: {
+              id: 'form-to-submit-photos-through-desktop',
+              aria: { label: t('forms.buttons.upload_photos') },
+            },
           ) do |f| %>
         <%= f.submit t('forms.buttons.upload_photos'), outline: true %>
       <% end %>

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -41,9 +41,8 @@
             as: :doc_auth,
             url: url_for(type: :mobile, combined: true),
             method: 'PUT',
-            html: { autocomplete: 'off',
-                    id: 'form-to-submit-photos-through-mobile',
-                    'aria-label': t('forms.buttons.send_link') },
+            html: { id: 'form-to-submit-photos-through-mobile' },
+            aria: { label: t('forms.buttons.send_link') },
           ) do |f| %>
         <%= render PhoneInputComponent.new(
               form: f,
@@ -76,9 +75,8 @@
           as: :doc_auth,
           url: url_for(type: :mobile, combined: true),
           method: 'PUT',
-          html: { autocomplete: 'off',
-                  id: 'form-to-submit-photos-through-mobile',
-                  'aria-label': t('forms.buttons.send_link') },
+          html: { id: 'form-to-submit-photos-through-mobile' },
+          aria: { label: t('forms.buttons.send_link') },
         ) do |f| %>
       <%= render PhoneInputComponent.new(
             form: f,
@@ -123,10 +121,8 @@
             url: url_for(type: :desktop),
             method: 'PUT',
             class: 'margin-bottom-4',
-            html: {
-              id: 'form-to-submit-photos-through-desktop',
-              'aria-label': t('forms.buttons.upload_photos'),
-            },
+            html: { id: 'form-to-submit-photos-through-desktop' },
+            aria: { label: t('forms.buttons.upload_photos') },
           ) do |f| %>
         <%= f.submit t('forms.buttons.upload_photos'), outline: true %>
       <% end %>

--- a/app/views/idv/in_person/address/show.html.erb
+++ b/app/views/idv/in_person/address/show.html.erb
@@ -16,8 +16,7 @@
 <% end %>
 
 <%= simple_form_for(
-      form, url: url_for, method: 'PUT',
-            html: { autocomplete: 'off' }
+      form, url: url_for, method: 'PUT'
     ) do |f| %>
   <%= render ValidatedFieldComponent.new(
         collection: us_states_territories,

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -40,7 +40,7 @@
 <%= simple_form_for form,
                     url: url_for,
                     method: 'put',
-                    html: { autocomplete: 'off', class: 'margin-y-5' } do |f| %>
+                    html: { class: 'margin-y-5' } do |f| %>
 
   <div class="margin-bottom-4">
     <%= render ValidatedFieldComponent.new(

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -47,7 +47,7 @@
 <%= simple_form_for form,
                     url: url_for,
                     method: 'put',
-                    html: { autocomplete: 'off', class: 'margin-y-5' } do |f| %>
+                    html: { class: 'margin-y-5' } do |f| %>
 
   <div class="margin-bottom-4">
     <%= render ValidatedFieldComponent.new(

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -54,10 +54,7 @@
         wait_step_path: idv_phone_path,
         poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
       },
-      html: {
-        autocomplete: 'off',
-        method: :put,
-      },
+      method: :put,
     ) do |f| %>
   <%= render PhoneInputComponent.new(
         form: f,

--- a/app/views/idv/shared/ssn.html.erb
+++ b/app/views/idv/shared/ssn.html.erb
@@ -68,7 +68,6 @@ locals:
       @ssn_presenter.ssn_form,
       url: url_for,
       method: :put,
-      html: { autocomplete: 'off' },
     ) do |f| %>
   <div class="tablet:grid-col-8">
     <%= render 'shared/ssn_field', f: f %>

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -34,7 +34,7 @@
         :doc_auth,
         url: url_for,
         method: 'put',
-        html: { autocomplete: 'off', class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
+        html: { class: 'margin-top-2 margin-bottom-5 js-consent-continue-form' },
       ) do |f| %>
 
   <div class="margin-top-4">

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -6,8 +6,7 @@
       current_user,
       as: :user,
       url: capture_password_url,
-      method: :post,
-      html: { autocomplete: 'off', class: 'margin-top-4' },
+      html: { class: 'margin-top-4' },
     ) do |f| %>
   <%= render PasswordToggleComponent.new(
         form: f,

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -6,6 +6,7 @@
       current_user,
       as: :user,
       url: capture_password_url,
+      method: :post,
       html: { class: 'margin-top-4' },
     ) do |f| %>
   <%= render PasswordToggleComponent.new(

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -8,8 +8,6 @@
 <%= simple_form_for(
       @password_form,
       url: sign_up_create_password_path,
-      method: :post,
-      html: { autocomplete: 'off' },
     ) do |f| %>
   <%= text_field_tag('username', @email_address.email, hidden: true, autocomplete: 'username') %>
   <%= render PasswordConfirmationComponent.new(

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -19,7 +19,6 @@
 
 <%= simple_form_for(
       @register_user_email_form,
-      html: { autocomplete: 'off' },
       url: sign_up_register_path,
     ) do |f| %>
   <%= render ValidatedFieldComponent.new(

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -9,7 +9,6 @@
 <%= simple_form_for(
       @backup_code_form,
       url: login_two_factor_backup_code_path,
-      html: { autocomplete: 'off', method: :post },
     ) do |f| %>
   <%= render 'partials/backup_code/entry_fields', f: f, attribute_name: :backup_code %>
   <%= f.input(

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -16,8 +16,6 @@
 
 <%= simple_form_for(
       @two_factor_options_form,
-      html: { autocomplete: 'off' },
-      method: :post,
       url: login_two_factor_options_path,
     ) do |f| %>
   <div role="group" aria-label="<%= @presenter.heading %>">

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -20,7 +20,7 @@
   <%= @presenter.phone_number_message %>
 </p>
 
-<%= simple_form_for('', method: :post) do |f| %>
+<%= simple_form_for('') do |f| %>
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -7,8 +7,7 @@
 </p>
 
 <%= simple_form_for(
-      @personal_key_form, url: login_two_factor_personal_key_path,
-                          html: { autocomplete: 'off', method: :post }
+      @personal_key_form, url: login_two_factor_personal_key_path
     ) do |f| %>
   <%= render 'partials/personal_key/entry_fields', f: f, attribute_name: :personal_key %>
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.header) %>
 
-<%= simple_form_for('', method: :post, html: { class: 'margin-bottom-5' }) do |f| %>
+<%= simple_form_for('', html: { class: 'margin-bottom-5' }) do |f| %>
   <% if @presenter.reauthn %>
     <%= render 'two_factor_authentication/totp_verification/reauthn' %>
   <% end %>

--- a/app/views/users/auth_app/edit.html.erb
+++ b/app/views/users/auth_app/edit.html.erb
@@ -6,7 +6,6 @@
       @form,
       as: :form,
       method: :put,
-      html: { autocomplete: 'off' },
       url: auth_app_path(id: @form.configuration.id),
     ) do |f| %>
   <%= render ValidatedFieldComponent.new(

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -16,7 +16,6 @@
 <%= simple_form_for(
       current_user,
       url: account_delete_path,
-      html: { autocomplete: 'off', method: :post },
     ) do |f| %>
   <p class="margin-bottom-4">
     <%= t('users.delete.instructions') %>

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -16,6 +16,7 @@
 <%= simple_form_for(
       current_user,
       url: account_delete_path,
+      method: :post,
     ) do |f| %>
   <p class="margin-bottom-4">
     <%= t('users.delete.instructions') %>

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -3,7 +3,7 @@
 
 <%= simple_form_for(
       @edit_phone_form,
-      html: { autocomplete: 'off', method: :put },
+      method: :put,
       url: manage_phone_path(id: @phone_configuration.id),
     ) do |f| %>
 

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -5,14 +5,12 @@
 <div class="margin-bottom-6">
   <%= simple_form_for(
         @add_user_email_form,
-        html: { autocomplete: 'off' },
         url: add_email_path,
       ) do |f| %>
     <%= render ValidatedFieldComponent.new(
           form: f,
           name: :email,
           label: t('forms.registration.labels.email'),
-          input_html: { autocomplete: 'off' },
           required: true,
         ) %>
     <%= f.submit t('forms.buttons.submit.default') %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -7,8 +7,9 @@
 </p>
 
 <%= simple_form_for(
-      @update_user_password_form, url: manage_password_path,
-                                  html: { autocomplete: 'off', method: :patch }
+      @update_user_password_form,
+      url: manage_password_path,
+      method: :patch,
     ) do |f| %>
   <%= f.error_notification %>
   <%= render PasswordConfirmationComponent.new(

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -15,8 +15,6 @@
 
 <%= simple_form_for(
       @new_phone_form,
-      method: :post,
-      html: { autocomplete: 'off' },
       url: phone_setup_path,
     ) do |f| %>
 

--- a/app/views/users/piv_cac/edit.html.erb
+++ b/app/views/users/piv_cac/edit.html.erb
@@ -6,7 +6,6 @@
       @form,
       as: :form,
       method: :put,
-      html: { autocomplete: 'off' },
       url: piv_cac_path(id: @form.configuration.id),
     ) do |f| %>
   <%= render ValidatedFieldComponent.new(

--- a/app/views/users/rules_of_use/new.html.erb
+++ b/app/views/users/rules_of_use/new.html.erb
@@ -15,7 +15,6 @@
 <%= t('users.rules_of_use.details_html', app_name: APP_NAME) %>
 <%= simple_form_for(
       @rules_of_use_form,
-      html: { autocomplete: 'off' },
       url: rules_of_use_path,
     ) do |f| %>
   <%= render ValidatedFieldComponent.new(

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -33,7 +33,6 @@
 <% end %>
 
 <%= simple_form_for @two_factor_options_form,
-                    html: { autocomplete: 'off' },
                     method: :patch,
                     url: authentication_methods_setup_path do |f| %>
   <div class="margin-bottom-4">

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -7,8 +7,9 @@
 </p>
 
 <%= simple_form_for(
-      current_user, url: update_verify_password_path,
-                    html: { autocomplete: 'off', method: :put }
+      current_user,
+      url: update_verify_password_path,
+      method: :put,
     ) do |f| %>
   <%= render PasswordToggleComponent.new(
         form: f,

--- a/app/views/users/webauthn/edit.html.erb
+++ b/app/views/users/webauthn/edit.html.erb
@@ -6,7 +6,6 @@
       @form,
       as: :form,
       method: :put,
-      html: { autocomplete: 'off' },
       url: webauthn_path(id: @form.configuration.id),
     ) do |f| %>
   <%= render ValidatedFieldComponent.new(

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -2,14 +2,10 @@
 
 # rubocop:disable Metrics/BlockLength
 SimpleForm.setup do |config|
-  require Rails.root.join('lib', 'extensions', 'simple_form', 'error_notification')
-  require Rails.root.join('lib', 'extensions', 'simple_form', 'components', 'submit_component')
-  require Rails.root.join(
-    'lib', 'extensions', 'simple_form', 'components', 'html5_no_aria_required'
-  )
-  require Rails.root.join(
-    'lib', 'extensions', 'simple_form', 'active_view_extensions', 'form_helper'
-  )
+  require 'extensions/simple_form/active_view_extensions/form_helper'
+  require 'extensions/simple_form/components/html5_no_aria_required'
+  require 'extensions/simple_form/components/submit_component'
+  require 'extensions/simple_form/error_notification'
 
   config.button_class = 'usa-button'
   config.boolean_label_class = nil

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -7,6 +7,9 @@ SimpleForm.setup do |config|
   require Rails.root.join(
     'lib', 'extensions', 'simple_form', 'components', 'html5_no_aria_required'
   )
+  require Rails.root.join(
+    'lib', 'extensions', 'simple_form', 'active_view_extensions', 'form_helper'
+  )
 
   config.button_class = 'usa-button'
   config.boolean_label_class = nil

--- a/lib/extensions/simple_form/active_view_extensions/form_helper.rb
+++ b/lib/extensions/simple_form/active_view_extensions/form_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Monkey-patch SimpleForm::ActionViewExtensions::FormHelper apply default `autocomplete` attribute.
+#
+# See: https://github.com/heartcombo/simple_form/blob/main/lib/simple_form/action_view_extensions/form_helper.rb
+
+module Extensions
+  SimpleForm::ActionViewExtensions::FormHelper.class_eval do
+    prepend(
+      Module.new do
+        def simple_form_for(record, options = {}, &block)
+          options[:html] ||= {}
+          options[:html][:autocomplete] ||= 'off'
+          super(record, options, &block)
+        end
+      end,
+    )
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Monkey-patches SimpleForm to apply the `autocomplete="off"` attribute automatically for all forms.

**Why?**

- Reduce boilerplate for form markup
- Fix inconsistencies (see instances below in "Audit" for forms where we should have this attribute, but it is not currently applied)

**Audit:**

I reviewed every `simple_form_for` as part of this work. Aside from those modified in the included changes, the views below included `simple_form_for` _without_ an explicit `autocomplete`, along with a rationale for why it should be opted in to automatic `autocomplete` with these changes:

- app/views/idv/otp_verification/show.html.erb
  - OneTimeCodeInputComponent applies its own autocomplete
- app/views/idv/shared/_document_capture.html.erb
  - Only hidden fields
- app/views/saml_idp/shared/saml_post_binding.html.erb
  - Only hidden fields
- app/views/shared/_personal_key.html.erb
  - Personal key should not be autocompleted
- app/views/shared/saml_post_form.html.erb
  - Only hidden fields
- app/views/sign_up/completions/show.html.erb
  - Only includes button
- app/views/sign_up/emails/show.html.erb
  - Only includes hidden fields and button
- app/views/test/piv_cac_authentication_test_subject/new.html.erb
  - Test route
- app/views/two_factor_authentication/otp_verification/show.html.erb
  - OneTimeCodeInputComponent applies its own autocomplete
- app/views/two_factor_authentication/totp_verification/show.html.erb
  - OneTimeCodeInputComponent applies its own autocomplete
  - Otherwise includes only checkbox and button
- app/views/two_factor_authentication/webauthn_verification/show.html.erb
  - Only includes checkbox and button
- app/views/users/backup_code_setup/index.html.erb
  - Only includes checkbox and button
- app/views/users/email_language/show.html.erb
  - Only includes radio options and button
- app/views/users/piv_cac_authentication_setup/new.html.erb
  - This has a text field for nickname, but reasonable expectation we would not want to support autocomplete
- app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
  - This has a text field for nickname, but reasonable expectation we would not want to support autocomplete
- app/views/users/totp_setup/new.html.erb
  - This has a text field for nickname, but reasonable expectation we would not want to support autocomplete
- app/views/users/two_factor_authentication_setup/index.html.erb
  - Only includes checkboxes and button
- app/views/users/verify_personal_key/new.html.erb
  - Personal key should not be autocompleted

## 📜 Testing Plan

Verify no regressions in form autocompletion.