### PR TITLE
Stop writing IAL and AAL to the Identity model

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -142,10 +142,7 @@ module SamlIdpAuthConcern
   def link_identity_from_session_data
     IdentityLinker.
       new(current_user, saml_request_service_provider).
-      link_identity(
-        ial: resolved_authn_context_int_ial,
-        rails_session_id: session.id,
-      )
+      link_identity(rails_session_id: session.id)
   end
 
   def identity_needs_verification?

--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -24,7 +24,6 @@ module VerifySpAttributesConcern
       current_user,
       current_sp,
     ).link_identity(
-      ial: linked_identity_ial,
       verified_attributes: sp_session[:requested_attributes],
       last_consented_at: Time.zone.now,
       clear_deleted_at: true,
@@ -62,16 +61,6 @@ module VerifySpAttributesConcern
     verification_timestamp = current_user.active_profile&.verified_at
 
     verification_timestamp.present? && last_estimated_consent < verification_timestamp
-  end
-
-  def linked_identity_ial
-    if resolved_authn_context_result.ialmax?
-      0
-    elsif resolved_authn_context_result.identity_proofing?
-      2
-    else
-      1
-    end
   end
 
   def find_sp_session_identity

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -96,8 +96,6 @@ class OpenidConnectAuthorizeForm
     @identity = identity_linker.link_identity(
       nonce: nonce,
       rails_session_id: rails_session_id,
-      ial: ial,
-      aal: aal,
       acr_values: acr_values&.join(' '),
       vtr: vtr,
       requested_aal_value: requested_aal_value,

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -203,7 +203,6 @@ class OpenidConnectTokenForm
       code_digest: code ? Digest::SHA256.hexdigest(code) : nil,
       code_verifier_present: code_verifier.present?,
       service_provider_pkce: service_provider&.pkce,
-      ial: identity&.ial,
     }
   end
 

--- a/app/models/service_provider_identity.rb
+++ b/app/models/service_provider_identity.rb
@@ -4,6 +4,8 @@
 class ServiceProviderIdentity < ApplicationRecord
   self.table_name = :identities
 
+  self.ignored_columns = %w[ial aal]
+
   include NonNullUuid
 
   belongs_to :user

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -20,7 +20,6 @@ class AccessTokenVerifier
       errors:,
       extra: {
         client_id: @identity&.service_provider,
-        ial: @identity&.ial,
       },
     )
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4160,14 +4160,12 @@ module AnalyticsEvents
 
   # Tracks when an openid connect bearer token authentication request is made
   # @param [Boolean] success
-  # @param [Integer] ial
   # @param [String] client_id Service Provider issuer
   # @param [Hash] errors
