### PR TITLE
Remove track_mfa_submit analytics pass-through method

### DIFF
--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -22,9 +22,7 @@ module TwoFactorAuthentication
     def create
       @backup_code_form = BackupCodeVerificationForm.new(current_user)
       result = @backup_code_form.submit(backup_code_params)
-      analytics.track_mfa_submit_event(
-        result.to_h.merge(new_device: new_device?),
-      )
+      analytics.multi_factor_auth(**result.to_h.merge(new_device: new_device?))
       irs_attempts_api_tracker.mfa_login_backup_code(success: result.success?)
       handle_result(result)
     end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -136,7 +136,7 @@ module TwoFactorAuthentication
       properties = result.to_h.merge(analytics_properties, new_device: new_device?)
       analytics.multi_factor_auth_setup(**properties) if context == 'confirmation'
 
-      analytics.track_mfa_submit_event(properties)
+      analytics.multi_factor_auth(**properties)
 
       if UserSessionContext.reauthentication_context?(context)
         irs_attempts_api_tracker.mfa_login_phone_otp_submitted(

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -32,7 +32,10 @@ module TwoFactorAuthentication
         new_device: new_device?,
       )
 
-      analytics.track_mfa_submit_event(analytics_hash)
+      analytics.multi_factor_auth(
+        **analytics_hash,
+        pii_like_keypaths: [[:errors, :personal_key], [:error_details, :personal_key]],
+      )
     end
 
     def check_personal_key_enabled

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -30,9 +30,7 @@ module TwoFactorAuthentication
 
     def process_token
       result = piv_cac_verification_form.submit
