### PR TITLE
Less caching for idp image builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
-# Jobs defined here use the idp/ci docker image from ECR by default. To find
-# other available images:
+# Jobs defined here use the idp/ci docker image from ECR by default. To
+# find other available images:
 #   aws ecr describe-repositories | jq '.repositories[].repositoryUri'
 # Images are built via the identity-devops GitLab pipeline.
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,7 +182,7 @@ build-idp-image:
       --destination "${ECR_REGISTRY}/identity-idp/idp:${CI_COMMIT_SHA}"
       ${BRANCH_TAGGING_STRING}
       --cache-repo="${ECR_REGISTRY}/identity-idp/idp/cache"
-      --cache-ttl=168h
+      --cache-ttl=1h
       --cache=true
       --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,4 @@
+
 GIT
   remote: https://github.com/18F/identity-hostdata.git
   revision: 9574e05398833c531f450c3da99a6afde4ce68fc


### PR DESCRIPTION
## 🛠 Summary of changes

only cache for 1h so we can quickly re-run builds if we need to, but otherwise we will be getting/building the latest/greatest gems at least once an hour.
