### PR TITLE
lg-13193 key metrics user count updates

### DIFF
--- a/app/services/reporting/total_user_count_report.rb
+++ b/app/services/reporting/total_user_count_report.rb
@@ -60,13 +60,13 @@ module Reporting
 
     def verified_user_count
       Reports::BaseReport.transaction_with_timeout do
-        Profile.where(active: true).where('activated_at <= ?', end_date).count
+        Profile.where(active: true).where('verified_at <= ?', end_date).count
       end
     end
 
     def new_verified_user_count
       Reports::BaseReport.transaction_with_timeout do
-        Profile.where(active: true).where(activated_at: current_month).count
+        Profile.where(active: true).where(verified_at: current_month).count
       end
     end
 
@@ -79,7 +79,7 @@ module Reporting
     def annual_verified_user_count
       Reports::BaseReport.transaction_with_timeout do
         Profile.where(active: true).
-          where(activated_at: annual_start_date..annual_end_date).
+          where(verified_at: annual_start_date..annual_end_date).
           count
       end
     end

--- a/lib/reporting/proofing_rate_report.rb
+++ b/lib/reporting/proofing_rate_report.rb
@@ -91,7 +91,7 @@ module Reporting
             issuers: nil, # all issuers
             time_range: Range.new(
               (end_date - slice_start.days).beginning_of_day,
-              (end_date - slice_end.days).beginning_of_day,
+              (end_date - slice_end.days).end_of_day,
             ),
             cloudwatch_client: cloudwatch_client,
           )

--- a/lib/reporting/proofing_rate_report.rb
+++ b/lib/reporting/proofing_rate_report.rb
@@ -87,14 +87,25 @@ module Reporting
     def reports
       @reports ||= begin
         sub_reports = [0, *DATE_INTERVALS].each_cons(2).map do |slice_end, slice_start|
-          Reporting::IdentityVerificationReport.new(
-            issuers: nil, # all issuers
-            time_range: Range.new(
-              (end_date - slice_start.days).beginning_of_day,
-              (end_date - slice_end.days).end_of_day,
-            ),
-            cloudwatch_client: cloudwatch_client,
-          )
+          if slice_end.zero?
+            Reporting::IdentityVerificationReport.new(
+              issuers: nil, # all issuers
+              time_range: Range.new(
+                (end_date - slice_start.days).beginning_of_day,
+                (end_date - slice_end.days).end_of_day,
+              ),
+              cloudwatch_client: cloudwatch_client,
+            )
+          else
+            Reporting::IdentityVerificationReport.new(
+              issuers: nil, # all issuers
+              time_range: Range.new(
+                (end_date - slice_start.days).beginning_of_day,
+                (end_date - slice_end.days).end_of_day - 1.day,
+              ),
+              cloudwatch_client: cloudwatch_client,
+            )
+          end
         end
 
         reports = if parallel?

--- a/spec/lib/reporting/proofing_rate_report_spec.rb
+++ b/spec/lib/reporting/proofing_rate_report_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Reporting::ProofingRateReport do
             successfully_verified_users: 1,
             idv_doc_auth_rejected: 1,
             idv_fraud_rejected: 0,
-            time_range: (end_date.beginning_of_day - 30.days)..end_date,
+            time_range: (end_date - 30.days).beginning_of_day..end_date,
           ),
           instance_double(
             'Reporting::IdentityVerificationReport',
@@ -39,7 +39,7 @@ RSpec.describe Reporting::ProofingRateReport do
             successfully_verified_users: 2,
             idv_doc_auth_rejected: 1,
             idv_fraud_rejected: 1,
-            time_range: (end_date.beginning_of_day - 60.days)..end_date,
+            time_range: (end_date - 60.days).beginning_of_day..end_date,
           ),
           instance_double(
             'Reporting::IdentityVerificationReport',
@@ -53,7 +53,7 @@ RSpec.describe Reporting::ProofingRateReport do
             successfully_verified_users: 3,
             idv_doc_auth_rejected: 1,
             idv_fraud_rejected: 2,
-            time_range: (end_date.beginning_of_day - 90.days)..end_date,
+            time_range: (end_date - 90.days).beginning_of_day..end_date,
           ),
         ],
       )
