### PR TITLE
LG-13593 Update the cloudwatch query for identity verification report to filter fraud-pending in-person users

### DIFF
--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -300,7 +300,7 @@ module Reporting
           , coalesce(properties.event_properties.success, 0) AS success
         #{issuers.present? ? '| filter properties.service_provider IN %{issuers}' : ''}
         | filter name in %{event_names}
-        | filter (name = %{usps_enrollment_status_updated} and properties.event_properties.passed = 1 and properties.event_properties.tmx_status = 'threatmetrix_pass')
+        | filter (name = %{usps_enrollment_status_updated} and properties.event_properties.passed = 1 and properties.event_properties.tmx_status not in ['threatmetrix_review', 'threatmetrix_reject'])
                  or (name != %{usps_enrollment_status_updated})
         | filter (name in %{gpo_verification_submitted} and properties.event_properties.success = 1 and !properties.event_properties.pending_in_person_enrollment and !properties.event_properties.fraud_check_failed)
                  or (name not in %{gpo_verification_submitted})

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -300,7 +300,7 @@ module Reporting
           , coalesce(properties.event_properties.success, 0) AS success
         #{issuers.present? ? '| filter properties.service_provider IN %{issuers}' : ''}
         | filter name in %{event_names}
-        | filter (name = %{usps_enrollment_status_updated} and properties.event_properties.passed = 1)
+        | filter (name = %{usps_enrollment_status_updated} and properties.event_properties.passed = 1 and properties.event_properties.tmx_status = 'threatmetrix_pass')
                  or (name != %{usps_enrollment_status_updated})
         | filter (name in %{gpo_verification_submitted} and properties.event_properties.success = 1 and !properties.event_properties.pending_in_person_enrollment and !properties.event_properties.fraud_check_failed)
                  or (name not in %{gpo_verification_submitted})


### PR DESCRIPTION
When the identity verification report was built the fraud-review functionality did not apply to in-person pending. This was changed in #9928, but the report was not updated to filter fraud-pending users out of the successfully verified count for in-person events.

This commit modifies the cloudwatch query to filter those users who are not verified from being counted as successfully verified.
