### PR TITLE
Billing Report Updates for Unique User Calculations (LG-13703)

### DIFF
--- a/app/jobs/reports/combined_invoice_supplement_report_v2.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report_v2.rb
@@ -96,7 +96,7 @@ module Reports
 
           'iaa_ial1_unique_users',
           'iaa_ial2_unique_users',
-          'iaa_ial1_plus_2_unique_users',
+          'iaa_unique_users',
           'partner_ial2_unique_user_events_year1',
           'partner_ial2_unique_user_events_year2',
           'partner_ial2_unique_user_events_year3',
@@ -133,7 +133,7 @@ module Reports
 
           'issuer_ial1_unique_users',
           'issuer_ial2_unique_users',
-          'issuer_ial1_plus_2_unique_users',
+          'issuer_unique_users',
         ]
         by_issuer_iaa_issuer_year_months.each do |iaa_key, issuer_year_months|
           issuer_year_months.each do |issuer, year_months_data|
@@ -167,9 +167,9 @@ module Reports
                 year_month,
                 year_month_start.strftime('%B %Y'),
 
-                (iaa_ial1_unique_users = extract(iaa_results, :unique_users, ial: 1)),
-                (iaa_ial2_unique_users = extract(iaa_results, :unique_users, ial: 2)),
-                iaa_ial1_unique_users + iaa_ial2_unique_users,
+                extract(iaa_results, :unique_users, ial: 1),
+                extract(iaa_results, :unique_users, ial: 2),
+                extract(iaa_results, :unique_users, ial: :all),
                 partner_results[:partner_ial2_unique_user_events_year1] || 0,
                 partner_results[:partner_ial2_unique_user_events_year2] || 0,
                 partner_results[:partner_ial2_unique_user_events_year3] || 0,
@@ -204,9 +204,9 @@ module Reports
                 (ial2_total_auth_count = extract(issuer_results, :total_auth_count, ial: 2)),
                 ial1_total_auth_count + ial2_total_auth_count,
 
-                (issuer_ial1_unique_users = extract(issuer_results, :unique_users, ial: 1)),
-                (issuer_ial2_unique_users = extract(issuer_results, :unique_users, ial: 2)),
-                issuer_ial1_unique_users + issuer_ial2_unique_users,
+                extract(issuer_results, :unique_users, ial: 1),
+                extract(issuer_results, :unique_users, ial: 2),
+                extract(issuer_results, :unique_users, ial: :all),
               ]
             end
           end

--- a/spec/jobs/reports/combined_invoice_supplement_report_v2_spec.rb
+++ b/spec/jobs/reports/combined_invoice_supplement_report_v2_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
     end
 
     context 'with data generates reports by iaa + order number, issuer and year_month' do
-      let(:user1) { create(:user, profiles: [profile1]) }
-      let(:profile1) { build(:profile, verified_at: DateTime.new(2019, 10, 15).utc) }
-
       context 'with an IAA with a single issuer in April 2020' do
         let(:partner_account1) { create(:partner_account) }
         let(:iaa1_range) { DateTime.new(2020, 4, 15).utc..DateTime.new(2021, 4, 14).utc }
@@ -49,11 +46,11 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
         let(:inside_iaa1) { iaa1_range.begin + 1.day }
 
+        let(:user1) { create(:user, profiles: [profile1]) }
+        let(:profile1) { build(:profile, verified_at: DateTime.new(2018, 6, 1).utc) }
+
         let(:user2) { create(:user, profiles: [profile2]) }
         let(:profile2) { build(:profile, verified_at: DateTime.new(2018, 6, 1).utc) }
-
-        let(:user3) { create(:user, profiles: [profile3]) }
-        let(:profile3) { build(:profile, verified_at: DateTime.new(2018, 6, 1).utc) }
 
         let(:csv) { CSV.parse(report.perform(Time.zone.today), headers: true) }
 
