### PR TITLE
Add an unused service provider issuer argument to the resolution proofing job

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -23,6 +23,7 @@ class ResolutionProofingJob < ApplicationJob
     should_proof_state_id:,
     ipp_enrollment_in_progress:,
     user_id: nil,
+    service_provider_issuer: nil, # rubocop:disable Lint/UnusedMethodArgument
     threatmetrix_session_id: nil,
     request_ip: nil,
     instant_verify_ab_test_discriminator: nil


### PR DESCRIPTION
We are planning on passing the SP into the background job and using it for work in the job such as computing UUID prefixes and SP costs. First we need all of the workers to know about the new argument so we do not see `ArgumentError`s when the argument is passed to the job. This commit adds the argument
