### PR TITLE
Update to newest saml_idp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.21.0-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.21.1-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,10 +35,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 33275d69f7609e448942d6e3ce5c27779920995f
-  tag: 0.21.0-18f
+  revision: 85c9a24bd4edab43320d0454e2c0e2fac31ffb90
+  tag: 0.21.1-18f
   specs:
-    saml_idp (0.21.0.pre.18f)
+    saml_idp (0.21.1.pre.18f)
       activesupport
       builder
       faraday


### PR DESCRIPTION
## 🎫 Ticket
https://gitlab.login.gov/lg-people/lg-people-appdev/protocols/backlog-fy24/-/issues/34

## 🛠 Summary of changes
Our current SAML implementation has a bug where we are unable to identify the correct node that indicates the  DigestMethod algorithm node if it is not namespaced with `ds` , falilng back onto a SHA1 default. If this is the incorrect method, then the validation will fail, and the IdP is unable to correctly match registered certificates.

Related saml_idp PR: https://github.com/18F/saml_idp/pull/102

question: Should I be feature flagging this change in the Gemfile? It *shouldn't* break any working implementations, but after this past week's incident I'm a bit wary.