### PR TITLE
LG-13233: add sponsor_id to in_person_enrollments model

### DIFF
--- a/db/primary_migrate/20240604173515_add_sponsor_id_to_in_person_enrollment.rb
+++ b/db/primary_migrate/20240604173515_add_sponsor_id_to_in_person_enrollment.rb
@@ -1,0 +1,5 @@
+class AddSponsorIdToInPersonEnrollment < ActiveRecord::Migration[7.1]
+  def change
+    add_column :in_person_enrollments, :sponsor_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -318,7 +318,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_173515) do
     t.boolean "ready_for_status_check", default: false
     t.datetime "notification_sent_at", comment: "The time a notification was sent"
     t.datetime "last_batch_claimed_at"
-    t.string "sponsor_id"
+    t.string "sponsor_id", comment: "The identification number for USPS to recognize us and our flow (ex: Enhanced IPP)"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["ready_for_status_check"], name: "index_in_person_enrollments_on_ready_for_status_check", where: "(ready_for_status_check = true)"
     t.index ["status_check_attempted_at"], name: "index_in_person_enrollments_on_status_check_attempted_at", where: "(status = 1)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_31_175935) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_04_173515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -318,6 +318,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_175935) do
     t.boolean "ready_for_status_check", default: false
     t.datetime "notification_sent_at", comment: "The time a notification was sent"
     t.datetime "last_batch_claimed_at"
+    t.string "sponsor_id"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["ready_for_status_check"], name: "index_in_person_enrollments_on_ready_for_status_check", where: "(ready_for_status_check = true)"
     t.index ["status_check_attempted_at"], name: "index_in_person_enrollments_on_status_check_attempted_at", where: "(status = 1)"


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13233](https://cm-jira.usa.gov/browse/LG-13233)


## 🛠 Summary of changes

As a part of the Enhanced IPP effort, we'll need a way to check whether an enrollment was created during the Enhanced IPP flow during the background jobs. Adding the `sponsor_id` to the enrollment model will allow us to derive whether the flow - sponsor_id == usps_ipp_sponsor_id means Enhanced IPP

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Run pending migration
- [ ] Verify sponsor_id is an attribute on the `in_person_enrollments`