### PR TITLE
Ignore IAL and AAL columns on ServiceProviderIdentity

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -220,7 +220,6 @@ module OpenidConnect
 
     def track_events
       analytics.sp_redirect_initiated(
-        ial: ial_context.ial,
         billed_ial: ial_context.bill_for_ial_1_or_2,
         sign_in_flow: session[:sign_in_flow],
         vtr: sp_session[:vtr],

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -200,7 +200,6 @@ class SamlIdpController < ApplicationController
 
   def track_events
     analytics.sp_redirect_initiated(
-      ial: resolved_authn_context_int_ial,
       billed_ial: ial_context.bill_for_ial_1_or_2,
       sign_in_flow: session[:sign_in_flow],
       vtr: sp_session[:vtr],

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -203,7 +203,7 @@ class OpenidConnectTokenForm
       code_digest: code ? Digest::SHA256.hexdigest(code) : nil,
       code_verifier_present: code_verifier.present?,
       service_provider_pkce: service_provider&.pkce,
-      ial: identity&.ial,
+      # ial: identity&.ial,
     }
   end
 

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -203,7 +203,6 @@ class OpenidConnectTokenForm
       code_digest: code ? Digest::SHA256.hexdigest(code) : nil,
       code_verifier_present: code_verifier.present?,
       service_provider_pkce: service_provider&.pkce,
-      # ial: identity&.ial,
     }
   end
 

--- a/app/models/service_provider_identity.rb
+++ b/app/models/service_provider_identity.rb
@@ -4,6 +4,11 @@
 class ServiceProviderIdentity < ApplicationRecord
   self.table_name = :identities
 
+  self.ignored_columns = [
+    :ial,
+    :aal,
+  ]
+
   include NonNullUuid
 
   belongs_to :user

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -20,7 +20,7 @@ class AccessTokenVerifier
       errors:,
       extra: {
         client_id: @identity&.service_provider,
-        ial: @identity&.ial,
+        # ial: @identity&.ial,
       },
     )
 

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -20,7 +20,6 @@ class AccessTokenVerifier
       errors:,
       extra: {
         client_id: @identity&.service_provider,
-        # ial: @identity&.ial,
       },
     )
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4330,7 +4330,6 @@ module AnalyticsEvents
 
   # Tracks when an openid connect bearer token authentication request is made
   # @param [Boolean] success Whether form validation was successful
-  # @param [Integer] ial
   # @param [String] client_id Service Provider issuer
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
@@ -4405,7 +4404,6 @@ module AnalyticsEvents
   # @param [String] user_id
   # @param [String] code_digest hash of "code" param
   # @param [Integer, nil] expires_in time to expiration of token
