### PR TITLE
LG-13420 Add the `two_pieces_of_fair_evidence` requirement

### DIFF
--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -11,6 +11,7 @@ module Vot
       :hspd12?,
       :identity_proofing?,
       :biometric_comparison?,
+      :two_pieces_of_fair_evidence?,
       :ialmax?,
       :enhanced_ipp?,
     ) do
@@ -22,6 +23,7 @@ module Vot
           hspd12?: false,
           identity_proofing?: false,
           biometric_comparison?: false,
+          two_pieces_of_fair_evidence?: false,
           ialmax?: false,
           enhanced_ipp?: false,
         )
@@ -59,6 +61,7 @@ module Vot
         hspd12?: requirement_list.include?(:hspd12),
         identity_proofing?: requirement_list.include?(:identity_proofing),
         biometric_comparison?: requirement_list.include?(:biometric_comparison),
+        two_pieces_of_fair_evidence?: requirement_list.include?(:two_pieces_of_fair_evidence),
         ialmax?: requirement_list.include?(:ialmax),
         enhanced_ipp?: requirement_list.include?(:enhanced_ipp),
       )

--- a/app/services/vot/supported_component_values.rb
+++ b/app/services/vot/supported_component_values.rb
@@ -36,7 +36,7 @@ module Vot
       name: 'Pb',
       description: 'A biometric comparison is required as part of identity proofing',
       implied_component_values: ['P1'],
-      requirements: [:biometric_comparison],
+      requirements: [:biometric_comparison, :two_pieces_of_fair_evidence],
     ).freeze
     Pe = ComponentValue.new(
       name: 'Pe',

--- a/spec/policies/service_provider_mfa_policy_spec.rb
+++ b/spec/policies/service_provider_mfa_policy_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ServiceProviderMfaPolicy do
       phishing_resistant?: phishing_resistant,
       identity_proofing?: false,
       biometric_comparison?: false,
+      two_pieces_of_fair_evidence?: false,
       ialmax?: false,
       enhanced_ipp?: false,
     )

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -186,6 +186,7 @@ RSpec.describe Analytics do
           sp_request: {
             aal2: true,
             biometric_comparison: true,
+            two_pieces_of_fair_evidence: true,
             component_values: {
               'C1' => true,
               'C2' => true,

--- a/spec/services/vot/parser_spec.rb
+++ b/spec/services/vot/parser_spec.rb
@@ -48,14 +48,17 @@ RSpec.describe Vot::Parser do
         result = Vot::Parser.new(vector_of_trust:).parse
 
         expect(result.component_values.map(&:name).join('.')).to eq('C1.C2.P1.Pe')
-        expect(result.aal2?).to eq(true)
-        expect(result.phishing_resistant?).to eq(false)
-        expect(result.hspd12?).to eq(false)
-        expect(result.identity_proofing?).to eq(true)
-        expect(result.biometric_comparison?).to eq(false)
-        expect(result.ialmax?).to eq(false)
         expect(result.enhanced_ipp?).to eq(true)
       end
+    end
+
+    it 'adds the two pieces of fair evidence components' do
+      vector_of_trust = 'Pb'
+
+      result = Vot::Parser.new(vector_of_trust:).parse
+
+      expect(result.component_values.map(&:name).join('.')).to eq('C1.C2.P1.Pb')
+      expect(result.two_pieces_of_fair_evidence?).to eq(true)
     end
 
     context 'when a vector includes unrecognized components' do

--- a/spec/services/vot/parser_spec.rb
+++ b/spec/services/vot/parser_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Vot::Parser do
 
         result = Vot::Parser.new(vector_of_trust:).parse
 
-        expect(result.component_values.map(&:name).join('.')).to eq('C1.C2.Cb')
+        expect(result.expanded_component_values).to eq('C1.C2.Cb')
         expect(result.aal2?).to eq(true)
         expect(result.phishing_resistant?).to eq(false)
         expect(result.hspd12?).to eq(true)
@@ -32,7 +32,7 @@ RSpec.describe Vot::Parser do
 
         result = Vot::Parser.new(vector_of_trust:).parse
 
-        expect(result.component_values.map(&:name).join('.')).to eq('C1.C2.P1.Pb')
+        expect(result.expanded_component_values).to eq('C1.C2.P1.Pb')
         expect(result.aal2?).to eq(true)
         expect(result.phishing_resistant?).to eq(false)
         expect(result.hspd12?).to eq(false)
@@ -47,7 +47,7 @@ RSpec.describe Vot::Parser do
 
         result = Vot::Parser.new(vector_of_trust:).parse
 
-        expect(result.component_values.map(&:name).join('.')).to eq('C1.C2.P1.Pe')
+        expect(result.expanded_component_values).to eq('C1.C2.P1.Pe')
         expect(result.enhanced_ipp?).to eq(true)
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe Vot::Parser do
 
       result = Vot::Parser.new(vector_of_trust:).parse
 
-      expect(result.component_values.map(&:name).join('.')).to eq('C1.C2.P1.Pb')
+      expect(result.expanded_component_values).to eq('C1.C2.P1.Pb')
       expect(result.two_pieces_of_fair_evidence?).to eq(true)
     end
 


### PR DESCRIPTION
When a service provider requests a biometric comparison we want to make this user proof through a process that requires 2 pieces of fair evidence. This commit starts the work for that by adding a requirement to the `Pb` component. Whenever the biometric request is made this requirement will be present on the `resolved_authn_context_result`. We can use this requirement to determine if the verify-by-mail flow is available to the user.
