### PR TITLE
Lg 13006 rename skip doc auth, add scaffolding

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -43,7 +43,6 @@ module Idv
     end
 
     def extra_view_variables
-
       doc_auth_selfie_capture =
         FeatureManagement.idv_allow_selfie_check? &&
         resolved_authn_context_result.biometric_comparison?

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -43,6 +43,7 @@ module Idv
     end
 
     def extra_view_variables
+
       doc_auth_selfie_capture =
         FeatureManagement.idv_allow_selfie_check? &&
         resolved_authn_context_result.biometric_comparison?
@@ -53,6 +54,7 @@ module Idv
         sp_name: decorated_sp_session.sp_name,
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         skip_doc_auth: idv_session.skip_doc_auth,
+        skip_doc_auth_from_how_to_verify: false,
         skip_doc_auth_from_handoff: idv_session.skip_doc_auth_from_handoff,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
         doc_auth_selfie_capture:,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -27,6 +27,7 @@ module Idv
       selfie_check_required
       skip_doc_auth
       skip_doc_auth_from_handoff
+      skip_doc_auth_from_how_to_verify
       skip_hybrid_handoff
       ssn
       threatmetrix_review_status

--- a/app/views/idv/document_capture/show.html.erb
+++ b/app/views/idv/document_capture/show.html.erb
@@ -9,6 +9,7 @@
       acuant_version: acuant_version,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
       skip_doc_auth: skip_doc_auth,
+      skip_doc_auth_from_how_to_verify: false,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
     ) %>

--- a/app/views/idv/hybrid_mobile/document_capture/show.html.erb
+++ b/app/views/idv/hybrid_mobile/document_capture/show.html.erb
@@ -9,6 +9,7 @@
       acuant_version: acuant_version,
       opted_in_to_in_person_proofing: false,
       skip_doc_auth: false,
+      skip_doc_auth_from_how_to_verify: false,
       skip_doc_auth_from_handoff: nil,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
     ) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -39,6 +39,7 @@
       doc_auth_selfie_capture: FeatureManagement.idv_allow_selfie_check? && doc_auth_selfie_capture,
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
       skip_doc_auth: skip_doc_auth,
+      skip_doc_auth_from_how_to_verify: false,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       how_to_verify_url: idv_how_to_verify_url,
       previous_step_url: @previous_step_url,

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       acuant_version: acuant_version,
       doc_auth_selfie_capture: selfie_capture_enabled,
       skip_doc_auth: skip_doc_auth,
+      skip_doc_auth_from_how_to_verify: false,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
     }


### PR DESCRIPTION
## 🎫 Ticket

[LG-13006](https://cm-jira.usa.gov/browse/LG-13006)

## 🛠 Summary of changes
Adds the new field name `skip_doc_auth_from_how_to_verify` in preparation for the name switch.



