### PR TITLE
A quick update to change the SP used for the Test OIDC links from /test/oidc/login.

### DIFF
--- a/app/controllers/test/oidc_test_controller.rb
+++ b/app/controllers/test/oidc_test_controller.rb
@@ -8,7 +8,7 @@ module Test
     BIOMETRIC_REQUIRED = 'biometric-comparison-required'
 
     def initialize
-      @client_id = 'urn:gov:gsa:openidconnect:sp:test'
+      @client_id = 'urn:gov:gsa:openidconnect:sp:sinatra'
       super
     end
 


### PR DESCRIPTION
A quick update to change the SP used for the Test OIDC links from /test/oidc/login.

I found the existing SP failed with errors for me. This changes makes the links work again.

Note: the test routes are disabled in production envs (i.e., deployed envs)

## 📜 Testing Plan

Run your local server and go to /test/oidc/login and try the links.