-      analytics.track_mfa_submit_event(
-        result.to_h.merge(analytics_properties),
-      )
+      analytics.multi_factor_auth(**result.to_h.merge(analytics_properties))
       irs_attempts_api_tracker.mfa_login_piv_cac(
         success: result.success?,
         subject_dn: piv_cac_verification_form.x509_dn,

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -21,7 +21,7 @@ module TwoFactorAuthentication
 
     def create
       result = TotpVerificationForm.new(current_user, params.require(:code).strip).submit
-      analytics.track_mfa_submit_event(result.to_h.merge(new_device: new_device?))
+      analytics.multi_factor_auth(**result.to_h.merge(new_device: new_device?))
       irs_attempts_api_tracker.mfa_login_totp(success: result.success?)
 
       if result.success?

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -18,7 +18,7 @@ module TwoFactorAuthentication
 
     def confirm
       result = form.submit
-      analytics.track_mfa_submit_event(
+      analytics.multi_factor_auth(
         **result.to_h,
         **analytics_properties,
         multi_factor_auth_method_created_at:

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -52,13 +52,6 @@ class Analytics
     session[:first_event]
   end
 
-  def track_mfa_submit_event(attributes)
-    multi_factor_auth(
-      **attributes,
-      pii_like_keypaths: [[:errors, :personal_key], [:error_details, :personal_key]],
-    )
-  end
-
   def request_attributes
     attributes = {
       user_ip: request.remote_ip,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3730,6 +3730,7 @@ module AnalyticsEvents
 
   # @param [Boolean] success Whether authentication was successful
   # @param [Hash] errors Authentication error reasons, if unsuccessful
+  # @param [Hash] error_details Details for error that occurred in unsuccessful submission
   # @param [String] context
   # @param [Boolean] new_device
   # @param [String] multi_factor_auth_method
@@ -3748,6 +3749,7 @@ module AnalyticsEvents
   def multi_factor_auth(
     success:,
     errors: nil,
+    error_details: nil,
     context: nil,
     new_device: nil,
     multi_factor_auth_method: nil,
@@ -3767,24 +3769,27 @@ module AnalyticsEvents
   )
     track_event(
       'Multi-Factor Authentication',
-      success: success,
-      errors: errors,
-      context: context,
-      new_device: new_device,
-      multi_factor_auth_method: multi_factor_auth_method,
-      multi_factor_auth_method_created_at: multi_factor_auth_method_created_at,
-      auth_app_configuration_id: auth_app_configuration_id,
-      piv_cac_configuration_id: piv_cac_configuration_id,
-      key_id: key_id,
-      webauthn_configuration_id: webauthn_configuration_id,
-      confirmation_for_add_phone: confirmation_for_add_phone,
-      phone_configuration_id: phone_configuration_id,
-      pii_like_keypaths: pii_like_keypaths,
-      area_code: area_code,
-      country_code: country_code,
-      phone_fingerprint: phone_fingerprint,
-      frontend_error:,
-      **extra,
+      {
+        success: success,
+        errors: errors,
+        error_details: error_details,
+        context: context,
+        new_device: new_device,
+        multi_factor_auth_method: multi_factor_auth_method,
+        multi_factor_auth_method_created_at: multi_factor_auth_method_created_at,
+        auth_app_configuration_id: auth_app_configuration_id,
+        piv_cac_configuration_id: piv_cac_configuration_id,
+        key_id: key_id,
+        webauthn_configuration_id: webauthn_configuration_id,
+        confirmation_for_add_phone: confirmation_for_add_phone,
+        phone_configuration_id: phone_configuration_id,
+        pii_like_keypaths: pii_like_keypaths,
+        area_code: area_code,
+        country_code: country_code,
+        phone_fingerprint: phone_fingerprint,
+        frontend_error:,
+        **extra,
+      }.compact,
     )
   end
 

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -27,16 +27,6 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
           sign_in_before_2fa(user)
           stub_analytics
           stub_attempts_tracker
-          analytics_hash = {
-            success: true,
-            errors: {},
-            multi_factor_auth_method: 'backup_code',
-            multi_factor_auth_method_created_at: Time.zone.now.strftime('%s%L'),
-            new_device: true,
-          }
-
-          expect(@analytics).to receive(:track_mfa_submit_event).
-            with(analytics_hash)
 
           expect(@irs_attempts_api_tracker).to receive(:track_event).
             with(:mfa_login_backup_code, success: true)
@@ -46,6 +36,15 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
             and_call_original
 
           post :create, params: payload
+
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication',
+            success: true,
+            errors: {},
+            multi_factor_auth_method: 'backup_code',
+            multi_factor_auth_method_created_at: Time.zone.now.strftime('%s%L'),
+            new_device: true,
+          )
 
           expect(subject.user_session[:auth_events]).to eq(
             [
@@ -93,22 +92,23 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
           stub_analytics
           stub_attempts_tracker
 
-          expect(@analytics).to receive(:track_mfa_submit_event).
-            with({
-              success: true,
-              errors: {},
-              multi_factor_auth_method: 'backup_code',
-              multi_factor_auth_method_created_at: Time.zone.now.strftime('%s%L'),
-              new_device: true,
-            })
-
           expect(@irs_attempts_api_tracker).to receive(:track_event).
             with(:mfa_login_backup_code, success: true)
 
-          expect(@analytics).to receive(:track_event).
-            with('User marked authenticated', authentication_type: :valid_2fa)
-
           post :create, params: payload
+
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication',
+            success: true,
+            errors: {},
+            multi_factor_auth_method: 'backup_code',
+            multi_factor_auth_method_created_at: Time.zone.now.strftime('%s%L'),
+            new_device: true,
+          )
+          expect(@analytics).to have_logged_event(
+            'User marked authenticated',
+            authentication_type: :valid_2fa,
+          )
         end
       end
     end
@@ -122,10 +122,12 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
         stub_analytics
         stub_sign_in_before_2fa(user)
 
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(hash_including(new_device: false))
-
         post :create, params: payload
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
+          hash_including(new_device: false),
+        )
       end
     end
 
@@ -171,25 +173,12 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
         user.second_factor_attempts_count =
           IdentityConfig.store.login_otp_confirmation_max_attempts - 1
         user.save
-        properties = {
-          success: false,
-          errors: {},
-          multi_factor_auth_method: 'backup_code',
-          multi_factor_auth_method_created_at: nil,
-          new_device: true,
-        }
 
         stub_analytics
         stub_attempts_tracker
 
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(properties)
-
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_login_backup_code, success: false)
-
-        expect(@analytics).to receive(:track_event).
-          with('Multi-Factor Authentication: max attempts reached')
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
           with(mfa_device_type: 'backup_code')
@@ -198,6 +187,15 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 
         post :create, params: payload
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
+          success: false,
+          errors: {},
+          multi_factor_auth_method: 'backup_code',
+          new_device: true,
+        )
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
       end
 
       it 'records unsuccessful 2fa event' do

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -122,41 +122,43 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
   end
 
   describe '#create' do
-    let(:parsed_phone) { Phonelib.parse(controller.current_user.default_phone_configuration.phone) }
+    let(:user) { create(:user, :with_phone) }
+    let(:parsed_phone) { Phonelib.parse(user.default_phone_configuration.phone) }
     context 'when the user enters an invalid OTP during authentication context' do
       subject(:response) { post :create, params: { code: '12345', otp_delivery_preference: 'sms' } }
 
       before do
-        sign_in_before_2fa
+        sign_in_before_2fa(user)
         controller.user_session[:mfa_selections] = ['sms']
         expect(controller.current_user.reload.second_factor_attempts_count).to eq 0
-        phone_configuration_created_at = controller.current_user.
-          default_phone_configuration.created_at
 
-        properties = {
+        stub_analytics
+        stub_attempts_tracker
+
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_submitted).
+          with({ reauthentication: false, success: false })
+      end
+
+      it 'logs analytics' do
+        response
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
           success: false,
           error_details: { code: { wrong_length: true, incorrect: true } },
           confirmation_for_add_phone: false,
           context: 'authentication',
           multi_factor_auth_method: 'sms',
-          multi_factor_auth_method_created_at: phone_configuration_created_at.strftime('%s%L'),
+          multi_factor_auth_method_created_at: user.default_phone_configuration.created_at.
+            strftime('%s%L'),
           new_device: true,
-          phone_configuration_id: controller.current_user.default_phone_configuration.id,
+          phone_configuration_id: user.default_phone_configuration.id,
           area_code: parsed_phone.area_code,
           country_code: parsed_phone.country,
           phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
           enabled_mfa_methods_count: 1,
           in_account_creation_flow: false,
-        }
-
-        stub_analytics
-        stub_attempts_tracker
-
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(properties)
-
-        expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_submitted).
-          with({ reauthentication: false, success: false })
+        )
       end
 
       it 'increments second_factor_attempts_count' do
