### PR TITLE
Document critical-path MFA setup analytics methods

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3766,13 +3766,22 @@ module AnalyticsEvents
   # Tracks when the the user has added the MFA method phone to their account
   # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
   # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
-  def multi_factor_auth_added_phone(enabled_mfa_methods_count:, recaptcha_annotation:, **extra)
+  # @param [Boolean] in_account_creation_flow whether user is going through creation flow
+  # @Param ['phone'] method_name Authentication method added
+  def multi_factor_auth_added_phone(
+    enabled_mfa_methods_count:,
+    recaptcha_annotation:,
+    in_account_creation_flow:,
+    method_name: :phone,
+    **extra
+  )
     track_event(
       'Multi-Factor Authentication: Added phone',
       {
-        method_name: :phone,
+        method_name:,
         enabled_mfa_methods_count: enabled_mfa_methods_count,
         recaptcha_annotation:,
+        in_account_creation_flow:,
         **extra,
       }.compact,
     )
@@ -3995,6 +4004,14 @@ module AnalyticsEvents
   # @param [String] multi_factor_auth_method
   # @param [Boolean] in_account_creation_flow whether user is going through account creation flow
   # @param [integer] enabled_mfa_methods_count
+  # @param [DateTime] multi_factor_auth_method_created_at time auth method was created
+  # @param ['authentication','reauthentication','confirmation'] context User session context
+  # @param [Boolean] confirmation_for_add_phone Whether authenticating while adding phone
+  # @param [String] area_code Area code of phone number
+  # @param [String] country_code Country code associated with phone number
+  # @param [String] phone_fingerprint The hmac fingerprint of the phone number formatted as e164
+  # @param [Integer] phone_configuration_id Database ID of phone configuration
+  # @param [Boolean] new_device Whether the user is authenticating from a new device
   def multi_factor_auth_setup(
     success:,
     multi_factor_auth_method:,
@@ -4002,6 +4019,14 @@ module AnalyticsEvents
     in_account_creation_flow:,
     errors: nil,
     error_details: nil,
+    multi_factor_auth_method_created_at: nil,
+    context: nil,
+    confirmation_for_add_phone: nil,
+    area_code: nil,
+    country_code: nil,
+    phone_fingerprint: nil,
+    phone_configuration_id: nil,
+    new_device: nil,
     **extra
   )
     track_event(
@@ -4012,6 +4037,14 @@ module AnalyticsEvents
       multi_factor_auth_method:,
       in_account_creation_flow:,
       enabled_mfa_methods_count:,
+      multi_factor_auth_method_created_at:,
+      context:,
+      confirmation_for_add_phone:,
+      area_code:,
+      country_code:,
+      phone_fingerprint:,
+      phone_configuration_id:,
+      new_device:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3767,7 +3767,7 @@ module AnalyticsEvents
   # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
   # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # @param [Boolean] in_account_creation_flow whether user is going through creation flow
-  # @Param ['phone'] method_name Authentication method added
+  # @param ['phone'] method_name Authentication method added
   def multi_factor_auth_added_phone(
     enabled_mfa_methods_count:,
     recaptcha_annotation:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3807,12 +3807,17 @@ module AnalyticsEvents
   # Tracks when the user has added the MFA method TOTP to their account
   # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
   # @param [Boolean] in_account_creation_flow whether user is going through creation flow
-  def multi_factor_auth_added_totp(enabled_mfa_methods_count:, in_account_creation_flow:,
-                                   **extra)
+  # @param ['totp'] method_name Authentication method added
+  def multi_factor_auth_added_totp(
+    enabled_mfa_methods_count:,
+    in_account_creation_flow:,
+    method_name: :totp,
+    **extra
+  )
     track_event(
       'Multi-Factor Authentication: Added TOTP',
       {
-        method_name: :totp,
+        method_name:,
         in_account_creation_flow:,
         enabled_mfa_methods_count:,
         **extra,
@@ -4011,6 +4016,8 @@ module AnalyticsEvents
   # @param [String] country_code Country code associated with phone number
   # @param [String] phone_fingerprint The hmac fingerprint of the phone number formatted as e164
   # @param [Integer] phone_configuration_id Database ID of phone configuration
+  # @param [Integer] auth_app_configuration_id Database ID of authentication app configuration
+  # @param [Boolean] totp_secret_present Whether TOTP secret was present in form validation
   # @param [Boolean] new_device Whether the user is authenticating from a new device
   def multi_factor_auth_setup(
     success:,
@@ -4026,26 +4033,32 @@ module AnalyticsEvents
     country_code: nil,
     phone_fingerprint: nil,
     phone_configuration_id: nil,
+    totp_secret_present: nil,
+    auth_app_configuration_id: nil,
     new_device: nil,
     **extra
   )
     track_event(
       'Multi-Factor Authentication Setup',
-      success:,
-      errors:,
-      error_details:,
-      multi_factor_auth_method:,
-      in_account_creation_flow:,
-      enabled_mfa_methods_count:,
-      multi_factor_auth_method_created_at:,
-      context:,
-      confirmation_for_add_phone:,
-      area_code:,
-      country_code:,
-      phone_fingerprint:,
-      phone_configuration_id:,
-      new_device:,
-      **extra,
+      {
+        success:,
+        errors:,
+        error_details:,
+        multi_factor_auth_method:,
+        in_account_creation_flow:,
+        enabled_mfa_methods_count:,
+        multi_factor_auth_method_created_at:,
+        context:,
+        confirmation_for_add_phone:,
+        area_code:,
+        country_code:,
+        phone_fingerprint:,
+        phone_configuration_id:,
+        totp_secret_present:,
+        auth_app_configuration_id:,
+        new_device:,
+        **extra,
+      }.compact,
     )
   end
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TwoFactorAuthentication::OtpVerificationController, allowed_extra_analytics: [:*] do
+RSpec.describe TwoFactorAuthentication::OtpVerificationController do
   describe '#show' do
     context 'when resource is not fully authenticated yet' do
       before do

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -466,10 +466,19 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
             phone_configuration_created_at = controller.current_user.
               default_phone_configuration.created_at
 
-            properties = {
+            controller.user_session[:phone_id] = phone_id
+
+            post(
+              :create,
+              params: {
+                code: subject.current_user.direct_otp,
+                otp_delivery_preference: 'sms',
+              },
+            )
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication Setup',
               success: true,
-              errors: nil,
-              error_details: nil,
               confirmation_for_add_phone: true,
               context: 'confirmation',
               multi_factor_auth_method: 'sms',
@@ -481,19 +490,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
               phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
               enabled_mfa_methods_count: 1,
               in_account_creation_flow: true,
-            }
-
-            controller.user_session[:phone_id] = phone_id
-
-            post(
-              :create,
-              params: {
-                code: subject.current_user.direct_otp,
-                otp_delivery_preference: 'sms',
-              },
             )
-
-            expect(@analytics).to have_logged_event('Multi-Factor Authentication Setup', properties)
           end
 
           it 'resets otp session data' do
@@ -547,27 +544,23 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
           end
 
           it 'tracks an event' do
-            phone_configuration_created_at = controller.current_user.
-              default_phone_configuration.created_at
-
-            properties = {
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication Setup',
               success: false,
-              errors: nil,
               error_details: { code: { wrong_length: true, incorrect: true } },
               confirmation_for_add_phone: true,
               context: 'confirmation',
               multi_factor_auth_method: 'sms',
               phone_configuration_id: controller.current_user.default_phone_configuration.id,
-              multi_factor_auth_method_created_at: phone_configuration_created_at.strftime('%s%L'),
+              multi_factor_auth_method_created_at: controller.current_user.
+                default_phone_configuration.created_at.strftime('%s%L'),
               new_device: true,
               area_code: parsed_phone.area_code,
               country_code: parsed_phone.country,
               phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
               enabled_mfa_methods_count: 1,
               in_account_creation_flow: false,
-            }
-
-            expect(@analytics).to have_logged_event('Multi-Factor Authentication Setup', properties)
+            )
           end
 
           context 'user enters in valid code after invalid entry' do
@@ -618,26 +611,22 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
 
           it 'tracks the confirmation event' do
             parsed_phone = Phonelib.parse('+1 (703) 555-5555')
-            properties = {
+
+            response
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication Setup',
               success: true,
-              errors: nil,
-              error_details: nil,
               context: 'confirmation',
               multi_factor_auth_method: 'sms',
-              multi_factor_auth_method_created_at: nil,
               new_device: true,
               confirmation_for_add_phone: false,
-              phone_configuration_id: nil,
               area_code: parsed_phone.area_code,
               country_code: parsed_phone.country,
               phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
               enabled_mfa_methods_count: 0,
               in_account_creation_flow: false,
-            }
-
-            response
-
-            expect(@analytics).to have_logged_event('Multi-Factor Authentication Setup', properties)
+            )
 
             expect(controller).to have_received(:create_user_event).with(:phone_confirmed)
             expect(controller).to have_received(:create_user_event).exactly(:once)

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -97,7 +97,15 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
 
       it 'tracks the submission' do
         Funnel::Registration::AddMfa.call(user.id, 'phone', @analytics)
-        result = {
+
+        patch :confirm, params: params
+
+        expect(@analytics).to have_logged_event(
+          'User marked authenticated',
+          authentication_type: :valid_2fa_confirmation,
+        )
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication Setup',
           enabled_mfa_methods_count: 3,
           mfa_method_counts: {
             auth_app: 1, phone: 1, webauthn: 1
@@ -105,7 +113,6 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
           multi_factor_auth_method: 'webauthn',
           success: true,
           errors: {},
-          error_details: nil,
           in_account_creation_flow: false,
           authenticator_data_flags: {
             up: true,
@@ -115,22 +122,13 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
             at: true,
             ed: false,
           },
-          pii_like_keypaths: [[:mfa_method_counts, :phone]],
-        }
-        expect(@analytics).to receive(:track_event).
-          with('User marked authenticated', { authentication_type: :valid_2fa_confirmation })
-        expect(@analytics).to receive(:track_event).
-          with('Multi-Factor Authentication Setup', result)
-
-        expect(@analytics).to receive(:track_event).
-          with(
-            :webauthn_setup_submitted,
-            errors: nil,
-            platform_authenticator: false,
-            success: true,
-          )
-
-        patch :confirm, params: params
+        )
+        expect(@analytics).to have_logged_event(
+          :webauthn_setup_submitted,
+          platform_authenticator: false,
+          success: true,
+          errors: nil,
+        )
       end
     end
   end
@@ -238,31 +236,28 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
 
         it 'should log expected events' do
           Funnel::Registration::AddMfa.call(user.id, 'phone', @analytics)
-          expect(@analytics).to receive(:track_event).
-            with('User marked authenticated', { authentication_type: :valid_2fa_confirmation })
-          expect(@analytics).to receive(:track_event).with(
-            'Multi-Factor Authentication Setup',
-            {
-              enabled_mfa_methods_count: 1,
-              errors: {},
-              error_details: nil,
-              in_account_creation_flow: true,
-              mfa_method_counts: { webauthn: 1 },
-              multi_factor_auth_method: 'webauthn',
-              pii_like_keypaths: [[:mfa_method_counts, :phone]],
-              success: true,
-            },
-          )
-
-          expect(@analytics).to receive(:track_event).
-            with(
-              :webauthn_setup_submitted,
-              errors: nil,
-              platform_authenticator: false,
-              success: true,
-            )
 
           patch :confirm, params: params
+
+          expect(@analytics).to have_logged_event(
+            'User marked authenticated',
+            authentication_type: :valid_2fa_confirmation,
+          )
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication Setup',
+            enabled_mfa_methods_count: 1,
+            errors: {},
+            in_account_creation_flow: true,
+            mfa_method_counts: { webauthn: 1 },
+            multi_factor_auth_method: 'webauthn',
+            success: true,
+          )
+          expect(@analytics).to have_logged_event(
+            :webauthn_setup_submitted,
+            errors: nil,
+            platform_authenticator: false,
+            success: true,
+          )
         end
       end
 
@@ -293,36 +288,31 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
         end
 
         it 'should log expected events' do
-          expect(@analytics).to receive(:track_event).
-            with(
-              :webauthn_setup_submitted,
-              errors: nil,
-              platform_authenticator: true,
-              success: true,
-            )
-
-          expect(@analytics).to receive(:track_event).
-            with('User marked authenticated', { authentication_type: :valid_2fa_confirmation })
-          expect(@analytics).to receive(:track_event).with(
-            'User Registration: User Fully Registered',
-            { mfa_method: 'webauthn_platform' },
-          )
-
-          expect(@analytics).to receive(:track_event).with(
-            'Multi-Factor Authentication Setup',
-            {
-              enabled_mfa_methods_count: 1,
-              errors: {},
-              error_details: nil,
-              in_account_creation_flow: true,
-              mfa_method_counts: { webauthn_platform: 1 },
-              multi_factor_auth_method: 'webauthn_platform',
-              pii_like_keypaths: [[:mfa_method_counts, :phone]],
-              success: true,
-            },
-          )
-
           patch :confirm, params: params
+
+          expect(@analytics).to have_logged_event(
+            :webauthn_setup_submitted,
+            errors: nil,
+            platform_authenticator: true,
+            success: true,
+          )
+          expect(@analytics).to have_logged_event(
+            'User marked authenticated',
+            authentication_type: :valid_2fa_confirmation,
+          )
+          expect(@analytics).to have_logged_event(
+            'User Registration: User Fully Registered',
+            mfa_method: 'webauthn_platform',
+          )
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication Setup',
+            enabled_mfa_methods_count: 1,
+            errors: {},
+            in_account_creation_flow: true,
+            mfa_method_counts: { webauthn_platform: 1 },
+            multi_factor_auth_method: 'webauthn_platform',
+            success: true,
+          )
         end
 
         it 'should log submitted failure' do

