### PR TITLE
LG-13758: Bypass secondary id check for Enhanced IPP

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -121,8 +121,8 @@ class GetUspsProofingResultsJob < ApplicationJob
     enrollment.update(status_check_attempted_at: status_check_attempted_at)
   end
 
-  def passed_with_unsupported_secondary_id_type?(response)
-    return response['secondaryIdType'].present? &&
+  def passed_with_unsupported_secondary_id_type?(enrollment, response)
+    return !enrollment.enhanced_ipp? && response['secondaryIdType'].present? &&
            SUPPORTED_SECONDARY_ID_TYPES.exclude?(response['secondaryIdType'])
   end
 
@@ -483,7 +483,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     when IPP_STATUS_PASSED
       if fraud_result_pending?(enrollment)
         handle_passed_with_fraud_review_pending(enrollment, response)
-      elsif passed_with_unsupported_secondary_id_type?(response)
+      elsif passed_with_unsupported_secondary_id_type?(enrollment, response)
         handle_unsupported_secondary_id(enrollment, response)
       elsif passed_with_primary_id_check?(enrollment, response)
         handle_successful_status_update(enrollment, response)

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -122,8 +122,10 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def passed_with_unsupported_secondary_id_type?(enrollment, response)
-    return !enrollment.enhanced_ipp? && response['secondaryIdType'].present? &&
-           SUPPORTED_SECONDARY_ID_TYPES.exclude?(response['secondaryIdType'])
+    return false if enrollment.enhanced_ipp?
+
+    response['secondaryIdType'].present? &&
+      SUPPORTED_SECONDARY_ID_TYPES.exclude?(response['secondaryIdType'])
   end
 
   def analytics(user: AnonymousUser.new)

--- a/app/services/usps_in_person_proofing/mock/fixtures.rb
+++ b/app/services/usps_in_person_proofing/mock/fixtures.rb
@@ -77,6 +77,12 @@ module UspsInPersonProofing
         )
       end
 
+      def self.request_passed_proofing_secondary_id_type_results_response_ial_2
+        load_response_fixture(
+          'request_passed_proofing_secondary_id_type_results_response_ial_2.json',
+        )
+      end
+
       def self.request_expired_proofing_results_response
         load_response_fixture('request_expired_proofing_results_response.json')
       end

--- a/app/services/usps_in_person_proofing/mock/responses/request_passed_proofing_secondary_id_type_results_response_ial_2.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_passed_proofing_secondary_id_type_results_response_ial_2.json
@@ -1,0 +1,14 @@
+{
+  "status": "In-person passed",
+  "proofingPostOffice": "WILKES BARRE",
+  "proofingCity": "WILKES BARRE",
+  "proofingState": "PA",
+  "enrollmentCode": "2090002197504352",
+  "primaryIdType": "State driver's license",
+  "transactionStartDateTime": "12/17/2020 033855",
+  "transactionEndDateTime": "12/17/2020 034055",
+  "secondaryIdType": "State driver's license",
+  "fraudSuspected": false,
+  "proofingConfirmationNumber": "350040248346701",
+  "ippAssuranceLevel": "2.0"
+}

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -1568,7 +1568,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
 
         context 'By passes the Secondary ID check when enrollment is Enhanced IPP' do
           before do
-            stub_request_passed_proofing_secondary_id_type_results
+            stub_request_passed_proofing_secondary_id_type_results_ial_2
           end
 
           it_behaves_like(
@@ -1577,7 +1577,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
             email_type: 'Success',
             enrollment_status: InPersonEnrollment::STATUS_PASSED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
-              request_passed_proofing_secondary_id_type_results_response,
+            request_passed_proofing_secondary_id_type_results_response_ial_2,
           )
         end
       end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -1498,24 +1498,28 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
       end
 
       describe 'Enhanced In-Person Proofing' do
+        let!(:pending_enrollment) do
+          create(
+            :in_person_enrollment,
+            :pending,
+            :with_notification_phone_configuration,
+            issuer: 'http://localhost:3000',
+            selected_location_details: { name: 'BALTIMORE' },
+            sponsor_id: usps_eipp_sponsor_id,
+          )
+        end
+
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+        end
+
         context <<~STR.squish do
           When an Enhanced IPP enrollment passess proofing
           with unsupported ID,enrollment by-passes the
           Primary ID check and
         STR
