### PR TITLE
Remove RISC network errors from NewRelic

### DIFF
--- a/app/jobs/risc_delivery_job.rb
+++ b/app/jobs/risc_delivery_job.rb
@@ -14,10 +14,15 @@ class RiscDeliveryJob < ApplicationJob
     *NETWORK_ERRORS,
     wait: :polynomially_longer,
     attempts: 2,
-  )
+  ) do |_job, _exception|
+    # Don't bubble up the exception when retries are exhausted
+  end
+
   retry_on RedisRateLimiter::LimitError,
            wait: :polynomially_longer,
-           attempts: 10
+           attempts: 10 do |_job, _exception|
+             # Don't bubble up the exception when retries are exhausted
+           end
 
   def self.warning_error_classes
     NETWORK_ERRORS + [RedisRateLimiter::LimitError]


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/37



## 🛠 Summary of changes

Don't bubble up the network errors. Let ActiveJob retry based on its configuration.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Network errors in the RISC delivery job should not show up in NewRelic errors dashboard 


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
