### PR TITLE
Optimize preload response headers to prioritize critical assets

### DIFF
--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -21,6 +21,7 @@ module ScriptHelper
             **attributes,
             crossorigin: local_crossorigin_sources? ? true : nil,
             integrity: asset_sources.get_integrity(source),
+            nopush: false,
           )
         end
       end

--- a/app/helpers/stylesheet_helper.rb
+++ b/app/helpers/stylesheet_helper.rb
@@ -13,7 +13,7 @@ module StylesheetHelper
   def render_stylesheet_once_tags(*names)
     stylesheet_tag_once(*names) if names.present?
     return if @stylesheets.blank?
-    safe_join(@stylesheets.map { |stylesheet| stylesheet_link_tag(stylesheet) })
+    safe_join(@stylesheets.map { |stylesheet| stylesheet_link_tag(stylesheet, nopush: false) })
   end
 end
 # rubocop:enable Rails/HelperInstanceVariable

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -85,12 +85,13 @@
   </p>
 <% end %>
 
-<%= javascript_packs_tag_once('platform-authenticator-available') %>
+<%= javascript_packs_tag_once('platform-authenticator-available', preload_links_header: false) %>
 <% if IdentityConfig.store.participate_in_dap %>
   <!-- <%= t('notices.dap_participation') %> -->
   <%= javascript_packs_tag_once(
         'https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS',
         async: true,
         id: '_fed_an_ua_tag',
+        preload_links_header: false,
       ) %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:head) do %>
-  <%= javascript_include_tag('init.js') %>
+  <%= javascript_include_tag('init.js', nopush: false) %>
 <% end %>
 
 <%= extends_layout :base, body_class: local_assigns.fetch(:body_class, 'site tablet:bg-primary-lighter') do %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -19,7 +19,7 @@
   <%= preload_link_tag font_url('public-sans/PublicSans-Bold.woff2') %>
   <%= preload_link_tag font_url('public-sans/PublicSans-Regular.woff2') %>
   <%= render_stylesheet_once_tags %>
-  <%= stylesheet_link_tag 'application' %>
+  <%= stylesheet_link_tag 'application', nopush: false %>
   <%= stylesheet_link_tag 'print', media: :print, preload_links_header: false %>
   <%= csrf_meta_tags %>
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -69,7 +69,7 @@
         { type: 'application/json', data: { config: '' } },
         false,
       ) %>
-  <%= javascript_packs_tag_once('track-errors', async: true) if BrowserSupport.supported?(request.user_agent) %>
+  <%= javascript_packs_tag_once('track-errors', async: true, preload_links_header: false) if BrowserSupport.supported?(request.user_agent) %>
   <%= render_javascript_pack_once_tags %>
 <% end %>
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -16,8 +16,8 @@
   <%= javascript_tag(nonce: true) do %>
     document.documentElement.classList.replace('no-js', 'js');
   <% end %>
-  <%= preload_link_tag font_url('public-sans/PublicSans-Bold.woff2') %>
-  <%= preload_link_tag font_url('public-sans/PublicSans-Regular.woff2') %>
+  <%= preload_link_tag font_path('public-sans/PublicSans-Bold.woff2') %>
+  <%= preload_link_tag font_path('public-sans/PublicSans-Regular.woff2') %>
   <%= render_stylesheet_once_tags %>
   <%= stylesheet_link_tag 'application', nopush: false %>
   <%= stylesheet_link_tag 'print', media: :print, preload_links_header: false %>

--- a/app/views/session_timeout/_expire_session.html.erb
+++ b/app/views/session_timeout/_expire_session.html.erb
@@ -4,4 +4,4 @@
               timeout_refresh_path: timeout_refresh_path,
             } %>
 
-<%= javascript_packs_tag_once 'session-expire-session' %>
+<%= javascript_packs_tag_once 'session-expire-session', preload_links_header: false %>

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe ScriptHelper do
         )
       end
 
+      it 'adds preload header without nopush attribute' do
+        render_javascript_pack_once_tags
+
+        expect(response.headers['link']).to eq(
+          '</application.js>; rel=preload; as=script,' \
+            '</document-capture.js>; rel=preload; as=script',
+        )
+      end
+
       context 'with script integrity available' do
         before do
           allow(Rails.application.config.asset_sources).to receive(:get_integrity).and_return(nil)

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe ScriptHelper do
           '</application.js>; rel=preload; as=script,' \
             '</document-capture.js>; rel=preload; as=script',
         )
-        expect(response.haeders['link']).to_not include('nopush')
+        expect(response.headers['link']).to_not include('nopush')
       end
 
       context 'with script integrity available' do

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe ScriptHelper do
           '</application.js>; rel=preload; as=script,' \
             '</document-capture.js>; rel=preload; as=script',
         )
+        expect(response.haeders['link']).to_not include('nopush')
       end
 
       context 'with script integrity available' do

--- a/spec/helpers/stylesheet_helper_spec.rb
+++ b/spec/helpers/stylesheet_helper_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe StylesheetHelper do
           visible: :all,
         )
       end
+
+      it 'adds preload header without nopush attribute' do
+        render_stylesheet_once_tags
+
+        expect(response.headers['link']).to eq('</stylesheets/styles.css>; rel=preload; as=style')
+      end
     end
 
     context 'same stylesheet enqueued multiple times' do

