### PR TITLE
Rename reCAPTCHA mock validator configuration, enable in review apps

### DIFF
--- a/app/components/captcha_submit_button_component.rb
+++ b/app/components/captcha_submit_button_component.rb
@@ -13,7 +13,7 @@ class CaptchaSubmitButtonComponent < BaseComponent
   end
 
   def show_mock_score_field?
-    IdentityConfig.store.phone_recaptcha_mock_validator
+    IdentityConfig.store.recaptcha_mock_validator
   end
 
   def recaptcha_script_src

--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -143,7 +143,7 @@ class NewPhoneForm
 
   def recaptcha_form_args
     args = { analytics: }
-    if IdentityConfig.store.phone_recaptcha_mock_validator
+    if IdentityConfig.store.recaptcha_mock_validator
       args.merge(form_class: RecaptchaMockForm, score: recaptcha_mock_score)
     elsif FeatureManagement.recaptcha_enterprise?
       args.merge(form_class: RecaptchaEnterpriseForm)
@@ -154,7 +154,7 @@ class NewPhoneForm
 
   def validate_recaptcha_token?
     FeatureManagement.phone_recaptcha_enabled? ||
-      IdentityConfig.store.phone_recaptcha_mock_validator
+      IdentityConfig.store.recaptcha_mock_validator
   end
 
   def parsed_phone

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -222,7 +222,6 @@ short_term_phone_otp_max_attempts: 2
 phone_confirmation_max_attempts: 20
 phone_confirmation_max_attempt_window_in_minutes: 1_440
 phone_service_check: true
-phone_recaptcha_mock_validator: true
 phone_recaptcha_score_threshold: 0.0
 phone_recaptcha_country_score_overrides: '{"AS":0.0,"GU":0.0,"MP":0.0,"PR":0.0,"US":0.0,"VI":0.0,"CA":0.0,"MX":0.0}'
 phone_setups_per_ip_limit: 25
@@ -253,6 +252,7 @@ raise_on_missing_title: false
 reauthn_window: 1200
 recaptcha_enterprise_api_key: ''
 recaptcha_enterprise_project_id: ''
+recaptcha_mock_validator: true
 recaptcha_site_key: ''
 recaptcha_secret_key: ''
 recovery_code_length: 4
@@ -473,9 +473,8 @@ production:
   otp_delivery_blocklist_findtime: 5
   participate_in_dap: true
   password_pepper:
-  phone_recaptcha_mock_validator: false
   piv_cac_verify_token_secret:
-  session_encryptor_alert_enabled: true
+  recaptcha_mock_validator: false
   redis_throttle_url: redis://redis.login.gov.internal:6379/1
   redis_url: redis://redis.login.gov.internal:6379
   report_timeout: 1_000_000
@@ -488,6 +487,7 @@ production:
   secret_key_base:
   seed_agreements_data: false
   session_encryption_key:
+  session_encryptor_alert_enabled: true
   skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:int"]'
   state_tracking_enabled: false
   telephony_adapter: pinpoint

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -16,10 +16,12 @@ production:
   database_worker_jobs_sslmode: ['env', 'POSTGRES_WORKER_SSLMODE']
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   rails_mailer_previews_enabled: true
+  recaptcha_mock_validator: true
   redis_throttle_url: ['env', 'REDIS_THROTTLE_URL']
   redis_url: ['env', 'REDIS_URL']
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
+  phone_recaptcha_score_threshold: 0.5
   piv_cac_service_url: ['env', 'PIV_CAC_SERVICE_URL']
   piv_cac_verify_token_secret: "a6ed2fb16320ae85a7a8e48f4b0eeb6afca5f1ac64af2a05a0c486df1c20b693987832a11f0910729f199b3ce5c7609fe6d580bed428d035ea8460990e38a382"
   piv_cac_verify_token_url: ['env', 'PIV_CAC_VERIFY_TOKEN_URL']

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -276,7 +276,6 @@ module IdentityConfig
       type: :json,
       options: { symbolize_names: true },
     )
-    config.add(:phone_recaptcha_mock_validator, type: :boolean)
     config.add(:phone_recaptcha_score_threshold, type: :float)
     config.add(:phone_service_check, type: :boolean)
     config.add(:phone_setups_per_ip_limit, type: :integer)
@@ -312,6 +311,7 @@ module IdentityConfig
     config.add(:reauthn_window, type: :integer)
     config.add(:recaptcha_enterprise_api_key, type: :string)
     config.add(:recaptcha_enterprise_project_id, type: :string)
