### PR TITLE
Remove sp_request_requested_attributes from completion events

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -84,7 +84,6 @@ module SignUp
         ialmax: resolved_authn_context_result.ialmax?,
         service_provider_name: decorated_sp_session.sp_name,
         sp_session_requested_attributes: sp_session[:requested_attributes],
-        sp_request_requested_attributes: service_provider_request.requested_attributes,
         page_occurence: page_occurence,
         in_account_creation_flow: user_session[:in_account_creation_flow] || false,
         needs_completion_screen_reason: needs_completion_screen_reason,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5219,7 +5219,6 @@ module AnalyticsEvents
   # @param ['new_sp','new_attributes','reverified_after_consent'] needs_completion_screen_reason The
   # reason for the consent screen being shown
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation
-  # @param [Array] sp_request_requested_attributes Attributes requested by the service provider
   # @param [Array] sp_session_requested_attributes Attributes requested by the service provider
   def user_registration_agency_handoff_page_visit(
       ial2:,
@@ -5228,7 +5227,6 @@ module AnalyticsEvents
       needs_completion_screen_reason:,
       in_account_creation_flow:,
       sp_session_requested_attributes:,
-      sp_request_requested_attributes: nil,
       ialmax: nil,
       **extra
     )
@@ -5240,7 +5238,6 @@ module AnalyticsEvents
       page_occurence:,
       needs_completion_screen_reason:,
       in_account_creation_flow:,
-      sp_request_requested_attributes:,
       sp_session_requested_attributes:,
       **extra,
     )
@@ -5263,7 +5260,6 @@ module AnalyticsEvents
   # @param ['account-page','agency-page'] page_occurence Where the user concluded registration
   # @param ['new_sp','new_attributes','reverified_after_consent'] needs_completion_screen_reason The
   # reason for the consent screen being shown
-  # @param [Array] sp_request_requested_attributes Attributes requested by the service provider
   # @param [Array] sp_session_requested_attributes Attributes requested by the service provider
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation flow
   # @param [String, nil] disposable_email_domain Disposable email domain used for registration
@@ -5274,7 +5270,6 @@ module AnalyticsEvents
     in_account_creation_flow:,
     needs_completion_screen_reason:,
     sp_session_requested_attributes:,
-    sp_request_requested_attributes: nil,
     ialmax: nil,
     disposable_email_domain: nil,
     **extra
@@ -5287,7 +5282,6 @@ module AnalyticsEvents
       page_occurence:,
       in_account_creation_flow:,
       needs_completion_screen_reason:,
-      sp_request_requested_attributes:,
       sp_session_requested_attributes:,
       disposable_email_domain:,
       **extra,

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe SignUp::CompletionsController do
             service_provider_name: subject.decorated_sp_session.sp_name,
             page_occurence: '',
             needs_completion_screen_reason: :new_sp,
-            sp_request_requested_attributes: nil,
             sp_session_requested_attributes: [:email],
             in_account_creation_flow: false,
           )
@@ -85,7 +84,6 @@ RSpec.describe SignUp::CompletionsController do
             service_provider_name: subject.decorated_sp_session.sp_name,
             page_occurence: '',
             needs_completion_screen_reason: :new_sp,
-            sp_request_requested_attributes: nil,
             sp_session_requested_attributes: [:email],
             in_account_creation_flow: false,
           )
@@ -132,7 +130,6 @@ RSpec.describe SignUp::CompletionsController do
             service_provider_name: subject.decorated_sp_session.sp_name,
             page_occurence: '',
             needs_completion_screen_reason: :new_sp,
-            sp_request_requested_attributes: nil,
             sp_session_requested_attributes: [:email],
             in_account_creation_flow: false,
           )
@@ -236,7 +233,6 @@ RSpec.describe SignUp::CompletionsController do
           service_provider_name: subject.decorated_sp_session.sp_name,
           page_occurence: 'agency-page',
           needs_completion_screen_reason: :new_sp,
-          sp_request_requested_attributes: nil,
           sp_session_requested_attributes: nil,
           in_account_creation_flow: true,
           disposable_email_domain: nil,
@@ -297,7 +293,6 @@ RSpec.describe SignUp::CompletionsController do
             service_provider_name: subject.decorated_sp_session.sp_name,
             page_occurence: 'agency-page',
             needs_completion_screen_reason: :new_sp,
-            sp_request_requested_attributes: nil,
             sp_session_requested_attributes: nil,
             in_account_creation_flow: true,
             disposable_email_domain: 'temporary.com',
@@ -334,7 +329,6 @@ RSpec.describe SignUp::CompletionsController do
           service_provider_name: subject.decorated_sp_session.sp_name,
           page_occurence: 'agency-page',
           needs_completion_screen_reason: :new_sp,
-          sp_request_requested_attributes: nil,
           sp_session_requested_attributes: ['email'],
           in_account_creation_flow: true,
           disposable_email_domain: 'temporary.com',


### PR DESCRIPTION
## 🛠 Summary of changes

Removes `sp_request_requested_attributes` from `'User registration: complete'` and `'User registration: agency handoff visited'` analytics events.

These values are never assigned (see https://github.com/18F/identity-idp/pull/10736#discussion_r1622830805), and are prone to confusion with the `sp_session_requested_attributes` analytics property.

Previous discussion: https://github.com/18F/identity-idp/pull/10736#discussion_r1622793203

## 📜 Testing Plan

Verify that this property is never logged in production analytics.