### PR TITLE
LG-13216: Gaze into the AAMVA SOAP abyss.

### DIFF
--- a/app/services/proofing/aamva/request/templates/verify.xml.erb
+++ b/app/services/proofing/aamva/request/templates/verify.xml.erb
@@ -1,17 +1,17 @@
 <soap:Envelope
   xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
-  xmlns:ns="http://aamva.org/dldv/wsdl/2.1"
+  xmlns:dldv="http://aamva.org/dldv/wsdl/2.1"
   xmlns:aa="http://aamva.org/niem/extensions/1.0"
   xmlns:nc="http://niem.gov/niem/niem-core/2.0">
   <soap:Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
     <wsa:Action>http://aamva.org/dldv/wsdl/2.1/IDLDVService21/VerifyDriverLicenseData</wsa:Action>
   </soap:Header>
   <soap:Body>
-    <ns:VerifyDriverLicenseData>
-      <ns:token>
+    <dldv:VerifyDriverLicenseData>
+      <dldv:token>
         <%= auth_token %>
-      </ns:token>
-      <ns:verifyDriverLicenseDataRequest>
+      </dldv:token>
+      <dldv:verifyDriverLicenseDataRequest>
         <aa:ControlData>
           <aa:MessageAddress>
             <aa:TransactionLocatorId>
@@ -35,7 +35,7 @@
           <nc:LocationStateUsPostalServiceCode></nc:LocationStateUsPostalServiceCode>
           <nc:LocationPostalCode></nc:LocationPostalCode>
         </aa:Address>
-      </ns:verifyDriverLicenseDataRequest>
-    </ns:VerifyDriverLicenseData>
+      </dldv:verifyDriverLicenseDataRequest>
+    </dldv:VerifyDriverLicenseData>
   </soap:Body>
 </soap:Envelope>

--- a/app/services/proofing/aamva/request/templates/verify.xml.erb
+++ b/app/services/proofing/aamva/request/templates/verify.xml.erb
@@ -1,4 +1,8 @@
-<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:ns="http://aamva.org/dldv/wsdl/2.1" xmlns:ns1="http://aamva.org/niem/extensions/1.0" xmlns:ns2="http://niem.gov/niem/niem-core/2.0">
+<soap:Envelope
+  xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+  xmlns:ns="http://aamva.org/dldv/wsdl/2.1"
+  xmlns:aa="http://aamva.org/niem/extensions/1.0"
+  xmlns:nc="http://niem.gov/niem/niem-core/2.0">
   <soap:Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
     <wsa:Action>http://aamva.org/dldv/wsdl/2.1/IDLDVService21/VerifyDriverLicenseData</wsa:Action>
   </soap:Header>
@@ -8,29 +12,29 @@
         <%= auth_token %>
       </ns:token>
       <ns:verifyDriverLicenseDataRequest>
-        <ns1:ControlData>
-          <ns1:MessageAddress>
-            <ns1:TransactionLocatorId>
+        <aa:ControlData>
+          <aa:MessageAddress>
+            <aa:TransactionLocatorId>
               <%= transaction_locator_id %>
