### PR TITLE
LG-13512 Add zipcode to ipp analytics logging

### DIFF
--- a/app/forms/idv/in_person/address_form.rb
+++ b/app/forms/idv/in_person/address_form.rb
@@ -26,6 +26,7 @@ module Idv
         FormResponse.new(
           success: validation_success,
           errors: cleaned_errors,
+          extra: extra_analytics_attributes(params),
         )
       end
 
@@ -40,6 +41,10 @@ module Idv
 
       def raise_invalid_address_parameter_error(key)
         raise ArgumentError, "#{key} is an invalid address attribute"
+      end
+
+      def extra_analytics_attributes(params)
+        { current_address_zip_code: params.dig(:zipcode)&.slice(0, 5) }
       end
     end
   end

--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -45,12 +45,13 @@ module Idv
       end
     end
 
-    def extra_analytics_attributes(params)
-      { birth_year: params.dig(:dob, :year) }
-    end
-
     def raise_invalid_state_id_parameter_error(key)
       raise ArgumentError, "#{key} is an invalid state ID attribute"
+    end
+
+    def extra_analytics_attributes(params)
+      { birth_year: params.dig(:dob, :year),
+        document_zip_code: params.dig(:identity_doc_zipcode)&.slice(0, 5) }
     end
   end
 end

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Idv::InPerson::AddressController do
       let(:address1) { '1 FAKE RD' }
       let(:address2) { 'APT 1B' }
       let(:city) { 'GREAT FALLS' }
-      let(:zipcode) { '59010' }
+      let(:zipcode) { '59010-4444' }
       let(:state) { 'Montana' }
       let(:params) do
         { in_person_address: {
@@ -141,6 +141,7 @@ RSpec.describe Idv::InPerson::AddressController do
                                :state_id_jurisdiction]],
           same_address_as_id: false,
           skip_hybrid_handoff: nil,
+          current_address_zip_code: '59010',
         }
       end
 
@@ -156,7 +157,7 @@ RSpec.describe Idv::InPerson::AddressController do
         )
       end
 
-      it 'logs idv_in_person_proofing_address_visited' do
+      it 'logs idv_in_person_proofing_address_submitted with 5-digit zipcode' do
         put :update, params: params
 
         expect(@analytics).to have_received(
@@ -228,13 +229,19 @@ RSpec.describe Idv::InPerson::AddressController do
                                :state_id_jurisdiction]],
           same_address_as_id: false,
           skip_hybrid_handoff: nil,
+          current_address_zip_code: '59010',
         }
       end
 
-      it 'does not proceed to next page' do
+      before do
         put :update, params: params
+      end
 
+      it 'does not proceed to next page' do
         expect(response).to have_rendered(:show)
+      end
+
+      it 'logs idv_in_person_proofing_address_submitted without zipcode' do
         expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
       end
     end

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe Idv::InPerson::StateIdController do
                                :state_id_jurisdiction]],
           same_address_as_id: true,
           birth_year: dob[:year],
+          document_zip_code: identity_doc_zipcode&.slice(0, 5),
         }.merge(ab_test_args)
       end
 
@@ -227,6 +228,7 @@ RSpec.describe Idv::InPerson::StateIdController do
         expect(pii_from_user[:first_name]).to eq first_name
         expect(pii_from_user[:last_name]).to eq last_name
         expect(pii_from_user[:dob]).to eq formatted_dob
