### PR TITLE
Lg 11850 remove invalid usps states

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -11,6 +11,7 @@ module Idv
     before_action :confirm_not_rate_limited, except: [:update]
     before_action :confirm_step_allowed, unless: -> { allow_direct_ipp? }
     before_action :override_csp_to_allow_acuant
+    before_action :set_usps_form_presenter
 
     def show
       analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)
@@ -130,6 +131,10 @@ module Idv
       idv_session.skip_doc_auth_from_handoff = true
       idv_session.skip_hybrid_handoff = nil
       true
+    end
+
+    def set_usps_form_presenter
+      @presenter = Idv::InPerson::UspsFormPresenter.new
     end
   end
 end

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -10,6 +10,7 @@ module Idv
       before_action :check_valid_document_capture_session
       before_action :override_csp_to_allow_acuant
       before_action :confirm_document_capture_needed, only: :show
+      before_action :set_usps_form_presenter
 
       def show
         analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)
@@ -86,6 +87,10 @@ module Idv
         return unless document_capture_session.requested_at
 
         document_capture_session.requested_at > stored_result.captured_at
+      end
+
+      def set_usps_form_presenter
+        @presenter = Idv::InPerson::UspsFormPresenter.new
       end
     end
   end

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -9,6 +9,7 @@ module Idv
       before_action :confirm_in_person_state_id_step_complete
       ## before_action :confirm_step_allowed # pending FSM removal of state id step
       before_action :confirm_in_person_address_step_needed, only: :show
+      before_action :set_usps_form_presenter
 
       def show
         analytics.idv_in_person_proofing_address_visited(**analytics_arguments)
@@ -120,6 +121,10 @@ module Idv
                   !pii_from_user.has_key?(:address1)
         return if request.referer == idv_in_person_verify_info_url
         redirect_to idv_in_person_ssn_url
+      end
+
+      def set_usps_form_presenter
+        @presenter = Idv::InPerson::UspsFormPresenter.new
       end
     end
   end

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -8,6 +8,7 @@ module Idv
 
       before_action :render_404_if_controller_not_enabled
       before_action :redirect_unless_enrollment # confirm previous step is complete
+      before_action :set_usps_form_presenter
 
       def show
         flow_session[:pii_from_user] ||= {}
@@ -164,6 +165,10 @@ module Idv
 
       def form
         @form ||= Idv::StateIdForm.new(current_user)
+      end
+
+      def set_usps_form_presenter
+        @presenter = Idv::InPerson::UspsFormPresenter.new
       end
     end
   end

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -16,6 +16,8 @@ module Idv
 
     before_action :redirect_if_flow_completed
 
+    before_action :set_usps_form_presenter
+
     FLOW_STATE_MACHINE_SETTINGS = {
       step_url: :idv_in_person_step_url,
       final_url: :idv_in_person_address_url,
@@ -31,6 +33,10 @@ module Idv
 
     def redirect_if_flow_completed
       flow_finish if idv_session.applicant
+    end
+
+    def set_usps_form_presenter
+      @presenter = Idv::InPerson::UspsFormPresenter.new
     end
   end
 end

--- a/app/presenters/idv/in_person/usps_form_presenter.rb
+++ b/app/presenters/idv/in_person/usps_form_presenter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Idv::InPerson::UspsFormPresenter
+  include FormHelper
+  # Filtered list to remove territories that cause errors in the USPS API
+  def usps_states_territories
+    us_states_territories.reject { |_name, abbrev| %w[AA AE AP UM].include?(abbrev) }
+  end
+end

--- a/app/views/idv/in_person/address/show.html.erb
+++ b/app/views/idv/in_person/address/show.html.erb
@@ -17,7 +17,7 @@
 
 <%= simple_form_for(form, url: url_for, method: 'PUT') do |f| %>
   <%= render ValidatedFieldComponent.new(
-        collection: us_states_territories,
+        collection: @presenter.usps_states_territories,
         form: f,
         input_html: { class: 'address-state-selector' },
         label: t('idv.form.state'),

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -99,7 +99,7 @@
   <div class="margin-bottom-4">
     <%= render ValidatedFieldComponent.new(
           name: :state_id_jurisdiction,
-          collection: us_states_territories,
+          collection: @presenter.usps_states_territories,
           form: f,
           hint: t('in_person_proofing.form.state_id.state_id_jurisdiction_hint'),
           input_html: { class: 'jurisdiction-state-selector' },
@@ -155,7 +155,7 @@
   <h2> <%= t('in_person_proofing.headings.id_address') %> </h2>
     <%= render ValidatedFieldComponent.new(
           name: :identity_doc_address_state,
-          collection: us_states_territories,
+          collection: @presenter.usps_states_territories,
           form: f,
           input_html: { class: 'address-state-selector' },
           label: t('in_person_proofing.form.state_id.identity_doc_address_state'),

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -106,7 +106,7 @@
   <div class="margin-bottom-4">
     <%= render ValidatedFieldComponent.new(
           name: :state_id_jurisdiction,
-          collection: us_states_territories,
+          collection: @presenter.usps_states_territories,
           form: f,
           hint: t('in_person_proofing.form.state_id.state_id_jurisdiction_hint'),
           input_html: { class: 'jurisdiction-state-selector' },
@@ -160,7 +160,7 @@
   <h2> <%= t('in_person_proofing.headings.id_address') %> </h2>
     <%= render ValidatedFieldComponent.new(
           name: :identity_doc_address_state,
-          collection: us_states_territories,
+          collection: @presenter.usps_states_territories,
           form: f,
           input_html: { class: 'address-state-selector' },
           label: t('in_person_proofing.form.state_id.identity_doc_address_state'),

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -34,7 +34,7 @@
       in_person_full_address_entry_enabled: IdentityConfig.store.in_person_full_address_entry_enabled,
       in_person_outage_message_enabled: IdentityConfig.store.in_person_outage_message_enabled,
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
-      us_states_territories: us_states_territories,
+      us_states_territories: @presenter.usps_states_territories,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
       skip_doc_auth: skip_doc_auth,

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe Idv::DocumentCaptureController, allowed_extra_analytics: [:*] do
         :check_for_mail_only_outage,
       )
     end
+
+    it 'includes setup_usps_form_presenter before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :set_usps_form_presenter,
+      )
+    end
   end
 
   describe '#show' do
@@ -105,6 +112,11 @@ RSpec.describe Idv::DocumentCaptureController, allowed_extra_analytics: [:*] do
         liveness_checking_required: false,
         selfie_check_required: sp_selfie_enabled,
       }.merge(ab_test_args)
+    end
+
+    it 'has non-nil presenter' do
+      get :show
+      expect(assigns(:presenter)).to be_kind_of(Idv::InPerson::UspsFormPresenter)
     end
 
     it 'renders the show template' do

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Idv::InPerson::AddressController do
   end
 
   describe 'before_actions' do
+    it 'includes correct before_actions' do
+      expect(subject).to have_actions(
+        :before,
+        :set_usps_form_presenter,
+      )
+    end
+
     context '#confirm_in_person_state_id_step_complete' do
       context 'in_person_state_id_controller_enabled is enabled' do
         before do
@@ -109,6 +116,11 @@ RSpec.describe Idv::InPerson::AddressController do
       expect(subject.extra_view_variables[:pii]).to_not have_key(
         :address1,
       )
+    end
+
+    it 'has non-nil presenter' do
+      get :show
+      expect(assigns(:presenter)).to be_kind_of(Idv::InPerson::UspsFormPresenter)
     end
   end
 

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Idv::InPerson::StateIdController do
   end
 
   describe 'before_actions' do
+    it 'includes correct before_actions' do
+      expect(subject).to have_actions(
+        :before,
+        :set_usps_form_presenter,
+      )
+    end
+
     context '#render_404_if_controller_not_enabled' do
       context 'flag not set' do
         before do
@@ -75,6 +82,11 @@ RSpec.describe Idv::InPerson::StateIdController do
                             [:proofing_results, :context, :stages, :state_id,
                              :state_id_jurisdiction]],
       }.merge(ab_test_args)
+    end
+
+    it 'has non-nil presenter' do
+      get :show
+      expect(assigns(:presenter)).to be_kind_of(Idv::InPerson::UspsFormPresenter)
     end
 
     it 'renders the show template' do

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Idv::InPersonController do
         :confirm_two_factor_authenticated,
         :initialize_flow_state_machine,
         :ensure_correct_step,
+        :set_usps_form_presenter,
       )
     end
   end
