### PR TITLE
Fix 500 on blank Bearer Token in AccessTokenVerifier

### DIFF
--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -59,7 +59,7 @@ class AccessTokenVerifier
     end
 
     bearer, access_token = header.split(' ', 2)
-    if bearer != 'Bearer'
+    if bearer != 'Bearer' || access_token.blank?
       errors.add(
         :access_token, t('openid_connect.user_info.errors.malformed_authorization'),
         type: :malformed_authorization

--- a/spec/requests/openid_connect_userinfo_spec.rb
+++ b/spec/requests/openid_connect_userinfo_spec.rb
@@ -16,5 +16,19 @@ RSpec.describe 'OpenID Connect UserInfo controller' do
           headers: { 'HTTP_AUTHORIZATION' => authorization_header }
       expect(response.headers['Set-Cookie']).to_not include(APPLICATION_SESSION_COOKIE_KEY)
     end
+
+    it 'returns error with blank Bearer Token' do
+      identity = create(
+        :service_provider_identity,
+        rails_session_id: SecureRandom.hex,
+        access_token: nil,
+        user: create(:user),
+      )
+      authorization_header = 'Bearer'
+      OutOfBandSessionAccessor.new(identity.rails_session_id).put_empty_user_session(50)
+      get api_openid_connect_userinfo_path,
+          headers: { 'HTTP_AUTHORIZATION' => authorization_header }
+      expect(response).to be_unauthorized
+    end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🛠 Summary of changes

This PR fixes a 500 where we have a nil `identity` returned from the `AccessTokenVerifier`. There are two potential errors in validating the access token currently. The first is if the value doesn't start with `"Bearer"`, and the second is if we don't load an identity for the token. The value `"Bearer"` passes the first one, but we don't attempt to load the identity when `access_token` is nil, which means we also don't attempt to load the identity or add the error.

This PR adds an error if we get a blank `access_token`.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
