### PR TITLE
Simplify queries with a GpoConfirmationCode relationship

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ class User < ApplicationRecord
   has_many :sign_in_restrictions, dependent: :destroy
   has_many :in_person_enrollments, dependent: :destroy
   has_many :fraud_review_requests, dependent: :destroy
+  has_many :gpo_confirmation_codes, through: :profiles
 
   has_one :pending_in_person_enrollment,
           -> { where(status: :pending).order(created_at: :desc) },

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -46,11 +46,8 @@ module Idv
     def too_many_letter_requests_within_window?
       return false unless window_limit_enabled?
       current_user.gpo_confirmation_codes.where(
-        updated_at: Range.new(
-          IdentityConfig.store.max_mail_events_window_in_days.days.ago,
-          Time.zone.now,
-        ),
-      ).count > IdentityConfig.store.max_mail_events
+        updated_at: IdentityConfig.store.max_mail_events_window_in_days.days.ago..Time.zone.now,
+      ).count >= IdentityConfig.store.max_mail_events
     end
 
     def last_letter_request_too_recent?

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -35,7 +35,7 @@ module Idv
     def too_many_letter_requests_within_window?
       return false unless window_limit_enabled?
       current_user.gpo_confirmation_codes.where(
-        updated_at: IdentityConfig.store.max_mail_events_window_in_days.days.ago..Time.zone.now,
+        created_at: IdentityConfig.store.max_mail_events_window_in_days.days.ago..Time.zone.now,
       ).count >= IdentityConfig.store.max_mail_events
     end
 
@@ -45,7 +45,7 @@ module Idv
 
       current_user.gpo_verification_pending_profile.gpo_confirmation_codes.exists?(
         [
-          'updated_at > ?',
+          'created_at > ?',
           IdentityConfig.store.minimum_wait_before_another_usps_letter_in_hours.hours.ago,
         ],
       )

--- a/app/services/idv/gpo_mail.rb
+++ b/app/services/idv/gpo_mail.rb
@@ -2,6 +2,8 @@
 
 module Idv
   class GpoMail
+    attr_reader :current_user
+
     def initialize(current_user)
       @current_user = current_user
     end
@@ -41,39 +43,26 @@ module Idv
       IdentityConfig.store.minimum_wait_before_another_usps_letter_in_hours != 0
     end
 
-    attr_reader :current_user
-
     def too_many_letter_requests_within_window?
       return false unless window_limit_enabled?
-
-      number_of_letter_requests_within(
-        IdentityConfig.store.max_mail_events_window_in_days.days,
-        maximum: IdentityConfig.store.max_mail_events,
-      ) >= IdentityConfig.store.max_mail_events
+      current_user.gpo_confirmation_codes.where(
+        updated_at: Range.new(
+          IdentityConfig.store.max_mail_events_window_in_days.days.ago,
+          Time.zone.now,
+        ),
+      ).count > IdentityConfig.store.max_mail_events
     end
 
     def last_letter_request_too_recent?
       return false unless last_not_too_recent_enabled?
       return false unless current_user.gpo_verification_pending_profile?
 
-      number_of_letter_requests_within(
-        IdentityConfig.store.minimum_wait_before_another_usps_letter_in_hours.hours,
-        maximum: 1,
-        for_profile: current_user.gpo_verification_pending_profile,
-      ) > 0
-    end
-
-    def number_of_letter_requests_within(time_window, maximum:, for_profile: nil)
-      profile_query_conditions = { user: current_user }
-      profile_query_conditions[:id] = for_profile.id if for_profile
-
-      GpoConfirmationCode.joins(:profile).
-        where(
-          updated_at: (time_window.ago..),
-          profile: profile_query_conditions,
-        ).
-        limit(maximum).
-        count
+      current_user.gpo_verification_pending_profile.gpo_confirmation_codes.exists?(
+        [
+          'updated_at > ?',
+          IdentityConfig.store.minimum_wait_before_another_usps_letter_in_hours.hours.ago,
+        ],
+      )
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Adjacent to 13421


## 🛠 Summary of changes

Trying to shrink GpoMail, I wondered if `number_of_letter_requests_within` maybe better belonged on the GpoConfirmationCode model. @jmhooper and I got to looking at it and realized that adding a relation on User through Profile would let us simplify this a bit.

Also moved the `attr_reader` line up top due to deeply-held religious beliefs.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
