### PR TITLE
Update list of diffable files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -129,8 +129,9 @@ knapsack_rspec_report.json      lockfile
 package-lock.json               lockfile
 pnpm-lock.yaml                  lockfile
 
-### Force text diff for Gemfile.lock
+### Force text diff for specific lockfiles
 Gemfile.lock                    diff
+yarn.lock                       diff
 
 ## Executables and runtimes
 *.wasm                          binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -111,7 +111,8 @@
 
 
 # Fix syntax highlighting on GitHub to allow comments
-tsconfig.json       jsonc
+tsconfig.json              jsonc
+knapsack_rspec_report.json jsonc
 
 # Lock files (usually for managing project dependencies)
 *.lock              lockfile
@@ -122,10 +123,9 @@ tsconfig.json       jsonc
 
 # --------------------------------------------------------------------
 # PROJECT-SPEFICIC RULES
-# --------------------------------------------------------------------# 
+# --------------------------------------------------------------------#
 
 ## Lock files
-knapsack_rspec_report.json      lockfile
 package-lock.json               lockfile
 pnpm-lock.yaml                  lockfile
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -111,8 +111,7 @@
 
 
 # Fix syntax highlighting on GitHub to allow comments
-tsconfig.json              jsonc
-knapsack_rspec_report.json jsonc
+tsconfig.json       jsonc
 
 # Lock files (usually for managing project dependencies)
 *.lock              lockfile
@@ -132,7 +131,7 @@ pnpm-lock.yaml                  lockfile
 ### Force text diff for specific lockfiles
 Gemfile.lock                    diff
 yarn.lock                       diff
-knapsack_rspec_report.json      diff
+knapsack_rspec_report.json      jsonc
 
 ## Executables and runtimes
 *.wasm                          binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -132,6 +132,7 @@ pnpm-lock.yaml                  lockfile
 ### Force text diff for specific lockfiles
 Gemfile.lock                    diff
 yarn.lock                       diff
+knapsack_rspec_report.json      diff
 
 ## Executables and runtimes
 *.wasm                          binary


### PR DESCRIPTION
In #10518 we added `.gitattributes`

However, treating `yarn.lock` as a binary file has challenged my local workflow, so I can't add files incrementally with `git add --patch` (`git add -p`), they get skipped

This came up when I was working on https://github.com/18F/identity-idp/pull/10854

## Before 

```bash
> git status
...
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   yarn.lock

> git add -p
Only binary files changed.
```

## After
(I can update `yarn.lock` via `git add -p`)