### PR TITLE
Use ivars to clean up `ProgressiveProofer` methods

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -79,7 +79,7 @@ class ResolutionProofingJob < ApplicationJob
     should_proof_state_id:,
     ipp_enrollment_in_progress:
   )
-    result = Proofing::Resolution::ProgressiveProofer.new(
+    result = progressive_proofer.proof(
       applicant_pii: applicant_pii,
       user_email: user.confirmed_email_addresses.first.email,
       threatmetrix_session_id: threatmetrix_session_id,
@@ -87,7 +87,7 @@ class ResolutionProofingJob < ApplicationJob
       should_proof_state_id: should_proof_state_id,
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       timer: timer,
-    ).proof
+    )
 
     log_threatmetrix_info(result.device_profiling_result, user)
     add_threatmetrix_proofing_component(user.id, result.device_profiling_result) if user.present?
@@ -112,6 +112,10 @@ class ResolutionProofingJob < ApplicationJob
 
   def logger_info_hash(hash)
     logger.info(hash.to_json)
+  end
+
+  def progressive_proofer
+    @progressive_proofer ||= Proofing::Resolution::ProgressiveProofer.new
   end
 
   def add_threatmetrix_proofing_component(user_id, threatmetrix_result)

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -79,7 +79,7 @@ class ResolutionProofingJob < ApplicationJob
     should_proof_state_id:,
     ipp_enrollment_in_progress:
   )
-    result = resolution_proofer.proof(
+    result = Proofing::Resolution::ProgressiveProofer.new(
       applicant_pii: applicant_pii,
       user_email: user.confirmed_email_addresses.first.email,
       threatmetrix_session_id: threatmetrix_session_id,
@@ -87,7 +87,7 @@ class ResolutionProofingJob < ApplicationJob
       should_proof_state_id: should_proof_state_id,
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       timer: timer,
-    )
+    ).proof
 
     log_threatmetrix_info(result.device_profiling_result, user)
     add_threatmetrix_proofing_component(user.id, result.device_profiling_result) if user.present?
@@ -112,10 +112,6 @@ class ResolutionProofingJob < ApplicationJob
 
   def logger_info_hash(hash)
     logger.info(hash.to_json)
-  end
-
-  def resolution_proofer
-    @resolution_proofer ||= Proofing::Resolution::ProgressiveProofer.new
   end
 
   def add_threatmetrix_proofing_component(user_id, threatmetrix_result)

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -8,6 +8,14 @@ module Proofing
     #   2. The user has only provided one address for their residential and identity document
     #      address or separate residential and identity document addresses
     class ProgressiveProofer
+      attr_reader :applicant_pii,
+                  :request_ip,
+                  :should_proof_state_id,
+                  :threatmetrix_session_id,
+                  :timer,
+                  :user_email,
+                  :ipp_enrollment_in_progress
+
       # @param [Hash] applicant_pii keys are symbols and values are strings, confidential user info
       # @param [Boolean] ipp_enrollment_in_progress flag that indicates if user will have
       #   both state id address and current residential address verified
@@ -17,8 +25,7 @@ module Proofing
       # @param [String] threatmetrix_session_id identifies the threatmetrix session
       # @param [JobHelpers::Timer] timer indicates time elapsed to obtain results
       # @param [String] user_email email address for applicant
