### PR TITLE
Remove the `should_proof_state_id` argument from the `Idv::Agent` call to the `ResolutionProofingJob`

### DIFF
--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -29,8 +29,6 @@ module Idv
         threatmetrix_session_id: threatmetrix_session_id,
         request_ip: request_ip,
         ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-        # This argument is intended to be removed
-        should_proof_state_id: false,
       }
 
       if IdentityConfig.store.ruby_workers_idv_enabled


### PR DESCRIPTION
We deprecated this argument in #10796. This commit stops invoking the job with the argument. A future commit should remove the argument from the job.