### PR TITLE
Remove `user` and `ial` arguments from `AddSpCost` service

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -336,7 +336,7 @@ module Idv
     end
 
     def add_cost(token, transaction_id: nil)
-      Db::SpCost::AddSpCost.call(current_sp, 2, token, transaction_id: transaction_id)
+      Db::SpCost::AddSpCost.call(current_sp, token, transaction_id: transaction_id)
     end
   end
 end

--- a/app/jobs/address_proofing_job.rb
+++ b/app/jobs/address_proofing_job.rb
@@ -26,7 +26,7 @@ class AddressProofingJob < ApplicationJob
 
     service_provider = ServiceProvider.find_by(issuer: issuer)
     Db::SpCost::AddSpCost.call(
-      service_provider, 2, :lexis_nexis_address, transaction_id: proofer_result.transaction_id
+      service_provider, :lexis_nexis_address, transaction_id: proofer_result.transaction_id
     )
 
     document_capture_session = DocumentCaptureSession.new(result_id: result_id)

--- a/app/services/db/add_document_verification_and_selfie_costs.rb
+++ b/app/services/db/add_document_verification_and_selfie_costs.rb
@@ -19,7 +19,7 @@ module Db
     attr_reader :service_provider, :user_id, :liveness_checking_enabled
 
     def add_cost(token)
-      Db::SpCost::AddSpCost.call(service_provider, 2, token)
+      Db::SpCost::AddSpCost.call(service_provider, token)
     end
   end
 end

--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -17,21 +17,16 @@ module Db
         threatmetrix
       ].freeze
 
-      def self.call(service_provider, ial, token, transaction_id: nil, user: nil)
+      def self.call(service_provider, token, transaction_id: nil)
         return if token.blank?
         unless TOKEN_ALLOWLIST.include?(token.to_sym)
           NewRelic::Agent.notice_error(SpCostTypeError.new(token.to_s))
           return
         end
         agency_id = service_provider&.agency_id || 0
-        ial_context = IalContext.new(
-          ial: ial,
-          service_provider: service_provider,
-          user: user,
-        )
         ::SpCost.create(
           issuer: service_provider&.issuer.to_s,
-          ial: ial_context.bill_for_ial_1_or_2,
+          ial: 2,
           agency_id: agency_id,
           cost_type: token,
           transaction_id: transaction_id,

--- a/app/services/gpo_confirmation_maker.rb
+++ b/app/services/gpo_confirmation_maker.rb
@@ -64,6 +64,6 @@ class GpoConfirmationMaker
   end
 
   def update_proofing_cost
-    Db::SpCost::AddSpCost.call(service_provider, 2, :gpo_letter)
+    Db::SpCost::AddSpCost.call(service_provider, :gpo_letter)
   end
 end


### PR DESCRIPTION
These arguments are confusing for the following reasons:

1. We never actually pass in a user. We use the user to initialize an `IalContext` (see below)
2. We use the IAL to initialize an `IalContext`. We use this to call `bill_for_ial_1_or_2` which is intended to consider billing impacts of IALMax if the user is proofed. We always pass a nil user (see above) and we always pass an `ial` argument of 2 so this code always returns `2`.

We can shortcut all of this by hardcoding `2` for the `ial` attribute.
