### PR TITLE
Remove unnecessary allowed_extra_analytics in accessibility specs

### DIFF
--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 require 'axe-rspec'
 
-RSpec.feature 'Accessibility on pages that require authentication', :js,
-              allowed_extra_analytics: [:*] do
+RSpec.feature 'Accessibility on pages that require authentication', :js do
   scenario 'user registration page' do
     email = 'test@example.com'
     sign_up_with(email)


### PR DESCRIPTION
## 🛠 Summary of changes

Removes an unnecessary `alowed_extra_analytics` from `spec/features/accessibility/user_pages_spec.rb`.

This can occasionally cause builds to fail in unrelated pull requests, see https://github.com/18F/identity-idp/pull/10740#issuecomment-2145141042.

I'm still not totally positive what's causing this. My leading theory is what was mentioned in #10730 about parallelizing across runners, where the checks running `after(:all)` may not accurately assess if a spec file is split across runners. Without an obvious solution, I'm inclined to push forward to work toward continuing to eliminate all (most) `allowed_extra_analytics`. These false negatives are a mild inconvenience with a one-time fix in each instance.

## 📜 Testing Plan

Verify that build passes.