### PR TITLE
Remove `#is_a?` call from VTR in SAML request validator

### DIFF
--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -43,7 +43,7 @@ class SamlRequestValidator
     return @parsed_vectors_of_trust if defined?(@parsed_vectors_of_trust)
 
     @parsed_vectors_of_trust = begin
-      if vtr.is_a?(Array) && !vtr.empty?
+      if vtr.blank?
         vtr.map { |vot| Vot::Parser.new(vector_of_trust: vot).parse }
       end
     rescue Vot::Parser::ParseException

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -43,7 +43,7 @@ class SamlRequestValidator
     return @parsed_vectors_of_trust if defined?(@parsed_vectors_of_trust)
 
     @parsed_vectors_of_trust = begin
-      if vtr.blank?
+      if vtr.present?
         vtr.map { |vot| Vot::Parser.new(vector_of_trust: vot).parse }
       end
     rescue Vot::Parser::ParseException


### PR DESCRIPTION
When I was working on the code to parse a VTR in the SAML request validator I copied the code from the OIDC form object. This included a check that the `vtr` is an array. In OIDC that is necessarily because we are directly parsing the result of calling `JSON.parse` on the param. In SAML that is not the case; the vtr is parsed out of the authn request and will be an array or nil. For this reason we can use `#blank?` in the SAML implementation.