--- a/spec/helpers/stylesheet_helper_spec.rb
+++ b/spec/helpers/stylesheet_helper_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe StylesheetHelper do
         render_stylesheet_once_tags
 
         expect(response.headers['link']).to eq('</stylesheets/styles.css>; rel=preload; as=style')
+        expect(response.headers['link']).to_not include('nopush')
       end
     end
 

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -193,8 +193,12 @@ RSpec.describe 'devise/sessions/new.html.erb' do
 
       it 'renders DAP analytics' do
         allow(view).to receive(:javascript_packs_tag_once)
-        expect(view).to receive(:javascript_packs_tag_once).
-          with(a_string_matching('https://dap.digitalgov.gov/'), async: true, id: '_fed_an_ua_tag')
+        expect(view).to receive(:javascript_packs_tag_once).with(
+          a_string_matching('https://dap.digitalgov.gov/'),
+          async: true,
+          preload_links_header: false,
+          id: '_fed_an_ua_tag',
+        )
 
         render
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates asset rendering in common layouts and critical paths to optimize loading and deprioritize non-blocking assets.

Specifically:

- Exclude `nopush` from preload headers ([related resource](https://www.keycdn.com/blog/http-preload-vs-http2-push), [related documentation](https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-javascript_include_tag)) (c57441e816763326db9d732b89181dc9266a4159)
- Avoid preload headers for non-critical assets (undocumented, [related code](https://github.com/rails/rails/blob/a6e2bb04ddc845e425ee0e9cdcdfa5a51d98846d/actionview/lib/action_view/helpers/asset_tag_helper.rb#L117)) (12bad512aa517c8e5d3031472201048fb00f02f1)
- Shorten font preload to use path instead of full URL (e22a83b53a25abe035b6bad5be22d8fcf1e4b46a)

These changes stem from a discovery that Rails ([as of ActionView 7.1](https://github.com/rails/rails/blob/7-1-stable/actionview/CHANGELOG.md#:~:text=Stop%20generating%20Link%20preload%20headers%20once%20it%20has%20reached%201KB.)) caps `link` preload headers at 1kb. Since we aggressively split assets into small stylesheets and scripts, we currently exceed this limit, and therefore some assets are not preloaded using the response headers.

For example, `application-*.js` is not included as a preloaded asset in production today, despite being common to every page of the application and controlling critical, high visibility UI elements.

```
curl -I --silent https://secure.login.gov | grep link
```

It may be possible to configure or override the default value, though it is currently configured as a module constant `ActionView::Helpers::AssetTagHelper::MAX_HEADER_SIZE`. The changelog note about "diminishing returns" is a valid consideration as well., though further analysis is required.

In the meantime, the changes here are intended to eliminate some low-hanging fruit for more granular control over preloaded assets.

## 📜 Testing Plan

1. `curl -I --silent http://localhost:3000 | grep link`

Observe:

- No `nopush` anywhere in the header
- `dap`, `session-expire-session`, and  `platform-authenticator-available` are not included in the header
- `application` _is_ included in the header
- `PublicSans-Bold` and `PublicSans-Regular` are preloaded as root-relative paths rather than fully-qualified URLs

Example:

_Before:_

```
link: </assets/init-6ad4cfee.js>; rel=preload; as=script; nopush,<http://localhost:3000/assets/public-sans/PublicSans-Bold-7ae9760d.woff2>; rel=preload; as=font; type=font/woff2; crossorigin=anonymous,<http://localhost:3000/assets/public-sans/PublicSans-Regular-838cb6e3.woff2>; rel=preload; as=font; type=font/woff2; crossorigin=anonymous,</assets/tab_navigation_component-1df00155.css>; rel=preload; as=style; nopush,</assets/password_toggle_component-b3bd600a.css>; rel=preload; as=style; nopush,</assets/icon_component-4ccec652.css>; rel=preload; as=style; nopush,</assets/application-312c5cee.css>; rel=preload; as=style; nopush,</packs/js/validated_field_component.js>; rel=preload; as=script; nopush,</packs/js/password_toggle_component.js>; rel=preload; as=script; nopush,</packs/js/submit_button_component.js>; rel=preload; as=script; nopush,</packs/js/platform-authenticator-available.js>; rel=preload; as=script; nopush,</packs/js/session-expire-session.js>; rel=preload; as=script; nopush
```

_After:_

```
link: </assets/init-6ad4cfee.js>; rel=preload; as=script,</assets/public-sans/PublicSans-Bold-7ae9760d.woff2>; rel=preload; as=font; type=font/woff2; crossorigin=anonymous,</assets/public-sans/PublicSans-Regular-838cb6e3.woff2>; rel=preload; as=font; type=font/woff2; crossorigin=anonymous,</assets/tab_navigation_component-1df00155.css>; rel=preload; as=style,</assets/password_toggle_component-b3bd600a.css>; rel=preload; as=style,</assets/icon_component-4ccec652.css>; rel=preload; as=style,</assets/application-312c5cee.css>; rel=preload; as=style,</packs/js/validated_field_component.js>; rel=preload; as=script,</packs/js/password_toggle_component.js>; rel=preload; as=script,</packs/js/submit_button_component.js>; rel=preload; as=script,</packs/js/application.js>; rel=preload; as=script
```