### PR TITLE
lg-13006 rename skip_doc_auth

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -53,7 +53,7 @@ module Idv
         sp_name: decorated_sp_session.sp_name,
         failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
         skip_doc_auth: idv_session.skip_doc_auth,
-        skip_doc_auth_from_how_to_verify: false,
+        skip_doc_auth_from_how_to_verify: idv_session.skip_doc_auth_from_how_to_verify,
         skip_doc_auth_from_handoff: idv_session.skip_doc_auth_from_handoff,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
         doc_auth_selfie_capture:,
@@ -73,6 +73,7 @@ module Idv
                            idv_session.skip_doc_auth_from_handoff ||
                            idv_session.skip_hybrid_handoff ||
                             idv_session.skip_doc_auth ||
+                            idv_session.skip_doc_auth_from_how_to_verify ||
                             !idv_session.selfie_check_required || # desktop but selfie not required
                              idv_session.desktop_selfie_test_mode_enabled?
                          )

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -39,11 +39,13 @@ module Idv
         if how_to_verify_form_params['selection'] == Idv::HowToVerifyForm::REMOTE
           idv_session.opted_in_to_in_person_proofing = false
           idv_session.skip_doc_auth = false
+          idv_session.skip_doc_auth_from_how_to_verify = false
           redirect_to idv_hybrid_handoff_url
         else
           idv_session.opted_in_to_in_person_proofing = true
           idv_session.flow_path = 'standard'
           idv_session.skip_doc_auth = true
+          idv_session.skip_doc_auth_from_how_to_verify = true
           redirect_to idv_document_capture_url
         end
 
@@ -70,6 +72,7 @@ module Idv
         end,
         undo_step: ->(idv_session:, user:) {
                      idv_session.skip_doc_auth = nil
+                     idv_session.skip_doc_auth_from_how_to_verify = nil
                      idv_session.opted_in_to_in_person_proofing = nil
                    },
       )

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -52,8 +52,10 @@ module Idv
          IdentityConfig.store.in_person_proofing_enabled &&
          idv_session.service_provider&.in_person_proofing_enabled
         idv_session.skip_doc_auth == false
+        idv_session.skip_doc_auth_from_how_to_verify == false
       else
         idv_session.skip_doc_auth.nil? || idv_session.skip_doc_auth == false
+        idv_session.skip_doc_auth_from_how_to_verify.nil? || idv_session.skip_doc_auth_from_how_to_verify == false
       end
     end
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -52,10 +52,9 @@ module Idv
          IdentityConfig.store.in_person_proofing_enabled &&
          idv_session.service_provider&.in_person_proofing_enabled
         idv_session.skip_doc_auth == false
-        idv_session.skip_doc_auth_from_how_to_verify == false
       else
-        idv_session.skip_doc_auth.nil? || idv_session.skip_doc_auth == false
-        idv_session.skip_doc_auth_from_how_to_verify.nil? || idv_session.skip_doc_auth_from_how_to_verify == false
+        idv_session.skip_doc_auth.nil? ||
+          idv_session.skip_doc_auth == false
       end
     end
 

--- a/app/views/idv/document_capture/show.html.erb
+++ b/app/views/idv/document_capture/show.html.erb
@@ -9,7 +9,7 @@
       acuant_version: acuant_version,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
       skip_doc_auth: skip_doc_auth,
-      skip_doc_auth_from_how_to_verify: false,
+      skip_doc_auth_from_how_to_verify: skip_doc_auth_from_how_to_verify,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
     ) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -38,7 +38,7 @@
       doc_auth_selfie_capture: FeatureManagement.idv_allow_selfie_check? && doc_auth_selfie_capture,
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
       skip_doc_auth: skip_doc_auth,
-      skip_doc_auth_from_how_to_verify: false,
+      skip_doc_auth_from_how_to_verify: skip_doc_auth_from_how_to_verify,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       how_to_verify_url: idv_how_to_verify_url,
       previous_step_url: @previous_step_url,

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Idv::HowToVerifyController do
 
           expect(Idv::HowToVerifyController.enabled?).to be false
           expect(subject.idv_session.skip_doc_auth).to be_nil
+          expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be_nil
           expect(response).to redirect_to(idv_hybrid_handoff_url)
         end
       end
@@ -57,6 +58,7 @@ RSpec.describe Idv::HowToVerifyController do
 
           expect(Idv::HowToVerifyController.enabled?).to be false
           expect(subject.idv_session.skip_doc_auth).to be_nil
