### PR TITLE
Refactor `OpenidConnectAuthorizeForm` to remove `IalContext`

### DIFF
--- a/app/controllers/concerns/billable_event_trackable.rb
+++ b/app/controllers/concerns/billable_event_trackable.rb
@@ -13,20 +13,16 @@ module BillableEventTrackable
   private
 
   def create_sp_return_log(billable:)
-    user_ial_context = IalContext.new(
-      ial: ial_context.ial, service_provider: current_sp, user: current_user,
-    )
-
     SpReturnLog.create(
       request_id: request_id,
       user: current_user,
       billable: billable,
-      ial: user_ial_context.bill_for_ial_1_or_2,
+      ial: ial_context.bill_for_ial_1_or_2,
       issuer: current_sp.issuer,
-      profile_id: user_ial_context.bill_for_ial_1_or_2 > 1 ? current_user.active_profile&.id : nil,
-      profile_verified_at: user_ial_context.bill_for_ial_1_or_2 > 1 ?
+      profile_id: ial_context.bill_for_ial_1_or_2 > 1 ? current_user.active_profile&.id : nil,
+      profile_verified_at: ial_context.bill_for_ial_1_or_2 > 1 ?
         current_user.active_profile&.verified_at : nil,
-      profile_requested_issuer: user_ial_context.bill_for_ial_1_or_2 > 1 ?
+      profile_requested_issuer: ial_context.bill_for_ial_1_or_2 > 1 ?
         current_user.active_profile&.initiating_service_provider_issuer : nil,
       requested_at: session[:session_started_at],
       returned_at: Time.zone.now,

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -97,7 +97,11 @@ module OpenidConnect
     end
 
     def ial_context
-      @authorize_form.ial_context
+      IalContext.new(
+        ial: @authorize_form.ial,
+        service_provider: @authorize_form.service_provider,
+        user: current_user,
+      )
     end
 
     def handle_successful_handoff
@@ -211,14 +215,9 @@ module OpenidConnect
     end
 
     def track_events
-      event_ial_context = IalContext.new(
-        ial: @authorize_form.ial,
-        service_provider: @authorize_form.service_provider,
-        user: current_user,
-      )
       analytics.sp_redirect_initiated(
-        ial: event_ial_context.ial,
-        billed_ial: event_ial_context.bill_for_ial_1_or_2,
+        ial: ial_context.ial,
+        billed_ial: ial_context.bill_for_ial_1_or_2,
         sign_in_flow: session[:sign_in_flow],
         vtr: sp_session[:vtr],
         acr_values: sp_session[:acr_values],

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -28,7 +28,7 @@ module OpenidConnect
     before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: [:index]
 
     def index
-      if @authorize_form.ial2_or_greater?
+      if resolved_authn_context_result.identity_proofing?
         return redirect_to reactivate_account_url if user_needs_to_reactivate_account?
         return redirect_to url_for_pending_profile_reason if user_has_pending_profile?
         return redirect_to idv_url if identity_needs_verification?
@@ -122,7 +122,7 @@ module OpenidConnect
     end
 
     def identity_needs_verification?
-      (@authorize_form.ial2_requested? &&
+      (resolved_authn_context_result.identity_proofing? &&
         (current_user.identity_not_verified? ||
         decorated_sp_session.requested_more_recent_verification?)) ||
         current_user.reproof_for_irs?(service_provider: current_sp)

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -758,53 +758,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
     end
   end
 
-  describe '#ial2_requested?' do
-    subject(:ial2_requested?) { form.ial2_requested? }
-
-    context 'with vtr params' do
-      let(:acr_values) { nil }
-
-      context 'when identity proofing is requested' do
-        let(:vtr) { ['P1'].to_json }
-        it { expect(ial2_requested?).to eq(true) }
-      end
-
-      context 'when identity proofing is not requested' do
-        let(:vtr) { ['C1'].to_json }
-        it { expect(ial2_requested?).to eq(false) }
-      end
-    end
-
-    context 'with acr_values param' do
-      let(:vtr) { nil }
-
-      context 'with ial1' do
-        let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
-        it { expect(ial2_requested?).to eq(false) }
-      end
-
-      context 'with ial2' do
-        let(:acr_values) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
-        it { expect(ial2_requested?).to eq(true) }
-      end
-
-      context 'with ial1 and ial2' do
-        let(:acr_values) do
-          [
-            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-            Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-          ].join(' ')
-        end
-        it { expect(ial2_requested?).to eq(true) }
-      end
-
-      context 'with a malformed ial' do
-        let(:acr_values) { 'foobarbaz' }
-        it { expect(ial2_requested?).to eq(false) }
-      end
-    end
-  end
-
   describe '#client_id' do
     it 'returns the form client_id' do
       form = OpenidConnectAuthorizeForm.new(client_id: 'foobar')


### PR DESCRIPTION
The `OpenidConnectAuthorizeForm` class is a form object that validates an OpenID Connect authorization request. This includes validating things like whether the scopes and ACR values requested by the service provider are allowed. For example, if an SP that is not allowed to request identity proofing requests scopes that required identity proofing this form responds with an error.

The `IalContext` class provides a number of helper methods helper methods for determining the IAL of a request by consuming either the integer IAL or the ACR values from the request and considering that along with SP defaults to determine a requests IAL. The `IALContext` can optionally consider the user context to make determinations about IAL2 requests. Since this is optional it leads to inconsistent results. For example, in the `OpenidConnectAuthorizeForm` the user context is not provided so the `IALContext` will never return true from `ial2_or_greater?` for an IALMax request even if the user has identity proofed. The `IALContext` is being replaced with the `AuthnContextResolver` to address this.

The `OpenidConnectAuthorizeForm` does not necessarily need to be concerned with the state of the user and rather needs to be concerned with what was requested in totality and whether it is allowed. This will be more important when we begin accepting multiple vectors of trust to support an IALMax-like feature for service providers using that feature.

This commit changes the `OpenidConnectAuthorizeForm` to remove the `IALContext`.
