### PR TITLE
Remove unused Step Indicator component styles

### DIFF
--- a/app/assets/stylesheets/components/_step-indicator.scss
+++ b/app/assets/stylesheets/components/_step-indicator.scss
@@ -130,14 +130,3 @@ lg-step-indicator {
 .step-indicator__step--current .step-indicator__step-title {
   font-weight: bold;
 }
-
-.step-indicator__step-subtitle {
-  @include at-media-max('tablet') {
-    @include sr-only;
-  }
-
-  @include at-media('tablet') {
-    display: block;
-    font-style: italic;
-  }
-}

--- a/app/javascript/packages/step-indicator/step-indicator-step.spec.tsx
+++ b/app/javascript/packages/step-indicator/step-indicator-step.spec.tsx
@@ -14,7 +14,6 @@ describe('StepIndicatorStep', () => {
       expect(status).to.be.ok();
       expect(step.classList.contains('step-indicator__step--current')).to.be.true();
       expect(step.classList.contains('step-indicator__step--complete')).to.be.false();
-      expect(status.classList.contains('step-indicator__step-subtitle')).to.be.false();
       expect(status.classList.contains('usa-sr-only')).to.be.true();
     });
   });
@@ -31,7 +30,6 @@ describe('StepIndicatorStep', () => {
       expect(status).to.be.ok();
       expect(step.classList.contains('step-indicator__step--current')).to.be.false();
       expect(step.classList.contains('step-indicator__step--complete')).to.be.true();
-      expect(status.classList.contains('step-indicator__step-subtitle')).to.be.false();
       expect(status.classList.contains('usa-sr-only')).to.be.true();
     });
   });
@@ -50,7 +48,6 @@ describe('StepIndicatorStep', () => {
       expect(status).to.be.ok();
       expect(step.classList.contains('step-indicator__step--current')).to.be.false();
       expect(step.classList.contains('step-indicator__step--complete')).to.be.false();
-      expect(status.classList.contains('step-indicator__step-subtitle')).to.be.false();
       expect(status.classList.contains('usa-sr-only')).to.be.true();
     });
   });


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused `step-indicator__step-subtitle` styles.

**Why?**

- Unused code creates technical debt
- Reduce size of stylesheets
- Limit divergence with underlying U.S. Web Design System components
- Eliminate an instance of italics text
   - For context, this was discovered while auditing current use of italic text, since [italic text is not intended to be supported for Chinese content](https://en.wikipedia.org/wiki/Chinese_punctuation#:~:text=For%20emphasis%2C%20Chinese%20uses%20emphasis,hand%20side%20of%20each%20character).).

Added in #6817, last reference removed in #7623.

## 📜 Testing Plan

Verify no regressions in the appearance of Step Indicator in the identity verification flow.