### PR TITLE
LG-13423: Don't allow letter sends when an IPP enrollment is in progress

### DIFF
--- a/app/policies/idv/gpo_verify_by_mail_policy.rb
+++ b/app/policies/idv/gpo_verify_by_mail_policy.rb
@@ -18,6 +18,7 @@ module Idv
     def send_letter_available?
       @send_letter_available ||= FeatureManagement.gpo_verification_enabled? &&
                                  !disabled_for_biometric_comparison? &&
+                                 !disabled_for_ipp? &&
                                  !rate_limited?
     end
 
@@ -40,6 +41,12 @@ module Idv
       return false unless IdentityConfig.store.no_verify_by_mail_for_biometric_comparison_enabled
 
       resolved_authn_context_result.two_pieces_of_fair_evidence?
+    end
+
+    def disabled_for_ipp?
+      return false unless IdentityConfig.store.no_verify_by_mail_for_biometric_comparison_enabled
+
+      user.has_in_person_enrollment?
     end
 
     def window_limit_enabled?

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -280,6 +280,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
         sign_in_and_2fa_user
         begin_in_person_proofing
         complete_all_in_person_proofing_steps
+        expect(page).to have_current_path(idv_phone_path)
         expect(page).not_to have_content(t('idv.troubleshooting.options.verify_by_mail'))
       end
     end

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -270,55 +270,84 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
       allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
     end
 
-    it 'requires address verification before showing instructions', allow_browser_log: true do
-      sign_in_and_2fa_user
-      begin_in_person_proofing
-      complete_all_in_person_proofing_steps
-      click_on t('idv.troubleshooting.options.verify_by_mail')
-      expect_in_person_gpo_step_indicator_current_step(
-        t('step_indicator.flows.idv.verify_address'),
-      )
-      click_on t('idv.buttons.mail.send')
-      expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.verify_address'))
-      complete_enter_password_step
+    context 'verify by mail not allowed for biometric' do
+      before do
+        allow(IdentityConfig.store).to receive(:no_verify_by_mail_for_biometric_comparison_enabled).
+          and_return(true)
+      end
 
-      expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.verify_address'))
-      expect(page).to have_content(t('idv.titles.come_back_later'))
-      expect(page).to have_current_path(idv_letter_enqueued_path)
-
-      click_idv_continue
-      expect(page).to have_current_path(account_path)
-      expect(page).not_to have_content(t('headings.account.verified_account'))
-      click_on t('account.index.verification.reactivate_button')
-      expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.verify_address'))
-      click_button t('idv.gpo.form.submit')
-
-      # personal key
-      expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.secure_account'))
-      expect(page).to have_content(t('titles.idv.personal_key'))
-      acknowledge_and_confirm_personal_key
-
-      expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
-      expect_in_person_gpo_step_indicator_current_step(
-        t('step_indicator.flows.idv.go_to_the_post_office'),
-      )
-      expect(page).not_to have_content(t('account.index.verification.success'))
+      it 'does not present gpo as an option', allow_browser_log: true do
+        sign_in_and_2fa_user
+        begin_in_person_proofing
+        complete_all_in_person_proofing_steps
+        expect(page).not_to have_content(t('idv.troubleshooting.options.verify_by_mail'))
+      end
     end
 
-    it 'lets the user clear and start over from gpo confirmation', allow_browser_log: true do
-      sign_in_and_2fa_user
-      begin_in_person_proofing
-      complete_all_in_person_proofing_steps
-      click_on t('idv.troubleshooting.options.verify_by_mail')
-      click_on t('idv.buttons.mail.send')
-      complete_enter_password_step
-      click_idv_continue
-      click_on t('account.index.verification.reactivate_button')
-      click_on t('idv.gpo.address_accordion.title')
-      click_on t('idv.gpo.address_accordion.cta_link')
-      click_idv_continue
+    context 'verify by mail allowed for biometric' do
+      before do
+        allow(IdentityConfig.store).to receive(:no_verify_by_mail_for_biometric_comparison_enabled).
+          and_return(false)
+      end
 
