### PR TITLE
Remove unused User#new_device? method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -428,10 +428,6 @@ class User < ApplicationRecord
     !recent_devices.empty?
   end
 
-  def new_device?(cookie_uuid:)
-    !cookie_uuid || !devices.exists?(cookie_uuid:)
-  end
-
   def authenticated_device?(cookie_uuid:)
     return false if cookie_uuid.blank?
     devices.joins(:events).exists?(cookie_uuid:, events: { event_type: :sign_in_after_2fa })

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1540,55 +1540,6 @@ RSpec.describe User do
     end
   end
 
-  describe '#new_device?' do
-    let(:user_agent) { 'A computer on the internet' }
-    let(:ip_address) { '4.4.4.4' }
-    let(:existing_device_cookie) { 'existing_device_cookie' }
-    let(:cookie_jar) do
-      {
-        device: existing_device_cookie,
-      }.with_indifferent_access.tap do |cookie_jar|
-        allow(cookie_jar).to receive(:permanent).and_return({})
-      end
-    end
-    let(:request) do
-      double(
-        remote_ip: ip_address,
-        user_agent: user_agent,
-        cookie_jar: cookie_jar,
-      )
-    end
-    let(:user) { create(:user, :fully_registered) }
-    let(:device) { create(:device, user: user, cookie_uuid: existing_device_cookie) }
-
-    context 'with existing device' do
-      before do
-        # Memoize user and device before specs run
-        user
-        device
-      end
-      it 'does not expect a device to be new' do
-        cookies = request.cookie_jar
-        device_present = user.new_device?(cookie_uuid: cookies[:device])
-        expect(device_present).to eq(false)
-      end
-    end
-
-    context 'with new device' do
-      let(:device) { create(:device, user: user, cookie_uuid: 'non_existing_device_cookie') }
-      before do
-        # Memoize user and device before specs run
-        user
-        device
-      end
-      it 'expects a new device' do
-        cookies = request.cookie_jar
-        device_present = user.new_device?(cookie_uuid: cookies[:device])
-        expect(device_present).to eq(true)
-      end
-    end
-  end
-
   describe '#authenticated_device?' do
     let(:user) { create(:user, :fully_registered) }
     let(:device) { create(:device, user:) }


### PR DESCRIPTION
## 🛠 Summary of changes

Removes `User#new_device?`, as it is currently unused.

Recent work in #10628 has shifted how we consider new device for sign-in notifications to using the `User#authenticated_device?` method, leaving this unused.

Future work could consider renaming either `NewDeviceConcern#new_device?` or `User#authenticated_device?` to use consistent naming.

## 📜 Testing Plan

Verify there is no usage of `User#new_device?` anywhere in code, and that the build passes.