@@ -191,7 +193,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
 
     context 'when the user enters an invalid OTP during reauthentication context' do
       it 'increments second_factor_attempts_count' do
-        sign_in_before_2fa
+        sign_in_before_2fa(user)
         controller.user_session[:context] = 'reauthentication'
 
         post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
@@ -201,42 +203,23 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
     end
 
     context 'when the user has reached the max number of OTP attempts' do
-      it 'tracks the event' do
-        user = create(
+      let(:user) do
+        create(
           :user,
           :fully_registered,
+          :with_phone,
           second_factor_attempts_count:
             IdentityConfig.store.login_otp_confirmation_max_attempts - 1,
         )
+      end
+
+      it 'tracks the event' do
         sign_in_before_2fa(user)
         controller.user_session[:mfa_selections] = ['sms']
-        phone_configuration_created_at = controller.current_user.
-          default_phone_configuration.created_at
-
-        properties = {
-          success: false,
-          error_details: { code: { wrong_length: true, incorrect: true } },
-          confirmation_for_add_phone: false,
-          context: 'authentication',
-          multi_factor_auth_method: 'sms',
-          multi_factor_auth_method_created_at: phone_configuration_created_at.strftime('%s%L'),
-          new_device: true,
-          phone_configuration_id: controller.current_user.default_phone_configuration.id,
-          area_code: parsed_phone.area_code,
-          country_code: parsed_phone.country,
-          phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
-          enabled_mfa_methods_count: 1,
-          in_account_creation_flow: false,
-        }
 
         stub_analytics
         stub_attempts_tracker
 
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(properties)
-
-        expect(@analytics).to receive(:track_event).
-          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: controller.current_user))
 
@@ -246,15 +229,32 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
           with(mfa_device_type: 'otp')
 