-            </ns1:TransactionLocatorId>
-            <ns1:MessageOriginatorId>GSA</ns1:MessageOriginatorId>
-            <ns1:MessageDestinationId></ns1:MessageDestinationId>
-          </ns1:MessageAddress>
-        </ns1:ControlData>
-        <ns2:DriverLicenseIdentification>
-          <ns2:IdentificationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns2:PersonNameTextType"></ns2:IdentificationID>
-        </ns2:DriverLicenseIdentification>
-        <ns1:PersonBirthDate></ns1:PersonBirthDate>
-        <ns2:PersonName>
-          <ns2:PersonGivenName></ns2:PersonGivenName>
-          <ns2:PersonSurName></ns2:PersonSurName>
-        </ns2:PersonName>
-        <ns1:Address>
-          <ns2:AddressDeliveryPointText></ns2:AddressDeliveryPointText>
-          <ns2:LocationCityName></ns2:LocationCityName>
-          <ns2:LocationStateUsPostalServiceCode></ns2:LocationStateUsPostalServiceCode>
-          <ns2:LocationPostalCode></ns2:LocationPostalCode>
-        </ns1:Address>
+            </aa:TransactionLocatorId>
+            <aa:MessageOriginatorId>GSA</aa:MessageOriginatorId>
+            <aa:MessageDestinationId></aa:MessageDestinationId>
+          </aa:MessageAddress>
+        </aa:ControlData>
+        <nc:DriverLicenseIdentification>
+          <nc:IdentificationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="nc:PersonNameTextType"></nc:IdentificationID>
+        </nc:DriverLicenseIdentification>
+        <aa:PersonBirthDate></aa:PersonBirthDate>
+        <nc:PersonName>
+          <nc:PersonGivenName></nc:PersonGivenName>
+          <nc:PersonSurName></nc:PersonSurName>
+        </nc:PersonName>
+        <aa:Address>
+          <nc:AddressDeliveryPointText></nc:AddressDeliveryPointText>
+          <nc:LocationCityName></nc:LocationCityName>
+          <nc:LocationStateUsPostalServiceCode></nc:LocationStateUsPostalServiceCode>
+          <nc:LocationPostalCode></nc:LocationPostalCode>
+        </aa:Address>
       </ns:verifyDriverLicenseDataRequest>
     </ns:VerifyDriverLicenseData>
   </soap:Body>

--- a/app/services/proofing/aamva/request/verification_request.rb
+++ b/app/services/proofing/aamva/request/verification_request.rb
@@ -64,21 +64,21 @@ module Proofing
           end
 
           add_optional_element(
-            'ns2:AddressDeliveryPointText',
+            'nc:AddressDeliveryPointText',
             value: applicant.address2,
             document:,
-            after: '//ns1:Address/ns2:AddressDeliveryPointText',
+            after: '//aa:Address/nc:AddressDeliveryPointText',
           )
 
           add_optional_element(
-            'ns2:DriverLicenseIssueDate',
+            'aa:DriverLicenseIssueDate',
             value: applicant.state_id_data.state_id_issued,
             document:,
             inside: '//ns:verifyDriverLicenseDataRequest',
           )
 
           add_optional_element(
-            'ns2:DriverLicenseExpirationDate',
+            'aa:DriverLicenseExpirationDate',
             value: applicant.state_id_data.state_id_expiration,
             document:,
             inside: '//ns:verifyDriverLicenseDataRequest',
@@ -142,15 +142,15 @@ module Proofing
 
         def user_provided_data_map
           {
-            '//ns2:IdentificationID' => state_id_number,
-            '//ns1:MessageDestinationId' => message_destination_id,
-            '//ns2:PersonGivenName' => applicant.first_name,
-            '//ns2:PersonSurName' => applicant.last_name,
-            '//ns1:PersonBirthDate' => applicant.dob,
-            '//ns2:AddressDeliveryPointText' => applicant.address1,
-            '//ns2:LocationCityName' => applicant.city,
-            '//ns2:LocationStateUsPostalServiceCode' => applicant.state,
-            '//ns2:LocationPostalCode' => applicant.zipcode,
+            '//nc:IdentificationID' => state_id_number,
+            '//aa:MessageDestinationId' => message_destination_id,
+            '//nc:PersonGivenName' => applicant.first_name,
+            '//nc:PersonSurName' => applicant.last_name,
+            '//aa:PersonBirthDate' => applicant.dob,
+            '//nc:AddressDeliveryPointText' => applicant.address1,
+            '//nc:LocationCityName' => applicant.city,
+            '//nc:LocationStateUsPostalServiceCode' => applicant.state,
+            '//nc:LocationPostalCode' => applicant.zipcode,
           }
         end
 

--- a/app/services/proofing/aamva/request/verification_request.rb
+++ b/app/services/proofing/aamva/request/verification_request.rb
@@ -74,14 +74,14 @@ module Proofing
             'aa:DriverLicenseIssueDate',
             value: applicant.state_id_data.state_id_issued,
             document:,
-            inside: '//ns:verifyDriverLicenseDataRequest',
+            inside: '//dldv:verifyDriverLicenseDataRequest',
           )
 
           add_optional_element(
             'aa:DriverLicenseExpirationDate',
             value: applicant.state_id_data.state_id_expiration,
             document:,
-            inside: '//ns:verifyDriverLicenseDataRequest',
+            inside: '//dldv:verifyDriverLicenseDataRequest',
           )
 
           @body = document.to_s

