### PR TITLE
LG-13775 Retry GPO confirmation upload when SSH errors occur

### DIFF
--- a/app/services/gpo_confirmation_uploader.rb
+++ b/app/services/gpo_confirmation_uploader.rb
@@ -43,8 +43,14 @@ class GpoConfirmationUploader
   def upload_export(export)
     return unless FeatureManagement.gpo_upload_enabled?
     io = StringIO.new(export)
-    Net::SFTP.start(*sftp_config) do |sftp|
-      sftp.upload!(io, remote_path)
+
+    with_retries(
+      max_tries: 5,
+      rescue: [Net::SFTP::Exception, Net::SSH::Exception],
+    ) do
+      Net::SFTP.start(*sftp_config) do |sftp|
+        sftp.upload!(io, remote_path)
+      end
     end
   end
 


### PR DESCRIPTION
We have observed a number of SSH errors when attempting to upload the GPO file. When those have occurred re-running the GPO job has resulted in a successful upload. This commit attempts to automate that by adding retry logic to confirmation uploader.

This change is limited to the SSH connection and upload. This is to tread carefully around the job's logic. It deletes the records it uploads so we need to tread lightly when performing retries.
