### PR TITLE
Refactor `OpenidConnectUserInfoPresenter` to use `AuthnContextResolver`

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -27,7 +27,7 @@ class OpenidConnectUserInfoPresenter
       info[:ial] = if identity_proofing_requested_for_verified_user?
                      Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
                    else
-                    Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+                     Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
                    end
       info[:aal] = identity.requested_aal_value
     else
@@ -129,7 +129,8 @@ class OpenidConnectUserInfoPresenter
   end
 
   def ial2_data
-    @ial2_data ||= out_of_band_session_accessor.load_pii(active_profile.id)
+    @ial2_data ||= out_of_band_session_accessor.load_pii(active_profile.id) ||
+                   Pii::Attributes.new_from_hash({})
   end
 
   def identity_proofing_requested_for_verified_user?
@@ -140,7 +141,7 @@ class OpenidConnectUserInfoPresenter
   def resolved_authn_context_result
     @resolved_authn_context_result ||= AuthnContextResolver.new(
       service_provider: identity&.service_provider_record,
-      vtr: (JSON.parse(identity.vtr) if identity.vtr.present?),
+      vtr: identity.vtr.presence && JSON.parse(identity.vtr),
       acr_values: identity.acr_values,
     ).resolve
   end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -139,7 +139,7 @@ class OpenidConnectUserInfoPresenter
 
   def resolved_authn_context_result
     @resolved_authn_context_result ||= AuthnContextResolver.new(
-      service_provider: identity&.service_provider,
+      service_provider: identity&.service_provider_record,
       vtr: (JSON.parse(identity.vtr) if identity.vtr.present?),
       acr_values: identity.acr_values,
     ).resolve

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -10,337 +10,337 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   let(:service_provider_ial) { 2 }
   let(:service_provider) { create(:service_provider, ial: service_provider_ial) }
   let(:profile) { create(:profile, :active, :verified) }
+  let(:vtr) { ['C1.C2.P1'] }
+  let(:acr_values) { nil }
+  let(:requested_aal_value) { nil }
   let(:identity) do
     build(
       :service_provider_identity,
       rails_session_id: rails_session_id,
-      user: create(:user, profiles: [profile]),
+      user: create(:user, profiles: [profile].compact),
       service_provider: service_provider.issuer,
       scope: scope,
-      aal: 2,
-      requested_aal_value: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+      vtr: vtr,
+      acr_values: acr_values,
+      requested_aal_value: requested_aal_value,
     )
   end
 
   subject(:presenter) { OpenidConnectUserInfoPresenter.new(identity) }
 
   describe '#user_info' do
+    let(:pii) do
+      {
+        first_name: 'John',
+        last_name: 'Smith',
+        dob: '12/31/1970',
+        address1: '123 Fake St',
+        address2: 'Apt 456',
+        city: 'Washington',
+        state: 'DC',
+        zipcode: '  12345-1234',
+        phone: '(703) 555-5555',
+        ssn: '666661234',
+      }
+    end
+
+    before do
+      if pii.present?
+        OutOfBandSessionAccessor.new(rails_session_id).put_pii(
+          profile_id: profile.id,
+          pii: pii,
+          expiration: 5.minutes.to_i,
+        )
+      end
+    end
+
     subject(:user_info) { presenter.user_info }
 
-    context 'without a vtr parameter' do
-      context 'basic ial1' do
-        it 'has basic attributes' do
-          ial = Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[identity.ial]
-          aal = Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF
+    context 'with a vtr parameter' do
+      let(:acr_values) { nil }
 
+      context 'no identity proofing' do
+        let(:vtr) { ['C1.C2'] }
+        let(:scope) { 'openid email all_emails' }
+
+        it 'includes the correct attributes' do
           aggregate_failures do
             expect(user_info[:sub]).to eq(identity.uuid)
             expect(user_info[:iss]).to eq(root_url)
             expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
             expect(user_info[:email_verified]).to eq(true)
             expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
-            expect(user_info[:ial]).to eq(ial)
-            expect(user_info[:aal]).to eq(aal)
-            expect(user_info).not_to have_key(:vot)
+            expect(user_info).to_not have_key(:ial)
+            expect(user_info).to_not have_key(:aal)
+            expect(user_info[:vot]).to eq('C1.C2')
           end
         end
       end
 
-      context 'ialmax' do
-        let(:ial) { Idp::Constants::IAL_MAX }
-        let(:ial_value) { Saml::Idp::Constants::AUTHN_CONTEXT_IAL_TO_CLASSREF[ial] }
-        let(:aal) { Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF }
-        before { identity.ial = ial }
+      context 'identity proofing' do
+        let(:vtr) { ['C1.C2.P1'] }
+        let(:scope) { 'openid email all_emails address phone profile social_security_number' }
 
