### PR TITLE
Fix missing action for OIDC test route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,7 +159,7 @@ Rails.application.routes.draw do
         post '/saml/decode_slo_request' => 'saml_test#decode_slo_request'
 
         get '/oidc/login' => 'oidc_test#index'
-        get '/oidc' => 'oidc_test#start'
+        get '/oidc' => redirect('/test/oidc/auth_request', status: 302)
         get '/oidc/auth_request' => 'oidc_test#auth_request'
         get '/oidc/auth_result' => 'oidc_test#auth_result'
         get '/oidc/logout' => 'oidc_test#logout'


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a missing action for the `/test/oidc` route.

In #9923, test routes were added for an OIDC test login controller, including `/test/oidc` pointing to a `#start` action, but the `#start` action wasn't implemented.

The approach here redirects to `/test/oidc/auth_request`. The thinking being that the corresponding `/test/saml` request "starts" an IAL1 authentication and returns the user to the sign-in screen, which is the same as what the `/test/oidc/auth_request` route does.

## 📜 Testing Plan

1. Go to http://localhost:3000/test/oidc
2. Observe that you don't see a 500 error, and instead are redirected to sign in to the OIDC test app