### PR TITLE
LG-13570 we were parsing JSON as JSON and that was bad

### DIFF
--- a/app/jobs/reports/drop_off_report.rb
+++ b/app/jobs/reports/drop_off_report.rb
@@ -12,7 +12,7 @@ module Reports
       self.report_date = report_date
 
       subject = "Drop Off Report - #{report_date.to_date}"
-      JSON.parse(configs).each do |config|
+      configs.each do |config|
         reports = [report_maker(config['issuers']).as_emailable_reports]
         config['emails'].each do |email|
           ReportMailer.tables_report(

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -13,6 +13,7 @@ module IdentityConfig
     Identity::Hostdata.config
   end
 
+  # identity-hostdata transforms these configs to the described type
   # rubocop:disable Metrics/BlockLength
   BUILDER = proc do |config|
     #  ______________________________________

--- a/spec/jobs/reports/drop_off_report_spec.rb
+++ b/spec/jobs/reports/drop_off_report_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Reports::DropOffReport do
   let(:report_date) { Date.new(2023, 12, 12).in_time_zone('UTC') }
+  # This is in S3 as a string that gets parsed via identity_config.rb
   let(:report_config) do
-    '[{"emails":["ursula@example.com"],
-       "issuers":"urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"}]'
+    JSON.parse'[{"emails":["ursula@example.com"],
+       "issuers":["urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"]}]'
   end
 
   before do

--- a/spec/jobs/reports/drop_off_report_spec.rb
+++ b/spec/jobs/reports/drop_off_report_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Reports::DropOffReport do
   let(:report_date) { Date.new(2023, 12, 12).in_time_zone('UTC') }
   # This is in S3 as a string that gets parsed via identity_config.rb
   let(:report_config) do
-    JSON.parse'[{"emails":["ursula@example.com"],
+    JSON.parse '[{"emails":["ursula@example.com"],
        "issuers":["urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"]}]'
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13570](https://cm-jira.usa.gov/browse/LG-13570)

## 🛠 Summary of changes

We were seeing the error: `no implicit conversion of Array into String` on the dropoff report.
This was because we're implicitly converting our configs to their described `type` in `identity_config.rb`, and then trying to parse that JSON with `JSON.parse` in `drop_off_report.rb`. 

This PR comments our code and removes the offending `parse`.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Updated tests catch double-parsing
- [ ] Report should go out as planned.

Thanks to @h-m-m and @nprimak for working on this bug.
