### PR TITLE
Fix flaky IdentityLinker test

### DIFF
--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe IdentityLinker do
     end
 
     context 'identity.verified_at' do
-      context 'the request is includes identity proofing and verified_at is null' do
+      context 'the request includes identity proofing and verified_at is null' do
         it 'sets the timestamp' do
           IdentityLinker.new(user, service_provider).link_identity(ial: 2)
 
@@ -226,7 +226,7 @@ RSpec.describe IdentityLinker do
         end
       end
 
-      context 'the request is includes identity proofing and verified_at is not null' do
+      context 'the request includes identity proofing and verified_at is not null' do
         it 'does not set the timestamp' do
           freeze_time
           travel_to 1.week.ago do

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -228,6 +228,7 @@ RSpec.describe IdentityLinker do
 
       context 'the request is includes identity proofing and verified_at is not null' do
         it 'does not set the timestamp' do
+          freeze_time
           travel_to 1.week.ago do
             IdentityLinker.new(user, service_provider).link_identity(ial: 2)
           end
@@ -235,7 +236,7 @@ RSpec.describe IdentityLinker do
 
           expect(
             user.last_identity.verified_at,
-          ).to be_within(1.second).of(1.week.ago)
+          ).to eq(1.week.ago)
         end
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

I got a test [failure](https://gitlab.login.gov/lg/identity-idp/-/jobs/1253467) this morning due to a time-based flakiness:

```
Failures:
  1) IdentityLinker#link_identity identity.verified_at the request is includes identity proofing and verified_at is not null does not set the timestamp
     Failure/Error:
       expect(
         user.last_identity.verified_at,
       ).to be_within(1.second).of(1.week.ago)
       expected 2024-06-05 00:46:12.000000000 +0200 to be within 1 of 2024-06-05 00:46:13.011929850 +0200
     # ./spec/services/identity_linker_spec.rb:236:in `block (5 levels) in <top (required)>'
     # ./spec/support/fake_analytics.rb:181:in `block (2 levels) in <top (required)>'
```

This PR freezes time for the test to make it more reliable

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
