### PR TITLE
Fix LG99 report Cloudwatch Error

### DIFF
--- a/lib/reporting/fraud_metrics_lg99_report.rb
+++ b/lib/reporting/fraud_metrics_lg99_report.rb
@@ -106,6 +106,7 @@ module Reporting
             name
           , properties.user_id as user_id
         | filter name in %{event_names}
+        | limit 10000
       QUERY
     end
 

--- a/spec/lib/reporting/cloudwatch_client_spec.rb
+++ b/spec/lib/reporting/cloudwatch_client_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe Reporting::CloudwatchClient do
 
     subject(:fetch) { client.fetch(query:, from:, to:, time_slices:) }
 
-
     def stub_single_page
       stub_cloudwatch_logs(
         [

--- a/spec/lib/reporting/cloudwatch_client_spec.rb
+++ b/spec/lib/reporting/cloudwatch_client_spec.rb
@@ -58,33 +58,16 @@ RSpec.describe Reporting::CloudwatchClient do
 
     subject(:fetch) { client.fetch(query:, from:, to:, time_slices:) }
 
-    # Helps mimic Array<Aws::CloudWatchLogs::Types::ResultField>
-    # @return [Array<Hash>]
-    def to_result_fields(hsh)
-      hsh.map do |key, value|
-        { field: key, value: value }
-      end
-    end
 
     def stub_single_page
-      query_id = SecureRandom.hex
-
-      Aws.config[:cloudwatchlogs] = {
-        stub_responses: {
-          start_query: { query_id: query_id },
-          get_query_results: {
-            status: 'Complete',
-            results: [
-              # rubocop:disable Layout/LineLength
-              to_result_fields('@message' => 'aaa', '@timestamp' => now.iso8601, '@ptr' => SecureRandom.hex),
-              to_result_fields('@message' => 'bbb', '@timestamp' => now.iso8601, '@ptr' => SecureRandom.hex),
-              to_result_fields('@message' => 'ccc', '@timestamp' => now.iso8601, '@ptr' => SecureRandom.hex),
-              to_result_fields('@message' => 'ddd', '@timestamp' => now.iso8601, '@ptr' => SecureRandom.hex),
-              # rubocop:enable Layout/LineLength
-            ],
-          },
-        },
-      }
+      stub_cloudwatch_logs(
+        [
+          { '@message' => 'aaa', '@timestamp' => now.iso8601, '@ptr' => SecureRandom.hex },
+          { '@message' => 'bbb', '@timestamp' => now.iso8601, '@ptr' => SecureRandom.hex },
+          { '@message' => 'ccc', '@timestamp' => now.iso8601, '@ptr' => SecureRandom.hex },
+          { '@message' => 'ddd', '@timestamp' => now.iso8601, '@ptr' => SecureRandom.hex },
+        ],
+      )
     end
 
     context ':slice_interval is falsy' do

--- a/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe Reporting::FraudMetricsLg99Report do
   subject(:report) { Reporting::FraudMetricsLg99Report.new(time_range:) }
 
   before do
-    cloudwatch_client = double(
-      'Reporting::CloudwatchClient',
-      fetch: [
+    stub_cloudwatch_logs(
+      [
         { 'user_id' => 'user1', 'name' => 'IdV: Verify please call visited' },
         { 'user_id' => 'user1', 'name' => 'IdV: Verify please call visited' },
         { 'user_id' => 'user1', 'name' => 'IdV: Verify setup errors visited' },
@@ -32,8 +31,6 @@ RSpec.describe Reporting::FraudMetricsLg99Report do
         { 'user_id' => 'user5', 'name' => 'IdV: Verify setup errors visited' },
       ],
     )
-
-    allow(report).to receive(:cloudwatch_client).and_return(cloudwatch_client)
   end
 
   describe '#lg99_metrics_table' do

--- a/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'reporting/fraud_metrics_lg99_report'
 
 RSpec.describe Reporting::FraudMetricsLg99Report do
-  let(:time_range) { Date.new(2022, 1, 1).all_month }
+  let(:time_range) { Date.new(2022, 1, 1).in_time_zone('UTC').all_month }
   let(:expected_lg99_metrics_table) do
     [
       ['Metric', 'Total'],

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include AgreementsHelper
   config.include AnalyticsHelper
+  config.include AwsCloudwatchHelper
   config.include AwsKmsClientHelper
   config.include KeyRotationHelper
   config.include OtpHelper

--- a/spec/support/aws_cloudwatch_helper.rb
+++ b/spec/support/aws_cloudwatch_helper.rb
@@ -1,0 +1,24 @@
+module AwsCloudwatchHelper
+  # Helps mimic Array<Aws::CloudWatchLogs::Types::ResultField>
+  # @return [Array<Hash>]
+  def to_result_fields(hsh)
+    hsh.map do |key, value|
+      { field: key, value: value }
+    end
+  end
+
+  # @param rows [Array<Hash>]
+  def stub_cloudwatch_logs(rows)
+    query_id = SecureRandom.hex
+
+    Aws.config[:cloudwatchlogs] = {
+      stub_responses: {
+        start_query: { query_id: query_id },
+        get_query_results: {
+          status: 'Complete',
+          results: rows.map { |row| to_result_fields(row) },
+        },
+      },
+    }
+  end
+end

--- a/spec/support/aws_cloudwatch_helper.rb
+++ b/spec/support/aws_cloudwatch_helper.rb
@@ -11,6 +11,8 @@ module AwsCloudwatchHelper
   def stub_cloudwatch_logs(rows)
     query_id = SecureRandom.hex
 
+    stub_const('Reporting::CloudwatchClient::DEFAULT_WAIT_DURATION', 0)
+
     Aws.config[:cloudwatchlogs] = {
       stub_responses: {
         start_query: { query_id: query_id },


### PR DESCRIPTION
Background: https://github.com/18F/identity-idp/pull/10848 introduced a new runtime error when a query was misconfigured

This error triggered in int for the LG99 report: https://onenr.io/02R506rLmwb

This PR updates the stubbing to be more realistic so that the error shows up and can be handled, moves a helper to be shared more easily

