### PR TITLE
Collapse simplified simple_form_for to single line

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -6,11 +6,7 @@
   <%= t('instructions.password.password_key') %>
 </p>
 
-<%= simple_form_for(
-      @reset_password_form,
-      url: user_password_path,
-      method: :put,
-    ) do |f| %>
+<%= simple_form_for(@reset_password_form, url: user_password_path, method: :put) do |f| %>
   <%= f.input :reset_password_token, as: :hidden %>
   <%= f.full_error :reset_password_token %>
   <%= render PasswordConfirmationComponent.new(

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -8,10 +8,7 @@
   <%= t('instructions.password.forgot') %>
 </p>
 
-<%= simple_form_for(
-      @password_reset_email_form,
-      url: user_password_path,
-    ) do |f| %>
+<%= simple_form_for(@password_reset_email_form, url: user_password_path) do |f| %>
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :email,

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -23,12 +23,7 @@
   </p>
 <% end %>
 
-<%= simple_form_for(
-      resource,
-      as: resource_name,
-      url: session_path(resource_name),
-    ) do |f|
-%>
+<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :email,

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -2,10 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.passwords.change')) %>
 
-<%= simple_form_for(
-      @password_reset_from_disavowal_form,
-      url: events_disavowal_url,
-    ) do |f| %>
+<%= simple_form_for(@password_reset_from_disavowal_form, url: events_disavowal_url) do |f| %>
     <%= f.input :disavowal_token, as: :hidden,
                                   input_html: { value: @disavowal_token, name: :disavowal_token } %>
     <%= render PasswordToggleComponent.new(

--- a/app/views/idv/by_mail/enter_code/_form.html.erb
+++ b/app/views/idv/by_mail/enter_code/_form.html.erb
@@ -1,7 +1,4 @@
-<%= simple_form_for(
-      @gpo_verify_form,
-      url: idv_verify_by_mail_enter_code_path,
-    ) do |f| %>
+<%= simple_form_for(@gpo_verify_form, url: idv_verify_by_mail_enter_code_path) do |f| %>
   <div class="grid-row margin-top-neg-2 margin-bottom-5">
     <div class="grid-col-12 tablet:grid-col-6">
       <%= render ValidatedFieldComponent.new(

--- a/app/views/idv/in_person/address/show.html.erb
+++ b/app/views/idv/in_person/address/show.html.erb
@@ -15,9 +15,7 @@
   <%= render PageHeadingComponent.new.with_content(t('in_person_proofing.headings.address')) %>
 <% end %>
 
-<%= simple_form_for(
-      form, url: url_for, method: 'PUT'
-    ) do |f| %>
+<%= simple_form_for(form, url: url_for, method: 'PUT') do |f| %>
   <%= render ValidatedFieldComponent.new(
         collection: us_states_territories,
         form: f,

--- a/app/views/idv/shared/ssn.html.erb
+++ b/app/views/idv/shared/ssn.html.erb
@@ -64,11 +64,7 @@ locals:
   </div>
 <% end %>
 
-<%= simple_form_for(
-      @ssn_presenter.ssn_form,
-      url: url_for,
-      method: :put,
-    ) do |f| %>
+<%= simple_form_for(@ssn_presenter.ssn_form, url: url_for, method: :put) do |f| %>
   <div class="tablet:grid-col-8">
     <%= render 'shared/ssn_field', f: f %>
   </div>

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -5,10 +5,7 @@
 <p class="margin-top-2 margin-bottom-0" id="password-description">
   <%= t('instructions.password.info.lead_html', min_length: Devise.password_length.first) %>
 </p>
-<%= simple_form_for(
-      @password_form,
-      url: sign_up_create_password_path,
-    ) do |f| %>
+<%= simple_form_for(@password_form, url: sign_up_create_password_path) do |f| %>
   <%= text_field_tag('username', @email_address.email, hidden: true, autocomplete: 'username') %>
   <%= render PasswordConfirmationComponent.new(
         form: f,

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -17,10 +17,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.create_account_new_users')) %>
 
-<%= simple_form_for(
-      @register_user_email_form,
-      url: sign_up_register_path,
-    ) do |f| %>
+<%= simple_form_for(@register_user_email_form, url: sign_up_register_path) do |f| %>
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :email,

--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -6,10 +6,7 @@
   <%= t('two_factor_authentication.backup_code_prompt') %>
 </p>
 
-<%= simple_form_for(
-      @backup_code_form,
-      url: login_two_factor_backup_code_path,
-    ) do |f| %>
+<%= simple_form_for(@backup_code_form, url: login_two_factor_backup_code_path) do |f| %>
   <%= render 'partials/backup_code/entry_fields', f: f, attribute_name: :backup_code %>
   <%= f.input(
         :remember_device,

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -14,10 +14,7 @@
   <% end %>
 <% end %>
 
-<%= simple_form_for(
-      @two_factor_options_form,
-      url: login_two_factor_options_path,
-    ) do |f| %>
+<%= simple_form_for(@two_factor_options_form, url: login_two_factor_options_path) do |f| %>
   <div role="group" aria-label="<%= @presenter.heading %>">
     <% @presenter.options.each_with_index do |option, index| %>
       <%= render(option) do %>

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.erb
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.erb
@@ -6,9 +6,7 @@
   <%= t('two_factor_authentication.personal_key_prompt') %>
 </p>
 
-<%= simple_form_for(
-      @personal_key_form, url: login_two_factor_personal_key_path
-    ) do |f| %>
+<%= simple_form_for(@personal_key_form, url: login_two_factor_personal_key_path) do |f| %>
   <%= render 'partials/personal_key/entry_fields', f: f, attribute_name: :personal_key %>
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -13,11 +13,7 @@
   <li class="margin-bottom-1"><%= t('users.delete.bullet_4', app_name: APP_NAME) %></li>
 </ul>
 
-<%= simple_form_for(
-      current_user,
-      url: account_delete_path,
-      method: :post,
-    ) do |f| %>
+<%= simple_form_for(current_user, url: account_delete_path, method: :post) do |f| %>
   <p class="margin-bottom-4">
     <%= t('users.delete.instructions') %>
   </p>

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -3,10 +3,7 @@
 <%= render PageHeadingComponent.new.with_content(t('headings.add_email')) %>
 
 <div class="margin-bottom-6">
-  <%= simple_form_for(
-        @add_user_email_form,
-        url: add_email_path,
-      ) do |f| %>
+  <%= simple_form_for(@add_user_email_form, url: add_email_path) do |f| %>
     <%= render ValidatedFieldComponent.new(
           form: f,
           name: :email,

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -6,11 +6,7 @@
   <%= t('instructions.password.info.lead_html', min_length: Devise.password_length.first) %>
 </p>
 
-<%= simple_form_for(
-      @update_user_password_form,
-      url: manage_password_path,
-      method: :patch,
-    ) do |f| %>
+<%= simple_form_for(@update_user_password_form, url: manage_password_path, method: :patch) do |f| %>
   <%= f.error_notification %>
   <%= render PasswordConfirmationComponent.new(
         form: f,

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -13,11 +13,7 @@
   <%= t('two_factor_authentication.two_factor_choice_options.phone_info_no_voip') %>
 </p>
 
-<%= simple_form_for(
-      @new_phone_form,
-      url: phone_setup_path,
-    ) do |f| %>
-
+<%= simple_form_for(@new_phone_form, url: phone_setup_path) do |f| %>
   <%= render PhoneInputComponent.new(
         form: f,
         confirmed_phone: false,

--- a/app/views/users/rules_of_use/new.html.erb
+++ b/app/views/users/rules_of_use/new.html.erb
@@ -13,10 +13,7 @@
 </p>
 
 <%= t('users.rules_of_use.details_html', app_name: APP_NAME) %>
-<%= simple_form_for(
-      @rules_of_use_form,
-      url: rules_of_use_path,
-    ) do |f| %>
+<%= simple_form_for(@rules_of_use_form, url: rules_of_use_path) do |f| %>
   <%= render ValidatedFieldComponent.new(
         form: f,
         name: :terms_accepted,

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -6,11 +6,7 @@
   <%= t('idv.messages.sessions.enter_password_message', app_name: APP_NAME) %>
 </p>
 
-<%= simple_form_for(
-      current_user,
-      url: update_verify_password_path,
-      method: :put,
-    ) do |f| %>
+<%= simple_form_for(current_user, url: update_verify_password_path, method: :put) do |f| %>
   <%= render PasswordToggleComponent.new(
         form: f,
         field_options: {


### PR DESCRIPTION
## 🛠 Summary of changes

Updates form markup to collapse rendering of `simple_form_for` to a single line.

This is a follow-up to #10604. I had originally planned to include these changes as part of that pull request, but decided against it in order to keep the diff simpler. But the simplifications enabled by that work remove a lot of configuration from `simple_form_for` to allow many of them to reasonably fit within a single line of 100 column length or fewer.

## 📜 Testing Plan

These changes are formatting-only, so not expected to have an impact on end-user experience.