### PR TITLE
log whether "matching cert" is consistent with the bug fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.21.0-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.21.2-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,10 +35,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 33275d69f7609e448942d6e3ce5c27779920995f
-  tag: 0.21.0-18f
+  revision: 5ad9e188efdfa6597697dd87f9cb9e8efa8d7d09
+  tag: 0.21.2-18f
   specs:
-    saml_idp (0.21.0.pre.18f)
+    saml_idp (0.21.2.pre.18f)
       activesupport
       builder
       faraday

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -195,14 +195,17 @@ module SamlIdpAuthConcern
        saml_request_service_provider&.skip_encryption_allowed
       nil
     elsif saml_request_service_provider&.encrypt_responses?
-      cert = saml_request.service_provider.matching_cert ||
-             saml_request_service_provider&.ssl_certs&.first
       {
-        cert: cert,
+        cert: encryption_cert,
         block_encryption: saml_request_service_provider&.block_encryption,
         key_transport: 'rsa-oaep-mgf1p',
       }
     end
+  end
+
+  def encryption_cert
+    saml_request.service_provider.matching_cert ||
+      saml_request_service_provider&.ssl_certs&.first
   end
 
   def saml_response_signature_options

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4931,8 +4931,8 @@ module AnalyticsEvents
   # @param [Integer] requested_ial
   # @param [Boolean] request_signed
   # @param [String] matching_cert_serial
-  # @option extra [Boolean] encryption_cert_matches_matching_cert If the encryption certificate
-  # matches the request certificate
+  # @param [Boolean|nil] encryption_cert_matches_matching_cert If the encryption certificate
+  # matches the request certificate in a successful, signed request
   def saml_auth(
     success:,
     errors:,
@@ -4947,6 +4947,7 @@ module AnalyticsEvents
     requested_ial:,
     request_signed:,
     matching_cert_serial:,
+    encryption_cert_matches_matching_cert: nil,
     error_details: nil,
     **extra
   )
@@ -4966,6 +4967,7 @@ module AnalyticsEvents
       requested_ial:,
       request_signed:,
       matching_cert_serial:,
+      encryption_cert_matches_matching_cert:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4931,6 +4931,8 @@ module AnalyticsEvents
   # @param [Integer] requested_ial
   # @param [Boolean] request_signed
   # @param [String] matching_cert_serial
