### PR TITLE
Deploy RC 391.1 to Production

### DIFF
--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class AlertComponent < BaseComponent
-  VALID_TYPES = %i[info success warning error emergency other].freeze
+  VALID_TYPES = [nil, :info, :success, :warning, :error, :emergency].freeze
 
   attr_reader :type, :message, :tag_options, :text_tag
 
-  def initialize(type: :info, text_tag: 'p', message: nil, **tag_options)
+  def initialize(type: nil, text_tag: 'p', message: nil, **tag_options)
     if !VALID_TYPES.include?(type)
       raise ArgumentError, "`type` #{type} is invalid, expected one of #{VALID_TYPES}"
     end

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -59,7 +59,7 @@ module Users
         user_session: user_session,
         device_name: DeviceName.from_user_agent(request.user_agent),
       )
-      result = form.submit(request.protocol, confirm_params)
+      result = form.submit(confirm_params)
       @platform_authenticator = form.platform_authenticator?
       @presenter = WebauthnSetupPresenter.new(
         current_user: current_user,
@@ -161,7 +161,7 @@ module Users
         :name,
         :platform_authenticator,
         :transports,
-      )
+      ).merge(protocol: request.protocol)
     end
   end
 end

--- a/app/jobs/reports/drop_off_report.rb
+++ b/app/jobs/reports/drop_off_report.rb
@@ -12,7 +12,7 @@ module Reports
       self.report_date = report_date
 
       subject = "Drop Off Report - #{report_date.to_date}"
-      JSON.parse(configs).each do |config|
+      configs.each do |config|
         reports = [report_maker(config['issuers']).as_emailable_reports]
         config['emails'].each do |email|
           ReportMailer.tables_report(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4919,14 +4919,12 @@ module AnalyticsEvents
   # @param [String] client_id
   # @param [String] event_type
   # @param [Boolean] success
-  # @param ['async'|'direct'] transport
   # @param [Integer] status
   # @param [String] error
   def risc_security_event_pushed(
     client_id:,
     event_type:,
     success:,
-    transport:,
     status: nil,
     error: nil,
     **extra
@@ -4938,7 +4936,6 @@ module AnalyticsEvents
       event_type:,
       status:,
       success:,
-      transport:,
       **extra,
     )
   end

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -40,18 +40,12 @@ module PushNotification
     def deliver_one(service_provider)
       deliver_local(service_provider) if IdentityConfig.store.risc_notifications_local_enabled
 
-      job_arguments = {
+      RiscDeliveryJob.perform_later(
         push_notification_url: service_provider.push_notification_url,
         jwt: jwt(service_provider),
         event_type: event.event_type,
         issuer: service_provider.issuer,
-      }
-
-      if IdentityConfig.store.risc_notifications_active_job_enabled
-        RiscDeliveryJob.perform_later(**job_arguments)
-      else
-        RiscDeliveryJob.perform_now(**job_arguments)
-      end
+      )
     end
 
     def deliver_local(service_provider)

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -25,7 +25,7 @@
 
   <h3 class="margin-top-3"><%= t('i18n.language') %></h3>
   <div class="grid-row padding-1 border border-primary-light">
-    <div class="grid-col-8">
+    <div class="grid-col-8" lang="<%= @presenter.user.email_language || I18n.default_locale %>">
       <%= @presenter.user.email_language_preference_description %>
     </div>
     <div class="grid-col-4 text-right">

--- a/app/views/idv/by_mail/request_letter/index.html.erb
+++ b/app/views/idv/by_mail/request_letter/index.html.erb
@@ -26,7 +26,11 @@
         ) %>
   </p>
 <% else %>
-  <%= render AlertComponent.new(message: t('idv.messages.gpo.info_alert'), class: 'margin-bottom-4') %>
+  <%= render AlertComponent.new(
+        type: :info,
+        message: t('idv.messages.gpo.info_alert'),
+        class: 'margin-bottom-4',
+      ) %>
   <%= render PageHeadingComponent.new.with_content(@presenter.title) %>
   <p>
     <%= t('idv.messages.gpo.timeframe_html') %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -28,7 +28,7 @@
             ) %>
       </div>
 
-<%= render AlertComponent.new(class: 'margin-y-4', text_tag: :div) do %>
+<%= render AlertComponent.new(type: :info, class: 'margin-y-4', text_tag: :div) do %>
   <p class="margin-bottom-1 margin-top-0 h3"><strong><%= t('in_person_proofing.body.barcode.deadline', deadline: @presenter.formatted_due_date) %></strong></p>
   <p><%= t('in_person_proofing.body.barcode.deadline_restart') %></p>
 <% end %>

--- a/app/views/shared/_sp_alert.html.erb
+++ b/app/views/shared/_sp_alert.html.erb
@@ -1,6 +1,6 @@
 <% alert = decorated_sp_session.sp_alert(section) %>
 <% if alert %>