-          let!(:pending_enrollment) do
-            create(
-              :in_person_enrollment,
-              :pending,
-              :with_notification_phone_configuration,
-              issuer: 'http://localhost:3000',
-              selected_location_details: { name: 'BALTIMORE' },
-              sponsor_id: usps_eipp_sponsor_id,
-            )
-          end
 
           before do
-            allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
             stub_request_passed_proofing_unsupported_id_results
           end
 
@@ -1563,19 +1567,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
         end
 
         context 'By passes the Secondary ID check when enrollment is Enhanced IPP' do
-          let!(:pending_enrollment) do
-            create(
-              :in_person_enrollment,
-              :pending,
-              :with_notification_phone_configuration,
-              issuer: 'http://localhost:3000',
-              selected_location_details: { name: 'BALTIMORE' },
-              sponsor_id: usps_eipp_sponsor_id,
-            )
-          end
-
           before do
-            allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
             stub_request_passed_proofing_secondary_id_type_results
           end
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -1561,6 +1561,33 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
             )
           end
         end
+
+        context 'By passes the Secondary ID check when enrollment is Enhanced IPP' do
+          let!(:pending_enrollment) do
+            create(
+              :in_person_enrollment,
+              :pending,
+              :with_notification_phone_configuration,
+              issuer: 'http://localhost:3000',
+              selected_location_details: { name: 'BALTIMORE' },
+              sponsor_id: usps_eipp_sponsor_id,
+            )
+          end
+
+          before do
+            allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+            stub_request_passed_proofing_secondary_id_type_results
+          end
+
+          it_behaves_like(
+            'enrollment_with_a_status_update',
+            passed: true,
+            email_type: 'Success',
+            enrollment_status: InPersonEnrollment::STATUS_PASSED,
+            response_json: UspsInPersonProofing::Mock::Fixtures.
+              request_passed_proofing_secondary_id_type_results_response,
+          )
+        end
       end
     end
 

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -239,6 +239,15 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_passed_proofing_secondary_id_type_results_ial_2
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      status: 200,
+      body: UspsInPersonProofing::Mock::
+        Fixtures.request_passed_proofing_secondary_id_type_results_response_ial_2,
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_passed_proofing_unsupported_status_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
       status: 200,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13758](https://cm-jira.usa.gov/browse/LG-13758)

## 🛠 Summary of changes

As we await the new API contract from USPS with the expanded list of secondary ID options, we are temporarily bypassing the secondary check completely. This is to support the friends and family testing for Enhanced IPP

## 📜 Testing Plan

Please see the scenarios below for 
1. [EIPP Enabled with Unsupported Secondary ID](#eipp-enabled-unsupported)
1.  [EIPP Enabled with Supported Secondary ID](#eipp-enabled-supported)
1. [The current flow in production - EIPP Disabled (ID IPP) with Unsupported Secondary ID](#eipp-disabled-unsupported)
1. [The current flow in production - EIPP Disabled (ID IPP) with Supported Secondary ID](#eipp-disabled-supported)

## Enhanced In Person Proofing Enabled 

> [!NOTE]
> Pre requisite for all of this is to spin up the [OIDC-Sinatra](https://github.com/18F/identity-oidc-sinatra) app locally. You can find the setup steps here: https://docs.google.com/document/d/1FG9s8Cih9NGbrz7ag4WPLK_W10di-1xfDKy0Fjrg0fM/edit#heading=h.hepkwzlgvxf3. Once you have it running locally, you'll need to make sure you select the **Enhanced IPP** option from the dropdown. This is key since it sets the application up to enable Enhanced IPP.

![eipp-sinatra2](https://github.com/user-attachments/assets/38994892-3c0f-4617-881e-fdbd9020313b)

### Should _PASS_ enrollment with _UNSUPPORTED_ secondary ID <a href="#user-content-eipp-enabled-unsupported" id="eipp-enabled-unsupported">#</a>

#### Running the Job Manually 🧰 
- [x] After navigation to the application from the OIDC Sinatra application, proceed to create a test enrollment (https://handbook.login.gov/articles/identity-proofing-testing.html#gmail-extra-emails-trick) 
- [x] After the enrollment is created, open the `rails console` in the identity-idp application and grab that newly created enrollment 
```
e = InPersonEnrollment.last
```
- [x] Next, in the same console terminal setup the mocked response 
```
mock = UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_secondary_id_type_results_response
res = JSON.parse(mock)
```
- [x] Create an instance of the job 
```
job = GetUspsProofingResultsJob.new
```
- [x] Set the enrollments outcome instance variable 
```
job.instance_variable_set('@enrollment_outcomes', { enrollments_passed: 0 })
```
- [x] Start the job 
```
job.send(:process_enrollment_response, e, res)
```
- [x] Confirm the enrollment succeeded 
```
e.status == 'passed'
```

### Should _PASS_ enrollment with _SUPPORTED_ secondary ID <a href="#user-content-eipp-enabled-supported" id="eipp-enabled-supported">#</a>

#### Running the Job Manually 🧰 
- [x] After navigation to the application from the OIDC Sinatra application, proceed to create a test enrollment (https://handbook.login.gov/articles/identity-proofing-testing.html#gmail-extra-emails-trick) 
- [x] After the enrollment is created, open the `rails console` in the identity-idp application and grab that newly created enrollment 
```
e = InPersonEnrollment.last
```
- [x] Next, in the same console terminal setup the mocked response 
```
mock = UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_supported_secondary_id_type_results_response
res = JSON.parse(mock)
```
- [x] Create an instance of the job 
```
job = GetUspsProofingResultsJob.new
```
- [x] Set the enrollments outcome instance variable 
```
job.instance_variable_set('@enrollment_outcomes', { enrollments_passed: 0 })
```
- [x] Start the job 
```
job.send(:process_enrollment_response, e, res)
```
- [ ] Confirm the enrollment succeeded 
```
e.status == 'passed'
```

### ID IPP (EIPP _NOT_ Enabled) 

#### Should _FAIL_ enrollment with _UNSUPPORTED_ secondary ID <a href="#user-content-eipp-disabled-unsupported" id="eipp-disabled-unsupported">#</a>

#### Running the Job Manually 🧰 
- [ ] Open the identity-idp application and create a new test enrollment (https://handbook.login.gov/articles/identity-proofing-testing.html#gmail-extra-emails-trick) 
- [ ] After the enrollment is created, open the `rails console` in the identity-idp application and grab that newly created enrollment 
```
e = InPersonEnrollment.last
```
- [ ] Next, in the same console terminal setup the mocked response 
```
mock = UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_secondary_id_type_results_response
res = JSON.parse(mock)
```
- [ ] Create an instance of the job 
```
job = GetUspsProofingResultsJob.new
```
- [ ] Set the enrollments outcome instance variable 
```
job.instance_variable_set('@enrollment_outcomes', { enrollments_failed: 0 })
```
- [ ] Start the job 
```
job.send(:process_enrollment_response, e, res)
```
- [ ] Confirm the enrollment failed 
```
e.status == 'failed'
```

#### Should _PASS_ enrollment with _SUPPORTED_ secondary ID <a href="#user-content-eipp-disabled-supported" id="eipp-disabled-supported">#</a>

#### Running the Job Manually 🧰 
- [ ] Open the identity-idp application and create a new test enrollment (https://handbook.login.gov/articles/identity-proofing-testing.html#gmail-extra-emails-trick) 
- [ ] After the enrollment is created, open the `rails console` in the identity-idp application and grab that newly created enrollment 
```
e = InPersonEnrollment.last
```
- [ ] Next, in the same console terminal setup the mocked response 
```
mock = UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_supported_secondary_id_type_results_response
res = JSON.parse(mock)
```
- [ ] Create an instance of the job 
```
job = GetUspsProofingResultsJob.new
```
- [ ] Set the enrollments outcome instance variable 
```
job.instance_variable_set('@enrollment_outcomes', { enrollments_passed: 0 })
```
- [ ] Start the job 
```
job.send(:process_enrollment_response, e, res)
```
- [ ] Confirm the enrollment failed 
```
e.status == 'failed'
```