--- a/spec/features/account_creation/multiple_browsers_spec.rb
+++ b/spec/features/account_creation/multiple_browsers_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'account creation across multiple browsers', allowed_extra_analytics: [:*] do
+RSpec.feature 'account creation across multiple browsers' do
   include SpAuthHelper
   include SamlAuthHelper
   include OidcAuthHelper

--- a/spec/features/account_creation/sp_return_log_spec.rb
+++ b/spec/features/account_creation/sp_return_log_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'SP return logs', allowed_extra_analytics: [:*] do
+RSpec.feature 'SP return logs' do
   include SamlAuthHelper
 
   let(:email) { 'test@test.com' }

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'New device tracking', allowed_extra_analytics: [:*] do
+RSpec.describe 'New device tracking' do
   include SamlAuthHelper
 
   let(:user) { create(:user, :fully_registered) }

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'OIDC Authorization Confirmation', allowed_extra_analytics: [:*] do
+RSpec.feature 'OIDC Authorization Confirmation' do
   include OidcAuthHelper
 
   before do

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Add a new phone number', allowed_extra_analytics: [:*] do
+RSpec.describe 'Add a new phone number' do
   scenario 'Adding and confirming a new phone number allows the phone number to be used for MFA' do
     user = create(:user, :fully_registered)
     phone = '+1 (225) 278-1234'

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'phone otp confirmation', allowed_extra_analytics: [:*] do
+RSpec.describe 'phone otp confirmation' do
   let(:phone) { '2025551234' }
   let(:formatted_phone) { PhoneFormatter.format(phone) }
 

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'default phone selection', allowed_extra_analytics: [:*] do
+RSpec.describe 'default phone selection' do
   let(:user) { create(:user, :with_phone) }
   let(:phone_config2) do
     create(

--- a/spec/features/phone/rate_limiting_spec.rb
+++ b/spec/features/phone/rate_limiting_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'phone rate limiting', allowed_extra_analytics: [:*] do
+RSpec.describe 'phone rate limiting' do
   let(:phone) { '2025551234' }
 
   context 'on sign up' do

--- a/spec/features/remember_device/phone_spec.rb
+++ b/spec/features/remember_device/phone_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Remembering a phone', allowed_extra_analytics: [:*] do
+RSpec.feature 'Remembering a phone' do
   include IdvStepHelper
 
   before do

--- a/spec/features/remember_device/signed_in_sp_expiration_spec.rb
+++ b/spec/features/remember_device/signed_in_sp_expiration_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'SP expiration while signed in', allowed_extra_analytics: [:*] do
+RSpec.feature 'SP expiration while signed in' do
   include SamlAuthHelper
 
   ##

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -83,7 +83,7 @@ RSpec.shared_examples 'expiring remember device for an sp config' do |expiration
   end
 end
 
-RSpec.feature 'remember device sp expiration', allowed_extra_analytics: [:*] do
+RSpec.feature 'remember device sp expiration' do
   include SamlAuthHelper
 
   aal1_remember_device_expiration =

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Remembering a TOTP device', allowed_extra_analytics: [:*] do
+RSpec.describe 'Remembering a TOTP device' do
   before do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(1000)
   end

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'SAML Authorization Confirmation', allowed_extra_analytics: [:*] do
+RSpec.feature 'SAML Authorization Confirmation' do
   include SamlAuthHelper
 
   before do

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'IAL1 Single Sign On', allowed_extra_analytics: [:*] do
+RSpec.feature 'IAL1 Single Sign On' do
   include SamlAuthHelper
 
   context 'First time registration', email: true do

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Changing authentication factor', allowed_extra_analytics: [:*] do
+RSpec.feature 'Changing authentication factor' do
   describe 'requires re-authenticating' do
     let(:user) { sign_up_and_2fa_ial1_user }
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -121,8 +121,6 @@ RSpec.feature 'Sign Up', allowed_extra_analytics: [:*] do
       expect(fake_analytics).to have_logged_event(
         'Multi-Factor Authentication Setup',
         success: true,
-        errors: nil,
-        error_details: nil,
         multi_factor_auth_method: 'backup_codes',
         in_account_creation_flow: true,
         enabled_mfa_methods_count: 2,

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'totp management', allowed_extra_analytics: [:*] do
+RSpec.describe 'totp management' do
   context 'when the user has totp enabled' do
     let(:user) { create(:user, :fully_registered, :with_authentication_app) }
 

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Email confirmation during sign up', allowed_extra_analytics: [:*] do
+RSpec.feature 'Email confirmation during sign up' do
   it 'requires user to accept rules of use when registering email' do
     visit sign_up_email_path
     fill_in t('forms.registration.labels.email'), with: 'test@example.com'

--- a/spec/features/visitors/sign_up_with_email_spec.rb
+++ b/spec/features/visitors/sign_up_with_email_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Visitor signs up with email address', allowed_extra_analytics: [:*] do
+RSpec.feature 'Visitor signs up with email address' do
   scenario 'visitor can sign up with valid email address' do
     email = 'test@example.com'
     sign_up_with(email)


### PR DESCRIPTION
## 🛠 Summary of changes

This documents a few more analytics methods, intended to address low-hanging fruit of common analytics logged during account creation:

- `multi_factor_auth_setup`
- `multi_factor_auth_added_phone`
- `multi_factor_auth_added_totp`

This is similar in purpose to #10736, where #10736 addressed common analytics during sign-in.

**Why?**

- Improve discoverability of the availability of these properties
- Highlight potential redundancies or inconsistencies in logged analytics

## 📜 Testing Plan

Verify build passes. This should not have any impact on user-facing behavior.