-      # @return [ResultAdjudicator] object which contains the logic to determine proofing's result
-      def proof(
+      def initialize(
         applicant_pii:,
         request_ip:,
         should_proof_state_id:,
@@ -27,40 +34,21 @@ module Proofing
         user_email:,
         ipp_enrollment_in_progress:
       )
-        device_profiling_result = proof_with_threatmetrix_if_needed(
-          applicant_pii: applicant_pii,
-          request_ip: request_ip,
-          threatmetrix_session_id: threatmetrix_session_id,
-          timer: timer,
-          user_email: user_email,
-        )
+        @applicant_pii = applicant_pii
+        @request_ip = request_ip
+        @should_proof_state_id = should_proof_state_id
+        @threatmetrix_session_id = threatmetrix_session_id
+        @timer = timer
+        @user_email = user_email
+        @ipp_enrollment_in_progress = ipp_enrollment_in_progress
+      end
 
-        residential_instant_verify_result = proof_residential_address_if_needed(
-          applicant_pii: applicant_pii,
-          timer: timer,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-        )
-
-        applicant_pii_transformed = applicant_pii.clone
-        if ipp_enrollment_in_progress
-          applicant_pii_transformed = with_state_id_address(applicant_pii_transformed)
-        end
-
-        instant_verify_result = proof_id_address_with_lexis_nexis_if_needed(
-          applicant_pii: applicant_pii_transformed,
-          timer: timer,
-          residential_instant_verify_result: residential_instant_verify_result,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-        )
-
-        state_id_result = proof_id_with_aamva_if_needed(
-          applicant_pii: applicant_pii_transformed,
-          timer: timer,
-          residential_instant_verify_result: residential_instant_verify_result,
-          instant_verify_result: instant_verify_result,
-          should_proof_state_id: should_proof_state_id,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-        )
+      # @return [ResultAdjudicator] object which contains the logic to determine proofing's result
+      def proof
+        @device_profiling_result = proof_with_threatmetrix_if_needed
+        @residential_instant_verify_result = proof_residential_address_if_needed
+        @instant_verify_result = proof_id_address_with_lexis_nexis_if_needed
+        @state_id_result = proof_id_with_aamva_if_needed
 
         ResultAdjudicator.new(
           device_profiling_result: device_profiling_result,
@@ -75,13 +63,12 @@ module Proofing
 
       private
 
-      def proof_with_threatmetrix_if_needed(
-        applicant_pii:,
-        user_email:,
-        threatmetrix_session_id:,
-        request_ip:,
-        timer:
-      )
+      attr_reader :device_profiling_result,
+                  :residential_instant_verify_result,
+                  :instant_verify_result,
+                  :state_id_result
+
+      def proof_with_threatmetrix_if_needed
         unless FeatureManagement.proofing_device_profiling_collecting_enabled?
           return threatmetrix_disabled_result
         end
@@ -101,15 +88,11 @@ module Proofing
         end
       end
 
-      def proof_residential_address_if_needed(
-        applicant_pii:,
-        timer:,
-        ipp_enrollment_in_progress: false
-      )
+      def proof_residential_address_if_needed
         return residential_address_unnecessary_result unless ipp_enrollment_in_progress
 
         timer.time('residential address') do
-          resolution_proofer.proof(applicant_pii)
+          resolution_proofer.proof(applicant_pii_with_residential_address)
         end
       end
 
@@ -125,66 +108,56 @@ module Proofing
         )
       end
 
-      def proof_id_address_with_lexis_nexis_if_needed(applicant_pii:, timer:,
-                                                      residential_instant_verify_result:,
-                                                      ipp_enrollment_in_progress:)
-        if applicant_pii[:same_address_as_id] == 'true' && ipp_enrollment_in_progress
+      def proof_id_address_with_lexis_nexis_if_needed
+        if same_address_as_id? && ipp_enrollment_in_progress
           return residential_instant_verify_result
         end
         return resolution_cannot_pass unless residential_instant_verify_result.success?
 
         timer.time('resolution') do
-          resolution_proofer.proof(applicant_pii)
+          resolution_proofer.proof(applicant_pii_with_state_id_address)
         end
       end
 
-      def should_proof_state_id_with_aamva?(ipp_enrollment_in_progress:, same_address_as_id:,
-                                            should_proof_state_id:, instant_verify_result:,
-                                            residential_instant_verify_result:)
+      def should_proof_state_id_with_aamva?
         return false unless should_proof_state_id
         # If the user is in in-person-proofing and they have changed their address then
         # they are not eligible for get-to-yes
-        if !ipp_enrollment_in_progress || same_address_as_id == 'true'
-          user_can_pass_after_state_id_check?(instant_verify_result)
+        if !ipp_enrollment_in_progress || same_address_as_id?
+          user_can_pass_after_state_id_check?
         else
           residential_instant_verify_result.success?
         end
       end
 
-      def proof_id_with_aamva_if_needed(
-        applicant_pii:, timer:,
-        residential_instant_verify_result:,
-        instant_verify_result:,
-        should_proof_state_id:,
-        ipp_enrollment_in_progress:
-      )
-        same_address_as_id = applicant_pii[:same_address_as_id]
-        should_proof_state_id_with_aamva = should_proof_state_id_with_aamva?(
-          ipp_enrollment_in_progress:,
-          same_address_as_id:,
-          should_proof_state_id:,
-          instant_verify_result:,
-          residential_instant_verify_result:,
-        )
-        return out_of_aamva_jurisdiction_result unless should_proof_state_id_with_aamva
+      def proof_id_with_aamva_if_needed
+        return out_of_aamva_jurisdiction_result unless should_proof_state_id_with_aamva?
 
         timer.time('state_id') do
-          state_id_proofer.proof(applicant_pii)
+          state_id_proofer.proof(applicant_pii_with_state_id_address)
         end
       end
 
-      def user_can_pass_after_state_id_check?(resolution_result)
-        return true if resolution_result.success?
+      def user_can_pass_after_state_id_check?
+        return true if instant_verify_result.success?
         # For failed IV results, this method validates that the user is eligible to pass if the
         # failed attributes are covered by the same attributes in a successful AAMVA response
         # aka the Get-to-Yes w/ AAMVA feature.
-        return false unless resolution_result.failed_result_can_pass_with_additional_verification?
+        if !instant_verify_result.failed_result_can_pass_with_additional_verification?
+          return false
+        end
 
         attributes_aamva_can_pass = [:address, :dob, :state_id_number]
+        attributes_requiring_additional_verification =
+          instant_verify_result.attributes_requiring_additional_verification
         results_that_cannot_pass_aamva =
-          resolution_result.attributes_requiring_additional_verification - attributes_aamva_can_pass
+          attributes_requiring_additional_verification - attributes_aamva_can_pass
 
         results_that_cannot_pass_aamva.blank?
+      end
+
+      def same_address_as_id?
+        applicant_pii[:same_address_as_id] == 'true'
       end
 
       def threatmetrix_disabled_result
@@ -266,6 +239,18 @@ module Proofing
               verification_url: IdentityConfig.store.aamva_verification_url,
             )
           end
