### PR TITLE
Fix internationalization test to fail when there are unused allowed interpolation mismatches

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -280,8 +280,10 @@ RSpec.describe 'I18n' do
       # We group and sort by the Set of interpolation arguments and assume the group with the
       # most common interpolation arguments is the correct one. We then take the keys
       # in the remaining groups and add them to the missing keys list.
-      keys = interpolation_arguments.group_by { |k, _v| v }.sort_by { |_k, v| v.length * -1 }.drop(1).
-        map { |_k, group| group.flatten }.to_h.keys
+      keys =
+        interpolation_arguments.group_by { |_k, v| v }.
+          sort_by { |_k, v| v.length * -1 }.drop(1).
+          map { |x| x[1].flatten }.to_h.keys
 
       missing_interpolation_argument_locale_keys += keys
     end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe 'I18n' do
       # most common interpolation arguments is the correct one. We then take the keys
       # in the remaining groups and add them to the missing keys list.
       keys = interpolation_arguments.group_by { |k, _v| v }.sort_by { |_k, v| v.length * -1 }.drop(1).
-        map { |x| x[1].flatten }.to_h.keys
+        map { |_k, group| group.flatten }.to_h.keys
 
       missing_interpolation_argument_locale_keys += keys
     end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -20,11 +20,9 @@ ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS = [
   'zh.account_reset.pending.confirm',
   'zh.account_reset.pending.wait_html',
   'zh.account_reset.recovery_options.check_webauthn_platform_info',
-  'zh.doc_auth.headings.welcome',
   'zh.doc_auth.info.exit.with_sp',
   'zh.idv.cancel.headings.exit.with_sp',
   'zh.idv.failure.exit.with_sp',
-  'zh.in_person_proofing.body.barcode.return_to_partner_link',
   'zh.telephony.account_reset_notice',
   'zh.two_factor_authentication.account_reset.pending',
   'zh.user_mailer.account_reset_granted.intro_html',
@@ -258,24 +256,56 @@ RSpec.describe 'I18n' do
     missing_interpolation_argument_locale_keys = []
 
     i18n.data[i18n.base_locale].select_keys do |key, _node|
-      if key.start_with?('i18n.transliterate.rule.') || i18n.t(key).is_a?(Array) || i18n.t(key).nil?
+      if key.start_with?('i18n.transliterate.rule.') || i18n.t(key).is_a?(Array) || !i18n.t(key)
         next
       end
 
       interpolation_arguments = i18n.locales.map do |locale|
-        if ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS.include?("#{locale}.#{key}")
-          missing_interpolation_argument_locale_keys.push("#{locale}.#{key}")
-          next
+        value = extract_interpolation_arguments i18n.t(key, locale)
+        if value
+          ["#{locale}.#{key}", value]
         end
-        extract_interpolation_arguments i18n.t(key, locale)
-      end.compact
+      end.compact.to_h
 
-      missing_interpolation_argument_keys.push(key) if interpolation_arguments.uniq.length > 1
+      next if interpolation_arguments.blank?
+      next if interpolation_arguments.values.uniq.length == 1
+      if ALLOWED_INTERPOLATION_MISMATCH_KEYS.include?(key)
+        missing_interpolation_argument_keys.push(key)
+        next
+      end
+
+      # interpolation_arguments is a hash where the keys are the locale-specific content key,
+      # and values are the Set of interpolation arguments used in that key.
+      #
+      # We group and sort by the Set of interpolation arguments and assume the group with the
+      # most common interpolation arguments is the correct one. We then take the keys
+      # in the remaining groups and add them to the missing keys list.
+      keys = interpolation_arguments.group_by { |k, v| v }.sort_by { |k, v| v.length * -1 }.drop(1).
+        map { |x| x[1].flatten }.to_h.keys
+
+      missing_interpolation_argument_locale_keys += keys
     end
 
-    expect(missing_interpolation_argument_keys.sort).to eq ALLOWED_INTERPOLATION_MISMATCH_KEYS
-    expect(missing_interpolation_argument_locale_keys.sort).to eq(
-      ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS,
+    unused_allowed_interpolation_mismatch_keys =
+      ALLOWED_INTERPOLATION_MISMATCH_KEYS - missing_interpolation_argument_keys
+    expect(unused_allowed_interpolation_mismatch_keys.sort).to(
+      be_empty,
+      <<~EOS,
+        ALLOWED_INTERPOLATION_MISMATCH_KEYS contains unused allowed interpolation mismatches.
+        The following keys can be removed from ALLOWED_INTERPOLATION_MISMATCH_KEYS:
+        #{unused_allowed_interpolation_mismatch_keys.pretty_inspect}
+      EOS
+    )
+
+    unused_allowed_interpolation_mismatch_locale_keys =
+      ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS - missing_interpolation_argument_locale_keys
+    expect(unused_allowed_interpolation_mismatch_locale_keys).to(
+      be_empty,
+      <<~EOS,
+        ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS contains unused allowed interpolation mismatches.
+        The following keys can be removed from ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS:
+        #{unused_allowed_interpolation_mismatch_locale_keys.pretty_inspect}
+      EOS
     )
   end
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe 'I18n' do
       # We group and sort by the Set of interpolation arguments and assume the group with the
       # most common interpolation arguments is the correct one. We then take the keys
       # in the remaining groups and add them to the missing keys list.
-      keys = interpolation_arguments.group_by { |k, v| v }.sort_by { |k, v| v.length * -1 }.drop(1).
+      keys = interpolation_arguments.group_by { |k, _v| v }.sort_by { |_k, v| v.length * -1 }.drop(1).
         map { |x| x[1].flatten }.to_h.keys
 
       missing_interpolation_argument_locale_keys += keys


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

Addresses the comment here https://github.com/18F/identity-idp/pull/10758#discussion_r1626275135 where we were not failing as expected when we have unused exceptions to mismatched interpolation arguments. I'm not super happy with the logic at this point, but it does seem to work correctly.

The initial run in https://github.com/18F/identity-idp/pull/10783/commits/cc0fb0207421c1d26a9aba8fb85111c7ceb56502 is expected to fail.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
