### PR TITLE
LG-13527: Add submission analytics event for sign-in MFA selection screen

### DIFF
--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -58,11 +58,6 @@ module TwoFactorAuthentication
     end
 
     def process_valid_form
-      analytics.multi_factor_auth_method_selected(
-        multi_factor_auth_method: @two_factor_options_form.selection,
-        enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
-        mfa_methods_count: mfa_context.enabled_two_factor_configuration_counts_hash,
-      )
       url = mfa_redirect_url
       redirect_to url if url.present?
     end

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -34,7 +34,7 @@ module TwoFactorAuthentication
     def create
       @two_factor_options_form = TwoFactorLoginOptionsForm.new(current_user)
       result = @two_factor_options_form.submit(two_factor_options_form_params)
-      analytics.multi_factor_auth_option_list(**result.to_h)
+      analytics.multi_factor_auth_option_list(**result.to_h.merge(analytics_properties))
 
       if result.success?
         process_valid_form
@@ -81,6 +81,13 @@ module TwoFactorAuthentication
 
     def two_factor_options_form_params
       params.fetch(:two_factor_options_form, {}).permit(:selection)
+    end
+
+    def analytics_properties
+      {
+        enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
+        mfa_method_counts: mfa_context.enabled_two_factor_configuration_counts_hash,
+      }
     end
   end
 end

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -34,7 +34,7 @@ module TwoFactorAuthentication
     def create
       @two_factor_options_form = TwoFactorLoginOptionsForm.new(current_user)
       result = @two_factor_options_form.submit(two_factor_options_form_params)
-      analytics.multi_factor_auth_option_list(**result.to_h.merge(analytics_properties))
+      analytics.multi_factor_auth_option_list(**result.to_h)
 
       if result.success?
         process_valid_form
@@ -81,13 +81,6 @@ module TwoFactorAuthentication
 
     def two_factor_options_form_params
       params.fetch(:two_factor_options_form, {}).permit(:selection)
-    end
-
-    def analytics_properties
-      {
-        enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
-        mfa_method_counts: mfa_context.enabled_two_factor_configuration_counts_hash,
-      }
     end
   end
 end

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -58,6 +58,11 @@ module TwoFactorAuthentication
     end
 
     def process_valid_form
+      analytics.multi_factor_auth_method_at_sign_in_selected(
+        multi_factor_auth_method: @two_factor_options_form.selection,
+        enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
+        mfa_method_counts: mfa_user.enabled_two_factor_configuration_counts_hash,
+      )
       url = mfa_redirect_url
       redirect_to url if url.present?
     end

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -58,10 +58,10 @@ module TwoFactorAuthentication
     end
 
     def process_valid_form
-      analytics.multi_factor_auth_method_at_sign_in_selected(
+      analytics.multi_factor_auth_method_selected(
         multi_factor_auth_method: @two_factor_options_form.selection,
         enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
-        mfa_method_counts: mfa_user.enabled_two_factor_configuration_counts_hash,
+        mfa_methods_count: mfa_context.enabled_two_factor_configuration_counts_hash,
       )
       url = mfa_redirect_url
       redirect_to url if url.present?

--- a/app/forms/two_factor_login_options_form.rb
+++ b/app/forms/two_factor_login_options_form.rb
@@ -44,8 +44,6 @@ class TwoFactorLoginOptionsForm
   def extra_analytics_attributes
     {
       selection: selection,
-      enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
-      mfa_method_counts: mfa_user.enabled_two_factor_configuration_counts_hash,
     }
   end
 end

--- a/app/forms/two_factor_login_options_form.rb
+++ b/app/forms/two_factor_login_options_form.rb
@@ -46,6 +46,7 @@ class TwoFactorLoginOptionsForm
       selection: selection,
       enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
       mfa_method_counts: mfa_user.enabled_two_factor_configuration_counts_hash,
+      pii_like_keypaths: [[:mfa_method_counts, :phone]],
     }
   end
 end

--- a/app/forms/two_factor_login_options_form.rb
+++ b/app/forms/two_factor_login_options_form.rb
@@ -37,9 +37,15 @@ class TwoFactorLoginOptionsForm
     [selection, configuration_id]
   end
 
