### PR TITLE
LG-13487: Add birth year to state id submitted event

### DIFF
--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -32,6 +32,7 @@ module Idv
       FormResponse.new(
         success: validation_success,
         errors: cleaned_errors,
+        extra: extra_analytics_attributes(params),
       )
     end
 
@@ -42,6 +43,10 @@ module Idv
         raise_invalid_state_id_parameter_error(key) unless ATTRIBUTES.include?(key.to_sym)
         send(:"#{key}=", value)
       end
+    end
+
+    def extra_analytics_attributes(params)
+      { birth_year: params.dig(:dob, :year) }
     end
 
     def raise_invalid_state_id_parameter_error(key)

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -115,7 +115,13 @@ RSpec.describe Idv::InPerson::StateIdController do
   describe '#update' do
     let(:first_name) { 'Natalya' }
     let(:last_name) { 'Rostova' }
-    let(:dob) { InPersonHelper::GOOD_DOB }
+    let(:formatted_dob) { InPersonHelper::GOOD_DOB }
+    let(:dob) do
+      parsed_dob = Date.parse(formatted_dob)
+      { month: parsed_dob.month.to_s,
+        day: parsed_dob.day.to_s,
+        year: parsed_dob.year.to_s }
+    end
     # residential
     let(:address1) { InPersonHelper::GOOD_ADDRESS1 }
     let(:address2) { InPersonHelper::GOOD_ADDRESS2 }
@@ -175,10 +181,11 @@ RSpec.describe Idv::InPerson::StateIdController do
                               [:proofing_results, :context, :stages, :state_id,
                                :state_id_jurisdiction]],
           same_address_as_id: true,
+          birth_year: dob[:year],
         }.merge(ab_test_args)
       end
 
-      it 'logs idv_in_person_proofing_state_id_visited' do
+      it 'logs idv_in_person_proofing_state_id_submitted' do
         put :update, params: params
 
         expect(@analytics).to have_received(
@@ -219,27 +226,9 @@ RSpec.describe Idv::InPerson::StateIdController do
         pii_from_user = subject.user_session['idv/in_person'][:pii_from_user]
         expect(pii_from_user[:first_name]).to eq first_name
         expect(pii_from_user[:last_name]).to eq last_name
-        expect(pii_from_user[:dob]).to eq dob
+        expect(pii_from_user[:dob]).to eq formatted_dob
         expect(pii_from_user[:identity_doc_address_state]).to eq identity_doc_address_state
         expect(pii_from_user[:state_id_number]).to eq state_id_number
-      end
-
-      context 'receives hash dob' do
-        let(:dob) do
-          {
-            day: '3',
-            month: '9',
-            year: '1988',
-          }
-        end
-
-        it 'converts the date when setting it in flow session' do
-          expect(subject.user_session['idv/in_person'][:pii_from_user]).to_not have_key :dob
-
-          put :update, params: params
-
-          expect(subject.user_session['idv/in_person'][:pii_from_user][:dob]).to eq '1988-09-03'
-        end
       end
     end
 
@@ -322,8 +311,10 @@ RSpec.describe Idv::InPerson::StateIdController do
           } }
         end
 
-        it 'retains identity_doc_ attrs/value ands addr attr
-        with same value as identity_doc in flow session' do
+        it <<~EOS.squish do
+          retains identity_doc_ attrs/value ands addr attr
+          with same value as identity_doc in flow session
+        EOS
           Idv::StateIdForm::ATTRIBUTES.each do |attr|
             expect(subject.user_session['idv/in_person'][:pii_from_user]).to_not have_key attr
           end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -542,7 +542,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         step: 'state_id', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing', opted_in_to_in_person_proofing: nil
       },
       'IdV: in person proofing state_id submitted' => {
-        success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', errors: {}, error_details: nil, same_address_as_id: false, opted_in_to_in_person_proofing: nil
+        success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', errors: {}, error_details: nil, same_address_as_id: false, opted_in_to_in_person_proofing: nil, birth_year: '1938'
       },
       'IdV: in person proofing address visited' => {
         step: 'address', flow_path: 'standard', analytics_id: 'In Person Proofing', same_address_as_id: false, opted_in_to_in_person_proofing: nil, acuant_sdk_upgrade_ab_test_bucket: :default, skip_hybrid_handoff: nil

--- a/spec/forms/idv/state_id_form_spec.rb
+++ b/spec/forms/idv/state_id_form_spec.rb
@@ -13,7 +13,14 @@ RSpec.describe Idv::StateIdForm do
     ).permit(:year, :month, :day)
   end
   let(:too_young_dob) do