-        post :create, params:
-        { code: '12345',
-          otp_delivery_preference: 'sms' }
+        post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
+          success: false,
+          error_details: { code: { wrong_length: true, incorrect: true } },
+          confirmation_for_add_phone: false,
+          context: 'authentication',
+          multi_factor_auth_method: 'sms',
+          multi_factor_auth_method_created_at: user.default_phone_configuration.created_at.
+            strftime('%s%L'),
+          new_device: true,
+          phone_configuration_id: user.default_phone_configuration.id,
+          area_code: parsed_phone.area_code,
+          country_code: parsed_phone.country,
+          phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+          enabled_mfa_methods_count: 1,
+          in_account_creation_flow: false,
+        )
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
       end
     end
 
     context 'when the user enters a valid OTP' do
       before do
-        sign_in_before_2fa
+        sign_in_before_2fa(user)
         subject.user_session[:mfa_selections] = ['sms']
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
       end
@@ -279,30 +279,8 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
       end
 
       it 'tracks the valid authentication event' do
-        phone_configuration_created_at = controller.current_user.
-          default_phone_configuration.created_at
-        properties = {
-          success: true,
-          confirmation_for_add_phone: false,
-          context: 'authentication',
-          multi_factor_auth_method: 'sms',
-          multi_factor_auth_method_created_at: phone_configuration_created_at.strftime('%s%L'),
-          new_device: true,
-          phone_configuration_id: controller.current_user.default_phone_configuration.id,
-          area_code: parsed_phone.area_code,
-          country_code: parsed_phone.country,
-          phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
-          enabled_mfa_methods_count: 1,
-          in_account_creation_flow: false,
-        }
-
         stub_analytics
         stub_attempts_tracker
-
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(properties)
-        expect(@analytics).to receive(:track_event).
-          with('User marked authenticated', authentication_type: :valid_2fa)
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_phone_otp_submitted).
           with(reauthentication: false, success: true)
@@ -327,6 +305,27 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
           )
           expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq false
         end
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
+          success: true,
+          confirmation_for_add_phone: false,
+          context: 'authentication',
+          multi_factor_auth_method: 'sms',
+          multi_factor_auth_method_created_at: user.default_phone_configuration.created_at.
+            strftime('%s%L'),
+          new_device: true,
+          phone_configuration_id: user.default_phone_configuration.id,
+          area_code: parsed_phone.area_code,
+          country_code: parsed_phone.country,
+          phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+          enabled_mfa_methods_count: 1,
+          in_account_creation_flow: false,
+        )
+        expect(@analytics).to have_logged_event(
+          'User marked authenticated',
+          authentication_type: :valid_2fa,
+        )
       end
 
       context 'with existing device' do
@@ -337,13 +336,15 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
         it 'tracks new device value' do
           stub_analytics
 
-          expect(@analytics).to receive(:track_mfa_submit_event).
-            with(hash_including(new_device: false))
-
           post :create, params: {
             code: subject.current_user.reload.direct_otp,
             otp_delivery_preference: 'sms',
           }
+
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication',
+            hash_including(new_device: false),
+          )
         end
       end
 
@@ -402,7 +403,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra
 
     context 'when the user lockout period expires' do
       before do