-  def openid_connect_bearer_token(success:, ial:, client_id:, errors:, **extra)
+  def openid_connect_bearer_token(success:, client_id:, errors:, **extra)
     track_event(
       'OpenID Connect: bearer token authentication',
       success: success,
-      ial: ial,
       client_id: client_id,
       errors: errors,
       **extra,
@@ -4231,15 +4229,13 @@ module AnalyticsEvents
   # @param [String] user_id
   # @param [String] code_digest hash of "code" param
   # @param [Integer, nil] expires_in time to expiration of token
-  # @param [Integer, nil] ial ial level of identity
-  def openid_connect_token(client_id:, user_id:, code_digest:, expires_in:, ial:, **extra)
+  def openid_connect_token(client_id:, user_id:, code_digest:, expires_in:, **extra)
     track_event(
       'OpenID Connect: token',
       client_id: client_id,
       user_id: user_id,
       code_digest: code_digest,
       expires_in: expires_in,
-      ial: ial,
       **extra,
     )
   end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
         it 'redirects back to the client app with a code if server-side redirect is enabled' do
           allow(IdentityConfig.store).to receive(:openid_connect_redirect).
             and_return('server_side')
-          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          IdentityLinker.new(user, service_provider).link_identity
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
@@ -83,7 +83,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
         it 'renders a client-side redirect back to the client app with a code if it is enabled' do
           allow(IdentityConfig.store).to receive(:openid_connect_redirect).
             and_return('client_side')
-          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          IdentityLinker.new(user, service_provider).link_identity
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
@@ -99,7 +99,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
         it 'renders a JS client-side redirect back to the client app with a code if it is enabled' do
           allow(IdentityConfig.store).to receive(:openid_connect_redirect).
             and_return('client_side_js')
-          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          IdentityLinker.new(user, service_provider).link_identity
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
@@ -117,7 +117,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             travel_to now + 15.seconds
             stub_analytics
 
-            IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+            IdentityLinker.new(user, service_provider).link_identity
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
 
             action
@@ -173,7 +173,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             travel_to now + 15.seconds
             stub_analytics
 
-            IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+            IdentityLinker.new(user, service_provider).link_identity
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
 
             action
@@ -232,7 +232,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
               allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                 and_return('server_side')
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -245,7 +245,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             it 'renders a client-side redirect back to the client app immediately if it is enabled' do
               allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                 and_return('client_side')
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -259,7 +259,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             it 'renders a JS client-side redirect back to the client app immediately if it is enabled' do
               allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                 and_return('client_side_js')
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -275,7 +275,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 and_return('client_side')
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_uuid_override_map).
                 and_return({ user.uuid => 'server_side' })
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -290,7 +290,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 and_return('server_side')
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_uuid_override_map).
                 and_return({ user.uuid => 'client_side' })
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -306,7 +306,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 and_return('server_side')
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_uuid_override_map).
                 and_return({ user.uuid => 'client_side_js' })
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -325,7 +325,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_uuid_override_map).
                 and_return({ user.uuid => 'client_side_js' })
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -342,7 +342,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_issuer_override_map).
                 and_return({ service_provider.issuer => 'client_side_js' })
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -354,7 +354,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             end
 
             it 'redirects to the password capture url when pii is locked' do
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -368,7 +368,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               travel_to now + 15.seconds
               stub_analytics
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -424,7 +424,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                   and_return(selfie_capture_enabled)
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -481,7 +481,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
                 allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -530,7 +530,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             before do
               allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                 and_return('server_side')
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[birthdate family_name given_name verified_at],
               )
@@ -689,7 +689,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               it 'redirects to the redirect_uri immediately when pii is unlocked if server-side redirect is enabled' do
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -703,7 +703,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -718,7 +718,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side_js')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -730,7 +730,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               end
 
               it 'redirects to the password capture url when pii is locked' do
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -744,7 +744,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 travel_to now + 15.seconds
                 stub_analytics
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -796,7 +796,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               it 'redirects to the redirect_uri immediately without proofing if server-side redirect is enabled' do
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -810,7 +810,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -824,7 +824,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side_js')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -838,7 +838,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 travel_to now + 15.seconds
                 stub_analytics
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -892,7 +892,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -906,7 +906,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -920,7 +920,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side_js')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -934,7 +934,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 travel_to now + 15.seconds
                 stub_analytics
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1051,7 +1051,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
         it 'redirects back to the client app with a code if server-side redirect is enabled' do
           allow(IdentityConfig.store).to receive(:openid_connect_redirect).
             and_return('server_side')
-          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          IdentityLinker.new(user, service_provider).link_identity
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
@@ -1066,7 +1066,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
         it 'renders a client-side redirect back to the client app with a code if it is enabled' do
           allow(IdentityConfig.store).to receive(:openid_connect_redirect).
             and_return('client_side')
-          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          IdentityLinker.new(user, service_provider).link_identity
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
@@ -1082,7 +1082,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
         it 'renders a JS client-side redirect back to the client app with a code if it is enabled' do
           allow(IdentityConfig.store).to receive(:openid_connect_redirect).
             and_return('client_side_js')
-          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          IdentityLinker.new(user, service_provider).link_identity
           user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
@@ -1102,7 +1102,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
           it 'tracks IAL1 authentication event' do
             travel_to now + 15.seconds
             stub_analytics
