### PR TITLE
Fix logout confirmation page not shown on OIDC POST

### DIFF
--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -34,7 +34,7 @@ module OpenidConnect
     # @see {OpenID Connect RP-Initiated Logout 1.0 Specification}[https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout] # rubocop:disable Layout/LineLength
     def create
       session[:original_method] = request.method.to_s
-      redirect_to action: :show, **logout_params
+      redirect_to action: :show, status: :see_other, **logout_params
     end
 
     # Sign out without confirmation


### PR DESCRIPTION
* Send back a `303 See Other` for redirect to GET `/openid_connect/logout` route as explained by https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303 and https://www.rfc-editor.org/rfc/rfc9110#status.303

changelog: Bug Fixes, Routing, Do not skip logout confirmation on POST for OIDC

<!-- Uncomment and update the sections you need for your PR! -->


<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
