### PR TITLE
Add site_name OpenGraph metadata

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -3,9 +3,11 @@
 
 <head>
   <meta charset="utf-8" />
-  <meta content="<%= APP_NAME %>" name="description" />
-  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-  <meta content="telephone=no" name="format-detection" />
+  <meta name="description" content="<%= APP_NAME %>" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="format-detection" content="telephone=no" />
+  <meta name="theme-color" content="#ffffff" />
+  <meta name="og:site_name" content="<%= APP_NAME %>" />
 
   <% if content_for?(:meta_refresh) %>
   <meta content="<%= yield(:meta_refresh) %>" http-equiv="refresh" />
@@ -47,7 +49,6 @@
         color: '#e21c3d',
         type: nil,
       ) %>
-  <meta content="#ffffff" name="theme-color" />
 
   <%# Prelude script for error tracking (see `track-errors`) %>
   <%= javascript_tag(nonce: true) do %>


### PR DESCRIPTION
## 🛠 Summary of changes

Adds `<meta name="og:site_name">` metadata to the base layout.

Reference: https://ogp.me/#optional

Related Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1718979670446289?thread_ts=1718123385.428649&cid=C01710KMYUB

**Why?**

* For improved compatibility with tools which use this metadata (e.g. [iOS 18 Passwords app](https://developer.apple.com/videos/play/wwdc2024/10125/))

## 📜 Testing Plan

1. Go to an open graph tester tool like https://dev.me/products/url-scrapper
2. Enter (TBD) in URL field
3. Click "Scrape Data"
4. See `"name": "Login.gov"`