### PR TITLE
LG-13434 Link to overview article from IdV welcome

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -17,6 +17,7 @@ class MarketingSite
     verify-your-identity/phone-number
     verify-your-identity/verify-your-address-by-mail
     verify-your-identity/how-to-verify-your-identity
+    verify-your-identity/overview
   ].to_set.freeze
 
   def self.locale_segment

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -16,7 +16,6 @@ class MarketingSite
     verify-your-identity/verify-your-identity-in-person
     verify-your-identity/phone-number
     verify-your-identity/verify-your-address-by-mail
-    verify-your-identity/how-to-verify-your-identity
     verify-your-identity/overview
   ].to_set.freeze
 

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -100,17 +100,23 @@
       heading: t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
       options: [
         {
-          url: MarketingSite.help_center_article_url(
+          url: help_center_redirect_path(
             category: 'verify-your-identity',
             article: 'overview',
+            flow: :idv,
+            step: :how_to_verify,
+            location: 'troubleshooting_options',
           ),
           text: t('doc_auth.info.verify_online_link_text'),
           new_tab: true,
         },
         {
-          url: MarketingSite.help_center_article_url(
+          url: help_center_redirect_path(
             category: 'verify-your-identity',
             article: 'verify-your-identity-in-person',
+            flow: :idv,
+            step: :how_to_verify,
+            location: 'troubleshooting_options',
           ),
           text: t('doc_auth.info.verify_at_post_office_link_text'),
           new_tab: true,

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -102,7 +102,7 @@
         {
           url: MarketingSite.help_center_article_url(
             category: 'verify-your-identity',
-            article: 'how-to-verify-your-identity',
+            article: 'overview',
           ),
           text: t('doc_auth.info.verify_online_link_text'),
           new_tab: true,

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -11,7 +11,7 @@
             t('doc_auth.info.getting_started_learn_more'),
             help_center_redirect_path(
               category: 'verify-your-identity',
-              article: 'how-to-verify-your-identity',
+              article: 'overview',
               flow: :idv,
               step: :welcome,
               location: 'intro_paragraph',

--- a/spec/features/idv/doc_auth/welcome_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'welcome step', allowed_extra_analytics: [:*] do
       flow: 'idv',
       redirect_url: MarketingSite.help_center_article_url(
         category: 'verify-your-identity',
-        article: 'how-to-verify-your-identity',
+        article: 'overview',
       ),
     )
   end

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'idv/welcome/show.html.erb' do
         t('doc_auth.info.getting_started_learn_more'),
         href: help_center_redirect_path(
           category: 'verify-your-identity',
-          article: 'how-to-verify-your-identity',
+          article: 'overview',
           flow: :idv,
           step: :welcome,
           location: 'intro_paragraph',
@@ -63,7 +63,7 @@ RSpec.describe 'idv/welcome/show.html.erb' do
         t('doc_auth.info.getting_started_learn_more'),
         href: help_center_redirect_path(
           category: 'verify-your-identity',
-          article: 'how-to-verify-your-identity',
+          article: 'overview',
           flow: :idv,
           step: :welcome,
           location: 'intro_paragraph',


### PR DESCRIPTION
Prior to this commit the welcome screen at the beginning of IdV links to a page explaining how to verify your identity. The overview page on the static site is the more appropriate page for people trying to learn more about identity verification. This commit updates the URL to link to the correct place.