+    config.add(:recaptcha_mock_validator, type: :boolean)
     config.add(:recaptcha_secret_key, type: :string)
     config.add(:recaptcha_site_key, type: :string)
     config.add(:recovery_code_length, type: :integer)

--- a/spec/components/captcha_submit_button_component_spec.rb
+++ b/spec/components/captcha_submit_button_component_spec.rb
@@ -72,15 +72,15 @@ RSpec.describe CaptchaSubmitButtonComponent, type: :component do
   end
 
   describe 'mock score field' do
-    let(:phone_recaptcha_mock_validator) { nil }
+    let(:recaptcha_mock_validator) { nil }
 
     before do
-      allow(IdentityConfig.store).to receive(:phone_recaptcha_mock_validator).
-        and_return(phone_recaptcha_mock_validator)
+      allow(IdentityConfig.store).to receive(:recaptcha_mock_validator).
+        and_return(recaptcha_mock_validator)
     end
 
     context 'with mock validator disabled' do
-      let(:phone_recaptcha_mock_validator) { false }
+      let(:recaptcha_mock_validator) { false }
 
       it 'does not render mock score field' do
         expect(rendered).not_to have_field(t('components.captcha_submit_button.mock_score_label'))
@@ -88,7 +88,7 @@ RSpec.describe CaptchaSubmitButtonComponent, type: :component do
     end
 
     context 'with mock validator enabled' do
-      let(:phone_recaptcha_mock_validator) { true }
+      let(:recaptcha_mock_validator) { true }
 
       it 'renders mock score field' do
         expect(rendered).to have_field(t('components.captcha_submit_button.mock_score_label'))

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe 'Add a new phone number', allowed_extra_analytics: [:*] do
   scenario 'adding a phone with a reCAPTCHA challenge', :js do
     user = create(:user, :fully_registered)
 
-    allow(IdentityConfig.store).to receive(:phone_recaptcha_mock_validator).and_return(true)
+    allow(IdentityConfig.store).to receive(:recaptcha_mock_validator).and_return(true)
     allow(IdentityConfig.store).to receive(:phone_recaptcha_score_threshold).and_return(0.6)
     fake_analytics = FakeAnalytics.new(user:)
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -171,7 +171,7 @@ RSpec.feature 'Sign Up', allowed_extra_analytics: [:*] do
   end
 
   scenario 'signing up using phone with a reCAPTCHA challenge', :js do
-    allow(IdentityConfig.store).to receive(:phone_recaptcha_mock_validator).and_return(true)
+    allow(IdentityConfig.store).to receive(:recaptcha_mock_validator).and_return(true)
     allow(IdentityConfig.store).to receive(:phone_recaptcha_score_threshold).and_return(0.6)
 
     sign_up_and_set_password

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe NewPhoneForm do
       subject(:result) { form.submit(params) }
 
       before do
-        allow(IdentityConfig.store).to receive(:phone_recaptcha_mock_validator).and_return(true)
+        allow(IdentityConfig.store).to receive(:recaptcha_mock_validator).and_return(true)
         allow(IdentityConfig.store).to receive(:phone_recaptcha_score_threshold).
           and_return(score_threshold)
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Renames the reCAPTCHA mock validator configuration name from `phone_recaptcha_mock_validator` to `recaptcha_mock_validator`, so that it can be reused for non-phone-specific mock validation. This also aligns to [current usage in the otherwise-generic `CaptchaSubmitButtonComponent`](https://github.com/18F/identity-idp/blob/99ddc98bd752bfbe36332132860933bf7eca224c/app/components/captcha_submit_button_component.rb#L16).

It also enables mock validation in the review apps environments, to facilitate testing.

## 📜 Testing Plan

1. Go to TBD
2. Sign in or create an account
3. Add a phone to your account when presented the opportunity
   - From account dashboard: Click "Add phone number" in sidebar
   - From account creation: Choose "Text or voice message" from MFA selection
4. Observe field "reCAPTCHA score"
5. Enter a value above or below 0.5
6. Submit the page with an international phone number, e.g. `+610491570006`
7. Observe:
   - If you entered a value 0.5 or above, you are allowed to pass
   - Otherwise, observe you are shown an error message

## 👀 Screenshots

![image](https://github.com/18F/identity-idp/assets/1779930/d85627e1-31c5-4913-b434-4fc13b0a34b1)