@@ -135,26 +135,26 @@ RSpec.describe Reporting::ProofingRateReport do
           allow(Reporting::IdentityVerificationReport).to receive(:new).and_call_original
           expect(report.reports.map(&:time_range)).to eq(
             [
-              (end_date.beginning_of_day - 30.days)..end_date,
-              (end_date.beginning_of_day - 60.days)..end_date,
-              (end_date.beginning_of_day - 90.days)..end_date,
+              (end_date - 30.days).beginning_of_day..end_date,
+              (end_date - 60.days).beginning_of_day..end_date,
+              (end_date - 90.days).beginning_of_day..end_date,
             ],
           )
 
           expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-            time_range: (end_date.beginning_of_day - 30.days)..end_date,
+            time_range: (end_date - 30.days).beginning_of_day..end_date,
             issuers: nil,
             cloudwatch_client: report.cloudwatch_client,
           ).once
 
           expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-            time_range: (end_date.beginning_of_day - 60.days)..(end_date.end_of_day - 30.days),
+            time_range: (end_date - 60.days).beginning_of_day..(end_date - 30.days).end_of_day,
             issuers: nil,
             cloudwatch_client: report.cloudwatch_client,
           ).once
 
           expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-            time_range: (end_date.beginning_of_day - 90.days)..(end_date.end_of_day - 60.days),
+            time_range: (end_date - 90.days).beginning_of_day..(end_date - 60.days).end_of_day,
             issuers: nil,
             cloudwatch_client: report.cloudwatch_client,
           ).once

--- a/spec/lib/reporting/proofing_rate_report_spec.rb
+++ b/spec/lib/reporting/proofing_rate_report_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'reporting/proofing_rate_report'
 
 RSpec.describe Reporting::ProofingRateReport do
-  let(:end_date) { Date.new(2022, 1, 1).in_time_zone('UTC').beginning_of_day }
+  let(:end_date) { Date.new(2022, 1, 1).in_time_zone('UTC').end_of_day }
   let(:parallel) { true }
 
   subject(:report) do
@@ -25,7 +25,7 @@ RSpec.describe Reporting::ProofingRateReport do
             successfully_verified_users: 1,
             idv_doc_auth_rejected: 1,
             idv_fraud_rejected: 0,
-            time_range: (end_date - 30.days)..end_date,
+            time_range: (end_date.beginning_of_day - 30.days)..end_date,
           ),
           instance_double(
             'Reporting::IdentityVerificationReport',
@@ -39,7 +39,7 @@ RSpec.describe Reporting::ProofingRateReport do
             successfully_verified_users: 2,
             idv_doc_auth_rejected: 1,
             idv_fraud_rejected: 1,
-            time_range: (end_date - 60.days)..end_date,
+            time_range: (end_date.beginning_of_day - 60.days)..end_date,
           ),
           instance_double(
             'Reporting::IdentityVerificationReport',
@@ -53,7 +53,7 @@ RSpec.describe Reporting::ProofingRateReport do
             successfully_verified_users: 3,
             idv_doc_auth_rejected: 1,
             idv_fraud_rejected: 2,
-            time_range: (end_date - 90.days)..end_date,
+            time_range: (end_date.beginning_of_day - 90.days)..end_date,
           ),
         ],
       )
@@ -133,29 +133,28 @@ RSpec.describe Reporting::ProofingRateReport do
 
         it 'calls IdentityVerificationReport with separate slices, but merges them' do
           allow(Reporting::IdentityVerificationReport).to receive(:new).and_call_original
-
           expect(report.reports.map(&:time_range)).to eq(
             [
-              (end_date - 30.days)..end_date,
-              (end_date - 60.days)..end_date,
-              (end_date - 90.days)..end_date,
+              (end_date.beginning_of_day - 30.days)..end_date,
+              (end_date.beginning_of_day - 60.days)..end_date,
+              (end_date.beginning_of_day - 90.days)..end_date,
             ],
           )
 
           expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-            time_range: (end_date - 30.days)..end_date,
+            time_range: (end_date.beginning_of_day - 30.days)..end_date,
             issuers: nil,
             cloudwatch_client: report.cloudwatch_client,
           ).once
 
           expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-            time_range: (end_date - 60.days)..(end_date - 30.days),
+            time_range: (end_date.beginning_of_day - 60.days)..(end_date.end_of_day - 30.days),
             issuers: nil,
             cloudwatch_client: report.cloudwatch_client,
           ).once
 
           expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
