### PR TITLE
Avoid outputting font-face for unused light font weight

### DIFF
--- a/app/assets/stylesheets/_uswds-core.scss
+++ b/app/assets/stylesheets/_uswds-core.scss
@@ -2,6 +2,7 @@
   $theme-body-font-size: 'sm',
   $theme-button-icon-gap: 0.5,
   $theme-font-path: '',
+  $theme-font-weight-light: false,
   $theme-image-path: '',
   $theme-global-border-box-sizing: true,
   $theme-global-link-styles: true,


### PR DESCRIPTION
## 🛠 Summary of changes

Configures the design system to avoid outputting `@font-face` declarations for unused light weight font copy.

We only use normal and bold face text in the application, so this declaration is wasted bytes. This also controls the output of a few utility helpers related to light text.

```diff
23a24,31
>   font-weight: 300;
>   font-display: fallback;
>   src: url("/roboto-mono/roboto-mono-v5-latin-300.woff2") format("woff2");
> }
> 
> @font-face {
>   font-family: Roboto Mono Web;
>   font-style: normal;
39a48,55
>   font-weight: 300;
>   font-display: fallback;
>   src: url("/roboto-mono/roboto-mono-v5-latin-300italic.woff2") format("woff2");
> }
> 
> @font-face {
>   font-family: Roboto Mono Web;
>   font-style: italic;
55a72,79
>   font-weight: 300;
>   font-display: fallback;
>   src: url("/public-sans/PublicSans-Light.woff2") format("woff2");
> }
> 
> @font-face {
>   font-family: Public Sans Web;
>   font-style: normal;
71a96,103
>   font-weight: 300;
>   font-display: fallback;
>   src: url("/public-sans/PublicSans-LightItalic.woff2") format("woff2");
> }
> 
> @font-face {
>   font-family: Public Sans Web;
>   font-style: italic;
6337a6370,6373
> .text-light {
>   font-weight: 300;
> }
> 
9197a9234,9237
>   }
> 
>   .tablet\:text-light {
>     font-weight: 300;
```

**Performance Impact:**

```
NODE_ENV=production yarn build:css && brotli-size app/assets/builds/application.css
```

Before: 18.4 kB
After: 18.3 kB
Diff: -0.1 kB (-0.5%)

## 📜 Testing Plan

Verify no regression in the display of Public Sans font.