### PR TITLE
Fix language picker when displaying in Chinese

### DIFF
--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -954,9 +954,9 @@ help_text.requested_attributes.verified_at: 更新是在
 help_text.requested_attributes.x509_issuer: PIV/CAC 发放方
 help_text.requested_attributes.x509_subject: PIV/CAC 身份
 i18n.language: 语言
-i18n.locale.en: 英文
-i18n.locale.es: 西班牙文
-i18n.locale.fr: 法文
+i18n.locale.en: English
+i18n.locale.es: Español
+i18n.locale.fr: Français
 i18n.locale.zh: 中文 (简体)
 idv.accessible_labels.masked_ssn: 保护文本安全，从 %{first_number} 开始，到 %{last_number}结束
 idv.buttons.change_address_label: 更新地址


### PR DESCRIPTION
## 🛠 Summary of changes

Currently, we are displaying languages incorrectly when Chinese is selected as the language. It should be displaying the languages in their own language rather than the selected language. This PR fixes that.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