--- a/spec/fixtures/proofing/aamva/requests/verification_request.xml
+++ b/spec/fixtures/proofing/aamva/requests/verification_request.xml
@@ -1,4 +1,4 @@
-<soap:Envelope xmlns:ns='http://aamva.org/dldv/wsdl/2.1' xmlns:ns1='http://aamva.org/niem/extensions/1.0' xmlns:ns2='http://niem.gov/niem/niem-core/2.0' xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>
+<soap:Envelope xmlns:aa='http://aamva.org/niem/extensions/1.0' xmlns:nc='http://niem.gov/niem/niem-core/2.0' xmlns:ns='http://aamva.org/dldv/wsdl/2.1' xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>
   <soap:Header xmlns:wsa='http://www.w3.org/2005/08/addressing'>
     <wsa:Action>http://aamva.org/dldv/wsdl/2.1/IDLDVService21/VerifyDriverLicenseData</wsa:Action>
   </soap:Header>
@@ -8,29 +8,29 @@
         KEYKEYKEY
       </ns:token>
       <ns:verifyDriverLicenseDataRequest>
-        <ns1:ControlData>
-          <ns1:MessageAddress>
-            <ns1:TransactionLocatorId>
+        <aa:ControlData>
+          <aa:MessageAddress>
+            <aa:TransactionLocatorId>
               1234-abcd-efgh
-            </ns1:TransactionLocatorId>
-            <ns1:MessageOriginatorId>GSA</ns1:MessageOriginatorId>
-            <ns1:MessageDestinationId>CA</ns1:MessageDestinationId>
-          </ns1:MessageAddress>
-        </ns1:ControlData>
-        <ns2:DriverLicenseIdentification>
-          <ns2:IdentificationID xsi:type='ns2:PersonNameTextType' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>123456789</ns2:IdentificationID>
-        </ns2:DriverLicenseIdentification>
-        <ns1:PersonBirthDate>1942-10-29</ns1:PersonBirthDate>
-        <ns2:PersonName>
-          <ns2:PersonGivenName>Testy</ns2:PersonGivenName>
-          <ns2:PersonSurName>McTesterson</ns2:PersonSurName>
-        </ns2:PersonName>
-        <ns1:Address>
-          <ns2:AddressDeliveryPointText>123 Sunnyside way</ns2:AddressDeliveryPointText>
-          <ns2:LocationCityName>Sterling</ns2:LocationCityName>
-          <ns2:LocationStateUsPostalServiceCode>VA</ns2:LocationStateUsPostalServiceCode>
-          <ns2:LocationPostalCode>20176</ns2:LocationPostalCode>
-        </ns1:Address>
+            </aa:TransactionLocatorId>
+            <aa:MessageOriginatorId>GSA</aa:MessageOriginatorId>
+            <aa:MessageDestinationId>CA</aa:MessageDestinationId>
+          </aa:MessageAddress>
+        </aa:ControlData>
+        <nc:DriverLicenseIdentification>
+          <nc:IdentificationID xsi:type='nc:PersonNameTextType' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>123456789</nc:IdentificationID>
+        </nc:DriverLicenseIdentification>
+        <aa:PersonBirthDate>1942-10-29</aa:PersonBirthDate>
+        <nc:PersonName>
+          <nc:PersonGivenName>Testy</nc:PersonGivenName>
+          <nc:PersonSurName>McTesterson</nc:PersonSurName>
+        </nc:PersonName>
+        <aa:Address>
+          <nc:AddressDeliveryPointText>123 Sunnyside way</nc:AddressDeliveryPointText>
+          <nc:LocationCityName>Sterling</nc:LocationCityName>
+          <nc:LocationStateUsPostalServiceCode>VA</nc:LocationStateUsPostalServiceCode>
+          <nc:LocationPostalCode>20176</nc:LocationPostalCode>
+        </aa:Address>
       </ns:verifyDriverLicenseDataRequest>
     </ns:VerifyDriverLicenseData>
   </soap:Body>

