### PR TITLE
Use design system centered variant for banner

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,7 +1,0 @@
-@use 'uswds-core' as *;
-
-.usa-banner__inner {
-  @include at-media('tablet') {
-    justify-content: center;
-  }
-}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,7 +1,6 @@
 @forward 'account-header';
 @forward 'alert-icon';
 @forward 'alert';
-@forward 'banner';
 @forward 'block-link';
 @forward 'btn';
 @forward 'card';

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -1,6 +1,6 @@
 <header>
   <%= render 'shared/no_pii_banner' if FeatureManagement.show_no_pii_banner? %>
-  <section class="usa-banner" aria-label="<%= t('shared.banner.landmark_label') %>">
+  <section class="usa-banner usa-banner--centered" aria-label="<%= t('shared.banner.landmark_label') %>">
     <div class="usa-accordion">
       <div class="usa-banner__header">
         <div class="usa-banner__inner">


### PR DESCRIPTION
## 🛠 Summary of changes

Refactors the banner to use the "centered" variant introduced to the design system in [`@18f/identity-design-system@9.1.0`](https://github.com/18F/identity-design-system/releases/tag/v9.1.0), to avoid redundant, ad-hoc styles.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Verify no regressions in appearance of USA banner

## 👀 Screenshots

There are not expected to be any visual differences:

![Screenshot 2024-05-21 at 10 07 21 AM](https://github.com/18F/identity-idp/assets/1779930/e7a531a8-6004-4434-9a5d-7a30e5877c53)
