### PR TITLE
LG-13692 Use `PendingProfileConcern` to check for pending profiles during IdV

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -3,6 +3,7 @@
 module IdvStepConcern
   extend ActiveSupport::Concern
 
+  include VerifyProfileConcern
   include IdvSessionConcern
   include RateLimitConcern
   include FraudReviewConcern
@@ -14,9 +15,7 @@ module IdvStepConcern
     before_action :confirm_personal_key_acknowledged_if_needed
     before_action :confirm_idv_needed
     before_action :confirm_letter_recently_enqueued
-    before_action :confirm_no_pending_gpo_profile
-    before_action :confirm_no_pending_in_person_enrollment
-    before_action :handle_fraud
+    before_action :confirm_no_pending_profile
     before_action :check_for_mail_only_outage
   end
 
@@ -35,13 +34,8 @@ module IdvStepConcern
     return redirect_to idv_letter_enqueued_url if letter_recently_enqueued?
   end
 
-  def confirm_no_pending_gpo_profile
-    redirect_to idv_verify_by_mail_enter_code_url if letter_not_recently_enqueued?
-  end
-
-  def confirm_no_pending_in_person_enrollment
-    return if !IdentityConfig.store.in_person_proofing_enabled
-    redirect_to idv_in_person_ready_to_verify_url if current_user&.pending_in_person_enrollment
+  def confirm_no_pending_profile
+    redirect_to url_for_pending_profile_reason if user_has_pending_profile?
   end
 
   def check_for_mail_only_outage

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -6,15 +6,12 @@ module VerifyProfileConcern
   def url_for_pending_profile_reason
     return idv_verify_by_mail_enter_code_url if current_user.gpo_verification_pending_profile?
     return idv_in_person_ready_to_verify_url if current_user.in_person_pending_profile?
-    # We don't want to hit idv_please_call_url in cases where the user
-    # has fraud review pending and not passed at the post office
-    return idv_welcome_url if user_failed_ipp_with_fraud_review_pending?
     return idv_please_call_url if current_user.fraud_review_pending?
     idv_not_verified_url if current_user.fraud_rejection?
   end
 
   def user_has_pending_profile?
-    pending_profile_policy.user_has_pending_profile?
+    pending_profile_policy.user_has_pending_profile? && !user_failed_ipp_with_fraud_review_pending?
   end
 
   def pending_profile_policy
@@ -25,6 +22,10 @@ module VerifyProfileConcern
     )
   end
 
+  # Returns true if the user has not passed IPP at the post office and is
+  # flagged for fraud review, or has been rejected for fraud.
+  # Ultimately this is to allow users who fail at the post office to create another enrollment
+  # bypassing the typical flow of showing the Please Call or Fraud Rejection screens.
   def user_failed_ipp_with_fraud_review_pending?
     IdentityConfig.store.in_person_proofing_enforce_tmx &&
       current_user.ipp_enrollment_status_not_passed? &&

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -16,8 +16,7 @@ module Idv
     # standard before_actions and handle them in our own special way below.
     skip_before_action :confirm_idv_needed
     skip_before_action :confirm_personal_key_acknowledged_if_needed
