### PR TITLE
LG-13419: Fix new device notification on reauthentication

### DIFF
--- a/app/controllers/concerns/new_device_concern.rb
+++ b/app/controllers/concerns/new_device_concern.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 module NewDeviceConcern
-  def set_new_device_session
-    user_session[:new_device] = !current_user.authenticated_device?(cookie_uuid: cookies[:device])
+  def set_new_device_session(new_device = nil)
+    if new_device.nil?
+      new_device = !current_user.authenticated_device?(cookie_uuid: cookies[:device])
+    end
+
+    user_session[:new_device] = new_device
   end
 
   def new_device?

--- a/app/controllers/concerns/new_device_concern.rb
+++ b/app/controllers/concerns/new_device_concern.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module NewDeviceConcern
-  def set_new_device_session(new_device = nil)
+  def set_new_device_session(new_device)
     if new_device.nil?
       new_device = !current_user.authenticated_device?(cookie_uuid: cookies[:device])
     end

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -27,6 +27,7 @@ module TwoFactorAuthenticatableMethods
       )
     end
 
+    set_new_device_session(false)
     reset_second_factor_attempts_count
   end
 

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -75,7 +75,7 @@ module Users
         presented: true,
       )
 
-      set_new_device_session
+      set_new_device_session(nil)
       handle_valid_verification_for_authentication_context(
         auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -113,7 +113,7 @@ module Users
     def handle_valid_authentication
       sign_in(resource_name, resource)
       cache_profiles(auth_params[:password])
-      set_new_device_session
+      set_new_device_session(nil)
       event, = create_user_event(:sign_in_before_2fa)
       UserAlerts::AlertUserAboutNewDevice.schedule_alert(event:) if new_device?
       EmailAddress.update_last_sign_in_at_on_user_id_and_email(

--- a/spec/controllers/concerns/new_device_concern_spec.rb
+++ b/spec/controllers/concerns/new_device_concern_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe NewDeviceConcern, type: :controller do
 
         expect(user_session[:new_device]).to eq(true)
       end
+
+      context 'with explicitly false parameter value' do
+        it 'sets user session value to the value provided' do
+          instance.set_new_device_session(false)
+
+          expect(user_session[:new_device]).to eq(false)
+        end
+      end
     end
 
     context 'with authenticated device' do
@@ -37,6 +45,14 @@ RSpec.describe NewDeviceConcern, type: :controller do
         instance.set_new_device_session
 
         expect(user_session[:new_device]).to eq(false)
+      end
+
+      context 'with explicitly true parameter value' do
+        it 'sets user session value to the value provided' do
+          instance.set_new_device_session(true)
+
+          expect(user_session[:new_device]).to eq(true)
+        end
       end
     end
   end

--- a/spec/controllers/concerns/new_device_concern_spec.rb
+++ b/spec/controllers/concerns/new_device_concern_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe NewDeviceConcern, type: :controller do
   describe '#set_new_device_session' do
     context 'with new device' do
       it 'sets user session value to true' do
-        instance.set_new_device_session
+        instance.set_new_device_session(nil)
 
         expect(user_session[:new_device]).to eq(true)
       end
@@ -42,7 +42,7 @@ RSpec.describe NewDeviceConcern, type: :controller do
       let(:cookies) { { device: current_user.devices.last.cookie_uuid } }
 
       it 'sets user session value to false' do
-        instance.set_new_device_session
+        instance.set_new_device_session(nil)
 
         expect(user_session[:new_device]).to eq(false)
       end

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -149,8 +149,9 @@ RSpec.describe Users::PivCacLoginController do
             )
           end
 
-          it 'sets new device session value' do
-            expect(controller).to receive(:set_new_device_session)
+          it 'sets and then unsets new device session value' do
+            expect(controller).to receive(:set_new_device_session).with(nil).ordered
+            expect(controller).to receive(:set_new_device_session).with(false).ordered
 
             response
           end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Users::SessionsController, devise: true do
       end
 
       it 'sets new device session value' do
-        expect(controller).to receive(:set_new_device_session)
+        expect(controller).to receive(:set_new_device_session).with(nil)
 
         response
       end

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -134,6 +134,25 @@ RSpec.describe 'New device tracking', allowed_extra_analytics: [:*] do
         expect_delivered_email_count(0)
       end
     end
+
+    context 'when reauthenticating' do
+      it 'does not send a second user notification' do
+        # Regression: LG-13419: Reset new-device session value after fully authenticating, so that
+        # reauthentication doesn't consider the device as new and send another notification.
+        sign_in_live_with_2fa(user)
+        expect_delivered_email_count(1)
+
+        expire_reauthn_window
+
+        within('.sidenav') { click_on t('account.navigation.add_phone_number') }
+        expect(page).to have_current_path(login_two_factor_options_path)
+        click_on t('forms.buttons.continue')
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect_delivered_email_count(1)
+      end
+    end
   end
 
   context 'user does not have existing devices' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-13419](https://cm-jira.usa.gov/browse/LG-13419)

## 🛠 Summary of changes

Fixes an issue where a user may receive a second notification about a new-device authentication when reauthenticating from a device that was considered new at the start of their session.

The change here will update the session value for tracking a new device after the user fully authenticates.

This feature is not currently enabled in production.

## 📜 Testing Plan

1. In a new private browsing session, go to http://localhost:3000
2. Sign in and complete MFA
3. Once you arrive at the account dashboard, wait at least 2 minutes (this would be 20 minutes in production)
4. Click "Add phone number" to add a phone
5. You should see "Reauthentication required"
6. Complete reauthentication
7. Observe that you don't receive an email (in local development, an email would open a new tab automatically via [`letter_opener`](https://rubygems.org/gems/letter_opener))