-            IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+            IdentityLinker.new(user, service_provider).link_identity
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
 
             action
@@ -1160,7 +1160,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             travel_to now + 15.seconds
             stub_analytics
 
-            IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+            IdentityLinker.new(user, service_provider).link_identity
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
 
             action
@@ -1220,7 +1220,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             it 'redirects to the redirect_uri immediately when pii is unlocked if client-side redirect is disabled' do
               allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                 and_return('server_side')
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1233,7 +1233,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             it 'renders a client-side redirect back to the client app immediately if it is enabled' do
               allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                 and_return('client_side')
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1247,7 +1247,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             it 'renders a JS client-side redirect back to the client app immediately if it is enabled' do
               allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                 and_return('client_side_js')
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1263,7 +1263,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 and_return('client_side')
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_uuid_override_map).
                 and_return({ user.uuid => 'server_side' })
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1278,7 +1278,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 and_return('server_side')
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_uuid_override_map).
                 and_return({ user.uuid => 'client_side' })
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1294,7 +1294,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 and_return('server_side')
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_uuid_override_map).
                 and_return({ user.uuid => 'client_side_js' })
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1313,7 +1313,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_uuid_override_map).
                 and_return({ user.uuid => 'client_side_js' })
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1330,7 +1330,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               allow(IdentityConfig.store).to receive(:openid_connect_redirect_issuer_override_map).
                 and_return({ service_provider.issuer => 'client_side_js' })
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1342,7 +1342,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             end
 
             it 'redirects to the password capture url when pii is locked' do
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1356,7 +1356,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               travel_to now + 15.seconds
               stub_analytics
 
-              IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[given_name family_name birthdate verified_at],
               )
@@ -1412,7 +1412,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                   and_return(selfie_capture_enabled)
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1469,7 +1469,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
                 allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1518,7 +1518,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
             before do
               allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                 and_return('server_side')
-              IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+              IdentityLinker.new(user, service_provider).link_identity
               user.identities.last.update!(
                 verified_attributes: %w[birthdate family_name given_name verified_at],
               )
@@ -1679,7 +1679,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               it 'redirects to the redirect_uri immediately when pii is unlocked if server-side redirect is enabled' do
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1693,7 +1693,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1708,7 +1708,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side_js')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1720,7 +1720,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               end
 
               it 'redirects to the password capture url when pii is locked' do
-                IdentityLinker.new(user, service_provider).link_identity(ial: 3)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1734,7 +1734,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 travel_to now + 15.seconds
                 stub_analytics
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1786,7 +1786,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
               it 'redirects to the redirect_uri immediately without proofing if server-side redirect is enabled' do
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1800,7 +1800,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1814,7 +1814,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side_js')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1828,7 +1828,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 travel_to now + 15.seconds
                 stub_analytics
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1882,7 +1882,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('server_side')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1896,7 +1896,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1910,7 +1910,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 allow(IdentityConfig.store).to receive(:openid_connect_redirect).
                   and_return('client_side_js')
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )
@@ -1924,7 +1924,7 @@ RSpec.describe OpenidConnect::AuthorizationController, allowed_extra_analytics: 
                 travel_to now + 15.seconds
                 stub_analytics
 
-                IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+                IdentityLinker.new(user, service_provider).link_identity
                 user.identities.last.update!(
                   verified_attributes: %w[given_name family_name birthdate verified_at],
                 )

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
     let!(:identity) do
       IdentityLinker.new(user, service_provider).link_identity(
         rails_session_id: SecureRandom.hex,
-        ial: 1,
       )
     end
 
@@ -62,7 +61,6 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
             code_verifier_present: false,
             service_provider_pkce: nil,
             expires_in: 0,
-            ial: 1,
           })
         action
       end
@@ -93,7 +91,6 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
             service_provider_pkce: nil,
             error_details: hash_including(:grant_type),
             expires_in: nil,
