### PR TITLE
Determine whether an AAMVA check is required in the progressive proofer

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -26,7 +26,6 @@ module Idv
 
       Idv::Agent.new(pii).proof_resolution(
         document_capture_session,
-        should_proof_state_id: aamva_state?,
         trace_id: amzn_trace_id,
         user_id: current_user.id,
         threatmetrix_session_id: idv_session.threatmetrix_session_id,
@@ -41,10 +40,6 @@ module Idv
 
     def ipp_enrollment_in_progress?
       current_user.has_in_person_enrollment?
-    end
-
-    def aamva_state?
-      IdentityConfig.store.aamva_supported_jurisdictions.include?(pii['state_id_jurisdiction'])
     end
 
     def resolution_rate_limiter

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -26,7 +26,7 @@ class ResolutionProofingJob < ApplicationJob
     threatmetrix_session_id: nil,
     request_ip: nil,
     # DEPRECATED ARGUMENTS
-    should_proof_state_id: false
+    should_proof_state_id: false # rubocop:disable Lint/UnusedMethodArgument
   )
     timer = JobHelpers::Timer.new
 

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -20,12 +20,13 @@ class ResolutionProofingJob < ApplicationJob
     result_id:,
     encrypted_arguments:,
     trace_id:,
-    should_proof_state_id:,
     ipp_enrollment_in_progress:,
     user_id: nil,
     service_provider_issuer: nil,
     threatmetrix_session_id: nil,
-    request_ip: nil
+    request_ip: nil,
+    # DEPRECATED ARGUMENTS
+    should_proof_state_id: false
   )
     timer = JobHelpers::Timer.new
 
@@ -49,7 +50,6 @@ class ResolutionProofingJob < ApplicationJob
       applicant_pii: applicant_pii,
       threatmetrix_session_id: threatmetrix_session_id,
       request_ip: request_ip,
-      should_proof_state_id: should_proof_state_id,
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       current_sp: current_sp,
     )
@@ -77,7 +77,6 @@ class ResolutionProofingJob < ApplicationJob
     applicant_pii:,
     threatmetrix_session_id:,
     request_ip:,
-    should_proof_state_id:,
     ipp_enrollment_in_progress:,
     current_sp:
   )
@@ -86,7 +85,6 @@ class ResolutionProofingJob < ApplicationJob
       user_email: user.confirmed_email_addresses.first.email,
       threatmetrix_session_id: threatmetrix_session_id,
       request_ip: request_ip,
