### PR TITLE
WIP for allowing unknown AuthnContext values

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,6 +111,7 @@ class ApplicationController < ActionController::Base
         service_provider: service_provider,
         vtr: sp_session[:vtr],
         acr_values: sp_session[:acr_values],
+        saml: !!sp_session[:request_url]&.include?('?SAMLRequest='),
       ).resolve
     end
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -125,6 +125,7 @@ class Analytics
       service_provider:,
       vtr: session[:sp][:vtr],
       acr_values: session[:sp][:acr_values],
+      saml: !!session[:sp][:request_url]&.include?('?SAMLRequest='),
     ).resolve
   rescue Vot::Parser::ParseException
     return

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -75,6 +75,7 @@ class AttributeAsserter
         service_provider: service_provider,
         vtr: saml.vtr,
         acr_values: saml.acr_values,
+        saml: true,
       ).resolve
     end
   end

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class AuthnContextResolver
-  attr_reader :user, :service_provider, :vtr, :acr_values
+  attr_reader :user, :service_provider, :vtr, :acr_values, :saml
 
-  def initialize(user:, service_provider:, vtr:, acr_values:)
+  def initialize(user:, service_provider:, vtr:, acr_values:, saml: false)
     @user = user
     @service_provider = service_provider
     @vtr = vtr
     @acr_values = acr_values
+    @saml = saml
   end
 
   def resolve
@@ -63,7 +64,7 @@ class AuthnContextResolver
   end
 
   def acr_result_without_sp_defaults
-    @acr_result_without_sp_defaults ||= Vot::Parser.new(acr_values: acr_values).parse
+    @acr_result_without_sp_defaults ||= Vot::Parser.new(acr_values:, saml:).parse
   end
 
   def result_with_sp_aal_defaults(result)

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -44,7 +44,7 @@ class SamlRequestValidator
 
     @parsed_vectors_of_trust = begin
       if vtr.present?
-        vtr.map { |vot| Vot::Parser.new(vector_of_trust: vot).parse }
+        vtr.map { |vot| Vot::Parser.new(vector_of_trust: vot, saml: true).parse }
       end
     rescue Vot::Parser::ParseException
       nil
@@ -92,7 +92,8 @@ class SamlRequestValidator
       next true if classref.match?(SamlIdp::Request::VTR_REGEXP) &&
                    IdentityConfig.store.use_vot_in_sp_requests
     end
-    authn_contexts.all? do |classref|
+
+    !authn_contexts.present? || authn_contexts.any? do |classref|
       valid_contexts.include?(classref)
     end
   end

--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -38,11 +38,12 @@ module Vot
       end
     end.freeze
 
-    attr_reader :vector_of_trust, :acr_values
+    attr_reader :vector_of_trust, :acr_values, :saml
 
-    def initialize(vector_of_trust: nil, acr_values: nil)
+    def initialize(vector_of_trust: nil, acr_values: nil, saml: nil)
       @vector_of_trust = vector_of_trust
       @acr_values = acr_values
+      @saml = saml
     end
 
     def parse
@@ -76,8 +77,9 @@ module Vot
       @initial_components ||= component_string.split(component_separator).map do |component_name|
         component_map.fetch(component_name)
       rescue KeyError
+        next if saml
         raise_unsupported_component_exception(component_name)
-      end
+      end.compact
     end
 
     def component_separator
@@ -104,9 +106,10 @@ module Vot
 
     def raise_unsupported_component_exception(component_value_name)
       if vector_of_trust.present?
-        raise ParseException, "#{vector_of_trust} contains unkown component #{component_value_name}"
+        raise ParseException,
+              "#{vector_of_trust} contains unknown component #{component_value_name}"
       else
-        raise ParseException, "#{acr_values} contains unkown acr value #{component_value_name}"
+        raise ParseException, "#{acr_values} contains unknown acr value #{component_value_name}"
       end
     end
 
@@ -114,7 +117,7 @@ module Vot
       if vector_of_trust.present?
         raise ParseException, "#{vector_of_trust} contains duplicate components"
       else
-        raise ParseException, "#{acr_values} ontains duplicate acr values"
+        raise ParseException, "#{acr_values} contains duplicate acr values"
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -460,8 +460,9 @@ RSpec.describe ApplicationController do
 
   describe '#resolved_authn_context_result' do
     let(:sp) { build(:service_provider, ial: 2) }
+    let(:request_url) { 'http://secure.login.gov/' }
 
-    let(:sp_session) { { vtr: vtr, acr_values: acr_values } }
+    let(:sp_session) { { vtr: vtr, acr_values: acr_values, request_url: } }
 
     let(:result) { subject.resolved_authn_context_result }
 
@@ -489,6 +490,17 @@ RSpec.describe ApplicationController do
 
         it 'returns a no-SP result' do
           expect(result).to eq(Vot::Parser::Result.no_sp_result)
+        end
+      end
+
+      context 'an unknow acr value' do
+        context 'a SAML request' do
+          let(:request_url) { 'https://secure.login.gov/api/saml/auth2023?SAMLRequest=' }
+
+          it 'returns a resolved authn context result' do
+            expect(result.aal2?).to eq(true)
+            expect(result.identity_proofing?).to eq(true)
+          end
         end
       end
     end

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe Idv::InPerson::UspsLocationsController, allowed_extra_analytics: 
       it 'requests enhanced ipp locations' do
         expect(AuthnContextResolver).to receive(:new).with(
           user: user, service_provider: sp,
-          vtr: vtr, acr_values: nil
+          vtr: vtr, acr_values: nil,
+          saml: false
         ).and_call_original
         expect(proofer).to receive(:request_facilities).with(address, true)
 

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe SamlRequestValidator do
         )
       end
 
+      context 'valid authn context and also an unknown authncontext' do
+        before do
+          authn_context.push('unknown/authn/context')
+        end
+
+        it 'returns FormResponse with success: true' do
+          expect(response.to_h).to include(
+            success: true,
+            errors: {},
+            **extra,
+          )
+        end
+      end
+
       context 'ialmax authncontext and ialmax provider' do
         let(:authn_context) { [Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF] }
         before do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/51
The backstory is that we have a partner who would like to integrate with Login.gov, but has to send an AuthnContext value that we do not process. (it is a valid AuthnContext for other IdPs that the partner integrates with.)

We currently reject unknown ones, but the spec does not provide any specific guidance about what to do about unknown values.

In terms of what to process, it does read:
> If Comparison is set to "exact" or omitted, then the resulting authentication context in the authentication
> statement MUST be the exact match of at least one of the authentication contexts specified.
so as long as there is a matching AuthnContext that we can process, this should be fine.

## 🛠 Summary of changes
This change allows SAML authentication requests to include unknown AuthnContext values.

The WIP does not include accepting unknown OIDC values. The OIDC spec also does not have guidance about how to process unknown values, so ignoring them as long as there is a valid one we can accept.

Changing both would be my preference. That would keep the implementations more consistent. Also, to get this to work for a SAML-only implementation, I think we have to pass more session information into the VoT::Parser class, which doesn't feel great. (Other suggestions on how to make that work if we decide to do SAML-only would be happily accepted!)

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