@@ -67,16 +64,21 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
           # 1 new unique user in month 1 at IAA 1 sp @ IAL 1
           7.times do
             create_sp_return_log(
-              user: user1, issuer: iaa1_sp.issuer, ial: 1,
-              returned_at: inside_iaa1
+              user: user1,
+              issuer: iaa1_sp.issuer,
+              ial: 1,
+              returned_at: inside_iaa1,
             )
           end
 
           # 2 new unique users in month 1 at IAA 1 sp @ IAL 2 with profile age 2
-          [user2, user3].each do |user|
+          # user1 is both IAL1 and IAL2
+          [user1, user2].each do |user|
             create_sp_return_log(
-              user: user, issuer: iaa1_sp.issuer, ial: 2,
-              returned_at: inside_iaa1
+              user: user,
+              issuer: iaa1_sp.issuer,
+              ial: 2,
+              returned_at: inside_iaa1,
             )
           end
         end
@@ -98,7 +100,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['iaa_ial1_unique_users'].to_i).to eq(1)
             expect(row['iaa_ial2_unique_users'].to_i).to eq(2)
-            expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(3)
+            expect(row['iaa_unique_users'].to_i).to eq(2)
             expect(row['partner_ial2_unique_user_events_year1'].to_i).to eq(0)
             expect(row['partner_ial2_unique_user_events_year2'].to_i).to eq(2)
             expect(row['partner_ial2_unique_user_events_year3'].to_i).to eq(0)
@@ -135,7 +137,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['issuer_ial1_unique_users'].to_i).to eq(1)
             expect(row['issuer_ial2_unique_users'].to_i).to eq(2)
-            expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(3)
+            expect(row['issuer_unique_users'].to_i).to eq(2)
           end
         end
       end
@@ -179,6 +181,9 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
         end
 
         let(:inside_iaa2) { iaa2_range.begin + 1.day }
+
+        let(:user1) { create(:user, profiles: [profile1]) }
+        let(:profile1) { build(:profile, verified_at: DateTime.new(2019, 10, 15).utc) }
 
         let(:user4) { create(:user, profiles: [profile4]) }
         let(:profile4) { build(:profile, verified_at: nil) }
@@ -278,7 +283,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['iaa_ial1_unique_users'].to_i).to eq(0)
             expect(row['iaa_ial2_unique_users'].to_i).to eq(8)
-            expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(8)
+            expect(row['iaa_unique_users'].to_i).to eq(8)
             expect(row['partner_ial2_unique_user_events_year1'].to_i).to eq(1)
             expect(row['partner_ial2_unique_user_events_year2'].to_i).to eq(2)
             expect(row['partner_ial2_unique_user_events_year3'].to_i).to eq(1)
@@ -315,7 +320,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['issuer_ial1_unique_users'].to_i).to eq(0)
             expect(row['issuer_ial2_unique_users'].to_i).to eq(4)
-            expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(4)
+            expect(row['issuer_unique_users'].to_i).to eq(4)
           end
 
           aggregate_failures do
@@ -334,7 +339,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['iaa_ial1_unique_users'].to_i).to eq(0)
             expect(row['iaa_ial2_unique_users'].to_i).to eq(8)
-            expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(8)
+            expect(row['iaa_unique_users'].to_i).to eq(8)
             expect(row['partner_ial2_unique_user_events_year1'].to_i).to eq(1)
             expect(row['partner_ial2_unique_user_events_year2'].to_i).to eq(2)
             expect(row['partner_ial2_unique_user_events_year3'].to_i).to eq(1)
@@ -371,7 +376,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['issuer_ial1_unique_users'].to_i).to eq(0)
             expect(row['issuer_ial2_unique_users'].to_i).to eq(4)
-            expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(4)
+            expect(row['issuer_unique_users'].to_i).to eq(4)
           end
         end
       end
@@ -473,7 +478,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['iaa_ial1_unique_users'].to_i).to eq(0)
             expect(row['iaa_ial2_unique_users'].to_i).to eq(1)
-            expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(1)
+            expect(row['iaa_unique_users'].to_i).to eq(1)
             expect(row['partner_ial2_unique_user_events_year1'].to_i).to eq(1)
             expect(row['partner_ial2_unique_user_events_year2'].to_i).to eq(0)
             expect(row['partner_ial2_unique_user_events_year3'].to_i).to eq(0)
