### PR TITLE
Remove infinite recursion in `Vot::Parser`

### DIFF
--- a/app/services/vot/component_expander.rb
+++ b/app/services/vot/component_expander.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Vot
   class ComponentExpander
     attr_reader :initial_components, :component_map, :expanded_components

--- a/app/services/vot/component_expander.rb
+++ b/app/services/vot/component_expander.rb
@@ -1,0 +1,32 @@
+module Vot
+  class ComponentExpander
+    attr_reader :initial_components, :component_map, :expanded_components
+
+    def initialize(initial_components:, component_map:)
+      @initial_components = initial_components
+      @component_map = component_map
+      @expanded_components = []
+    end
+
+    def expand
+      initial_components.each do |component|
+        expand_and_add_component(component)
+      end
+      expanded_components.sort_by(&:name)
+    end
+
+    private
+
+    def expand_and_add_component(component)
+      # Do not add components if we have alread expanded and added them.
+      # This prevents infinite recursion.
+      return if expanded_components.include?(component)
+
+      expanded_components.push(component)
+      component.implied_component_values.each do |implied_component_name|
+        implied_component = component_map[implied_component_name]
+        expand_and_add_component(implied_component)
+      end
+    end
+  end
+end

--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -44,44 +44,16 @@ module Vot
     end
 
     def parse
-      initial_components =
-        if vector_of_trust.present?
-          map_initial_vector_of_trust_components_to_component_values
-        elsif acr_values.present?
-          map_initial_acr_values_to_component_values
-        end
-
-      if !initial_components
+      if initial_components.blank?
         raise ParseException.new('VoT parser called without VoT or ACR values')
       end
-
-      expand_components_with_initial_components(initial_components)
-    end
-
-    private
-
-    def map_initial_vector_of_trust_components_to_component_values
-      vector_of_trust.split('.').map do |component_value_name|
-        SupportedComponentValues.by_name.fetch(component_value_name)
-      rescue KeyError
-        raise_unsupported_component_exception(component_value_name)
-      end
-    end
-
-    def map_initial_acr_values_to_component_values
-      acr_values.split(' ').map do |component_value_name|
-        LegacyComponentValues.by_name.fetch(component_value_name)
-      rescue KeyError
-        raise_unsupported_component_exception(component_value_name)
-      end
-    end
-
-    def expand_components_with_initial_components(initial_components)
       validate_component_uniqueness!(initial_components)
-      resulting_components = add_implied_components(initial_components).sort_by(&:name)
-      requirement_list = resulting_components.flat_map(&:requirements)
+
+      expanded_components = Vot::ComponentExpander.new(initial_components:, component_map:).expand
+
+      requirement_list = expanded_components.flat_map(&:requirements)
       Result.new(
-        component_values: resulting_components,
+        component_values: expanded_components,
         aal2?: requirement_list.include?(:aal2),
         phishing_resistant?: requirement_list.include?(:phishing_resistant),
         hspd12?: requirement_list.include?(:hspd12),
@@ -92,25 +64,37 @@ module Vot
       )
     end
 
+    private
+
+    def initial_components
+      component_string = vector_of_trust.presence || acr_values || ''
+      component_string.split(component_separator).map do |component_value_name|
+        component_map.fetch(component_value_name)
+      rescue KeyError
+        raise_unsupported_component_exception(component_value_name)
+      end
+    end
+
+    def component_separator
+      if vector_of_trust.present?
+        '.'
+      else
+        ' '
+      end
+    end
+
+    def component_map
+      if vector_of_trust.present?
+        SupportedComponentValues.by_name
+      else
+        LegacyComponentValues.by_name
+      end
+    end
+
     def validate_component_uniqueness!(component_values)
       if component_values.length != component_values.uniq.length
         raise_duplicate_component_exception
       end
-    end
-
-    def add_implied_components(component_values)
-      component_values.flat_map do |component_value|
-        component_with_implied_components(component_value)
-      end.uniq
-    end
-
-    def component_with_implied_components(component_value)
-      [
-        component_value,
-        *component_value.implied_component_values.map do |implied_component_value|
-          component_with_implied_components(implied_component_value)
-        end,
-      ].flatten
     end
 
     def raise_unsupported_component_exception(component_value_name)

--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -67,11 +67,13 @@ module Vot
     private
 
     def initial_components
+      return @initial_components if defined?(@initial_components)
+
       component_string = vector_of_trust.presence || acr_values || ''
-      component_string.split(component_separator).map do |component_value_name|
-        component_map.fetch(component_value_name)
+      @initial_components ||= component_string.split(component_separator).map do |component_name|
+        component_map.fetch(component_name)
       rescue KeyError
-        raise_unsupported_component_exception(component_value_name)
+        raise_unsupported_component_exception(component_name)
       end
     end
 

