### PR TITLE
Clean up UriService

### DIFF
--- a/app/services/uri_service.rb
+++ b/app/services/uri_service.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 module UriService
+  # @return [Hash]
   def self.params(original_uri)
     uri = URI(original_uri)
     Rack::Utils.parse_nested_query(uri.query).with_indifferent_access
   end
 
-  def self.add_params(original_uri, params_to_add = {})
+  # @param [#to_s] original_uri
+  # @param [Hash] params_to_add
+  # @return [URI, nil]
+  def self.add_params(original_uri, params_to_add)
     return if original_uri.blank?
 
     URI(original_uri).tap do |uri|

--- a/spec/services/uri_service_spec.rb
+++ b/spec/services/uri_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UriService do
     end
 
     it 'is nil with a bad uri' do
-      uri = UriService.add_params('https://example.com/new.2;;9429"{+![$]`}9839')
+      uri = UriService.add_params('https://example.com/new.2;;9429"{+![$]`}9839', foo: 'bar')
 
       expect(uri).to be_nil
     end


### PR DESCRIPTION
Little Friday cleanup

- Main change: Make `params_to_add` required instead of optional, it's always provided anyways
- Bonus: Add YARD documentation for method
