### PR TITLE
Remove scheduled CI checks from main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -339,32 +339,6 @@ js_tests:
     - *yarn_install
     - yarn test
 
-# Can be removed once pinpoint_check_scheduled is confirmed
-pinpoint-check:
-  needs:
-    - job: install
-  stage: test
-  cache:
-    - <<: *ruby_cache
-    - <<: *yarn_cache
-  script:
-    - *bundle_install
-    - *yarn_install
-    - make lint_country_dialing_codes
-
-# Can be removed once audit_packages_scheduled is confirmed
-audit_packages:
-  needs:
-    - job: install
-  stage: test
-  cache:
-    - <<: *ruby_cache
-    - <<: *yarn_cache
-  script:
-    - *bundle_install
-    - *yarn_install
-    - make audit
-
 prepare_deploy:
   # Runs in parallel with tests so we can deploy more quickly after passing
   stage: test


### PR DESCRIPTION
**Why**: These checks look for external changes (vulnerabilities reported, documentation out of date), so failing branch builds on them causes noisy issues for everybody.

They are now scheduled on main so they can be fixed for everybody

- [x] Can be merged after https://github.com/18F/identity-idp/pull/10834 has been merged and enabled on `main`