### PR TITLE
Use SHA256 for JavaScript subresource integrity

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,7 +88,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
       },
       writeToDisk: true,
       integrity: isProductionEnv,
-      integrityHashes: ['sha512'],
+      integrityHashes: ['sha256'],
       output: 'manifest.json',
       transform(manifest) {
         const srcIntegrity = {};


### PR DESCRIPTION
## 🛠 Summary of changes

Updates subresource integrity hashes produced by the Webpack configuration to use SHA256 instead of SHA512.

This is a continuation of improvements around resource hints started in #10612, where Rails' hard cap of 1kb resource hints also includes integrity hashes, which you can see in production today for all preloaded JavaScript (except `init.js`):

```
curl -I https://secure.login.gov | grep link
```

The intent of these changes is to use a hash with a smaller byte size, without meaningfully sacrificing security. By using smaller hashes, the hope is that more assets can fit within the 1kb resource hint limit.

Additional considerations:

- This also reduces the overall size of the markup produced on every page of the application, since integrity hashes are included in each `<script>` tag (`integrity` attributes currently account for ~6% of the markup size on https://secure.login.gov )
- Even if we circumvented Rails limitation as proposed in https://github.com/18F/identity-idp/pull/10612#issuecomment-2108667459, this would still have a benefit in reducing the response headers size overall

## 📜 Testing Plan

1. Build JavaScript assets for production: `NODE_ENV=production yarn build`
2. Start the server directly: `rails s`
3. Go to http://localhost:3000
4. Observe no regression in JavaScript behaviors (accordions, etc.)
5. Inspect page markup
6. Observe `<script>` tags at the bottom of `<body>` include `integrity=sha256-` attributes