### PR TITLE
Ensure the drop-off report and its tests are more robust

### DIFF
--- a/app/jobs/reports/drop_off_report.rb
+++ b/app/jobs/reports/drop_off_report.rb
@@ -13,7 +13,7 @@ module Reports
 
       subject = "Drop Off Report - #{report_date.to_date}"
       configs.each do |config|
-        reports = [report_maker(config['issuers']).as_emailable_reports]
+        reports = [report_maker(config['issuers']).as_emailable_reports].flatten
         config['emails'].each do |email|
           ReportMailer.tables_report(
             email: email,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -81,7 +81,7 @@ doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_selfie_desktop_test_mode: false
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
 doc_capture_request_valid_for_minutes: 15
-drop_off_report_config: '[{"emails":["ursula@example.com"],"issuers":"urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"}]'
+drop_off_report_config: '[{"emails":["ursula@example.com"],"issuers": ["urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"]}]'
 email_from: no-reply@login.gov
 email_from_display_name: Login.gov
 email_registrations_per_ip_limit: 20

--- a/lib/reporting/drop_off_report.rb
+++ b/lib/reporting/drop_off_report.rb
@@ -82,7 +82,7 @@ module Reporting
         ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
         # This needs to be Date.today so it works when run on the command line
         ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
-        ['Issuer', issuers.join(', ')],
+        ['Issuer', [issuers].flatten.join(', ')],
       ]
     end
 

--- a/lib/reporting/drop_off_report.rb
+++ b/lib/reporting/drop_off_report.rb
@@ -82,7 +82,7 @@ module Reporting
         ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
         # This needs to be Date.today so it works when run on the command line
         ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
-        ['Issuer', [issuers].flatten.join(', ')],
+        ['Issuer', Array(issuers).join(', ')],
       ]
     end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-13722](https://cm-jira.usa.gov/browse/LG-13722)

## 🛠 Summary of changes

We didn't have test coverage that made sure to exercise the boundary between `Reporting::DropOffReport` and `Reports::DropOffReport`. There were some mismatches in expectations. Now we have tests that exercise and changes that make those tests pass by updating those two classes to be more lenient in the arguments they accept

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