-  <%= render AlertComponent.new(text_tag: 'div', class: 'margin-bottom-4') do %>
+  <%= render AlertComponent.new(type: :info, text_tag: 'div', class: 'margin-bottom-4') do %>
     <%= raw sanitize(alert, tags: %w[a b strong em br p ol ul li], attributes: %w[href target]) %>
   <% end %>
 <% end %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -276,7 +276,6 @@ reset_password_email_max_attempts: 20
 reset_password_email_window_in_minutes: 60
 reset_password_on_auth_fraud_event: true
 risc_notifications_local_enabled: false
-risc_notifications_active_job_enabled: false
 risc_notifications_rate_limit_interval: 60
 risc_notifications_rate_limit_max_requests: 1_000
 risc_notifications_rate_limit_overrides: '{"https://example.com/push":{"interval":120,"max_requests":10000}}'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -13,6 +13,7 @@ module IdentityConfig
     Identity::Hostdata.config
   end
 
+  # identity-hostdata transforms these configs to the described type
   # rubocop:disable Metrics/BlockLength
   BUILDER = proc do |config|
     #  ______________________________________

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -334,7 +334,6 @@ module IdentityConfig
     config.add(:reset_password_email_max_attempts, type: :integer)
     config.add(:reset_password_email_window_in_minutes, type: :integer)
     config.add(:reset_password_on_auth_fraud_event, type: :boolean)
-    config.add(:risc_notifications_active_job_enabled, type: :boolean)
     config.add(:risc_notifications_local_enabled, type: :boolean)
     config.add(:risc_notifications_rate_limit_interval, type: :integer)
     config.add(:risc_notifications_rate_limit_max_requests, type: :integer)

--- a/spec/components/alert_component_spec.rb
+++ b/spec/components/alert_component_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe AlertComponent, type: :component do
     expect(rendered).to have_content('locals')
   end
 
-  it 'defaults to type "info"' do
+  it 'renders without modifier classes by default' do
     rendered = render_inline AlertComponent.new(message: 'FYI')
 
-    expect(rendered).to have_selector('.usa-alert.usa-alert--info')
+    expect(rendered).to have_selector('.usa-alert:not([class*=usa-alert--])')
   end
 
   it 'accepts alert type param' do

--- a/spec/components/previews/alert_component_preview.rb
+++ b/spec/components/previews/alert_component_preview.rb
@@ -24,18 +24,14 @@ class AlertComponentPreview < BaseComponentPreview
     render(AlertComponent.new(message: 'An emergency message', type: :emergency))
   end
 
-  def other
-    render(AlertComponent.new(message: 'An other message', type: :other))
-  end
-
   def with_custom_text_tag
     render(AlertComponent.new(type: :success, message: 'A custom message', text_tag: 'div'))
   end
   # @!endgroup
 
   # @param message text
-  # @param type select [info, success, warning, error, emergency, other]
-  def workbench(message: 'An important message', type: :info)
-    render(AlertComponent.new(message:, type:))
+  # @param type select [~, info, success, warning, error, emergency]
+  def workbench(message: 'An important message', type: nil)
+    render(AlertComponent.new(message:, type: type&.to_sym))
   end
 end

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -348,8 +348,10 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
             'Multi-Factor Authentication Setup',
             {
               enabled_mfa_methods_count: 0,
-              errors: { name: [I18n.t('errors.webauthn_platform_setup.general_error')] },
-              error_details: { name: { attestation_error: true } },
+              errors: {
+                attestation_object: [I18n.t('errors.webauthn_platform_setup.general_error')],
+              },
+              error_details: { attestation_object: { invalid: true } },
               in_account_creation_flow: false,
               mfa_method_counts: {},
               multi_factor_auth_method: 'webauthn_platform',

--- a/spec/jobs/reports/drop_off_report_spec.rb
+++ b/spec/jobs/reports/drop_off_report_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Reports::DropOffReport do
   let(:report_date) { Date.new(2023, 12, 12).in_time_zone('UTC') }
+  # This is in S3 as a string that gets parsed via identity_config.rb
   let(:report_config) do
-    '[{"emails":["ursula@example.com"],
-       "issuers":"urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"}]'
+    JSON.parse '[{"emails":["ursula@example.com"],
+       "issuers":["urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"]}]'
   end
 
   before do

--- a/spec/services/push_notification/http_push_spec.rb
+++ b/spec/services/push_notification/http_push_spec.rb
@@ -22,87 +22,55 @@ RSpec.describe PushNotification::HttpPush do
     )
   end
   let(:now) { Time.zone.now }
-  let(:risc_notifications_active_job_enabled) { false }
   let(:push_notifications_enabled) { true }
