### PR TITLE
Do not track SP costs in AAMVA exception case

### DIFF
--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -142,7 +142,7 @@ module Proofing
         timer.time('state_id') do
           state_id_proofer.proof(applicant_pii_with_state_id_address)
         end.tap do |result|
-          add_sp_cost(:aamva, result.transaction_id)
+          add_sp_cost(:aamva, result.transaction_id) if !result.exception.present?
         end
       end
 

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -142,7 +142,7 @@ module Proofing
         timer.time('state_id') do
           state_id_proofer.proof(applicant_pii_with_state_id_address)
         end.tap do |result|
-          add_sp_cost(:aamva, result.transaction_id) if !result.exception.present?
+          add_sp_cost(:aamva, result.transaction_id) if result.exception.blank?
         end
       end
 

--- a/spec/services/proofing/resolution/progressive_proofer_spec.rb
+++ b/spec/services/proofing/resolution/progressive_proofer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
       Proofing::StateIdResult,
       success?: false,
       transaction_id: 'aamva-123',
+      exception: nil,
     )
   end
   let(:aamva_proofer) { instance_double(Proofing::Aamva::Proofer, proof: aamva_proofer_result) }
@@ -202,6 +203,21 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
           expect(threatmetrix_sp_costs.count).to eq(0)
         end
       end
+
+      context 'AAMVA raises an exception' do
+        let(:aamva_proofer_result) do
+          instance_double(
+            Proofing::StateIdResult,
+            success?: false,
+            transaction_id: 'aamva-123',
+            exception: RuntimeError.new('this is a fun test error!!'),
+          )
+        end
+
+        it 'does not track an SP cost for AAMVA' do
+          expect { proof }.to_not change { SpCost.where(cost_type: :aamva).count }
+        end
+      end
     end
 
     context 'ipp flow' do
@@ -279,6 +295,7 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
                   verified_attributes: [],
                   success?: false,
                   transaction_id: 'aamva-123',
+                  exception: nil,
                 )
               end
 
@@ -294,6 +311,7 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
                   verified_attributes: [:address],
                   success?: true,
                   transaction_id: 'aamva-123',
+                  exception: nil,
                 )
               end
 
@@ -332,6 +350,7 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
                   Proofing::StateIdResult,
                   success?: false,
                   transaction_id: 'aamva-123',
+                  exception: nil,
                 )
               end
 
@@ -413,6 +432,7 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
                   Proofing::StateIdResult,
                   success?: false,
                   transaction_id: 'aamva-123',
+                  exception: nil,
                 )
               end
 


### PR DESCRIPTION
I was looking at the changes in #10786 for the move of SP cost tracking from the `VerifyInfoConcern` to the `ProgressiveProofer` when I noticed this condition that was not accounted for:

https://github.com/18F/identity-idp/pull/10786/files#diff-5d8b1370b1c579364bb79a0813ca9bf9a15c65e7a974829886ab3e00f3441cedL310

This logic prevents a AAMVA cost from being added if an AAMVA exception occurs. Presumably this is because we are not billed for AAMVA exception which happen frequently. This commit applies that logic to the `ProgressiveProofer` where SP costs are now tracked.
