### PR TITLE
Stop creating `ServiceProviderRequest` records with unused fields

### DIFF
--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -4,27 +4,29 @@ class ServiceProviderRequest
   # WARNING - Modification of these params requires particular care
   # since these objects are serialized to/from Redis and may be present
   # upon deployment
-  attr_accessor :uuid, :issuer, :url, :ial, :aal, :requested_attributes,
-                :biometric_comparison_required, :acr_values, :vtr
+  attr_accessor :uuid, :issuer, :url, :requested_attributes, :acr_values, :vtr
+
+  # Deprecated attributes to remove
+  attr_accessor :ial, :aal, :biometric_comparison_required
 
   def initialize(
     uuid: nil,
     issuer: nil,
     url: nil,
+    requested_attributes: [],
+    acr_values: nil,
+    vtr: nil,
+    # Deprecated attributes to remove
+    # rubocop:disable Lint/UnusedMethodArgument
     ial: nil,
     aal: nil,
-    requested_attributes: [],
-    biometric_comparison_required: false,
-    acr_values: nil,
-    vtr: nil
+    biometric_comparison_required: false
+    # rubocop:enable Lint/UnusedMethodArgument
   )
     @uuid = uuid
     @issuer = issuer
     @url = url
-    @ial = ial
-    @aal = aal
     @requested_attributes = requested_attributes&.map(&:to_s)
-    @biometric_comparison_required = biometric_comparison_required
     @acr_values = acr_values
     @vtr = vtr
   end

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -63,12 +63,9 @@ class ServiceProviderRequestHandler
   def attributes
     {
       issuer: protocol.issuer,
-      ial: protocol.ial,
-      aal: protocol.aal,
       acr_values: protocol.acr_values,
       vtr: protocol.vtr,
       requested_attributes: protocol.requested_attributes,
-      biometric_comparison_required: protocol.biometric_comparison_required?,
       uuid: request_id,
       url: url,
     }

--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -34,9 +34,12 @@ class ServiceProviderRequestProxy
     obj = find_by(uuid: uuid)
     return obj if obj
     spr = ServiceProviderRequest.new(
-      uuid: uuid, issuer: nil, url: nil, ial: nil,
-      aal: nil, requested_attributes: nil,
-      biometric_comparison_required: false, acr_values: nil, vtr: nil
+      uuid: uuid,
+      issuer: nil,
+      url: nil,
+      requested_attributes: nil,
+      acr_values: nil,
+      vtr: nil,
     )
 
     yield(spr)
@@ -44,10 +47,7 @@ class ServiceProviderRequestProxy
       uuid: uuid,
       issuer: spr.issuer,
       url: spr.url,
-      ial: spr.ial,
-      aal: spr.aal,
       requested_attributes: spr.requested_attributes,
-      biometric_comparison_required: spr.biometric_comparison_required,
       acr_values: spr.acr_values,
       vtr: spr.vtr,
     )
@@ -58,10 +58,7 @@ class ServiceProviderRequestProxy
     obj = hash.slice(
       :issuer,
       :url,
-      :ial,
-      :aal,
       :requested_attributes,
-      :biometric_comparison_required,
       :vtr,
       :acr_values,
     )


### PR DESCRIPTION
Previous commits retired the following fields on the `ServiceProviderRequest` model:

- `ial`
- `aal`
- `biometric_comparison_required`

These fields were left behind because removing them leads to issues during deploys when old and new versions of the code are running at the same time.

The `ServiceProviderRequest` model has default values for these fields. This means that we can stop creating records with these fields and the defaults will be used. However, we use the hash that is written to redis is converted into keyword args to create `ServiceProviderRequest`s. This means that if we remove the keys for these fields we will encounter a `ArgumentError` when we try to create a record on a new host with a hash written by an old host. This commit leaves them behind and a follow-up will be needed to remove them.
