### PR TITLE
LG-13317: Log 10-digit OTP A/B test params for OTP sends

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2851,6 +2851,7 @@ module AnalyticsEvents
   # @param [Idv::ProofingComponentsLogging] proofing_components User's current proofing components
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Hash, nil] ab_tests data for ongoing A/B tests
   # The user resent an OTP during the IDV phone step
   def idv_phone_confirmation_otp_resent(
     success:,
@@ -2864,6 +2865,7 @@ module AnalyticsEvents
     proofing_components: nil,
     active_profile_idv_level: nil,
     pending_profile_idv_level: nil,
+    ab_tests: nil,
     **extra
   )
     track_event(
@@ -2879,6 +2881,7 @@ module AnalyticsEvents
       proofing_components: proofing_components,
       active_profile_idv_level: active_profile_idv_level,
       pending_profile_idv_level: pending_profile_idv_level,
+      ab_tests: ab_tests,
       **extra,
     )
   end

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -112,6 +112,11 @@ module Idv
         phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
         rate_limit_exceeded: rate_limit_exceeded?,
         telephony_response: @telephony_response,
+        ab_tests: {
+          AbTests::IDV_TEN_DIGIT_OTP.experiment_name => {
+            bucket: bucket,
+          },
+        },
       }
     end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13317](https://cm-jira.usa.gov/browse/LG-13317)

## 🛠 Summary of changes

Adds the `ab_tests` hash to the OTP sent event.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