-            ial: 1,
           })
 
         action

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe OpenidConnect::UserInfoController, allowed_extra_analytics: [:*] 
           with('OpenID Connect: bearer token authentication',
                success: false,
                client_id: nil,
-               ial: nil,
                errors: hash_including(:access_token),
                error_details: hash_including(:access_token))
 
@@ -47,7 +46,6 @@ RSpec.describe OpenidConnect::UserInfoController, allowed_extra_analytics: [:*] 
           with('OpenID Connect: bearer token authentication',
                success: false,
                client_id: nil,
-               ial: nil,
                errors: hash_including(:access_token),
                error_details: hash_including(:access_token))
 
@@ -71,7 +69,6 @@ RSpec.describe OpenidConnect::UserInfoController, allowed_extra_analytics: [:*] 
                success: false,
                errors: hash_including(:access_token),
                client_id: nil,
-               ial: nil,
                error_details: hash_including(:access_token))
 
         action
@@ -100,7 +97,6 @@ RSpec.describe OpenidConnect::UserInfoController, allowed_extra_analytics: [:*] 
           success: false,
           errors: { access_token: [t('openid_connect.user_info.errors.not_found')] },
           client_id: nil,
-          ial: nil,
           error_details: { access_token: { not_found: true } },
         )
       end
@@ -131,7 +127,6 @@ RSpec.describe OpenidConnect::UserInfoController, allowed_extra_analytics: [:*] 
           'OpenID Connect: bearer token authentication',
           success: true,
           client_id: identity.service_provider,
-          ial: identity.ial,
           errors: {},
         )
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -743,7 +743,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
       before do
         stub_sign_in(user)
         session[:sign_in_flow] = sign_in_flow
-        IdentityLinker.new(user, sp1).link_identity(ial: Idp::Constants::IAL2)
+        IdentityLinker.new(user, sp1).link_identity
         user.identities.last.update!(
           verified_attributes: %w[given_name family_name social_security_number address],
         )
@@ -761,11 +761,6 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
         expect(asserter).to receive(:build).at_least(:once).and_call_original
 
         saml_get_auth(ial2_settings)
-      end
-
-      it 'sets identity ial' do
-        saml_get_auth(ial2_settings)
-        expect(user.identities.last.ial).to eq(Idp::Constants::IAL2)
       end
 
       it 'does not redirect the user to the IdV URL' do
@@ -892,7 +887,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
       before do
         stub_sign_in(user)
         session[:sign_in_flow] = sign_in_flow
-        IdentityLinker.new(user, ServiceProvider.find_by(issuer: sp1_issuer)).link_identity(ial: 2)
+        IdentityLinker.new(user, ServiceProvider.find_by(issuer: sp1_issuer)).link_identity
         user.identities.last.update!(
           verified_attributes: %w[email given_name family_name social_security_number address],
         )
@@ -910,11 +905,6 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
         expect(asserter).to receive(:build).at_least(:once).and_call_original
 
         saml_get_auth(ialmax_settings)
