### PR TITLE
LG-13383 Use the SP issuer to compute the UUID and UUID prefix in the `ResolutionProofingJob`

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -23,7 +23,7 @@ class ResolutionProofingJob < ApplicationJob
     should_proof_state_id:,
     ipp_enrollment_in_progress:,
     user_id: nil,
-    service_provider_issuer: nil, # rubocop:disable Lint/UnusedMethodArgument
+    service_provider_issuer: nil,
     threatmetrix_session_id: nil,
     request_ip: nil,
     instant_verify_ab_test_discriminator: nil # rubocop:disable Lint/UnusedMethodArgument
@@ -37,9 +37,12 @@ class ResolutionProofingJob < ApplicationJob
       symbolize_names: true,
     )
 
-    applicant_pii = decrypted_args[:applicant_pii]
-
     user = User.find_by(id: user_id)
+    current_sp = ServiceProvider.find_by(issuer: service_provider_issuer)
+
+    applicant_pii = decrypted_args[:applicant_pii]
+    applicant_pii[:uuid_prefix] = current_sp&.app_id
+    applicant_pii[:uuid] = user&.uuid
 
     callback_log_data = make_vendor_proofing_requests(
       timer: timer,

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -42,7 +42,7 @@ class ResolutionProofingJob < ApplicationJob
 
     applicant_pii = decrypted_args[:applicant_pii]
     applicant_pii[:uuid_prefix] = current_sp&.app_id
-    applicant_pii[:uuid] = user&.uuid
+    applicant_pii[:uuid] = user.uuid
 
     callback_log_data = make_vendor_proofing_requests(
       timer: timer,
@@ -82,7 +82,7 @@ class ResolutionProofingJob < ApplicationJob
   )
     result = resolution_proofer.proof(
       applicant_pii: applicant_pii,
-      user_email: user&.confirmed_email_addresses&.first&.email,
+      user_email: user.confirmed_email_addresses.first.email,
       threatmetrix_session_id: threatmetrix_session_id,
       request_ip: request_ip,
       should_proof_state_id: should_proof_state_id,
@@ -105,7 +105,7 @@ class ResolutionProofingJob < ApplicationJob
   def log_threatmetrix_info(threatmetrix_result, user)
     logger_info_hash(
       name: 'ThreatMetrix',
-      user_id: user&.uuid,
+      user_id: user.uuid,
       threatmetrix_request_id: threatmetrix_result.transaction_id,
       threatmetrix_success: threatmetrix_result.success?,
     )

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'ostruct'
 
 RSpec.describe Idv::Agent do
-  let(:user) { build(:user) }
+  let(:user) { create(:user) }
 
   let(:bad_phone) do
     Proofing::Mock::AddressMockClient::UNVERIFIABLE_PHONE_NUMBER


### PR DESCRIPTION
In #10726 started passing the service provider issuer to the `ResolutionProofingJob`. This commit uses it to compute the UUID and UUID prefix for downstream proofers. This will eventually supersede the logic that does the same in the `VerifyInfoConcern`.
    
The logic is left in the `VerifyInfoConcern` since we will still need to pass the UUID and UUID prefix to jobs until this is fully deployed. Once this is fully deployed that logic can be removed.

This cannot be safely merged until all of the jobs are receiving the service provider issuer. That change is made in #10726 