--- a/spec/fixtures/proofing/aamva/requests/verification_request.xml
+++ b/spec/fixtures/proofing/aamva/requests/verification_request.xml
@@ -1,13 +1,13 @@
-<soap:Envelope xmlns:aa='http://aamva.org/niem/extensions/1.0' xmlns:nc='http://niem.gov/niem/niem-core/2.0' xmlns:ns='http://aamva.org/dldv/wsdl/2.1' xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>
+<soap:Envelope xmlns:aa='http://aamva.org/niem/extensions/1.0' xmlns:dldv='http://aamva.org/dldv/wsdl/2.1' xmlns:nc='http://niem.gov/niem/niem-core/2.0' xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>
   <soap:Header xmlns:wsa='http://www.w3.org/2005/08/addressing'>
     <wsa:Action>http://aamva.org/dldv/wsdl/2.1/IDLDVService21/VerifyDriverLicenseData</wsa:Action>
   </soap:Header>
   <soap:Body>
-    <ns:VerifyDriverLicenseData>
-      <ns:token>
+    <dldv:VerifyDriverLicenseData>
+      <dldv:token>
         KEYKEYKEY
-      </ns:token>
-      <ns:verifyDriverLicenseDataRequest>
+      </dldv:token>
+      <dldv:verifyDriverLicenseDataRequest>
         <aa:ControlData>
           <aa:MessageAddress>
             <aa:TransactionLocatorId>
@@ -31,7 +31,7 @@
           <nc:LocationStateUsPostalServiceCode>VA</nc:LocationStateUsPostalServiceCode>
           <nc:LocationPostalCode>20176</nc:LocationPostalCode>
         </aa:Address>
-      </ns:verifyDriverLicenseDataRequest>
-    </ns:VerifyDriverLicenseData>
+      </dldv:verifyDriverLicenseDataRequest>
+    </dldv:VerifyDriverLicenseData>
   </soap:Body>
 </soap:Envelope>

--- a/spec/lib/aamva_test_spec.rb
+++ b/spec/lib/aamva_test_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe AamvaTest do
 
       expect(WebMock).to(
         have_requested(:post, verification_url).with do |req|
-          expect(Nokogiri::XML(req.body).at_xpath('//ns1:MessageDestinationId').text).
+          expect(Nokogiri::XML(req.body).at_xpath('//aa:MessageDestinationId').text).
             to eq('P6'), 'it sends a request with the designated fake state'
         end,
       )

--- a/spec/services/proofing/aamva/request/verification_request_spec.rb
+++ b/spec/services/proofing/aamva/request/verification_request_spec.rb
@@ -47,7 +47,10 @@ RSpec.describe Proofing::Aamva::Request::VerificationRequest do
       applicant.address2 = 'Apt 1'
 
       document = REXML::Document.new(subject.body)
-      address_node = REXML::XPath.first(document, '//ns:verifyDriverLicenseDataRequest/aa:Address')
+      address_node = REXML::XPath.first(
+        document,
+        '//dldv:verifyDriverLicenseDataRequest/aa:Address',
+      )
 
       address_node_element_names = address_node.elements.map(&:name)
       address_node_element_values = address_node.elements.map(&:text)

--- a/spec/services/proofing/aamva/request/verification_request_spec.rb
+++ b/spec/services/proofing/aamva/request/verification_request_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Proofing::Aamva::Request::VerificationRequest do
       applicant.address2 = 'Apt 1'
 
       document = REXML::Document.new(subject.body)
