### PR TITLE
Render negated test cases in account specs

### DIFF
--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'accounts/show.html.erb' do
 
   before do
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:user_session).and_return({})
     assign(
       :presenter,
       AccountShowPresenter.new(
@@ -89,6 +90,8 @@ RSpec.describe 'accounts/show.html.erb' do
       end
 
       it 'does not render phone' do
+        render
+
         expect(view).to_not render_template(partial: '_phone')
       end
     end
@@ -116,16 +119,14 @@ RSpec.describe 'accounts/show.html.erb' do
       let(:user) { create(:user, :fully_registered, :with_authentication_app) }
 
       it 'does not render piv/cac' do
+        render
+
         expect(view).to_not render_template(partial: '_piv_cac')
       end
     end
 
     context 'user has a piv/cac' do
       let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
-
-      before do
-        allow(view).to receive(:user_session).and_return({})
-      end
 
       it 'renders the piv/cac section' do
         render


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes specs for the account page view to ensure that the view is consistently rendered when asserting expected behavior.

Because it's easy to assert that something doesn't render a particular template when you don't render anything at all, but it's not particularly useful 😉 Another case of `to_not` giving us a false sense of confidence.

Discovered via #10847

## 📜 Testing Plan

```
rspec spec/views/accounts/show.html.erb_spec.rb
```