### PR TITLE
Remove all code related to the x509_presented_hash_attribute_requested_issuers

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -173,13 +173,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def x509_presented
-    if IdentityConfig.store.x509_presented_hash_attribute_requested_issuers.include?(
-      identity&.service_provider,
-    )
-      x509_data.presented
-    else
-      !!x509_data.presented.raw
-    end
+    !!x509_data.presented.raw
   end
 
   def active_profile

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -85,7 +85,7 @@ class OpenidConnectUserInfoPresenter
     {
       x509_subject: stringify_attr(x509_data.subject),
       x509_issuer: stringify_attr(x509_data.issuer),
-      x509_presented:,
+      x509_presented: !!x509_data.presented.raw,
     }
   end
 
@@ -170,10 +170,6 @@ class OpenidConnectUserInfoPresenter
 
   def x509_session?
     identity.piv_cac_enabled?
-  end
-
-  def x509_presented
-    !!x509_data.presented.raw
   end
 
   def active_profile

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -371,7 +371,6 @@ get_usps_proofing_results_job_request_delay_milliseconds: 1000
 voice_otp_pause_time: '0.5s'
 voice_otp_speech_rate: 'slow'
 weekly_auth_funnel_report_config: '[]'
-x509_presented_hash_attribute_requested_issuers: '[]'
 
 development:
   aamva_private_key: 123abc

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -439,7 +439,6 @@ module IdentityConfig
     config.add(:voice_otp_speech_rate)
     config.add(:vtm_url)
     config.add(:weekly_auth_funnel_report_config, type: :json)
-    config.add(:x509_presented_hash_attribute_requested_issuers, type: :json)
   end.freeze
   # rubocop:enable Metrics/BlockLength
 end

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -324,25 +324,6 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           end
         end
       end
-
-      context 'when the sp requested x509_presented scope before it was fixed to string' do
-        before do
-          expect(IdentityConfig.store).to receive(
-            :x509_presented_hash_attribute_requested_issuers,
-          ).and_return([identity.service_provider])
-          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
-        end
-
-        it 'returns x509_presented as an X509::Attribute' do
-          # This is guarding against partners who may have coded against
-          # a bug where we returning the wrong data type for x509_presented
-          aggregate_failures do
-            expect(user_info[:x509_subject]).to eq(x509_subject)
-            expect(user_info[:x509_presented].class).to eq(X509::Attribute)
-            expect(user_info[:x509_issuer]).to eq(x509_issuer)
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket
https://gitlab.login.gov/lg-people/lg-people-appdev/protocols/backlog-fy24/-/issues/16

## 🛠 Summary of changes
This change is removing vestigial code left over from fixing the [x509:presented attribute bug](https://cm-jira.usa.gov/browse/LG-12678). The changes include:
- removing the backwards compatibility conditional
- removing the configuration key from the IdentityConfig and application.yml.default
- removing the now unnecessary test