-    skip_before_action :confirm_no_pending_in_person_enrollment
-    skip_before_action :handle_fraud
+    skip_before_action :confirm_no_pending_profile
 
     def show
       analytics.idv_personal_key_visited(

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -19,13 +19,6 @@ RSpec.describe 'IdvStepConcern' do
   end
 
   describe 'before_actions' do
-    it 'includes handle_fraud' do
-      expect(idv_step_controller_class).to have_actions(
-        :before,
-        :handle_fraud,
-      )
-    end
-
     it 'includes check_for_mail_only_outage before_action' do
       expect(idv_step_controller_class).to have_actions(
         :before,
@@ -176,6 +169,7 @@ RSpec.describe 'IdvStepConcern' do
   describe '#confirm_letter_recently_enqueued' do
     controller(idv_step_controller_class) do
       before_action :confirm_letter_recently_enqueued
+      before_action :confirm_no_pending_profile
     end
 
     before(:each) do
@@ -209,9 +203,9 @@ RSpec.describe 'IdvStepConcern' do
     end
   end
 
-  describe '#confirm_no_pending_in_person_enrollment' do
+  describe '#confirm_no_pending_profile' do
     controller(idv_step_controller_class) do
-      before_action :confirm_no_pending_in_person_enrollment
+      before_action :confirm_no_pending_profile
     end
 
     before(:each) do
@@ -243,20 +237,6 @@ RSpec.describe 'IdvStepConcern' do
         get :show
 
         expect(response).to redirect_to idv_in_person_ready_to_verify_url
-      end
-    end
-  end
-
-  describe '#confirm_no_pending_gpo_profile' do
-    controller(idv_step_controller_class) do
-      before_action :confirm_no_pending_gpo_profile
-    end
-
-    before(:each) do
-      sign_in(user)
-      allow(subject).to receive(:current_user).and_return(user)
-      routes.draw do
-        get 'show' => 'anonymous#show'
       end
     end
 

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Idv::PersonalKeyController do
         :confirm_idv_needed,
         :confirm_personal_key_acknowledged_if_needed,
         :confirm_no_pending_in_person_enrollment,
-        :handle_fraud,
+        :confirm_no_pending_profile,
       )
     end
 

--- a/spec/features/idv/verify_by_mail_pending_spec.rb
+++ b/spec/features/idv/verify_by_mail_pending_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'a user that is pending verify by mail', allowed_extra_analytics: 
 
     expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
 
-    # Attempting to start IdV should require enter-code to be entered
+    # Attempting to start IdV should require enter-code to be completed
     visit idv_welcome_path
     expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
 

--- a/spec/features/idv/verify_by_mail_pending_spec.rb
+++ b/spec/features/idv/verify_by_mail_pending_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.feature 'a user that is pending verify by mail', allowed_extra_analytics: [:*] do
+  include IdvStepHelper
+
+  it 'requires them to enter code or cancel to enter the proofing flow' do
+    user = create(:user, :fully_registered)
+    profile = create(:profile, :with_pii, :verify_by_mail_pending, user: user)
+    create(:gpo_confirmation_code, profile: profile, created_at: 2.days.ago, updated_at: 2.days.ago)
+
+    start_idv_from_sp(biometric_comparison_required: false)
+    sign_in_live_with_2fa(user)
+
+    expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
+
+    # Attempting to start IdV should require enter-code to be entered
+    visit idv_welcome_path
+    expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
+
+    # Cancelling redirects to IdV flow start
+    click_on t('idv.gpo.address_accordion.cta_link')
+    click_idv_continue
+
+    expect(current_path).to eq(idv_welcome_path)
+  end
+
+  it 'does not require them to enter their code if they are upgrading to biometric' do
+    user = create(:user, :fully_registered)
+    profile = create(:profile, :with_pii, :verify_by_mail_pending, user: user)
+    create(:gpo_confirmation_code, profile: profile, created_at: 2.days.ago, updated_at: 2.days.ago)
+
+    start_idv_from_sp(biometric_comparison_required: true)
+    sign_in_live_with_2fa(user)
+
+    # The user is redirected to proofing since their pending profile does not meet
+    # the biometric comparison requirement
+    expect(current_path).to eq(idv_welcome_path)
+  end
+end


### PR DESCRIPTION
The `PendingProfileConcern` uses the `PendingProfilePolicy` to check if a user has a pending profile and needs to be redirected to finish proofing. We have code in the `IdvStepConcern` that does the same, but does not factor all of the things that go into that function, such as whether the SP requested a biometric comparison and the pending profile had a biometric comparison.

This commit uses the `PendingProfileConcern` in the `IdvStepConcern` to ensure the pending profile logic is consistent.
