### PR TITLE
LG-12214: Refresh device cookie on every user event

### DIFF
--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -102,19 +102,13 @@ class UserEventCreator
   def create_device_for_user(user)
     cookie_uuid = cookies[:device].presence || SecureRandom.hex(COOKIE_LENGTH / 2)
 
-    device = Device.create!(
+    Device.create!(
       user: user,
       user_agent: request.user_agent.to_s,
       cookie_uuid: cookie_uuid,
       last_used_at: Time.zone.now,
       last_ip: request.remote_ip,
     )
-    assign_device_cookie(device.cookie_uuid)
-    device
-  end
-
-  def assign_device_cookie(device_cookie)
-    cookies.permanent[:device] = device_cookie unless device_cookie == cookies[:device]
   end
 
   def send_new_device_notification(event:, device:, disavowal_token:)
@@ -133,6 +127,8 @@ class UserEventCreator
       event_type: event_type,
       disavowal_token_fingerprint: disavowal_token_fingerprint,
     )
+
+    cookies.permanent[:device] = device.cookie_uuid if device
 
     [event, disavowal_token]
   end

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UserEventCreator do
         expect(device.last_used_at).to be_within(1).of(Time.zone.now)
       end
 
-      it 'saves the cookie permanently' do
+      it 'refreshes the permanent cookie' do
         expect(cookie_jar.permanent).to receive(:[]=).with(:device, existing_device_cookie)
 
         subject.create_user_event(event_type, user)

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe UserEventCreator do
         it 'saves the cookie permanently' do
           expect { subject.create_user_event(event_type, user) }.to change { cookie_jar[:device] }.
             from(nil).
-            to(kind_of(String))
+            to(lambda { |value| value == Device.last.cookie_uuid })
         end
       end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-12214](https://cm-jira.usa.gov/browse/LG-12214)

## 🛠 Summary of changes

Ensures that the "permanent" device cookie is effectively permanent by re-assigning it on each user event.

Additional background from the ticket:

>When a user signs in to Login.gov, we [set a cookie](https://github.com/18F/identity-idp/blob/32826b1f54581dbc3f9b9e2ea41c99d356f35915/app/services/user_event_creator.rb#L120-L122) to uniquely identify that device so that it is remembered for subsequent sign-ins. As seen in the linked code, the cookie is intended to be permanent, which is [documented as expiring "in 20 years from now"](https://api.rubyonrails.org/v7.0/classes/ActionDispatch/Cookies.html). However, some browsers may impose limits on the duration of cookies. [Chrome sets a maximum cookie expiration to 400 days](https://developer.chrome.com/blog/cookie-max-age-expires#:~:text=With%20this%20change%2C%20Chrome%20caps,set%20to%20400%20days%20instead).
>
>Because of this, a user who signs in with the same Chrome device after 400 days will be treated as a new device, thereby triggering new device notifications, and creating a new device entry in the user's account dashboard.
>
>As [documented on the same blog post](https://developer.chrome.com/blog/cookie-max-age-expires#extending_cookie_expiration), there are no restrictions which prevent us from refreshing the cookie expiration every time the user signs-in. Currently we do not do this, since we [only set the cookie if the cookie isn't already set](https://github.com/18F/identity-idp/blob/32826b1f54581dbc3f9b9e2ea41c99d356f35915/app/services/user_event_creator.rb#L121).

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in
3. Open "Cookies" tab in browser dev tools to see your cookies
4. Take note of the expiration of the "device" cookie
5. Sign out
6. Repeat Steps 2-4
7. Observe that the expiration date is extended on your second sign-in