+  def mfa_user
+    MfaContext.new(user)
+  end
+
   def extra_analytics_attributes
     {
       selection: selection,
+      enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
+      mfa_method_counts: mfa_user.enabled_two_factor_configuration_counts_hash,
     }
   end
 end

--- a/app/forms/two_factor_login_options_form.rb
+++ b/app/forms/two_factor_login_options_form.rb
@@ -44,6 +44,8 @@ class TwoFactorLoginOptionsForm
   def extra_analytics_attributes
     {
       selection: selection,
+      enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
+      mfa_method_counts: mfa_user.enabled_two_factor_configuration_counts_hash,
     }
   end
 end

--- a/app/forms/two_factor_login_options_form.rb
+++ b/app/forms/two_factor_login_options_form.rb
@@ -37,15 +37,15 @@ class TwoFactorLoginOptionsForm
     [selection, configuration_id]
   end
 
-  def mfa_user
+  def mfa_context
     MfaContext.new(user)
   end
 
   def extra_analytics_attributes
     {
       selection: selection,
-      enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
-      mfa_method_counts: mfa_user.enabled_two_factor_configuration_counts_hash,
+      enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
+      mfa_method_counts: mfa_context.enabled_two_factor_configuration_counts_hash,
       pii_like_keypaths: [[:mfa_method_counts, :phone]],
     }
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4084,16 +4084,18 @@ module AnalyticsEvents
   # @param [String] multi_factor_auth_method What option the user selected
   # @param [integer] enabled_mfa_methods_count
   # @param [Hash] mfa_method_counts
-  def multi_factor_auth_method_at_sign_in_selected(
+  def multi_factor_auth_method_selected(
     multi_factor_auth_method:,
     enabled_mfa_methods_count:,
-    mfa_method_counts:
+    mfa_methods_count:,
+    **extra
   )
     track_event(
-      :multi_factor_auth_method_at_sign_in_selected,
-      mult_factor_auth_method: multi_factor_auth_method,
+      :multi_factor_auth_method_selected,
+      multi_factor_auth_method: multi_factor_auth_method,
       enabled_mfa_methods_count: enabled_mfa_methods_count,
-      mfa_method_counts: mfa_method_counts,
+      mfa_methods_count: mfa_methods_count,
+      **extra,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4064,6 +4064,8 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] selection
+  # @param [integer] enabled_mfa_methods_count
+  # @param [Hash] mfa_method_counts
   def multi_factor_auth_option_list(
     success:,
     errors:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4080,6 +4080,25 @@ module AnalyticsEvents
     track_event('Multi-Factor Authentication: option list visited')
   end
 
+  # User selects their MFA method during the sign in process.
+  # @param [String] multi_factor_auth_method What option the user selected
+  # @param [integer] enabled_mfa_methods_count
+  # @param [Hash] mfa_method_counts
+  def multi_factor_auth_method_at_sign_in_selected(
+    multi_factor_auth_method:,
+    enabled_mfa_methods_count:,
+    mfa_method_counts:,
+    success:
+  )
+    track_event(
+      :multi_factor_auth_method_at_sign_in_selected,
+      mult_factor_auth_method: multi_factor_auth_method,
+      enabled_mfa_methods_count: enabled_mfa_methods_count,
+      mfa_method_counts: mfa_method_counts,
+      success: success,
+    )
+  end
+
   # Multi factor auth phone setup
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4087,15 +4087,13 @@ module AnalyticsEvents
   def multi_factor_auth_method_at_sign_in_selected(
     multi_factor_auth_method:,
     enabled_mfa_methods_count:,
-    mfa_method_counts:,
-    success:
+    mfa_method_counts:
   )
     track_event(
       :multi_factor_auth_method_at_sign_in_selected,
       mult_factor_auth_method: multi_factor_auth_method,
       enabled_mfa_methods_count: enabled_mfa_methods_count,
       mfa_method_counts: mfa_method_counts,
-      success: success,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4080,25 +4080,6 @@ module AnalyticsEvents
     track_event('Multi-Factor Authentication: option list visited')
   end
 
-  # User selects their MFA method during the sign in process.
-  # @param [String] multi_factor_auth_method What option the user selected
-  # @param [integer] enabled_mfa_methods_count
-  # @param [Hash] mfa_method_counts
-  def multi_factor_auth_method_selected(
-    multi_factor_auth_method:,
-    enabled_mfa_methods_count:,
-    mfa_methods_count:,
-    **extra
-  )
-    track_event(
-      :multi_factor_auth_method_selected,
-      multi_factor_auth_method: multi_factor_auth_method,
-      enabled_mfa_methods_count: enabled_mfa_methods_count,
-      mfa_methods_count: mfa_methods_count,
-      **extra,
-    )
-  end
-
   # Multi factor auth phone setup
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4064,13 +4064,23 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] selection
-  def multi_factor_auth_option_list(success:, errors:, selection:, error_details: nil, **extra)
+  def multi_factor_auth_option_list(
+    success:,
+    errors:,
+    selection:,
+    enabled_mfa_methods_count:,
+    mfa_method_counts:,
+    error_details: nil,
+    **extra
+  )
     track_event(
       'Multi-Factor Authentication: option list',
       success:,
       errors:,
       error_details:,
       selection:,
+      enabled_mfa_methods_count:,
+      mfa_method_counts:,
       **extra,
     )
   end

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -88,6 +88,8 @@ RSpec.describe TwoFactorAuthentication::OptionsController do
         success: true,
         errors: {},
         error_details: nil,
+        enabled_mfa_methods_count:,
+        mfa_method_counts:,
       )
     end
   end

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe TwoFactorAuthentication::OptionsController do
     end
 
     it 'tracks analytics event' do
-      stub_sign_in_before_2fa
+      user = build(:user, :with_phone, :with_piv_or_cac)
+      stub_sign_in_before_2fa(user)
       stub_analytics
 
       post :create, params: { two_factor_options_form: { selection: 'sms' } }
@@ -88,8 +89,8 @@ RSpec.describe TwoFactorAuthentication::OptionsController do
         success: true,
         errors: {},
         error_details: nil,
-        enabled_mfa_methods_count:,
-        mfa_method_counts:,
+        enabled_mfa_methods_count: 2,
+        mfa_method_counts: { phone: 1, piv_cac: 1 },
       )
     end
   end

