### PR TITLE
Fix small bug in matching cert tracking metrics

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -148,7 +148,7 @@ class SamlIdpController < ApplicationController
   end
 
   def encryption_cert_matches_matching_cert?
-    matching_cert == encryption_cert
+    (matching_cert || saml_request_service_provider&.ssl_certs&.first) == encryption_cert
   end
 
   def log_external_saml_auth_request

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1490,7 +1490,7 @@ RSpec.describe SamlIdpController do
             expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
           end
 
-          context 'Certificate does not match because of order bug' do
+          context 'Certificate sig validation fails because of namespace bug' do
             let(:encryption_cert_matches_matching_cert) { false }
             let(:matching_cert_serial) { nil }
             let(:request_sp) { double  }


### PR DESCRIPTION
## 🎫 Ticket
https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/36

## 🛠 Summary of changes
The `encryption_cert_matches_matching_cert?` method did not consider conditions where `matching_cert` might evaluate to `nil`, and therefore be comparing `nil` to the encryption_certificate, which will always be not `nil`. This change updates the code to ensure both matching_cert falls back on the first registered cert value if `nil`


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
