### PR TITLE
Remove unused redirect URL code for CountdownAlertComponent

### DIFF
--- a/app/components/countdown_alert_component.rb
+++ b/app/components/countdown_alert_component.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
 class CountdownAlertComponent < BaseComponent
-  attr_reader :show_at_remaining, :alert_options, :countdown_options, :redirect_url, :tag_options
+  attr_reader :show_at_remaining, :alert_options, :countdown_options, :tag_options
 
   def initialize(
     show_at_remaining: nil,
     alert_options: {},
     countdown_options: {},
-    redirect_url: nil,
     **tag_options
   )
     @show_at_remaining = show_at_remaining
     @alert_options = alert_options
     @countdown_options = countdown_options
     @tag_options = tag_options
-    @redirect_url = redirect_url
   end
 
   def call
@@ -24,7 +22,6 @@ class CountdownAlertComponent < BaseComponent
       **tag_options,
       class: css_class,
       'show-at-remaining': show_at_remaining&.in_milliseconds,
-      'redirect-url': redirect_url,
     )
   end
 

--- a/app/javascript/packages/countdown/countdown-alert-element.spec.ts
+++ b/app/javascript/packages/countdown/countdown-alert-element.spec.ts
@@ -5,14 +5,9 @@ import './countdown-element';
 describe('CountdownAlertElement', () => {
   const sandbox = useSandbox({ useFakeTimers: true });
 
-  function createElement({
-    showAtRemaining,
-    redirectURL,
-  }: { showAtRemaining?: number; redirectURL?: string } = {}) {
+  function createElement({ showAtRemaining }: { showAtRemaining?: number } = {}) {
     document.body.innerHTML = `
-      <lg-countdown-alert
-        ${showAtRemaining ? `show-at-remaining="${showAtRemaining}"` : ''}
-        ${redirectURL ? `redirect-url="${redirectURL}"` : ''}>
+      <lg-countdown-alert ${showAtRemaining ? `show-at-remaining="${showAtRemaining}"` : ''}>
         <div class="usa-alert usa-alert--info margin-bottom-4 usa-alert--info-time" role="status">
           <div class="usa-alert__body">
             <p class="usa-alert__text">
@@ -45,14 +40,5 @@ describe('CountdownAlertElement', () => {
       sandbox.clock.tick(1000);
       expect(element.show).to.have.been.called();
     });
-  });
-
-  it('redirects when time has expired', () => {
-    createElement({ redirectURL: '#teapot' });
-
-    sandbox.clock.tick(91000);
-    expect(window.location.hash).to.equal('');
-    sandbox.clock.tick(1000);
-    expect(window.location.hash).to.equal('#teapot');
   });
 });

--- a/app/javascript/packages/countdown/countdown-alert-element.ts
+++ b/app/javascript/packages/countdown/countdown-alert-element.ts
@@ -1,4 +1,3 @@
-import { trackEvent } from '@18f/identity-analytics';
 import type { CountdownElement } from './countdown-element';
 
 export class CountdownAlertElement extends HTMLElement {
@@ -6,18 +5,10 @@ export class CountdownAlertElement extends HTMLElement {
     if (this.showAtRemaining) {
       this.addEventListener('lg:countdown:tick', this.handleShowAtRemainingTick);
     }
-
-    if (this.redirectURL) {
-      this.addEventListener('lg:countdown:tick', this.handleRedirectTick);
-    }
   }
 
   get showAtRemaining(): number | null {
     return Number(this.getAttribute('show-at-remaining')) || null;
-  }
-
-  get redirectURL(): string | null {
-    return this.getAttribute('redirect-url') || null;
   }
 
   get countdown(): CountdownElement {
@@ -28,18 +19,6 @@ export class CountdownAlertElement extends HTMLElement {
     if (this.countdown.timeRemaining <= this.showAtRemaining!) {
       this.show();
       this.removeEventListener('lg:countdown:tick', this.handleShowAtRemainingTick);
-    }
-  };
-
-  handleRedirectTick = () => {
-    if (this.countdown.timeRemaining <= 0) {
-      trackEvent('Countdown timeout redirect', {
-        path: this.redirectURL,
-        expiration: this.countdown.expiration,
-        timeRemaining: this.countdown.timeRemaining,
-      });
-      window.location.href = this.redirectURL!;
-      this.removeEventListener('lg:countdown:tick', this.handleRedirectTick);
     }
   };
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes code related to a redirect option for `CountdownAlertComponent` which was meant to have been removed with #8701.

## 📜 Testing Plan

This code is unused, but verify there are no regressions in the countdown alert component preview:

http://localhost:3000/components/inspect/countdown_alert/preview