### PR TITLE
LG-11285: Reset the callback property descriptor on cleanup of useEffect.

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -13,16 +13,13 @@ import AcuantContext from '../context/acuant';
  * @param {(nextValue: any) => void} onChangeCallback Callback to trigger on change.
  */
 export function defineObservableProperty(object, property, onChangeCallback) {
-  console.log('      defineObservableProperty');
   let currentValue;
 
   Object.defineProperty(object, property, {
     get() {
-      console.log('        get');
       return currentValue;
     },
     set(nextValue) {
-      console.log('        set');
       currentValue = nextValue;
       onChangeCallback(nextValue);
     },
@@ -39,7 +36,6 @@ export function defineObservableProperty(object, property, onChangeCallback) {
  * @param {any} originalDescriptor The descriptor to reset the property with.
  */
 export function resetObservableProperty(object, property, originalDescriptor) {
-  console.log('      resetObservableProperty');
   if (originalDescriptor !== undefined) {
     Object.defineProperty(object, property, originalDescriptor);
   } else {
@@ -48,28 +44,23 @@ export function resetObservableProperty(object, property, originalDescriptor) {
 }
 
 function AcuantCaptureCanvas() {
-  console.log('AcuantCaptureCanvas');
   const { isReady, acuantCaptureMode, setAcuantCaptureMode } = useContext(AcuantContext);
   const { t } = useI18n();
   const cameraRef = useRef(/** @type {HTMLDivElement?} */ (null));
 
   useEffect(() => {
-    console.log('  useEffect');
     let canvas;
     let originalDescriptor;
 
     function onAcuantCameraCreated() {
-      console.log('    onAcuantCameraCreated');
       canvas = document.getElementById('acuant-ui-canvas');
       if (originalDescriptor === undefined) {
         originalDescriptor = Object.getOwnPropertyDescriptor(canvas, 'callback');
       }
-      console.log('    - originalDescriptor: ', originalDescriptor);
 
       // Acuant SDK assigns a callback property to the canvas when it switches to its "Tap to
       // Capture" mode (Acuant SDK v11.4.4, L158). Infer capture type by presence of the property.
       defineObservableProperty(canvas, 'callback', (callback) => {
-        console.log('          callback');
         setAcuantCaptureMode(callback ? 'TAP' : 'AUTO');
       });
     }

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -13,13 +13,16 @@ import AcuantContext from '../context/acuant';
  * @param {(nextValue: any) => void} onChangeCallback Callback to trigger on change.
  */
 export function defineObservableProperty(object, property, onChangeCallback) {
+  console.log('      defineObservableProperty');
   let currentValue;
 
   Object.defineProperty(object, property, {
     get() {
+      console.log('        get');
       return currentValue;
     },
     set(nextValue) {
+      console.log('        set');
       currentValue = nextValue;
       onChangeCallback(nextValue);
     },
@@ -36,6 +39,7 @@ export function defineObservableProperty(object, property, onChangeCallback) {
  * @param {any} originalDescriptor The descriptor to reset the property with.
  */
 export function resetObservableProperty(object, property, originalDescriptor) {
+  console.log('      resetObservableProperty');
   if (originalDescriptor !== undefined) {
     Object.defineProperty(object, property, originalDescriptor);
   } else {
@@ -44,23 +48,28 @@ export function resetObservableProperty(object, property, originalDescriptor) {
 }
 
 function AcuantCaptureCanvas() {
+  console.log('AcuantCaptureCanvas');
   const { isReady, acuantCaptureMode, setAcuantCaptureMode } = useContext(AcuantContext);
   const { t } = useI18n();
   const cameraRef = useRef(/** @type {HTMLDivElement?} */ (null));
 
   useEffect(() => {
+    console.log('  useEffect');
     let canvas;
     let originalDescriptor;
 
     function onAcuantCameraCreated() {
+      console.log('    onAcuantCameraCreated');
       canvas = document.getElementById('acuant-ui-canvas');
       if (originalDescriptor === undefined) {
         originalDescriptor = Object.getOwnPropertyDescriptor(canvas, 'callback');
       }
+      console.log('    - originalDescriptor: ', originalDescriptor);
 
       // Acuant SDK assigns a callback property to the canvas when it switches to its "Tap to
       // Capture" mode (Acuant SDK v11.4.4, L158). Infer capture type by presence of the property.
       defineObservableProperty(canvas, 'callback', (callback) => {
+        console.log('          callback');
         setAcuantCaptureMode(callback ? 'TAP' : 'AUTO');
       });
     }

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -27,22 +27,39 @@ export function defineObservableProperty(object, property, onChangeCallback) {
   });
 }
 
+/**
+ * Resets a property on the given object, applying the originalDescriptor, if provided,
+ * or deleting the property entirely if not.
+ *
+ * @param {any} object Object on which to define property.
+ * @param {string} property Property name to observe.
+ * @param {any} originalDescriptor The descriptor to reset the property with.
+ */
+export function resetObservableProperty(object, property, originalDescriptor) {
+  if (originalDescriptor !== undefined) {
+    Object.defineProperty(object, property, originalDescriptor);
+  } else {
+    delete object[property];
+  }
+}
+
 function AcuantCaptureCanvas() {
   const { isReady, acuantCaptureMode, setAcuantCaptureMode } = useContext(AcuantContext);
   const { t } = useI18n();
   const cameraRef = useRef(/** @type {HTMLDivElement?} */ (null));
 
   useEffect(() => {
-    let originalDescriptor;
     let canvas;
+    let originalDescriptor;
 
     function onAcuantCameraCreated() {
       canvas = document.getElementById('acuant-ui-canvas');
-      // Acuant SDK assigns a callback property to the canvas when it switches to its "Tap to
-      // Capture" mode (Acuant SDK v11.4.4, L158). Infer capture type by presence of the property.
       if (originalDescriptor === undefined) {
         originalDescriptor = Object.getOwnPropertyDescriptor(canvas, 'callback');
       }
+
+      // Acuant SDK assigns a callback property to the canvas when it switches to its "Tap to
+      // Capture" mode (Acuant SDK v11.4.4, L158). Infer capture type by presence of the property.
       defineObservableProperty(canvas, 'callback', (callback) => {
         setAcuantCaptureMode(callback ? 'TAP' : 'AUTO');
       });
@@ -51,11 +68,7 @@ function AcuantCaptureCanvas() {
     cameraRef.current?.addEventListener('acuantcameracreated', onAcuantCameraCreated);
     return () => {
       cameraRef.current?.removeEventListener('acuantcameracreated', onAcuantCameraCreated);
-      if (originalDescriptor !== undefined) {
-        Object.defineProperty(canvas, 'callback', originalDescriptor);
-      } else {
-        delete canvas?.callback;
-      }
+      resetObservableProperty(canvas, 'callback', originalDescriptor);
     };
   }, []);
 

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -36,6 +36,10 @@ export function defineObservableProperty(object, property, onChangeCallback) {
  * @param {any} originalDescriptor The descriptor to reset the property with.
  */
 export function resetObservableProperty(object, property, originalDescriptor) {
+  if (object === undefined) {
+    return;
+  }
+
   if (originalDescriptor !== undefined) {
     Object.defineProperty(object, property, originalDescriptor);
   } else {

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -13,6 +13,10 @@ import AcuantContext from '../context/acuant';
  * @param {(nextValue: any) => void} onChangeCallback Callback to trigger on change.
  */
 export function defineObservableProperty(object, property, onChangeCallback) {
+  if (Object.hasOwn(object, property)) {
+    return;
+  }
+
   let currentValue;
 
   Object.defineProperty(object, property, {

--- a/app/javascript/packages/document-capture/higher-order/observable-property.tsx
+++ b/app/javascript/packages/document-capture/higher-order/observable-property.tsx
@@ -1,0 +1,39 @@
+/**
+ * Defines a property on the given object, calling the change callback when that property is set to
+ * a new value.
+ *
+ * @param object Object on which to define property.
+ * @param property Property name to observe.
+ * @param onChangeCallback Callback to trigger on change.
+ */
+export function defineObservableProperty(
+  object: any,
+  property: string,
+  onChangeCallback: (nextValue: any) => void,
+) {
+  let currentValue: any;
+
+  Object.defineProperty(object, property, {
+    get() {
+      return currentValue;
+    },
+    set(nextValue) {
+      currentValue = nextValue;
+      onChangeCallback(nextValue);
+    },
+    configurable: true,
+  });
+}
+
+/**
+ * Removes an observable property by removing the defined getter/setter methods
+ * and replaces the value with the most recent value.
+ *
+ * @param object Object on which to remove defined property.
+ * @param property Property name to remove observer for
+ */
+export function stopObservingProperty(object: any, property: string) {
+  const currentValue = object[property];
+
+  Object.defineProperty(object, property, { value: currentValue, writable: true });
+}

--- a/spec/javascript/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -26,24 +26,6 @@ describe('document-capture/components/acuant-capture-canvas', () => {
 
       expect(callback).to.have.been.calledOnceWithExactly('value');
     });
-
-    it('ignores the second call if called twice for the same property', () => {
-      const object = {};
-      let callbackOneCalled = false;
-      let callbackTwoCalled = false;
-
-      defineObservableProperty(object, 'key', () => {
-        callbackOneCalled = true;
-      });
-      defineObservableProperty(object, 'key', () => {
-        callbackTwoCalled = true;
-      });
-
-      object.key = 'new value';
-
-      expect(callbackOneCalled).to.equal(true);
-      expect(callbackTwoCalled).to.equal(false);
-    });
   });
 
   it('renders a "take photo" button', async () => {

--- a/spec/javascript/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -26,6 +26,24 @@ describe('document-capture/components/acuant-capture-canvas', () => {
 
       expect(callback).to.have.been.calledOnceWithExactly('value');
     });
+
+    it('ignores the second call if called twice for the same property', () => {
+      const object = {};
+      let callbackOneCalled = false;
+      let callbackTwoCalled = false;
+
+      defineObservableProperty(object, 'key', () => {
+        callbackOneCalled = true;
+      });
+      defineObservableProperty(object, 'key', () => {
+        callbackTwoCalled = true;
+      });
+
+      object.key = 'new value';
+
+      expect(callbackOneCalled).to.equal(true);
+      expect(callbackTwoCalled).to.equal(false);
+    });
   });
 
   it('renders a "take photo" button', async () => {

--- a/spec/javascript/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -1,32 +1,11 @@
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
 import { AcuantContextProvider, DeviceContext } from '@18f/identity-document-capture';
-import AcuantCaptureCanvas, {
-  defineObservableProperty,
-} from '@18f/identity-document-capture/components/acuant-capture-canvas';
+import AcuantCaptureCanvas from '@18f/identity-document-capture/components/acuant-capture-canvas';
 import { render, useAcuant } from '../../../support/document-capture';
 
 describe('document-capture/components/acuant-capture-canvas', () => {
   const { initialize } = useAcuant();
-
-  describe('defineObservableProperty', () => {
-    it('behaves like an object', () => {
-      const object = {};
-      defineObservableProperty(object, 'key', () => {});
-      object.key = 'value';
-
-      expect(object.key).to.equal('value');
-    });
-
-    it('calls the callback on changes, with the changed value', () => {
-      const callback = sinon.spy();
-      const object = {};
-      defineObservableProperty(object, 'key', callback);
-      object.key = 'value';
-
-      expect(callback).to.have.been.calledOnceWithExactly('value');
-    });
-  });
 
   it('renders a "take photo" button', async () => {
     const { getByRole, container } = render(

--- a/spec/javascript/packages/document-capture/higher-order/observable-property-spec.tsx
+++ b/spec/javascript/packages/document-capture/higher-order/observable-property-spec.tsx
@@ -1,0 +1,44 @@
+import sinon from 'sinon';
+import {
+  defineObservableProperty,
+  stopObservingProperty,
+} from '@18f/identity-document-capture/higher-order/observable-property';
+
+describe('document-capture/higher-order/observable-property', () => {
+  describe('defineObservableProperty', () => {
+    it('behaves like an object', () => {
+      const object = {} as { key?: string };
+      defineObservableProperty(object, 'key', () => {});
+      object.key = 'value';
+
+      expect(object.key).to.equal('value');
+    });
+
+    it('calls the callback on changes, with the changed value', () => {
+      const callback = sinon.spy();
+      const object = {} as { key?: string };
+      defineObservableProperty(object, 'key', callback);
+      object.key = 'value';
+
+      expect(callback).to.have.been.calledOnceWithExactly('value');
+    });
+  });
+
+  describe('stopObservingProperty', () => {
+    it('removes the defined property and set the last value as a plain value', () => {
+      const object = {} as { key?: string };
+      const callback = sinon.spy();
+      defineObservableProperty(object, 'key', callback);
+
+      object.key = 'value';
+
+      stopObservingProperty(object, 'key');
+      expect(object.key).to.equal('value');
+
+      object.key = 'second_value';
+      expect(object.key).to.equal('second_value');
+
+      expect(callback).to.have.been.calledOnceWithExactly('value');
+    });
+  });
+});


### PR DESCRIPTION
## 🎫 Ticket

[LG-11285](https://cm-jira.usa.gov/browse/LG-11285)

## 🛠 Summary of changes

The call to `defineObservableProperty` is happening twice, and since the object property in question (`canvas.callback`) is not configurable, we raise a TypeError on the second call.

This PR makes the property configurable, and resets the property in the cleanup call for the `useEffect` where it is used.

## 📜 Testing Plan

**Before applying this change:**
To reproduce the error using your phone configured for [mobile local development](https://github.com/18F/identity-idp/blob/main/docs/mobile.md), go through IdV until document capture, then note that when the Acuant SDK starts up, we see the error `Uncaught TypeError: Cannot redefine property: callback` in the browser console.

**On this branch:**
Again, go through IdV up until the Acuant SDK starts up for document capture, then note the error is no longer thrown.

## 👀 Screenshots

Here's what the original error looks like in the console prior to this fix:

<img width="810" alt="lg-11285-before" src="https://github.com/18F/identity-idp/assets/2583060/2c5a1abf-5b9d-4eef-a38e-06fdf2241cb0">

