### PR TITLE
Clarify instructions for committing optimized fonts and glyphs.txt

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -406,7 +406,7 @@ Font files are optimized to remove unused character data. If a new character is 
    1. `cd tmp/public-sans-v2/fonts/ttf`
    2. `find . -name "*-subset.woff2" -exec sh -c 'cp $1 "../../../../app/assets/fonts/public-sans/${1%-subset.woff2}.woff2"' _ {} \;`
 
-At this point, your working directory should reflect changes to all of the files within `app/assets/fonts/public-sans`.
+At this point, your working directory should reflect changes to all of the files within `app/assets/fonts/public-sans`, and new or removed characters in `app/assets/fonts/glyphs.txt`. These changes should be committed to resolve the lint failure for character data.
 
 ## Devices
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates frontend documentation to clarify language around resolving optimized fonts lint failures.

The instructions included the necessary steps to produce changes to `glyphs.txt`, but it was not clear that changes needed to be committed, and particularly changes to both the font files themselves as well as `glyphs.txt`. These changes seek to clarify this.

Related: https://github.com/18F/identity-idp/pull/10755#issuecomment-2155106672

## 📜 Testing Plan

Read [the updated "Fonts" documentation](https://github.com/18F/identity-idp/blob/aduth-clarify-frontend-fonts/docs/frontend.md#fonts) and verify that it makes sense.