### PR TITLE
LG-13578: Backfill sponsor id for in_person_enrollments

### DIFF
--- a/lib/tasks/backfill_sponsor_id.rake
+++ b/lib/tasks/backfill_sponsor_id.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 namespace :in_person_enrollments do
   desc 'Backfill the sponsor_id column.'
 
@@ -9,7 +10,7 @@ namespace :in_person_enrollments do
   #
   task backfill_sponsor_id: :environment do |_task, _args|
     with_timeout do
-      ipp_sponsor_id = IdentityConfig.store.usps_ipp_sponsor_id.to_i
+      ipp_sponsor_id = IdentityConfig.store.usps_ipp_sponsor_id
       enrollments_without_sponsor_id = InPersonEnrollment.where(sponsor_id: nil)
       enrollments_without_sponsor_id_count = enrollments_without_sponsor_id.count
 

--- a/lib/tasks/backfill_sponsor_id.rake
+++ b/lib/tasks/backfill_sponsor_id.rake
@@ -1,0 +1,46 @@
+namespace :in_person_enrollments do
+  desc 'Backfill the sponsor_id column.'
+
+  ##
+  # Usage:
+  #
+  # bundle exec rake in_person_enrollments:backfill_sponsor_id
+  #
+  task backfill_sponsor_id: environment do |_task, _args|
+    with_statement_timeout do
+      ipp_sponsor_id = IdentityConfig.usps_ipp_sponsor_id
+      enrollments_without_sponsor_id = InPersonEnrollment.where(sponsor_id: nil)
+      enrollments_without_sponsor_id_count = enrollments_without_sponsor_id.count
+
+      warn("Found #{enrollments_without_sponsor_id_count} enrollments needing backfill")
+
+      tally = 0
+      enrollments_without_sponsor_id.in_batches(of: batch_size) do |batch|
+        tally += batch.update_all(sponsor_id: ipp_sponsor_id) # rubocop:disable Rails/SkipsModelValidations
+        warn("set sponsor_id for #{tally} in_person_enrollments")
+      end
+      warn("COMPLETE: Updated #{tally} in_person_enrollments")
+
+      enrollments_without_sponsor_id = InPersonEnrollment.where(sponsor_id: nil)
+      enrollments_without_sponsor_id_count = enrollments_without_sponsor_id.count
+      warn("#{enrollments_without_sponsor_id_count} enrollments without a sponsor id")
+    end
+
+    def batch_size
+      ENV['BATCH_SIZE'] ? ENV['BATCH_SIZE'].to_i : 1000
+    end
+
+    def with_statement_timeout(timeout_in_seconds = nil)
+      timeout_in_seconds ||= if ENV['STATEMENT_TIMEOUT_IN_SECONDS']
+                               ENV['STATEMENT_TIMEOUT_IN_SECONDS'].to_i.seconds
+                            else
+                              60.seconds
+                            end
+      ActiveRecord::Base.transaction do
+        quoted_timeout = ActiveRecord::Base.connection.quote(timeout_in_seconds.in_milliseconds)
+        ActiveRecord::Base.connection.execute("SET statement_timeout = #{quoted_timeout}")
+        yield
+      end
+    end
+  end
+end

--- a/lib/tasks/backfill_sponsor_id.rake
+++ b/lib/tasks/backfill_sponsor_id.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :in_person_enrollments do
   desc 'Backfill the sponsor_id column.'
 
@@ -6,13 +7,13 @@ namespace :in_person_enrollments do
   #
   # bundle exec rake in_person_enrollments:backfill_sponsor_id
   #
-  task backfill_sponsor_id: environment do |_task, _args|
-    with_statement_timeout do
-      ipp_sponsor_id = IdentityConfig.usps_ipp_sponsor_id
+  task backfill_sponsor_id: :environment do |_task, _args|
+    with_timeout do
+      ipp_sponsor_id = IdentityConfig.store.usps_ipp_sponsor_id.to_i
       enrollments_without_sponsor_id = InPersonEnrollment.where(sponsor_id: nil)
       enrollments_without_sponsor_id_count = enrollments_without_sponsor_id.count
 
-      warn("Found #{enrollments_without_sponsor_id_count} enrollments needing backfill")
+      warn("Found #{enrollments_without_sponsor_id_count} in_person_enrollments needing backfill")
 
       tally = 0
       enrollments_without_sponsor_id.in_batches(of: batch_size) do |batch|
@@ -25,22 +26,22 @@ namespace :in_person_enrollments do
       enrollments_without_sponsor_id_count = enrollments_without_sponsor_id.count
       warn("#{enrollments_without_sponsor_id_count} enrollments without a sponsor id")
     end
+  end
 
-    def batch_size
-      ENV['BATCH_SIZE'] ? ENV['BATCH_SIZE'].to_i : 1000
-    end
+  def batch_size
+    ENV['BATCH_SIZE'] ? ENV['BATCH_SIZE'].to_i : 1000
+  end
 
