### PR TITLE
Validate unnecessary exempted files in TypeScript enforcement

### DIFF
--- a/scripts/enforce-typescript-files.mjs
+++ b/scripts/enforce-typescript-files.mjs
@@ -61,7 +61,6 @@ const LEGACY_FILE_EXCEPTIONS = [
   'spec/javascript/packages/document-capture/context/acuant-spec.jsx',
   'spec/javascript/packages/document-capture/context/device-spec.jsx',
   'spec/javascript/packages/document-capture/context/failed-capture-attempts-spec.jsx',
-  'spec/javascript/packages/document-capture/context/feature-flag-spec.jsx',
   'spec/javascript/packages/document-capture/context/file-base64-cache-spec.js',
   'spec/javascript/packages/document-capture/context/index-spec.js',
   'spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx',
@@ -83,15 +82,24 @@ const packagesWithEntrypoints = await glob('app/javascript/packages/*/package.js
 
 const jsFiles = await glob(
   ['app/{javascript/packages,components}/**/*.{js,jsx}', 'spec/javascript/*/**/*.{js,jsx}'],
-  {
-    ignore: [...packagesWithEntrypoints.map((path) => join(path, '**')), ...LEGACY_FILE_EXCEPTIONS],
-  },
+  { ignore: [...packagesWithEntrypoints.map((path) => join(path, '**'))] },
 );
 
+const invalidExceptions = LEGACY_FILE_EXCEPTIONS.filter((file) => !jsFiles.includes(file));
+
 assert(
-  !jsFiles.length,
+  !invalidExceptions.length,
+  `Unnecessary exception should be removed from LEGACY_FILE_EXCEPTIONS allowlist.
+
+Found ${JSON.stringify(invalidExceptions)}`,
+);
+
+const unexpectedJSFiles = jsFiles.filter((file) => !LEGACY_FILE_EXCEPTIONS.includes(file));
+
+assert(
+  !unexpectedJSFiles.length,
   `All new JavaScript files should be written with TypeScript extensions (.ts, .tsx).
 
-Found ${JSON.stringify(jsFiles)}
+Found ${JSON.stringify(unexpectedJSFiles)}
 `,
 );


### PR DESCRIPTION
## 🛠 Summary of changes

Enhances the TypeScript enforcement script `scripts/enforce-typescript-files.mjs` to check the `LEGACY_FILE_EXCEPTIONS` allowlist for unnecessary exceptions.

This helps ensure that the exceptions file is an actionable set of the remaining files to be ported.

## 📜 Testing Plan

Verify that the script exits without error:

1. `scripts/enforce-typescript-files.mjs`
2. `echo $?` (should output `0`)

(Optional) Verify that adding back `'spec/javascript/packages/document-capture/context/feature-flag-spec.jsx'` and re-running the steps above results in an error, including error message and non-zero exit code.