-        it 'has basic attributes' do
+        it 'includes the correct non-proofed attributes' do
           aggregate_failures do
             expect(user_info[:sub]).to eq(identity.uuid)
             expect(user_info[:iss]).to eq(root_url)
             expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
             expect(user_info[:email_verified]).to eq(true)
             expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
-            expect(user_info[:ial]).to eq(ial_value)
-            expect(user_info[:aal]).to eq(aal)
-            expect(user_info).not_to have_key(:vot)
+            expect(user_info).to_not have_key(:ial)
+            expect(user_info).to_not have_key(:aal)
+            expect(user_info[:vot]).to eq('C1.C2.P1')
           end
         end
 
-        it 'does not return ial2 attributes' do
+        it 'includes the proofed attributes' do
           aggregate_failures do
-            expect(user_info[:given_name]).to eq(nil)
-            expect(user_info[:family_name]).to eq(nil)
-            expect(user_info[:birthdate]).to eq(nil)
-            expect(user_info[:phone]).to eq(nil)
-            expect(user_info[:phone_verified]).to eq(nil)
-            expect(user_info[:address]).to eq(nil)
-            expect(user_info).not_to have_key(:vot)
-          end
-        end
-      end
-
-      context 'when a piv/cac was used as second factor' do
-        let(:x509_subject) { 'x509-subject' }
-        let(:presented) { true }
-        let(:issuer) { 'trusted issuer' }
-
-        let(:x509) do
-          X509::Attributes.new_from_hash(
-            subject: x509_subject,
-            presented:,
-            issuer:,
-          )
-        end
-
-        before do
-          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
-        end
-
-        context 'when the identity has piv/cac associated' do
-          let(:identity) do
-            build(
-              :service_provider_identity,
-              rails_session_id: rails_session_id,
-              user: create(:user, :with_piv_or_cac),
-              scope: scope,
+            expect(user_info[:given_name]).to eq('John')
+            expect(user_info[:family_name]).to eq('Smith')
+            expect(user_info[:birthdate]).to eq('1970-12-31')
+            expect(user_info[:phone]).to eq('+17035555555')
+            expect(user_info[:phone_verified]).to eq(true)
+            expect(user_info[:address]).to eq(
+              formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
+              street_address: "123 Fake St\nApt 456",
+              locality: 'Washington',
+              region: 'DC',
+              postal_code: '12345',
             )
-          end
-
-          context 'when the scope includes all attributes' do
-            it 'returns x509 attributes' do
-              aggregate_failures do
-                expect(user_info[:x509_subject]).to eq(x509_subject)
-                expect(user_info[:x509_presented]).to eq(presented)
-                expect(user_info[:x509_issuer]).to eq(issuer)
-              end
-            end
-
-            it 'renders values as simple strings as json' do
-              json = user_info.as_json
-
-              expect(json['x509_subject']).to eq(x509_subject)
-              expect(json['x509_presented']).to eq(presented)
-              expect(json['x509_issuer']).to eq(issuer)
-            end
-          end
-
-          context 'when the sp requested x509_presented scope before it was fixed to string' do
-            before do
-              expect(IdentityConfig.store).to receive(
-                :x509_presented_hash_attribute_requested_issuers,
-              ).
-                and_return([identity.service_provider])
-            end
-
-            it 'returns x509_presented as an (X509::Attribute' do
-              # This is guarding against partners who may have coded against
-              # a bug where we returning the wrong data type for x509_presented
-              aggregate_failures do
-                expect(user_info[:x509_subject]).to eq(x509_subject)
-                expect(user_info[:x509_presented].class).to eq(X509::Attribute)
-                expect(user_info[:x509_issuer]).to eq(issuer)
-              end
-            end
+            expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
+            expect(user_info[:social_security_number]).to eq('666661234')
           end
         end
+      end
+    end
 
-        context 'when the identity has no piv/cac associated' do
-          context 'when the scope includes all attributes' do
-            it 'returns no x509 attributes' do
-              aggregate_failures do
-                expect(user_info[:x509_subject]).to be_blank
-                expect(user_info[:x509_issuer]).to be_blank
-                expect(user_info[:x509_presented]).to be false
-              end
-            end
+    context 'with ACR values' do
+      let(:vtr) { nil }
+
+      context 'no identity proofing' do
+        let(:acr_values) do
+          [
+            Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          ].join(' ')
+        end
+        let(:requested_aal_value) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
+        let(:scope) { 'openid email all_emails' }
+
+        it 'includes the correct attributes' do
+          aggregate_failures do
+            expect(user_info[:sub]).to eq(identity.uuid)
+            expect(user_info[:iss]).to eq(root_url)
+            expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
+            expect(user_info[:email_verified]).to eq(true)
+            expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
+            expect(user_info[:ial]).to eq(Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF)
+            expect(user_info[:aal]).to eq(Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF)
+            expect(user_info).to_not have_key(:vot)
           end
         end
       end
 
-      context 'when there is decrypted ial2 session data in redis' do
-        let(:pii) do
-          {
-            first_name: 'John',
-            last_name: 'Smith',
-            dob: '12/31/1970',
-            address1: '123 Fake St',
-            address2: 'Apt 456',
-            city: 'Washington',
-            state: 'DC',
-            zipcode: '  12345-1234',
-            phone: '(703) 555-5555',
-            ssn: '666661234',
-          }
+      context 'identity proofing' do
+        let(:acr_values) do
+          [
+            Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          ].join(' ')
         end
+        let(:requested_aal_value) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
+        let(:scope) { 'openid email all_emails address phone profile social_security_number' }
 
-        before do
-          OutOfBandSessionAccessor.new(rails_session_id).put_pii(
-            profile_id: profile.id,
-            pii: pii,
-            expiration: 5.minutes.to_i,
-          )
-        end
-
-        context 'when the identity has ial2 access' do
-          before { identity.ial = Idp::Constants::IAL2 }
-
-          context 'when the scope includes all attributes' do
-            it 'returns ial2 attributes' do
-              aggregate_failures do
-                expect(user_info[:given_name]).to eq('John')
-                expect(user_info[:family_name]).to eq('Smith')
-                expect(user_info[:birthdate]).to eq('1970-12-31')
-                expect(user_info[:phone]).to eq('+17035555555')
-                expect(user_info[:phone_verified]).to eq(true)
-                expect(user_info[:address]).to eq(
-                  formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
-                  street_address: "123 Fake St\nApt 456",
-                  locality: 'Washington',
-                  region: 'DC',
-                  postal_code: '12345',
-                )
-                expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
-                expect(user_info[:social_security_number]).to eq('666661234')
-              end
-            end
-
-            it 'renders values as simple strings as json' do
-              json = user_info.as_json
-
-              expect(json['given_name']).to eq('John')
-            end
-          end
-
-          context 'when the scope only includes minimal attributes' do
-            let(:scope) { 'openid email phone' }
-
-            it 'returns attributes allowed by the scope' do
-              aggregate_failures do
-                expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
-                expect(user_info[:email_verified]).to eq(true)
-                expect(user_info[:given_name]).to eq(nil)
-                expect(user_info[:family_name]).to eq(nil)
-                expect(user_info[:birthdate]).to eq(nil)
-                expect(user_info[:phone]).to eq('+17035555555')
-                expect(user_info[:phone_verified]).to eq(true)
-                expect(user_info[:address]).to eq(nil)
-                expect(user_info[:verified_at]).to eq(nil)
-                expect(user_info[:social_security_number]).to eq(nil)
-              end
-            end
-          end
-
-          context 'verified_at' do
-            let(:scope) { 'openid profile:verified_at' }
-
-            context 'when the service provider has ial1 access' do
-              let(:service_provider_ial) { 1 }
-
-              it 'does not provide verified_at' do
-                expect(user_info[:verified_at]).to eq(nil)
-              end
-            end
-
-            context 'when the service provider has ial2 access' do
-              let(:service_provider_ial) { 2 }
-
-              it 'provides verified_at' do
-                expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
-              end
-            end
+        it 'includes the correct non-proofed attributes' do
+          aggregate_failures do
+            expect(user_info[:sub]).to eq(identity.uuid)
+            expect(user_info[:iss]).to eq(root_url)
+            expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
+            expect(user_info[:email_verified]).to eq(true)
+            expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
+            expect(user_info[:ial]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
+            expect(user_info[:aal]).to eq(Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF)
+            expect(user_info).to_not have_key(:vot)
           end
         end
 
-        context 'when the identity only has ial1 access' do
-          before { identity.ial = Idp::Constants::IAL1 }
+        it 'includes the proofed attributes' do
+          aggregate_failures do
+            expect(user_info[:given_name]).to eq('John')
+            expect(user_info[:family_name]).to eq('Smith')
+            expect(user_info[:birthdate]).to eq('1970-12-31')
+            expect(user_info[:phone]).to eq('+17035555555')
+            expect(user_info[:phone_verified]).to eq(true)
+            expect(user_info[:address]).to eq(
+              formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
+              street_address: "123 Fake St\nApt 456",
+              locality: 'Washington',
+              region: 'DC',
+              postal_code: '12345',
+            )
+            expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
+            expect(user_info[:social_security_number]).to eq('666661234')
+          end
+        end
+      end
 
-          it 'does not return ial2 attributes' do
+      context 'IALMax' do
+        let(:acr_values) do
+          [
+            Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+          ].join(' ')
+        end
+        let(:requested_aal_value) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
+        let(:scope) { 'openid email all_emails address phone profile social_security_number' }
+
+        context 'the user has verified their identity' do
+          it 'includes the proofed attributes' do
             aggregate_failures do
-              expect(user_info[:given_name]).to eq(nil)
-              expect(user_info[:family_name]).to eq(nil)
-              expect(user_info[:birthdate]).to eq(nil)
-              expect(user_info[:phone]).to eq(nil)
-              expect(user_info[:phone_verified]).to eq(nil)
-              expect(user_info[:address]).to eq(nil)
+              expect(user_info[:ial]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
+              expect(user_info[:aal]).to eq(Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF)
+              expect(user_info).to_not have_key(:vot)
+              expect(user_info[:given_name]).to eq('John')
+              expect(user_info[:family_name]).to eq('Smith')
+              expect(user_info[:birthdate]).to eq('1970-12-31')
+              expect(user_info[:phone]).to eq('+17035555555')
+              expect(user_info[:phone_verified]).to eq(true)
+              expect(user_info[:address]).to eq(
+                formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
+                street_address: "123 Fake St\nApt 456",
+                locality: 'Washington',
+                region: 'DC',
+                postal_code: '12345',
+              )
+              expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
+              expect(user_info[:social_security_number]).to eq('666661234')
             end
           end
         end
 
-        context 'when the identity has ialmax access' do
-          before { identity.ial = Idp::Constants::IAL_MAX }
+        context 'the user has not verified their identity' do
+          let(:pii) { nil }
+          let(:profile) { nil }
 
-          context 'when the scope includes all attributes' do
-            it 'returns ial2 attributes' do
-              aggregate_failures do
-                expect(user_info[:given_name]).to eq('John')
-                expect(user_info[:family_name]).to eq('Smith')
-                expect(user_info[:birthdate]).to eq('1970-12-31')
-                expect(user_info[:phone]).to eq('+17035555555')
-                expect(user_info[:phone_verified]).to eq(true)
-                expect(user_info[:address]).to eq(
-                  formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
-                  street_address: "123 Fake St\nApt 456",
-                  locality: 'Washington',
-                  region: 'DC',
-                  postal_code: '12345',
-                )
-                expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
-                expect(user_info[:social_security_number]).to eq('666661234')
-              end
-            end
-
-            it 'renders values as simple strings as json' do
-              json = user_info.as_json
-
-              expect(json['given_name']).to eq('John')
-            end
-          end
-
-          context 'when the scope only includes minimal attributes' do
-            let(:scope) { 'openid email phone' }
-
-            it 'returns attributes allowed by the scope' do
-              aggregate_failures do
-                expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
-                expect(user_info[:email_verified]).to eq(true)
-                expect(user_info[:given_name]).to eq(nil)
-                expect(user_info[:family_name]).to eq(nil)
-                expect(user_info[:birthdate]).to eq(nil)
-                expect(user_info[:phone]).to eq('+17035555555')
-                expect(user_info[:phone_verified]).to eq(true)
-                expect(user_info[:address]).to eq(nil)
-                expect(user_info[:verified_at]).to eq(nil)
-                expect(user_info[:social_security_number]).to eq(nil)
-              end
+          it 'does not include proofed attributes' do
+            aggregate_failures do
+              expect(user_info[:ial]).to eq(Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF)
+              expect(user_info[:aal]).to eq(Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF)
+              expect(user_info).to_not have_key(:vot)
+              expect(user_info).to_not have_key(:given_name)
+              expect(user_info).to_not have_key(:family_name)
+              expect(user_info).to_not have_key(:birthdate)
+              expect(user_info).to_not have_key(:phone)
+              expect(user_info).to_not have_key(:phone_verified)
+              expect(user_info).to_not have_key(:address)
+              expect(user_info).to_not have_key(:social_security_number)
             end
           end
         end
       end
     end
 
-    context 'with a vtr parameter' do
+    context 'when minimal scopes are requested for proofed attributes' do
+      let(:scope) do
+        'openid email all_emails profile'
+      end
+
+      it 'only returns the requested attributes' do
+        expect(user_info[:given_name]).to eq('John')
+        expect(user_info[:family_name]).to eq('Smith')
+        expect(user_info[:birthdate]).to eq('1970-12-31')
+        expect(user_info).to_not have_key(:phone)
+        expect(user_info).to_not have_key(:phone_verified)
+        expect(user_info).to_not have_key(:address)
+        expect(user_info).to_not have_key(:social_security_number)
+      end
+    end
+
+    context 'when x509 scopes are requested' do
+      let(:x509_subject) { 'x509-subject' }
+      let(:x509_presented) { true }
+      let(:x509_issuer) { 'trusted issuer' }
+      let(:x509) do
+        X509::Attributes.new_from_hash(
+          subject: x509_subject,
+          presented: x509_presented,
+          issuer: x509_issuer,
+        )
+      end
+
+      let(:scope) do
+        'openid email x509'
+      end
+
       let(:identity) do
         build(
           :service_provider_identity,
           rails_session_id: rails_session_id,
-          user: create(:user, profiles: [profile]),
-          service_provider: service_provider.issuer,
+          user: create(:user, :with_piv_or_cac),
           scope: scope,
-          aal: 2,
-          vtr: ['C1'],
         )
       end
 
-      it 'has basic attributes' do
-        aggregate_failures do
-          expect(user_info[:sub]).to eq(identity.uuid)
-          expect(user_info[:iss]).to eq(root_url)
-          expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
-          expect(user_info[:email_verified]).to eq(true)
-          expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
-          expect(user_info).not_to have_key(:ial)
-          expect(user_info).not_to have_key(:aal)
-          expect(user_info[:vot]).to eq('C1')
-          expect(user_info[:vtm]).to eq(IdentityConfig.store.vtm_url)
+      context 'when the piv/cac was used as a second factor' do
+        before do
+          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
+        end
+
+        it 'includes the x509 claims' do
+          aggregate_failures do
+            expect(user_info[:x509_subject]).to eq(x509_subject)
+            expect(user_info[:x509_presented]).to eq(x509_presented)
+            expect(user_info[:x509_issuer]).to eq(x509_issuer)
+          end
+        end
+      end
+
+      context 'when the piv/cac was not used as a second factor' do
+        it 'includes blank x509 claims' do
+          aggregate_failures do
+            expect(user_info[:x509_subject]).to be_blank
+            expect(user_info[:x509_issuer]).to be_blank
+            expect(user_info[:x509_presented]).to be false
+          end
+        end
+      end
+
+      context 'when the user does not have an associated piv/cac' do
+        let(:identity) do
+          build(
+            :service_provider_identity,
+            rails_session_id: rails_session_id,
+            user: create(:user, :fully_registered),
+            scope: scope,
+          )
+        end
+
+        it 'includes blank x509 claims' do
+          aggregate_failures do
+            expect(user_info[:x509_subject]).to be_blank
+            expect(user_info[:x509_issuer]).to be_blank
+            expect(user_info[:x509_presented]).to be false
+          end
+        end
+      end
+
+      context 'when the sp requested x509_presented scope before it was fixed to string' do
+        before do
+          expect(IdentityConfig.store).to receive(
+            :x509_presented_hash_attribute_requested_issuers,
+          ).and_return([identity.service_provider])
+          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
+        end
+
+        it 'returns x509_presented as an X509::Attribute' do
+          # This is guarding against partners who may have coded against
+          # a bug where we returning the wrong data type for x509_presented
+          aggregate_failures do
+            expect(user_info[:x509_subject]).to eq(x509_subject)
+            expect(user_info[:x509_presented].class).to eq(X509::Attribute)
+            expect(user_info[:x509_issuer]).to eq(x509_issuer)
+          end
         end
       end
     end


### PR DESCRIPTION
The `OpenidConnectUserInfoPresenter` is responsible for building the user info hash. This is stored in the identity token and exposed at the user info endpoint as part of the OIDC protocol.

The `OpenidConnectUserInfoPresenter` is reponsible for looking at the parameters of the request to determine which attributes to include in the hash. This can include things like the level of service for identity proofing and the requested scopes.

Prior to this commit the `OpenidConnectUserInfoPresenter` was using the `ServiceProviderIdentity#ial` to determine whether identity proofing was performed. This approach does not work when using multiple vectors of trust determine the authentication context. The `#ial` column represents the level of service that was set when the identity was linked when the SP request was stored in the session. This could change with multiple vectors of trust if the state of the users account changes during the transaction.

This commit starts using the `AuthnContextResolver` to compute the level of service and set the attributes so that it matches the dynamic behavior of the rest of the application with multiple vectors of trust in play.