### PR TITLE
LG-13402: Remove temporary feature flag for backup code confirmation

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -80,16 +80,7 @@ module Users
     private
 
     def validate_multi_mfa_selection
-      if IdentityConfig.store.backup_code_confirm_setup_screen_enabled
-        redirect_to backup_code_confirm_setup_url unless in_multi_mfa_selection_flow?
-      else
-        redirect_to root_url unless internal_referrer?
-      end
-    end
-
-    def internal_referrer?
-      UserSessionContext.reauthentication_context?(context) ||
-        session[:account_redirect_path] || in_multi_mfa_selection_flow?
+      redirect_to backup_code_confirm_setup_url unless in_multi_mfa_selection_flow?
     end
 
     def analytics_properties_for_visit

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -7,7 +7,7 @@
 
   <%= render ButtonComponent.new(
         url: backup_code_setup_path,
-        method: IdentityConfig.store.backup_code_confirm_setup_screen_enabled ? :post : :get,
+        method: :post,
         big: true,
         wide: true,
         class: 'margin-top-3 margin-bottom-2',

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -58,7 +58,6 @@ aws_kms_multi_region_key_id: alias/login-dot-gov-keymaker-multi-region
 aws_kms_session_key_id: alias/login-dot-gov-test-keymaker
 aws_logo_bucket: ''
 aws_region: 'us-west-2'
-backup_code_confirm_setup_screen_enabled: true
 backup_code_cost: '2000$8$1$'
 broken_personal_key_window_start: '2021-07-29T00:00:00Z'
 broken_personal_key_window_finish: '2021-09-22T00:00:00Z'
@@ -455,7 +454,6 @@ production:
   attribute_encryption_key_queue: '[]'
   available_locales: 'en,es,fr'
   aws_logo_bucket: ''
-  backup_code_confirm_setup_screen_enabled: false
   dashboard_api_token: ''
   dashboard_url: https://dashboard.demo.login.gov
   database_host: ''

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -74,7 +74,6 @@ module IdentityConfig
     config.add(:aws_kms_session_key_id, type: :string)
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)
-    config.add(:backup_code_confirm_setup_screen_enabled, type: :boolean)
     config.add(:backup_code_cost, type: :string)
     config.add(:broken_personal_key_window_finish, type: :timestamp)
     config.add(:broken_personal_key_window_start, type: :timestamp)

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -70,33 +70,6 @@ RSpec.describe Users::BackupCodeSetupController do
 
       it_behaves_like 'valid backup codes creation'
     end
-
-    context 'backup code confirm setup feature disabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:backup_code_confirm_setup_screen_enabled).
-          and_return(false)
-      end
-
-      it 'redirects to root url' do
-        expect(response).to redirect_to(root_url)
-      end
-
-      context 'in multi mfa setup flow' do
-        before do
-          allow(controller).to receive(:in_multi_mfa_selection_flow?).and_return(true)
-        end
-
-        it_behaves_like 'valid backup codes creation'
-      end
-
-      context 'adding backup codes from account dashboard' do
-        before do
-          controller.user_session[:account_redirect_path] = account_path
-        end
-
-        it_behaves_like 'valid backup codes creation'
-      end
-    end
   end
 
   describe '#create' do

--- a/spec/features/account/backup_codes_spec.rb
+++ b/spec/features/account/backup_codes_spec.rb
@@ -36,29 +36,6 @@ RSpec.feature 'Backup codes' do
       expect(page).to have_content(t('notices.backup_codes_deleted'))
       expect(page).to have_current_path(account_two_factor_authentication_path)
     end
-
-    context 'backup code confirm setup feature disabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:backup_code_confirm_setup_screen_enabled).
-          and_return(false)
-      end
-
-      it 'allows user to regenerate backup codes' do
-        expect(page).to have_content(t('account.index.backup_codes_exist'))
-        old_backup_code = user.backup_code_configurations.sample
-        click_link t('forms.backup_code.regenerate'), href: backup_code_regenerate_path
-        click_on t('account.index.backup_code_confirm_regenerate')
-
-        expect(page).to have_current_path(backup_code_setup_path)
-        expect(page).to have_content(t('forms.backup_code.title'))
-        expect(BackupCodeConfiguration.where(id: old_backup_code.id).any?).to eq(false)
-
-        click_continue
-
-        expect(page).to have_content(t('notices.backup_codes_configured'))
-        expect(page).to have_current_path(account_two_factor_authentication_path)
-      end
-    end
   end
 
   context 'without backup codes and having another mfa method' do
@@ -104,34 +81,6 @@ RSpec.feature 'Backup codes' do
       expect(page).to have_content(t('notices.backup_codes_configured'))
       expect(page).to have_current_path(account_two_factor_authentication_path)
       expect(page).to have_content(expected_message)
-    end
-
-    context 'backup code confirm setup feature disabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:backup_code_confirm_setup_screen_enabled).
-          and_return(false)
-      end
-
-      it 'allows user to create backup codes' do
-        click_on t('forms.backup_code.generate')
-
-        expect(page).to have_current_path(backup_code_setup_path)
-
-        generated_at = user.backup_code_configurations.
-          order(created_at: :asc).first.created_at.
-          in_time_zone('UTC')
-        formatted_generated_at = l(generated_at, format: t('time.formats.event_timestamp'))
-
-        expected_message = "#{t('account.index.backup_codes_exist')} #{formatted_generated_at}"
-
-        expect(page).to have_current_path(backup_code_setup_path)
-        expect(page).to have_content(t('forms.backup_code.title'))
-        click_continue
-
-        expect(page).to have_content(t('notices.backup_codes_configured'))
-        expect(page).to have_current_path(account_two_factor_authentication_path)
-        expect(page).to have_content(expected_message)
-      end
     end
   end
 

--- a/spec/views/users/backup_code_setup/edit.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/edit.html.erb_spec.rb
@@ -13,18 +13,4 @@ RSpec.describe 'users/backup_code_setup/edit.html.erb' do
   it 'has a link to cancel and return to account page' do
     expect(rendered).to have_link(t('links.cancel'), href: account_path)
   end
-
-  context 'backup code confirm setup feature disabled' do
-    before do
-      allow(IdentityConfig.store).to receive(:backup_code_confirm_setup_screen_enabled).
-        and_return(false)
-    end
-
-    it 'has a link to confirm and proceed to setup' do
-      expect(rendered).to have_link(
-        t('account.index.backup_code_confirm_regenerate'),
-        href: backup_code_setup_path,
-      )
-    end
-  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Clean-up for [LG-13402](https://cm-jira.usa.gov/browse/LG-13402)

## 🛠 Summary of changes

Removes the temporary feature flag added in #10685 which was included to facilitate the 50/50 deploy state. Now that the feature is fully deployed, the feature flag is no longer necessary.

## 📜 Testing Plan

Repeat Testing Plan from #10685