### PR TITLE
LG-13739: Avoid sending new device email after account creation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -425,7 +425,10 @@ class User < ApplicationRecord
 
   def authenticated_device?(cookie_uuid:)
     return false if cookie_uuid.blank?
-    devices.joins(:events).exists?(cookie_uuid:, events: { event_type: :sign_in_after_2fa })
+    devices.joins(:events).exists?(
+      cookie_uuid:,
+      events: { event_type: [:account_created, :sign_in_after_2fa] },
+    )
   end
 
   # Returns the number of times the user has signed in, corresponding to the `sign_in_before_2fa`

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -197,6 +197,26 @@ RSpec.describe 'New device tracking' do
         end
       end
     end
+
+    context 'authenticating after new account creation from the same device' do
+      let(:user) do
+        user = sign_up_and_2fa_ial1_user
+        click_on t('links.sign_out')
+        user
+      end
+
+      before do
+        user
+        reset_email
+      end
+
+      it 'does not send a second user notification' do
+        visit new_user_session_path
+        sign_in_live_with_2fa(user)
+
+        expect_delivered_email_count(0)
+      end
+    end
   end
 
   context 'user does not have existing devices' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1564,6 +1564,14 @@ RSpec.describe User do
       end
 
       it { expect(result).to eq(false) }
+
+      context 'with account_created event' do
+        before do
+          create(:event, device:, event_type: :account_created)
+        end
+
+        it { expect(result).to eq(true) }
+      end
     end
 
     context 'with existing device with sign_in_after_2fa event' do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -137,9 +137,9 @@ module Features
     end
 
     def sign_up
-      user = create(:user, :unconfirmed)
+      email = Faker::Internet.safe_email
+      sign_up_with(email)
       confirm_last_user
-      user
     end
 
     def sign_up_and_set_password
@@ -232,15 +232,18 @@ module Features
     end
 
     def confirm_last_user
+      user = User.last
       @raw_confirmation_token, = Devise.token_generator.generate(EmailAddress, :confirmation_token)
 
-      User.last.email_addresses.first.update(
+      user.email_addresses.first.update(
         confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.zone.now,
       )
 
       visit sign_up_create_email_confirmation_path(
         confirmation_token: @raw_confirmation_token,
       )
+
+      user
     end
 
     def click_send_one_time_code


### PR DESCRIPTION
## 🎫 Ticket

[LG-13739](https://cm-jira.usa.gov/browse/LG-13739)

## 🛠 Summary of changes

Updates logic of `User#authenticated_device?` to consider the device authenticated if it was the one that had created the account. This fixes an issue where the new-device email would be unexpectedly sent the first time the user signs in after creating an account, even if that was the device they'd used to create the account.

The issue stems from the fact that we previously relied on `:sign_in_after_2fa` event existing for the device, but this event is only created if a user authenticates with 2FA, which doesn't happen during the account creation process.

## 📜 Testing Plan

1. In a private browsing window, go to http://localhost:3000
2. Create an account
3. Once you reach the account dashboard, sign out
4. Sign in to that new account

Before: You'd receive a [new device sign-in email](https://idp.dev.identitysandbox.gov/rails/mailers/user_mailer/new_device_sign_in_after_2fa)
After: You don't receive a new device sign-in email
