### PR TITLE
Remove unused reported_fraud_at column from account_reset_requests

### DIFF
--- a/app/models/account_reset_request.rb
+++ b/app/models/account_reset_request.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class AccountResetRequest < ApplicationRecord
-  self.ignored_columns = %w[reported_fraud_at]
-
   belongs_to :user
   # rubocop:disable Rails/InverseOf
   belongs_to :requesting_service_provider,

--- a/db/primary_migrate/20240531175935_drop_reported_fraud_at_from_account_reset_requests.rb
+++ b/db/primary_migrate/20240531175935_drop_reported_fraud_at_from_account_reset_requests.rb
@@ -1,0 +1,7 @@
+class DropReportedFraudAtFromAccountResetRequests < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :account_reset_requests, :reported_fraud_at, :datetime, precision: nil
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_02_192930) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_31_175935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -22,7 +22,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_02_192930) do
     t.datetime "requested_at", precision: nil
     t.string "request_token"
     t.datetime "cancelled_at", precision: nil
-    t.datetime "reported_fraud_at", precision: nil
     t.datetime "granted_at", precision: nil
     t.string "granted_token"
     t.datetime "created_at", precision: nil, null: false


### PR DESCRIPTION
## 🛠 Summary of changes

Drops the `reported_fraud_at` column from the `account_reset_requests` database table.

This was last used and marked ignored in #2528, but the field was never dropped from the database.

## 📜 Testing Plan

Verify that migration applies cleanly (`rails db:migrate`) and the application runs without errors.