### PR TITLE
LG-13585: Render H1 for inactive service provider error page

### DIFF
--- a/app/views/users/service_provider_inactive/index.html.erb
+++ b/app/views/users/service_provider_inactive/index.html.erb
@@ -1,21 +1,16 @@
 <% self.title = t('service_providers.errors.inactive.heading', sp_name: @sp_name, app_name: APP_NAME) %>
 
-<%= render AlertIconComponent.new(icon_name: :error) %>
+<%= render StatusPageComponent.new(status: :error) do |c| %>
+  <% c.with_header { t('service_providers.errors.inactive.heading', sp_name: @sp_name, app_name: APP_NAME) } %>
 
-<h3 class="margin-bottom-1 margin-top-4">
-  <%= t('service_providers.errors.inactive.heading', sp_name: @sp_name, app_name: APP_NAME) %>
-</h3>
+  <p>
+    <%= t('service_providers.errors.inactive.instructions', sp_name: @sp_name, app_name: APP_NAME) %>
+  </p>
 
-<p>
-  <%= t('service_providers.errors.inactive.instructions', sp_name: @sp_name, app_name: APP_NAME) %>
-</p>
+  <p>
+    <%= t('service_providers.errors.inactive.instructions2') %>
+  </p>
 
-<p>
-  <%= t('service_providers.errors.inactive.instructions2', sp_link: @sp_link) %>
-</p>
-
-<%= link_to(
-      t('service_providers.errors.inactive.button_text', app_name: APP_NAME),
-      root_path,
-      class: 'usa-button usa-button--wide usa-button--big margin-top-3',
-    ) %>
+  <% c.with_action_button(url: root_path).
+       with_content(t('service_providers.errors.inactive.button_text', app_name: APP_NAME)) %>
+<% end %>

--- a/spec/views/users/service_provider_inactive/index.html.erb_spec.rb
+++ b/spec/views/users/service_provider_inactive/index.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'users/service_provider_inactive/index.html.erb' do
+  let(:sp_name) { t('service_providers.errors.generic_sp_name') }
+
+  subject(:rendered) { render }
+
+  before do
+    assign(:sp_name, sp_name)
+  end
+
+  it 'renders heading' do
+    expect(rendered).to have_css(
+      'h1',
+      text: t('service_providers.errors.inactive.heading', sp_name:, app_name: APP_NAME),
+    )
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[LG-13585](https://cm-jira.usa.gov/browse/LG-13585)

## 🛠 Summary of changes

Updates the inactive service provider error page to ensure that it renders with an H1.

Related resources:

- https://dequeuniversity.com/rules/axe/4.9/page-has-heading-one
- https://www.w3.org/WAI/tutorials/page-structure/headings/
- https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html

It may be simpler to review with whitespace changes hidden: https://github.com/18F/identity-idp/pull/10921/files?w=1

## 📜 Testing Plan

1. Go to http://localhost:3000/errors/service_provider_inactive
2. Inspect heading
3. Verify markup includes `<h1>` element

Alternatively, run an accessibility checker to verify no headings-related errors.

## 👀 Screenshots

&nbsp;|Before|After
---|---|---
With SP|![image](https://github.com/18F/identity-idp/assets/1779930/b45ea1dc-9e68-4acc-925d-87cc6f876dab)|![image](https://github.com/18F/identity-idp/assets/1779930/cffa6e74-6320-4ab1-adf7-06b650cfd157)
Without SP|![image](https://github.com/18F/identity-idp/assets/1779930/53cb1946-7b77-4fc6-95f4-b4f3916d8c2e)|![image](https://github.com/18F/identity-idp/assets/1779930/d30f4e9f-f47b-41bc-81d8-99f7679182b5)
