### PR TITLE
Translate Post Office search results

### DIFF
--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -34,7 +34,7 @@ module Idv
         def localized_locations(locations)
           return nil if locations.nil?
           locations.map do |location|
-            EnrollmentHelper.localized_location(location)
+            UspsInPersonProofing::EnrollmentHelper.localized_location(location)
           end
         end
 

--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -34,25 +34,7 @@ module Idv
         def localized_locations(locations)
           return nil if locations.nil?
           locations.map do |location|
-            {
-              address: location[:address],
-              city: location[:city],
-              distance: location[:distance],
-              name: location[:name],
-              saturday_hours: UspsInPersonProofing::EnrollmentHelper.localized_hours(
-                location[:saturday_hours],
-              ),
-              state: location[:state],
-              sunday_hours: UspsInPersonProofing::EnrollmentHelper.localized_hours(
-                location[:sunday_hours],
-              ),
-              weekday_hours: UspsInPersonProofing::EnrollmentHelper.localized_hours(
-                location[:weekday_hours],
-              ),
-              zip_code_4: location[:zip_code_4],
-              zip_code_5: location[:zip_code_5],
-              is_pilot: location[:is_pilot],
-            }
+            EnrollmentHelper.localized_location(location)
           end
         end
 

--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -18,17 +18,42 @@ module Idv
           )
           locations = proofer.request_facilities(candidate, false)
 
-          render json: locations.to_json
+          render json: localized_locations(locations).to_json
         end
 
         def options
           head :ok
         end
 
-        protected
+        private
 
         def proofer
           @proofer ||= UspsInPersonProofing::EnrollmentHelper.usps_proofer
+        end
+
+        def localized_locations(locations)
+          return nil if locations.nil?
+          locations.map do |location|
+            {
+              address: location[:address],
+              city: location[:city],
+              distance: location[:distance],
+              name: location[:name],
+              saturday_hours: UspsInPersonProofing::EnrollmentHelper.localized_hours(
+                location[:saturday_hours],
+              ),
+              state: location[:state],
+              sunday_hours: UspsInPersonProofing::EnrollmentHelper.localized_hours(
+                location[:sunday_hours],
+              ),
+              weekday_hours: UspsInPersonProofing::EnrollmentHelper.localized_hours(
+                location[:weekday_hours],
+              ),
+              zip_code_4: location[:zip_code_4],
+              zip_code_5: location[:zip_code_5],
+              is_pilot: location[:is_pilot],
+            }
+          end
         end
 
         def enabled?

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -67,19 +67,7 @@ module Idv
       def localized_locations(locations)
         return nil if locations.nil?
         locations.map do |location|
-          {
-            address: location[:address],
-            city: location[:city],
-            distance: location[:distance],
-            name: location[:name],
-            saturday_hours: EnrollmentHelper.localized_hours(location[:saturday_hours]),
-            state: location[:state],
-            sunday_hours: EnrollmentHelper.localized_hours(location[:sunday_hours]),
-            weekday_hours: EnrollmentHelper.localized_hours(location[:weekday_hours]),
-            zip_code_4: location[:zip_code_4],
-            zip_code_5: location[:zip_code_5],
-            is_pilot: location[:is_pilot],
-          }
+          EnrollmentHelper.localized_location(location)
         end
       end
 

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -39,6 +39,7 @@ interface AppRootData {
   howToVerifyURL: string;
   previousStepUrl: string;
   docAuthSelfieDesktopTestMode: string;
+  locationsUrl: string;
 }
 
 const appRoot = document.getElementById('document-capture-form')!;
@@ -107,6 +108,7 @@ const {
   howToVerifyUrl,
   previousStepUrl,
   docAuthSelfieDesktopTestMode,
+  locationsUrl: locationsURL,
 } = appRoot.dataset as DOMStringMap & AppRootData;
 
 let parsedUsStatesTerritories = [];
