### PR TITLE
Remove unused spec user factory traits

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -169,14 +169,6 @@ FactoryBot.define do
       end
     end
 
-    trait :admin do
-      role { :admin }
-    end
-
-    trait :tech_support do
-      role { :tech }
-    end
-
     trait :fully_registered do
       with_phone
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused (non-functional?) traits in the user model factories for specs:

- `admin`
- `tech_support`

These originate from #2943, though it's unclear that they were ever used.

## 📜 Testing Plan

These changes only affect specs, so it should suffice to verify that the build passes.