### PR TITLE
Don't allow letter sends when 2 pieces of fair evidence are required

### DIFF
--- a/app/controllers/concerns/idv/verify_by_mail_concern.rb
+++ b/app/controllers/concerns/idv/verify_by_mail_concern.rb
@@ -3,7 +3,10 @@
 module Idv
   module VerifyByMailConcern
     def gpo_verify_by_mail_policy
-      @gpo_verify_by_mail_policy ||= Idv::GpoVerifyByMailPolicy.new(current_user)
+      @gpo_verify_by_mail_policy ||= Idv::GpoVerifyByMailPolicy.new(
+        current_user,
+        resolved_authn_context_result,
+      )
     end
 
     def log_letter_requested_analytics(resend:)

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -28,7 +28,12 @@ module Idv
         end
 
         prefilled_code = session[:last_gpo_confirmation_code] if FeatureManagement.reveal_gpo_code?
-        @gpo_verify_form = GpoVerifyForm.new(user: current_user, pii: pii, otp: prefilled_code)
+        @gpo_verify_form = GpoVerifyForm.new(
+          user: current_user,
+          pii: pii,
+          resolved_authn_context_result: resolved_authn_context_result,
+          otp: prefilled_code,
+        )
         render_enter_code_form
       end
 
@@ -121,6 +126,7 @@ module Idv
         GpoVerifyForm.new(
           user: current_user,
           pii: pii,
+          resolved_authn_context_result: resolved_authn_context_result,
           otp: params_otp,
         )
       end

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -9,11 +9,12 @@ class GpoVerifyForm
   validate :validate_pending_profile
 
   attr_accessor :otp, :pii, :pii_attributes
-  attr_reader :user
+  attr_reader :user, :resolved_authn_context_result
 
-  def initialize(user:, pii:, otp: nil)
+  def initialize(user:, pii:, resolved_authn_context_result:, otp: nil)
     @user = user
     @pii = pii
+    @resolved_authn_context_result = resolved_authn_context_result
     @otp = otp
   end
 
@@ -127,7 +128,7 @@ class GpoVerifyForm
   end
 
   def user_can_request_another_letter?
-    policy = Idv::GpoVerifyByMailPolicy.new(user)
+    policy = Idv::GpoVerifyByMailPolicy.new(user, resolved_authn_context_result)
     policy.resend_letter_available?
   end
 end

--- a/app/policies/idv/gpo_verify_by_mail_policy.rb
+++ b/app/policies/idv/gpo_verify_by_mail_policy.rb
@@ -2,10 +2,11 @@
 
 module Idv
   class GpoVerifyByMailPolicy
-    attr_reader :user
+    attr_reader :user, :resolved_authn_context_result
 
-    def initialize(user)
+    def initialize(user, resolved_authn_context_result)
       @user = user
+      @resolved_authn_context_result = resolved_authn_context_result
     end
 
     def resend_letter_available?
@@ -16,6 +17,7 @@ module Idv
 
     def send_letter_available?
       @send_letter_available ||= FeatureManagement.gpo_verification_enabled? &&
+                                 !disabled_for_biometric_comparison? &&
                                  !rate_limited?
     end
 
@@ -33,6 +35,12 @@ module Idv
     end
 
     private
+
+    def disabled_for_biometric_comparison?
+      return false unless IdentityConfig.store.verify_by_mail_disabled_for_biometric_comparison
+
+      resolved_authn_context_result.two_pieces_of_fair_evidence?
+    end
 
     def window_limit_enabled?
       IdentityConfig.store.max_mail_events != 0 &&

--- a/app/policies/idv/gpo_verify_by_mail_policy.rb
+++ b/app/policies/idv/gpo_verify_by_mail_policy.rb
@@ -37,7 +37,7 @@ module Idv
     private
 
     def disabled_for_biometric_comparison?
