### PR TITLE
Remove the `sp_costs_added` flag from the resolution result

### DIFF
--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -39,7 +39,6 @@ module Proofing
               device_profiling_adjudication_reason: device_profiling_reason,
               resolution_adjudication_reason: resolution_reason,
               should_proof_state_id: should_proof_state_id?,
-              sp_costs_added: true,
               stages: {
                 resolution: resolution_result.to_h,
                 residential_address: residential_resolution_result.to_h,

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -273,7 +273,6 @@ RSpec.describe Idv::VerifyInfoController, allowed_extra_analytics: [:*] do
           same_address_as_id: true,
           should_proof_state_id: true,
         ).adjudicated_result.to_h
-        adjudicated_result[:context].delete(:sp_costs_added)
 
         document_capture_session.create_proofing_session
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -83,7 +83,6 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         device_profiling_adjudication_reason: 'device_profiling_result_pass',
         resolution_adjudication_reason: 'pass_resolution_and_state_id',
         should_proof_state_id: true,
-        sp_costs_added: true,
         stages: {
           resolution: resolution_block,
           residential_address: { attributes_requiring_additional_verification: [],
@@ -113,7 +112,6 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         device_profiling_adjudication_reason: 'device_profiling_result_pass',
         resolution_adjudication_reason: 'pass_resolution_and_state_id',
         should_proof_state_id: true,
-        sp_costs_added: true,
         stages: {
           resolution: resolution_block,
           residential_address: { errors: {},


### PR DESCRIPTION
The `VerifyInfoConcern` used to add SP costs to the database by inspecting the result from the `ResolutionProofingJob`. We have made the following changes in an effort to move the logic for tracking SP costs into the resolution proofing job:

- In #10743 we added a conditional to the `VerifyInfoConcern` to stop writing SP costs if a `sp_costs_added` flag is present on the result
- In #10767 we started adding costs in the `ResolutionProofingJob` and had the job set the `sp_costs_added` flag
- In #10786 we removed the code that added the SP costs in the `VerifyInfoConcern`

This commit includes the changes for the final step: Removing the `sp_costs_added` flag now that nothing is reading it.

This commit can be safely merged into main when all of the above changes are fully deployed.
