### PR TITLE
Move log_irs_threatmetrix_fraud_check_event to VerifyInfoConcern

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -342,6 +342,7 @@ module Idv
           add_cost(:aamva, transaction_id: hash[:transaction_id])
           track_aamva
         elsif stage == :threatmetrix
+          # transaction_id comes from request_id
           if hash[:transaction_id]
             add_cost(
               :threatmetrix,

--- a/app/services/idv/steps/threat_metrix_step_helper.rb
+++ b/app/services/idv/steps/threat_metrix_step_helper.rb
@@ -48,23 +48,6 @@ module Idv
           session_id: session_id,
         )
       end
-
-      def log_irs_tmx_fraud_check_event(result, user)
-        return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
-
-        success = result[:review_status] == 'pass'
-
-        unless success
-          FraudReviewRequest.create(
-            user: user,
-            login_session_id: Digest::SHA1.hexdigest(user.unique_session_id.to_s),
-          )
-        end
-
-        irs_attempts_api_tracker.idv_tmx_fraud_check(
-          success: success,
-        )
-      end
     end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

This supports [LG-13382](https://cm-jira.usa.gov/browse/LG-13382)

## 🛠 Summary of changes

This is a minor refactor, clearing the way to move some proofing cost calculation code out of the way in a future PR.

I'm taking `log_irs_threatmetrix_fraud_check_event` out of `ThreatMetrixStepHelper` and splitting it into two methods in `VerifyInfoConcern`, then moving the calls to those methods out of `add_proofing_costs`. The idea is that I want the `add_proofing_costs` method to ultimately only be concerned with adding proofing costs so that it's easier to move.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
