### PR TITLE
LG-13318: Ensure user_id present in account deletion submitted event

### DIFF
--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -133,9 +133,9 @@ module OpenidConnect
     def handle_logout(result, redirect_uri)
       analytics.logout_initiated(**to_event(result))
 
-      sign_out
-
       redirect_user(redirect_uri, @logout_form.service_provider&.issuer, current_user&.uuid)
+
+      sign_out
     end
 
     # Convert FormResponse into loggable analytics event

--- a/app/controllers/users/delete_controller.rb
+++ b/app/controllers/users/delete_controller.rb
@@ -16,10 +16,10 @@ module Users
       send_push_notifications
       notify_user_via_email_of_deletion
       notify_user_via_sms_of_deletion
+      analytics.account_delete_submitted(success: true)
       delete_user
       sign_out
       flash[:success] = t('devise.registrations.destroyed')
-      analytics.account_delete_submitted(success: true)
       redirect_to root_url
     end
 

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -44,13 +44,12 @@ RSpec.describe Users::DeleteController do
       end
 
       it 'logs a failed submit' do
-        stub_analytics
-        stub_signed_in_user
-
-        expect(@analytics).to receive(:track_event).
-          with('Account Delete submitted', success: false)
+        user = stub_signed_in_user
+        stub_analytics(user:)
 
         delete
+
+        expect(@analytics).to have_logged_event('Account Delete submitted', success: false)
       end
     end
 
@@ -82,13 +81,12 @@ RSpec.describe Users::DeleteController do
     end
 
     it 'logs a succesful submit' do
-      stub_analytics
-      stub_signed_in_user
-
-      expect(@analytics).to receive(:track_event).
-        with('Account Delete submitted', success: true)
+      user = stub_signed_in_user
+      stub_analytics(user:)
 
       delete
+
+      expect(@analytics).to have_logged_event('Account Delete submitted', success: true)
     end
 
     it 'does not delete identities to prevent uuid reuse' do

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Users::PivCacLoginController do
   describe 'GET new' do
+    let(:user) {}
+
     before do
-      stub_analytics
+      stub_analytics(user:)
     end
 
     context 'without a token' do
@@ -47,7 +49,6 @@ RSpec.describe Users::PivCacLoginController do
       end
 
       context 'with a valid token' do
-        let(:user) {}
         let(:service_provider) { create(:service_provider) }
         let(:sp_session) { { ial: 1, issuer: service_provider.issuer, vtr: vtr } }
         let(:nonce) { SecureRandom.base64(20) }
@@ -68,7 +69,6 @@ RSpec.describe Users::PivCacLoginController do
           controller.session[:sp] = sp_session
 
           allow(PivCacService).to receive(:decode_token).with(token) { data }
-          stub_analytics(user:)
         end
 
         context 'without a valid user' do

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -3,8 +3,8 @@ module AnalyticsHelper
     analytics = FakeAnalytics.new
 
     if user
-      allow(controller).to receive(:analytics) do
-        expect(controller.analytics_user).to eq(user)
+      allow(controller).to receive(:analytics).and_wrap_original do |original|
+        expect(original.call.user).to eq(user)
         analytics
       end
     else

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -19,6 +19,9 @@ module ControllerHelper
     allow(controller).to receive(:user_session).and_return({}.with_indifferent_access)
     controller.auth_methods_session.authenticate!(TwoFactorAuthenticatable::AuthMethod::SMS)
     allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:sign_out) do
+      allow(controller).to receive(:current_user).and_return(nil)
+    end
     allow(controller).to receive(:confirm_two_factor_authenticated).and_return(true)
     allow(controller).to receive(:user_fully_authenticated?).and_return(true)
     allow(controller).to receive(:remember_device_expired_for_sp?).and_return(false)


### PR DESCRIPTION
## 🎫 Ticket

[LG-13318](https://cm-jira.usa.gov/browse/LG-13318)

## 🛠 Summary of changes

Fixes analytics logging for account deletion event to ensure that the user ID is logged correctly

## 📜 Testing Plan

Verify you see `user_id` in logged events after deleting an account:

1. Run `make watch_events` in a separate terminal process
2. Go to http://localhost:3000
3. Sign in to an account you don't mind deleting, or create a new account
4. Click "Delete account" in account dashboard sidebar
5. Confirm account deletion
6. In terminal process for `make watch_events`, observe `"Account Delete submitted"` event includes a non-`nil` `properties.user_id`

Spec updates should provide regression assurance:

```
rspec spec/controllers/users/delete_controller_spec.rb
```