-      address_node = REXML::XPath.first(document, '//ns:verifyDriverLicenseDataRequest/ns1:Address')
+      address_node = REXML::XPath.first(document, '//ns:verifyDriverLicenseDataRequest/aa:Address')
 
       address_node_element_names = address_node.elements.map(&:name)
       address_node_element_values = address_node.elements.map(&:text)
@@ -75,14 +75,14 @@ RSpec.describe Proofing::Aamva::Request::VerificationRequest do
     it 'includes issue date if present' do
       applicant.state_id_data.state_id_issued = '2024-05-06'
       expect(subject.body).to include(
-        '<ns2:DriverLicenseIssueDate>2024-05-06</ns2:DriverLicenseIssueDate>',
+        '<aa:DriverLicenseIssueDate>2024-05-06</aa:DriverLicenseIssueDate>',
       )
     end
 
     it 'includes expiration date if present' do
       applicant.state_id_data.state_id_expiration = '2030-01-02'
       expect(subject.body).to include(
-        '<ns2:DriverLicenseExpirationDate>2030-01-02</ns2:DriverLicenseExpirationDate>',
+        '<aa:DriverLicenseExpirationDate>2030-01-02</aa:DriverLicenseExpirationDate>',
       )
     end
   end
@@ -156,7 +156,7 @@ RSpec.describe Proofing::Aamva::Request::VerificationRequest do
     let(:state_id_jurisdiction) { 'SC' }
     let(:rendered_state_id_number) do
       body = REXML::Document.new(subject.body)
-      REXML::XPath.first(body, '//ns2:IdentificationID')&.text
+      REXML::XPath.first(body, '//nc:IdentificationID')&.text
     end
 
     context 'id is greater than 8 digits' do

--- a/spec/services/proofing/aamva/verification_client_spec.rb
+++ b/spec/services/proofing/aamva/verification_client_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Proofing::Aamva::VerificationClient do
       verification_stub = stub_request(:post, AamvaFixtures.example_config.verification_url).
         to_return(body: AamvaFixtures.verification_response, status: 200).
         with do |request|
-          xml_text_at_path(request.body, '//ns:token').gsub(/\s/, '') == 'ThisIsTheToken'
+          xml_text_at_path(request.body, '//dldv:token').gsub(/\s/, '') == 'ThisIsTheToken'
         end
 
       verification_client.send_verification_request(


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-13216](https://cm-jira.usa.gov/browse/LG-13216)

## 🛠 Summary of changes

#10653 added two new fields to our requests to AAMVA's DLDV service: issue date and expiration date. In manual testing in our staging environment, I discovered that these fields weren't being processed by AAMVA because I used the incorrect namespace in the SOAP XML we were sending. I found it was difficult to keep track of what namespaces our code was referring to because we were labeling them differently from the [AAMVA DLDV documentation](https://drive.google.com/file/d/1TsYeL0xpqfqcL9V3lw5BF-WOy21CytZ3/view?usp=sharing).

This PR:

1. Updates the namespace abbreviations used in DLDV verification requests to match those used in the AAMVA documentation
2. Fixes the issue date + expiration date fields to use the correct namespaces

Here is what I just said, but in table form:

| What we used to call it | What we call it now | What it means |
| -- | -- | -- |
| `ns2:` | `nc:` | Elements from [NIEM core](https://niem.github.io/niem-releases/2.0/) |
|  `ns1:` | `aa:` | AAMVA-specific extensions to NIEM core |
| `ns:` | `dldv:` | Elements specifically related to the SOAP interface to DLDV |
 
(I only touched the verification service here--the authentication service is left as-is.)

## 📜 Testing Plan

I'll be executing this test after merging in the staging environment before this code goes into production:

- [ ] Make an AAMVA request including all PII elements from a known good source (first name, last name, license no., issue date, expiry date, dob, and address)
- [ ] Verify that all fields are listed in the `requested_attributes` field on the result
- [ ] Verify that all elements are validated by AAMVA
- [ ] Repeat this test, altering one PII element at a time and verifying that each item fails appropriately