-      return false unless IdentityConfig.store.verify_by_mail_disabled_for_biometric_comparison
+      return false unless IdentityConfig.store.no_verify_by_mail_for_biometric_comparison_enabled
 
       resolved_authn_context_result.two_pieces_of_fair_evidence?
     end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -323,6 +323,7 @@ vendor_status_voice: 'operational'
 vendor_status_idv_scheduled_maintenance_start: ''
 vendor_status_idv_scheduled_maintenance_finish: ''
 verification_errors_report_configs: '[]'
+verify_by_mail_disabled_for_biometric_comparison: true
 verify_gpo_key_attempt_window_in_minutes: 10
 verify_gpo_key_max_attempts: 5
 verify_personal_key_attempt_window_in_minutes: 15
@@ -497,6 +498,7 @@ production:
   usps_upload_sftp_host: ''
   usps_upload_sftp_password: ''
   usps_upload_sftp_username: ''
+  verify_by_mail_disabled_for_biometric_comparison: false
 
 test:
   aamva_private_key: 123abc

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -199,6 +199,7 @@ min_password_score: 3
 minimum_wait_before_another_usps_letter_in_hours: 24
 mx_timeout: 3
 new_device_alert_delay_in_minutes: 5
+no_verify_by_mail_for_biometric_comparison_enabled: true
 openid_connect_redirect: client_side_js
 openid_connect_content_security_form_action_enabled: false
 openid_connect_redirect_uuid_override_map: '{}'
@@ -323,7 +324,6 @@ vendor_status_voice: 'operational'
 vendor_status_idv_scheduled_maintenance_start: ''
 vendor_status_idv_scheduled_maintenance_finish: ''
 verification_errors_report_configs: '[]'
-verify_by_mail_disabled_for_biometric_comparison: true
 verify_gpo_key_attempt_window_in_minutes: 10
 verify_gpo_key_max_attempts: 5
 verify_personal_key_attempt_window_in_minutes: 15
@@ -468,6 +468,7 @@ production:
   logins_per_ip_period: 20
   logins_per_ip_track_only_mode: true
   newrelic_license_key: ''
+  no_verify_by_mail_for_biometric_comparison_enabled: false
   openid_connect_redirect: server_side
   openid_connect_content_security_form_action_enabled: true
   otp_delivery_blocklist_findtime: 5
@@ -498,7 +499,6 @@ production:
   usps_upload_sftp_host: ''
   usps_upload_sftp_password: ''
   usps_upload_sftp_username: ''
-  verify_by_mail_disabled_for_biometric_comparison: false
 
 test:
   aamva_private_key: 123abc

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -239,6 +239,7 @@ module IdentityConfig
     config.add(:mx_timeout, type: :integer)
     config.add(:new_device_alert_delay_in_minutes, type: :integer)
     config.add(:newrelic_license_key, type: :string)
