### PR TITLE
Stop writing to `sp_session[:biometric_comparison_required]`

### DIFF
--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -18,20 +18,6 @@ class StoreSpMetadataInSession
 
   attr_reader :session, :request_id
 
-  def parsed_vot
-    return nil if !sp_request.vtr && !sp_request.acr_values
-
-    @parsed_vot ||= AuthnContextResolver.new(
-      service_provider: service_provider,
-      vtr: sp_request.vtr,
-      acr_values: sp_request.acr_values,
-    ).resolve
-  end
-
-  def ial_context
-    @ial_context ||= IalContext.new(ial: sp_request.ial, service_provider: service_provider)
-  end
-
   def sp_request
     @sp_request ||= ServiceProviderRequestProxy.from_uuid(request_id)
   end
@@ -42,7 +28,6 @@ class StoreSpMetadataInSession
       request_url: sp_request.url,
       request_id: sp_request.uuid,
       requested_attributes: sp_request.requested_attributes,
-      biometric_comparison_required: parsed_vot&.biometric_comparison?,
       acr_values: sp_request.acr_values,
       vtr: sp_request.vtr,
     }

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -2511,7 +2511,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             request_id: sp_request_id,
             request_url: request.original_url,
             requested_attributes: %w[],
-            biometric_comparison_required: false,
             vtr: nil,
           )
         end
@@ -2645,7 +2644,6 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             request_id: sp_request_id,
             request_url: request.original_url,
             requested_attributes: %w[],
-            biometric_comparison_required: false,
             vtr: ['C1'],
           )
         end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1375,7 +1375,6 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
           request_url: @stored_request_url.gsub('authpost', 'auth'),
           request_id: sp_request_id,
           requested_attributes: ['email'],
-          biometric_comparison_required: false,
           vtr: nil,
         )
       end
@@ -1409,7 +1408,6 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
           request_url: @saml_request.request.original_url.gsub('authpost', 'auth'),
           request_id: sp_request_id,
           requested_attributes: ['email'],
-          biometric_comparison_required: false,
           vtr: nil,
         )
       end


### PR DESCRIPTION
In #10531 we stopped reading from `sp_session[:biometric_comparison_required]`. In that commit we switched to using the `AuthnContextResolver` result to determine if biometric comparison is required.

This removes the unread value from `sp_session`.
