### PR TITLE
LG-13599 Failed doc auth result offers IPP offramp

### DIFF
--- a/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
+++ b/app/javascript/packages/document-capture/components/barcode-attention-warning.tsx
@@ -53,7 +53,6 @@ function BarcodeAttentionWarning({ onDismiss, pii }: BarcodeAttentionWarningProp
         <DocumentCaptureTroubleshootingOptions
           location="post_submission_warning"
           showDocumentTips={false}
-          showAlternativeProofingOptions
         />
       }
     >

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
@@ -73,18 +73,6 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
 
         expect(section).not.to.exist();
       });
-
-      context('with showAlternativeProofingOptions', () => {
-        it('renders in-person call to action', () => {
-          const { queryByRole } = render(
-            <DocumentCaptureTroubleshootingOptions showAlternativeProofingOptions />,
-          );
-
-          const section = queryByRole('region', { name: 'in_person_proofing.headings.cta' });
-
-          expect(section).not.to.exist();
-        });
-      });
     });
 
     context('with inPersonURL', () => {
@@ -94,25 +82,12 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
         </InPersonContext.Provider>
       );
 
-      it('does not render in-person call to action', () => {
+      it('renders in-person call to action', () => {
         const { queryByRole } = render(<DocumentCaptureTroubleshootingOptions />, { wrapper });
 
         const section = queryByRole('region', { name: 'in_person_proofing.headings.cta' });
 
-        expect(section).not.to.exist();
-      });
-
-      context('with showAlternativeProofingOptions', () => {
-        it('renders in-person call to action', () => {
-          const { queryByRole } = render(
-            <DocumentCaptureTroubleshootingOptions showAlternativeProofingOptions />,
-            { wrapper },
-          );
-
-          const section = queryByRole('region', { name: 'in_person_proofing.headings.cta' });
-
-          expect(section).to.exist();
-        });
+        expect(section).to.exist();
       });
     });
   });

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -21,18 +21,12 @@ interface DocumentCaptureTroubleshootingOptionsProps {
    * Whether to include tips for taking a good photo.
    */
   showDocumentTips?: boolean;
-
-  /**
-   * Whether to display alternative options for verifying.
-   */
-  showAlternativeProofingOptions?: boolean;
 }
 
 function DocumentCaptureTroubleshootingOptions({
   heading,
   location = 'document_capture_troubleshooting_options',
   showDocumentTips = true,
-  showAlternativeProofingOptions,
 }: DocumentCaptureTroubleshootingOptionsProps) {
   const { t } = useI18n();
   const { inPersonURL } = useContext(InPersonContext);
@@ -40,7 +34,7 @@ function DocumentCaptureTroubleshootingOptions({
 
   return (
     <>
-      {showAlternativeProofingOptions && inPersonURL && <InPersonCallToAction />}
+      {inPersonURL && <InPersonCallToAction />}
       <TroubleshootingOptions
         heading={heading}
         options={

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -118,7 +118,6 @@ function DocumentCaptureWarning({
         troubleshootingOptions={
           <DocumentCaptureTroubleshootingOptions
             location="post_submission_warning"
-            showAlternativeProofingOptions
             heading={t('components.troubleshooting_options.ipp_heading')}
           />
         }

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -118,7 +118,7 @@ function DocumentCaptureWarning({
         troubleshootingOptions={
           <DocumentCaptureTroubleshootingOptions
             location="post_submission_warning"
-            showAlternativeProofingOptions={!isFailedResult}
+            showAlternativeProofingOptions
             heading={t('components.troubleshooting_options.ipp_heading')}
           />
         }

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -153,8 +153,6 @@ describe('DocumentCaptureWarning', () => {
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
-        // the ipp section isn't displayed with isFailedResult=true
-        validateIppSection(false);
         // troubleshooting section
         validateTroubleShootingSection();
       });
@@ -173,8 +171,6 @@ describe('DocumentCaptureWarning', () => {
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
-        // ipp section not existing
-        validateIppSection(false);
         // troubleshooting section
         validateTroubleShootingSection();
       });


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-13599](https://cm-jira.usa.gov/browse/LG-13599)



## 🛠 Summary of changes

When a user goes through doc auth and gets a failed doc auth result, they are now offered the option to go through In-Person Proofing.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV until the doc auth step.
- [ ] Upload a yml file with a doc_auth_result: Failed (I used `spec/fixtures/ial2_test_credential_doc_auth_fail_and_no_liveness.yml`)
- [ ] Confirm that it offers IPP


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
