### PR TITLE
LG-13668: Stop reading "Document capture" in voice over on selfie capture.

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -755,11 +755,7 @@ function AcuantCapture(
           onSelfieTaken={onSelfieTaken}
           onSelfieRetaken={onSelfieRetaken}
         >
-          <FullScreen
-            ref={fullScreenRef}
-            label={t('doc_auth.accessible_labels.document_capture_dialog')}
-            hideCloseButton
-          >
+          <FullScreen ref={fullScreenRef} label={undefined} hideCloseButton>
             <AcuantSelfieCaptureCanvas
               imageCaptureText={imageCaptureText}
               onSelfieCaptureClosed={onSelfieCaptureClosed}


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13668](https://cm-jira.usa.gov/browse/LG-13668)

## 🛠 Summary of changes

Removes the aria label for the capture dialog for selfie capture so a screen reader won't read "document capture"

## 📜 Testing Plan

With a screen reader on go to selfie capture. Before this fix, it reads "Document capture. Web dialog...". After this fix, "Web dialog..."
