### PR TITLE
LG-13214: Log presence of issue date and exp date

### DIFF
--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -43,6 +43,8 @@ module Idv
         extra: {
           pii_like_keypaths: self.class.pii_like_keypaths,
           attention_with_barcode: attention_with_barcode?,
+          id_issued_status: pii_from_doc[:state_id_issued].present? ? 'present' : 'missing',
+          id_expiration_status: pii_from_doc[:state_id_expiration].present? ? 'present' : 'missing',
         },
       )
       response.pii_from_doc = pii_from_doc

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -478,6 +478,8 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
           selfie_image_fingerprint: nil,
           liveness_checking_required: boolean,
           classification_info: a_kind_of(Hash),
+          id_issued_status: 'present',
+          id_expiration_status: 'present',
         )
 
         expect_funnel_update_counts(user, 1)
@@ -669,6 +671,8 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
                 Front: hash_including(ClassName: 'Identification Card', CountryCode: 'USA'),
                 Back: hash_including(ClassName: 'Identification Card', CountryCode: 'USA'),
               ),
+              id_issued_status: 'missing',
+              id_expiration_status: 'missing',
             )
           end
         end
@@ -780,6 +784,8 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
                 Front: hash_including(ClassName: 'Identification Card', CountryCode: 'USA'),
                 Back: hash_including(ClassName: 'Identification Card', CountryCode: 'USA'),
               ),
+              id_issued_status: 'missing',
+              id_expiration_status: 'missing',
             )
           end
         end
@@ -888,6 +894,8 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
               selfie_image_fingerprint: nil,
               liveness_checking_required: boolean,
               classification_info: hash_including(:Front, :Back),
+              id_issued_status: 'missing',
+              id_expiration_status: 'missing',
             )
           end
         end
@@ -996,6 +1004,8 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
               selfie_image_fingerprint: nil,
               liveness_checking_required: boolean,
               classification_info: hash_including(:Front, :Back),
+              id_issued_status: 'missing',
+              id_expiration_status: 'missing',
             )
           end
         end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: doc auth image upload vendor submitted' => hash_including(success: true, flow_path: 'standard', attention_with_barcode: false, doc_auth_result: 'Passed', liveness_checking_required: boolean),
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, submit_attempts: 1, remaining_submit_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), selfie_image_fingerprint: nil, liveness_checking_required: boolean, classification_info: {}
+        success: true, errors: {}, user_id: user.uuid, submit_attempts: 1, remaining_submit_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), selfie_image_fingerprint: nil, liveness_checking_required: boolean, classification_info: {}, id_issued_status: 'present', id_expiration_status: 'present'
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, analytics_id: 'Doc Auth', skip_hybrid_handoff: nil, irs_reproofing: false, selfie_check_required: boolean, liveness_checking_required: boolean
@@ -204,7 +204,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: doc auth image upload vendor submitted' => hash_including(success: true, flow_path: 'hybrid', attention_with_barcode: false, doc_auth_result: 'Passed', liveness_checking_required: boolean),
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, submit_attempts: 1, remaining_submit_attempts: 3, flow_path: 'hybrid', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), selfie_image_fingerprint: nil, liveness_checking_required: boolean, classification_info: {}
+        success: true, errors: {}, user_id: user.uuid, submit_attempts: 1, remaining_submit_attempts: 3, flow_path: 'hybrid', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), selfie_image_fingerprint: nil, liveness_checking_required: boolean, classification_info: {}, id_issued_status: 'present', id_expiration_status: 'present'
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'hybrid', step: 'document_capture', acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false, selfie_check_required: boolean, liveness_checking_required: boolean
@@ -327,7 +327,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: doc auth image upload vendor submitted' => hash_including(success: true, flow_path: 'standard', attention_with_barcode: false, doc_auth_result: 'Passed', liveness_checking_required: boolean),
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, submit_attempts: 1, remaining_submit_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), selfie_image_fingerprint: nil, liveness_checking_required: boolean, classification_info: {}
+        success: true, errors: {}, user_id: user.uuid, submit_attempts: 1, remaining_submit_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), selfie_image_fingerprint: nil, liveness_checking_required: boolean, classification_info: {}, id_issued_status: 'present', id_expiration_status: 'present'
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, skip_hybrid_handoff: nil, analytics_id: 'Doc Auth', irs_reproofing: false, selfie_check_required: boolean, liveness_checking_required: boolean
@@ -575,7 +575,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
       },
       'IdV: doc auth image upload vendor submitted' => hash_including(success: true, flow_path: 'standard', attention_with_barcode: false, doc_auth_result: 'Passed', liveness_checking_required: boolean),
       'IdV: doc auth image upload vendor pii validation' => {
-        success: true, errors: {}, user_id: user.uuid, submit_attempts: 1, remaining_submit_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), selfie_image_fingerprint: an_instance_of(String), liveness_checking_required: boolean, classification_info: {}
+        success: true, errors: {}, user_id: user.uuid, submit_attempts: 1, remaining_submit_attempts: 3, flow_path: 'standard', attention_with_barcode: false, front_image_fingerprint: an_instance_of(String), back_image_fingerprint: an_instance_of(String), selfie_image_fingerprint: an_instance_of(String), liveness_checking_required: boolean, classification_info: {}, id_issued_status: 'present', id_expiration_status: 'present'
       },
       'IdV: doc auth document_capture submitted' => {
         success: true, errors: {}, flow_path: 'standard', step: 'document_capture', redo_document_capture: nil, skip_hybrid_handoff: nil, acuant_sdk_upgrade_ab_test_bucket: :default, lexisnexis_instant_verify_workflow_ab_test_bucket: :default, analytics_id: 'Doc Auth', irs_reproofing: false, selfie_check_required: boolean, liveness_checking_required: true

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Idv::DocPiiForm do
       state: Faker::Address.state_abbr,
       state_id_jurisdiction: 'AL',
       state_id_number: 'S59397998',
+      state_id_issued: '2024-01-01',
+      state_id_expiration: '2024-01-01',
     }
   end
   let(:name_errors_pii) do
