### PR TITLE
Add coverage metric to GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -391,6 +391,7 @@ coverage:
     - *bundle_install
     - bundle exec spec/simplecov_merger.rb
     - mv coverage/coverage/* coverage/
+  coverage: '/LOC \(\d+.\d+\%\) covered/'
   artifacts:
     reports:
       coverage_report:


### PR DESCRIPTION
## 🛠 Summary of changes

Adds the coverage percentage metric as described in https://docs.gitlab.com/ee/ci/testing/code_coverage.html#view-code-coverage-results-in-the-mr


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>

<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

![image](https://github.com/18F/identity-idp/assets/1430443/fef185b2-7642-48e3-ab27-3d7f87bb9387)

</details>
