### PR TITLE
LG-13624 document capture with selfie crashes on cancel

### DIFF
--- a/app/controllers/concerns/idv_session_concern.rb
+++ b/app/controllers/concerns/idv_session_concern.rb
@@ -60,15 +60,29 @@ module IdvSessionConcern
   end
 
   def user_needs_biometric_comparison?
-    # puts "IdvSessionConcern#user_needs_biometric_comparison?: current_user: #{current_user.inspect}"
-    # puts "   idv_session_user: #{idv_session_user}"
-    # puts "   User.count: #{User.count}"
+    # puts "IdvSessionConcern#user_needs_biometric_comparison?"
+    # puts "  current_user: #{current_user.inspect}"
+    # puts "  idv_session_user: #{idv_session_user.inspect}"
+    # puts "  User.count: #{User.count}"
     # User.all.to_a.each do |u|
-    #   puts "        #{u.inspect}"
+    #   puts "    #{u.inspect}"
     # end
 
+    puts "params: #{params.inspect}"
+    puts "sp_session: #{sp_session.inspect}"
+    puts "user_needs_biometric_comparison?: biometric_comparison?: #{resolved_authn_context_result.biometric_comparison?.inspect}"
+
+    if current_user.nil?
+      puts "  current user nil; in #{self.class.name}"
+      puts "  idv_session_user: #{idv_session_user.inspect}"
+      puts "  User.count: #{User.count}"
+      User.all.to_a.each do |u|
+        puts "    #{u.inspect}"
+      end
+    end
+
     resolved_authn_context_result.biometric_comparison? &&
-      !idv_session_user.identity_verified_with_biometric_comparison?
-      # !current_user.identity_verified_with_biometric_comparison?
+      !current_user.identity_verified_with_biometric_comparison?
+    # !idv_session_user.identity_verified_with_biometric_comparison?
   end
 end

--- a/app/controllers/concerns/idv_session_concern.rb
+++ b/app/controllers/concerns/idv_session_concern.rb
@@ -60,7 +60,15 @@ module IdvSessionConcern
   end
 
   def user_needs_biometric_comparison?
+    # puts "IdvSessionConcern#user_needs_biometric_comparison?: current_user: #{current_user.inspect}"
+    # puts "   idv_session_user: #{idv_session_user}"
+    # puts "   User.count: #{User.count}"
+    # User.all.to_a.each do |u|
+    #   puts "        #{u.inspect}"
+    # end
+
     resolved_authn_context_result.biometric_comparison? &&
-      !current_user.identity_verified_with_biometric_comparison?
+      !idv_session_user.identity_verified_with_biometric_comparison?
+      # !current_user.identity_verified_with_biometric_comparison?
   end
 end

--- a/app/controllers/concerns/idv_session_concern.rb
+++ b/app/controllers/concerns/idv_session_concern.rb
@@ -60,29 +60,7 @@ module IdvSessionConcern
   end
 
   def user_needs_biometric_comparison?
-    # puts "IdvSessionConcern#user_needs_biometric_comparison?"
-    # puts "  current_user: #{current_user.inspect}"
-    # puts "  idv_session_user: #{idv_session_user.inspect}"
-    # puts "  User.count: #{User.count}"
-    # User.all.to_a.each do |u|
-    #   puts "    #{u.inspect}"
-    # end
-
-    puts "params: #{params.inspect}"
-    puts "sp_session: #{sp_session.inspect}"
-    puts "user_needs_biometric_comparison?: biometric_comparison?: #{resolved_authn_context_result.biometric_comparison?.inspect}"
-
-    if current_user.nil?
-      puts "  current user nil; in #{self.class.name}"
-      puts "  idv_session_user: #{idv_session_user.inspect}"
-      puts "  User.count: #{User.count}"
-      User.all.to_a.each do |u|
-        puts "    #{u.inspect}"
-      end
-    end
-
     resolved_authn_context_result.biometric_comparison? &&
-      !current_user.identity_verified_with_biometric_comparison?
-    # !idv_session_user.identity_verified_with_biometric_comparison?
+      !idv_session_user.identity_verified_with_biometric_comparison?
   end
 end

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
       expect(page).to have_current_path(root_url)
       visit idv_hybrid_mobile_document_capture_url
 
