### PR TITLE
Add subresource integrity for design system initializer script

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:head) do %>
-  <%= javascript_include_tag('init.js', nopush: false) %>
+  <%= javascript_include_tag('init.js', nopush: false, integrity: 'sha256-eMXV2njRJxgQrFbuljRT/UTWePGrhl83bHHDDd+jFPw=') %>
 <% end %>
 
 <%= extends_layout :base, body_class: local_assigns.fetch(:body_class, 'site tablet:bg-primary-lighter') do %>

--- a/spec/requests/asset_sri_spec.rb
+++ b/spec/requests/asset_sri_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'asset subresource integrity' do
+  let(:load_path) { Rails.application.assets.resolver.resolve(logical_path) }
+  let(:content) { Rails.application.assets.resolver.read(logical_path) }
+  let(:link_header) { response.headers['link'] }
+  let(:rendered_digest) { link_header.match(%r{<#{load_path}[^,]+integrity=([^,]+)})[1] }
+  let(:expected_digest) { "sha256-#{Digest::SHA256.base64digest(content)}" }
+
+  before { get root_url }
+
+  ['init.js'].each do |path|
+    describe path do
+      let(:logical_path) { path }
+
+      it { expect(rendered_digest).to eq(expected_digest) }
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Manually adds subresource integrity hash for a script contained within the design system dependency, with spec coverage to ensure it is kept in sync should the contents of the file change.

Most of our JavaScript is compiled through Webpack, where the subresource integrity hashes are computed as part of the Webpack compilation. This script is loaded directly from the `@18f/identity-design-system` NPM package, and therefore cannot take advantage of this.

To ensure broad coverage of subresource integrity of all JavaScript assets loaded in critical paths, this manually assigns the integrity value. Test coverage ensures that this value is correct, in case a future update of `@18f/identity-design-system` changes the content of the script.

Alternative solutions:

- We could create a new "pass-through" Webpack pack, whose sole purpose is to import the initializer script. The mere existence of the Webpack pack would be enough to create the integrity.

## 📜 Testing Plan

Verify specs pass:

```
rspec spec/requests/asset_sri_spec.rb
```

Verify subresource integrity is valid:

1. Go to http://localhost:3000
2. Open browser developer tools
3. Observe no console errors about subresource integrity