### PR TITLE
LG-13363: Fix Screenreader Focus Jumping During Selfie Capture

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -529,7 +529,6 @@ function AcuantCapture(
     });
 
     setImageCaptureText('');
-    setIsCapturingEnvironment(true);
   }
 
   function onSelfieCaptureClosed() {

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -22,6 +22,10 @@ function AcuantSelfieCaptureCanvas({ imageCaptureText, onSelfieCaptureClosed }) 
   // this id. It then uses that element as the root for the full screen selfie capture
   const acuantCaptureContainerId = 'acuant-face-capture-container';
 
+  // This solves a fairly nasty bug for screenreader users where the screenreader focus would jump away
+  // from the capture button (added by Acuant SDK) to the button in this component. Specifically we
+  // need to detect when Acuant actually hydrates in their capture screen and hide the button.
+  // See PR 10668 for more information.
   const elementInShadow = document
     ?.getElementById('acuant-face-capture-camera')
     ?.shadowRoot?.getElementById('cameraContainer');

--- a/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-selfie-capture-canvas.jsx
@@ -21,6 +21,12 @@ function AcuantSelfieCaptureCanvas({ imageCaptureText, onSelfieCaptureClosed }) 
   // The Acuant SDK script AcuantPassiveLiveness attaches to whatever element has
   // this id. It then uses that element as the root for the full screen selfie capture
   const acuantCaptureContainerId = 'acuant-face-capture-container';
+
+  const elementInShadow = document
+    ?.getElementById('acuant-face-capture-camera')
+    ?.shadowRoot?.getElementById('cameraContainer');
+  const loadedAcuantCamera = !!elementInShadow;
+
   return (
     <>
       {!isReady && <LoadingSpinner />}
@@ -31,9 +37,11 @@ function AcuantSelfieCaptureCanvas({ imageCaptureText, onSelfieCaptureClosed }) 
           )}
         </p>
       </div>
-      <button type="button" onClick={onSelfieCaptureClosed} className="usa-sr-only">
-        {t('doc_auth.buttons.close')}
-      </button>
+      {!loadedAcuantCamera && (
+        <button type="button" onClick={onSelfieCaptureClosed} className="usa-sr-only">
+          {t('doc_auth.buttons.close')}
+        </button>
+      )}
     </>
   );
 }

--- a/spec/javascript/packages/document-capture/components/acuant-selfie-capture-canvas-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-selfie-capture-canvas-spec.jsx
@@ -1,6 +1,5 @@
 import AcuantSelfieCaptureCanvas from '@18f/identity-document-capture/components/acuant-selfie-capture-canvas';
 import { AcuantContext, DeviceContext } from '@18f/identity-document-capture';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { render } from '../../../support/document-capture';
 
 it('shows the loading spinner when the script hasnt loaded', () => {

--- a/spec/javascript/packages/document-capture/components/acuant-selfie-capture-canvas-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-selfie-capture-canvas-spec.jsx
@@ -1,5 +1,6 @@
 import AcuantSelfieCaptureCanvas from '@18f/identity-document-capture/components/acuant-selfie-capture-canvas';
 import { AcuantContext, DeviceContext } from '@18f/identity-document-capture';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { render } from '../../../support/document-capture';
 
 it('shows the loading spinner when the script hasnt loaded', () => {
@@ -26,4 +27,48 @@ it('shows the Acuant div when the script has loaded', () => {
 
   expect(container.querySelector('#acuant-face-capture-container')).to.exist();
   expect(container.querySelector('.acuant-capture-canvas__spinner')).not.to.exist();
+});
+
+it('shows the fullscreen close button before acuant is hydrated in', () => {
+  // Render the AcuantSelfieCaptureCanvas component with some text
+  const imageCaptureText = 'Face not found';
+  const { rerender, container, queryByRole } = render(
+    <DeviceContext.Provider value={{ isMobile: true }}>
+      <AcuantContext.Provider value={{ isReady: true }}>
+        <AcuantSelfieCaptureCanvas imageCaptureText={imageCaptureText} />
+      </AcuantContext.Provider>
+    </DeviceContext.Provider>,
+  );
+  // Check that the button exists
+  expect(queryByRole('button')).to.exist();
+
+  // Mock how Acuant sets up the dom by creating this structure of divs
+  // '#acuant-face-capture-container>#acuant-face-capture-camera>#cameraContainer'
+  const acuantFaceCaptureDiv = document.createElement('div');
+  acuantFaceCaptureDiv.id = 'acuant-face-capture-camera';
+  const acuantFaceCaptureContainer = container.querySelector('#acuant-face-capture-container');
+  acuantFaceCaptureContainer.appendChild(acuantFaceCaptureDiv);
+  expect(
+    container.querySelector('#acuant-face-capture-container>#acuant-face-capture-camera'),
+  ).to.exist();
+
+  // Mock how Acuant sets up the shadow dom with the #cameraContainer div inside it
+  const cameraContainer = document.createElement('div');
+  cameraContainer.id = 'cameraContainer';
+  const shadow = container
+    .querySelector('#acuant-face-capture-camera')
+    .attachShadow({ mode: 'open' });
+  shadow.appendChild(cameraContainer);
+
+  // Rerender the component, the shadow dom continues to exist
+  const newImageCaptureText = 'Too many faces';
+  rerender(
+    <DeviceContext.Provider value={{ isMobile: true }}>
+      <AcuantContext.Provider value={{ isReady: true }}>
+        <AcuantSelfieCaptureCanvas imageCaptureText={newImageCaptureText} />
+      </AcuantContext.Provider>
+    </DeviceContext.Provider>,
+  );
+  // The button now disappears
+  expect(queryByRole('button')).not.to.exist();
 });


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
https://cm-jira.usa.gov/browse/LG-13363

## 🛠 Summary of changes

Fix a problem where when using a screenreader focus would jump away from the capture button in selfie capture. Slack thread [here](https://gsa-tts.slack.com/archives/C056RD1NEHW/p1716225740192659).

## 📜 Testing Plan

- [ ] Make sure you can reproduce the problem
    - [ ] Check out `main`
    - [ ] Log in
    - [ ] Get to front/back/selfie page
    - [ ] Turn on screenreader (iOS/chrome)
    - [ ] Open the selfie capture
    - [ ] Dismiss the camera permissions prompt (or allow)
    - [ ] Tap near or on the red capture button
    - [ ] Instead of focusing that button the focus of the screenreader jumps to the hidden close button in the top right.

- [ ] Check that the problem is fixed by this PR
    - [ ] Check out this branch.
    - [ ] Do the above steps again.
    - [ ] When you click the near the red button, focus will jump to to the red button. Clicking on the red button will also focus it correctly.