@@ -122,7 +124,7 @@ const App = composeComponents(
     {
       value: {
         inPersonURL,
-        locationsURL: new URL('/verify/in_person/usps_locations', window.location.href).toString(),
+        locationsURL,
         addressSearchURL: new URL('/api/addresses', window.location.href).toString(),
         inPersonOutageMessageEnabled: inPersonOutageMessageEnabled === 'true',
         inPersonOutageExpectedUpdateDate,

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -31,7 +31,7 @@ module Idv
       def selected_location_hours(prefix)
         return unless selected_location_details
         hours = selected_location_details["#{prefix}_hours"]
-        return localized_hours(hours) if hours
+        return UspsInPersonProofing::EnrollmentHelper.localized_hours(hours) if hours
       end
 
       def service_provider
@@ -105,18 +105,6 @@ module Idv
 
       def format_outage_date(date)
         I18n.l(date.to_date, format: :short)
-      end
-
-      def localized_hours(hours)
-        case hours
-        when 'Closed'
-          I18n.t('in_person_proofing.body.barcode.retail_hours_closed')
-        else
-          hours.
-            split(' - '). # Hyphen
-            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
-            join(' – ') # Endash
-        end
       end
 
       def sp_return_url_resolver

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -31,7 +31,7 @@ module Idv
       def selected_location_hours(prefix)
         return unless selected_location_details
         hours = selected_location_details["#{prefix}_hours"]
-        return UspsInPersonProofing::EnrollmentHelper.localized_hours(hours) if hours
+        UspsInPersonProofing::EnrollmentHelper.localized_hours(hours) if hours
       end
 
       def service_provider

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -95,6 +95,22 @@ module UspsInPersonProofing
         end
       end
 
+      def localized_location(location)
+        {
+          address: location.address,
+          city: location.city,
+          distance: location.distance,
+          name: location.name,
+          saturday_hours: EnrollmentHelper.localized_hours(location.saturday_hours),
+          state: location.state,
+          sunday_hours: EnrollmentHelper.localized_hours(location.sunday_hours),
+          weekday_hours: EnrollmentHelper.localized_hours(location.weekday_hours),
+          zip_code_4: location.zip_code_4,
+          zip_code_5: location.zip_code_5,
+          is_pilot: location.is_pilot,
+        }
+      end
+
       def localized_hours(hours)
         if hours == 'Closed'
           I18n.t('in_person_proofing.body.barcode.retail_hours_closed')

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -95,6 +95,24 @@ module UspsInPersonProofing
         end
       end
 
+      def localized_hours(hours)
+        if hours == 'Closed'
+          I18n.t('in_person_proofing.body.barcode.retail_hours_closed')
+        elsif hours.include?(' - ') # Hyphen
+          hours.
+            split(' - '). # Hyphen
+            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
+            join(' – ') # Endash
+        elsif hours.include?(' – ') # Endash
+          hours.
+            split(' – '). # Endash
+            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
+            join(' – ') # Endash
+        else
+          hours
+        end
+      end
+
       private
 
       SECONDARY_ID_ADDRESS_MAP = {

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -42,6 +42,7 @@
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       how_to_verify_url: idv_how_to_verify_url,
       previous_step_url: @previous_step_url,
+      locations_url: idv_in_person_usps_locations_url,
     } %>
   <%= simple_form_for(
         :doc_auth,

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Idv::InPerson::UspsLocationsController, allowed_extra_analytics: 
     let(:proofer) { double('Proofer') }
     let(:locations) do
       [
-        { address: '3118 WASHINGTON BLVD',
+        UspsInPersonProofing::PostOffice.new(
+          address: '3118 WASHINGTON BLVD',
           city: 'ARLINGTON',
           distance: '6.02 mi',
           name: 'ARLINGTON',
@@ -51,8 +52,10 @@ RSpec.describe Idv::InPerson::UspsLocationsController, allowed_extra_analytics: 
           sunday_hours: 'Closed',
           weekday_hours: '9:00 AM - 5:00 PM',
           zip_code_4: '9998',
-          zip_code_5: '22201' },
-        { address: '4005 WISCONSIN AVE NW',
+          zip_code_5: '22201',
+        ),
+        UspsInPersonProofing::PostOffice.new(
+          address: '4005 WISCONSIN AVE NW',
           city: 'WASHINGTON',
           distance: '6.59 mi',
           name: 'FRIENDSHIP',
@@ -61,8 +64,10 @@ RSpec.describe Idv::InPerson::UspsLocationsController, allowed_extra_analytics: 
           sunday_hours: '10:00 AM - 4:00 PM',
           weekday_hours: '8:00 AM - 6:00 PM',
           zip_code_4: '9997',
-          zip_code_5: '20016' },
-        { address: '6900 WISCONSIN AVE STE 100',
+          zip_code_5: '20016',
+        ),
+        UspsInPersonProofing::PostOffice.new(
+          address: '6900 WISCONSIN AVE STE 100',
           city: 'CHEVY CHASE',
           distance: '8.99 mi',
           name: 'BETHESDA',
@@ -71,7 +76,8 @@ RSpec.describe Idv::InPerson::UspsLocationsController, allowed_extra_analytics: 
           sunday_hours: 'Closed',
           weekday_hours: '9:00 AM - 5:00 PM',
           zip_code_4: '9996',
-          zip_code_5: '20815' },
+          zip_code_5: '20815',
+        ),
       ]
     end
     subject(:response) do


### PR DESCRIPTION
## 🛠 Summary of changes

Re-uses existing hours translation functionality in the `ReadyToVerifyPresenter` for the translation of content for the Post Office search results controllers.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
