### PR TITLE
Translate Post Office search results

### DIFF
--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -18,17 +18,24 @@ module Idv
           )
           locations = proofer.request_facilities(candidate, false)
 
-          render json: locations.to_json
+          render json: localized_locations(locations).to_json
         end
 
         def options
           head :ok
         end
 
-        protected
+        private
 
         def proofer
           @proofer ||= UspsInPersonProofing::EnrollmentHelper.usps_proofer
+        end
+
+        def localized_locations(locations)
+          return nil if locations.nil?
+          locations.map do |location|
+            UspsInPersonProofing::EnrollmentHelper.localized_location(location)
+          end
         end
 
         def enabled?

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -27,18 +27,18 @@ module Idv
           zip_code: search_params['zip_code']
         )
         is_enhanced_ipp = resolved_authn_context_result.enhanced_ipp?
-        response = proofer.request_facilities(candidate, is_enhanced_ipp)
-        if response.length > 0
+        locations = proofer.request_facilities(candidate, is_enhanced_ipp)
+        if locations.length > 0
           analytics.idv_in_person_locations_searched(
             success: true,
-            result_total: response.length,
+            result_total: locations.length,
           )
         else
           analytics.idv_in_person_locations_searched(
             success: false, errors: 'No USPS locations found',
           )
         end
-        render json: response.to_json
+        render json: localized_locations(locations).to_json
       end
 
       # save the Post Office location the user selected to an enrollment
@@ -62,6 +62,13 @@ module Idv
         ProofingComponent.
           create_or_find_by(user: current_or_hybrid_user).
           update(document_check: Idp::Constants::Vendors::USPS)
+      end
+
+      def localized_locations(locations)
+        return nil if locations.nil?
+        locations.map do |location|
+          EnrollmentHelper.localized_location(location)
+        end
       end
 
       def handle_error(err)

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -31,7 +31,7 @@ module Idv
       def selected_location_hours(prefix)
         return unless selected_location_details
         hours = selected_location_details["#{prefix}_hours"]
-        localized_hours(hours)
+        UspsInPersonProofing::EnrollmentHelper.localized_hours(hours)
       end
 
       def service_provider
@@ -105,26 +105,6 @@ module Idv
 
       def format_outage_date(date)
         I18n.l(date.to_date, format: :short)
-      end
-
-      def localized_hours(hours)
-        return nil if hours.nil?
-
-        if hours == 'Closed'
-          I18n.t('in_person_proofing.body.barcode.retail_hours_closed')
-        elsif hours.include?(' - ') # Hyphen
-          hours.
-            split(' - '). # Hyphen
-            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
-            join(' – ') # Endash
-        elsif hours.include?(' – ') # Endash
-          hours.
-            split(' – '). # Endash
-            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
-            join(' – ') # Endash
-        else
-          hours
-        end
       end
 
       def sp_return_url_resolver

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -102,6 +102,42 @@ module UspsInPersonProofing
         end
       end
 
