### PR TITLE
Use Random.hex for base component unique ID

### DIFF
--- a/app/components/base_component.rb
+++ b/app/components/base_component.rb
@@ -22,7 +22,7 @@ class BaseComponent < ViewComponent::Base
   end
 
   def unique_id
-    @unique_id ||= SecureRandom.hex(4)
+    @unique_id ||= Random.hex(4)
   end
 
   private


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `BaseComponent` to use `Random.hex` instead of `SecureRandom.hex`.

These IDs are not security-sensitive, and merely need to be reasonably unique within instances of the component of a single request, to satisfy HTML validation of unique IDs across elements ([ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)).

Benchmark:

```rb
require 'benchmark/ips'
require 'securerandom'

Benchmark.ips do |x|
  x.report('SecureRandom.hex') do
    SecureRandom.hex(4)
  end

  x.report('Random.hex') do
    Random.hex(4)
  end

  x.compare!
end
```

Results:

```
Warming up --------------------------------------
    SecureRandom.hex   317.139k i/100ms
          Random.hex   506.735k i/100ms
Calculating -------------------------------------
    SecureRandom.hex      3.170M (± 0.4%) i/s -     15.857M in   5.002178s
          Random.hex      5.075M (± 0.2%) i/s -     25.843M in   5.092296s

Comparison:
          Random.hex:  5075034.7 i/s
    SecureRandom.hex:  3170062.9 i/s - 1.60x  slower
```

## 📜 Testing Plan

```
rspec spec/components/base_component_spec.rb
```