### PR TITLE
Allow OIDC routes to be localizable

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,11 +53,6 @@ Rails.application.routes.draw do
   post '/api/verify/images' => 'idv/image_uploads#create'
   post '/api/logger' => 'frontend_log#create'
 
-  get '/openid_connect/authorize' => 'openid_connect/authorization#index'
-  get '/openid_connect/logout' => 'openid_connect/logout#show'
-  post '/openid_connect/logout' => 'openid_connect/logout#create'
-  delete '/openid_connect/logout' => 'openid_connect/logout#delete'
-
   get '/robots.txt' => 'robots#index'
   get '/no_js/detect.css' => 'no_js#index', as: :no_js_detect_css
 
@@ -274,6 +269,11 @@ Rails.application.routes.draw do
     delete '/manage/auth_app/:id' => 'users/auth_app#destroy', as: nil
     get '/account/personal_key' => 'accounts/personal_keys#new', as: :create_new_personal_key
     post '/account/personal_key' => 'accounts/personal_keys#create'
+
+    get '/openid_connect/authorize' => 'openid_connect/authorization#index'
+    get '/openid_connect/logout' => 'openid_connect/logout#show'
+    post '/openid_connect/logout' => 'openid_connect/logout#create'
+    delete '/openid_connect/logout' => 'openid_connect/logout#delete'
 
     get '/otp/send' => 'users/two_factor_authentication#send_code'
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where trying to change the language on the OpenID Connect logout confirmation screen results in a 404 page, by allowing the pages to be localizable (within the `:locale` block in the `routes.rb` file).

The only other routes defined out side the `:locale` block are not meant to be human-facing.

## 📜 Testing Plan

1. Prerequisite: Have the [OIDC sample application](https://github.com/18f/identity-oidc-sinatra) running in a separate process
2. Visit http://localhost:9292
3. Click "Sign in"
4. Complete sign-in
5. At SP, click "Sign out"
6. Observe OIDC logout screen
7. Change language of the page using the language selector

Before: You'd see a 404
After: You see the page translated in the language you're expecting

Verify there are no regressions in other places which reference these URLs.

Example: http://localhost:3000/.well-known/openid-configuration

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/815502c0-04a7-4a01-b49a-a17d854f3cc1)|![image](https://github.com/user-attachments/assets/39995565-72a3-4b3d-b906-a641f6cd5166)
