### PR TITLE
Remove unnecessary allowed_extra_analytics

### DIFF
--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'throttling requests', allowed_extra_analytics: [:*] do
+RSpec.describe 'throttling requests' do
   before(:all) { Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new }
   before(:each) { Rack::Attack.cache.store.clear }
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes an unnecessary `allowed_extra_analytics`.

This is being caught by new checks added in #10571, but not failing on `main` in all cases. It fails locally, and [sometimes in other pull requests](https://github.com/18F/identity-idp/pull/10560#discussion_r1599041326).

Further investigation is needed to determine why it only fails in some cases, but this should help unblock any branches impacted by the test failure.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1715632785782359

## 📜 Testing Plan

Verify `rspec spec/requests/rack_attack_spec.rb` passes.