+  # @option extra [Boolean] encryption_cert_matches_matching_cert If the encryption certificate
+  # matches the request certificate
   def saml_auth(
     success:,
     errors:,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
+RSpec.describe SamlIdpController do
   include SamlAuthHelper
 
   render_views
@@ -1434,81 +1434,16 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
       end
     end
 
-    context 'SAML request is not signed' do
+    describe 'SAML signature behavior' do
+      let(:authn_requests_signed) { false }
+      let(:encryption_cert_matches_matching_cert) { nil }
+      let(:matching_cert_serial) { nil }
+      let(:service_provider) { ServiceProvider.find_by(issuer: auth_settings.issuer)}
       let(:user) { create(:user, :fully_registered) }
-
-      before do
-        stub_analytics
-        allow(@analytics).to receive(:track_event)
-      end
-
-      it 'notes that in the analytics event' do
-        auth_settings = saml_settings(
-          overrides: {
-            authn_context: [
-              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-            ],
-            security: {
-              authn_requests_signed: false,
-            },
-          },
-        )
-        service_provider = build(:service_provider, issuer: auth_settings.issuer)
-        IdentityLinker.new(user, service_provider).link_identity
-        user.identities.last.update!(verified_attributes: ['email'])
-        generate_saml_response(user, auth_settings)
-
-        expect(response.status).to eq(200)
-
-        analytics_hash = {
-          success: true,
-          errors: {},
-          error_details: nil,
-          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: [
-            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-          ],
-          authn_context_comparison: 'exact',
-          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          service_provider: 'http://localhost:3000',
-          endpoint: "/api/saml/auth#{path_year}",
-          idv: false,
-          finish_profile: false,
-          request_signed: false,
-          matching_cert_serial: nil,
-        }
-
-        expect(@analytics).to have_received(:track_event).
-          with('SAML Auth', hash_including(analytics_hash))
-      end
-    end
-
-    context 'SAML request is signed' do
-      let(:user) { create(:user, :fully_registered) }
-      let(:authn_requests_signed) { true }
-      let(:service_provider) do
-        create(
-          :service_provider,
-          certs: ['sp_sinatra_demo', 'saml_test_sp'],
-          active: true,
-          assertion_consumer_logout_service_url: 'https://example.com',
-        )
-      end
 
       let(:auth_settings) do
         saml_settings(
           overrides: {
-            authn_context: [
-              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-            ],
-            certificate: File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt')),
-            issuer: service_provider.issuer,
-            private_key: OpenSSL::PKey::RSA.new(
-              File.read(Rails.root + 'keys/saml_test_sp2.key'),
-            ).to_pem,
             security: {
               authn_requests_signed:,
             },
@@ -1516,39 +1451,80 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
         )
       end
 
-      before do
-        stub_analytics
+      let(:analytics_hash) do
+        {
+          success: true,
+          request_signed: authn_requests_signed,
+          matching_cert_serial:,
+          encryption_cert_matches_matching_cert:,
+        }
       end
 
-      it 'notes that in the analytics event' do
+      before do
+        stub_analytics
         IdentityLinker.new(user, service_provider).link_identity
-        user.identities.last.update!(verified_attributes: ['email'])
-        generate_saml_response(user, auth_settings)
+      end
 
-        expect(response.status).to eq(200)
+      context 'SAML request is not signed' do
+        it 'notes that in the analytics event' do
+          user.identities.last.update!(verified_attributes: ['email'])
+          generate_saml_response(user, auth_settings)
 
-        analytics_hash = {
-          success: true,
-          errors: {},
-          error_details: nil,
-          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          requested_nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-          authn_context: [
-            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-          ],
-          authn_context_comparison: 'exact',
-          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          service_provider: service_provider.issuer,
-          endpoint: "/api/saml/auth#{path_year}",
-          idv: false,
-          finish_profile: false,
-          request_signed: authn_requests_signed,
-          matching_cert_serial: nil,
-          encryption_cert_matches_matching_cert: false,
-        }
+          expect(response.status).to eq(200)
+          expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
+        end
+      end
 
-        expect(@analytics).to have_logged_event('SAML Auth', analytics_hash)
+      context 'SAML request is signed' do
+        let(:authn_requests_signed) { true }
+
+        context 'Matching certificate' do
+          let(:encryption_cert_matches_matching_cert) { true }
+          let(:matching_cert_serial) {  saml_test_sp_cert_serial }
+
+          it 'notes that in the analytics event' do
+            user.identities.last.update!(verified_attributes: ['email'])
+            generate_saml_response(user, auth_settings)
+
+            expect(response.status).to eq(200)
+            expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
+          end
+        end
+
+        context 'No matching certificate' do
+          let(:encryption_cert_matches_matching_cert) { false }
+          let(:service_provider) do
+            create(
+              :service_provider,
+              certs: ['sp_sinatra_demo', 'saml_test_sp'],
+              active: true,
+              assertion_consumer_logout_service_url: 'https://example.com',
+            )
+          end
+
+          let(:auth_settings) do
+            saml_settings(
+              overrides: {
+                certificate: File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt')),
+                issuer: service_provider.issuer,
+                private_key: OpenSSL::PKey::RSA.new(
+                  File.read(Rails.root + 'keys/saml_test_sp2.key'),
+                ).to_pem,
+                security: {
+                  authn_requests_signed:,
+                },
+              },
+            )
+          end
+
+          it 'notes that in the analytics event' do
+            user.identities.last.update!(verified_attributes: ['email'])
+            generate_saml_response(user, auth_settings)
+
+            expect(response.status).to eq(200)
+            expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
+          end
+        end
       end
     end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1518,7 +1518,6 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
 
       before do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
       end
 
       it 'notes that in the analytics event' do
@@ -1533,6 +1532,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
           errors: {},
           error_details: nil,
           nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+          requested_nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: [
             Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
@@ -1548,8 +1548,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
           encryption_cert_matches_matching_cert: false,
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('SAML Auth', analytics_hash)
+        expect(@analytics).to have_logged_event('SAML Auth', analytics_hash)
       end
     end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -789,6 +789,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
               finish_profile: false,
               request_signed: true,
               matching_cert_serial: saml_test_sp_cert_serial,
+              encryption_cert_matches_matching_cert: true,
             ),
           )
         expect(@analytics).to receive(:track_event).with(
@@ -942,6 +943,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
               finish_profile: false,
               request_signed: true,
               matching_cert_serial: saml_test_sp_cert_serial,
+              encryption_cert_matches_matching_cert: true,
             ),
           )
         expect(@analytics).to receive(:track_event).with(
@@ -1603,6 +1605,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
           finish_profile: false,
           request_signed: true,
           matching_cert_serial: saml_test_sp_cert_serial,
+          encryption_cert_matches_matching_cert: true,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -2316,6 +2319,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
           finish_profile: false,
           request_signed: true,
           matching_cert_serial: saml_test_sp_cert_serial,
+          encryption_cert_matches_matching_cert: true,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -2371,6 +2375,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
           finish_profile: true,
           request_signed: true,
           matching_cert_serial: saml_test_sp_cert_serial,
+          encryption_cert_matches_matching_cert: true,
         }
 
         expect(@analytics).to receive(:track_event).

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1438,7 +1438,7 @@ RSpec.describe SamlIdpController do
       let(:authn_requests_signed) { false }
       let(:encryption_cert_matches_matching_cert) { nil }
       let(:matching_cert_serial) { nil }
