### PR TITLE
Move dependency audit checks into own task in Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -319,6 +319,8 @@ js_tests:
     - yarn test
 
 pinpoint-check:
+  needs:
+    - job: install
   stage: test
   cache:
     - <<: *ruby_cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -329,6 +329,8 @@ pinpoint-check:
     - make lint_country_dialing_codes
 
 audit_packages:
+  needs:
+    - job: install
   stage: test
   cache:
     - <<: *ruby_cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -328,6 +328,16 @@ pinpoint-check:
     - *yarn_install
     - make lint_country_dialing_codes
 
+audit_packages:
+  stage: test
+  cache:
+    - <<: *ruby_cache
+    - <<: *yarn_cache
+  script:
+    - *bundle_install
+    - *yarn_install
+    - make audit
+
 prepare_deploy:
   # Runs in parallel with tests so we can deploy more quickly after passing
   stage: test

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 
 .PHONY: \
 	analytics_events \
+	audit \
 	brakeman \
 	build_artifact \
 	check \
@@ -74,11 +75,7 @@ endif
 	make lint_analytics_events_sorted
 	@echo "--- brakeman ---"
 	make brakeman
-	@echo "--- bundler-audit ---"
-	bundle exec bundler-audit check --update
 	# JavaScript
-	@echo "--- yarn audit ---"
-	yarn audit --groups dependencies; test $$? -le 7
 	@echo "--- eslint ---"
 	yarn run lint
 	@echo "--- typescript ---"
@@ -104,6 +101,12 @@ endif
 	make lint_spec_file_name
 	@echo "--- lint migrations ---"
 	make lint_migrations
+
+audit: ## Checks packages for vulnerabilities
+	@echo "--- bundler-audit ---"
+	bundle exec bundler-audit check --update
+	@echo "--- yarn audit ---"
+	yarn audit --groups dependencies; test $$? -le 7
 
 lint_erb: ## Lints ERB files
 	bundle exec erblint app/views app/components


### PR DESCRIPTION
**Why**: This is prep work that enables running these checks on a schedule on main branch, instead of on feature branches