-      should_proof_state_id: should_proof_state_id,
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       timer: timer,
       current_sp: current_sp,

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -22,7 +22,6 @@ module Idv
 
       job_arguments = {
         encrypted_arguments: encrypted_arguments,
-        should_proof_state_id: false,
         trace_id: trace_id,
         result_id: document_capture_session.result_id,
         user_id: user_id,
@@ -30,6 +29,8 @@ module Idv
         threatmetrix_session_id: threatmetrix_session_id,
         request_ip: request_ip,
         ipp_enrollment_in_progress: ipp_enrollment_in_progress,
+        # This argument is intended to be removed
+        should_proof_state_id: false,
       }
 
       if IdentityConfig.store.ruby_workers_idv_enabled

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -8,7 +8,6 @@ module Idv
 
     def proof_resolution(
       document_capture_session,
-      should_proof_state_id:,
       trace_id:,
       user_id:,
       threatmetrix_session_id:,
@@ -23,7 +22,7 @@ module Idv
 
       job_arguments = {
         encrypted_arguments: encrypted_arguments,
-        should_proof_state_id: should_proof_state_id,
+        should_proof_state_id: false,
         trace_id: trace_id,
         result_id: document_capture_session.result_id,
         user_id: user_id,

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -133,7 +133,6 @@ module Proofing
 
       def aamva_supports_state_id_jurisdiction?
         state_id_jurisdiction = applicant_pii[:state_id_jurisdiction]
-        raise 'blank state_id_jurisdiction' if state_id_jurisdiction.blank?
         IdentityConfig.store.aamva_supported_jurisdictions.include?(state_id_jurisdiction)
       end
 

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -133,6 +133,7 @@ module Proofing
 
       def aamva_supports_state_id_jurisdiction?
         state_id_jurisdiction = applicant_pii[:state_id_jurisdiction]
+        raise 'blank state_id_jurisdiction' if state_id_jurisdiction.blank?
         IdentityConfig.store.aamva_supported_jurisdictions.include?(state_id_jurisdiction)
       end
 

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -156,7 +156,6 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
         expect_any_instance_of(Idv::Agent).to receive(:proof_resolution).
           with(
             kind_of(DocumentCaptureSession),
-            should_proof_state_id: anything,
             trace_id: subject.send(:amzn_trace_id),
             threatmetrix_session_id: nil,
             user_id: anything,
@@ -172,7 +171,6 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
       it 'indicates to the IDV agent that ipp_enrollment_in_progress is enabled' do
         expect_any_instance_of(Idv::Agent).to receive(:proof_resolution).with(
           kind_of(DocumentCaptureSession),
-          should_proof_state_id: anything,
           trace_id: anything,
           threatmetrix_session_id: anything,
           user_id: anything,
@@ -195,7 +193,6 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
       expect_any_instance_of(Idv::Agent).to receive(:proof_resolution).
         with(
           kind_of(DocumentCaptureSession),
-          should_proof_state_id: anything,
           trace_id: subject.send(:amzn_trace_id),
           threatmetrix_session_id: nil,
           user_id: anything,

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -249,29 +249,17 @@ RSpec.feature 'verify_info step and verify_info_concern', :js, allowed_extra_ana
     let(:mock_state_id_jurisdiction) do
       [Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction]]
     end
-    let(:proof_resolution_args) do
-      {
-        trace_id: anything,
-        threatmetrix_session_id: anything,
-        request_ip: kind_of(String),
-        ipp_enrollment_in_progress: false,
-      }
-    end
 
     context 'when the user lives in an AAMVA supported state' do
       it 'performs a resolution and state ID check' do
         allow(IdentityConfig.store).to receive(:aamva_supported_jurisdictions).and_return(
           mock_state_id_jurisdiction,
         )
-        expect_any_instance_of(Idv::Agent).
-          to receive(:proof_resolution).
-          with(
-            anything,
-            should_proof_state_id: true,
-            user_id: user.id,
-            **proof_resolution_args,
-          ).
-          and_call_original
+        expect_any_instance_of(Proofing::Mock::StateIdMockClient).to receive(:proof).with(
+          hash_including(
+            **Idp::Constants::MOCK_IDV_APPLICANT,
+          ),
+        ).and_call_original
 
         complete_ssn_step
         complete_verify_step
@@ -284,15 +272,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js, allowed_extra_ana
           IdentityConfig.store.aamva_supported_jurisdictions -
             mock_state_id_jurisdiction,
         )
-        expect_any_instance_of(Idv::Agent).
-          to receive(:proof_resolution).
-          with(
-            anything,
-            should_proof_state_id: false,
-            user_id: user.id,
-            **proof_resolution_args,
-          ).
-          and_call_original
+        expect_any_instance_of(Proofing::Mock::StateIdMockClient).to_not receive(:proof)
 
         complete_ssn_step
         complete_verify_step

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:document_capture_session) do
     DocumentCaptureSession.new(result_id: SecureRandom.hex, uuid: SecureRandom.uuid)
   end
-  let(:should_proof_state_id) { true }
   let(:trace_id) { SecureRandom.uuid }
   let(:user) { create(:user, :fully_registered) }
   let(:service_provider) { create(:service_provider, app_id: 'fake-app-id') }
@@ -35,7 +34,6 @@ RSpec.describe ResolutionProofingJob, type: :job do
     subject(:perform) do
       instance.perform(
         result_id: document_capture_session.result_id,
-        should_proof_state_id: should_proof_state_id,
         encrypted_arguments: encrypted_arguments,
         trace_id: trace_id,
         user_id: user.id,
@@ -249,7 +247,9 @@ RSpec.describe ResolutionProofingJob, type: :job do
     end
 
     context 'in a state where AAMVA is not supported' do
-      let(:should_proof_state_id) { false }
+      let(:pii) do
+        Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.merge(state_id_jurisdiction: 'NY')
+      end
 
       it 'does not make an AAMVA request' do
         stub_vendor_requests
@@ -332,7 +332,6 @@ RSpec.describe ResolutionProofingJob, type: :job do
       subject(:perform) do
         instance.perform(
           result_id: document_capture_session.result_id,
-          should_proof_state_id: should_proof_state_id,
           encrypted_arguments: encrypted_arguments,
           trace_id: trace_id,
           user_id: user.id,

--- a/spec/services/proofing/resolution/progressive_proofer_spec.rb
+++ b/spec/services/proofing/resolution/progressive_proofer_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
       address2: applicant_pii[:identity_doc_address2],
       city: applicant_pii[:identity_doc_city],
       state: applicant_pii[:identity_doc_address_state],
-      state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],
       zipcode: applicant_pii[:identity_doc_zipcode],
     }
   end
@@ -63,7 +62,6 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
       address2: applicant_pii[:address2],
       city: applicant_pii[:city],
       state: applicant_pii[:state],
-      state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],
       zipcode: applicant_pii[:zipcode],
     }
   end
@@ -77,7 +75,7 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
       address2: '2nd Address Line',
       city: 'Best City',
       zipcode: '12345',
-      state_id_jurisdiction: 'Virginia',
+      state_id_jurisdiction: 'VA',
       address_state: 'VA',
       state_id_number: '1111111111111',
       same_address_as_id: 'true',
@@ -120,7 +118,6 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
         applicant_pii: applicant_pii,
         ipp_enrollment_in_progress: ipp_enrollment_in_progress,
         request_ip: Faker::Internet.ip_v4_address,
-        should_proof_state_id: true,
         threatmetrix_session_id: threatmetrix_session_id,
         timer: JobHelpers::Timer.new,
         user_email: Faker::Internet.email,


### PR DESCRIPTION
Prior to this commit we have been passing `should_proof_state_id` from the `VerifyInfoConcern` down to the `ProgressiveProofer` through the async proofing tooling. This requires this argument to be passed down the call stack and stored as a background job argument.

The `should_proof_state_id` value is determined by configuration that is available to the IdP and the workers. It is not clear why it needs to be computed in the `VerifyInfoConcern` and passed down through the job to the `ProgressiveProofer`. This commit shortcuts everything by moving the logic closer to where the value is actually inspected.
