### PR TITLE
Render lang attribute for email language preference

### DIFF
--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -25,7 +25,7 @@
 
   <h3 class="margin-top-3"><%= t('i18n.language') %></h3>
   <div class="grid-row padding-1 border border-primary-light">
-    <div class="grid-col-8">
+    <div class="grid-col-8" lang="<%= @presenter.user.email_language || I18n.default_locale %>">
       <%= @presenter.user.email_language_preference_description %>
     </div>
     <div class="grid-col-4 text-right">

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -182,4 +182,34 @@ RSpec.describe 'accounts/show.html.erb' do
       )
     end
   end
+
+  describe 'email language' do
+    context 'without explicit user language preference' do
+      let(:user) { create(:user, :fully_registered, email_language: nil) }
+
+      before do
+        I18n.locale = :es
+      end
+
+      it 'renders email language with language of parts as English' do
+        # Ensure that non-English content in English page is annotated with language.
+        # See: https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts
+        render
+
+        expect(rendered).to have_css('[lang=en]', text: t('account.email_language.name.en'))
+      end
+    end
+
+    context 'with user language preference' do
+      let(:user) { create(:user, :fully_registered, email_language: :es) }
+
+      it 'renders email language with language of parts as that language' do
+        # Ensure that non-English content in English page is annotated with language.
+        # See: https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts
+        render
+
+        expect(rendered).to have_css('[lang=es]', text: t('account.email_language.name.es'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates account page email language preference to render `lang` attribute when showing content in a language other than the page's current language, following #10808 and to satisfy [WCAG SC 3.1.2 Language of Parts](https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts).

Previously: https://github.com/18F/identity-idp/pull/10808#pullrequestreview-2130329877

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in
3. On account dashboard, change email language preference to a language other than English (or conversely, change the current page language to a language other than English)
4. Activate screen reader
5. Navigate to the text value for current email language preference
6. Observe that screen reader announces language value in that language

## 👀 Screenshots

(You may need to unmute video player for audio to play)

_Before:_

https://github.com/18F/identity-idp/assets/1779930/71b6d84b-726e-4d70-b4a5-ecded72632ce

_After:_

https://github.com/18F/identity-idp/assets/1779930/2ab77763-1b79-4e45-891d-eaa188a17a13