### PR TITLE
Remove dead code in the `Idv::AddressController`

### DIFF
--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -20,7 +20,6 @@ module Idv
       @address_form = build_address_form
       form_result = @address_form.submit(profile_params)
       track_submit_event(form_result)
-      capture_address_edited(form_result)
       if form_result.success?
         success
       else
@@ -69,8 +68,11 @@ module Idv
     end
 
     def track_submit_event(form_result)
-      address_edited = form_result.success? && address_edited?
-      analytics.idv_address_submitted(**form_result.to_h.merge(address_edited:))
+      analytics.idv_address_submitted(
+        **form_result.to_h.merge(
+          address_edited: address_edited?,
+        ),
+      )
     end
 
     def address_edited?
@@ -79,11 +81,6 @@ module Idv
 
     def profile_params
       params.require(:idv_form).permit(Idv::AddressForm::ATTRIBUTES)
-    end
-
-    def capture_address_edited(result)
-      address_edited = result.to_h[:address_edited]
-      idv_session.address_edited = true if address_edited
     end
   end
 end

--- a/app/forms/idv/address_form.rb
+++ b/app/forms/idv/address_form.rb
@@ -30,6 +30,8 @@ module Idv
     end
 
     def updated_user_address
+      return nil unless valid?
+
       Pii::Address.new(
         address1: address1,
         address2: address2,


### PR DESCRIPTION
I found some code referencing `address_edited` on the `AddressForm` response. We removed that so there is not reason to inspect it.

This commit also does some touch-ups to the form and the controller to clean up the logic.
