### PR TITLE
Begin using the new `ResendLetterController`

### DIFF
--- a/app/views/idv/by_mail/enter_code/_did_not_receive_letter.html.erb
+++ b/app/views/idv/by_mail/enter_code/_did_not_receive_letter.html.erb
@@ -42,7 +42,7 @@
 </p>
 
 <% if @can_request_another_letter %>
-  <%= link_to t('idv.messages.gpo.resend'), idv_request_letter_path, class: 'display-block margin-top-4' %>
+  <%= link_to t('idv.messages.gpo.resend'), idv_resend_letter_path, class: 'display-block margin-top-4' %>
 <% end %>
 
 <hr class="margin-y-4" />

--- a/app/views/idv/by_mail/enter_code/_enter_code.html.erb
+++ b/app/views/idv/by_mail/enter_code/_enter_code.html.erb
@@ -44,7 +44,7 @@
 </p>
 
 <% if @can_request_another_letter %>
-  <%= link_to t('idv.messages.gpo.resend'), idv_request_letter_path, class: 'display-block margin-top-4' %>
+  <%= link_to t('idv.messages.gpo.resend'), idv_resend_letter_path, class: 'display-block margin-top-4' %>
 <% end %>
 
 <hr class="margin-y-4" />

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -93,11 +93,11 @@ RSpec.feature 'idv request letter step', allowed_extra_analytics: [:*] do
 
         # Confirm that user cannot visit other IdV pages while unverified
         visit idv_agreement_path
-        expect(page).to have_current_path(idv_letter_enqueued_path)
+        expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
         visit idv_ssn_url
-        expect(page).to have_current_path(idv_letter_enqueued_path)
+        expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
         visit idv_verify_info_url
-        expect(page).to have_current_path(idv_letter_enqueued_path)
+        expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
 
         # complete verification: end to end gpo test
         sign_out

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature 'IAL2 Single Sign On', allowed_extra_analytics: [:*] do
         click_link(t('idv.messages.gpo.resend'))
 
         expect(user.events.account_verified.size).to be(0)
-        expect(current_path).to eq(idv_request_letter_path)
+        expect(current_path).to eq(idv_resend_letter_path)
 
         click_button(t('idv.gpo.request_another_letter.button'))
 

--- a/spec/views/idv/by_mail/enter_code/index.html.erb_spec.rb
+++ b/spec/views/idv/by_mail/enter_code/index.html.erb_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe 'idv/by_mail/enter_code/index.html.erb' do
 
   context 'user is allowed to request another GPO letter' do
     it 'includes the send another letter link' do
-      expect(rendered).to have_link(t('idv.messages.gpo.resend'), href: idv_request_letter_path)
+      expect(rendered).to have_link(t('idv.messages.gpo.resend'), href: idv_resend_letter_path)
     end
   end
 
   context 'user is NOT allowed to request another GPO letter' do
     let(:can_request_another_letter) { false }
     it 'does not include the send another letter link' do
-      expect(rendered).not_to have_link(t('idv.messages.gpo.resend'), href: idv_request_letter_path)
+      expect(rendered).not_to have_link(t('idv.messages.gpo.resend'), href: idv_resend_letter_path)
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe 'idv/by_mail/enter_code/index.html.erb' do
     it 'links to requesting a new letter' do
       expect(rendered).to have_link(
         t('idv.messages.gpo.resend'),
-        href: idv_request_letter_path,
+        href: idv_resend_letter_path,
       )
     end
 
@@ -104,7 +104,7 @@ RSpec.describe 'idv/by_mail/enter_code/index.html.erb' do
       it 'does not link to requesting a new letter' do
         expect(rendered).to_not have_link(
           t('idv.messages.gpo.resend'),
-          href: idv_request_letter_path,
+          href: idv_resend_letter_path,
         )
       end
     end


### PR DESCRIPTION
The `ResendLetterController` was introduced in #10864. It was not used to support the 50/50 state when old instances will not have the route and would 404 if users were linked there.

Once the changes in #10864 are fully merged this change can be merged to start linking users to the new `ResendLetterController`. From there the functionality to support resends can be removed from the `RequestLetterController`.
