### PR TITLE
Add logging for certificate errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.21.2-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.21.4-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,10 +35,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 5ad9e188efdfa6597697dd87f9cb9e8efa8d7d09
-  tag: 0.21.2-18f
+  revision: 5e9999ef8e9260cda74cfea0a637f754994e0f9d
+  tag: 0.21.4-18f
   specs:
-    saml_idp (0.21.2.pre.18f)
+    saml_idp (0.21.4.pre.18f)
       activesupport
       builder
       faraday

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -137,6 +137,7 @@ class SamlIdpController < ApplicationController
       # Logging to indicate if a validation bug fix will create a potentially breaking change
       analytics_payload[:encryption_cert_matches_matching_cert] =
         encryption_cert_matches_matching_cert?
+      analytics_payload[:cert_error_details] = saml_request.cert_errors
     end
 
     analytics.saml_auth(**analytics_payload)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4979,7 +4979,8 @@ module AnalyticsEvents
   # @param [String] matching_cert_serial
   # @param [Boolean|nil] encryption_cert_matches_matching_cert If the encryption certificate
   # matches the request certificate in a successful, signed request
-  # @param [Hash] cert_error_details Details for errors that occurred because of an invalid signature
+  # @param [Hash] cert_error_details Details for errors that occurred because of an invalid
+  # signature
   def saml_auth(
     success:,
     errors:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4979,6 +4979,7 @@ module AnalyticsEvents
   # @param [String] matching_cert_serial
   # @param [Boolean|nil] encryption_cert_matches_matching_cert If the encryption certificate
   # matches the request certificate in a successful, signed request
+  # @param [Hash] cert_error_details Details for errors that occurred because of an invalid signature
   def saml_auth(
     success:,
     errors:,
@@ -4995,6 +4996,7 @@ module AnalyticsEvents
     matching_cert_serial:,
     encryption_cert_matches_matching_cert: nil,
     error_details: nil,
+    cert_error_details: nil,
     **extra
   )
     track_event(
@@ -5014,6 +5016,7 @@ module AnalyticsEvents
       request_signed:,
       matching_cert_serial:,
       encryption_cert_matches_matching_cert:,
+      cert_error_details:,
       **extra,
     )
   end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1451,15 +1451,6 @@ RSpec.describe SamlIdpController do
         )
       end
 
-      let(:analytics_hash) do
-        {
-          success: true,
-          request_signed: authn_requests_signed,
-          matching_cert_serial:,
-          encryption_cert_matches_matching_cert:,
-        }
-      end
-
       before do
         stub_analytics
         IdentityLinker.new(user, service_provider).link_identity
@@ -1471,7 +1462,13 @@ RSpec.describe SamlIdpController do
           generate_saml_response(user, auth_settings)
 
           expect(response.status).to eq(200)
-          expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
+          expect(@analytics).to have_logged_event(
+            'SAML Auth', hash_including(
+              request_signed: false,
+              matching_cert_serial: nil,
+              encryption_cert_matches_matching_cert: nil,
+            )
+          )
         end
       end
 
@@ -1479,21 +1476,23 @@ RSpec.describe SamlIdpController do
         let(:authn_requests_signed) { true }
 
         context 'Matching certificate' do
-          let(:encryption_cert_matches_matching_cert) { true }
-          let(:matching_cert_serial) { saml_test_sp_cert_serial }
-
           it 'notes that in the analytics event' do
             user.identities.last.update!(verified_attributes: ['email'])
             generate_saml_response(user, auth_settings)
 
             expect(response.status).to eq(200)
-            expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
+            expect(@analytics).to have_logged_event(
+              'SAML Auth', hash_including(
+                request_signed: authn_requests_signed,
+                matching_cert_serial: saml_test_sp_cert_serial,
+                encryption_cert_matches_matching_cert: true,
+                cert_error_details: nil,
+              )
+            )
           end
 
           context 'Certificate sig validation fails because of namespace bug' do
-            let(:encryption_cert_matches_matching_cert) { false }
-            let(:matching_cert_serial) { nil }
-            let(:request_sp) { double  }
+            let(:request_sp) { double }
 
             before do
               service_provider.update(certs: ['sp_sinatra_demo', 'saml_test_sp'])
@@ -1507,17 +1506,22 @@ RSpec.describe SamlIdpController do
               generate_saml_response(user, auth_settings)
 
               expect(response.status).to eq(200)
-              expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
+              expect(@analytics).to have_logged_event(
+                'SAML Auth', hash_including(
+                  request_signed: authn_requests_signed,
+                  matching_cert_serial: nil,
+                  encryption_cert_matches_matching_cert: false,
+                )
+              )
             end
           end
         end
 
         context 'Certificate does not match' do
-          let(:encryption_cert_matches_matching_cert) { true }
           let(:service_provider) do
             create(
               :service_provider,
-              certs: ['sp_sinatra_demo', 'saml_test_sp'],
+              certs: ['saml_test_sp'],
               active: true,
               assertion_consumer_logout_service_url: 'https://example.com',
             )
@@ -1541,9 +1545,22 @@ RSpec.describe SamlIdpController do
           it 'notes that in the analytics event' do
             user.identities.last.update!(verified_attributes: ['email'])
             generate_saml_response(user, auth_settings)
+            cert_error_details = [
+              {
+                cert: saml_test_sp_cert_serial,
+                error_code: :fingerprint_mismatch,
+              },
+            ]
 
             expect(response.status).to eq(200)
-            expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
+            expect(@analytics).to have_logged_event(
+              'SAML Auth', hash_including(
+                request_signed: authn_requests_signed,
+                matching_cert_serial:,
+                encryption_cert_matches_matching_cert: true,
+                cert_error_details:,
+              )
+            )
           end
         end
       end


### PR DESCRIPTION
## 🎫 Ticket
https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/42

## 🛠 Summary of changes
- Updates the version of saml_idp gem 
- Updates logging to include `cert_error_details` to log specific certificate errors if the request is signed and successful
- Adds tests
