### PR TITLE
Ensure proper behavior for default and invalid NameID format requests

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -66,7 +66,7 @@ module SamlIdpAuthConcern
       service_provider: saml_request_service_provider,
       authn_context: requested_authn_contexts,
       authn_context_comparison: saml_request.requested_authn_context_comparison,
-      nameid_format: name_id_format,
+      nameid_format: saml_request.name_id_format,
     )
   end
 
@@ -78,8 +78,8 @@ module SamlIdpAuthConcern
     @saml_request_validator = SamlRequestValidator.new(blank_cert: true)
   end
 
-  def name_id_format
-    @name_id_format ||= specified_name_id_format || default_name_id_format
+  def response_name_id_format
+    @response_name_id_format ||= specified_name_id_format || default_name_id_format
   end
 
   def specified_name_id_format
@@ -93,9 +93,6 @@ module SamlIdpAuthConcern
   end
 
   def default_name_id_format
-    if saml_request_service_provider&.email_nameid_format_allowed
-      return Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
-    end
     Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
   end
 
@@ -170,7 +167,7 @@ module SamlIdpAuthConcern
     AttributeAsserter.new(
       user: principal,
       service_provider: saml_request_service_provider,
-      name_id_format: name_id_format,
+      name_id_format: response_name_id_format,
       authn_request: saml_request,
       decrypted_pii: decrypted_pii,
       user_session: user_session,
@@ -190,7 +187,7 @@ module SamlIdpAuthConcern
   def saml_response
     encode_response(
       current_user,
-      name_id_format: name_id_format,
+      name_id_format: response_name_id_format,
       authn_context_classref: response_authn_context,
       reference_id: active_identity.session_uuid,
       encryption: encryption_opts,

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -7,7 +7,7 @@ class SamlRequestValidator
   validate :authorized_service_provider
   validate :authorized_authn_context
   validate :parsable_vtr
-  validate :authorized_email_nameid_format
+  validate :authorized_nameid_format
 
   def initialize(blank_cert: false)
     @blank_cert = blank_cert
@@ -119,17 +119,24 @@ class SamlRequestValidator
     Array(authn_context).include?(Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF)
   end
 
-  def authorized_email_nameid_format
-    return unless email_nameid_format?
-    return if service_provider&.email_nameid_format_allowed
+  def authorized_nameid_format
+    return if satisfiable_nameid_format?
+    return if email_nameid_format? && service_provider&.email_nameid_format_allowed
+    return if legacy_name_id_behavior_needed?
 
     errors.add(:nameid_format, :unauthorized_nameid_format, type: :unauthorized_nameid_format)
   end
 
+  def satisfiable_nameid_format?
+    nameid_format.nil? || [Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+                           Saml::Idp::Constants::NAME_ID_FORMAT_UNSPECIFIED].include?(nameid_format)
+  end
+
+  def legacy_name_id_behavior_needed?
+    service_provider&.use_legacy_name_id_behavior && !email_nameid_format?
+  end
+
   def email_nameid_format?
-    [
-      'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
-      'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
-    ].include?(nameid_format)
+    nameid_format == Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
   end
 end

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -30,6 +30,7 @@ module Saml
 
       NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
       NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+      NAME_ID_FORMAT_UNSPECIFIED = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
       VALID_NAME_ID_FORMATS = [NAME_ID_FORMAT_PERSISTENT, NAME_ID_FORMAT_EMAIL].freeze
 
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-people/lg-people-appdev/protocols/saml/-/issues/2
-->

## 🛠 Summary of changes

- Refactored tests to remove duplication and make contexts explicit
- Fail on unsupported NameID formats unless service provider is configured with `use_legacy_name_id_behavior`.
- Use `persistent` as default NameID format when the requested NameID format is "unspecified" or there is no requested NameID format. In particular, don't send back email even if the service provider is configured for using email, unless email is explicitly requested.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Ensure that `use_legacy_name_id_behavior` is false for the service provider, and make a SAML Authn request with an unsupported NameID format like 'urn:oasis:names:tc:SAML:1.1:nameid-format:transient'.
- [ ] Make a SAML Authn request with NameID format missing or with the value 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'. Ensure that the response is always 'urn:oasis:names:tc:SAML:1.1:nameid-format:persistent'. This should be true regardless of the service provider's `email_nameid_format_allowed` attribute.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