-      let(:service_provider) { ServiceProvider.find_by(issuer: auth_settings.issuer)}
+      let(:service_provider) { ServiceProvider.find_by(issuer: auth_settings.issuer) }
       let(:user) { create(:user, :fully_registered) }
 
       let(:auth_settings) do
@@ -1480,7 +1480,7 @@ RSpec.describe SamlIdpController do
 
         context 'Matching certificate' do
           let(:encryption_cert_matches_matching_cert) { true }
-          let(:matching_cert_serial) {  saml_test_sp_cert_serial }
+          let(:matching_cert_serial) { saml_test_sp_cert_serial }
 
           it 'notes that in the analytics event' do
             user.identities.last.update!(verified_attributes: ['email'])

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1434,7 +1434,7 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
       end
     end
 
-    context 'no matching cert from the SAML request' do
+    context 'SAML request is not signed' do
       let(:user) { create(:user, :fully_registered) }
 
       before do
@@ -1482,6 +1482,74 @@ RSpec.describe SamlIdpController, allowed_extra_analytics: [:*] do
 
         expect(@analytics).to have_received(:track_event).
           with('SAML Auth', hash_including(analytics_hash))
+      end
+    end
+
+    context 'SAML request is signed' do
+      let(:user) { create(:user, :fully_registered) }
+      let(:authn_requests_signed) { true }
+      let(:service_provider) do
+        create(
+          :service_provider,
+          certs: ['sp_sinatra_demo', 'saml_test_sp'],
+          active: true,
+          assertion_consumer_logout_service_url: 'https://example.com',
+        )
+      end
+
+      let(:auth_settings) do
+        saml_settings(
+          overrides: {
+            authn_context: [
+              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            ],
+            certificate: File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt')),
+            issuer: service_provider.issuer,
+            private_key: OpenSSL::PKey::RSA.new(
+              File.read(Rails.root + 'keys/saml_test_sp2.key'),
+            ).to_pem,
+            security: {
+              authn_requests_signed:,
+            },
+          },
+        )
+      end
+
+      before do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+      end
+
+      it 'notes that in the analytics event' do
+        IdentityLinker.new(user, service_provider).link_identity
+        user.identities.last.update!(verified_attributes: ['email'])
+        generate_saml_response(user, auth_settings)
+
+        expect(response.status).to eq(200)
+
+        analytics_hash = {
+          success: true,
+          errors: {},
+          error_details: nil,
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+          authn_context: [
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+          ],
+          authn_context_comparison: 'exact',
+          requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          service_provider: service_provider.issuer,
+          endpoint: "/api/saml/auth#{path_year}",
+          idv: false,
+          finish_profile: false,
+          request_signed: authn_requests_signed,
+          matching_cert_serial: nil,
+          encryption_cert_matches_matching_cert: false,
+        }
+
+        expect(@analytics).to have_received(:track_event).
+          with('SAML Auth', analytics_hash)
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Add SAML request validation matching certificate logging](https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/36)


## 🛠 Summary of changes
Adds logging so that we can determine which partners, if any, may experience breaking changes when we deploy the code that accurately finds the DigestMethod for SAML request assertions that are not using the `ds` namespace. 
This change:
- Adds a field to the Saml Auth event if the request is successful and signed. This field indicates whether the certificate that is being used to encrypt the response is the same certificate that is being found via the code that fixes a bug where the DigestMethod will be found.
- Updates and adds tests
- Updates the saml_idp version

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