-  # @param [Integer, nil] ial ial level of identity
   def openid_connect_token(client_id:, user_id:, code_digest:, expires_in:, **extra)
     track_event(
       'OpenID Connect: token',
@@ -5293,7 +5291,6 @@ module AnalyticsEvents
   end
 
   # Tracks when a user is redirected back to the service provider
-  # @param [Integer] ial
   # @param [Integer] billed_ial
   # @param [String, nil] sign_in_flow
   # @param [String, nil] vtr

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4334,11 +4334,10 @@ module AnalyticsEvents
   # @param [String] client_id Service Provider issuer
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  def openid_connect_bearer_token(success:, ial:, client_id:, errors:, error_details: nil, **extra)
+  def openid_connect_bearer_token(success:, client_id:, errors:, error_details: nil, **extra)
     track_event(
       'OpenID Connect: bearer token authentication',
       success:,
-      ial:,
       client_id:,
       errors:,
       error_details:,
@@ -4407,14 +4406,13 @@ module AnalyticsEvents
   # @param [String] code_digest hash of "code" param
   # @param [Integer, nil] expires_in time to expiration of token
   # @param [Integer, nil] ial ial level of identity
-  def openid_connect_token(client_id:, user_id:, code_digest:, expires_in:, ial:, **extra)
+  def openid_connect_token(client_id:, user_id:, code_digest:, expires_in:, **extra)
     track_event(
       'OpenID Connect: token',
       client_id: client_id,
       user_id: user_id,
       code_digest: code_digest,
       expires_in: expires_in,
-      ial: ial,
       **extra,
     )
   end
@@ -5302,7 +5300,6 @@ module AnalyticsEvents
   # @param [String, nil] acr_values
   # @param [Integer] sign_in_duration_seconds
   def sp_redirect_initiated(
-    ial:,
     billed_ial:,
     sign_in_flow:,
     vtr:,
@@ -5312,7 +5309,6 @@ module AnalyticsEvents
   )
     track_event(
       'SP redirect initiated',
-      ial:,
       billed_ial:,
       sign_in_flow:,
       vtr: vtr,

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -13,6 +13,7 @@ class IdentityLinker
     @requested_aal_value = nil
   end
 
+  # rubocop:disable Lint/UnusedMethodArgument
   def link_identity(
     code_challenge: nil,
     ial: nil,
@@ -52,6 +53,7 @@ class IdentityLinker
     AgencyIdentityLinker.new(identity).link_identity
     identity
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 
   private
 

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -34,8 +34,8 @@ class IdentityLinker
     identity.update!(
       identity_attributes.merge(
         code_challenge: code_challenge,
-        ial: ial,
-        aal: aal,
+        # ial: ial,
+        # aal: aal,
         acr_values: acr_values,
         vtr: vtr,
         requested_aal_value: requested_aal_value,

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -152,7 +152,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
             )
             expect(@analytics).to have_logged_event(
               'SP redirect initiated',
-              ial: 1,
               billed_ial: 1,
               sign_in_duration_seconds: 15,
               sign_in_flow:,
@@ -211,7 +210,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
             expect(@analytics).to have_logged_event(
               'SP redirect initiated',
-              ial: 1,
               sign_in_duration_seconds: 15,
               billed_ial: 1,
               sign_in_flow:,
@@ -409,7 +407,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
               expect(@analytics).to have_logged_event(
                 'SP redirect initiated',
-                ial: 2,
                 sign_in_duration_seconds: 15,
                 billed_ial: 2,
                 sign_in_flow:,
@@ -747,7 +744,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 expect(@analytics).to have_logged_event(
                   'SP redirect initiated',
-                  ial: 0,
                   sign_in_duration_seconds: 15,
                   billed_ial: 2,
                   sign_in_flow:,
@@ -841,7 +837,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 expect(@analytics).to have_logged_event(
                   'SP redirect initiated',
-                  ial: 0,
                   sign_in_duration_seconds: 15,
                   billed_ial: 1,
                   sign_in_flow:,
@@ -938,7 +933,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 expect(@analytics).to have_logged_event(
                   'SP redirect initiated',
-                  ial: 0,
                   sign_in_duration_seconds: 15,
                   billed_ial: 1,
                   sign_in_flow:,
@@ -1106,7 +1100,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
             expect(@analytics).to have_logged_event(
               'SP redirect initiated',
-              ial: 1,
               sign_in_duration_seconds: 15,
               billed_ial: 1,
               sign_in_flow:,
@@ -1165,7 +1158,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
             expect(@analytics).to have_logged_event(
               'SP redirect initiated',
-              ial: 1,
               sign_in_duration_seconds: 15,
               billed_ial: 1,
               sign_in_flow:,
@@ -1364,7 +1356,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
               expect(@analytics).to have_logged_event(
                 'SP redirect initiated',
-                ial: 2,
                 sign_in_duration_seconds: 15,
                 billed_ial: 2,
                 sign_in_flow:,
@@ -1704,7 +1695,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 expect(@analytics).to have_logged_event(
                   'SP redirect initiated',
-                  ial: 0,
                   sign_in_duration_seconds: 15,
                   billed_ial: 2,
                   sign_in_flow:,
@@ -1798,7 +1788,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 expect(@analytics).to have_logged_event(
                   'SP redirect initiated',
-                  ial: 0,
                   sign_in_duration_seconds: 15,
                   billed_ial: 1,
                   sign_in_flow:,
@@ -1895,7 +1884,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
                 expect(@analytics).to have_logged_event(
                   'SP redirect initiated',
-                  ial: 0,
                   sign_in_duration_seconds: 15,
                   billed_ial: 1,
                   sign_in_flow:,

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
             code_verifier_present: false,
             service_provider_pkce: nil,
             expires_in: 0,
-            ial: 1,
           })
         action
       end
@@ -93,7 +92,6 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
             service_provider_pkce: nil,
             error_details: hash_including(:grant_type),
             expires_in: nil,
-            ial: 1,
           })
 
         action

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe OpenidConnect::UserInfoController do
           with('OpenID Connect: bearer token authentication',
                success: false,
                client_id: nil,
-               ial: nil,
                errors: hash_including(:access_token),
                error_details: hash_including(:access_token))
 
@@ -47,7 +46,6 @@ RSpec.describe OpenidConnect::UserInfoController do
           with('OpenID Connect: bearer token authentication',
                success: false,
                client_id: nil,
-               ial: nil,
                errors: hash_including(:access_token),
                error_details: hash_including(:access_token))
 
@@ -71,7 +69,6 @@ RSpec.describe OpenidConnect::UserInfoController do
                success: false,
                errors: hash_including(:access_token),
                client_id: nil,
-               ial: nil,
                error_details: hash_including(:access_token))
 
         action
@@ -100,7 +97,6 @@ RSpec.describe OpenidConnect::UserInfoController do
           success: false,
           errors: { access_token: [t('openid_connect.user_info.errors.not_found')] },
           client_id: nil,
-          ial: nil,
           error_details: { access_token: { not_found: true } },
         )
       end
@@ -131,7 +127,6 @@ RSpec.describe OpenidConnect::UserInfoController do
           'OpenID Connect: bearer token authentication',
           success: true,
           client_id: identity.service_provider,
-          ial: identity.ial,
           errors: {},
           error_details: nil,
         )

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -736,11 +736,6 @@ RSpec.describe SamlIdpController do
         saml_get_auth(ial2_settings)
       end
 
-      it 'sets identity ial' do
-        saml_get_auth(ial2_settings)
-        expect(user.identities.last.ial).to eq(Idp::Constants::IAL2)
-      end
-
       it 'does not redirect the user to the IdV URL' do
         saml_get_auth(ial2_settings)
 
@@ -794,7 +789,6 @@ RSpec.describe SamlIdpController do
           )
         expect(@analytics).to receive(:track_event).with(
           'SP redirect initiated',
-          ial: Idp::Constants::IAL2,
           sign_in_duration_seconds: nil,
           billed_ial: Idp::Constants::IAL2,
           sign_in_flow:,
@@ -890,11 +884,6 @@ RSpec.describe SamlIdpController do
         saml_get_auth(ialmax_settings)
       end
 
-      it 'sets identity ial to 0' do
-        saml_get_auth(ialmax_settings)
-        expect(user.identities.last.ial).to eq(0)
-      end
-
       it 'does not redirect the user to the IdV URL' do
         saml_get_auth(ialmax_settings)
 
@@ -948,7 +937,6 @@ RSpec.describe SamlIdpController do
           )
         expect(@analytics).to receive(:track_event).with(
           'SP redirect initiated',
-          ial: 0,
           sign_in_duration_seconds: nil,
           billed_ial: 2,
           sign_in_flow:,
@@ -2418,7 +2406,6 @@ RSpec.describe SamlIdpController do
         )
         expect(@analytics).to receive(:track_event).with(
           'SP redirect initiated',
-          ial: 1,
           sign_in_duration_seconds: nil,
           billed_ial: 1,
           sign_in_flow: :sign_in,
@@ -2474,7 +2461,6 @@ RSpec.describe SamlIdpController do
         )
         expect(@analytics).to receive(:track_event).with(
           'SP redirect initiated',
-          ial: 1,
           sign_in_duration_seconds: nil,
           billed_ial: 1,
           sign_in_flow: :sign_in,

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -483,7 +483,6 @@ RSpec.feature 'Sign Up', allowed_extra_analytics: [:*] do
 
       expect(analytics).to have_logged_event(
         'SP redirect initiated',
-        ial: 1,
         sign_in_duration_seconds: 15,
         billed_ial: 1,
         sign_in_flow: 'create_account',

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -631,7 +631,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
         expect(identity.code_challenge).to eq(code_challenge)
         expect(identity.nonce).to eq(nonce)
-        expect(identity.ial).to eq(1)
         expect(identity.acr_values).to eq ''
         expect(identity.vtr).to eq ['C1'].to_json
       end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -381,7 +381,6 @@ RSpec.describe OpenidConnectTokenForm do
           code_digest: Digest::SHA256.hexdigest(code),
           code_verifier_present: false,
           service_provider_pkce: nil,
-          ial: 1,
         )
       end
     end

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe IdTokenBuilder do
       :service_provider_identity,
       nonce: SecureRandom.hex,
       uuid: SecureRandom.uuid,
-      ial: 2,
       rails_session_id: '123',
       # this is a known value from an example developer guide
       # https://www.pingidentity.com/content/developer/en/resources/openid-connect-developers-guide.html
@@ -84,7 +83,6 @@ RSpec.describe IdTokenBuilder do
     context 'context sp requests ACR values' do
       context 'aal and ial request' do
         before do
-          identity.aal = 2
           acr_values = [
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
             Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
@@ -99,7 +97,6 @@ RSpec.describe IdTokenBuilder do
 
       context 'ial2 request' do
         before do
-          identity.ial = 2
           identity.acr_values = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
         end
 
@@ -110,7 +107,6 @@ RSpec.describe IdTokenBuilder do
 
       context 'ial1 request' do
         before do
-          identity.ial = 1
           identity.acr_values = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
         end
 
@@ -121,7 +117,6 @@ RSpec.describe IdTokenBuilder do
 
       context 'ialmax request' do
         before do
-          identity.ial = 0
           identity.acr_values = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
         end
 

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe IdentityLinker do
       last_identity = user.last_identity
       expect(last_identity.nonce).to eq(nonce)
       expect(last_identity.rails_session_id).to eq(rails_session_id)
-      expect(last_identity.ial).to eq(ial)
+      # expect(last_identity.ial).to eq(ial)
       expect(last_identity.acr_values).to eq(acr_values)
       expect(last_identity.vtr).to eq(vtr)
       expect(last_identity.scope).to eq(scope)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -48,7 +48,6 @@ RSpec.shared_examples 'signing in from service provider' do |sp|
 
       expect(analytics).to have_logged_event(
         'SP redirect initiated',
-        ial: 1,
         sign_in_duration_seconds: 15,
         billed_ial: 1,
         sign_in_flow: 'sign_in',


### PR DESCRIPTION
We have a hypothesis that these columns are only used for reporting and billing purposes. This commit intends to run CI without those columns to see if tests for any end-user facing features begin failing.

This is not intended to be merged to main.