@@ -510,7 +515,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['issuer_ial1_unique_users'].to_i).to eq(0)
             expect(row['issuer_ial2_unique_users'].to_i).to eq(1)
-            expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(1)
+            expect(row['issuer_unique_users'].to_i).to eq(1)
           end
 
           aggregate_failures do
@@ -529,7 +534,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['iaa_ial1_unique_users'].to_i).to eq(0)
             expect(row['iaa_ial2_unique_users'].to_i).to eq(2)
-            expect(row['iaa_ial1_plus_2_unique_users'].to_i).to eq(2)
+            expect(row['iaa_unique_users'].to_i).to eq(2)
             expect(row['partner_ial2_unique_user_events_year1'].to_i).to eq(2)
             expect(row['partner_ial2_unique_user_events_year2'].to_i).to eq(1)
             expect(row['partner_ial2_unique_user_events_year3'].to_i).to eq(0)
@@ -566,7 +571,7 @@ RSpec.describe Reports::CombinedInvoiceSupplementReportV2 do
 
             expect(row['issuer_ial1_unique_users'].to_i).to eq(0)
             expect(row['issuer_ial2_unique_users'].to_i).to eq(2)
-            expect(row['issuer_ial1_plus_2_unique_users'].to_i).to eq(2)
+            expect(row['issuer_unique_users'].to_i).to eq(2)
           end
         end
       end

--- a/spec/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window_spec.rb
+++ b/spec/services/db/monthly_sp_auth_count/total_monthly_auth_counts_within_iaa_window_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe Db::MonthlySpAuthCount::TotalMonthlyAuthCountsWithinIaaWindow do
             iaa_start_date: iaa_range.begin.to_s,
             iaa_end_date: iaa_range.end.to_s,
           },
+          {
+            year_month: partial_month_date.strftime('%Y%m'),
+            ial: :all,
+            issuer: service_provider.issuer,
+            iaa: service_provider.iaa,
+            iaa_start_date: iaa_range.begin.to_s,
+            iaa_end_date: iaa_range.end.to_s,
+            unique_users: 1,
+          },
+          {
+            year_month: full_month_date.strftime('%Y%m'),
+            ial: :all,
+            issuer: service_provider.issuer,
+            iaa: service_provider.iaa,
+            iaa_start_date: iaa_range.begin.to_s,
+            iaa_end_date: iaa_range.end.to_s,
+            unique_users: 1,
+          },
         ]
 
         expect(result).to match_array(rows)

--- a/spec/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa_spec.rb
+++ b/spec/services/db/monthly_sp_auth_count/unique_monthly_auth_counts_by_iaa_spec.rb
@@ -158,6 +158,14 @@ RSpec.describe Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa do
             new_unique_users: 2,
           },
           {
+            ial: :all,
+            key: key,
+            year_month: '202009',
+            iaa_start_date: iaa_range.begin.to_s,
+            iaa_end_date: iaa_range.end.to_s,
+            unique_users: 2,
+          },
+          {
             ial: 1,
             key: key,
             year_month: '202010',
@@ -176,6 +184,14 @@ RSpec.describe Db::MonthlySpAuthCount::UniqueMonthlyAuthCountsByIaa do
             total_auth_count: 21,
             unique_users: 3,
             new_unique_users: 1,
+          },
+          {
+            ial: :all,
+            key: key,
+            year_month: '202010',
+            iaa_start_date: iaa_range.begin.to_s,
+            iaa_end_date: iaa_range.end.to_s,
+            unique_users: 3,
           },
         ]
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13703](https://cm-jira.usa.gov/browse/LG-13703)

## 🛠 Summary of changes

Updates calculations of unique users in CombinedInvoiceSupplementReportV2 to match finops team needs. Full description of logic changes is in the [FY24 Billing Report Explainer](https://docs.google.com/document/d/171lf1rSH1w1aSKVIejjb4z-ebtmdJxgyBVdpKp98GBM/edit) document
    
- remove iaa_ial1_plus_2_unique_users
- remove issuer_ial1_plus_2_unique_users
- add iaa_unique_users
- add issuer_unique_users
