### PR TITLE
Update translations for Chinese in language pickers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -953,7 +953,7 @@ i18n.language: Language
 i18n.locale.en: English
 i18n.locale.es: Español
 i18n.locale.fr: Français
-i18n.locale.zh: Chinese
+i18n.locale.zh: 中文 (简体)
 idv.accessible_labels.masked_ssn: secure text, starting with %{first_number} and ending with %{last_number}
 idv.buttons.change_address_label: Update address
 idv.buttons.change_label: Update

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -952,7 +952,7 @@ i18n.language: Idioma
 i18n.locale.en: English
 i18n.locale.es: Español
 i18n.locale.fr: Français
-i18n.locale.zh: Chinese
+i18n.locale.zh: 中文 (简体)
 idv.accessible_labels.masked_ssn: texto seguro, a partir de %{first_number} y hasta %{last_number}
 idv.buttons.change_address_label: Actualizar dirección
 idv.buttons.change_label: Actualizar

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -953,7 +953,7 @@ i18n.language: Langue
 i18n.locale.en: English
 i18n.locale.es: Español
 i18n.locale.fr: Français
-i18n.locale.zh: Chinese
+i18n.locale.zh: 中文 (简体)
 idv.accessible_labels.masked_ssn: SMS sécurisé, commençant par %{first_number} et finissant par %{last_number}
 idv.buttons.change_address_label: Mettre à jour votre adresse
 idv.buttons.change_label: Mettre à jour

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -46,7 +46,7 @@ account.email_language.languages_list: '%{app_name} 允许你以 %{list}接受�
 account.email_language.name.en: 英文
 account.email_language.name.es: 西班牙文
 account.email_language.name.fr: 法文
-account.email_language.name.zh: Chinese
+account.email_language.name.zh: 中文 (简体)
 account.email_language.sentence_connector: 或者
 account.email_language.updated: 你的电邮语言选择已更新。
 account.forget_all_browsers.longer_description: 你选择“忘掉所有浏览器“后，我们将需要额外信息来知道的确是你在登录你自己的账户。每次你要访问自己的账户时，我们都会向你要一个多因素身份证实方法（比如短信/SMS 代码或安全密钥）
@@ -957,7 +957,7 @@ i18n.language: 语言
 i18n.locale.en: 英文
 i18n.locale.es: 西班牙文
 i18n.locale.fr: 法文
-i18n.locale.zh: Chinese
+i18n.locale.zh: 中文 (简体)
 idv.accessible_labels.masked_ssn: 保护文本安全，从 %{first_number} 开始，到 %{last_number}结束
 idv.buttons.change_address_label: 更新地址
 idv.buttons.change_label: 更新

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -66,6 +66,7 @@ module I18n
         { key: 'i18n.locale.en', locales: %i[es fr zh] },
         { key: 'i18n.locale.es', locales: %i[es fr zh] },
         { key: 'i18n.locale.fr', locales: %i[es fr zh] },
+        { key: 'i18n.locale.zh', locales: %i[es fr zh] },
         { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
         { key: 'saml_idp.auth.error.title', locales: %i[es] }, # "Error" is "Error" in Spanish
         { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
@@ -77,8 +78,7 @@ module I18n
         { key: 'time.formats.event_time', locales: %i[es zh] },
         { key: 'time.formats.event_timestamp', locales: %i[zh] },
         # need to be fixed
-        { key: 'i18n.locale.zh', locales: %i[es fr zh] },
-        { key: 'account.email_language.name.zh', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.zh', locales: %i[es fr] },
         { key: 'account_reset.pending.canceled', locales: %i[zh] },
         { key: 'account_reset.recovery_options.check_saved_credential', locales: %i[zh] },
         { key: 'account_reset.recovery_options.use_same_device', locales: %i[zh] },


### PR DESCRIPTION
## 🛠 Summary of changes

This adds the translation so that we show the Chinese language translation in the language picker.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

![image](https://github.com/18F/identity-idp/assets/1430443/3dc3a3d7-e5c6-46b0-a846-8a71c514ae12)

</details>

<details>
<summary>After:</summary>

![image](https://github.com/18F/identity-idp/assets/1430443/07078a9e-a0af-43ed-833f-75c767709244)

</details>
