### PR TITLE
LG-12086 | Renames CaptureDocStatusController

### DIFF
--- a/app/controllers/idv/link_sent_poll_controller.rb
+++ b/app/controllers/idv/link_sent_poll_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Idv
-  class CaptureDocStatusController < ApplicationController
+  class LinkSentPollController < ApplicationController
     include Idv::AvailabilityConcern
 
     before_action :confirm_two_factor_authenticated

--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -42,7 +42,7 @@
 
 <% if FeatureManagement.doc_capture_polling_enabled? %>
   <%= content_tag 'script', '', data: {
-        status_endpoint: idv_capture_doc_status_url,
+        status_endpoint: idv_link_sent_poll_url,
       } %>
   <%= javascript_packs_tag_once 'doc-capture-polling' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -351,7 +351,7 @@ Rails.application.routes.draw do
       put '/hybrid_handoff' => 'hybrid_handoff#update'
       get '/link_sent' => 'link_sent#show'
       put '/link_sent' => 'link_sent#update'
-      get '/link_sent/poll' => 'capture_doc_status#show', as: :capture_doc_status
+      get '/link_sent/poll' => 'link_sent_poll#show'
       get '/ssn' => 'ssn#show'
       put '/ssn' => 'ssn#update'
       get '/verify_info' => 'verify_info#show'

--- a/spec/controllers/idv/link_sent_poll_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_poll_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::CaptureDocStatusController do
+RSpec.describe Idv::LinkSentPollController do
   let(:user) { build(:user) }
   let(:doc_auth_response) do
     DocAuth::Response.new(


### PR DESCRIPTION
changelog: Internal, Tech Debt, Renames CaptureDocStatusController to LinkSentPollController


## 🎫 Ticket

Link to the relevant ticket:
[LG-12086](https://cm-jira.usa.gov/browse/LG-12086)


## 🛠 Summary of changes

From the ticket:

> The name is left over from the FlowStateMachine. What it does is poll to see if hybrid flow DocumentCapture is complete. The route has already been renamed to /link_sent/poll

This updates the name to match.