### PR TITLE
Add resource hints for reCAPTCHA

### DIFF
--- a/app/controllers/concerns/recaptcha_concern.rb
+++ b/app/controllers/concerns/recaptcha_concern.rb
@@ -11,6 +11,14 @@ module RecaptchaConcern
     'https://recaptcha.google.com/recaptcha/',
   ].freeze
 
+  def add_recaptcha_resource_hints
+    response.headers['Link'] = [
+      response.headers['Link'],
+      '<https://www.google.com>;rel=preconnect',
+      '<https://www.gstatic.com>;rel=preconnect;crossorigin',
+    ].compact.join(',')
+  end
+
   def allow_csp_recaptcha_src
     policy = current_content_security_policy
     policy.script_src(*policy.script_src, *RECAPTCHA_SCRIPT_SRC)

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -16,6 +16,8 @@ module Users
     before_action :confirm_recently_authenticated_2fa
     before_action :check_max_phone_numbers_per_account, only: %i[index create]
 
+    after_action :add_recaptcha_resource_hints, if: :recaptcha_enabled?
+
     helper_method :in_multi_mfa_selection_flow?
 
     def index

--- a/spec/controllers/concerns/recaptcha_concern_spec.rb
+++ b/spec/controllers/concerns/recaptcha_concern_spec.rb
@@ -1,23 +1,71 @@
 require 'rails_helper'
 
 RSpec.describe RecaptchaConcern, type: :controller do
-  controller ApplicationController do
-    include RecaptchaConcern
-
-    before_action :allow_csp_recaptcha_src
-
-    def index
-      render plain: ''
-    end
-  end
-
   describe '#allow_csp_recaptcha_src' do
+    controller ApplicationController do
+      include RecaptchaConcern
+
+      before_action :allow_csp_recaptcha_src
+
+      def index
+        render plain: ''
+      end
+    end
+
     it 'overrides csp to add directives for recaptcha' do
       get :index
 
       csp = response.request.content_security_policy
       expect(csp.script_src).to include(*RecaptchaConcern::RECAPTCHA_SCRIPT_SRC)
       expect(csp.frame_src).to include(*RecaptchaConcern::RECAPTCHA_FRAME_SRC)
+    end
+  end
+
+  describe '#add_recaptcha_resource_hints' do
+    controller ApplicationController do
+      include RecaptchaConcern
+
+      after_action :add_recaptcha_resource_hints
+
+      def index
+        if params[:add_link]
+          response.headers['Link'] = '<https://example.com>;rel=preconnect'
+        end
+
+        render plain: ''
+      end
+    end
+
+    subject(:response) { get :index }
+    let(:processed_links) do
+      response.headers['Link'].split(',').map { |link| link.chomp.split(';').map(&:chomp) }
+    end
+
+    it 'adds resource hints for recaptcha to response headers' do
+      response
+
+      expect(processed_links).to match_array(
+        [
+          ['<https://www.google.com>', 'rel=preconnect'],
+          ['<https://www.gstatic.com>', 'rel=preconnect', 'crossorigin'],
+        ],
+      )
+    end
+
+    context 'with existing link header' do
+      subject(:response) { get :index, params: { add_link: '' } }
+
+      it 'appends new resource hints' do
+        response
+
+        expect(processed_links).to match_array(
+          [
+            ['<https://example.com>', 'rel=preconnect'],
+            ['<https://www.google.com>', 'rel=preconnect'],
+            ['<https://www.gstatic.com>', 'rel=preconnect', 'crossorigin'],
+          ],
+        )
+      end
     end
   end
 end

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -292,4 +292,26 @@ RSpec.describe Users::PhoneSetupController, allowed_extra_analytics: [:*] do
       end
     end
   end
+
+  describe 'after actions' do
+    before { stub_sign_in }
+
+    it 'does not add recaptcha resource hints' do
+      expect(subject).not_to receive(:add_recaptcha_resource_hints)
+
+      get :index
+    end
+
+    context 'recaptcha enabled' do
+      before do
+        allow(FeatureManagement).to receive(:phone_recaptcha_enabled?).and_return(true)
+      end
+
+      it 'adds recaptcha resource hints' do
+        expect(subject).to receive(:add_recaptcha_resource_hints)
+
+        get :index
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds resource hints to the response headers when loading reCAPTCHA, to improve load times.

Related documentation: https://cloud.google.com/recaptcha-enterprise/docs/using-features#instrument-site

>(Optional) To improve the loading performance of reCAPTCHA Enterprise, do the following:
>[...]
>2. Add the following resource hints in the `<head>` tag of pages that load `enterprise.js`:
>  - `<link rel="preconnect" href="https://www.google.com">`
>  - `<link rel="preconnect" href="https://www.gstatic.com" crossorigin>`

The changes here add the resource hints as a response header, which allow the browser to resolve the hint before parsing page markup.

## 📜 Testing Plan

Prerequisite: You'll need valid reCAPTCHA keys. In local development, you can use keys generated yourself with the free version of reCAPTCHA:

1. Go to https://www.google.com/recaptcha/admin
2. Create keys for local development as a "Score based (v3)" type
3. Update configuration in `config/application.yml`, adding your site and secret keys
    ```
    recaptcha_site_key: '[insert-v3-site-key]'
    recaptcha_secret_key: '[insert-v3-secret-key]'
    ```

Verify response header is present on pages where reCAPTCHA is loaded:

1. Go to http://localhost:3000
2. Sign in
3. From account dashboard, click "Add phone number"
4. Use browser developer tools network tab to inspect response headers for the page ("document") request (see [Chrome DevTools reference](https://developer.chrome.com/docs/devtools/network/reference#headers))
5. See "link:" response header includes `<https://www.google.com>` and `<https://www.gstatic.com>` entries