+      def localized_location(location)
+        {
+          address: location.address,
+          city: location.city,
+          distance: location.distance,
+          name: location.name,
+          saturday_hours: EnrollmentHelper.localized_hours(location.saturday_hours),
+          state: location.state,
+          sunday_hours: EnrollmentHelper.localized_hours(location.sunday_hours),
+          weekday_hours: EnrollmentHelper.localized_hours(location.weekday_hours),
+          zip_code_4: location.zip_code_4,
+          zip_code_5: location.zip_code_5,
+          is_pilot: location.is_pilot,
+        }
+      end
+
+      def localized_hours(hours)
+        return nil if hours.nil?
+
+        if hours == 'Closed'
+          I18n.t('in_person_proofing.body.barcode.retail_hours_closed')
+        elsif hours.include?(' - ') # Hyphen
+          hours.
+            split(' - '). # Hyphen
+            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
+            join(' – ') # Endash
+        elsif hours.include?(' – ') # Endash
+          hours.
+            split(' – '). # Endash
+            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
+            join(' – ') # Endash
+        else
+          hours
+        end
+      end
+
       private
 
       SECONDARY_ID_ADDRESS_MAP = {

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -66,33 +66,44 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
   end
 
   describe '#selected_location_hours' do
-    let(:hours_open) { '8:00 AM - 4:30 PM' }
-    let(:hours_closed) { 'Closed' }
-
-    before do
-      allow(presenter).to receive(:selected_location_details).and_return(
-        {
-          'weekday_hours' => hours_open,
-          'saturday_hours' => hours_open,
-          'sunday_hours' => hours_closed,
-        },
-      )
-    end
-
     it 'returns localized location hours for weekdays and weekends by prefix' do
-      expect(presenter.selected_location_hours(:weekday)).to eq '8:00 AM – 4:30 PM'
-      expect(presenter.selected_location_hours(:saturday)).to eq '8:00 AM – 4:30 PM'
+      expect(presenter.selected_location_hours(:weekday)).to eq '9:00 AM – 5:00 PM'
+      expect(presenter.selected_location_hours(:saturday)).to eq '9:00 AM – 1:00 PM'
       expect(presenter.selected_location_hours(:sunday)).to eq(
         I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
       )
+    end
+
+    context 'with previously localized hours' do
+      let(:enrollment_selected_location_details) do
+        json = JSON.parse(UspsInPersonProofing::Mock::Fixtures.enrollment_selected_location_details)
+        json['weekday_hours'] = UspsInPersonProofing::EnrollmentHelper.localized_hours(
+          json['weekday_hours'],
+        )
+        json['saturday_hours'] = UspsInPersonProofing::EnrollmentHelper.localized_hours(
+          json['saturday_hours'],
+        )
+        json['sunday_hours'] = UspsInPersonProofing::EnrollmentHelper.localized_hours(
+          json['sunday_hours'],
+        )
+        json
+      end
+
+      it 'localizes appropriately' do
+        expect(presenter.selected_location_hours(:weekday)).to eq '9:00 AM – 5:00 PM'
+        expect(presenter.selected_location_hours(:saturday)).to eq '9:00 AM – 1:00 PM'
+        expect(presenter.selected_location_hours(:sunday)).to eq(
+          I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
+        )
+      end
     end
 
     context 'with Spanish locale' do
       before { I18n.locale = :es }
 
       it 'returns localized location hours for weekdays and weekends by prefix' do
-        expect(presenter.selected_location_hours(:weekday)).to eq '8:00 AM – 4:30 PM'
-        expect(presenter.selected_location_hours(:saturday)).to eq '8:00 AM – 4:30 PM'
+        expect(presenter.selected_location_hours(:weekday)).to eq '9:00 AM – 5:00 PM'
+        expect(presenter.selected_location_hours(:saturday)).to eq '9:00 AM – 1:00 PM'
         expect(presenter.selected_location_hours(:sunday)).to eq(
           I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
         )
@@ -103,8 +114,8 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
       before { I18n.locale = :fr }
 
       it 'returns localized location hours for weekdays and weekends by prefix' do
-        expect(presenter.selected_location_hours(:weekday)).to eq '8 h 00 AM – 4 h 30 PM'
-        expect(presenter.selected_location_hours(:saturday)).to eq '8 h 00 AM – 4 h 30 PM'
+        expect(presenter.selected_location_hours(:weekday)).to eq '9 h 00 AM – 5 h 00 PM'
+        expect(presenter.selected_location_hours(:saturday)).to eq '9 h 00 AM – 1 h 00 PM'
         expect(presenter.selected_location_hours(:sunday)).to eq(
           I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
         )

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -121,6 +121,18 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
         )
       end
     end
+
+    context 'with Chinese locale' do
+      before { I18n.locale = :zh }
+
+      it 'returns localized location hours for weekdays and weekends by prefix' do
+        expect(presenter.selected_location_hours(:weekday)).to eq '9:00 AM – 5:00 PM'
+        expect(presenter.selected_location_hours(:saturday)).to eq '9:00 AM – 1:00 PM'
+        expect(presenter.selected_location_hours(:sunday)).to eq(
+          I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
+        )
+      end
+    end
   end
 
   describe '#sp_name' do


### PR DESCRIPTION
## 🛠 Summary of changes

Follow up to https://github.com/18F/identity-idp/pull/10925  (and #10882 / #10912) that implements the remainder of the changes to display translated results for Post Office search. This should not be merged until #10925 has been deployed.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
