### PR TITLE
LG-13537: Remove the term online from failure CTA body

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1825,7 +1825,7 @@ user_mailer.in_person_failed_suspected_fraud.body.help_center_html: If you need 
 user_mailer.in_person_failed_suspected_fraud.body.intro: We understand that you were attempting to verify your identity through %{app_name}, however your identity could not be verified at the %{location} Post Office on %{date}.
 user_mailer.in_person_failed_suspected_fraud.greeting: Hello,
 user_mailer.in_person_failed_suspected_fraud.subject: Your identity could not be verified in person
-user_mailer.in_person_failed.body.with_cta: Click the button or copy the link below to try verifying your identity online again through %{sp_or_app_name}. If you are still experiencing issues, please contact the agency you are trying to access.
+user_mailer.in_person_failed.body.with_cta: Click the button or copy the link below to try verifying your identity again through %{sp_or_app_name}. If you are still experiencing issues, please contact the agency you are trying to access.
 user_mailer.in_person_failed.body.without_cta: Please try verifying your identity again from %{sp_name}’s website. If you are still experiencing issues, please contact the agency you are trying to access.
 user_mailer.in_person_failed.intro: Your identity could not be verified at the %{location} Post Office on %{date}.
 user_mailer.in_person_failed.subject: Your identity could not be verified in person

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1836,7 +1836,7 @@ user_mailer.in_person_failed_suspected_fraud.body.help_center_html: Si necesita 
 user_mailer.in_person_failed_suspected_fraud.body.intro: Entendemos que estaba intentando verificar su identidad usando %{app_name}; sin embargo, su identidad no pudo ser verificada en la oficina de correos de %{location} el %{date}.
 user_mailer.in_person_failed_suspected_fraud.greeting: 'Hola:'
 user_mailer.in_person_failed_suspected_fraud.subject: No se pudo verificar su identidad en persona
-user_mailer.in_person_failed.body.with_cta: Haga clic en el botón o copie el vínculo siguiente para volver a intentar verificar su identidad en línea con %{sp_or_app_name}. Si sigue teniendo problemas, contacte con la agencia a la que está intentando acceder.
+user_mailer.in_person_failed.body.with_cta: Haga clic en el botón o copie el vínculo siguiente para volver a intentar verificar su identidad con %{sp_or_app_name}. Si sigue teniendo problemas, póngase en contacto con la agencia a la que intenta acceder.
 user_mailer.in_person_failed.body.without_cta: Vuelva a intentar verificar su identidad en el sitio web de %{sp_name}. Si sigue teniendo problemas, contacte con la agencia a la que está intentando acceder.
 user_mailer.in_person_failed.intro: No se pudo verificar su identidad en la oficina de correos de %{location} el %{date}.
 user_mailer.in_person_failed.subject: No se pudo verificar su identidad en persona

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1825,7 +1825,7 @@ user_mailer.in_person_failed_suspected_fraud.body.help_center_html: Si vous avez
 user_mailer.in_person_failed_suspected_fraud.body.intro: Vous avez tenté de confirmer votre identité par le biais de %{app_name}, mais votre identité n’a pas pu être confirmée au bureau de poste de %{location} le %{date}.
 user_mailer.in_person_failed_suspected_fraud.greeting: Bonjour,
 user_mailer.in_person_failed_suspected_fraud.subject: Votre identité n’a pas pu être vérifiée en personne
-user_mailer.in_person_failed.body.with_cta: Cliquez sur le bouton ou copiez le lien ci-dessous pour réessayer de confirmer votre identité en ligne par le biais de %{sp_or_app_name}. Si vous rencontrez toujours des difficultés, veuillez contacter l’organisme auquel vous essayez d’accéder.
+user_mailer.in_person_failed.body.with_cta: Cliquez sur le bouton ou copiez le lien ci-dessous pour réessayer de confirmer votre identité par le biais de %{sp_or_app_name}. Si vous rencontrez toujours des difficultés, veuillez contacter l’organisme auquel vous essayez d’accéder.
 user_mailer.in_person_failed.body.without_cta: Veuillez réessayer de confirmer votre identité sur le site Web de %{sp_name}. Si vous rencontrez toujours des difficultés, veuillez contacter l’organisme auquel vous essayez d’accéder.
 user_mailer.in_person_failed.intro: Votre identité n’a pas pu être vérifiée au bureau de poste de %{location} le %{date}.
 user_mailer.in_person_failed.subject: Votre identité n’a pas pu être vérifiée en personne

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1840,7 +1840,7 @@ user_mailer.in_person_failed_suspected_fraud.body.help_center_html: 如需要更
 user_mailer.in_person_failed_suspected_fraud.body.intro: 我们知道你曾经试图通过 %{app_name} 验证身份，但是你的身份于 %{date}在 %{location} 邮局未能得到验证。
 user_mailer.in_person_failed_suspected_fraud.greeting: 你好，
 user_mailer.in_person_failed_suspected_fraud.subject: 你的身份未能亲身被验证。
-user_mailer.in_person_failed.body.with_cta: 点击按钮或者复制下面的链接来再次在网上通过 %{sp_or_app_name}验证你的身份。如果你仍然遇到问题，请联系你要访问的政府机构。
+user_mailer.in_person_failed.body.with_cta: 点击按钮或复制下面的链接，尝试通过 %{sp_or_app_name} 再次验证你的身份。
 user_mailer.in_person_failed.body.without_cta: 请尝试从 %{sp_name}的网站再次验证你的身份。如果你仍然遇到问题，请联系你要访问的政府机构。
 user_mailer.in_person_failed.intro: 你的身份于 %{date}在 %{location} 邮局未能得到验证。
 user_mailer.in_person_failed.subject: 你的身份未能亲身被验证。


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13537](https://cm-jira.usa.gov/browse/LG-13537)

## 🛠 Summary of changes

In-person failure to verify email content and translations changed.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1: Edit `app/presenters/idv/in_person/verification_results_email_presenter.rb` so that the last line of `show_cta?` returns true. This allows one to see the proper view when previewing the email.
- [ ] Step 2: Navigate to `localhost:3000/rails/mailers/user_mailer/in_person_failed.html`
- [ ] Step 3: Toggle language to view other translations

Note: The main change here is the removal of the word 'online'.

## 👀 Screenshots

Screenshots are in JIRA ticket for design review.