+          expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be_nil
           expect(response).to redirect_to(idv_hybrid_handoff_url)
         end
       end
@@ -72,6 +74,7 @@ RSpec.describe Idv::HowToVerifyController do
 
           expect(Idv::HowToVerifyController.enabled?).to be false
           expect(subject.idv_session.skip_doc_auth).to be_nil
+          expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be_nil
           expect(response).to redirect_to(idv_hybrid_handoff_url)
         end
       end
@@ -84,6 +87,7 @@ RSpec.describe Idv::HowToVerifyController do
             expect(Idv::HowToVerifyController.enabled?).to be true
             expect(subject.idv_session.service_provider.in_person_proofing_enabled).to be true
             expect(subject.idv_session.skip_doc_auth).to be_nil
+            expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be_nil
             expect(response).to render_template :show
           end
         end
@@ -120,6 +124,7 @@ RSpec.describe Idv::HowToVerifyController do
       get :show
 
       expect(subject.idv_session.skip_doc_auth).to be_nil
+      expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be_nil
       expect(response).to render_template :show
     end
 
@@ -193,6 +198,7 @@ RSpec.describe Idv::HowToVerifyController do
         put :update, params: params
 
         expect(subject.idv_session.skip_doc_auth).to be false
+        expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be false
         expect(response).to redirect_to(idv_hybrid_handoff_url)
       end
 
@@ -220,6 +226,7 @@ RSpec.describe Idv::HowToVerifyController do
         put :update, params: params
 
         expect(subject.idv_session.skip_doc_auth).to be true
+        expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be true
         expect(response).to redirect_to(idv_document_capture_url)
       end
 
@@ -235,6 +242,7 @@ RSpec.describe Idv::HowToVerifyController do
         put :update, params: { undo_step: true }
 
         expect(subject.idv_session.skip_doc_auth).to be_nil
+        expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be_nil
         expect(subject.idv_session.opted_in_to_in_person_proofing).to be_nil
         expect(response).to redirect_to(idv_how_to_verify_url)
       end

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe Idv::HybridHandoffController, allowed_extra_analytics: [:*] do
           allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
             and_return(false)
           subject.idv_session.skip_doc_auth = nil
+          subject.idv_session.skip_doc_auth_from_how_to_verify = nil
         end
 
         it 'redirects to how to verify' do
@@ -241,6 +242,7 @@ RSpec.describe Idv::HybridHandoffController, allowed_extra_analytics: [:*] do
           allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
             and_return(false)
           subject.idv_session.skip_doc_auth = true
+          subject.idv_session.skip_doc_auth_from_how_to_verify = true
           subject.idv_session.skip_hybrid_handoff = true
         end
 
@@ -255,6 +257,7 @@ RSpec.describe Idv::HybridHandoffController, allowed_extra_analytics: [:*] do
         before do
           subject.idv_session.service_provider.in_person_proofing_enabled = false
           subject.idv_session.skip_doc_auth = nil
+          subject.idv_session.skip_doc_auth_from_how_to_verify = nil
         end
 
         it 'renders the show template' do

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -15,6 +15,7 @@ module FlowPolicyHelper
       idv_session.idv_consent_given = true
     when :how_to_verify
       idv_session.skip_doc_auth = false
+      idv_session.skip_doc_auth_from_how_to_verify = false
     when :hybrid_handoff
       idv_session.flow_path = 'standard'
     when :link_sent

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
 
   let(:acuant_version) { '1.3.3.7' }
   let(:skip_doc_auth) { false }
+  let(:skip_doc_auth_from_how_to_verify) { false }
   let(:skip_doc_auth_from_handoff) { false }
   let(:opted_in_to_in_person_proofing) { false }
 
@@ -48,7 +49,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       acuant_version: acuant_version,
       doc_auth_selfie_capture: selfie_capture_enabled,
       skip_doc_auth: skip_doc_auth,
-      skip_doc_auth_from_how_to_verify: false,
+      skip_doc_auth_from_how_to_verify: skip_doc_auth_from_how_to_verify,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
     }


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13006](https://cm-jira.usa.gov/browse/LG-13006)

## 🛠 Summary of changes
Added `skip_doc_auth_from_how_to_verify` alongside `skip_doc_auth` for eventual removal of `skip_doc_auth`.