-    (Time.zone.today - IdentityConfig.store.idv_min_age_years.years + 1.day).to_s
+    dob = Time.zone.today - IdentityConfig.store.idv_min_age_years.years + 1.day
+    ActionController::Parameters.new(
+      {
+        year: dob.year,
+        month: dob.month,
+        day: dob.mday,
+      },
+    )
   end
   let(:good_params) do
     {
@@ -64,11 +71,16 @@ RSpec.describe Idv::StateIdForm do
   let(:pii) { nil }
   describe '#submit' do
     context 'when the form is valid' do
+      let(:form_response) do
+        FormResponse.new(
+          success: true,
+          errors: {},
+          extra: { birth_year: valid_dob[:year] },
+        )
+      end
+
       it 'returns a successful form response' do
-        result = subject.submit(good_params)
-        expect(result).to be_kind_of(FormResponse)
-        expect(result.success?).to eq(true)
-        expect(result.errors).to be_empty
+        expect(subject.submit(good_params)).to eq(form_response)
       end
     end
 

--- a/spec/services/idv/steps/in_person/state_id_step_spec.rb
+++ b/spec/services/idv/steps/in_person/state_id_step_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
   let(:submitted_values) { {} }
   let(:params) { ActionController::Parameters.new({ state_id: submitted_values }) }
   let(:user) { build(:user) }
+  let(:formatted_dob) { InPersonHelper::GOOD_DOB }
+  let(:dob) do
+    parsed_dob = Date.parse(formatted_dob)
+    { month: parsed_dob.month.to_s,
+      day: parsed_dob.day.to_s,
+      year: parsed_dob.year.to_s }
+  end
   let(:enrollment) { InPersonEnrollment.new }
   let(:service_provider) { create(:service_provider) }
   let(:controller) do
@@ -29,7 +36,6 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
     context 'with values submitted' do
       let(:first_name) { 'Natalya' }
       let(:last_name) { 'Rostova' }
-      let(:dob) { '1980-01-01' }
       let(:identity_doc_address_state) { 'Nevada' }
       let(:state_id_number) { 'ABC123234' }
       let(:submitted_values) do
@@ -45,46 +51,27 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
       before do
         allow(user).to receive(:establishing_in_person_enrollment).
           and_return(enrollment)
-      end
 
-      it 'sets values in flow session' do
         Idv::StateIdForm::ATTRIBUTES.each do |attr|
           expect(flow.flow_session[:pii_from_user]).to_not have_key attr
         end
 
-        step.call
+        @result = step.call
+      end
 
+      it 'sets values in flow session' do
         pii_from_user = flow.flow_session[:pii_from_user]
         expect(pii_from_user[:first_name]).to eq first_name
         expect(pii_from_user[:last_name]).to eq last_name
-        expect(pii_from_user[:dob]).to eq dob
+        expect(pii_from_user[:dob]).to eq formatted_dob
         expect(pii_from_user[:identity_doc_address_state]).to eq identity_doc_address_state
         expect(pii_from_user[:state_id_number]).to eq state_id_number
-      end
-
-      context 'receives hash dob' do
-        let(:dob) do
-          {
-            day: '3',
-            month: '9',
-            year: '1988',
-          }
-        end
-
-        it 'converts the date when setting it in flow session' do
-          expect(flow.flow_session[:pii_from_user]).to_not have_key :dob
-
-          step.call
-
-          expect(flow.flow_session[:pii_from_user][:dob]).to eq '1988-09-03'
-        end
       end
     end
 
     context 'when same_address_as_id is...' do
       let(:pii_from_user) { flow.flow_session[:pii_from_user] }
       let(:params) { ActionController::Parameters.new({ state_id: submitted_values }) }
-      let(:dob) { InPersonHelper::GOOD_DOB }
       # residential
       let(:address1) { InPersonHelper::GOOD_ADDRESS1 }
       let(:address2) { InPersonHelper::GOOD_ADDRESS2 }
@@ -121,7 +108,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
           }
         end
 
-        it 'retains identity_doc_ attrs/value but removes addr attr in flow session' do
+        before do
           Idv::StateIdForm::ATTRIBUTES.each do |attr|
             expect(flow.flow_session[:pii_from_user]).to_not have_key attr
           end
@@ -130,9 +117,10 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
 
           # On Verify, user changes response from "Yes,..." to
           # "No, I live at a different address", see submitted_values above
-          step.call
+          @result = step.call
+        end
 
-          # retains identity_doc_ attributes and values in flow session
+        it 'retains identity_doc_ attrs/value but removes addr attr in flow session' do
           expect(flow.flow_session[:pii_from_user]).to include(
             identity_doc_address1:,
             identity_doc_address2:,
@@ -170,8 +158,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
           }
         end
 