-      expect(page).to have_current_path(idv_welcome_path)
+      it 'requires address verification before showing instructions', allow_browser_log: true do
+        sign_in_and_2fa_user
+        begin_in_person_proofing
+        complete_all_in_person_proofing_steps
+        click_on t('idv.troubleshooting.options.verify_by_mail')
+        expect_in_person_gpo_step_indicator_current_step(
+          t('step_indicator.flows.idv.verify_address'),
+        )
+        click_on t('idv.buttons.mail.send')
+        expect_in_person_gpo_step_indicator_current_step(
+          t('step_indicator.flows.idv.verify_address'),
+        )
+        complete_enter_password_step
+
+        expect_in_person_gpo_step_indicator_current_step(
+          t('step_indicator.flows.idv.verify_address'),
+        )
+        expect(page).to have_content(t('idv.titles.come_back_later'))
+        expect(page).to have_current_path(idv_letter_enqueued_path)
+
+        click_idv_continue
+        expect(page).to have_current_path(account_path)
+        expect(page).not_to have_content(t('headings.account.verified_account'))
+        click_on t('account.index.verification.reactivate_button')
+        expect_in_person_gpo_step_indicator_current_step(
+          t('step_indicator.flows.idv.verify_address'),
+        )
+        click_button t('idv.gpo.form.submit')
+
+        # personal key
+        expect_in_person_gpo_step_indicator_current_step(
+          t('step_indicator.flows.idv.secure_account'),
+        )
+        expect(page).to have_content(t('titles.idv.personal_key'))
+        acknowledge_and_confirm_personal_key
+
+        expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
+        expect_in_person_gpo_step_indicator_current_step(
+          t('step_indicator.flows.idv.go_to_the_post_office'),
+        )
+        expect(page).not_to have_content(t('account.index.verification.success'))
+      end
+
+      it 'lets the user clear and start over from gpo confirmation', allow_browser_log: true do
+        sign_in_and_2fa_user
+        begin_in_person_proofing
+        complete_all_in_person_proofing_steps
+        click_on t('idv.troubleshooting.options.verify_by_mail')
+        click_on t('idv.buttons.mail.send')
+        complete_enter_password_step
+        click_idv_continue
+        click_on t('account.index.verification.reactivate_button')
+        click_on t('idv.gpo.address_accordion.title')
+        click_on t('idv.gpo.address_accordion.cta_link')
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_welcome_path)
+      end
     end
   end
 

--- a/spec/policies/idv/gpo_verify_by_mail_policy_spec.rb
+++ b/spec/policies/idv/gpo_verify_by_mail_policy_spec.rb
@@ -106,6 +106,46 @@ RSpec.describe Idv::GpoVerifyByMailPolicy do
           expect(subject.send_letter_available?).to eq(true)
         end
       end
+
+      context 'user has a pending in-person enrollment' do
+        let!(:in_person_enrollment) { create(:in_person_enrollment, :pending, user: user) }
+
+        it 'returns false when the feature flag is enabled' do
+          allow(IdentityConfig.store).to receive(
+            :no_verify_by_mail_for_biometric_comparison_enabled,
+          ).and_return(true)
+
+          expect(subject.send_letter_available?).to eq(false)
+        end
+
+        it 'returns true when the feature flag is disabled' do
+          allow(IdentityConfig.store).to receive(
+            :no_verify_by_mail_for_biometric_comparison_enabled,
+          ).and_return(false)
+
+          expect(subject.send_letter_available?).to eq(true)
+        end
+      end
+
+      context 'user has an establishing in-person enrollment' do
+        let!(:in_person_enrollment) { create(:in_person_enrollment, :establishing, user: user) }
+
+        it 'returns false when the feature flag is enabled' do
+          allow(IdentityConfig.store).to receive(
+            :no_verify_by_mail_for_biometric_comparison_enabled,
+          ).and_return(true)
+
+          expect(subject.send_letter_available?).to eq(false)
+        end
+
+        it 'returns true when the feature flag is disabled' do
+          allow(IdentityConfig.store).to receive(
+            :no_verify_by_mail_for_biometric_comparison_enabled,
+          ).and_return(false)
+
+          expect(subject.send_letter_available?).to eq(true)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13423](https://cm-jira.usa.gov/browse/LG-13423)

## 🛠 Summary of changes

Update `GpoVerifyByMailPolicy` to disallow requesting GPO letters if the user has opted for in-person proofing.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Set `no_verify_by_mail_for_biometric_comparison_enabled` to true
- Go through Idv w/ IPP
- Ensure you're not offered the chance to verify your address by mail

- Set `no_verify_by_mail_for_biometric_comparison_enabled` to false
- Go through Idv w/ IPP
- Ensure you *are* offered the chance to verify your address by mail

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
