### PR TITLE
LG-7434: Allow cross origin for POST OIDC Logout

### DIFF
--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -12,7 +12,7 @@ module OpenidConnect
     skip_before_action :verify_authenticity_token, only: [:create]
 
     # +GET+ Handle logout (with confirmation if initiated by relying partner)
-    # @see {OpenID Connect RP-Initiated Logout 1.0 Specification}[https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout]
+    # @see {OpenID Connect RP-Initiated Logout 1.0 Specification}[https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout]  # rubocop:disable Layout/LineLength
     def show
       @logout_form = build_logout_form
       result = @logout_form.submit
@@ -27,10 +27,8 @@ module OpenidConnect
       end
     end
 
-    # rubocop:disable Layout/LineLength
-
     # +POST+ Handle logout request (with confirmation if initiated by relying partner)
-    # @see {OpenID Connect RP-Initiated Logout 1.0 Specification}[https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout]
+    # @see {OpenID Connect RP-Initiated Logout 1.0 Specification}[https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout] # rubocop:disable Layout/LineLength
     # @note Response status code is <tt>307 Temporary Redirect</tt>
     #   to preserve the method and body of the request
     #   and to prevent non-conformant browsers from automatically
@@ -54,7 +52,6 @@ module OpenidConnect
         render :error
       end
     end
-    # rubocop:enable Layout/LineLength
 
     # Sign out without confirmation
     def delete

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -35,8 +35,8 @@ module OpenidConnect
     #   redirecting this route to {OpenidConnectLogoutForm#redirect_uri}
     #   and skipping over the render of the logout confirmation page
     def create
+      # @type [OpenidConnectLogoutForm]
       @logout_form = build_logout_form
-      # @type [FormResponse]
       result = @logout_form.submit
       redirect_uri = result.extra[:redirect_uri]
       analytics.oidc_logout_requested(**to_event(result))
@@ -117,6 +117,7 @@ module OpenidConnect
         current_user
     end
 