-        it 'retains identity_doc_ attrs/value ands addr attr
-        with same value as identity_doc in flow session' do
+        before do
           Idv::StateIdForm::ATTRIBUTES.each do |attr|
             expect(flow.flow_session[:pii_from_user]).to_not have_key attr
           end
@@ -180,8 +167,13 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
 
           # On Verify, user changes response from "No,..." to
           # "Yes, I live at the address on my state-issued ID
-          step.call
-          # expect addr attr values to the same as the identity_doc attr values
+          @result = step.call
+        end
+
+        it <<~EOS.squish do
+          retains identity_doc_ attrs/value and addr attr
+          with same value as identity_doc in flow session
+        EOS
           expect(pii_from_user[:address1]).to eq identity_doc_address1
           expect(pii_from_user[:address2]).to eq identity_doc_address2
           expect(pii_from_user[:city]).to eq identity_doc_city
@@ -207,7 +199,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
             identity_doc_zipcode:,
           }
         end
-        it 'retains identity_doc_ and addr attrs/value in flow session' do
+        before do
           Idv::StateIdForm::ATTRIBUTES.each do |attr|
             expect(flow.flow_session[:pii_from_user]).to_not have_key attr
           end
@@ -216,9 +208,10 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
           make_pii(same_address_as_id: 'false')
 
           # On Verify, user does not changes response "No,..."
-          step.call
+          @result = step.call
+        end
 
-          # retains identity_doc_ & addr attributes and values in flow session
+        it 'retains identity_doc_ and addr attrs/value in flow session' do
           expect(flow.flow_session[:pii_from_user]).to include(
             identity_doc_address1:,
             identity_doc_address2:,
@@ -233,6 +226,69 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
           )
 
           # those values are different
+          pii_from_user = flow.flow_session[:pii_from_user]
+          expect(pii_from_user[:address1]).to_not eq identity_doc_address1
+          expect(pii_from_user[:address2]).to_not eq identity_doc_address2
+          expect(pii_from_user[:city]).to_not eq identity_doc_city
+          expect(pii_from_user[:state]).to_not eq identity_doc_address_state
+          expect(pii_from_user[:zipcode]).to_not eq identity_doc_zipcode
+        end
+      end
+    end
+
+    context 'skip address step?' do
+      let(:pii_from_user) { flow.flow_session[:pii_from_user] }
+      let(:params) { ActionController::Parameters.new({ state_id: submitted_values }) }
+      let(:enrollment) { InPersonEnrollment.new }
+      let(:identity_doc_address_state) { 'Nevada' }
+      let(:identity_doc_city) { 'Twin Peaks' }
+      let(:identity_doc_address1) { '123 Sesame Street' }
+      let(:identity_doc_address2) { 'Apt. #C' }
+      let(:identity_doc_zipcode) { '90001' }
+      let(:submitted_values) do
+        {
+          dob: dob,
+          identity_doc_address_state: identity_doc_address_state,
+          identity_doc_city: identity_doc_city,
+          identity_doc_address1: identity_doc_address1,
+          identity_doc_address2: identity_doc_address2,
+          identity_doc_zipcode: identity_doc_zipcode,
+          same_address_as_id: same_address_as_id,
+        }
+      end
+
+      before(:each) do
+        allow(step).to receive(:current_user).
+          and_return(user)
+        allow(user).to receive(:establishing_in_person_enrollment).
+          and_return(enrollment)
+      end
+
+      context 'same address as id' do
+        let(:same_address_as_id) { 'true' }
+
+        before do
+          @result = step.call
+        end
+
+        it 'adds state id values to address values in pii' do
+          pii_from_user = flow.flow_session[:pii_from_user]
+          expect(pii_from_user[:address1]).to eq identity_doc_address1
+          expect(pii_from_user[:address2]).to eq identity_doc_address2
+          expect(pii_from_user[:city]).to eq identity_doc_city
+          expect(pii_from_user[:state]).to eq identity_doc_address_state
+          expect(pii_from_user[:zipcode]).to eq identity_doc_zipcode
+        end
+      end
+
+      context 'different address from id' do
+        let(:same_address_as_id) { 'false' }
+
+        before do
+          @result = step.call
+        end
+
+        it 'does not add state id values to address values in pii' do
           pii_from_user = flow.flow_session[:pii_from_user]
           expect(pii_from_user[:address1]).to_not eq identity_doc_address1
           expect(pii_from_user[:address2]).to_not eq identity_doc_address2
@@ -299,64 +355,6 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
           parsed_dob: Date.parse(dob),
           updating_state_id: false,
         )
