### PR TITLE
Support more formats for translation of Post Office hours

### DIFF
--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -31,7 +31,7 @@ module Idv
       def selected_location_hours(prefix)
         return unless selected_location_details
         hours = selected_location_details["#{prefix}_hours"]
-        return localized_hours(hours) if hours
+        localized_hours(hours)
       end
 
       def service_provider
@@ -108,14 +108,22 @@ module Idv
       end
 
       def localized_hours(hours)
-        case hours
-        when 'Closed'
+        return nil if hours.nil?
+
+        if hours == 'Closed'
           I18n.t('in_person_proofing.body.barcode.retail_hours_closed')
-        else
+        elsif hours.include?(' - ') # Hyphen
           hours.
             split(' - '). # Hyphen
             map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
             join(' – ') # Endash
+        elsif hours.include?(' – ') # Endash
+          hours.
+            split(' – '). # Endash
+            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
+            join(' – ') # Endash
+        else
+          hours
         end
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

This is a follow-up to the reversion in #10882 and #10912 to do it in two stages. This change adds support so the ReadyToVerifyPresenter can handle either hyphens or endash prior to making the changes that will do that.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
