### PR TITLE
Update email language preference to its associated language

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,9 +44,9 @@ account.email_language.default: '%{language} (default)'
 account.email_language.edit_title: Edit email language preference
 account.email_language.languages_list: '%{app_name} allows you to receive your email communication in %{list}.'
 account.email_language.name.en: English
-account.email_language.name.es: Spanish
-account.email_language.name.fr: French
-account.email_language.name.zh: Chinese
+account.email_language.name.es: Español
+account.email_language.name.fr: Français
+account.email_language.name.zh: 中文 (简体)
 account.email_language.sentence_connector: or
 account.email_language.updated: Your email language preference has been updated.
 account.forget_all_browsers.longer_description: Once you choose to ‘forget all browsers,’ we’ll need additional information to know that it’s actually you signing in to your account. We’ll ask for a multi-factor authentication method (such as text/SMS code or a security key) each time you want to access your account.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -43,10 +43,10 @@ account.connected_apps.description: Con su cuenta de %{app_name}, puede conectar
 account.email_language.default: '%{language} (predeterminado)'
 account.email_language.edit_title: Editar la preferencia de idioma del correo electrónico
 account.email_language.languages_list: '%{app_name} le permite recibir su comunicación por correo electrónico en %{list}.'
-account.email_language.name.en: Inglés
+account.email_language.name.en: English
 account.email_language.name.es: Español
-account.email_language.name.fr: Francés
-account.email_language.name.zh: Chinese
+account.email_language.name.fr: Français
+account.email_language.name.zh: 中文 (简体)
 account.email_language.sentence_connector: o
 account.email_language.updated: Se actualizó su preferencia de idioma del correo electrónico.
 account.forget_all_browsers.longer_description: Una vez que elija “Olvidar todos los navegadores”, necesitaremos más información para saber que realmente es usted quien está iniciando sesión en su cuenta. Le pediremos un método de autenticación multifactor (como código de texto o de SMS, o una clave de seguridad) cada vez que desee acceder a su cuenta.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,10 +43,10 @@ account.connected_apps.description: Avec votre compte %{app_name}, vous pouvez v
 account.email_language.default: '%{language} (par défaut)'
 account.email_language.edit_title: Modifier la langue dans laquelle vous préférez recevoir les e-mails
 account.email_language.languages_list: '%{app_name} vous permet de recevoir des communications par e-mail en %{list}.'
-account.email_language.name.en: anglais
-account.email_language.name.es: espagnol
-account.email_language.name.fr: français
-account.email_language.name.zh: Chinese
+account.email_language.name.en: English
+account.email_language.name.es: Español
+account.email_language.name.fr: Français
+account.email_language.name.zh: 中文 (简体)
 account.email_language.sentence_connector: ou
 account.email_language.updated: Votre langue de préférence pour les e-mails a été mise à jour.
 account.forget_all_browsers.longer_description: Une fois que vous aurez choisi d’« oublier tous les navigateurs », nous aurons besoin d’informations supplémentaires pour savoir que c’est bien vous qui vous connectez à votre compte. Nous vous demanderons une méthode d’authentification multi-facteurs (comme un code SMS/texto ou une clé de sécurité) chaque fois que vous souhaiterez accéder à votre compte.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -43,9 +43,9 @@ account.connected_apps.description: 使用你的 %{app_name} 账户，你可以�
 account.email_language.default: '%{language} （默认）'
 account.email_language.edit_title: 编辑电邮语言选择
 account.email_language.languages_list: '%{app_name} 允许你以 %{list}接受电邮沟通。'
-account.email_language.name.en: 英文
-account.email_language.name.es: 西班牙文
-account.email_language.name.fr: 法文
+account.email_language.name.en: English
+account.email_language.name.es: Español
+account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
 account.email_language.sentence_connector: 或者
 account.email_language.updated: 你的电邮语言选择已更新。

--- a/spec/features/account_email_language_spec.rb
+++ b/spec/features/account_email_language_spec.rb
@@ -16,30 +16,31 @@ RSpec.describe 'Account email language', allowed_extra_analytics: [:*] do
     end
 
     it 'lets them view their current email language' do
-      within(page.find('.profile-info-box', text: 'Language')) do
-        expect(page).to have_content('Spanish')
+      within(page.find('.profile-info-box', text: t('i18n.language'))) do
+        expect(page).to have_content(t("account.email_language.name.#{original_email_language}"))
       end
     end
 
     context 'changing their email language' do
+      let('chosen_email_language') { 'fr' }
       before do
-        within(page.find('.profile-info-box', text: 'Language')) do
-          click_link('Edit')
+        within(page.find('.profile-info-box', text: t('i18n.language'))) do
+          click_link(t('forms.buttons.edit'))
         end
 
-        choose 'Français'
-        click_button 'Submit'
+        choose t("account.email_language.name.#{chosen_email_language}")
+        click_button t('forms.buttons.submit.default')
       end
 
       it 'reflects the updated language preference' do
-        within(page.find('.profile-info-box', text: 'Language')) do
-          expect(page).to have_content('French')
+        within(page.find('.profile-info-box', text: t('i18n.language'))) do
+          expect(page).to have_content(t("account.email_language.name.#{chosen_email_language}"))
         end
       end
 
       it 'respects the language preference in emails, such as password reset emails' do
         within(page.find('.profile-info-box', text: 'Password')) do
-          click_link('Edit')
+          click_link(t('forms.buttons.edit'))
         end
 
         fill_in t('forms.passwords.edit.labels.password'),
@@ -49,7 +50,12 @@ RSpec.describe 'Account email language', allowed_extra_analytics: [:*] do
         click_button 'Update'
 
         mail = ActionMailer::Base.deliveries.last
-        expect(mail.subject).to eq(I18n.t('devise.mailer.password_updated.subject', locale: 'fr'))
+        expect(mail.subject).to eq(
+          I18n.t(
+            'devise.mailer.password_updated.subject',
+            locale: chosen_email_language,
+          ),
+        )
       end
     end
   end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -53,6 +53,10 @@ module I18n
         { key: 'i18n.locale.es', locales: %i[es fr zh] },
         { key: 'i18n.locale.fr', locales: %i[es fr zh] },
         { key: 'i18n.locale.zh', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.en', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.es', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.fr', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.zh', locales: %i[es fr zh] },
         { key: 'account.navigation.menu', locales: %i[fr] }, # "Menu" is "Menu" in French
         { key: /^countries/ }, # Some countries have the same name across languages
         { key: 'date.formats.long', locales: %i[es zh] },

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -71,8 +71,6 @@ module I18n
         { key: 'time.formats.event_timestamp', locales: %i[zh] },
         { key: 'time.formats.full_date', locales: %i[es] }, # format is the same in Spanish and English
         { key: 'time.formats.sms_date' }, # for us date format
-        # need to be fixed
-        { key: 'account.email_language.name.zh', locales: %i[es fr] }, # needs to be translated
       ].freeze
       # rubocop:enable Layout/LineLength
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updating the language email preference is displayed in the language it is describing. This is similar practice in the language picker and should be consistent in both places.

Ref https://github.com/18F/identity-idp/pull/10291#discussion_r1579992009