### PR TITLE
LG-13424 Fix phone confirmation OTP length message during sign up in auth

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -321,17 +321,13 @@ module Users
     end
 
     def otp_length
-      if TwoFactorAuthenticatable::DIRECT_OTP_LENGTH == 6
+      configured_length = TwoFactorAuthenticatable::DIRECT_OTP_LENGTH
+      if configured_length == 6
         I18n.t('telephony.format_length.six')
-      elsif TwoFactorAuthenticatable::DIRECT_OTP_LENGTH == 10
+      elsif Tconfigured_length == 10
         I18n.t('telephony.format_length.ten')
       else
-        raise(
-          [
-            'Missing translation for OTP length:,',
-            TwoFactorAuthenticatable::DIRECT_OTP_LENGTH.to_s,
-          ].join(' '),
-        )
+        raise "Missing translation for OTP length: #{configured_length}"
       end
     end
 

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -321,9 +321,13 @@ module Users
     end
 
     def otp_length
-      bucket = AbTests::IDV_TEN_DIGIT_OTP.bucket(current_user.uuid)
-      length = bucket == :ten_digit_otp ? 'ten' : 'six'
-      I18n.t("telephony.format_length.#{length}")
+      if TwoFactorAuthenticatable::DIRECT_OTP_LENGTH == 6
+        I18n.t('telephony.format_length.six')
+      elsif TwoFactorAuthenticatable::DIRECT_OTP_LENGTH == 10
+        I18n.t('telephony.format_length.ten')
+      else
+        raise ArgumentError, "Invalid OTP length: #{TwoFactorAuthenticatable::DIRECT_OTP_LENGTH}"
+      end
     end
 
     def user_selected_default_number

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -324,7 +324,7 @@ module Users
       configured_length = TwoFactorAuthenticatable::DIRECT_OTP_LENGTH
       if configured_length == 6
         I18n.t('telephony.format_length.six')
-      elsif Tconfigured_length == 10
+      elsif configured_length == 10
         I18n.t('telephony.format_length.ten')
       else
         raise "Missing translation for OTP length: #{configured_length}"

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -327,7 +327,6 @@ module Users
         I18n.t('telephony.format_length.ten')
       else
         raise(
-          ArgumentError,
           [
             'Missing translation for OTP length:,',
             TwoFactorAuthenticatable::DIRECT_OTP_LENGTH.to_s,

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -326,7 +326,13 @@ module Users
       elsif TwoFactorAuthenticatable::DIRECT_OTP_LENGTH == 10
         I18n.t('telephony.format_length.ten')
       else
-        raise ArgumentError, "Invalid OTP length: #{TwoFactorAuthenticatable::DIRECT_OTP_LENGTH}"
+        raise(
+          ArgumentError,
+          [
+            'Missing translation for OTP length:,',
+            TwoFactorAuthenticatable::DIRECT_OTP_LENGTH.to_s,
+          ].join(' '),
+        )
       end
     end
 


### PR DESCRIPTION
In #10480 we added an A/B test that made voice OTPs 10-digits for IdV phone confirmation for some percentage of users. This was to test whether a 10-digit numeric code sees more success than a 6-digit alphanumeric code.

This included a change to the message for the voice OTP since the message includes the length, e.g. "Your 10-digit Login.gov one time code is 1234567890". The translation for the 10-digit code was erroneously applied to 6-digit codes when auth users chose voice calls to confirm phones during sign up. This commit fixes that issue.