-        sign_in_before_2fa
+        sign_in_before_2fa(user)
         lockout_period = IdentityConfig.store.lockout_period_in_minutes.minutes
         subject.current_user.update(
           second_factor_locked_at: Time.zone.now - lockout_period - 1.second,

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -105,17 +105,26 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
         stub_attempts_tracker
         cfg = controller.current_user.piv_cac_configurations.first
 
-        attributes = {
+        expect(@irs_attempts_api_tracker).to receive(:mfa_login_piv_cac).with(
+          success: true,
+          subject_dn: x509_subject,
+        )
+
+        expect(controller).to receive(:handle_valid_verification_for_authentication_context).
+          with(auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC).
+          and_call_original
+
+        get :show, params: { token: 'good-token' }
+
+        expect(@analytics).to have_logged_event(
+          :multi_factor_auth_enter_piv_cac,
           context: 'authentication',
           multi_factor_auth_method: 'piv_cac',
           new_device: true,
           piv_cac_configuration_id: nil,
-        }
-
-        expect(@analytics).to receive(:track_event).
-          with(:multi_factor_auth_enter_piv_cac, attributes)
-
-        submit_attributes = {
+        )
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
           success: true,
           errors: {},
           context: 'authentication',
@@ -125,23 +134,11 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
           piv_cac_configuration_id: cfg.id,
           piv_cac_configuration_dn_uuid: cfg.x509_dn_uuid,
           key_id: 'foo',
-        }
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(submit_attributes)
-
-        expect(@irs_attempts_api_tracker).to receive(:mfa_login_piv_cac).with(
-          success: true,
-          subject_dn: x509_subject,
         )
-
-        expect(@analytics).to receive(:track_event).
-          with('User marked authenticated', authentication_type: :valid_2fa)
-
-        expect(controller).to receive(:handle_valid_verification_for_authentication_context).
-          with(auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC).
-          and_call_original
-
-        get :show, params: { token: 'good-token' }
+        expect(@analytics).to have_logged_event(
+          'User marked authenticated',
+          authentication_type: :valid_2fa,
+        )
       end
 
       context 'with existing device' do
@@ -153,10 +150,12 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
           stub_analytics
           stub_sign_in_before_2fa(user)
 
-          expect(@analytics).to receive(:track_mfa_submit_event).
-            with(hash_including(new_device: false))
-
           get :show, params: { token: 'good-token' }
+
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication',
+            hash_including(new_device: false),
+          )
         end
       end
     end
@@ -240,46 +239,39 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
         stub_analytics
         stub_attempts_tracker
 
-        attributes = {
-          context: 'authentication',
-          multi_factor_auth_method: 'piv_cac',
-          new_device: true,
-          piv_cac_configuration_id: nil,
-        }
-
-        expect(@analytics).to receive(:track_event).
-          with(:multi_factor_auth_enter_piv_cac, attributes)
-
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_rate_limited).
           with(mfa_device_type: 'piv_cac')
 
         piv_cac_mismatch = { type: 'user.piv_cac_mismatch' }
-
-        submit_attributes = {
-          success: false,
-          errors: piv_cac_mismatch,
-          context: 'authentication',
-          multi_factor_auth_method: 'piv_cac',
-          multi_factor_auth_method_created_at: nil,
-          new_device: true,
-          key_id: 'foo',
-          piv_cac_configuration_dn_uuid: 'bad-uuid',
-          piv_cac_configuration_id: nil,
-        }
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(submit_attributes)
 
         expect(@irs_attempts_api_tracker).to receive(:mfa_login_piv_cac).with(
           success: false,
           subject_dn: bad_dn,
         )
 
-        expect(@analytics).to receive(:track_event).
-          with('Multi-Factor Authentication: max attempts reached')
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 
         get :show, params: { token: 'bad-token' }
+
+        expect(@analytics).to have_logged_event(
+          :multi_factor_auth_enter_piv_cac,
+          context: 'authentication',
+          multi_factor_auth_method: 'piv_cac',
+          new_device: true,
+          piv_cac_configuration_id: nil,
+        )
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
+          success: false,
+          errors: piv_cac_mismatch,
+          context: 'authentication',
+          multi_factor_auth_method: 'piv_cac',
+          new_device: true,
+          key_id: 'foo',
+          piv_cac_configuration_dn_uuid: 'bad-uuid',
+        )
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
       end
     end
 

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -45,18 +45,6 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
       it 'tracks the valid authentication event' do
         cfg = controller.current_user.auth_app_configurations.first
 
-        attributes = {
-          success: true,
-          errors: {},
-          multi_factor_auth_method: 'totp',
-          multi_factor_auth_method_created_at: cfg.created_at.strftime('%s%L'),
-          new_device: true,
-          auth_app_configuration_id: controller.current_user.auth_app_configurations.first.id,
-        }
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(attributes)
-        expect(@analytics).to receive(:track_event).
-          with('User marked authenticated', authentication_type: :valid_2fa)
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_login_totp, success: true)
         expect(controller).to receive(:handle_valid_verification_for_authentication_context).
