### PR TITLE
Prevent USPS Proofing Results Job from failing when in_person_enrollments_ready_job_enabled is true

### DIFF
--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -211,6 +211,8 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
       and_return(reprocess_delay_minutes)
     allow(IdentityConfig.store).to receive(:in_person_proofing_enforce_tmx).
       and_return(in_person_proofing_enforce_tmx)
+    allow(IdentityConfig.store).to receive(:in_person_enrollments_ready_job_enabled).
+      and_return(false)
     stub_const(
       'GetUspsProofingResultsJob::REQUEST_DELAY_IN_SECONDS',
       request_delay_ms / GetUspsProofingResultsJob::MILLISECONDS_PER_SECOND,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13367 ](https://cm-jira.usa.gov/browse/LG-13367 )

## 🛠 Summary of changes

Added a top level mock config value so the spec doesn't break on launch. This spec could maybe use a refactor once the config value (in_person_enrollments_ready_job_enabled) is toggled to true. 

## 📜 Testing Plan

Make sure the specs are all green.