+    # @return [OpenidConnectLogoutForm]
     def build_logout_form
       OpenidConnectLogoutForm.new(
         params: logout_params,

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -17,11 +17,10 @@ module OpenidConnect
       @logout_form = build_logout_form
       result = @logout_form.submit
       redirect_uri = result.extra[:redirect_uri]
-      extra_event_props = session[:event] || {}
       analytics.oidc_logout_requested(
         **to_event(result),
         method: request.method.to_s,
-        **extra_event_props,
+        original_method: session[:original_method],
       )
 
       if result.success? && redirect_uri
@@ -34,9 +33,7 @@ module OpenidConnect
     # +POST+ Handle logout request (with confirmation if initiated by relying partner)
     # @see {OpenID Connect RP-Initiated Logout 1.0 Specification}[https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout] # rubocop:disable Layout/LineLength
     def create
-      session[:event] = {
-        original_method: request.method.to_s,
-      }
+      session[:original_method] = request.method.to_s
       redirect_to action: :show, **logout_params
     end
 

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -29,21 +29,8 @@ module OpenidConnect
 
     # +POST+ Handle logout request (with confirmation if initiated by relying partner)
     # @see {OpenID Connect RP-Initiated Logout 1.0 Specification}[https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout] # rubocop:disable Layout/LineLength
-    # @note This action is identical to #show, but attempting to use the same action for both
-    #   methods results in the confirmation page not getting rendered and is not recommended by the
-    #   Rails team (source: {Rails Routing - HTTP Verb Constraints}[https://guides.rubyonrails.org/routing.html#http-verb-constraints]).  # rubocop:disable Layout/LineLength
     def create
-      @logout_form = build_logout_form
-      result = @logout_form.submit
-      redirect_uri = result.extra[:redirect_uri]
-
-      analytics.oidc_logout_requested(**to_event(result))
-
-      if result.success? && redirect_uri
-        handle_successful_logout_request(result, redirect_uri)
-      else
-        render :error
-      end
+      redirect_to action: :show, **logout_params
     end
 
     # Sign out without confirmation

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -17,7 +17,7 @@ module OpenidConnect
       @logout_form = build_logout_form
       result = @logout_form.submit
       redirect_uri = result.extra[:redirect_uri]
-      extra_event_props = flash[:event] || {}
+      extra_event_props = session[:event] || {}
       analytics.oidc_logout_requested(
         **to_event(result),
         method: request.method.to_s,
@@ -34,7 +34,7 @@ module OpenidConnect
     # +POST+ Handle logout request (with confirmation if initiated by relying partner)
     # @see {OpenID Connect RP-Initiated Logout 1.0 Specification}[https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout] # rubocop:disable Layout/LineLength
     def create
-      flash[:event] = {
+      session[:event] = {
         original_method: request.method.to_s,
       }
       redirect_to action: :show, **logout_params

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -46,6 +46,7 @@ class OpenidConnectLogoutForm
     @identity = load_identity
   end
 
+  # @return [FormResponse]
   def submit
     @success = valid?
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4040,6 +4040,7 @@ module AnalyticsEvents
   # @param [Hash] errors
   # @param [Hash] error_details
   # @param [String] method
+  # @param [String] original_method Method of referring request
   # OIDC Logout Requested
   def oidc_logout_requested(
     success: nil,
@@ -4052,6 +4053,7 @@ module AnalyticsEvents
     errors: nil,
     error_details: nil,
     method: nil,
+    original_method: nil,
     **extra
   )
     track_event(
@@ -4066,6 +4068,7 @@ module AnalyticsEvents
       oidc: oidc,
       saml_request_valid: saml_request_valid,
       method: method,
+      original_method: original_method,
       **extra,
     )
   end

--- a/app/views/openid_connect/logout/confirm_logout.html.erb
+++ b/app/views/openid_connect/logout/confirm_logout.html.erb
@@ -16,4 +16,5 @@
       form_class: 'margin-top-5 margin-bottom-2',
       class: 'usa-button usa-button--big usa-button usa-button--full-width',
     ) { t('openid_connect.logout.confirm', app_name: APP_NAME) } %>
+<%#  %>
 <%= link_to(account_path, class: 'usa-button usa-button--big usa-button--outline usa-button--full-width') { t('openid_connect.logout.deny') } %>

--- a/app/views/openid_connect/logout/confirm_logout.html.erb
+++ b/app/views/openid_connect/logout/confirm_logout.html.erb
@@ -16,5 +16,4 @@
       form_class: 'margin-top-5 margin-bottom-2',
       class: 'usa-button usa-button--big usa-button usa-button--full-width',
     ) { t('openid_connect.logout.confirm', app_name: APP_NAME) } %>
-<%#  %>
 <%= link_to(account_path, class: 'usa-button usa-button--big usa-button--outline usa-button--full-width') { t('openid_connect.logout.deny') } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,8 @@ Rails.application.routes.draw do
   post '/api/logger' => 'frontend_log#create'
 
   get '/openid_connect/authorize' => 'openid_connect/authorization#index'
-  match '/openid_connect/logout' => 'openid_connect/logout#logout', via: %i[get post]
+  get '/openid_connect/logout' => 'openid_connect/logout#show'
+  post '/openid_connect/logout' => 'openid_connect/logout#create'
   delete '/openid_connect/logout' => 'openid_connect/logout#delete'
 
   get '/robots.txt' => 'robots#index'

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -282,15 +282,6 @@ RSpec.describe OpenidConnect::LogoutController do
 
     context 'when sending client_id' do
       subject(:action) do
-        # args = request_builder(
-        #   req_method,
-        #   {
-        #     client_id: service_provider.issuer,
-        #     post_logout_redirect_uri: post_logout_redirect_uri,
-        #     state: state,
-        #   },
-        # )
-        # process(req_action, **args)
         process req_action,
                 method: req_method,
                 params: {

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -590,10 +590,6 @@ RSpec.describe OpenidConnect::LogoutController do
       it_behaves_like 'logout allows id_token_hint', :show, 'GET'
     end
 
-    describe '#create' do
-      it_behaves_like 'logout allows id_token_hint', :create, 'POST'
-    end
-
     describe '#delete' do
       context 'when sending client_id' do
         subject(:action) do
@@ -747,10 +743,6 @@ RSpec.describe OpenidConnect::LogoutController do
 
     describe '#show' do
       it_behaves_like 'logout rejects id_token_hint', :show, 'GET'
-    end
-
-    describe '#create' do
-      it_behaves_like 'logout rejects id_token_hint', :create, 'POST'
     end
 
     describe '#delete' do

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe OpenidConnect::LogoutController do
     end
   end
 
-  shared_examples 'logout allows id_token_hint' do |req_action, req_method|
+  shared_examples 'when allowing id_token_hint' do |req_action, req_method|
     let(:id_token_hint) { valid_id_token_hint }
 
     context 'when sending id_token_hint' do
@@ -209,16 +209,17 @@ RSpec.describe OpenidConnect::LogoutController do
             expect(@analytics).to receive(:track_event).
               with(
                 'OIDC Logout Requested',
-                success: false,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: false,
-                id_token_hint_parameter_present: true,
-                errors: errors,
-                error_details: hash_including(*errors.keys),
-                sp_initiated: true,
-                oidc: true,
-                method: nil,
-                saml_request_valid: nil,
+                hash_including(
+                  success: false,
+                  client_id: service_provider.issuer,
+                  client_id_parameter_present: false,
+                  id_token_hint_parameter_present: true,
+                  errors: errors,
+                  error_details: hash_including(*errors.keys),
+                  sp_initiated: true,
+                  oidc: true,
+                  saml_request_valid: nil,
+                ),
               )
 
             action
@@ -234,18 +235,18 @@ RSpec.describe OpenidConnect::LogoutController do
             expect(@analytics).to receive(:track_event).
               with(
                 'OIDC Logout Requested',
-                success: false,
-                client_id: nil,
-                client_id_parameter_present: false,
-                id_token_hint_parameter_present: true,
-                errors: hash_including(*errors_keys),
-                error_details: hash_including(*errors_keys),
-                sp_initiated: true,
-                oidc: true,
-                method: nil,
-                saml_request_valid: nil,
+                hash_including(
+                  success: false,
+                  client_id: nil,
+                  client_id_parameter_present: false,
+                  id_token_hint_parameter_present: true,
+                  errors: hash_including(*errors_keys),
+                  error_details: hash_including(*errors_keys),
+                  sp_initiated: true,
+                  oidc: true,
+                  saml_request_valid: nil,
+                ),
               )
-
             action
           end
         end
@@ -365,7 +366,6 @@ RSpec.describe OpenidConnect::LogoutController do
                   error_details: hash_including(*errors.keys),
                   sp_initiated: true,
                   oidc: true,
-                  method: nil,
                   saml_request_valid: nil,
                 ),
               )
