### PR TITLE
Verify and consume backup code in single database transaction

### DIFF
--- a/app/forms/backup_code_verification_form.rb
+++ b/app/forms/backup_code_verification_form.rb
@@ -19,18 +19,19 @@ class BackupCodeVerificationForm
   attr_reader :user, :backup_code
 
   def valid_backup_code?
-    backup_code_config.present?
+    valid_backup_code_config_created_at.present?
   end
 
-  def backup_code_config
-    @backup_code_config ||= BackupCodeGenerator.new(@user).
-      if_valid_consume_code_return_config(backup_code)
+  def valid_backup_code_config_created_at
+    return @valid_backup_code_config_created_at if defined?(@valid_backup_code_config_created_at)
+    @valid_backup_code_config_created_at = BackupCodeGenerator.new(@user).
+      if_valid_consume_code_return_config_created_at(backup_code)
   end
 
   def extra_analytics_attributes
     {
       multi_factor_auth_method: 'backup_code',
-      multi_factor_auth_method_created_at: backup_code_config&.created_at&.strftime('%s%L'),
+      multi_factor_auth_method_created_at: valid_backup_code_config_created_at&.strftime('%s%L'),
     }
   end
 end

--- a/app/models/backup_code_configuration.rb
+++ b/app/models/backup_code_configuration.rb
@@ -35,18 +35,21 @@ class BackupCodeConfiguration < ApplicationRecord
     def find_with_code(code:, user_id:)
       return if code.blank?
       code = RandomPhrase.normalize(code)
+      user_salted_fingerprints = self.salted_fingerprints(code: code, user_id: user_id)
 
+      where(salted_code_fingerprint: user_salted_fingerprints).find_by(user_id: user_id)
+    end
+
+    def salted_fingerprints(code:, user_id:)
       user_salt_costs = select(:code_salt, :code_cost).
         distinct.
         where(user_id: user_id).
         where.not(code_salt: nil).where.not(code_cost: nil).
         pluck(:code_salt, :code_cost)
 
-      salted_fingerprints = user_salt_costs.map do |salt, cost|
+      user_salt_costs.map do |salt, cost|
         scrypt_password_digest(password: code, salt: salt, cost: cost)
       end
-
-      where(salted_code_fingerprint: salted_fingerprints).find_by(user_id: user_id)
     end
 
     def scrypt_password_digest(password:, salt:, cost:)


### PR DESCRIPTION
## 🛠 Summary of changes

This PR borrows a bit of the logic from #8118 to improve the performance and reliability of verifying backup codes by wrapping the verification and usage update in a transaction. It was prompted by work in #10686.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
