### PR TITLE
LG-13477: Fix reprompt for adding PIV on sign-in after reauthentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -227,9 +227,9 @@ class ApplicationController < ActionController::Base
     return user_please_call_url if current_user.suspended?
     return user_password_compromised_url if session[:redirect_to_password_compromised].present?
     return authentication_methods_setup_url if user_needs_sp_auth_method_setup?
-    return login_add_piv_cac_prompt_url if session[:needs_to_setup_piv_cac_after_sign_in].present?
     return fix_broken_personal_key_url if current_user.broken_personal_key?
     return user_session.delete(:stored_location) if user_session.key?(:stored_location)
+    return login_add_piv_cac_prompt_url if session[:needs_to_setup_piv_cac_after_sign_in].present?
     return reactivate_account_url if user_needs_to_reactivate_account?
     return login_piv_cac_recommended_path if user_recommended_for_piv_cac?
     return second_mfa_reminder_url if user_needs_second_mfa_reminder?


### PR DESCRIPTION
## 🎫 Ticket

[LG-13477](https://cm-jira.usa.gov/browse/LG-13477)

## 🛠 Summary of changes

Fixes an issue where a user would be returned to the PIV prompt screen when prompted to add a PIV card to their account after signing in when having previously failed logging in with PIV due to the card not being associated with a user.

Part of the changes here improve spec helpers relating to PIV/CAC, which currently do not reflect real-world usage, since the PIV/CAC-after-sign-in prompt does _not_ return a user to `'login/add_piv_cac/success'` in live code. Instead, the prompt page submits to the `'/present_piv_cac'` route (`Users::PivCacAuthenticationSetupController#submit_new_piv_cac`), and is therefore redirected back to `'/piv_cac'` after being returned from the PKI service. The stub abstractions wrongly assumes that the PKI service will always redirect back to the URL that the user submitted the form at.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign into your account, make sure to complete MFA and click “Remember this browser”
3. Sign out
4. Wait for reauthentication window to lapse (20 minutes)
   - Optionally, reconfigure `reauthn_window` to a short number in `config/application.yml` to streamline testing 
5. Click “Sign in with your government employee ID”
6. Click “Insert your PIV/CAC”
7. Authenticate with your PIV
8. See error message “Your PIV/CAC is not connected to an account”
9. Click “Sign in” (or “Go back to sign in”)
10. Proceed to sign in to your account using email and password
11. Finish signing in. You should see “Reauthentication required” after signing in. Finish reauthentication
12. See screen “Add your PIV or CAC”
13. Enter a nickname in the “PIV/CAC nickname” field
14. Click “Add PIV/CAC card”

Before: The page appears to reload, with a success banner "A PIV/CAC card was added to your account"
After: You're brought to the account page, with a success banner "A PIV/CAC card was added to your account"

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-idp/assets/1779930/59a2b466-5bba-44cc-b773-2d3775b7cfc0)|![image](https://github.com/user-attachments/assets/5c8303ec-7b9e-46a9-81be-d09426cf3251)
