### PR TITLE
Update factory_bot to fix deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,10 +315,10 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
-    factory_bot (6.2.1)
+    factory_bot (6.4.6)
       activesupport (>= 5.0.0)
-    factory_bot_rails (6.2.0)
-      factory_bot (~> 6.2.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
       railties (>= 5.0.0)
     faker (2.19.0)
       i18n (>= 1.6, < 2)


### PR DESCRIPTION
## 🛠 Summary of changes

Updating fixes the following warning when running tests:


> warning: ruby/3.3.0/observer.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add observer to your Gemfile or gemspec. Also contact author of factory_bot-6.2.1 to add observer into its gemspec.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