-      end
-    end
-  end
-
-  describe 'skip address step?' do
-    let(:pii_from_user) { flow.flow_session[:pii_from_user] }
-    let(:params) { ActionController::Parameters.new({ state_id: submitted_values }) }
-    let(:enrollment) { InPersonEnrollment.new }
-    let(:dob) { '1980-01-01' }
-    let(:identity_doc_address_state) { 'Nevada' }
-    let(:identity_doc_city) { 'Twin Peaks' }
-    let(:identity_doc_address1) { '123 Sesame Street' }
-    let(:identity_doc_address2) { 'Apt. #C' }
-    let(:identity_doc_zipcode) { '90001' }
-    let(:same_address_as_id) { 'true' }
-    let(:submitted_values) do
-      {
-        dob: dob,
-        identity_doc_address_state: identity_doc_address_state,
-        identity_doc_city: identity_doc_city,
-        identity_doc_address1: identity_doc_address1,
-        identity_doc_address2: identity_doc_address2,
-        identity_doc_zipcode: identity_doc_zipcode,
-        same_address_as_id: same_address_as_id,
-      }
-    end
-
-    before(:each) do
-      allow(step).to receive(:current_user).
-        and_return(user)
-      allow(user).to receive(:establishing_in_person_enrollment).
-        and_return(enrollment)
-    end
-
-    context 'same address as id' do
-      it 'adds state id values to address values in pii' do
-        step.call
-
-        pii_from_user = flow.flow_session[:pii_from_user]
-        expect(pii_from_user[:address1]).to eq identity_doc_address1
-        expect(pii_from_user[:address2]).to eq identity_doc_address2
-        expect(pii_from_user[:city]).to eq identity_doc_city
-        expect(pii_from_user[:state]).to eq identity_doc_address_state
-        expect(pii_from_user[:zipcode]).to eq identity_doc_zipcode
-      end
-    end
-
-    context 'different address from id' do
-      let(:same_address_as_id) { 'false' }
-      it 'does not add state id values to address values in pii' do
-        step.call
-
-        pii_from_user = flow.flow_session[:pii_from_user]
-        expect(pii_from_user[:address1]).to_not eq identity_doc_address1
-        expect(pii_from_user[:address2]).to_not eq identity_doc_address2
-        expect(pii_from_user[:city]).to_not eq identity_doc_city
-        expect(pii_from_user[:state]).to_not eq identity_doc_address_state
-        expect(pii_from_user[:zipcode]).to_not eq identity_doc_zipcode
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13487](https://cm-jira.usa.gov/browse/LG-13487)



## 🛠 Summary of changes

- Add `birth_year` property to the event_properties for the `IdV: in person proofing state_id submitted` event log when submitting state id form data in the idv state id form step.
- Update both Flow State Machine `state_id_step` code and the `state_id_controller`.


## 📜 Testing Plan

### State Flow Machine Steps

Scenario: Verify birth_year is logged after state_id form submission. (Flow State Machine)
- [x] Create an account and proceed through the ipp flow until the `/verify/in_person_proofing/state_id` page is reached.
- [x] Fill out and submit the `state_id` form.
- [x] Verify the `birth_year` property is logged in the `IdV: in person proofing state_id submitted` event inside the `properties.event_properties` json

Scenario: Verify birth_year is logged after state_id form re-submission. (Flow State Machine)
- [x] Create an account and proceed through the ipp flow until the `/verify/in_person/verify_info` page is reached.
- [x] Click on the `update` link for the `State‑issued ID` section.
- [x] Fill out and submit the `state_id` form.
- [x] Verify the `birth_year` property is logged in the `IdV: in person proofing state_id submitted` event inside the `properties.event_properties` json

---

### State ID Controller Steps

Before Execution: 
- [x] Set the `in_person_state_id_controller_enabled` flag to true.

Scenario: Verify birth_year is logged after state_id form submission. 
- [x] Create an account and proceed through the ipp flow until the `/verify/in_person_proofing/state_id` page is reached.
- [x] Fill out and submit the `state_id` form.
- [x] Verify the `birth_year` property is logged in the `IdV: in person proofing state_id submitted` event inside the `properties.event_properties` json

Scenario: Verify birth_year is logged after state_id form re-submission. 
- [x] Create an account and proceed through the ipp flow until the `/verify/in_person/verify_info` page is reached.
- [x] Click on the `update` link for the `State‑issued ID` section.
- [x] Fill out and submit the `state_id` form.
- [x] Verify the `birth_year` property is logged in the `IdV: in person proofing state_id submitted` event inside the `properties.event_properties` json
