### PR TITLE
Update Stylelint configuration to forbid CSS !important

### DIFF
--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -119,14 +119,6 @@ h6 {
   }
 }
 
-@media only screen and (max-width: #{$global-breakpoint}) {
-  table.body .columns,
-  table.body .column {
-    padding-left: $global-gutter-small !important;
-    padding-right: $global-gutter-small !important;
-  }
-}
-
 .info-alert,
 .warning-alert {
   padding: 0 units(0.5);

--- a/app/javascript/packages/stylelint-config/CHANGELOG.md
+++ b/app/javascript/packages/stylelint-config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.0-beta.1
+## Unreleased
 
 ### Breaking Changes
 

--- a/app/javascript/packages/stylelint-config/CHANGELOG.md
+++ b/app/javascript/packages/stylelint-config/CHANGELOG.md
@@ -13,6 +13,8 @@
     - [`scss/double-slash-comment-empty-line-before`](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/double-slash-comment-empty-line-before/README.md)
     - [`color-function-notation`](https://stylelint.io/user-guide/rules/color-function-notation/) (due to [Sass incompatibilities](https://github.com/sass/sass/issues/2831))
 - The ruleset now configures [`"reportNeedlessDisables": true`](https://stylelint.io/user-guide/options/#reportneedlessdisables), which will report inline configuration that disables rules unnecessarily.
+- The [`declaration-no-important`](https://stylelint.io/user-guide/rules/declaration-no-important/) rule is now enabled, which disallows `!important` in stylesheets.
+  - `!important` is a sledgehammer solution which often causes more problems than it helps, and usually stems from misunderstandings of [CSS specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity). See related ["Best practices" MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/important#best_practices).
 
 ## 4.1.0
 

--- a/app/javascript/packages/stylelint-config/index.js
+++ b/app/javascript/packages/stylelint-config/index.js
@@ -4,6 +4,7 @@ module.exports = {
     'at-rule-empty-line-before': null,
     'color-function-notation': null,
     'declaration-empty-line-before': null,
+    'declaration-no-important': true,
     'no-descending-specificity': null,
     'rule-empty-line-before': null,
     'scss/comment-no-empty': null,


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `@18f/identity-stylelint-config` shared Stylelint configuration to enable the [`declaration-no-important`](https://stylelint.io/user-guide/rules/declaration-no-important/) rule.

Related changelog entry, from proposed code:

> ### Breaking Changes
>[...]
>- The [`declaration-no-important`](https://stylelint.io/user-guide/rules/declaration-no-important/) rule is now enabled, which disallows `!important` in stylesheets.
>   - `!important` is a sledgehammer solution which often causes more problems than it helps, and usually stems from misunderstandings of [CSS specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity). See related ["Best practices" MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/important#best_practices).

As part of this, the changes remove one instance of `!important` currently used in email stylesheets. These styles appear to be redundant, as they're already applied via upstream Foundation email styles ([source](https://github.com/foundation/foundation-emails/blob/9e371709f93bbe99e897db6b9976115c0aba45d3/scss/components/_media-query.scss#L31-L32)).

## 📜 Testing Plan

Verify no regressions in the padding of email templates at small viewports.

Compare:

- Before: https://idp.dev.identitysandbox.gov/rails/mailers/user_mailer/add_email
- After: http://localhost:3000/rails/mailers/user_mailer/add_email
