### PR TITLE
Modify `OpenidConnect::AuthorizationController#link_identity_to_service_provider` to match pattern in `SamlIdpController`

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -93,15 +93,29 @@ module OpenidConnect
     end
 
     def link_identity_to_service_provider
-      @authorize_form.link_identity_to_service_provider(current_user, session.id)
+      @authorize_form.link_identity_to_service_provider(
+        current_user: current_user,
+        ial: resolved_authn_context_int_ial,
+        rails_session_id: session.id,
+      )
     end
 
     def ial_context
       IalContext.new(
-        ial: @authorize_form.ial,
+        ial: resolved_authn_context_int_ial,
         service_provider: @authorize_form.service_provider,
         user: current_user,
       )
+    end
+
+    def resolved_authn_context_int_ial
+      if resolved_authn_context_result.ialmax?
+        0
+      elsif resolved_authn_context_result.identity_proofing?
+        2
+      else
+        1
+      end
     end
 
     def handle_successful_handoff

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -91,13 +91,16 @@ class OpenidConnectAuthorizeForm
     @service_provider = ServiceProvider.find_by(issuer: client_id)
   end
 
-  def link_identity_to_service_provider(current_user, rails_session_id)
+  def link_identity_to_service_provider(
+    current_user:,
+    ial:,
+    rails_session_id:
+  )
     identity_linker = IdentityLinker.new(current_user, service_provider)
     @identity = identity_linker.link_identity(
       nonce: nonce,
       rails_session_id: rails_session_id,
       ial: ial,
-      aal: aal,
       acr_values: acr_values&.join(' '),
       vtr: vtr,
       requested_aal_value: requested_aal_value,
@@ -117,28 +120,8 @@ class OpenidConnectAuthorizeForm
     acr_values.filter { |acr| acr.include?('ial') || acr.include?('loa') }
   end
 
-  def ial
-    if parsed_vector_of_trust&.identity_proofing?
-      2
-    elsif parsed_vector_of_trust.present?
-      1
-    else
-      Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL[ial_values.sort.max]
-    end
-  end
-
   def aal_values
     acr_values.filter { |acr| acr.include?('aal') }
-  end
-
-  def aal
-    if parsed_vector_of_trust&.aal2?
-      2
-    elsif parsed_vector_of_trust.present?
-      1
-    else
-      Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_AAL[requested_aal_value]
-    end
   end
 
   def requested_aal_value
@@ -336,7 +319,11 @@ class OpenidConnectAuthorizeForm
   end
 
   def identity_proofing_requested?
-    ial == 2
+    if parsed_vector_of_trust.present?
+      parsed_vector_of_trust.identity_proofing?
+    else
+      Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL[ial_values.sort.max] == 2
+    end
   end
 
   def identity_proofing_service_provider?
@@ -348,7 +335,7 @@ class OpenidConnectAuthorizeForm
   end
 
   def ialmax_requested?
-    ial == 0
+    Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL[ial_values.sort.max] == 0
   end
 
   def highest_level_aal(aal_values)

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -416,160 +416,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
     end
   end
 
-  describe '#ial' do
-    context 'with vtr param' do
-      let(:acr_values) { nil }
-
-      context 'when proofing is requested' do
-        let(:vtr) { ['C1.P1'].to_json }
-
-        it { expect(form.ial).to eq(2) }
-      end
-
-      context 'when proofing is not requested' do
-        let(:vtr) { ['C1'].to_json }
-
-        it { expect(form.ial).to eq(1) }
-      end
-    end
-
-    context 'with acr_values param' do
-      let(:vtr) { nil }
-
-      context 'when IAL1 passed' do
-        let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 1' do
-          expect(form.ial).to eq(1)
-        end
-      end
-
-      context 'when IAL2 passed' do
-        let(:acr_values) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 2' do
-          expect(form.ial).to eq(2)
-        end
-      end
-
-      context 'when IALMAX passed' do
-        let(:acr_values) { Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 0' do
-          expect(form.ial).to eq(0)
-        end
-      end
-
-      context 'when LOA1 passed' do
-        let(:acr_values) { Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 1' do
-          expect(form.ial).to eq(1)
-        end
-      end
-
-      context 'when LOA3 passed' do
-        let(:acr_values) { Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 2' do
-          expect(form.ial).to eq(2)
-        end
-      end
-    end
-  end
-
-  describe '#aal' do
-    context 'with vtr param' do
-      let(:acr_values) { nil }
-
-      context 'when AAL2 is requested' do
-        let(:vtr) { ['C2'].to_json }
-
-        it { expect(form.aal).to eq(2) }
-      end
-
-      context 'when AAL2 is not requested' do
-        let(:vtr) { ['C1'].to_json }
-
-        it { expect(form.aal).to eq(1) }
-      end
-    end
-
-    context 'with acr_values param' do
-      let(:vtr) { nil }
-
-      context 'when no AAL passed' do
-        let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 0' do
-          expect(form.aal).to eq(0)
-        end
-      end
-
-      context 'when DEFAULT_AAL passed' do
-        let(:acr_values) { Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 0' do
-          expect(form.aal).to eq(0)
-        end
-      end
-
-      context 'when AAL2 passed' do
-        let(:acr_values) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 2' do
-          expect(form.aal).to eq(2)
-        end
-      end
-
-      context 'when AAL2_PHISHING_RESISTANT passed' do
-        let(:acr_values) { Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 2' do
-          expect(form.aal).to eq(2)
-        end
-      end
-
-      context 'when AAL2_HSPD12 passed' do
-        let(:acr_values) { Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 2' do
-          expect(form.aal).to eq(2)
-        end
-      end
-
-      context 'when AAL3 passed' do
-        let(:acr_values) { Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 3' do
-          expect(form.aal).to eq(3)
-        end
-      end
-
-      context 'when AAL3_HSPD12 passed' do
-        let(:acr_values) { Saml::Idp::Constants::AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF }
-
-        it 'returns 3' do
-          expect(form.aal).to eq(3)
-        end
-      end
-
-      context 'when IAL and AAL passed' do
-        aal2 = Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
-        ial2 = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
-
-        let(:acr_values) do
-          "#{aal2} #{ial2}"
-        end
-
-        it 'returns ial and aal' do
-          expect(form.aal).to eq(2)
-          expect(form.ial).to eq(2)
-        end
-      end
-    end
-  end
-
   describe '#requested_aal_value' do
     context 'with ACR values' do
       let(:vtr) { nil }
@@ -775,7 +621,11 @@ RSpec.describe OpenidConnectAuthorizeForm do
       let(:code_challenge_method) { 'S256' }
 
       it 'records the code_challenge on the identity' do
-        form.link_identity_to_service_provider(user, rails_session_id)
+        form.link_identity_to_service_provider(
+          current_user: user,
+          ial: 1,
+          rails_session_id: rails_session_id,
+        )
 
         identity = user.identities.where(service_provider: client_id).first
 
@@ -794,7 +644,11 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
     context 'when the identity has been linked' do
       before do
-        form.link_identity_to_service_provider(user, rails_session_id)
+        form.link_identity_to_service_provider(
+          current_user: user,
+          ial: 1,
+          rails_session_id: rails_session_id,
+        )
       end
 
       it 'returns a redirect URI with the code from the identity session_uuid' do


### PR DESCRIPTION

Both the `OpenidConnect::AuthorizationController` and `SamlIdpController` have logic that ultimately invokes the `IdentityLinker` to link a user to a service provider. This code consumes an `ial` value which is used to set values on the `ServiceProviderIdentity` record that are eventually used for analytics and reporting purposes.

In the `SamlIdpController` the `ial` value is computed using `resolved_authn_contenxt_result`. This means that it considers the SP defaults and the content of the SP request. Eventually this will also include the user context when multiple vectors of trust support is added.

Prior to this commit the `OpenidConnect::AuthorizationController` did not use the `resolved_authn_contenxt_result` and instead computed the value itself in its form object. Its computation ignored SP defaults and would ignore the user context when multiple vectors of trust support is added.

This commit modifies the `OpenidConnect::AuthorizationController1` to match the pattern on `SamlIdpController` to avoid these issues.