@@ -138,6 +140,8 @@ RSpec.describe Idv::DocPiiForm do
         expect(result.extra).to eq(
           attention_with_barcode: false,
           pii_like_keypaths: pii_like_keypaths,
+          id_issued_status: 'present',
+          id_expiration_status: 'present',
         )
       end
     end
@@ -154,6 +158,8 @@ RSpec.describe Idv::DocPiiForm do
         expect(result.extra).to eq(
           attention_with_barcode: false,
           pii_like_keypaths: pii_like_keypaths,
+          id_issued_status: 'missing',
+          id_expiration_status: 'missing',
         )
       end
     end
@@ -176,6 +182,8 @@ RSpec.describe Idv::DocPiiForm do
         expect(result.extra).to eq(
           attention_with_barcode: false,
           pii_like_keypaths: pii_like_keypaths,
+          id_issued_status: 'missing',
+          id_expiration_status: 'missing',
         )
       end
     end
@@ -194,6 +202,8 @@ RSpec.describe Idv::DocPiiForm do
         expect(result.extra).to eq(
           attention_with_barcode: false,
           pii_like_keypaths: pii_like_keypaths,
+          id_issued_status: 'missing',
+          id_expiration_status: 'missing',
         )
       end
     end
@@ -212,6 +222,8 @@ RSpec.describe Idv::DocPiiForm do
         expect(result.extra).to eq(
           attention_with_barcode: false,
           pii_like_keypaths: pii_like_keypaths,
+          id_issued_status: 'missing',
+          id_expiration_status: 'missing',
         )
       end
     end
@@ -230,6 +242,8 @@ RSpec.describe Idv::DocPiiForm do
         expect(result.extra).to eq(
           attention_with_barcode: false,
           pii_like_keypaths: pii_like_keypaths,
+          id_issued_status: 'missing',
+          id_expiration_status: 'missing',
         )
       end
     end
@@ -256,6 +270,8 @@ RSpec.describe Idv::DocPiiForm do
         expect(result.extra).to eq(
           attention_with_barcode: false,
           pii_like_keypaths: pii_like_keypaths,
+          id_issued_status: 'missing',
+          id_expiration_status: 'missing',
         )
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13214](https://cm-jira.usa.gov/browse/LG-13214)

## 🛠 Summary of changes

Adds two keys to the `IdV: doc auth image upload vendor pii validation` event: `:id_issued_status` and `id_expiration_status`. Possible values are 'missing' or 'present'.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
