### PR TITLE
Log email language for new account creation

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -120,6 +120,7 @@ class RegisterUserEmailForm
       user_id: user.uuid || existing_user.uuid,
       domain_name: email&.split('@')&.last,
       rate_limited: rate_limited?,
+      email_language:,
     }
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5825,24 +5825,24 @@ module AnalyticsEvents
     success:,
     rate_limited:,
     errors:,
+    user_id:,
+    email_already_exists:,
+    domain_name:,
+    email_language:,
     error_details: nil,
-    user_id: nil,
-    email_already_exists: nil,
-    domain_name: nil,
     **extra
   )
     track_event(
       'User Registration: Email Submitted',
-      {
-        success:,
-        rate_limited:,
-        errors:,
-        error_details:,
-        user_id:,
-        email_already_exists:,
-        domain_name:,
-        **extra,
-      }.compact,
+      success:,
+      rate_limited:,
+      errors:,
+      error_details:,
+      user_id:,
+      email_already_exists:,
+      domain_name:,
+      email_language:,
+      **extra,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5815,12 +5815,13 @@ module AnalyticsEvents
 
   # Tracks when user submits registration email
   # @param [Boolean] success Whether form validation was successful
-  # @param [Boolean] rate_limited
+  # @param [Boolean] rate_limited Whether form submission was prevented by rate-limiting
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  # @param [String] user_id
-  # @param [Boolean] email_already_exists
-  # @param [String] domain_name
+  # @param [String] user_id ID of user associated with existing user, or current user
+  # @param [Boolean] email_already_exists Whether an account with the email address already exists
+  # @param [String] domain_name Domain name of email address submitted
+  # @param [String] email_language Preferred language for email communication
   def user_registration_email(
     success:,
     rate_limited:,

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -58,49 +58,50 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
   end
 
   describe '#create' do
-    let(:success_properties) { { success: true } }
+    let(:email) { 'new@example.com' }
+    let(:email_language) { 'es' }
+    let(:params) { { user: { email:, terms_accepted: '1', email_language: } } }
+
     context 'when registering with a new email' do
       it 'tracks successful user registration' do
         stub_analytics
 
-        allow(@analytics).to receive(:track_event)
         allow(subject).to receive(:create_user_event)
 
-        post :create, params: { user: { email: 'new@example.com', terms_accepted: '1' } }
+        post :create, params: params
 
         user = User.find_with_email('new@example.com')
 
-        analytics_hash = {
+        expect(@analytics).to have_logged_event(
+          'User Registration: Email Submitted',
           success: true,
           rate_limited: false,
           errors: {},
+          error_details: nil,
           email_already_exists: false,
           user_id: user.uuid,
           domain_name: 'example.com',
-        }
-
-        expect(@analytics).to have_received(:track_event).
-          with('User Registration: Email Submitted', analytics_hash)
+          email_language:,
+        )
 
         expect(subject).to have_received(:create_user_event).with(:account_created, user)
       end
 
       it 'sets the users preferred email locale and sends an email in that locale' do
-        post :create, params: { user: { email: 'test@test.com',
-                                        email_language: 'es',
-                                        terms_accepted: '1' } }
+        post :create, params: params
 
-        expect(User.find_with_email('test@test.com').email_language).to eq('es')
+        expect(User.find_with_email(email).email_language).to eq(email_language)
 
         mail = ActionMailer::Base.deliveries.last
-        expect(mail.subject).
-          to eq(I18n.t('user_mailer.email_confirmation_instructions.subject', locale: 'es'))
+        expect(mail.subject).to eq(
+          I18n.t('user_mailer.email_confirmation_instructions.subject', locale: email_language),
+        )
       end
 
       it 'sets the email in the session and redirects to sign_up_verify_email_path' do
-        post :create, params: { user: { email: 'test@test.com', terms_accepted: '1' } }
+        post :create, params: params
 
-        expect(session[:email]).to eq('test@test.com')
+        expect(session[:email]).to eq(email)
         expect(response).to redirect_to(sign_up_verify_email_path)
       end
 
@@ -108,7 +109,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
         user = create(:user)
         stub_sign_in(user)
 
-        post :create, params: { user: { email: user.email, terms_accepted: '1' } }
+        post :create, params: params
 
         expect(response).to redirect_to account_path
       end
@@ -119,28 +120,31 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
 
       stub_analytics
 
-      analytics_hash = {
+      expect(subject).to_not receive(:create_user_event)
+
+      post :create, params: params.deep_merge(user: { email: 'test@example.com' })
+
+      expect(subject.session[:sign_in_flow]).to eq(:create_account)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Submitted',
         success: true,
         rate_limited: false,
         errors: {},
+        error_details: nil,
         email_already_exists: true,
         user_id: existing_user.uuid,
         domain_name: 'example.com',
-      }
-
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Submitted', analytics_hash)
-
-      expect(subject).to_not receive(:create_user_event)
-
-      post :create, params: { user: { email: 'TEST@example.com ', terms_accepted: '1' } }
-      expect(subject.session[:sign_in_flow]).to eq(:create_account)
+        email_language:,
+      )
     end
 
     it 'tracks unsuccessful user registration' do
       stub_analytics
 
-      analytics_hash = {
+      post :create, params: params.deep_merge(user: { email: 'invalid@' })
+
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Submitted',
         success: false,
         rate_limited: false,
         errors: { email: [t('valid_email.validations.email.invalid')] },
@@ -148,28 +152,24 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
         email_already_exists: false,
         user_id: 'anonymous-uuid',
         domain_name: 'invalid',
-      }
-
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Submitted', analytics_hash)
-
-      post :create, params: { user: { email: 'invalid@', request_id: '', terms_accepted: '1' } }
+        email_language:,
+      )
     end
 
     it 'renders new if email is nil' do
-      post :create, params: { user: { request_id: '123789', terms_accepted: '1' } }
+      post :create, params: params.deep_merge(user: { email: nil })
 
       expect(response).to render_template(:new)
     end
 
     it 'renders new if email is a Hash' do
-      put :create, params: { user: { email: { foo: 'bar' } } }
+      put :create, params: params.deep_merge(user: { email: { foo: 'bar' } })
 
       expect(response).to render_template(:new)
     end
 
     it 'renders new if request_id is blank' do
-      post :create, params: { user: { email: 'invalid@' } }
+      post :create, params: params.deep_merge(user: { email: 'invalid@' })
 
       expect(response).to render_template(:new)
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates logging for new account email submission to include `email_language` property.

This is planned to be used for measuring how frequently this field is changed by users to select an option other than the current page locale.

## 📜 Testing Plan

1. Run `make watch_events` in a separate terminal process
2. Go to http://localhost:3000
3. Click "Create an account"
4. Enter an email
5. Optional: Change the value for "Select your email language preference"
6. Check "I have read and accept the Login.gov Rules of Use"
7. Click "Submit"
8. In `make watch_events` terminal tab, look for "User Registration: Email Submitted" event
9. Observe `email_language` property matches what had been selected when submitting the form