### PR TITLE
Align PIV/CAC setup-after-sign-in specs to user behavior

### DIFF
--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -9,7 +9,6 @@ module Users
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_recently_authenticated_2fa
-    before_action :apply_secure_headers_override, only: :success
     before_action :set_piv_cac_setup_csp_form_action_uris, only: :prompt
 
     def prompt
@@ -18,12 +17,6 @@ module Users
       else
         render_prompt
       end
-    end
-
-    def success; end
-
-    def next
-      redirect_to after_sign_in_path_for(current_user)
     end
 
     def decline

--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -2,9 +2,7 @@
 
 module Users
   class PivCacSetupFromSignInController < ApplicationController
-    include TwoFactorAuthenticatableMethods
     include PivCacConcern
-    include SecureHeadersConcern
     include ReauthenticationRequiredConcern
 
     before_action :confirm_two_factor_authenticated
@@ -12,68 +10,12 @@ module Users
     before_action :set_piv_cac_setup_csp_form_action_uris, only: :prompt
 
     def prompt
-      if params.key?(:token)
-        process_piv_cac_setup
-      else
-        render_prompt
-      end
+      analytics.piv_cac_setup_visited(in_account_creation_flow: false)
     end
 
     def decline
       session.delete(:needs_to_setup_piv_cac_after_sign_in)
       redirect_to after_sign_in_path_for(current_user)
-    end
-
-    private
-
-    def render_prompt
-      analytics.piv_cac_setup_visited(in_account_creation_flow: false)
-      render :prompt
-    end
-
-    def process_piv_cac_setup
-      result = user_piv_cac_form.submit
-      properties = result.to_h.merge(analytics_properties)
-      analytics.multi_factor_auth_setup(**properties)
-      if result.success?
-        process_valid_submission
-      else
-        process_invalid_submission
-      end
-    end
-
-    def user_piv_cac_form
-      @user_piv_cac_form ||= UserPivCacSetupForm.new(
-        user: current_user,
-        token: params[:token],
-        nonce: piv_cac_nonce,
-        name: user_session[:piv_cac_nickname],
-      )
-    end
-
-    def process_invalid_submission
-      redirect_to login_piv_cac_error_url(error: user_piv_cac_form.error_type)
-    end
-
-    def process_valid_submission
-      handle_valid_verification_for_confirmation_context(
-        auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
-      )
-      session.delete(:needs_to_setup_piv_cac_after_sign_in)
-      save_piv_cac_information(
-        subject: user_piv_cac_form.x509_dn,
-        issuer: user_piv_cac_form.x509_issuer,
-        presented: true,
-      )
-      create_user_event(:piv_cac_enabled)
-      redirect_to login_add_piv_cac_success_url
-    end
-
-    def analytics_properties
-      {
-        in_account_creation_flow: false,
-        enabled_mfa_methods_count: MfaContext.new(current_user).enabled_mfa_methods_count,
-      }
     end
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4125,12 +4125,17 @@ module AnalyticsEvents
   # Tracks when the user has added the MFA method piv_cac to their account
   # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
   # @param [Boolean] in_account_creation_flow whether user is going through creation flow
