### PR TITLE
LG-13336: Low confidence Score Exemption

### DIFF
--- a/app/forms/recaptcha_form.rb
+++ b/app/forms/recaptcha_form.rb
@@ -96,7 +96,7 @@ class RecaptchaForm
 
   def recaptcha_result_valid?(result)
     return true if result.blank?
-    return true if result_reason_exempt(result)
+    return true if result_reason_exempt?(result)
 
     if result.success?
       result.score >= score_threshold
@@ -109,8 +109,8 @@ class RecaptchaForm
     RESULT_ERRORS.include?(error_code)
   end
 
-  def result_reason_exempt(result)
-    EXEMPT_RESULT_REASONS.any? { |reason| result.reasons.include?(reason) }
+  def result_reason_exempt?(result)
+    (EXEMPT_RESULT_REASONS & result.reasons).any?
   end
 
   def log_analytics(result: nil, error: nil)

--- a/app/forms/recaptcha_form.rb
+++ b/app/forms/recaptcha_form.rb
@@ -6,6 +6,7 @@ class RecaptchaForm
 
   VERIFICATION_ENDPOINT = 'https://www.google.com/recaptcha/api/siteverify'
   RESULT_ERRORS = ['missing-input-secret', 'invalid-input-secret'].freeze
+  EXEMPT_RESULT_REASONS = ['LOW_CONFIDENCE_SCORE'].freeze
 
   attr_reader :recaptcha_action,
               :recaptcha_token,
@@ -95,6 +96,7 @@ class RecaptchaForm
 
   def recaptcha_result_valid?(result)
     return true if result.blank?
+    return true if result_reason_exempt(result)
 
     if result.success?
       result.score >= score_threshold
@@ -105,6 +107,10 @@ class RecaptchaForm
 
   def is_result_error?(error_code)
     RESULT_ERRORS.include?(error_code)
+  end
+
+  def result_reason_exempt(result)
+    EXEMPT_RESULT_REASONS.any? { |reason| result.reasons.include?(reason) }
   end
 
   def log_analytics(result: nil, error: nil)

--- a/spec/forms/recaptcha_enterprise_form_spec.rb
+++ b/spec/forms/recaptcha_enterprise_form_spec.rb
@@ -270,6 +270,46 @@ RSpec.describe RecaptchaEnterpriseForm do
           form_class: 'RecaptchaEnterpriseForm',
         )
       end
+
+      context 'with low confidence score as one of the reasons for failure' do
+        before do
+          stub_recaptcha_response(
+            body: {
+              tokenProperties: { valid: true, action: },
+              riskAnalysis: { score:, reasons: ['LOW_CONFIDENCE_SCORE'] },
+              event: {},
+              name:,
+            },
+            action:,
+            token:,
+          )
+        end
+
+        it 'is successful with assessment id' do
+          response, assessment_id = result
+
+          expect(response.to_h).to eq(success: true)
+          expect(assessment_id).to eq(name)
+        end
+
+        it 'logs analytics of the body' do
+          result
+
+          expect(analytics).to have_logged_event(
+            'reCAPTCHA verify result received',
+            recaptcha_result: {
+              success: true,
+              score:,
+              reasons: ['LOW_CONFIDENCE_SCORE'],
+              errors: [],
+              assessment_id: name,
+            },
+            evaluated_as_valid: true,
+            score_threshold: score_threshold,
+            form_class: 'RecaptchaEnterpriseForm',
+          )
+        end
+      end
     end
 
     context 'with successful score from validation service' do


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-13336](https://cm-jira.usa.gov/browse/LG-13336)

## 🛠 Summary of changes
This adds LOW_CONFIDENCE_SCORE as a type of reason we will currently ignore and allow users to continue. 

## 📜 Testing Plan

1.  Mimic recaptcha logging and return a LOW_CONFIDENCE_SCORE reason
2. Should not be blocked from continuing on. 

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
