### PR TITLE
LG-13848 | ActionAccount reinstated message

### DIFF
--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -80,6 +80,7 @@ class ActionAccount
         user_reinstated: 'User has been reinstated and the user has been emailed',
         user_already_suspended: 'User has already been suspended',
         user_is_not_suspended: 'User is not suspended',
+        user_already_reinstated: 'User has already been reinstated',
       }
     end
   end
@@ -108,6 +109,8 @@ class ActionAccount
           if user.suspended?
             user.reinstate!
             log_texts << log_text[:user_reinstated]
+          elsif user.reinstated?
+            log_texts << (log_text[:user_already_reinstated] + " (at #{user.reinstated_at})")
           else
             log_texts << log_text[:user_is_not_suspended]
           end

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -307,6 +307,21 @@ RSpec.describe ActionAccount do
         expect(result.subtask).to eq('reinstate-user')
         expect(result.uuids).to match_array([user.uuid, suspended_user.uuid])
       end
+
+      context 'with a reinstated user' do
+        let(:user) { create(:user, :reinstated) }
+        let(:args) { [user.uuid] }
+
+        it 'gives a helpful error if the user has been reinstated' do
+          message = "User has already been reinstated (at #{user.reinstated_at})"
+          expect(result.table).to match_array(
+            [
+              ['uuid', 'status', 'reason'],
+              [user.uuid, message, 'INV1234'],
+            ],
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13848](https://cm-jira.usa.gov/browse/LG-13848)


## 🛠 Summary of changes

When a user is reinstated, for some reason the Cloudwatch log doesn't always show up. (This should be investigated separately!)

If the (employee) user tries to reinstate a user who has already been reinstated, let's give a clearer error message.

I have included a timestamp because that was helpful to Rebecca in digging into this yesterday, so let's just include that.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