-  let(:job_analytics) { FakeAnalytics.new }
-  let(:risc_event_payload) do
-    {
-      client_id: sp_with_push_url.issuer,
-      error: nil,
-      event_type: event.event_type,
-      status: nil,
-      success: false,
-      transport: 'direct',
-    }
-  end
 
   subject(:http_push) { PushNotification::HttpPush.new(event, now: now) }
 
   before do
-    allow(IdentityConfig.store).to receive(:risc_notifications_active_job_enabled).
-      and_return(risc_notifications_active_job_enabled)
+    ActiveJob::Base.queue_adapter = :test
     allow(Identity::Hostdata).to receive(:env).and_return('dev')
     allow(IdentityConfig.store).to receive(:push_notifications_enabled).
       and_return(push_notifications_enabled)
-    allow(Analytics).to receive(:new).and_return(job_analytics)
   end
 
   describe '#deliver' do
     subject(:deliver) { http_push.deliver }
 
-    context 'when push_notifications_enabled is disabled' do
+    it 'enqueues a background job to deliver a notification' do
+      expect { deliver }.to have_enqueued_job(RiscDeliveryJob).once
+    end
+
+    it 'enqueues a background job with the correct arguments' do
+      expect { deliver }.to have_enqueued_job(RiscDeliveryJob).with { |args|
+        expect(args[:push_notification_url]).to eq sp_with_push_url.push_notification_url
+        expect(args[:event_type]).to eq event.event_type
+        expect(args[:issuer]).to eq sp_with_push_url.issuer
+
+        jwt_payload, headers = JWT.decode(
+          args[:jwt],
+          AppArtifacts.store.oidc_public_key,
+          true,
+          algorithm: 'RS256',
+          kid: JWT::JWK.new(AppArtifacts.store.oidc_private_key).kid,
+        )
+
+        expect(headers['typ']).to eq('secevent+jwt')
+        expect(headers['kid']).to eq(JWT::JWK.new(AppArtifacts.store.oidc_private_key).kid)
+
+        expect(jwt_payload['iss']).to eq(root_url)
+        expect(jwt_payload['iat']).to eq(now.to_i)
+        expect(jwt_payload['exp']).to eq((now + 12.hours).to_i)
+        expect(jwt_payload['aud']).to eq(sp_with_push_url.push_notification_url)
+        expect(jwt_payload['events']).to eq(event.event_type => event.payload.as_json)
+      }
+    end
+
+    context 'when push_notifications_enabled is false' do
       let(:push_notifications_enabled) { false }
 
-      it 'does not deliver any notifications' do
-        expect(http_push).to_not receive(:deliver_one)
-
-        deliver
+      it 'does not enqueue a RISC notification' do
+        expect { deliver }.not_to have_enqueued_job(RiscDeliveryJob)
       end
-    end
-
-    context 'when risc_notifications_active_job_enabled is enabled' do
-      let(:risc_notifications_active_job_enabled) { true }
-
-      it 'delivers a notification via background job' do
-        expect(RiscDeliveryJob).to receive(:perform_later)
-
-        deliver
-      end
-    end
-
-    it 'makes an HTTP post to service providers with a push_notification_url' do
-      stub_request(:post, sp_with_push_url.push_notification_url).
-        with do |request|
-          expect(request.headers['Content-Type']).to eq('application/secevent+jwt')
-          expect(request.headers['Accept']).to eq('application/json')
-
-          payload, headers = JWT.decode(
-            request.body,
-            AppArtifacts.store.oidc_public_key,
-            true,
-            algorithm: 'RS256',
-            kid: JWT::JWK.new(AppArtifacts.store.oidc_private_key).kid,
-          )
-
-          expect(headers['typ']).to eq('secevent+jwt')
-          expect(headers['kid']).to eq(JWT::JWK.new(AppArtifacts.store.oidc_private_key).kid)
-
-          expect(payload['iss']).to eq(root_url)
-          expect(payload['iat']).to eq(now.to_i)
-          expect(payload['exp']).to eq((now + 12.hours).to_i)
-          expect(payload['aud']).to eq(sp_with_push_url.push_notification_url)
-          expect(payload['events']).to eq(event.event_type => event.payload.as_json)
-        end
-
-      deliver
-
-      expect(job_analytics).to have_logged_event(
-        :risc_security_event_pushed,
-        risc_event_payload.merge(
-          status: 200,
-          success: true,
-        ),
-      )
     end
 
     context 'with an event that sends agency-specific iss_sub' do
@@ -111,97 +79,35 @@ RSpec.describe PushNotification::HttpPush do
       let(:agency_uuid) { AgencyIdentityLinker.new(sp_with_push_url_identity).link_identity.uuid }
 
       it 'sends the agency-specific uuid' do
