### PR TITLE
Update JavaScript request handler to localize requests automatically

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -281,8 +281,14 @@ class ApplicationController < ActionController::Base
       controller: controller_info,
       user_signed_in: user_signed_in?,
     )
-    flash[:error] = t('errors.general')
-    redirect_back fallback_location: new_user_session_url, allow_other_host: false
+
+    if request.format.json?
+      render json: { redirect: url_from(request.referer) || new_user_session_url },
+             status: :bad_request
+    else
+      flash[:error] = t('errors.general')
+      redirect_back fallback_location: new_user_session_url, allow_other_host: false
+    end
   end
 
   def unsafe_redirect_error(_exception)

--- a/app/javascript/packages/document-capture/services/upload.ts
+++ b/app/javascript/packages/document-capture/services/upload.ts
@@ -87,19 +87,15 @@ const upload: UploadImplementation = async function (payload, { method = 'POST',
     body: toFormData(payload),
     json: false,
     read: false,
+    headers: {
+      Accept: 'application/json',
+    },
   });
 
   if (!response.ok && !response.status.toString().startsWith('4')) {
     // 4xx is an expected error state, handled after JSON deserialization. Anything else not OK
     // should be treated as an unhandled error.
     throw new Error(response.statusText);
-  }
-
-  if (response.url !== endpoint) {
-    forceRedirect(response.url);
-
-    // Avoid settling the promise, allowing the redirect to complete.
-    return new Promise(() => {});
   }
 
   const result: UploadSuccessResponse | UploadErrorResponse = await response.json();

--- a/app/javascript/packages/request/index.ts
+++ b/app/javascript/packages/request/index.ts
@@ -101,7 +101,12 @@ export async function request(url: string, options: Partial<RequestOptions> = {}
     }
   }
 
-  const response = await fetch(url, { ...fetchOptions, headers, body });
+  const urlWithLocale = new URL(url);
+  if (!urlWithLocale.searchParams.has('locale')) {
+    urlWithLocale.searchParams.set('locale', document.documentElement.lang);
+  }
+
+  const response = await fetch(urlWithLocale, { ...fetchOptions, headers, body });
   CSRF.token = response.headers.get('X-CSRF-Token');
 
   if (read) {

--- a/app/javascript/packages/request/index.ts
+++ b/app/javascript/packages/request/index.ts
@@ -101,7 +101,7 @@ export async function request(url: string, options: Partial<RequestOptions> = {}
     }
   }
 
-  const urlWithLocale = new URL(url);
+  const urlWithLocale = new URL(url, window.location.href);
   if (!urlWithLocale.searchParams.has('locale')) {
     urlWithLocale.searchParams.set('locale', document.documentElement.lang);
   }

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -84,7 +84,6 @@ const trackEvent: typeof baseTrackEvent = (event, payload) => {
 
 const formData: Record<string, any> = {
   document_capture_session_uuid: appRoot.getAttribute('data-document-capture-session-uuid'),
-  locale: document.documentElement.lang,
 };
 
 const {

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -279,7 +279,10 @@ describe('document-capture/components/document-capture', () => {
 
     const response = new Response(JSON.stringify({ redirect: '#teapot' }), { status: 418 });
     sandbox.stub(response, 'url').get(() => endpoint);
-    sandbox.stub(global, 'fetch').withArgs(endpoint).resolves(response);
+    sandbox
+      .stub(global, 'fetch')
+      .withArgs(sandbox.match((url) => url.pathname === endpoint))
+      .resolves(response);
 
     const frontImage = getByLabelText('doc_auth.headings.document_capture_front');
     const backImage = getByLabelText('doc_auth.headings.document_capture_back');
@@ -337,7 +340,10 @@ describe('document-capture/components/document-capture', () => {
           { status: 400 },
         );
         sandbox.stub(response, 'url').get(() => endpoint);
-        sandbox.stub(global, 'fetch').withArgs(endpoint).resolves(response);
+        sandbox
+          .stub(global, 'fetch')
+          .withArgs(sandbox.match((url) => url.pathname === endpoint))
+          .resolves(response);
 
         expect(queryByText('idv.troubleshooting.options.verify_in_person')).not.to.exist();
         await userEvent.click(getByText('forms.buttons.submit.default'));


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `request` JavaScript helper to automatically handle localization.

This simplifies existing code, and ensures consistency with JavaScript requests to ensure that the locale is set correctly on the backend.

Specifically, this is planned to be used for localizing in-person proofing location results ([related Slack discussion](https://gsa-tts.slack.com/archives/C04GA9WQ85B/p1718919297887639)).

_Draft:_

- [ ] Spec updates

## 📜 Testing Plan

TBD verify that document capture errors localize correctly.