-            time_range: (end_date - 90.days)..(end_date - 60.days),
+            time_range: (end_date.beginning_of_day - 90.days)..(end_date.end_of_day - 60.days),
             issuers: nil,
             cloudwatch_client: report.cloudwatch_client,
           ).once

--- a/spec/services/reporting/total_user_count_report_spec.rb
+++ b/spec/services/reporting/total_user_count_report_spec.rb
@@ -47,29 +47,6 @@ RSpec.describe Reporting::TotalUserCountReport do
       end
     end
 
-    context 'with 2 users, 1 verified but deactivated ' do
-      before do
-        user1 = create(:user)
-        create(:profile, :active, :verified, user: user1)
-        user2 = create(:user)
-        # MW: The :verified trait doesn't set active: true. This feels confusing.
-        create(:profile, :active, :verified, user: user2)
-        user2.profiles.first.update!(
-          active: false,
-          deactivation_reason: :verification_cancelled,
-        )
-      end
-      let(:expected_total_count) { 2 }
-      let(:expected_verified_count) { 1 }
-      let(:expected_total_fully_registered) { 0 }
-      let(:expected_new_count) { 2 }
-      let(:expected_new_verified_count) { 1 }
-      let(:expected_annual_count) { expected_total_count }
-      let(:expected_annual_verified_count) { 1 }
-
-      it_behaves_like 'a report with the specified counts'
-    end
-
     context 'with only a non-verified user' do
       before { create(:user) }
       let(:expected_total_count) { 1 }
@@ -100,10 +77,16 @@ RSpec.describe Reporting::TotalUserCountReport do
 
     context 'with one verified and one non-verified user' do
       before do
-        create(:user)
+        user1 = create(:user)
         user2 = create(:user)
+        create(:profile, :active, :verified, user: user1)
         # MW: The :verified trait doesn't set active: true. This feels confusing.
-        create(:profile, :active, user: user2)
+        create(:profile, :active, :verified, user: user2)
+        user2.profiles.first.update!(
+          active: false,
+          verified_at: nil,
+          deactivation_reason: :password_reset,
+        )
       end
       let(:expected_total_count) { 2 }
       let(:expected_verified_count) { 1 }

--- a/spec/services/reporting/total_user_count_report_spec.rb
+++ b/spec/services/reporting/total_user_count_report_spec.rb
@@ -47,6 +47,29 @@ RSpec.describe Reporting::TotalUserCountReport do
       end
     end
 
+    context 'with 2 users, 1 verified but deactivated ' do
+      before do
+        user1 = create(:user)
+        create(:profile, :active, :verified, user: user1)
+        user2 = create(:user)
+        # MW: The :verified trait doesn't set active: true. This feels confusing.
+        create(:profile, :active, :verified, user: user2)
+        user2.profiles.first.update!(
+          active: false,
+          deactivation_reason: :verification_cancelled,
+        )
+      end
+      let(:expected_total_count) { 2 }
+      let(:expected_verified_count) { 1 }
+      let(:expected_total_fully_registered) { 0 }
+      let(:expected_new_count) { 2 }
+      let(:expected_new_verified_count) { 1 }
+      let(:expected_annual_count) { expected_total_count }
+      let(:expected_annual_verified_count) { 1 }
+
+      it_behaves_like 'a report with the specified counts'
+    end
+
     context 'with only a non-verified user' do
       before { create(:user) }
       let(:expected_total_count) { 1 }

--- a/spec/services/reporting/total_user_count_report_spec.rb
+++ b/spec/services/reporting/total_user_count_report_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Reporting::TotalUserCountReport do
         user2 = create(:user)
         create(:profile, :active, :verified, user: user1)
         # MW: The :verified trait doesn't set active: true. This feels confusing.
+        # user2 active profile but unverified
         create(:profile, :active, :verified, user: user2)
         user2.profiles.first.update!(
           active: false,


### PR DESCRIPTION
changelog: Internal, Reporting,key metrics user counts

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-13193](https://cm-jira.usa.gov/browse/LG-13193)



## 🛠 Summary of changes

For the proofing rate report included the last day end date in the query for 30,60 and 90 days trailing and verified user counts in Total user counts(updated to verified_at from activated_at


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Updated proofing rate report spec file 
- [ ] Validated proofing rate report spec shows expected end date as end of the day 
- [ ] Validated total user counts spec for validated_at count


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
