### PR TITLE
Rename the `Pb` vector to be the IAL2 conformant vector

### DIFF
--- a/app/services/vot/supported_component_values.rb
+++ b/app/services/vot/supported_component_values.rb
@@ -34,7 +34,7 @@ module Vot
     ).freeze
     Pb = ComponentValue.new(
       name: 'Pb',
-      description: 'A biometric comparison is required as part of identity proofing',
+      description: 'IAL2 features are enabled (experimental)',
       implied_component_values: ['P1'],
       requirements: [:biometric_comparison],
     ).freeze


### PR DESCRIPTION
Initially the `Pb` vector was intended to be the "biometric comparison" vector with other vectors building out the IAL2 conformant features set. Per [this slack thread](https://gsa-tts.slack.com/archives/C07152J9ACT/p1717094341824729) that is no longer the direction we are pursuing. This vector will describe IAL2 conformance and requirements will be added to the requirement set.