+      end
+
+      def applicant_pii_with_state_id_address
+        if ipp_enrollment_in_progress
+          with_state_id_address(applicant_pii)
+        else
+          applicant_pii
+        end
+      end
+
+      def applicant_pii_with_residential_address
+        applicant_pii
       end
 
       # Make a copy of pii with the user's state ID address overwriting the address keys

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -24,7 +24,8 @@ module Proofing
       # @param [String] threatmetrix_session_id identifies the threatmetrix session
       # @param [JobHelpers::Timer] timer indicates time elapsed to obtain results
       # @param [String] user_email email address for applicant
-      def initialize(
+      # @return [ResultAdjudicator] object which contains the logic to determine proofing's result
+      def proof(
         applicant_pii:,
         request_ip:,
         should_proof_state_id:,
@@ -40,10 +41,7 @@ module Proofing
         @timer = timer
         @user_email = user_email
         @ipp_enrollment_in_progress = ipp_enrollment_in_progress
-      end
 
-      # @return [ResultAdjudicator] object which contains the logic to determine proofing's result
-      def proof
         @device_profiling_result = proof_with_threatmetrix_if_needed
         @residential_instant_verify_result = proof_residential_address_if_needed
         @instant_verify_result = proof_id_address_with_lexis_nexis_if_needed
@@ -51,7 +49,7 @@ module Proofing
 
         ResultAdjudicator.new(
           device_profiling_result: device_profiling_result,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress?,
+          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
           resolution_result: instant_verify_result,
           should_proof_state_id: should_proof_state_id,
           state_id_result: state_id_result,

--- a/lib/aamva_test.rb
+++ b/lib/aamva_test.rb
@@ -45,6 +45,14 @@ class AamvaTest
   end
 
   def build_proofer
-    Proofing::Resolution::ProgressiveProofer.new.send(:state_id_proofer)
+    Proofing::Aamva::Proofer.new(
+      auth_request_timeout: IdentityConfig.store.aamva_auth_request_timeout,
+      auth_url: IdentityConfig.store.aamva_auth_url,
+      cert_enabled: IdentityConfig.store.aamva_cert_enabled,
+      private_key: IdentityConfig.store.aamva_private_key,
+      public_key: IdentityConfig.store.aamva_public_key,
+      verification_request_timeout: IdentityConfig.store.aamva_verification_request_timeout,
+      verification_url: IdentityConfig.store.aamva_verification_url,
+    )
   end
 end

--- a/lib/aamva_test.rb
+++ b/lib/aamva_test.rb
@@ -45,14 +45,6 @@ class AamvaTest
   end
 
   def build_proofer
-    Proofing::Aamva::Proofer.new(
-      auth_request_timeout: IdentityConfig.store.aamva_auth_request_timeout,
-      auth_url: IdentityConfig.store.aamva_auth_url,
-      cert_enabled: IdentityConfig.store.aamva_cert_enabled,
-      private_key: IdentityConfig.store.aamva_private_key,
-      public_key: IdentityConfig.store.aamva_public_key,
-      verification_request_timeout: IdentityConfig.store.aamva_verification_request_timeout,
-      verification_url: IdentityConfig.store.aamva_verification_url,
-    )
+    Proofing::Resolution::ProgressiveProofer.new.send(:state_id_proofer)
   end
 end

--- a/spec/services/proofing/resolution/progressive_proofer_spec.rb
+++ b/spec/services/proofing/resolution/progressive_proofer_spec.rb
@@ -29,17 +29,7 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
 
   let(:dcs_uuid) { SecureRandom.uuid }
 
-  subject(:progressive_proofer) do
-    described_class.new(
-      applicant_pii: applicant_pii,
-      ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-      request_ip: Faker::Internet.ip_v4_address,
-      should_proof_state_id: true,
-      threatmetrix_session_id: threatmetrix_session_id,
-      timer: JobHelpers::Timer.new,
-      user_email: Faker::Internet.email,
-    )
-  end
+  subject(:progressive_proofer) { described_class.new }
 
   let(:state_id_address) do
     {
@@ -110,7 +100,17 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
       allow(IdentityConfig.store).to receive(:proofer_mock_fallback).and_return(false)
     end
 
-    subject(:proof) { progressive_proofer.proof }
+    subject(:proof) do
+      progressive_proofer.proof(
+        applicant_pii: applicant_pii,
+        ipp_enrollment_in_progress: ipp_enrollment_in_progress,
+        request_ip: Faker::Internet.ip_v4_address,
+        should_proof_state_id: true,
+        threatmetrix_session_id: threatmetrix_session_id,
+        timer: JobHelpers::Timer.new,
+        user_email: Faker::Internet.email,
+      )
+    end
 
     context 'remote proofing' do
       it 'returns a ResultAdjudicator' do


### PR DESCRIPTION
The `ProgressiveProofer` class has a `#proof` method which does the bulk of the footwork when it comes to orchestrating proofing API calls on the Verify-Your-Info step. This includes things like double address verification, get-to-yes, and skipping necessary API calls for users who cannot pass.

Prior to this commit this class did not store any instance variables. This meant that the child methods in the job needed all of the context necessary to do their work passed in as arguments. This led to long lists of keyword arguments for these methods which distracted from the methods' purpose.

This commit refactors the `ProgressiveProofer` to take the arguments that were passed to `#proof` in an initializer and store them as ivars. It also makes a change to store the vendor results as ivars. Finally since the PII passed into the job is an ivar it adds helper methods for transforming and operating on the PII with the aim of making that self-documenting. This adds some brevity to the implementation and hopefully removes some of the distraction that was associated with tracing arguments through the call stack.