### PR TITLE
Replace Alert component "other" as default style

### DIFF
--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class AlertComponent < BaseComponent
-  VALID_TYPES = %i[info success warning error emergency].freeze
+  VALID_TYPES = [nil, :info, :success, :warning, :error, :emergency].freeze
 
   attr_reader :type, :message, :tag_options, :text_tag
 
   def initialize(type: nil, text_tag: 'p', message: nil, **tag_options)
-    if !type.nil? && !VALID_TYPES.include?(type)
+    if !VALID_TYPES.include?(type)
       raise ArgumentError, "`type` #{type} is invalid, expected one of #{VALID_TYPES}"
     end
 

--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class AlertComponent < BaseComponent
-  VALID_TYPES = %i[info success warning error emergency other].freeze
+  VALID_TYPES = %i[info success warning error emergency].freeze
 
   attr_reader :type, :message, :tag_options, :text_tag
 
-  def initialize(type: :info, text_tag: 'p', message: nil, **tag_options)
-    if !VALID_TYPES.include?(type)
+  def initialize(type: nil, text_tag: 'p', message: nil, **tag_options)
+    if !type.nil? && !VALID_TYPES.include?(type)
       raise ArgumentError, "`type` #{type} is invalid, expected one of #{VALID_TYPES}"
     end
 

--- a/app/views/idv/by_mail/request_letter/index.html.erb
+++ b/app/views/idv/by_mail/request_letter/index.html.erb
@@ -26,7 +26,11 @@
         ) %>
   </p>
 <% else %>
-  <%= render AlertComponent.new(message: t('idv.messages.gpo.info_alert'), class: 'margin-bottom-4') %>
+  <%= render AlertComponent.new(
+        type: :info,
+        message: t('idv.messages.gpo.info_alert'),
+        class: 'margin-bottom-4',
+      ) %>
   <%= render PageHeadingComponent.new.with_content(@presenter.title) %>
   <p>
     <%= t('idv.messages.gpo.timeframe_html') %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -28,7 +28,7 @@
             ) %>
       </div>
 
-<%= render AlertComponent.new(class: 'margin-y-4', text_tag: :div) do %>
+<%= render AlertComponent.new(type: :info, class: 'margin-y-4', text_tag: :div) do %>
   <p class="margin-bottom-1 margin-top-0 h3"><strong><%= t('in_person_proofing.body.barcode.deadline', deadline: @presenter.formatted_due_date) %></strong></p>
   <p><%= t('in_person_proofing.body.barcode.deadline_restart') %></p>
 <% end %>

--- a/app/views/shared/_sp_alert.html.erb
+++ b/app/views/shared/_sp_alert.html.erb
@@ -1,6 +1,6 @@
 <% alert = decorated_sp_session.sp_alert(section) %>
 <% if alert %>
-  <%= render AlertComponent.new(text_tag: 'div', class: 'margin-bottom-4') do %>
+  <%= render AlertComponent.new(type: :info, text_tag: 'div', class: 'margin-bottom-4') do %>
     <%= raw sanitize(alert, tags: %w[a b strong em br p ol ul li], attributes: %w[href target]) %>
   <% end %>
 <% end %>

--- a/spec/components/alert_component_spec.rb
+++ b/spec/components/alert_component_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe AlertComponent, type: :component do
     expect(rendered).to have_content('locals')
   end
 
-  it 'defaults to type "info"' do
+  it 'renders without modifier classes by default' do
     rendered = render_inline AlertComponent.new(message: 'FYI')
 
-    expect(rendered).to have_selector('.usa-alert.usa-alert--info')
+    expect(rendered).to have_selector('.usa-alert:not([class*=usa-alert--])')
   end
 
   it 'accepts alert type param' do

--- a/spec/components/previews/alert_component_preview.rb
+++ b/spec/components/previews/alert_component_preview.rb
@@ -24,18 +24,14 @@ class AlertComponentPreview < BaseComponentPreview
     render(AlertComponent.new(message: 'An emergency message', type: :emergency))
   end
 
-  def other
-    render(AlertComponent.new(message: 'An other message', type: :other))
-  end
-
   def with_custom_text_tag
     render(AlertComponent.new(type: :success, message: 'A custom message', text_tag: 'div'))
   end
   # @!endgroup
 
   # @param message text
-  # @param type select [info, success, warning, error, emergency, other]
-  def workbench(message: 'An important message', type: :info)
-    render(AlertComponent.new(message:, type:))
+  # @param type select [~, info, success, warning, error, emergency]
+  def workbench(message: 'An important message', type: nil)
+    render(AlertComponent.new(message:, type: type&.to_sym))
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `AlertComponent` to replace the explicit `:other` variant to be used as the default, instead of `:info`.

For additional context, refer to https://github.com/18F/identity-design-system/pull/449

Stylistically, there is visual difference in the previous `type: :other` compared with the new default appearance, since we never actually applied the `usa-alert--other` class. This works to our benefit, since there's effectively no change as a result of the upcoming design system release, and no logic changes needed to remove the application of a `usa-alert--other` class.

As part of these changes, I searched code for existing usage of `AlertComponent` not specifying `type` with the assumption of rendering an `:info` alert banner and passed an explicit `type: :info` to avoid regressions.

## 📜 Testing Plan

Verify there are no regressions in the impacted code previously assuming default `:info` alert type.

Verify the "Other" type styles are now shown as the "Default" (`type: nil`) styles in the component preview:

1. Go to https://review-aduth-aler-cgle14.review-app.identitysandbox.gov/components/inspect/alert/preview (local: http://localhost:3000/components/inspect/alert/preview)

## 👀 Screenshots

Before|After
---|---
![before](https://github.com/18F/identity-idp/assets/1779930/16a36efa-a82e-40f3-8487-945ceb50ec0d)|![after](https://github.com/18F/identity-idp/assets/1779930/3278415c-a31d-42be-b935-c1fec02d6817)
