### PR TITLE
LG-13382: Don't add SP costs again if worker already did it

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -336,6 +336,8 @@ module Idv
     end
 
     def add_proofing_costs(results)
+      return if results[:context][:sp_costs_added]
+
       results[:context][:stages].each do |stage, hash|
         if stage == :resolution
           # transaction_id comes from ConversationId

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -481,4 +481,43 @@ RSpec.describe Idv::VerifyInfoController, allowed_extra_analytics: [:*] do
       end
     end
   end
+
+  describe '#add_proofing_costs' do
+    let(:sp_costs_added) { nil }
+    let(:result) do
+      {
+        context: {
+          sp_costs_added:,
+          stages: {
+            resolution: {
+              transaction_id: 'ABCD1234',
+            },
+            residential_address: {
+              vendor_name: 'ResidentialAddressNotRequired',
+            },
+            state_id: {
+              transaction_id: 'EFGH5678',
+            },
+            threatmetrix: {
+              transaction_id: 'IJKL9012',
+            },
+          },
+        },
+      }
+    end
+
+    it 'adds proofing costs' do
+      expect(subject).to receive(:add_cost).exactly(3).times
+      subject.send(:add_proofing_costs, result)
+    end
+
+    context 'when proofing costs have already been added' do
+      let(:sp_costs_added) { true }
+
+      it 'does not add proofing costs' do
+        expect(subject).not_to receive(:add_cost)
+        subject.send(:add_proofing_costs, result)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13382](https://cm-jira.usa.gov/browse/LG-13382)

## 🛠 Summary of changes

We'd like to move SP cost tracking out of VerifyInfoConcern and into the background job. To handle the 50/50 state, we need to make sure that VIC is not doing SP cost tracking if the worker already did.

A future PR will add SP cost tracking to the worker and will ensure that `sp_costs_added` is set on the resolution result.
