### PR TITLE
LG-13684 Add enhanced_ipp to enrollment created event

### DIFF
--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -39,6 +39,7 @@ module UspsInPersonProofing
           service_provider: enrollment.service_provider&.issuer,
           opted_in_to_in_person_proofing: opt_in,
           tmx_status: enrollment.profile&.tmx_status,
+          enhanced_ipp: enrollment.enhanced_ipp?,
         )
 
         send_ready_to_verify_email(user, enrollment, is_enhanced_ipp: is_enhanced_ipp)

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
               second_address_line_present: false,
               service_provider: nil,
               tmx_status: nil,
+              enhanced_ipp: false,
             )
           end
         end
@@ -214,18 +215,40 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
           let(:issuer) { 'this-is-an-issuer' }
           let(:service_provider) { build(:service_provider, issuer: issuer) }
 
-          it 'logs event' do
-            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+          context 'when the enrollment is enhanced_ipp' do
+            let(:is_enhanced_ipp) { true }
 
-            expect(subject_analytics).to have_logged_event(
-              'USPS IPPaaS enrollment created',
-              enrollment_code: user.in_person_enrollments.first.enrollment_code,
-              enrollment_id: user.in_person_enrollments.first.id,
-              opted_in_to_in_person_proofing: nil,
-              second_address_line_present: false,
-              service_provider: issuer,
-              tmx_status: nil,
-            )
+            it 'logs event' do
+              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+
+              expect(subject_analytics).to have_logged_event(
+                'USPS IPPaaS enrollment created',
+                enrollment_code: user.in_person_enrollments.first.enrollment_code,
+                enrollment_id: user.in_person_enrollments.first.id,
+                opted_in_to_in_person_proofing: nil,
+                second_address_line_present: false,
+                service_provider: issuer,
+                tmx_status: nil,
+                enhanced_ipp: true,
+              )
+            end
+          end
+
+          context 'when the enrollment is not enhanced_ipp' do
+            it 'logs event' do
+              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+
+              expect(subject_analytics).to have_logged_event(
+                'USPS IPPaaS enrollment created',
+                enrollment_code: user.in_person_enrollments.first.enrollment_code,
+                enrollment_id: user.in_person_enrollments.first.id,
+                opted_in_to_in_person_proofing: nil,
+                second_address_line_present: false,
+                service_provider: issuer,
+                tmx_status: nil,
+                enhanced_ipp: false,
+              )
+            end
           end
         end
 
@@ -252,6 +275,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
               second_address_line_present: false,
               service_provider: nil,
               tmx_status: nil,
+              enhanced_ipp: false,
             )
           end
 
@@ -272,6 +296,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
                 second_address_line_present: true,
                 service_provider: nil,
                 tmx_status: nil,
+                enhanced_ipp: false,
               )
             end
           end
@@ -291,6 +316,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
               second_address_line_present: false,
               service_provider: nil,
               tmx_status: nil,
+              enhanced_ipp: false,
             )
           end
         end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13684](https://cm-jira.usa.gov/browse/LG-13684)

## 🛠 Summary of changes

* Added `enhanced_ipp` to the `properties.event_properties` of the `USPS IPPaaS enrollment created` event

## 📜 Testing Plan

**Scenario: When the Service Provider has requests EIPP for the user**

- [x] Sign in using oidc-sinatra app with the level of service set to `Enhanced In-person Proofing`
- [x] Create an account and proceed through the IPP flow until reaching the `/verify/enter_password` page
- [x] Complete the re-enter password form and submit
- [x] Check the event logs for the `USPS IPPaaS enrollment created` event
- [x] Verify the `properties.event_properties.enhanced_ipp` property is set to `true`

**Scenario: When the Service Provider has requests any other identity verification level**

- [x] Sign in using oidc-sinatra app with the level of service set to `Identity-verified` 
- [x] Create an account and proceed through the IPP flow until reaching the `/verify/enter_password` page
- [x] Complete the re-enter password form and submit
- [x] Check the event logs for the `USPS IPPaaS enrollment created` event
- [x] Verify the `properties.event_properties.enhanced_ipp` property is set to `false`