-        stub_request(:post, sp_with_push_url.push_notification_url).
-          with do |request|
-            payload, _headers = JWT.decode(
-              request.body,
-              AppArtifacts.store.oidc_public_key,
-              true,
-              algorithm: 'RS256',
-            )
-
-            expect(payload['events'][event.event_type]['subject']['sub']).to eq(agency_uuid)
-          end
-
-        deliver
-      end
-    end
-
-    context 'with a timeout when posting to one url' do
-      let(:third_sp) { create(:service_provider, active: true, push_notification_url: 'http://sp.url/push') }
-
-      before do
-        IdentityLinker.new(user, third_sp).link_identity
-
-        stub_request(:post, sp_with_push_url.push_notification_url).to_timeout
-        stub_request(:post, third_sp.push_notification_url).to_return(status: 200)
-      end
-
-      it 'still posts to the others' do
-        deliver
-
-        expect(WebMock).to have_requested(:post, third_sp.push_notification_url)
-      end
-
-      it 'logs both events' do
-        deliver
-
-        expect(job_analytics).to have_logged_event(
-          :risc_security_event_pushed,
-          risc_event_payload.merge(
-            error: 'execution expired',
-          ),
-        )
-        expect(job_analytics).to have_logged_event(
-          :risc_security_event_pushed,
-          risc_event_payload.merge(
-            client_id: third_sp.issuer,
-            status: 200,
-            success: true,
-          ),
-        )
-      end
-    end
-
-    context 'with a non-200 response from a push notification url' do
-      before do
-        stub_request(:post, sp_with_push_url.push_notification_url).
-          to_return(status: 500)
-      end
-
-      it 'logs an event' do
-        deliver
-
-        expect(job_analytics).to have_logged_event(
-          :risc_security_event_pushed,
-          risc_event_payload.merge(
-            error: 'http_push_error',
-            status: 500,
-          ),
-        )
+        expect { deliver }.to have_enqueued_job(RiscDeliveryJob).with { |args|
+          jwt_payload, _headers = JWT.decode(
+            args[:jwt],
+            AppArtifacts.store.oidc_public_key,
+            true,
+            algorithm: 'RS256',
+            kid: JWT::JWK.new(AppArtifacts.store.oidc_private_key).kid,
+          )
+          expect(jwt_payload['events'][event.event_type]['subject']['sub']).to eq(agency_uuid)
+        }
       end
     end
 
     context 'when a service provider is no longer active' do
       before { sp_with_push_url.update!(active: false) }
 
-      it 'does not notify that SP' do
-        deliver
-
-        expect(WebMock).not_to have_requested(:get, sp_with_push_url.push_notification_url)
+      it 'does not enqueue a RISC notification' do
+        expect { deliver }.not_to have_enqueued_job(RiscDeliveryJob)
       end
     end
 
-    context 'when a user has revoked access to an SP' do
+    context 'when a user has revoked access to a service provider' do
       before do
         identity = user.identities.find_by(service_provider: sp_with_push_url.issuer)
         RevokeServiceProviderConsent.new(identity).call
       end
 
-      it 'does not notify that SP' do
-        deliver
-
-        expect(WebMock).not_to have_requested(:get, sp_with_push_url.push_notification_url)
+      it 'does not enqueue a RISC notification' do
+        expect { deliver }.not_to have_enqueued_job(RiscDeliveryJob)
       end
     end
   end

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -182,4 +182,34 @@ RSpec.describe 'accounts/show.html.erb' do
       )
     end
   end
+
+  describe 'email language' do
+    context 'without explicit user language preference' do
+      let(:user) { create(:user, :fully_registered, email_language: nil) }
+
+      before do
+        I18n.locale = :es
+      end
+
+      it 'renders email language with language of parts as English' do
+        # Ensure that non-English content in English page is annotated with language.
+        # See: https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts
+        render
+
+        expect(rendered).to have_css('[lang=en]', text: t('account.email_language.name.en'))
+      end
+    end
+
+    context 'with user language preference' do
+      let(:user) { create(:user, :fully_registered, email_language: :es) }
+
+      it 'renders email language with language of parts as that language' do
+        # Ensure that non-English content in English page is annotated with language.
+        # See: https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts
+        render
+
+        expect(rendered).to have_css('[lang=es]', text: t('account.email_language.name.es'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Bug Fixes
- Accessibility: Render email language preference as language of parts ([#10841](https://github.com/18F/identity-idp/pull/10841))
- Reports: Resolve double-parsing JSON in Dropoff report (LG-13570) ([#10846](https://github.com/18F/identity-idp/pull/10846))

## Internal
- RISC: Remove obsolete code ([#10826](https://github.com/18F/identity-idp/pull/10826))
- UI Components: Replace Alert component "other" as default style ([#10779](https://github.com/18F/identity-idp/pull/10779))
- WebAuthn: Standardize form validation for WebauthnSetupForm ([#10782](https://github.com/18F/identity-idp/pull/10782))
