### PR TITLE
Proof of Concept: PIV upsell

### DIFF
--- a/app/controllers/concerns/mfa_setup_concern.rb
+++ b/app/controllers/concerns/mfa_setup_concern.rb
@@ -82,7 +82,7 @@ module MfaSetupConcern
   end
 
   def check_if_possible_piv_user
-    if current_user.has_gov_or_mil_email? && current_user.piv_cac_recommended_dismissed_at.nil?
+    if current_user.has_agency_with_piv_card_issued_email? && current_user.piv_cac_recommended_dismissed_at.nil?
       redirect_to login_piv_cac_recommended_path
     end
   end

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -37,6 +37,15 @@ class EmailAddress < ApplicationRecord
     email.end_with?('.gov', '.mil')
   end
 
+  def fed_agency_issues_piv?
+    email_domain = get_email_domain
+    IdentityConfig.store.federal_agencies_with_piv.include?(email_domain)
+  end
+
+  def get_email_domain
+    email.split('@').last
+  end
+
   class << self
     def find_with_email(email)
       return nil if !email.is_a?(String) || email.empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,10 @@ class User < ApplicationRecord
     confirmed_email_addresses.any?(&:gov_or_mil?)
   end
 
+  def has_agency_with_piv_card_issued_email?
+    confirmed_email_addresses.any?(&:fed_agency_issues_piv?)
+  end
+
   def accepted_rules_of_use_still_valid?
     if self.accepted_terms_at.present?
       self.accepted_terms_at > IdentityConfig.store.rules_of_use_updated_at &&

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -108,6 +108,7 @@ enable_rate_limiting: true
 enable_test_routes: true
 enable_usps_verification: true
 event_disavowal_expiration_hours: 240
+federal_agencies_with_piv: '["gsa.gov", "army.mil"]'
 feature_idv_force_gpo_verification_enabled: false
 feature_idv_hybrid_flow_enabled: true
 feature_new_device_alert_aggregation_enabled: true

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -145,6 +145,7 @@ module IdentityConfig
     config.add(:feature_idv_force_gpo_verification_enabled, type: :boolean)
     config.add(:feature_idv_hybrid_flow_enabled, type: :boolean)
     config.add(:feature_new_device_alert_aggregation_enabled, type: :boolean)
+    config.add(:federal_agencies_with_piv, type: :json)
     config.add(:geo_data_file_path, type: :string)
     config.add(:get_usps_proofing_results_job_cron, type: :string)
     config.add(:get_usps_proofing_results_job_reprocess_delay_minutes, type: :integer)


### PR DESCRIPTION
Steps to reproduce:

**To skip the PIV upsell**
- Create an account. Use an agency that is not `gsa.gov` or `army.mil` to see how this would work if the email is not in a dataset.
- Confirm account creation.
- Create a password. After you create a password, you will be redirected to the authentication methods setup page.

**To view the upsell**
- Create an account with an email using a `gsa.gov` or `army.mil` domain.
- Confirm account creation
- Create a password. On submit, you will see the PIV recommendation upsell.