@@ -26,7 +27,6 @@ RSpec.describe Idv::InPersonController do
   describe '#index' do
     it 'renders 404 not found' do
       get :index
-
       expect(response.status).to eq 404
     end
 
@@ -57,6 +57,11 @@ RSpec.describe Idv::InPersonController do
             get :index
 
             expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+          end
+
+          it 'has non-nil presenter' do
+            get :index
+            expect(assigns(:presenter)).to be_kind_of(Idv::InPerson::UspsFormPresenter)
           end
 
           context 'with associated service provider' do

--- a/spec/presenters/idv/in_person/usps_form_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/usps_form_presenter_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Idv::InPerson::UspsFormPresenter do
+  subject(:presenter) { Idv::InPerson::UspsFormPresenter.new }
+
+  it 'does not include territories that cause usps api to error' do
+    expect(
+      presenter.usps_states_territories.map do |_name, abbrev|
+        abbrev
+      end,
+    ).not_to include('AA', 'AE', 'AP', 'UM')
+  end
+end

--- a/spec/views/idv/in_person/state_id.html.erb_spec.rb
+++ b/spec/views/idv/in_person/state_id.html.erb_spec.rb
@@ -4,9 +4,11 @@ RSpec.describe 'idv/in_person/state_id.html.erb' do
   let(:pii) { {} }
   let(:form) { Idv::StateIdForm.new(pii) }
   let(:parsed_dob) { Date.new(1970, 1, 1) }
+  let(:presenter) { Idv::InPerson::UspsFormPresenter.new }
 
   before do
     allow(view).to receive(:url_for).and_return('https://example.com/')
+    assign(:presenter, presenter)
   end
 
   subject(:render_template) do

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
   let(:skip_doc_auth_from_how_to_verify) { false }
   let(:skip_doc_auth_from_handoff) { false }
   let(:opted_in_to_in_person_proofing) { false }
+  let(:presenter) { Idv::InPerson::UspsFormPresenter.new }
 
   before do
     decorated_sp_session = instance_double(
@@ -36,6 +37,8 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
         issuer == in_person_proofing_enabled_issuer
       end
     end
+
+    assign(:presenter, presenter)
   end
 
   subject(:render_partial) do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-11850](https://cm-jira.usa.gov/browse/LG-11850)

## 🛠 Summary of changes

Removed territories from IPP state selects that cause USPS API errors.

## 📜 Testing Plan

- [ ] Step 1: Navigate to part of IPP form where you can search for PO locations
- [ ] Step 2: Verify that the Armed Forces items and Outlying Islands item are removed from the state/territory select
- [ ] Step 3: Navigate to enrollment part of IPP form where you enter ID/license information
- [] Step 4: Verify that the Armed Forces items and Outlying Islands item are removed from the state/territory select
