### PR TITLE
LG-13352 fixed bug where new_unique_users_year_unknown columns were n…

### DIFF
--- a/app/jobs/reports/combined_invoice_supplement_report_v2.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report_v2.rb
@@ -103,7 +103,7 @@ module Reports
           'partner_ial2_new_unique_users_year4',
           'partner_ial2_new_unique_users_year5',
           'partner_ial2_new_unique_users_year_greater_than_5',
-          'partner_ial2_new_unique_users_year_unknown',
+          'partner_ial2_new_unique_users_unknown',
 
           'issuer_ial1_total_auth_count',
           'issuer_ial2_total_auth_count',
@@ -118,7 +118,7 @@ module Reports
           'issuer_ial2_new_unique_users_year4',
           'issuer_ial2_new_unique_users_year5',
           'issuer_ial2_new_unique_users_year_greater_than_5',
-          'issuer_ial2_new_unique_users_year_unknown',
+          'issuer_ial2_new_unique_users_unknown',
         ]
         by_issuer_iaa_issuer_year_months.each do |iaa_key, issuer_year_months|
           issuer_year_months.each do |issuer, year_months_data|
@@ -161,7 +161,7 @@ module Reports
                 partner_results[:partner_ial2_new_unique_users_year4] || 0,
                 partner_results[:partner_ial2_new_unique_users_year5] || 0,
                 partner_results[:partner_ial2_new_unique_users_year_greater_than_5] || 0,
-                partner_results[:partner_ial2_new_unique_users_year_unknown] || 0,
+                partner_results[:partner_ial2_new_unique_users_unknown] || 0,
 
                 (ial1_total_auth_count = extract(issuer_results, :total_auth_count, ial: 1)),
                 (ial2_total_auth_count = extract(issuer_results, :total_auth_count, ial: 2)),
@@ -176,7 +176,7 @@ module Reports
                 issuer_profile_age_results[:partner_ial2_new_unique_users_year4] || 0,
                 issuer_profile_age_results[:partner_ial2_new_unique_users_year5] || 0,
                 issuer_profile_age_results[:partner_ial2_new_unique_users_year_greater_than_5] || 0,
-                issuer_profile_age_results[:partner_ial2_new_unique_users_year_unknown] || 0,
+                issuer_profile_age_results[:partner_ial2_new_unique_users_unknown] || 0,
               ]
             end
           end

--- a/spec/jobs/reports/combined_invoice_supplement_report_v2_spec.rb
+++ b/spec/jobs/reports/combined_invoice_supplement_report_v2_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
       let(:user1) { create(:user) }
       let(:user2) { create(:user) }
       let(:user3) { create(:user) }
+      let(:user4) { create(:user) }
 
       before do
         iaa_order1.integrations << build_integration(
@@ -142,6 +143,18 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
             billable: true,
           )
         end
+
+        # 1 unique user in month 1 at IAA 2 sp 1 @ IAL 2 with profile age unknown
+        create(
+          :sp_return_log,
+          user_id: user4.id,
+          ial: 2,
+          issuer: iaa2_sp1.issuer,
+          requested_at: inside_iaa2,
+          returned_at: inside_iaa2,
+          profile_verified_at: nil,
+          billable: true,
+        )
       end
 
       it 'generates a report by iaa + order number and issuer and year month' do
@@ -171,7 +184,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
           expect(row['partner_ial2_new_unique_users_year4'].to_i).to eq(0)
           expect(row['partner_ial2_new_unique_users_year5'].to_i).to eq(0)
           expect(row['partner_ial2_new_unique_users_year_greater_than_5'].to_i).to eq(0)
-          expect(row['partner_ial2_new_unique_users_year_unknown'].to_i).to eq(0)
+          expect(row['partner_ial2_new_unique_users_unknown'].to_i).to eq(0)
 
           expect(row['issuer_ial1_total_auth_count'].to_i).to eq(1)
           expect(row['issuer_ial2_total_auth_count'].to_i).to eq(0)
@@ -186,7 +199,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
           expect(row['issuer_ial2_new_unique_users_year4'].to_i).to eq(0)
           expect(row['issuer_ial2_new_unique_users_year5'].to_i).to eq(0)
           expect(row['issuer_ial2_new_unique_users_year_greater_than_5'].to_i).to eq(0)
-          expect(row['issuer_ial2_new_unique_users_year_unknown'].to_i).to eq(0)
+          expect(row['issuer_ial2_new_unique_users_unknown'].to_i).to eq(0)
         end
 
         aggregate_failures do
@@ -204,30 +217,30 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
           expect(row['year_month_readable']).to eq('September 2020')
 
           expect(row['iaa_ial1_unique_users'].to_i).to eq(0)
