### PR TITLE
Flatten public packs directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ lint_asset_bundle_size: ## Lints JavaScript and CSS compiled bundle size
 	@# budget and accept the fact that this will force end-users to endure longer load times, you
 	@# should set the new budget to within a few thousand bytes of the production-compiled size.
 	find app/assets/builds/application.css -size -185000c | grep .
-	find public/packs/js/application-*.digested.js -size -5000c | grep .
+	find public/packs/application-*.digested.js -size -5000c | grep .
 
 lint_migrations:
 	scripts/migration_check

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -376,9 +376,9 @@ Note that NewRelic creates links in stack traces which are invalid, since they i
 Debugging these stack traces can be difficult, since files in production are minified, and the stack traces include line numbers and columns for minified files. With the following steps, you can find a reference to the original code:
 
 1. Download the minified JavaScript file referenced in the stack trace
-   - Example: https://secure.login.gov/packs/js/document-capture-e41c853e.digested.js
+   - Example: https://secure.login.gov/packs/document-capture-e41c853e.digested.js
 2. Download the sourcemap file for the JavaScript by appending `.map` to the previous URL
-   - Example: https://secure.login.gov/packs/js/document-capture-e41c853e.digested.js.map
+   - Example: https://secure.login.gov/packs/document-capture-e41c853e.digested.js.map
 3. Install the [`sourcemap-lookup` npm package](https://www.npmjs.com/package/sourcemap-lookup)
    - `npm i -g sourcemap-lookup`
 4. Open a terminal window to the directory where you downloaded the files in steps 1 and 2

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'throttling requests' do
     end
 
     context 'when the request is for a pack' do
-      let(:pack_url) { '/packs/js/application.js' }
+      let(:pack_url) { '/packs/application.js' }
       let(:pack_path) { Rails.public_path.join(pack_url.sub(/^\//, '')) }
 
       before do

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,9 +45,9 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
     return result;
   }, {}),
   output: {
-    filename: `js/[name]${hashSuffix}.js`,
-    chunkFilename: `js/[name].chunk${hashSuffix}.js`,
-    sourceMapFilename: `js/[name]${hashSuffix}.js.map`,
+    filename: `[name]${hashSuffix}.js`,
+    chunkFilename: `[name].chunk${hashSuffix}.js`,
+    sourceMapFilename: `[name]${hashSuffix}.js.map`,
     path: resolve(__dirname, 'public/packs'),
     publicPath:
       devServerPort && isLocalhost ? `http://localhost:${devServerPort}/packs/` : '/packs/',


### PR DESCRIPTION
## 🛠 Summary of changes

Flattens the `public/packs` directory to avoid nested `public/packs/js`.

**Why?**

- There are only JavaScript packs, so it's redundant to further qualify with a `js/` folder
- As a continuation of previous efforts #10647 #10612, this marginally reduces path size for asset references to help fit within Rails' 1kb hard cap for resource hints

Alternatively, I had considered flattening to `public/js` instead of `public/packs`, both to be more accurate to what it contains and to save a few more characters. This would require additional effort, since platform code exists which references `public/packs/manifest.json` and would need to be updated, in addition to corresponding [internal references](https://github.com/18F/identity-idp/blob/43ed1710423946ccf6643cadd9a9a46645cccf7c/scripts/artifact-upload#L42-L50).

## 📜 Testing Plan

Verify no regression in JavaScript interactivity.