+      # Confirm that clicking cancel and then coming back doesn't cause errors
+      click_link 'Cancel'
+      visit idv_hybrid_mobile_document_capture_url
+
       # Confirm that jumping to Phone page does not cause errors
       visit idv_phone_url
       expect(page).to have_current_path(root_url)
@@ -103,6 +107,102 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
       click_agree_and_continue
 
       validate_return_to_sp
+    end
+  end
+
+  context 'when biometric confirmation is requested' do
+    it 'proofs and hands off to mobile', js: true do
+      user = nil
+
+      perform_in_browser(:desktop) do
+        visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
+        binding.pry
+
+        user = sign_up_and_2fa_ial1_user
+
+        complete_doc_auth_steps_before_hybrid_handoff_step
+        clear_and_fill_in(:doc_auth_phone, phone_number)
+        click_send_link
+
+        expect(page).to have_content(t('doc_auth.headings.text_message'))
+        expect(page).to have_content(t('doc_auth.info.you_entered'))
+        expect(page).to have_content('+1 415-555-0199')
+
+        # Confirm that Continue button is not shown when polling is enabled
+        expect(page).not_to have_content(t('doc_auth.buttons.continue'))
+      end
+
+      expect(@sms_link).to be_present
+
+      perform_in_browser(:mobile) do
+        visit @sms_link
+        binding.pry
+
+        # Confirm that jumping to LinkSent page does not cause errors
+        visit idv_link_sent_url
+        expect(page).to have_current_path(root_url)
+        visit idv_hybrid_mobile_document_capture_url
+
+        # Confirm that clicking cancel and then coming back doesn't cause errors
+        click_link 'Cancel'
+        visit idv_hybrid_mobile_document_capture_url
+
+        # Confirm that jumping to Phone page does not cause errors
+        visit idv_phone_url
+        expect(page).to have_current_path(root_url)
+        visit idv_hybrid_mobile_document_capture_url
+
+        # Confirm that jumping to Welcome page does not cause errors
+        visit idv_welcome_url
+        expect(page).to have_current_path(root_url)
+        visit idv_hybrid_mobile_document_capture_url
+
+        expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+        attach_images
+        attach_selfie
+        submit_images
+
+        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+        expect(page).to have_content(t('doc_auth.headings.capture_complete').tr(' ', ' '))
+        expect(page).to have_text(t('doc_auth.instructions.switch_back'))
+        expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+        # Confirm app disallows jumping back to DocumentCapture page
+        visit idv_hybrid_mobile_document_capture_url
+        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+      end
+
+      perform_in_browser(:desktop) do
+        expect(page).to_not have_content(t('doc_auth.headings.text_message'), wait: 10)
+        expect(page).to have_current_path(idv_ssn_path)
+
+        fill_out_ssn_form_ok
+        click_idv_continue
+
+        expect(page).to have_content(t('headings.verify'))
+        complete_verify_step
+
+        prefilled_phone = page.find(id: 'idv_phone_form_phone').value
+
+        expect(
+          PhoneFormatter.format(prefilled_phone),
+        ).to eq(
+               PhoneFormatter.format(user.default_phone_configuration.phone),
+             )
+
+        fill_out_phone_form_ok
+        verify_phone_otp
+
+        fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
+        click_idv_continue
+
+        acknowledge_and_confirm_personal_key
+
+        validate_idv_completed_page(user)
+        click_agree_and_continue
+
+        validate_return_to_sp
+      end
     end
   end
 

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
 
       perform_in_browser(:desktop) do
         visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
-        binding.pry
 
         user = sign_up_and_2fa_ial1_user
 
@@ -136,7 +135,6 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
 
       perform_in_browser(:mobile) do
         visit @sms_link
-        binding.pry
 
         # Confirm that jumping to LinkSent page does not cause errors
         visit idv_link_sent_url

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -185,8 +185,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
         expect(
           PhoneFormatter.format(prefilled_phone),
         ).to eq(
-               PhoneFormatter.format(user.default_phone_configuration.phone),
-             )
+          PhoneFormatter.format(user.default_phone_configuration.phone),
+        )
 
         fill_out_phone_form_ok
         verify_phone_otp


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13624](https://cm-jira.usa.gov/browse/LG-13624)

## 🛠 Summary of changes

Fixed `IdvSessionConcern` to use `idv_session_user` rather than `current_usr` and added a test for this bug.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify that all tests pass without errors, especially the new one
- [ ] Manually walk through the reproduction steps in the ticket and verify that the crash does not occur.
