### PR TITLE
LG-13311: Avoid logging multi_factor_auth_enter_piv_cac twice for PIV MFA

### DIFF
--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -10,10 +10,10 @@ module TwoFactorAuthentication
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :show
 
     def show
-      analytics.multi_factor_auth_enter_piv_cac(**analytics_properties)
       if params[:token]
         process_token
       else
+        analytics.multi_factor_auth_enter_piv_cac(**analytics_properties)
         @presenter = presenter_for_two_factor_authentication_method
       end
     end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4032,6 +4032,7 @@ module AnalyticsEvents
   # @param [DateTime] multi_factor_auth_method_created_at time auth method was created
   # @param [Integer] auth_app_configuration_id Database ID of authentication app configuration
   # @param [Integer] piv_cac_configuration_id Database ID of PIV/CAC configuration
+  # @param [String] piv_cac_configuration_dn_uuid PIV/CAC X509 distinguished name UUID
   # @param [Integer] key_id PIV/CAC key_id
   # @param [Integer] webauthn_configuration_id Database ID of WebAuthn configuration
   # @param [Integer] phone_configuration_id Database ID of phone configuration
@@ -4054,6 +4055,7 @@ module AnalyticsEvents
     multi_factor_auth_method_created_at: nil,
     auth_app_configuration_id: nil,
     piv_cac_configuration_id: nil,
+    piv_cac_configuration_dn_uuid: nil,
     key_id: nil,
     webauthn_configuration_id: nil,
     confirmation_for_add_phone: nil,
@@ -4078,6 +4080,7 @@ module AnalyticsEvents
         multi_factor_auth_method_created_at: multi_factor_auth_method_created_at,
         auth_app_configuration_id: auth_app_configuration_id,
         piv_cac_configuration_id: piv_cac_configuration_id,
+        piv_cac_configuration_dn_uuid:,
         key_id: key_id,
         webauthn_configuration_id: webauthn_configuration_id,
         confirmation_for_add_phone: confirmation_for_add_phone,
@@ -4222,11 +4225,13 @@ module AnalyticsEvents
   # @param ["authentication","reauthentication","confirmation"] context user session context
   # @param ["piv_cac"] multi_factor_auth_method
   # @param [Integer, nil] piv_cac_configuration_id PIV/CAC configuration database ID
+  # @param [Boolean] new_device Whether the user is authenticating from a new device
   # User used a PIV/CAC as their mfa
   def multi_factor_auth_enter_piv_cac(
     context:,
     multi_factor_auth_method:,
     piv_cac_configuration_id:,
+    new_device:,
     **extra
   )
     track_event(
@@ -4234,6 +4239,7 @@ module AnalyticsEvents
       context: context,
       multi_factor_auth_method: multi_factor_auth_method,
       piv_cac_configuration_id: piv_cac_configuration_id,
+      new_device:,
       **extra,
     )
   end

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TwoFactorAuthentication::PivCacVerificationController,
-               allowed_extra_analytics: [:*] do
+RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
   let(:user) do
     create(
       :user, :fully_registered, :with_piv_or_cac,

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -60,6 +60,20 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
 
         expect(response).to render_template(:show)
       end
+
+      it 'logs the visit event' do
+        stub_analytics
+
+        get :show
+
+        expect(@analytics).to have_logged_event(
+          :multi_factor_auth_enter_piv_cac,
+          context: 'authentication',
+          multi_factor_auth_method: 'piv_cac',
+          new_device: true,
+          piv_cac_configuration_id: nil,
+        )
+      end
     end
 
     context 'when the user presents a valid PIV/CAC' do
@@ -109,13 +123,7 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
 
         get :show, params: { token: 'good-token' }
 
-        expect(@analytics).to have_logged_event(
-          :multi_factor_auth_enter_piv_cac,
-          context: 'authentication',
-          multi_factor_auth_method: 'piv_cac',
-          new_device: true,
-          piv_cac_configuration_id: nil,
-        )
+        expect(@analytics).not_to have_logged_event(:multi_factor_auth_enter_piv_cac)
         expect(@analytics).to have_logged_event(
           'Multi-Factor Authentication',
           success: true,
@@ -239,13 +247,7 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
 
         get :show, params: { token: 'bad-token' }
 
-        expect(@analytics).to have_logged_event(
-          :multi_factor_auth_enter_piv_cac,
-          context: 'authentication',
-          multi_factor_auth_method: 'piv_cac',
-          new_device: true,
-          piv_cac_configuration_id: nil,
-        )
+        expect(@analytics).not_to have_logged_event(:multi_factor_auth_enter_piv_cac)
         expect(@analytics).to have_logged_event(
           'Multi-Factor Authentication',
           success: false,


### PR DESCRIPTION
## 🎫 Ticket

[LG-13311](https://cm-jira.usa.gov/browse/LG-13311)

## 🛠 Summary of changes

Updates PIV/CAC verification controller to avoid logging `multi_factor_auth_enter_piv_cac` when the user visits the screen before being redirected to the PIV/CAC service.

The intent of this change is to avoid double-logging `multi_factor_auth_enter_piv_cac` for each PIV/CAC verification, and instead logging it once when the user visits, and relying on the existing "Multi-Factor Authentication" event to be logged when the user returns from the PKI service.

The `#show` action is used for both the initial visit as well as the return target from the PKI service. The changes here conditionally log the event only when the user is not being returned from the PKI service (when the token parameter is absent).

## 📜 Testing Plan

Prerequisite: Have an account with PIV associated, and use the real [PKI service](https://github.com/18f/identity-pki) in local development.

1. In a separate terminal process, run `make watch_events`
2. Go to http://localhost:3000
3. Submit email and password successfully
4. (You should be prompted for your PIV at this point; if you're sent to the account dashboard, click "Forget all browsers", sign out, and start over)
5. Authenticate with PIV successfully
6. View logs in the terminal process for `make watch_events`

Before: You'd see two events for `multi_factor_auth_enter_piv_cac`
After: You only see one event for `multi_factor_auth_enter_piv_cac`