### PR TITLE
Un-DRY GpoMail class a tad bit

### DIFF
--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -71,7 +71,10 @@ module Idv
           first_letter_requested_at: first_letter_requested_at,
           hours_since_first_letter:
             hours_since_first_letter(first_letter_requested_at),
-          phone_step_attempts: RateLimiter.new(user: @current_user, rate_limit_type: :proof_address).attempts,
+          phone_step_attempts: RateLimiter.new(
+            user: current_user,
+            rate_limit_type: :proof_address,
+          ).attempts,
           **ab_test_analytics_buckets,
         )
         create_user_event(:gpo_mail_sent, current_user)
@@ -103,7 +106,10 @@ module Idv
           first_letter_requested_at: first_letter_requested_at,
           hours_since_first_letter:
             hours_since_first_letter(first_letter_requested_at),
-          phone_step_attempts: RateLimiter.new(user: @current_user, rate_limit_type: :proof_address).attempts,
+          phone_step_attempts: RateLimiter.new(
+            user: current_user,
+            rate_limit_type: :proof_address,
+          ).attempts,
           **ab_test_analytics_buckets,
         )
         confirmation_maker = confirmation_maker_perform

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -70,8 +70,8 @@ module Idv
           resend: resend_requested?,
           first_letter_requested_at: first_letter_requested_at,
           hours_since_first_letter:
-            gpo_mail_service.hours_since_first_letter(first_letter_requested_at),
-          phone_step_attempts: gpo_mail_service.phone_step_attempts,
+            hours_since_first_letter(first_letter_requested_at),
+          phone_step_attempts: RateLimiter.new(user: @current_user, rate_limit_type: :proof_address).attempts,
           **ab_test_analytics_buckets,
         )
         create_user_event(:gpo_mail_sent, current_user)
@@ -87,6 +87,11 @@ module Idv
         current_user.gpo_verification_pending_profile&.gpo_verification_pending_at
       end
 
+      def hours_since_first_letter(first_letter_requested_at)
+        first_letter_requested_at ?
+          (Time.zone.now - first_letter_requested_at).to_i.seconds.in_hours.to_i : 0
+      end
+
       def confirm_mail_not_rate_limited
         redirect_to idv_enter_password_url if gpo_mail_service.rate_limited?
       end
@@ -97,8 +102,8 @@ module Idv
           resend: true,
           first_letter_requested_at: first_letter_requested_at,
           hours_since_first_letter:
-            gpo_mail_service.hours_since_first_letter(first_letter_requested_at),
-          phone_step_attempts: gpo_mail_service.phone_step_attempts,
+            hours_since_first_letter(first_letter_requested_at),
+          phone_step_attempts: RateLimiter.new(user: @current_user, rate_limit_type: :proof_address).attempts,
           **ab_test_analytics_buckets,
         )
         confirmation_maker = confirmation_maker_perform

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -129,7 +129,7 @@ module Idv
         analytics.idv_gpo_address_letter_enqueued(
           enqueued_at: Time.zone.now,
           resend: false,
-          phone_step_attempts: RateLimiter.new(user: @current_user, rate_limit_type: :proof_address).attempts,
+          phone_step_attempts: RateLimiter.new(user: current_user, rate_limit_type: :proof_address).attempts,
           first_letter_requested_at: first_letter_requested_at,
           hours_since_first_letter: hours_since_first_letter(first_letter_requested_at),
           **ab_test_analytics_buckets,

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -129,7 +129,10 @@ module Idv
         analytics.idv_gpo_address_letter_enqueued(
           enqueued_at: Time.zone.now,
           resend: false,
-          phone_step_attempts: RateLimiter.new(user: current_user, rate_limit_type: :proof_address).attempts,
+          phone_step_attempts: RateLimiter.new(
+            user: current_user,
+            rate_limit_type: :proof_address,
+          ).attempts,
           first_letter_requested_at: first_letter_requested_at,
           hours_since_first_letter: hours_since_first_letter(first_letter_requested_at),
           **ab_test_analytics_buckets,

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -19,17 +19,6 @@ module Idv
       current_user.pending_profile.created_at < min_creation_date
     end
 
-    # Next two methods are analytics helpers used from RequestLetterController and
-    # EnterPasswordController
-    def phone_step_attempts
-      RateLimiter.new(user: @current_user, rate_limit_type: :proof_address).attempts
-    end
-
-    def hours_since_first_letter(first_letter_requested_at)
-      first_letter_requested_at ?
-        (Time.zone.now - first_letter_requested_at).to_i.seconds.in_hours.to_i : 0
-    end
-
     private
 
     def window_limit_enabled?


### PR DESCRIPTION
## 🎫 Ticket

Indirectly related to 13421

## 🛠 Summary of changes

In my main story I'm adding a GpoVerifyByMailPolicy class. We want to eventually fold the GpoMail class into it.

As part of that, we noticed that `phone_step_attempts` in particular was sort of out of place in a class called GpoMail.

Because these are both small and simple, I just moved `hours_since_first_letter` into the two classes using it, and inlined what was formerly `phone_step_attempts`. It's ultimately a little less code.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
