### PR TITLE
Fix logging envs all being put in the same log group

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -469,7 +469,7 @@ trigger_devops:
     - >-
       helm upgrade --install --namespace review-apps
       --debug
-      --set env="reviewapps"
+      --set env="reviewapps-$CI_ENVIRONMENT_SLUG"
       --set idp.image.repository="${ECR_REGISTRY}/identity-idp/review"
       --set idp.image.tag="${CI_COMMIT_SHA}"
       --set worker.image.repository="${ECR_REGISTRY}/identity-idp/review"


### PR DESCRIPTION
Previously all reviewapps were being put mistakenly in the same `reviewapps`
cloudwatch log group.

This change fixes it so they're put in cloudwatch log groups named after the
reviewapp.

In cloudwatch you can search for your branch to find the log groups for your
reviewapp again.

-------

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->