### PR TITLE
Update RuboCop rules: prefer alias_method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1019,6 +1019,10 @@ Security/YAMLLoad:
   Enabled: true
   SafeAutoCorrect: false
 
+Style/Alias:
+  Enabled: true
+  EnforcedStyle: prefer_alias_method
+
 Style/AndOr:
   Description: Use &&/|| instead of and/or.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-and-or-or

--- a/app/services/encryption/user_access_key.rb
+++ b/app/services/encryption/user_access_key.rb
@@ -53,7 +53,7 @@ module Encryption
     def unlocked?
       cek.present?
     end
-    alias built? unlocked?
+    alias_method :built?, :unlocked?
 
     def encryption_key
       Base64.strict_encode64(masked_ciphertext)

--- a/app/services/proofing/aamva/hmac_secret.rb
+++ b/app/services/proofing/aamva/hmac_secret.rb
@@ -27,7 +27,7 @@ module Proofing
 
       attr_reader :client_secret, :server_secret, :psha1
 
-      alias secret client_secret
+      alias_method :secret, :client_secret
 
       def initialize(encoded_client_secret, encoded_server_secret)
         @client_secret = Base64.decode64(encoded_client_secret)

--- a/app/services/x509/attribute.rb
+++ b/app/services/x509/attribute.rb
@@ -13,6 +13,6 @@ module X509
     end
 
     delegate :blank?, :present?, :to_s, :to_date, :==, :eql?, to: :raw
-    alias to_str to_s
+    alias_method :to_str, :to_s
   end
 end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -21,8 +21,8 @@ module Rack
       end
     end
 
-    alias call_without_excludes call
-    alias call call_with_excludes
+    alias_method :call_without_excludes, :call
+    alias_method :call, :call_with_excludes
   end
 end
 

--- a/lib/aws/ses.rb
+++ b/lib/aws/ses.rb
@@ -18,7 +18,7 @@ module Aws
         response
       end
 
-      alias deliver! deliver
+      alias_method :deliver!, :deliver
 
       private
 

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe RememberDeviceConcern do
         include(RememberDeviceConcern)
 
         attr_reader :sp, :raw_session, :request, :current_user
-        alias :sp_from_sp_session :sp
-        alias :sp_session :raw_session
+        alias_method :sp_from_sp_session, :sp
+        alias_method :sp_session, :raw_session
 
         def initialize(sp, raw_session, request, current_user)
           @sp = sp

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -96,8 +96,8 @@ module IdvStepHelper
     complete_enter_password_step(user)
   end
 
-  alias complete_idv_steps_before_enter_password_step
-        complete_idv_steps_with_phone_before_enter_password_step
+  alias_method :complete_idv_steps_before_enter_password_step,
+               :complete_idv_steps_with_phone_before_enter_password_step
 
   def complete_idv_steps_with_gpo_before_enter_password_step(user = user_with_2fa)
     complete_idv_steps_before_gpo_step(user)


### PR DESCRIPTION
I was a little surprised to see `alias` instead of `alias_method` in our codebase. `alias_method` has more predictable behavior compared to `alias`. This updates our rules and corrects the codebase

Related: https://github.com/rubocop/ruby-style-guide/issues/821 and the [explainer blog post](https://www.bigbinary.com/blog/alias-vs-alias-method) that it links

