### PR TITLE
Standardize form validation for WebauthnSetupForm

### DIFF
--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -59,7 +59,7 @@ module Users
         user_session: user_session,
         device_name: DeviceName.from_user_agent(request.user_agent),
       )
-      result = form.submit(request.protocol, confirm_params)
+      result = form.submit(confirm_params)
       @platform_authenticator = form.platform_authenticator?
       @presenter = WebauthnSetupPresenter.new(
         current_user: current_user,
@@ -161,7 +161,7 @@ module Users
         :name,
         :platform_authenticator,
         :transports,
-      )
+      ).merge(protocol: request.protocol)
     end
   end
 end

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -99,7 +99,7 @@ class WebauthnSetupForm
 
   def validate_attestation_response
     return if valid_attestation_response?(protocol)
-    errors.add :name, :attestation_error, message: general_error_message
+    errors.add(:attestation_object, :invalid, message: general_error_message)
   end
 
   def valid_attestation_response?(protocol)

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -10,6 +10,7 @@ class WebauthnSetupForm
             :name,
             presence: { message: proc { |object| object.send(:generic_error_message) } }
   validate :name_is_unique
+  validate :validate_attestation_response
 
   attr_reader :attestation_response
 
@@ -22,12 +23,13 @@ class WebauthnSetupForm
     @name = nil
     @platform_authenticator = false
     @authenticator_data_flags = nil
+    @protocol = nil
     @device_name = device_name
   end
 
-  def submit(protocol, params)
+  def submit(params)
     consume_parameters(params)
-    success = valid? && valid_attestation_response?(protocol)
+    success = valid?
     if success
       create_webauthn_configuration
       event = PushNotification::RecoveryInformationChangedEvent.new(user: user)
@@ -59,7 +61,7 @@ class WebauthnSetupForm
 
   private
 
-  attr_reader :success, :transports, :invalid_transports
+  attr_reader :success, :transports, :invalid_transports, :protocol
   attr_accessor :user, :challenge, :attestation_object, :client_data_json,
                 :name, :platform_authenticator, :authenticator_data_flags, :device_name
 
@@ -74,6 +76,7 @@ class WebauthnSetupForm
     @transports, @invalid_transports = params[:transports]&.split(',')&.partition do |transport|
       WebauthnConfiguration::VALID_TRANSPORTS.include?(transport)
     end
+    @protocol = params[:protocol]
   end
 
   def name_is_unique
@@ -94,32 +97,22 @@ class WebauthnSetupForm
     end
   end
 
+  def validate_attestation_response
+    return if valid_attestation_response?(protocol)
+    errors.add :name, :attestation_error, message: general_error_message
+  end
+
   def valid_attestation_response?(protocol)
+    original_origin = "#{protocol}#{self.class.domain_name}"
     @attestation_response = ::WebAuthn::AuthenticatorAttestationResponse.new(
       attestation_object: Base64.decode64(@attestation_object),
       client_data_json: Base64.decode64(@client_data_json),
     )
-    safe_response("#{protocol}#{self.class.domain_name}")
-  end
 
-  def safe_response(original_origin)
-    response = @attestation_response.valid?(@challenge.pack('c*'), original_origin)
-    add_attestation_error unless response
-    response
-  rescue StandardError
-    add_attestation_error
-    false
-  end
-
-  def add_attestation_error
-    if @platform_authenticator
-      errors.add :name, I18n.t('errors.webauthn_platform_setup.general_error'),
-                 type: :attestation_error
-    else
-      errors.add :name, I18n.t(
-        'errors.webauthn_setup.general_error_html',
-        link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
-      ), type: :attestation_error
+    begin
+      attestation_response.valid?(@challenge.pack('c*'), original_origin)
+    rescue StandardError
+      false
     end
   end
 
@@ -149,6 +142,17 @@ class WebauthnSetupForm
       transports: transports.presence,
       authenticator_data_flags: authenticator_data_flags,
     )
