### PR TITLE
LG-13006 Rename skip_doc_auth, step 4

### DIFF
--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -12,9 +12,9 @@ module Idv
     check_or_render_not_found -> { self.class.enabled? }
 
     def show
-      @selection = if idv_session.skip_doc_auth == false
+      @selection = if idv_session.skip_doc_auth_from_how_to_verify == false
                      Idv::HowToVerifyForm::REMOTE
-      elsif idv_session.skip_doc_auth == true
+      elsif idv_session.skip_doc_auth_from_how_to_verify == true
         Idv::HowToVerifyForm::IPP
       end
 

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -51,10 +51,10 @@ module Idv
       if IdentityConfig.store.in_person_proofing_opt_in_enabled &&
          IdentityConfig.store.in_person_proofing_enabled &&
          idv_session.service_provider&.in_person_proofing_enabled
-        idv_session.skip_doc_auth == false
+        idv_session.skip_doc_auth_from_how_to_verify == false
       else
-        idv_session.skip_doc_auth.nil? ||
-          idv_session.skip_doc_auth == false
+        idv_session.skip_doc_auth_from_how_to_verify.nil? ||
+          idv_session.skip_doc_auth_from_how_to_verify == false
       end
     end
 

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Idv::HowToVerifyController do
     end
 
     context 'undo/back' do
-      it 'sets skip_doc_auth to nil and does not redirect' do
+      it 'sets skip_doc_auth_from_how_to_verify to nil and does not redirect' do
         put :update, params: { undo_step: true }
 
         expect(subject.idv_session.skip_doc_auth).to be_nil


### PR DESCRIPTION
## 🎫 Ticket

[LG-13006](https://cm-jira.usa.gov/browse/LG-13006)


## 🛠 Summary of changes
Change `skip_doc_auth` decision point to use `skip_doc_auth_from_how_to_verify`

Wait until next deployment AFTER 24 May 2024 to merge to main.