--- a/spec/forms/two_factor_login_options_form_spec.rb
+++ b/spec/forms/two_factor_login_options_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe TwoFactorLoginOptionsForm do
   subject do
     TwoFactorLoginOptionsForm.new(
-      build_stubbed(:user),
+      build_stubbed(:user, :with_phone),
     )
   end
 
@@ -12,6 +12,9 @@ RSpec.describe TwoFactorLoginOptionsForm do
       it 'returns true for success?' do
         extra = {
           selection: 'sms',
+          enabled_mfa_methods_count: 1,
+          mfa_method_counts: { phone: 1 },
+          pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 
         expect(subject.submit(selection: 'sms').to_h).to eq(
@@ -30,6 +33,9 @@ RSpec.describe TwoFactorLoginOptionsForm do
 
         extra = {
           selection: 'foo',
+          enabled_mfa_methods_count: 1,
+          mfa_method_counts: { phone: 1 },
+          pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 
         expect(subject.submit(selection: 'foo').to_h).to include(


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13527](https://cm-jira.usa.gov/browse/LG-13527)

## 🛠 Summary of changes

This ticket adds `enabled_mfa_methods_count` and `mfa_method_counts` to the `multi_factor_auth_option_list` event.

## 📜 Testing Plan
For local development QA, you will need an existing account with either a phone setup or multiple methods registered to the account. You will also need to run `make watch_analytics` to see the event.

- [ ] Login to secure.login.gov
- [ ] Select an authentication method. Remember your selection.
- [ ] Click continue. In the terminal, you will see the "Multi-Factor Authentication: option list" event with the new attributes.

https://github.com/18F/identity-idp/assets/17969963/0de58800-d420-4fb0-9cd0-d2c9c7e653dc

![Screen shot of "Multi-Factor Authentication: option list" event in the terminal](https://github.com/18F/identity-idp/assets/17969963/78ba23f8-ace6-4efa-81b3-882fd19ea050)
