### PR TITLE
Remove stray curly brace in Chinese verified text

### DIFF
--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1741,7 +1741,7 @@ user_mailer.account_reset_request.intro_html: '作为安全措施, %{app_name} �
 user_mailer.account_reset_request.subject: 如何删除你的 %{app_name} 账户
 user_mailer.account_verified.change_password_link: 更改密码
 user_mailer.account_verified.contact_link: 联系我们
-user_mailer.account_verified.intro_html: 你于 %{date} 使用 %{app_name} 在 %{sp_name}}成功验证了身份。如果你没有采取这一行动，请 %{contact_link_html} 并登录 %{change_password_link_html}。
+user_mailer.account_verified.intro_html: 你于 %{date} 使用 %{app_name} 在 %{sp_name}成功验证了身份。如果你没有采取这一行动，请 %{contact_link_html} 并登录 %{change_password_link_html}。
 user_mailer.account_verified.subject: 你在 %{sp_name} 验证了身份。
 user_mailer.add_email_associated_with_another_account.help_html: 如果你没有要求一封新电邮或怀疑有错， 请访问 %{app_name_html}的 %{help_link_html} 或者 %{contact_link_html}。
 user_mailer.add_email_associated_with_another_account.intro_html: 该电邮地址已与一个 %{app_name_html}账户相关联，所以我们不能把它加到另外一个账户上。你必须首先将其从与之相关的账户中删除或去掉。要做到这一点，点击以下链接并用该电邮地址登录。如果你没有试图将此电邮地址加到一个账户，可忽略这一信息。


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a presumed-unintended extra curly brace from locale files.

## 📜 Testing Plan

1. Go to http://localhost:3000/rails/mailers/user_mailer/account_verified.html?locale=zh
2. See "Example App" in body content
3. Observe no "}" character

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/d38bf537-adff-4aa0-b8b0-50fceff3d302)|![image](https://github.com/18F/identity-idp/assets/1779930/2dcc7e76-7ba0-4ee5-9bf5-6093d64a507c)
