### PR TITLE
Remove unused AAMVA DocAuthLog tracking

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -342,6 +342,7 @@ module Idv
           add_cost(:aamva, transaction_id: hash[:transaction_id])
           track_aamva
         elsif stage == :threatmetrix
+          # transaction_id comes from request_id
           if hash[:transaction_id]
             add_cost(
               :threatmetrix,

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -349,7 +349,6 @@ module Idv
           next if hash[:vendor_name] == 'UnsupportedJurisdiction'
           # transaction_id comes from TransactionLocatorId
           add_cost(:aamva, transaction_id: hash[:transaction_id])
-          track_aamva
         elsif stage == :threatmetrix
           # transaction_id comes from request_id
           if hash[:transaction_id]
@@ -360,14 +359,6 @@ module Idv
           end
         end
       end
-    end
-
-    def track_aamva
-      return unless IdentityConfig.store.state_tracking_enabled
-      doc_auth_log = DocAuthLog.find_by(user_id: current_user.id)
-      return unless doc_auth_log
-      doc_auth_log.aamva = true
-      doc_auth_log.save!
     end
 
     def add_cost(token, transaction_id: nil)

--- a/app/models/doc_auth_log.rb
+++ b/app/models/doc_auth_log.rb
@@ -11,6 +11,7 @@ class DocAuthLog < ApplicationRecord
 
   # rubocop:disable Rails/UnusedIgnoredColumns
   self.ignored_columns = [
+    :aamva,
     :email_sent_view_at,
     :email_sent_view_count,
     :send_link_view_at,

--- a/app/services/idv/steps/threat_metrix_step_helper.rb
+++ b/app/services/idv/steps/threat_metrix_step_helper.rb
@@ -48,23 +48,6 @@ module Idv
           session_id: session_id,
         )
       end
-
-      def log_irs_tmx_fraud_check_event(result, user)
-        return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
-
-        success = result[:review_status] == 'pass'
-
-        unless success
-          FraudReviewRequest.create(
-            user: user,
-            login_session_id: Digest::SHA1.hexdigest(user.unique_session_id.to_s),
-          )
-        end
-
-        irs_attempts_api_tracker.idv_tmx_fraud_check(
-          success: success,
-        )
-      end
     end
   end
 end

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -299,8 +299,6 @@ RSpec.feature 'verify_info step and verify_info_concern', :js, allowed_extra_ana
 
         complete_ssn_step
         complete_verify_step
-
-        expect(DocAuthLog.find_by(user_id: user.id).aamva).not_to be_nil
       end
     end
 
@@ -322,8 +320,6 @@ RSpec.feature 'verify_info step and verify_info_concern', :js, allowed_extra_ana
 
         complete_ssn_step
         complete_verify_step
-
-        expect(DocAuthLog.find_by(user_id: user.id).aamva).to be_nil
       end
     end
   end

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -255,7 +255,6 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
     expect(page).to have_content(t('doc_auth.forms.doc_success'))
     expect(user.proofing_component.resolution_check).to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
     expect(user.proofing_component.source_check).to eq(Idp::Constants::Vendors::AAMVA)
-    expect(DocAuthLog.find_by(user_id: user.id).aamva).to eq(true)
   end
 
   def validate_phone_page


### PR DESCRIPTION
## 🎫 Ticket

Supporting [LG-13382](https://cm-jira.usa.gov/browse/LG-13382)

## 🛠 Summary of changes

The `track_aamva` method in `VerifyInfoConcern` only does anything if the `state_tracking_enabled` feature flag is `true`. This flag has never been true in prod, so this is a no-op. 

I created [LG-13461](https://cm-jira.usa.gov/browse/LG-13461) to track completely removing the flag, but this specific method is in my way as I work on [LG-13382](https://cm-jira.usa.gov/browse/LG-13382).