@@ -405,7 +405,7 @@ RSpec.describe OpenidConnect::LogoutController do
     end
   end
 
-  shared_examples 'logout rejects id_token_hint' do |req_action, req_method|
+  shared_examples 'when rejecting id_token_hint' do |req_action, req_method|
     let(:id_token_hint) { nil }
     subject(:action) do
       process req_action,
@@ -486,16 +486,17 @@ RSpec.describe OpenidConnect::LogoutController do
           expect(@analytics).to receive(:track_event).
             with(
               'OIDC Logout Requested',
-              success: false,
-              client_id: service_provider.issuer,
-              client_id_parameter_present: true,
-              id_token_hint_parameter_present: true,
-              errors: errors,
-              error_details: hash_including(*errors.keys),
-              sp_initiated: true,
-              oidc: true,
-              method: nil,
-              saml_request_valid: nil,
+              hash_including(
+                success: false,
+                client_id: service_provider.issuer,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: true,
+                errors: errors,
+                error_details: hash_including(*errors.keys),
+                sp_initiated: true,
+                oidc: true,
+                saml_request_valid: nil,
+              ),
             )
 
           action
@@ -526,16 +527,17 @@ RSpec.describe OpenidConnect::LogoutController do
           expect(@analytics).to receive(:track_event).
             with(
               'OIDC Logout Requested',
-              success: false,
-              client_id: service_provider.issuer,
-              client_id_parameter_present: true,
-              id_token_hint_parameter_present: false,
-              errors: errors,
-              error_details: hash_including(*errors.keys),
-              sp_initiated: true,
-              oidc: true,
-              method: nil,
-              saml_request_valid: nil,
+              hash_including(
+                success: false,
+                client_id: service_provider.issuer,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: false,
+                errors: errors,
+                error_details: hash_including(*errors.keys),
+                sp_initiated: true,
+                oidc: true,
+                saml_request_valid: nil,
+              ),
             )
 
           action