--- a/app/services/vot/supported_component_values.rb
+++ b/app/services/vot/supported_component_values.rb
@@ -11,37 +11,37 @@ module Vot
     C2 = ComponentValue.new(
       name: 'C2',
       description: 'AAL2 conformant features are engaged',
-      implied_component_values: [C1],
+      implied_component_values: ['C1'],
       requirements: [:aal2],
     ).freeze
     Ca = ComponentValue.new(
       name: 'Ca',
       description: 'A phishing resistant authenticator is required',
-      implied_component_values: [C1],
+      implied_component_values: ['C1'],
       requirements: [:phishing_resistant],
     ).freeze
     Cb = ComponentValue.new(
       name: 'Cb',
       description: 'A PIV/CAC card is required',
-      implied_component_values: [C1],
+      implied_component_values: ['C1'],
       requirements: [:hspd12],
     ).freeze
     P1 = ComponentValue.new(
       name: 'P1',
       description: 'Identity proofing is performed',
-      implied_component_values: [C2],
+      implied_component_values: ['C2'],
       requirements: [:identity_proofing],
     ).freeze
     Pb = ComponentValue.new(
       name: 'Pb',
       description: 'A biometric comparison is required as part of identity proofing',
-      implied_component_values: [P1],
+      implied_component_values: ['P1'],
       requirements: [:biometric_comparison],
     ).freeze
     Pe = ComponentValue.new(
       name: 'Pe',
       description: 'Enhanced In Person Proofing is required',
-      implied_component_values: [P1],
+      implied_component_values: ['P1'],
       requirements: [:enhanced_ipp],
     ).freeze
 

--- a/spec/services/vot/component_expander_spec.rb
+++ b/spec/services/vot/component_expander_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Vot::ComponentExpander do
+  context 'with a component with no implied components' do
+    it 'returns the single component' do
+      component_a = Vot::ComponentValue.new(
+        name: 'A1', description: 'Test component', requirements: [],
+        implied_component_values: []
+      )
+      component_b = Vot::ComponentValue.new(
+        name: 'B1', description: 'Test component', requirements: [],
+        implied_component_values: []
+      )
+      component_map = { 'A1' => component_a, 'B1' => component_b }
+      initial_components = [component_a]
+
+      result = described_class.new(component_map:, initial_components:).expand
+
+      expect(result).to eq([component_a])
+    end
+  end
+
+  context 'with a component with several layers of implied components' do
+    it 'returns the components expanded into an array' do
+      component_a = Vot::ComponentValue.new(
+        name: 'A1', description: 'Test component', requirements: [],
+        implied_component_values: []
+      )
+      component_b = Vot::ComponentValue.new(
+        name: 'B1', description: 'Test component', requirements: [],
+        implied_component_values: ['A1']
+      )
+      component_c = Vot::ComponentValue.new(
+        name: 'C1', description: 'Test component', requirements: [],
+        implied_component_values: ['B1']
+      )
+      component_map = { 'A1' => component_a, 'B1' => component_b, 'C1' => component_c }
+      initial_components = [component_c]
+
+      result = described_class.new(component_map:, initial_components:).expand
+
+      expect(result).to eq([component_a, component_b, component_c])
+    end
+  end
+
+  context 'with a component with cyclic implied component relationships' do
+    it 'returns the components expanded into an array' do
+      component_a = Vot::ComponentValue.new(
+        name: 'A1', description: 'Test component', requirements: [],
+        implied_component_values: ['C1']
+      )
+      component_b = Vot::ComponentValue.new(
+        name: 'B1', description: 'Test component', requirements: [],
+        implied_component_values: ['A1']
+      )
+      component_c = Vot::ComponentValue.new(
+        name: 'C1', description: 'Test component', requirements: [],
+        implied_component_values: ['B1']
+      )
+      component_map = { 'A1' => component_a, 'B1' => component_b, 'C1' => component_c }
+      initial_components = [component_c]
+
+      result = described_class.new(component_map:, initial_components:).expand
+
+      expect(result).to eq([component_a, component_b, component_c])
+    end
+  end
+end


### PR DESCRIPTION
The `Vot::Parser` class consumes a VoT or ACR values string and parses it into a set of requirements to satisfy the vector.

Some vectors have dependencies on other vectors. For example, the biometric proofing vector (`Pb`) depends on the identity proofing vector (`P1`). In the [vector component value definitions](https://github.com/18F/identity-idp/blob/5442bbdb9af5421dcb4fabc7a8ec4ce9ab307526/app/services/vot/supported_component_values.rb#L4) these are described as “implied components” i.e. vector Pb implies vector P1.

When a partner requests a vector with a component that implies another component we expand the vector to include the implied component. For example, a partner may request `C1.Pb` which we will expand to `C1.C2.P1.Pb` since `Pb` implies `P1` and `P1` implies `C2`.

Prior to this commit these vectors depended on a recursive function which was subject to infinite recursion if vectors had mutual implications. For example, vector `A1` may imply vector `B1` which could imply vector `A1` resulting in infinite recursion expanding the vector. to `A1.B1.A1.B1....`. This commit refactors the parser to move the expansion logic into a new `Vot::ComponentExpander` which has a new implementation that does not have the infinite recursion issue.

Finally, the `implied_component_values` were constants prior to this commit. This commit makes those values strings that represent the names of the components. This was done because mutual component implication is not possible since both vectors are not defined when the first vector is defined. In this way the first vector cannot depend on the second when the second does not exist. Using strings allows the vectors to be looked up in a map after all of the vectors have been defined.
