### PR TITLE
LG-13383 Stop passing UUID and UUID prefix to `Idv::Agent`

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -24,13 +24,7 @@ module Idv
 
       idv_session.verify_info_step_document_capture_session_uuid = document_capture_session.uuid
 
-      # proof_resolution job expects these values
-      agent_pii = pii.merge(
-        uuid: current_user.uuid,
-        uuid_prefix: ServiceProvider.find_by(issuer: sp_session[:issuer])&.app_id,
-        ssn: idv_session.ssn,
-      )
-      Idv::Agent.new(agent_pii).proof_resolution(
+      Idv::Agent.new(pii).proof_resolution(
         document_capture_session,
         should_proof_state_id: aamva_state?,
         trace_id: amzn_trace_id,

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -74,7 +74,7 @@ module Idv
       end
 
       def pii
-        user_session.dig('idv/in_person', :pii_from_user)
+        user_session.dig('idv/in_person', :pii_from_user).merge(ssn: idv_session.ssn)
       end
 
       # override IdvSessionConcern

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -79,7 +79,8 @@ module Idv
 
     def pii
       idv_session.pii_from_doc.to_h.merge(
-        idv_session.updated_user_address.to_h,
+        ssn: idv_session.ssn,
+        **idv_session.updated_user_address.to_h,
       ).with_indifferent_access
     end
   end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -359,8 +359,8 @@ RSpec.describe Idv::VerifyInfoController, allowed_extra_analytics: [:*] do
 
       expect(Idv::Agent).to receive(:new).with(
         hash_including(
-          uuid_prefix: app_id,
-          uuid: user.uuid,
+          ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+          **Idp::Constants::MOCK_IDV_APPLICANT,
         ),
       ).and_call_original
 

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Idv::Agent do
       context 'proofing state_id enabled' do
         it 'does not proof state_id if resolution fails' do
           agent = Idv::Agent.new(
-            Idp::Constants::MOCK_IDV_APPLICANT.merge(uuid: user.uuid, ssn: '444-55-6666'),
+            Idp::Constants::MOCK_IDV_APPLICANT.merge(ssn: '444-55-6666'),
           )
           agent.proof_resolution(
             document_capture_session,
@@ -51,7 +51,7 @@ RSpec.describe Idv::Agent do
         end
 
         it 'does proof state_id if resolution succeeds' do
-          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(uuid: user.uuid))
+          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN)
           agent.proof_resolution(
             document_capture_session,
             should_proof_state_id: true,
@@ -76,7 +76,7 @@ RSpec.describe Idv::Agent do
       context 'proofing state_id disabled' do
         it 'does not proof state_id if resolution fails' do
           agent = Idv::Agent.new(
-            Idp::Constants::MOCK_IDV_APPLICANT.merge(uuid: user.uuid, ssn: '444-55-6666'),
+            Idp::Constants::MOCK_IDV_APPLICANT.merge(ssn: '444-55-6666'),
           )
           agent.proof_resolution(
             document_capture_session,
@@ -93,7 +93,7 @@ RSpec.describe Idv::Agent do
         end
 
         it 'does not proof state_id if resolution succeeds' do
-          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(uuid: user.uuid))
+          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN)
           agent.proof_resolution(
             document_capture_session,
             should_proof_state_id: false,
@@ -113,7 +113,7 @@ RSpec.describe Idv::Agent do
 
         it 'returns a successful result if SSN does not start with 900 but is in SSN allowlist' do
           agent = Idv::Agent.new(
-            Idp::Constants::MOCK_IDV_APPLICANT.merge(uuid: user.uuid, ssn: '999-99-9999'),
+            Idp::Constants::MOCK_IDV_APPLICANT.merge(ssn: '999-99-9999'),
           )
 
           agent.proof_resolution(
@@ -137,7 +137,7 @@ RSpec.describe Idv::Agent do
         issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
         document_capture_session.update!(issuer: issuer)
         agent = Idv::Agent.new(
-          Idp::Constants::MOCK_IDV_APPLICANT.merge(uuid: user.uuid, ssn: '999-99-9999'),
+          Idp::Constants::MOCK_IDV_APPLICANT.merge(ssn: '999-99-9999'),
         )
 
         expect(ResolutionProofingJob).to receive(:perform_later).with(
@@ -159,10 +159,7 @@ RSpec.describe Idv::Agent do
 
       it 'returns an unsuccessful result and notifies exception trackers if an exception occurs' do
         agent = Idv::Agent.new(
-          Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
-            uuid: user.uuid,
-            first_name: 'Time Exception',
-          ),
+          Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(first_name: 'Time Exception'),
         )
 
         agent.proof_resolution(
@@ -187,8 +184,7 @@ RSpec.describe Idv::Agent do
         let(:ipp_enrollment_in_progress) { true }
 
         it 'returns a successful result if resolution passes' do
-          addr = Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS
-          agent = Idv::Agent.new(addr.merge(uuid: user.uuid))
+          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS)
           agent.proof_resolution(
             document_capture_session,
             should_proof_state_id: true,
@@ -217,7 +213,6 @@ RSpec.describe Idv::Agent do
 
       it 'proofs addresses successfully with valid information' do
         agent = Idv::Agent.new(
-          uuid: SecureRandom.uuid,
           first_name: 'Fakey',
           last_name: 'Fakersgerald',
           dob: 50.years.ago.to_date.to_s,


### PR DESCRIPTION
In #10728 we started passing the service provider ID to the resolution proofing job. Since the job has the user ID this allows us to compute UUID and UUID prefix in the job instead of having to pass them through the applicant. Once that commit is deployed we can stop passing the UUID and UUID prefix via the applicant.

This commit removes the code that looks up the UUID prefix and UUID and merges them into the applicant. This should not be merged until #10728 is fully deployed to production.