@@ -586,8 +588,8 @@ RSpec.describe OpenidConnect::LogoutController do
         and_return(false)
     end
 
-    describe '#show' do
-      it_behaves_like 'logout allows id_token_hint', :show, 'GET'
+    describe '#logout[GET]' do
+      it_behaves_like 'when allowing id_token_hint', :show, 'GET'
     end
 
     describe '#delete' do
@@ -741,8 +743,8 @@ RSpec.describe OpenidConnect::LogoutController do
         and_return(true)
     end
 
-    describe '#show' do
-      it_behaves_like 'logout rejects id_token_hint', :show, 'GET'
+    describe '#logout[GET]' do
+      it_behaves_like 'when rejecting id_token_hint', :show, 'GET'
     end
 
     describe '#delete' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-7434](https://cm-jira.usa.gov/browse/LG-7434): Add support for POST OIDC logout requests (this ticket has been superseded by [this GitLab issue](https://gitlab.login.gov/lg-people/lg-people-appdev/protocols/backlog-fy24/-/issues/20)).

## 🛠 Summary of changes
- Updated the controller to use separate methods for `GET` and `POST`
- The `POST` route redirects to the `GET` route for better UX when using browser navigation
- Added analytics field `original_method` to capture redirected method for `OIDC Logout Requested` event. See https://github.com/18F/identity-idp/pull/10697#discussion_r1617923237 for details
- Updated tests
- Updated doc comments

## 📜 Testing Plan

Requires:
- A modified sample OIDC app to sign-out users with POST
- `identity-idp` app to have `reject_id_token_hint_in_logout: true` in `application.yml` OR the partner app must not send an `id_token_hint`

### Steps
1. Sign in to the partner app (see [this branch](https://github.com/18F/identity-oidc-sinatra/tree/lmgeorge/LG-7434-add-support-for-post-oidc-logout-requests) to get spun up quickly)
2. Click `Sign out`
3. Confirm that the appropriate confirmation view is shown
4. On `Do you want to sign out of Login.gov?`, ensure you are redirected to the sample app home page (or other configured redirect URI).

---

**Why**:

- It is expected that requests will be made by relying parties on verified external domains

- The specification for OpenID Connect RP-Initiated Logout 1.0 requires both HTTP `GET` and `POST` methods to be supported. See: https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout

- Data sent using the `POST` method remains encrypted during transport in the browser and in web application logs, preventing leakage of sensitive information

**How**:

- The same endpoint shall be used, `/openid_connect/logout`, but the request data must be sent as part of the body and use form serialization as required for  HTTP `POST` requests (RFC 9110, sec. 9.3.3).

- Disables Rail's CSRF token verification for the POST route only

resolves https://gitlab.login.gov/lg-people/lg-people-appdev/protocols/backlog-fy24/-/issues/20

changelog: Bug Fixes, Security, Fix CORS stopping POST for OIDC RP-Initiated Logout 1.0




