### PR TITLE
Add test that ensures punctuation pairs match correctly 

### DIFF
--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1320,7 +1320,7 @@ instructions.go_back_to_mobile_app: 要继续的话，请回到 %{friendly_name}
 instructions.mfa.authenticator.confirm_code_html: 输入来自你身份证实应用程序的代码。如果你在应用程序中设了几个账户，请输入与在 %{app_name_html}对应的代码。
 instructions.mfa.authenticator.manual_entry: 或者动手将这个密码输入你的身份证实应用程序。
 instructions.mfa.piv_cac.account_not_found_html: 用你的电邮地址和密码 <p><strong>%{sign_in}</strong>。然后把你的 PIV/CAC 添加到账户。</p> <p><strong>没有%{app_name} 账户？</strong> %{create_account}</p>
-instructions.mfa.piv_cac.add_from_sign_in_html: '<strong>说明:</strong> 看到<strong>“添加 PIV/CAC”</strong>时插入你的 PIV or CAC 。你将需要<strong>选择一个证书</strong> (恰当的证书可能会有你的名字）而且<strong>输入你的个人识别号码（PIN）</strong> (你的个人识别号码（PIN）是在设置 PIV/CAC 时设立的)。'
+instructions.mfa.piv_cac.add_from_sign_in_html: '<strong>说明:</strong> 看到<strong>“添加 PIV/CAC”</strong>时插入你的 PIV or CAC 。你将需要<strong>选择一个证书</strong> （恰当的证书可能会有你的名字）而且<strong>输入你的个人识别号码（PIN）</strong> (你的个人识别号码（PIN）是在设置 PIV/CAC 时设立的)。'
 instructions.mfa.piv_cac.already_associated_html: 请从另一个 PIV/CAC 选择证书，联系管理员以保证你的 PIV/CAC 是最新的。如果你认为这是一个错误， %{try_again_html}。
 instructions.mfa.piv_cac.back_to_sign_in: 返回去登录
 instructions.mfa.piv_cac.confirm_piv_cac: 提供与你账户相关的 PIV/CAC。
@@ -1334,7 +1334,7 @@ instructions.mfa.piv_cac.step_1: 给它一个昵称
 instructions.mfa.piv_cac.step_1_info: 这样如果你添加了一个以上 PIV/CA 话，你就能把它们分辨开来。
 instructions.mfa.piv_cac.step_2: 把 PIV/CAC 插入读卡器
 instructions.mfa.piv_cac.step_3: 添加 PIV/CAC
-instructions.mfa.piv_cac.step_3_info_html: 你将需要<strong>选择一个证书</strong> (恰当的证书可能会有你的名字）而且<strong>输入你的个人识别号码（PIN）</strong> (你的个人识别号码（PIN）是在设置 PIV/CAC 时设立的)。
+instructions.mfa.piv_cac.step_3_info_html: 你将需要<strong>选择一个证书</strong> （恰当的证书可能会有你的名字）而且<strong>输入你的个人识别号码（PIN）</strong> (你的个人识别号码（PIN）是在设置 PIV/CAC 时设立的)。
 instructions.mfa.piv_cac.try_again: 再试一次
 instructions.mfa.sms.number_message_html: 我们把带有一次性代码的短信发到了 %{number_html}。这一代码 %{expiration} 分钟后会作废。
 instructions.mfa.voice.number_message_html: 我们给 %{number_html}打了电话告知一次性代码。这一代码 %{expiration} 分钟后会作废。

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -35,6 +35,14 @@ ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS = [
   'zh.user_mailer.new_device_sign_in.info',
 ].sort.freeze
 
+PUNCTUATION_PAIRS = {
+  '{' => '}',
+  '[' => ']',
+  '(' => ')',
+  '<' => '>',
+  '（' => '）',
+}.freeze
+
 # A set of patterns which are expected to only occur within specific locales. This is an imperfect
 # solution based on current content, intended to help prevent accidents when adding new translated
 # content. If you are having issues with new content, it would be reasonable to remove or modify
@@ -182,6 +190,28 @@ RSpec.describe 'I18n' do
   let(:untranslated_keys) { i18n.untranslated_keys }
   let(:leading_or_trailing_whitespace_keys) do
     i18n.leading_or_trailing_whitespace_keys
+  end
+
+  it 'has matching pairs of punctuation' do
+    mismatched_punctuation_pairs = {}
+    i18n.locales.each do |locale|
+      i18n.data[locale].key_values.each do |key, value|
+        PUNCTUATION_PAIRS.each do |item1, item2|
+          Array(value).each do |value|
+            next if value.nil?
+            if value.count(item1) != value.count(item2)
+              mismatched_punctuation_pairs["#{locale}.#{key}"] ||= []
+              mismatched_punctuation_pairs["#{locale}.#{key}"].push("#{item1} #{item2}")
+            end
+          end
+        end
+      end
+    end
+
+    expect(mismatched_punctuation_pairs).to(
+      be_empty,
+      "keys with mismatched punctuation pairs: #{mismatched_punctuation_pairs.pretty_inspect}",
+    )
   end
 
   it 'does not have missing keys' do


### PR DESCRIPTION
## 🛠 Summary of changes

This PR adds a test that any paired punctuation like parentheses and brackets have an equal number.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