@@ -64,6 +52,20 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
           and_call_original
 
         post :create, params: { code: generate_totp_code(@secret) }
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
+          success: true,
+          errors: {},
+          multi_factor_auth_method: 'totp',
+          multi_factor_auth_method_created_at: cfg.created_at.strftime('%s%L'),
+          new_device: true,
+          auth_app_configuration_id: controller.current_user.auth_app_configurations.first.id,
+        )
+        expect(@analytics).to have_logged_event(
+          'User marked authenticated',
+          authentication_type: :valid_2fa,
+        )
       end
 
       context 'with existing device' do
@@ -74,10 +76,12 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
         it 'tracks new device value' do
           stub_analytics
 
-          expect(@analytics).to receive(:track_mfa_submit_event).
-            with(hash_including(new_device: false))
-
           post :create, params: { code: generate_totp_code(@secret) }
+
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication',
+            hash_including(new_device: false),
+          )
         end
       end
     end
@@ -88,18 +92,26 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
         app1 = Db::AuthAppConfiguration.create(user, user.generate_totp_secret, nil, 'foo')
         app2 = Db::AuthAppConfiguration.create(user, user.generate_totp_secret, nil, 'bar')
 
-        expect(@analytics).to receive(:track_event).
-          with('User marked authenticated', authentication_type: :valid_2fa).twice
-
         sign_in_as_user(user)
         post :create, params: { code: generate_totp_code(app1.otp_secret_key) }
         expect(response).to redirect_to account_url
+
+        expect(@analytics).to have_logged_event(
+          'User marked authenticated',
+          authentication_type: :valid_2fa,
+        )
+        @analytics.events.clear
 
         sign_out(user)
 
         sign_in_as_user(user)
         post :create, params: { code: generate_totp_code(app2.otp_secret_key) }
         expect(response).to redirect_to account_url
+
+        expect(@analytics).to have_logged_event(
+          'User marked authenticated',
+          authentication_type: :valid_2fa,
+        )
       end
     end
 
@@ -155,19 +167,6 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
         @secret = user.generate_totp_secret
         Db::AuthAppConfiguration.create(user, @secret, nil, 'foo')
 
-        attributes = {
-          success: false,
-          errors: {},
-          multi_factor_auth_method: 'totp',
-          multi_factor_auth_method_created_at: nil,
-          new_device: true,
-          auth_app_configuration_id: nil,
-        }
-
-        expect(@analytics).to receive(:track_mfa_submit_event).
-          with(attributes)
-        expect(@analytics).to receive(:track_event).
-          with('Multi-Factor Authentication: max attempts reached')
         expect(@irs_attempts_api_tracker).to receive(:track_event).
           with(:mfa_login_totp, success: false)
 
@@ -178,6 +177,15 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 
         post :create, params: { code: '12345' }
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication',
+          success: false,
+          errors: {},
+          multi_factor_auth_method: 'totp',
+          new_device: true,
+        )
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
       end
     end
 

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -168,10 +168,6 @@ class FakeAnalytics < Analytics
     nil
   end
 
-  def track_mfa_submit_event(_attributes)
-    # no-op
-  end
-
   def browser_attributes
     {}
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes `Analytics#track_mfa_submit`, updating call-sites to call `AnalyticsEvents#multi_factor_auth` directly.

**Why?**

- It's only purpose was to provide `pii_like_keypaths` for specific personal key verification properties, which is reasonable to expect to be passed in the one place it's necessary (`PersonalKeyVerificationController`)
- The method is the only one of its kind, and it causes confusion to what's actually being logged, since the method name does not correspond directly to an `AnalyticsEvents` module method or actual event name
- It is incompatible with `have_logged_event`, which is the preferred way to ensure that events are logged as expected, contains no PII, and all properties are documented
   - See included revision to document `error_details` now that it is correctly flagged as undocumented

## 📜 Testing Plan

Verify that the build passes.

Verify that when signing in with 2FA, the "Multi-Factor Authentication" event is still logged as expected:

1. Run `make watch_events` in a separate terminal process from the IdP server
2. Go to http://localhost:3000 in a private browsing session
3. Sign in
4. See "Multi-Factor Authentication" event in logged events, with expected properties