### PR TITLE
Update Cloudwatch client to ensure limits in query

### DIFF
--- a/spec/lib/reporting/cloudwatch_client_spec.rb
+++ b/spec/lib/reporting/cloudwatch_client_spec.rb
@@ -221,6 +221,14 @@ RSpec.describe Reporting::CloudwatchClient do
 
         expect(results.size).to eq(999)
       end
+
+      context 'query is missing a limit' do
+        let(:query) { 'fields @message | stats count(*) by bin(1d)' }
+
+        it 'raises' do
+          expect { fetch }.to raise_error(ArgumentError, /query is missing '| limit 10000'/)
+        end
+      end
     end
 
     context 'query is before Cloudwatch Insights Availability and AWS errors' do


### PR DESCRIPTION
**Why**: Without a "| limit 10000", the script will not be able to detect missing data, so it won't return the expected results

