### PR TITLE
Fix 500 in document capture when going to IPP

### DIFF
--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -12,8 +12,8 @@ module Idv
 
       check_or_render_not_found -> { IdentityConfig.store.in_person_proofing_enabled }
 
-      before_action :handle_fraud
       before_action :confirm_two_factor_authenticated
+      before_action :handle_fraud
       before_action :confirm_in_person_session
 
       def show

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
 
   before do
     stub_analytics
-    stub_sign_in(user)
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).
       and_return(in_person_proofing_enabled)
     allow(IdentityConfig.store).to receive(:in_person_proofing_enforce_tmx).
@@ -27,97 +26,117 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
     subject(:response) { get :show }
 
     it 'renders not found' do
+      stub_sign_in(user)
       expect(response.status).to eq 404
     end
 
     context 'with in person proofing enabled' do
       let(:in_person_proofing_enabled) { true }
 
-      it 'redirects to account page' do
-        expect(response).to redirect_to account_url
+      context 'authenticated' do
+        before do
+          stub_sign_in(user)
+        end
+
+        it 'redirects to account page' do
+          expect(response).to redirect_to account_url
+        end
+
+        context 'with enrollment' do
+          let(:user) { create(:user, :with_pending_in_person_enrollment) }
+          let(:profile) { create(:profile, :with_pii, user: user) }
+
+          it 'renders show template' do
+            expect(response).to render_template :show
+          end
+
+          it 'logs analytics' do
+            response
+
+            expect(@analytics).to have_logged_event('IdV: in person ready to verify visited')
+          end
+
+          context 'with in_person_proofing_enforce_tmx disabled and pending fraud review' do
+            let!(:profile) { create(:profile, fraud_review_pending_at: 1.day.ago, user: user) }
+            let!(:enrollment) do
+              create(:in_person_enrollment, :passed, user: user, profile: profile)
+            end
+            it 'redirects to please call page' do
+              response
+
+              expect(response).not_to render_template :show
+              expect(response).to redirect_to idv_please_call_url
+            end
+          end
+
+          context 'in_person_proofing_enforce_tmx enabled, pending fraud review, enrollment pass' do
+            let(:in_person_proofing_enforce_tmx) { true }
+            let!(:profile) { create(:profile, fraud_review_pending_at: 1.day.ago, user: user) }
+            let!(:enrollment) do
+              create(:in_person_enrollment, :passed, user: user, profile: profile)
+            end
+
+            it 'redirects to please call' do
+              response
+
+              expect(response).to redirect_to idv_please_call_url
+            end
+          end
+
+          context 'in_person_proofing_enforce_tmx enabled, pending fraud review,
+          enrollment not passed' do
+            let(:in_person_proofing_enforce_tmx) { true }
+            let!(:profile) { create(:profile, fraud_review_pending_at: 1.day.ago, user: user) }
+            let!(:enrollment) do
+              create(:in_person_enrollment, :establishing, user: user, profile: profile)
+            end
+
+            it 'does not redirect to please call' do
+              response
+
+              expect(response).to render_template :show
+              expect(response).not_to redirect_to idv_please_call_url
+            end
+          end
+
+          context 'when vtr (vector of trust) does not include Enhanced Proofing (Pe)' do
+            before do
+              resolved_authn_context_result = Vot::Parser.new(vector_of_trust: 'Pb').parse
+
+              allow(controller).to receive(:resolved_authn_context_result).
+                and_return(resolved_authn_context_result)
+            end
+
+            it 'evaluates to In Person Proofing' do
+              response
+
+              expect(assigns(:is_enhanced_ipp)).to be false
+            end
+          end
+
+          context 'when vtr (vector of trust) includes Enhanced Proofing (Pe)' do
+            before do
+              resolved_authn_context_result = Vot::Parser.new(vector_of_trust: 'Pe').parse
+
+              allow(controller).to receive(:resolved_authn_context_result).
+                and_return(resolved_authn_context_result)
+            end
+
+            it 'evaluates to Enhanced IPP' do
+              response
+
+              expect(assigns(:is_enhanced_ipp)).to be true
+            end
+          end
+        end
       end
 
-      context 'with enrollment' do
-        let(:user) { create(:user, :with_pending_in_person_enrollment) }
-        let(:profile) { create(:profile, :with_pii, user: user) }
+      context 'with hybrid session' do
+        let(:in_person_proofing_enforce_tmx) { true }
+        it 'redirects to root' do
+          controller.session[:doc_capture_user_id] = user.id
 
-        it 'renders show template' do
-          expect(response).to render_template :show
-        end
-
-        it 'logs analytics' do
-          response
-
-          expect(@analytics).to have_logged_event('IdV: in person ready to verify visited')
-        end
-
-        context 'with in_person_proofing_enforce_tmx disabled and pending fraud review' do
-          let!(:profile) { create(:profile, fraud_review_pending_at: 1.day.ago, user: user) }
-          let!(:enrollment) { create(:in_person_enrollment, :passed, user: user, profile: profile) }
-          it 'redirects to please call page' do
-            response
-
-            expect(response).not_to render_template :show
-            expect(response).to redirect_to idv_please_call_url
-          end
-        end
-
-        context 'in_person_proofing_enforce_tmx enabled, pending fraud review, enrollment passed' do
-          let(:in_person_proofing_enforce_tmx) { true }
-          let!(:profile) { create(:profile, fraud_review_pending_at: 1.day.ago, user: user) }
-          let!(:enrollment) { create(:in_person_enrollment, :passed, user: user, profile: profile) }
-
-          it 'redirects to please call' do
-            response
-
-            expect(response).to redirect_to idv_please_call_url
-          end
-        end
-
-        context 'in_person_proofing_enforce_tmx enabled, pending fraud review,
-          enrollment not passed' do
-          let(:in_person_proofing_enforce_tmx) { true }
-          let!(:profile) { create(:profile, fraud_review_pending_at: 1.day.ago, user: user) }
-          let!(:enrollment) do
-            create(:in_person_enrollment, :establishing, user: user, profile: profile)
-          end
-
-          it 'does not redirect to please call' do
-            response
-
-            expect(response).to render_template :show
-            expect(response).not_to redirect_to idv_please_call_url
-          end
-        end
-
-        context 'when vtr (vector of trust) does not include Enhanced Proofing (Pe)' do
-          before do
-            resolved_authn_context_result = Vot::Parser.new(vector_of_trust: 'Pb').parse
-
-            allow(controller).to receive(:resolved_authn_context_result).
-              and_return(resolved_authn_context_result)
-          end
-
-          it 'evaluates to In Person Proofing' do
-            response
-
-            expect(assigns(:is_enhanced_ipp)).to be false
-          end
-        end
-
-        context 'when vtr (vector of trust) includes Enhanced Proofing (Pe)' do
-          before do
-            resolved_authn_context_result = Vot::Parser.new(vector_of_trust: 'Pe').parse
-
-            allow(controller).to receive(:resolved_authn_context_result).
-              and_return(resolved_authn_context_result)
-          end
-
-          it 'evaluates to Enhanced IPP' do
-            response
-
-            expect(assigns(:is_enhanced_ipp)).to be true
-          end
+          expect(response).to redirect_to(new_user_session_url)
         end
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes a 500 from [New Relic](https://onenr.io/0ERzPNMgAQr) where `current_user` is nil in the `handle_fraud` methods further up the stack by moving the `confirm_two_factor_authenticated` check to be first.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