-    def with_statement_timeout(timeout_in_seconds = nil)
-      timeout_in_seconds ||= if ENV['STATEMENT_TIMEOUT_IN_SECONDS']
-                               ENV['STATEMENT_TIMEOUT_IN_SECONDS'].to_i.seconds
-                            else
-                              60.seconds
-                            end
-      ActiveRecord::Base.transaction do
-        quoted_timeout = ActiveRecord::Base.connection.quote(timeout_in_seconds.in_milliseconds)
-        ActiveRecord::Base.connection.execute("SET statement_timeout = #{quoted_timeout}")
-        yield
-      end
+  def with_timeout
+    timeout_in_seconds ||= if ENV['STATEMENT_TIMEOUT_IN_SECONDS']
+                             ENV['STATEMENT_TIMEOUT_IN_SECONDS'].to_i.seconds
+                          else
+                            60.seconds
+                          end
+    ActiveRecord::Base.transaction do
+      quoted_timeout = ActiveRecord::Base.connection.quote(timeout_in_seconds.in_milliseconds)
+      ActiveRecord::Base.connection.execute("SET statement_timeout = #{quoted_timeout}")
+      yield
     end
   end
 end

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -41,5 +41,9 @@ FactoryBot.define do
     trait :with_notification_phone_configuration do
       association :notification_phone_configuration
     end
+
+    trait :with_sponsor_id do
+      sponsor_id { '123458' }
+    end
   end
 end

--- a/spec/lib/tasks/backfill_sponsor_id_rake_spec.rb
+++ b/spec/lib/tasks/backfill_sponsor_id_rake_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'in_person_enrollments:backfill_sponsor_id rake task' do
+  let!(:task) do
+    Rake.application.rake_require 'tasks/backfill_sponsor_id'
+    Rake::Task.define_task(:environment)
+    Rake::Task['in_person_enrollments:backfill_sponsor_id']
+  end
+
+  subject(:invoke_task) do
+    actual_stderr = $stderr
+    proxy_stderr = StringIO.new
+    begin
+      $stderr = proxy_stderr
+      task.reenable
+      task.invoke
+      proxy_stderr.string
+    ensure
+      $stderr = actual_stderr
+    end
+  end
+
+  let(:pending_enrollment) { create(:in_person_enrollment, :pending) }
+  let(:expired_enrollment) { create(:in_person_enrollment, :expired) }
+  let(:failed_enrollment) { create(:in_person_enrollment, :failed) }
+  let(:enrollment_with_service_provider) { create(:in_person_enrollment, :with_service_provider) }
+  let(:enrollment_with_notification) do
+    create(
+      :in_person_enrollment,
+      :with_notification_phone_configuration,
+    )
+  end
+  let(:enrollment_with_sponsor_id) { create(:in_person_enrollment, :with_sponsor_id) }
+
+  before do
+    expect(pending_enrollment.sponsor_id).to be_nil
+    expect(expired_enrollment.sponsor_id).to be_nil
+    expect(failed_enrollment.sponsor_id).to be_nil
+    expect(enrollment_with_service_provider.sponsor_id).to be_nil
+    expect(enrollment_with_notification.sponsor_id).to be_nil
+    expect(enrollment_with_sponsor_id.sponsor_id).not_to be_nil
+  end
+
+  it 'does not change the value of an existing sponsor id' do
+    original_sponsor_id = enrollment_with_sponsor_id.sponsor_id
+    subject
+    expect(enrollment_with_sponsor_id.sponsor_id).to eq(original_sponsor_id)
+  end
+end

--- a/spec/lib/tasks/backfill_sponsor_id_rake_spec.rb
+++ b/spec/lib/tasks/backfill_sponsor_id_rake_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe 'in_person_enrollments:backfill_sponsor_id rake task' do
     expect(enrollments_with_nil_sponsor_id_count).to eq(0)
   end
 
+  it 'sets a sponsor id that is a string' do
+    subject
+    enrollments = InPersonEnrollment.all
+    enrollments.each do |enrollment|
+      expect(enrollment.sponsor_id).to be_a String
+    end
+  end
+
   it 'outputs what it did' do
     expect(invoke_task.to_s).to eql(
       <<~END,


### PR DESCRIPTION
## 🎫 Ticket

[LG-13578: Set Sponsor ID on existing enrollments in the database](https://cm-jira.usa.gov/browse/LG-13578)


## 🛠 Summary of changes
- Write a rake task that will set the sponsor id on existing in_person_enrollments in the database that have a nil sponsor_id
- Use the sponsor id associated with IPP for all existing enrollments



## 📜 Testing Plan
- [ ] Run automated tests
- [ ] Run the task in your local env: `bundle exec rake in_person_enrollments:backfill_sponsor_id`  Confirm it succeeds.