+        expect(pii_from_user[:identity_doc_zipcode]).to eq identity_doc_zipcode
         expect(pii_from_user[:identity_doc_address_state]).to eq identity_doc_address_state
         expect(pii_from_user[:state_id_number]).to eq state_id_number
       end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -542,13 +542,13 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         step: 'state_id', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing', opted_in_to_in_person_proofing: nil
       },
       'IdV: in person proofing state_id submitted' => {
-        success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', errors: {}, error_details: nil, same_address_as_id: false, opted_in_to_in_person_proofing: nil, birth_year: '1938'
+        success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', errors: {}, error_details: nil, same_address_as_id: false, opted_in_to_in_person_proofing: nil, birth_year: '1938', document_zip_code: '12345'
       },
       'IdV: in person proofing address visited' => {
         step: 'address', flow_path: 'standard', analytics_id: 'In Person Proofing', same_address_as_id: false, opted_in_to_in_person_proofing: nil, acuant_sdk_upgrade_ab_test_bucket: :default, skip_hybrid_handoff: nil
       },
       'IdV: in person proofing residential address submitted' => {
-        success: true, step: 'address', flow_path: 'standard', analytics_id: 'In Person Proofing', errors: {}, same_address_as_id: false, acuant_sdk_upgrade_ab_test_bucket: :default, skip_hybrid_handoff: nil
+        success: true, step: 'address', flow_path: 'standard', analytics_id: 'In Person Proofing', errors: {}, same_address_as_id: false, acuant_sdk_upgrade_ab_test_bucket: :default, skip_hybrid_handoff: nil, current_address_zip_code: '59010'
       },
       'IdV: doc auth ssn visited' => {
         analytics_id: 'In Person Proofing', step: 'ssn', flow_path: 'standard', acuant_sdk_upgrade_ab_test_bucket: :default, skip_hybrid_handoff: nil, same_address_as_id: false

--- a/spec/forms/idv/state_id_form_spec.rb
+++ b/spec/forms/idv/state_id_form_spec.rb
@@ -75,12 +75,24 @@ RSpec.describe Idv::StateIdForm do
         FormResponse.new(
           success: true,
           errors: {},
-          extra: { birth_year: valid_dob[:year] },
+          extra: { birth_year: valid_dob[:year],
+                   document_zip_code: good_params[:identity_doc_zipcode].slice(0, 5) },
         )
       end
 
       it 'returns a successful form response' do
         expect(subject.submit(good_params)).to eq(form_response)
+      end
+
+      it 'logs extra analytics attributes' do
+        result = subject.submit(good_params)
+
+        expect(result.extra).to eq(
+          {
+            birth_year: valid_dob[:year],
+            document_zip_code: good_params[:identity_doc_zipcode].slice(0, 5),
+          },
+        )
       end
     end
 

--- a/spec/services/idv/steps/in_person/state_id_step_spec.rb
+++ b/spec/services/idv/steps/in_person/state_id_step_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
       let(:last_name) { 'Rostova' }
       let(:identity_doc_address_state) { 'Nevada' }
       let(:state_id_number) { 'ABC123234' }
+      let(:identity_doc_zipcode) { InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE }
       let(:submitted_values) do
         {
           first_name: first_name,
@@ -45,6 +46,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
           dob: dob,
           identity_doc_address_state: identity_doc_address_state,
           state_id_number: state_id_number,
+          identity_doc_zipcode: identity_doc_zipcode,
         }
       end
 
@@ -66,6 +68,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
         expect(pii_from_user[:dob]).to eq formatted_dob
         expect(pii_from_user[:identity_doc_address_state]).to eq identity_doc_address_state
         expect(pii_from_user[:state_id_number]).to eq state_id_number
+        expect(pii_from_user[:identity_doc_zipcode]).to eq identity_doc_zipcode
       end
     end
 


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-13512](https://cm-jira.usa.gov/browse/LG-13512)

Note: These changes are closely related to LG-13487 and are based on those initial changes. See https://github.com/18F/identity-idp/pull/10899


## 🛠 Summary of changes

- Added `document_zip_code` property to the event_properties for the "IdV: in person proofing state_id submitted" event log when submitting state id form data in the idv state id form step.
    - Updated both Flow State Machine state_id_step code and the state_id_controller.

- Added `current_address_zip_code` property to the event_properties for the "IdV: in person proofing residential address submitted" event log when submitting current address data in the idv "current address" form step.
    - Only address_controller needed updating since this form does not use a Flow State Machine step.



## 📜 Testing Plan

### State ID (Flow Machine) Steps:

Scenario: Verify zip_code is logged after state_id form submission. (Flow State Machine way)

- [x] Create an account and proceed through the ipp flow until the /verify/in_person_proofing/state_id page is reached.
- [x] Fill out and submit the state_id form.
- [x] Verify the `document_zip_code` property is logged in the IdV: in person proofing state_id submitted event inside the properties.event_properties json

Scenario: Verify `document_zip_code` is logged after state_id form re-submission. (Flow State Machine)

- [ ] Create an account and proceed through the ipp flow until the /verify/in_person/verify_info page is reached.
- [x] Click on the update link for the State‑issued ID section.
- [x] Fill out and submit the state_id form.
- [x] Verify the `document_zip_code` property is logged in the IdV: in person proofing state_id submitted event inside the properties.event_properties json


### State ID (State ID Controller) Steps
Before Execution:

- [ ] Set the `in_person_state_id_controller_enabled` flag to true.

Scenario: Verify `document_zip_code` is logged after state_id form submission.

- [x] Create an account and proceed through the ipp flow until the /verify/in_person_proofing/state_id page is reached.
- [x] Fill out and submit the state_id form.
- [x] Verify the `document_zip_code` property is logged in the IdV: in person proofing state_id submitted event inside the properties.event_properties json
- [x] Verify that in the case where a zipcode with the +4 digits is submitted, only the first five digits are logged.


### Current Address Steps:

- [x] Create an account and proceed through the ipp flow until the verify/in_person/address page is reached, by choosing 
`No, I live at a different address` as the answer to the question "Do you currently live at the address listed on your state‑issued ID?" on the state ID page.
- [x] Fill out and submit the current address form.
- [x] Verify the `current_address_zip_code` property is logged in the "IdV: in person proofing residential address submitted" event inside the properties.event_properties json
- [x] Verify that in the case where a zipcode with the +4 digits is submitted, only the first five digits are logged.