+  end
+
+  def general_error_message
+    if platform_authenticator
+      I18n.t('errors.webauthn_platform_setup.general_error')
+    else
+      I18n.t(
+        'errors.webauthn_setup.general_error_html',
+        link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
+      )
+    end
   end
 
   def mfa_user

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -348,8 +348,10 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
             'Multi-Factor Authentication Setup',
             {
               enabled_mfa_methods_count: 0,
-              errors: { name: [I18n.t('errors.webauthn_platform_setup.general_error')] },
-              error_details: { name: { attestation_error: true } },
+              errors: {
+                attestation_object: [I18n.t('errors.webauthn_platform_setup.general_error')],
+              },
+              error_details: { attestation_object: { invalid: true } },
               in_account_creation_flow: false,
               mfa_method_counts: {},
               multi_factor_auth_method: 'webauthn_platform',

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe WebauthnSetupForm do
       platform_authenticator: false,
       transports: 'usb',
       authenticator_data_value: '153',
+      protocol:,
     }
   end
   let(:subject) { WebauthnSetupForm.new(user:, user_session:, device_name:) }
@@ -41,7 +42,7 @@ RSpec.describe WebauthnSetupForm do
           pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 
-        expect(subject.submit(protocol, params).to_h).to eq(
+        expect(subject.submit(params).to_h).to eq(
           success: true,
           errors: {},
           **extra_attributes,
@@ -57,7 +58,7 @@ RSpec.describe WebauthnSetupForm do
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
 
-        subject.submit(protocol, params)
+        subject.submit(params)
       end
 
       context 'with platform authenticator' do
@@ -66,7 +67,7 @@ RSpec.describe WebauthnSetupForm do
         end
 
         it 'creates a platform authenticator' do
-          result = subject.submit(protocol, params)
+          result = subject.submit(params)
           expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
 
           user.reload
@@ -81,7 +82,7 @@ RSpec.describe WebauthnSetupForm do
           let(:params) { super().merge(authenticator_data_value: '65') }
 
           it 'includes data flags with bs set as false ' do
-            result = subject.submit(protocol, params)
+            result = subject.submit(params)
 
             expect(result.to_h[:authenticator_data_flags]).to eq(
               up: true,
@@ -98,7 +99,7 @@ RSpec.describe WebauthnSetupForm do
           let(:params) { super().merge(authenticator_data_value: 'bad_error') }
 
           it 'should not include authenticator data flag' do
-            result = subject.submit(protocol, params)
+            result = subject.submit(params)
 
             expect(result.to_h[:authenticator_data_flags]).to be_nil
           end
@@ -108,7 +109,7 @@ RSpec.describe WebauthnSetupForm do
           let(:params) { super().merge(authenticator_data_value: nil) }
 
           it 'should not include authenticator data flag' do
-            result = subject.submit(protocol, params)
+            result = subject.submit(params)
 
             expect(result.to_h[:authenticator_data_flags]).to be_nil
           end
@@ -119,7 +120,7 @@ RSpec.describe WebauthnSetupForm do
         let(:params) { super().merge(transports: 'wrong') }
 
         it 'creates a webauthn configuration without transports' do
-          subject.submit(protocol, params)
+          subject.submit(params)
 
           user.reload
 
@@ -127,7 +128,7 @@ RSpec.describe WebauthnSetupForm do
         end
 
         it 'includes unknown transports in extra analytics' do
-          result = subject.submit(protocol, params)
+          result = subject.submit(params)
 
           expect(result.to_h).to eq(
             success: true,
@@ -169,7 +170,7 @@ RSpec.describe WebauthnSetupForm do
           pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 
-        expect(subject.submit(protocol, params).to_h).to eq(
+        expect(subject.submit(params).to_h).to eq(
           success: false,
           errors: { name: [I18n.t(
             'errors.webauthn_setup.general_error_html',
@@ -185,7 +186,7 @@ RSpec.describe WebauthnSetupForm do
       let(:params) { super().except(:transports) }
 
       it 'creates a webauthn configuration without transports' do
-        subject.submit(protocol, params)
+        subject.submit(params)
 
         user.reload
 
@@ -214,7 +215,7 @@ RSpec.describe WebauthnSetupForm do
           pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 
-        expect(subject.submit(protocol, params).to_h).to eq(
+        expect(subject.submit(params).to_h).to eq(
           success: false,
           errors: { name: [I18n.t(
             'errors.webauthn_setup.general_error_html',
@@ -234,7 +235,7 @@ RSpec.describe WebauthnSetupForm do
         user
       end
       it 'checks for unique device on a webauthn device' do
-        result = subject.submit(protocol, params)
+        result = subject.submit(params)
         expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn'
         expect(result.errors[:name]).to eq(
           [I18n.t(
@@ -263,7 +264,7 @@ RSpec.describe WebauthnSetupForm do
         end
 
         it 'adds a new platform device with the same existing name and appends a (1)' do
-          result = subject.submit(protocol, params)
+          result = subject.submit(params)
           expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
           expect(user.webauthn_configurations.platform_authenticators.count).to eq(2)
           expect(
@@ -289,7 +290,7 @@ RSpec.describe WebauthnSetupForm do
         end
 
         it 'adds a second new platform device with the same existing name and appends a (2)' do
-          result = subject.submit(protocol, params)
+          result = subject.submit(params)
 
           expect(result.success?).to eq(true)
           expect(user.webauthn_configurations.platform_authenticators.count).to eq(3)

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -172,11 +172,15 @@ RSpec.describe WebauthnSetupForm do
 
         expect(subject.submit(params).to_h).to eq(
           success: false,
-          errors: { name: [I18n.t(
-            'errors.webauthn_setup.general_error_html',
-            link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
-          )] },
-          error_details: { name: { attestation_error: true } },
+          errors: {
+            attestation_object: [
+              I18n.t(
+                'errors.webauthn_setup.general_error_html',
+                link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
+              ),
+            ],
+          },
+          error_details: { attestation_object: { invalid: true } },
           **extra_attributes,
         )
       end
@@ -217,11 +221,15 @@ RSpec.describe WebauthnSetupForm do
 
         expect(subject.submit(params).to_h).to eq(
           success: false,
-          errors: { name: [I18n.t(
-            'errors.webauthn_setup.general_error_html',
-            link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
-          )] },
-          error_details: { name: { attestation_error: true } },
+          errors: {
+            attestation_object: [
+              I18n.t(
+                'errors.webauthn_setup.general_error_html',
+                link_html: I18n.t('errors.webauthn_setup.additional_methods_link'),
+              ),
+            ],
+          },
+          error_details: { attestation_object: { invalid: true } },
           **extra_attributes,
         )
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Refactors `WebauthnSetupForm` to validate parameters in a standardized manner:

- `submit` accepts a single hash of parameters
- Use `ActiveModel::Model` validation methods (`validates`, etc.) to add errors
- Success is based on `ActiveModel::Model#valid?` alone

This originally started with a desire to replace the ad hoc [`webauthn_setup_submitted`](https://github.com/18F/identity-idp/blob/99bad4f9a546ab1728a74a715304d5a2ff40424e/app/services/analytics_events.rb#L5694-L5706) with `multi_factor_auth_setup`, which then led to the realization that setups can happen through multiple pathways and forms ([`WebauthnSetupForm`](https://github.com/18F/identity-idp/blob/main/app/forms/webauthn_setup_form.rb) and [`WebauthnVisitForm`](https://github.com/18F/identity-idp/blob/main/app/forms/webauthn_visit_form.rb)). The changes here are intended to standardize behaviors in `WebauthnSetupForm` to help prepare for the next step of merging `WebauthnSetupForm` and `WebauthnVisitForm`.

## 📜 Testing Plan

Verify there are no regressions in the setup of a Face or Touch Unlock or Security Key MFA method.

Verify that tests pass:

```
rspec spec/forms/webauthn_setup_form_spec.rb
```