-  def multi_factor_auth_added_piv_cac(enabled_mfa_methods_count:, in_account_creation_flow:,
-                                      **extra)
+  # @param ['piv_cac'] method_name Authentication method added
+  def multi_factor_auth_added_piv_cac(
+    enabled_mfa_methods_count:,
+    in_account_creation_flow:,
+    method_name: :piv_cac,
+    **extra
+  )
     track_event(
       :multi_factor_auth_added_piv_cac,
       {
-        method_name: :piv_cac,
+        method_name:,
         enabled_mfa_methods_count:,
         in_account_creation_flow:,
         **extra,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,8 +142,6 @@ Rails.application.routes.draw do
 
       get 'login/add_piv_cac/prompt' => 'users/piv_cac_setup_from_sign_in#prompt'
       post 'login/add_piv_cac/prompt' => 'users/piv_cac_setup_from_sign_in#decline'
-      get 'login/add_piv_cac/success' => 'users/piv_cac_setup_from_sign_in#success'
-      post 'login/add_piv_cac/success' => 'users/piv_cac_setup_from_sign_in#next'
       get 'login/piv_cac_recommended' => 'users/piv_cac_recommended#show'
       post 'login/piv_cac_recommended/add' => 'users/piv_cac_recommended#confirm'
       post 'login/piv_cac_recommended/skip' => 'users/piv_cac_recommended#skip'

--- a/spec/features/sign_in/setup_piv_cac_after_sign_in_spec.rb
+++ b/spec/features/sign_in/setup_piv_cac_after_sign_in_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe 'Setup PIV/CAC after sign-in' do
+  include SamlAuthHelper
+
+  scenario 'user opts to not add piv/cac card' do
+    perform_steps_to_get_to_add_piv_cac_during_sign_up
+
+    click_on t('forms.piv_cac_setup.no_thanks')
+
+    expect(page).to have_current_path(sign_up_completed_path)
+  end
+
+  context 'without an associated service provider' do
+    scenario 'user opts to not add piv/cac card' do
+      perform_steps_to_get_to_add_piv_cac_during_sign_up(sp: nil)
+
+      click_on t('forms.piv_cac_setup.no_thanks')
+
+      expect(page).to have_current_path(account_path)
+    end
+  end
+
+  scenario 'user opts to add piv/cac card' do
+    perform_steps_to_get_to_add_piv_cac_during_sign_up
+
+    fill_in t('forms.piv_cac_setup.nickname'), with: 'Card 1'
+    click_on t('forms.piv_cac_setup.submit')
+    follow_piv_cac_redirect
+
+    expect(page).to have_current_path(sign_up_completed_path)
+  end
+
+  scenario 'user opts to add piv/cac card but gets an error' do
+    perform_steps_to_get_to_add_piv_cac_during_sign_up
+
+    fill_in t('forms.piv_cac_setup.nickname'), with: 'Card 1'
+    stub_piv_cac_service(error: 'certificate.bad')
+    click_on t('forms.piv_cac_setup.submit')
+    follow_piv_cac_redirect
+
+    expect(page).to have_current_path(setup_piv_cac_error_path(error: 'certificate.bad'))
+  end
+
+  scenario 'user opts to add piv/cac card and has piv cac redirect in CSP' do
+    allow(Identity::Hostdata).to receive(:env).and_return('test')
+    allow(Identity::Hostdata).to receive(:domain).and_return('example.com')
+
+    perform_steps_to_get_to_add_piv_cac_during_sign_up
+
+    expected_form_action = <<-STR.squish
+      form-action https://*.pivcac.test.example.com 'self'
+      http://localhost:7654 https://example.com
+    STR
+
+    expect(page.response_headers['Content-Security-Policy']).
+      to(include(expected_form_action))
+  end
+
+  def perform_steps_to_get_to_add_piv_cac_during_sign_up(sp: :oidc)
+    user = create(:user, :fully_registered, :with_phone)
+    if sp
+      visit_idp_from_sp_with_ial1(sp)
+    else
+      visit new_user_session_path
+    end
+
+    click_on t('account.login.piv_cac')
+    stub_piv_cac_service
+    click_on t('forms.piv_cac_login.submit')
+
+    follow_piv_cac_redirect
+    expect(page).to have_current_path(login_piv_cac_error_path(error: 'user.not_found'))
+    click_on t('instructions.mfa.piv_cac.back_to_sign_in')
+
+    fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+    expect(current_path).to eq login_add_piv_cac_prompt_path
+    fill_in t('forms.piv_cac_setup.nickname'), with: 'Card 1'
+  end
+end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -32,20 +32,6 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
       to have_link t('devise.failure.not_found_in_database_link_text', href: link_url)
   end
 
-  scenario 'user opts to not add piv/cac card' do
-    perform_steps_to_get_to_add_piv_cac_during_sign_up
-    click_on t('forms.piv_cac_setup.no_thanks')
-    expect(current_path).to eq sign_up_completed_path
-  end
-
-  context 'without an associated service provider' do
-    scenario 'user opts to not add piv/cac card' do
-      perform_steps_to_get_to_add_piv_cac_during_sign_up(sp: nil)
-      click_on t('forms.piv_cac_setup.no_thanks')
-      expect(current_path).to eq account_path
-    end
-  end
-
   scenario 'user is suspended, gets show please call page after 2fa' do
     user = create(:user, :fully_registered, :suspended)
     service_provider = ServiceProvider.find_by(issuer: OidcAuthHelper::OIDC_IAL1_ISSUER)
@@ -59,22 +45,6 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
     click_submit_default
 
     expect(current_path).to eq(user_please_call_path)
-  end
-
-  scenario 'user opts to add piv/cac card' do
-    perform_steps_to_get_to_add_piv_cac_during_sign_up
-    nonce = piv_cac_nonce_from_form_action
-    visit_piv_cac_service(
-      current_url,
-      nonce: nonce,
-      dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-      uuid: SecureRandom.uuid,
-      subject: 'SomeIgnoredSubject',
-    )
-
-    expect(current_path).to eq login_add_piv_cac_success_path
-    click_continue
-    expect(current_path).to eq sign_up_completed_path
   end
 
   scenario 'user with old terms of use can accept and continue to IAL1 SP' do
@@ -130,36 +100,6 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
     expect(current_url).to eq rules_of_use_url
     accept_rules_of_use_and_continue_if_displayed
     expect(oidc_redirect_url).to start_with service_provider.redirect_uris.first
-  end
-
-  scenario 'user opts to add piv/cac card but gets an error' do
-    perform_steps_to_get_to_add_piv_cac_during_sign_up
-    nonce = piv_cac_nonce_from_form_action
-    visit_piv_cac_service(
-      current_url,
-      nonce: nonce,
-      dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-      uuid: SecureRandom.uuid,
-      error: 'certificate.bad',
-      subject: 'SomeIgnoredSubject',
-    )
-
-    expect(page).to have_current_path(login_piv_cac_error_path(error: 'certificate.bad'))
-  end
-
-  scenario 'user opts to add piv/cac card and has piv cac redirect in CSP' do
-    allow(Identity::Hostdata).to receive(:env).and_return('test')
-    allow(Identity::Hostdata).to receive(:domain).and_return('example.com')
-
-    perform_steps_to_get_to_add_piv_cac_during_sign_up
-
-    expected_form_action = <<-STR.squish
-      form-action https://*.pivcac.test.example.com 'self'
-      http://localhost:7654 https://example.com
-    STR
-
-    expect(page.response_headers['Content-Security-Policy']).
-      to(include(expected_form_action))
   end
 
   scenario 'User with gov/mil email directed to recommended PIV page' do
@@ -1093,35 +1033,6 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
       response = page.driver.post(action_url)
       expect(response).to be_redirect
     end
-  end
-
-  def perform_steps_to_get_to_add_piv_cac_during_sign_up(sp: :oidc)
-    user = create(:user, :fully_registered, :with_phone)
-    if sp
-      visit_idp_from_sp_with_ial1(sp)
-    else
-      visit new_user_session_path
-    end
-    click_on t('account.login.piv_cac')
-    allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
-
-    stub_piv_cac_service
-    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
-    visit_piv_cac_service(
-      current_url,
-      nonce: nonce,
-      dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-      uuid: SecureRandom.uuid,
-      subject: 'SomeIgnoredSubject',
-    )
-
-    expect(page).to have_current_path(login_piv_cac_error_path(error: 'user.not_found'))
-    visit new_user_session_path
-    fill_in_credentials_and_submit(user.email, user.password)
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-    expect(current_path).to eq login_add_piv_cac_prompt_path
-    fill_in 'name', with: 'Card 1'
   end
 
   def with_forgery_protection


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-13477](https://cm-jira.usa.gov/browse/LG-13477) (#10918)

## 🛠 Summary of changes

Updates feature specs targeting the expected behavior for prompting a user to add a PIV to their account after signing in when having previously failed logging in with PIV due to the card not being associated with a user.

Specifically:

- Shifts specs to a new file, since there's several scenarios related to this behavior, and this helps keep the size of `features/users/sign_in_spec.rb` in check
- Improves `stub_piv_cac_service` to behave more realistically to the deployed user behavior
   - Previously, the tests would manually "visit" the PKI service with the assumption that the user would always be redirected back to the current URL. This is not true for PIV/CAC setup after sign-in, which [submits to the default PIV/CAC enrollment route](https://github.com/18F/identity-idp/blob/3f564bd8767160336b62060e86502a16ee8d0dc1/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb#L13) and would therefore be redirected back _there_ after returning from the PKI service
- Removes unused code related to processing a token returned by the PKI service from `PivCacSetupFromSignInController`
   - As described under the previous bullet, these routes are never actually visited in the current live experience, and instead the user goes through `/present_piv_cac` (`PivCacAuthenticationSetupController`)

## 📜 Testing Plan

Verify specs pass:

```
rspec spec/features/sign_in/setup_piv_cac_after_sign_in_spec.rb
```

Ensure no regressions in the expected behavior:

1. Prerequisite: Remove any PIV/CAC association with existing account
2. Click “Sign in with your government employee ID”
3. Click “Insert your PIV/CAC”
4. Authenticate with your PIV
5. See error message “Your PIV/CAC is not connected to an account”
6. Click “Sign in” (or “Go back to sign in”)
7. Proceed to sign in to your account
8. See screen “Add your PIV or CAC”
9. Enter a nickname in the “PIV/CAC nickname” field
10. Click “Add PIV/CAC card”
11. Observe you're still redirected to the account page successfully upon enrollment