+    config.add(:no_verify_by_mail_for_biometric_comparison_enabled, type: :boolean)
     config.add(
       :openid_connect_redirect,
       type: :string,
@@ -412,7 +413,6 @@ module IdentityConfig
     config.add(:vendor_status_idv_scheduled_maintenance_start, type: :string)
     config.add(:vendor_status_idv_scheduled_maintenance_finish, type: :string)
     config.add(:verification_errors_report_configs, type: :json)
-    config.add(:verify_by_mail_disabled_for_biometric_comparison, type: :boolean)
     config.add(:verify_gpo_key_attempt_window_in_minutes, type: :integer)
     config.add(:verify_gpo_key_max_attempts, type: :integer)
     config.add(:verify_personal_key_attempt_window_in_minutes, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -412,6 +412,7 @@ module IdentityConfig
     config.add(:vendor_status_idv_scheduled_maintenance_start, type: :string)
     config.add(:vendor_status_idv_scheduled_maintenance_finish, type: :string)
     config.add(:verification_errors_report_configs, type: :json)
+    config.add(:verify_by_mail_disabled_for_biometric_comparison, type: :boolean)
     config.add(:verify_gpo_key_attempt_window_in_minutes, type: :integer)
     config.add(:verify_gpo_key_max_attempts, type: :integer)
     config.add(:verify_personal_key_attempt_window_in_minutes, type: :integer)

--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -453,7 +453,14 @@ RSpec.describe Idv::ByMail::EnterCodeController, allowed_extra_analytics: [:*] d
       end
       let(:is_enhanced_ipp) { true }
       let(:user) { create(:user, :with_pending_gpo_profile, created_at: 2.days.ago) }
-      let(:gpo_verify_form) { GpoVerifyForm.new(user: user, pii: {}, otp: good_otp) }
+      let(:gpo_verify_form) do
+        GpoVerifyForm.new(
+          user: user,
+          pii: {},
+          resolved_authn_context_result: Vot::Parser::Result.no_sp_result,
+          otp: good_otp,
+        )
+      end
       before do
         authn_context_result = Vot::Parser.new(vector_of_trust: 'Pe').parse
         allow(controller).to(

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -2,7 +2,12 @@ require 'rails_helper'
 
 RSpec.describe GpoVerifyForm, allowed_extra_analytics: [:*] do
   subject(:form) do
-    GpoVerifyForm.new(user: user, pii: applicant, otp: entered_otp)
+    GpoVerifyForm.new(
+      user: user,
+      pii: applicant,
+      resolved_authn_context_result: Vot::Parser::Result.no_sp_result,
+      otp: entered_otp,
+    )
   end
 
   let(:user) { create(:user, :fully_registered) }

--- a/spec/policies/idv/gpo_verify_by_mail_policy_spec.rb
+++ b/spec/policies/idv/gpo_verify_by_mail_policy_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Idv::GpoVerifyByMailPolicy do
 
         it 'returns false when the feature flag is enabled' do
           allow(IdentityConfig.store).to receive(
-            :verify_by_mail_disabled_for_biometric_comparison,
+            :no_verify_by_mail_for_biometric_comparison_enabled,
           ).and_return(true)
 
           expect(subject.send_letter_available?).to eq(false)
@@ -100,7 +100,7 @@ RSpec.describe Idv::GpoVerifyByMailPolicy do
 
         it 'returns true when the feature flag is disabled' do
           allow(IdentityConfig.store).to receive(
-            :verify_by_mail_disabled_for_biometric_comparison,
+            :no_verify_by_mail_for_biometric_comparison_enabled,
           ).and_return(false)
 
           expect(subject.send_letter_available?).to eq(true)

--- a/spec/policies/idv/gpo_verify_by_mail_policy_spec.rb
+++ b/spec/policies/idv/gpo_verify_by_mail_policy_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe Idv::GpoVerifyByMailPolicy do
           expect(subject.send_letter_available?).to eq(true)
         end
       end
-
     end
   end
 

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -175,6 +175,9 @@ RSpec.describe GpoReminderSender do
           GpoVerifyForm.new(
             user: user,
             pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE,
+            resolved_authn_context_result: Vot::Parser::Result.no_sp_result.with(
+              enhanced_ipp?: is_enhanced_ipp,
+            ),
             otp: otp,
           ).submit(is_enhanced_ipp)
         end

--- a/spec/views/idv/by_mail/enter_code/index.html.erb_spec.rb
+++ b/spec/views/idv/by_mail/enter_code/index.html.erb_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'idv/by_mail/enter_code/index.html.erb' do
     @gpo_verify_form = GpoVerifyForm.new(
       user: user,
       pii: pii,
+      resolved_authn_context_result: Vot::Parser::Result.no_sp_result,
       otp: '1234',
     )
 


### PR DESCRIPTION
In #10871 we added a requirement that 2 pieces of fair evidence are required during verification. This is active whenever a SP requests biometric comparison. This commit adds enforcement of that requirement. It uses the `GpoVerifyForm` added in #10844 to disallow sends when that requirement is in place.
