### PR TITLE
Commits uncommitted schema.rb changes

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_173515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "account_reset_requests", force: :cascade do |t|
@@ -656,7 +657,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_173515) do
   add_foreign_key "iaa_gtcs", "partner_accounts"
   add_foreign_key "iaa_orders", "iaa_gtcs"
   add_foreign_key "in_person_enrollments", "profiles"
-  add_foreign_key "in_person_enrollments", "service_providers", column: "issuer", primary_key: "issuer", validate: false
+  add_foreign_key "in_person_enrollments", "service_providers", column: "issuer", primary_key: "issuer"
   add_foreign_key "in_person_enrollments", "users"
   add_foreign_key "integration_usages", "iaa_orders"
   add_foreign_key "integration_usages", "integrations"


### PR DESCRIPTION
## 🎫 Ticket

None

## 🛠 Summary of changes

If I run `db:migrate` on main, I end up with this diff. Two things:

- These are unrelated to any changes I made, so I'm just 🧹 cleaning up. I'd appreciate it if someone would confirm they also have this diff hanging around and it's helpful for me to merge this.
- I thought @mitchellhenke just recently merged a linter to prevent this from happening? Did this change just land first?