-      end
-
-      it 'sets identity ial to 0' do
-        saml_get_auth(ialmax_settings)
-        expect(user.identities.last.ial).to eq(0)
       end
 
       it 'does not redirect the user to the IdV URL' do

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -252,7 +252,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           requested_attributes: ['email'],
         }
         expect(@linker).to receive(:link_identity).with(
-          ial: 1,
           verified_attributes: ['email'],
           last_consented_at: now,
           clear_deleted_at: true,
@@ -352,7 +351,6 @@ RSpec.describe SignUp::CompletionsController, allowed_extra_analytics: [:*] do
           requested_attributes: %w[email first_name verified_at],
         }
         expect(@linker).to receive(:link_identity).with(
-          ial: 2,
           verified_attributes: %w[email first_name verified_at],
           last_consented_at: now,
           clear_deleted_at: true,

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -115,7 +115,6 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
     service_provider = ServiceProvider.find_by(issuer: OidcAuthHelper::OIDC_ISSUER)
     IdentityLinker.new(user, service_provider).link_identity(
       verified_attributes: %w[email given_name family_name social_security_number address phone],
-      ial: 2,
     )
 
     visit_idp_from_sp_with_ial2(:oidc)

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -781,7 +781,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
         expect(identity.code_challenge).to eq(code_challenge)
         expect(identity.nonce).to eq(nonce)
-        expect(identity.ial).to eq(1)
         expect(identity.acr_values).to eq ''
         expect(identity.vtr).to eq ['C1'].to_json
       end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe OpenidConnectTokenForm do
       link_identity(
         nonce: nonce,
         rails_session_id: SecureRandom.hex,
-        ial: 1,
         code_challenge: code_challenge,
       )
   end
@@ -381,7 +380,6 @@ RSpec.describe OpenidConnectTokenForm do
           code_digest: Digest::SHA256.hexdigest(code),
           code_verifier_present: false,
           service_provider_pkce: nil,
-          ial: 1,
         )
       end
     end

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe IdTokenBuilder do
       :service_provider_identity,
       nonce: SecureRandom.hex,
       uuid: SecureRandom.uuid,
-      ial: 2,
       rails_session_id: '123',
       # this is a known value from an example developer guide
       # https://www.pingidentity.com/content/developer/en/resources/openid-connect-developers-guide.html
@@ -84,7 +83,6 @@ RSpec.describe IdTokenBuilder do
     context 'context sp requests ACR values' do
       context 'aal and ial request' do
         before do
-          identity.aal = 2
           acr_values = [
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
             Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
@@ -99,7 +97,6 @@ RSpec.describe IdTokenBuilder do
 
       context 'ial2 request' do
         before do
-          identity.ial = 2
           identity.acr_values = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
         end
 
@@ -110,7 +107,6 @@ RSpec.describe IdTokenBuilder do
 
       context 'ial1 request' do
         before do
-          identity.ial = 1
           identity.acr_values = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
         end
 
@@ -121,7 +117,6 @@ RSpec.describe IdTokenBuilder do
 
       context 'ialmax request' do
         before do
-          identity.ial = 0
           identity.acr_values = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
         end
 

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe IdentityLinker do
     it 'can take an additional optional attributes' do
       rails_session_id = SecureRandom.hex
       nonce = SecureRandom.hex
-      ial = 3
       acr_values = 'http://idmanagement.gov/ns/assurance/aal/1'
       vtr = ['C2.Pb'].to_json
       scope = 'openid profile email'
@@ -39,7 +38,6 @@ RSpec.describe IdentityLinker do
       IdentityLinker.new(user, service_provider).link_identity(
         rails_session_id: rails_session_id,
         nonce: nonce,
-        ial: ial,
         acr_values: acr_values,
         vtr: vtr,
         scope: scope,
@@ -51,7 +49,6 @@ RSpec.describe IdentityLinker do
       last_identity = user.last_identity
       expect(last_identity.nonce).to eq(nonce)
       expect(last_identity.rails_session_id).to eq(rails_session_id)
-      expect(last_identity.ial).to eq(ial)
       expect(last_identity.acr_values).to eq(acr_values)
       expect(last_identity.vtr).to eq(vtr)
       expect(last_identity.scope).to eq(scope)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -599,13 +599,11 @@ module Features
       nonce
     end
 
-    def link_identity(user, service_provider, ial = nil)
+    def link_identity(user, service_provider)
       IdentityLinker.new(
         user,
         service_provider,
-      ).link_identity(
-        ial: ial,
-      )
+      ).link_identity
     end
 
     def set_new_browser_session

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -199,7 +199,6 @@ module SamlAuthHelper
       user,
       build(:service_provider, issuer: settings.issuer),
     ).link_identity(
-      ial: ial2_requested?(settings) ? true : nil,
       verified_attributes: ['email'],
     )
   end


### PR DESCRIPTION
 The IAL and AAL values don't capture the full context that is expressed by the AuthnContextResolver. This commit removes them to see what all fails without them.