### PR TITLE
LG-13383 Pass SP issuer to the ResolutionProofingJob

### DIFF
--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -28,6 +28,7 @@ module Idv
         result_id: document_capture_session.result_id,
         instant_verify_ab_test_discriminator: document_capture_session.uuid,
         user_id: user_id,
+        service_provider_issuer: document_capture_session.issuer,
         threatmetrix_session_id: threatmetrix_session_id,
         request_ip: request_ip,
         ipp_enrollment_in_progress: ipp_enrollment_in_progress,

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -133,6 +133,30 @@ RSpec.describe Idv::Agent do
         end
       end
 
+      it 'passes the correct service provider to the ResolutionProofingJob' do
+        issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
+        document_capture_session.update!(issuer: issuer)
+        agent = Idv::Agent.new(
+          Idp::Constants::MOCK_IDV_APPLICANT.merge(uuid: user.uuid, ssn: '999-99-9999'),
+        )
+
+        expect(ResolutionProofingJob).to receive(:perform_later).with(
+          hash_including(
+            service_provider_issuer: issuer,
+          ),
+        )
+
+        agent.proof_resolution(
+          document_capture_session,
+          should_proof_state_id: true,
+          trace_id: trace_id,
+          user_id: user.id,
+          threatmetrix_session_id: nil,
+          request_ip: request_ip,
+          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
+        )
+      end
+
       it 'returns an unsuccessful result and notifies exception trackers if an exception occurs' do
         agent = Idv::Agent.new(
           Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
@@ -159,10 +183,10 @@ RSpec.describe Idv::Agent do
         )
       end
 
-      context 'successfully proofs in IPP flow' do
+      context 'in-person proofing is enabled' do
         let(:ipp_enrollment_in_progress) { true }
 
-        it 'returns a successful result' do
+        it 'returns a successful result if resolution passes' do
           addr = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS
           agent = Idv::Agent.new(addr.merge(uuid: user.uuid))
           agent.proof_resolution(


### PR DESCRIPTION
In #10722 we added an argument for passing the service provider issuer to the `ResolutionProofingJob` eventually this will be used for things like computing SP costs, creating `DocAuthLog` records, and determining the UUID prefix in the job.

This commit starts passing the issuer to the job but does not start using it. In order to ensure that results are consistent a future commit will start reading the issue once all of the web hosts are passing it to the job.

This can only be safely merged once #10722 is fully deployed.