-          expect(row['iaa_ial2_unique_users'].to_i).to eq(3)
-          expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(3)
+          expect(row['iaa_ial2_unique_users'].to_i).to eq(4)
+          expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(4)
           expect(row['partner_ial2_new_unique_users_year1'].to_i).to eq(1)
           expect(row['partner_ial2_new_unique_users_year2'].to_i).to eq(2)
           expect(row['partner_ial2_new_unique_users_year3'].to_i).to eq(0)
           expect(row['partner_ial2_new_unique_users_year4'].to_i).to eq(0)
           expect(row['partner_ial2_new_unique_users_year5'].to_i).to eq(0)
           expect(row['partner_ial2_new_unique_users_year_greater_than_5'].to_i).to eq(0)
-          expect(row['partner_ial2_new_unique_users_year_unknown'].to_i).to eq(0)
+          expect(row['partner_ial2_new_unique_users_unknown'].to_i).to eq(1)
 
           expect(row['issuer_ial1_total_auth_count'].to_i).to eq(0)
-          expect(row['issuer_ial2_total_auth_count'].to_i).to eq(1)
-          expect(row['issuer_ial1_plus_2_total_auth_count'].to_i).to eq(1)
+          expect(row['issuer_ial2_total_auth_count'].to_i).to eq(2)
+          expect(row['issuer_ial1_plus_2_total_auth_count'].to_i).to eq(2)
 
           expect(row['issuer_ial1_unique_users'].to_i).to eq(0)
-          expect(row['issuer_ial2_unique_users'].to_i).to eq(1)
-          expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(1)
+          expect(row['issuer_ial2_unique_users'].to_i).to eq(2)
+          expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(2)
           expect(row['issuer_ial2_new_unique_users_year1'].to_i).to eq(1)
           expect(row['issuer_ial2_new_unique_users_year2'].to_i).to eq(0)
           expect(row['issuer_ial2_new_unique_users_year3'].to_i).to eq(0)
           expect(row['issuer_ial2_new_unique_users_year4'].to_i).to eq(0)
           expect(row['issuer_ial2_new_unique_users_year5'].to_i).to eq(0)
           expect(row['issuer_ial2_new_unique_users_year_greater_than_5'].to_i).to eq(0)
-          expect(row['issuer_ial2_new_unique_users_year_unknown'].to_i).to eq(0)
+          expect(row['issuer_ial2_new_unique_users_unknown'].to_i).to eq(1)
         end
 
         aggregate_failures do
@@ -245,15 +258,15 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
           expect(row['year_month_readable']).to eq('September 2020')
 
           expect(row['iaa_ial1_unique_users'].to_i).to eq(0)
-          expect(row['iaa_ial2_unique_users'].to_i).to eq(3)
-          expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(3)
+          expect(row['iaa_ial2_unique_users'].to_i).to eq(4)
+          expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(4)
           expect(row['partner_ial2_new_unique_users_year1'].to_i).to eq(1)
           expect(row['partner_ial2_new_unique_users_year2'].to_i).to eq(2)
           expect(row['partner_ial2_new_unique_users_year3'].to_i).to eq(0)
           expect(row['partner_ial2_new_unique_users_year4'].to_i).to eq(0)
           expect(row['partner_ial2_new_unique_users_year5'].to_i).to eq(0)
           expect(row['partner_ial2_new_unique_users_year_greater_than_5'].to_i).to eq(0)
-          expect(row['partner_ial2_new_unique_users_year_unknown'].to_i).to eq(0)
+          expect(row['partner_ial2_new_unique_users_unknown'].to_i).to eq(1)
 
           expect(row['issuer_ial1_total_auth_count'].to_i).to eq(0)
           expect(row['issuer_ial2_total_auth_count'].to_i).to eq(2)
@@ -268,7 +281,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
           expect(row['issuer_ial2_new_unique_users_year4'].to_i).to eq(0)
           expect(row['issuer_ial2_new_unique_users_year5'].to_i).to eq(0)
           expect(row['issuer_ial2_new_unique_users_year_greater_than_5'].to_i).to eq(0)
-          expect(row['issuer_ial2_new_unique_users_year_unknown'].to_i).to eq(0)
+          expect(row['issuer_ial2_new_unique_users_unknown'].to_i).to eq(0)
         end
       end
     end


### PR DESCRIPTION
changelog: Internal, Reporting, Fixed a bug where the new_unique_users_unknown column were not properly populating the numbers



 🎫 Ticket

Link to the relevant ticket:
[LG-13352](https://cm-jira.usa.gov/browse/LG-13352)

🛠 Summary of changes

Fixed a bug where the new_unique_users_unknown was not properly populating the numbers
The bug is not present in the main helper function but the addressing between the helper function and the report was incorrect. Plan to address any automated test vulnerabilities with the report in a new ticket despite potential redundancy
Added unit tests to make sure this bug does not show up again unaddressed
