### PR TITLE
Use improved PKI service test stub consistently

### DIFF
--- a/spec/features/openid_connect/vtr_spec.rb
+++ b/spec/features/openid_connect/vtr_spec.rb
@@ -88,15 +88,10 @@ RSpec.feature 'OIDC requests using VTR', allowed_extra_analytics: [:*] do
     expect(page).to have_content(t('two_factor_authentication.two_factor_hspd12_choice_intro'))
 
     # User must setup PIV/CAC before continuing
-    visit setup_piv_cac_path
-
-    nonce = piv_cac_nonce_from_form_action
-    visit_piv_cac_service(
-      setup_piv_cac_url,
-      nonce: nonce,
-      uuid: SecureRandom.uuid,
-      subject: 'SomeIgnoredSubject',
-    )
+    select_2fa_option('piv_cac')
+    fill_in t('instructions.mfa.piv_cac.step_1'), with: 'Card'
+    click_on t('forms.piv_cac_setup.submit')
+    follow_piv_cac_redirect
 
     click_agree_and_continue
     click_on 'Continue'

--- a/spec/features/saml/vtr_spec.rb
+++ b/spec/features/saml/vtr_spec.rb
@@ -116,16 +116,11 @@ RSpec.feature 'SAML requests using VTR', allowed_extra_analytics: [:*] do
     expect(page).to have_content(t('two_factor_authentication.two_factor_hspd12_choice_intro'))
 
     # User must setup PIV/CAC before continuing
-    visit setup_piv_cac_path
-    nonce = piv_cac_nonce_from_form_action
-    visit_piv_cac_service(
-      setup_piv_cac_url,
-      nonce: nonce,
-      uuid: SecureRandom.uuid,
-      subject: 'SomeIgnoredSubject',
-    )
+    select_2fa_option('piv_cac')
+    fill_in t('instructions.mfa.piv_cac.step_1'), with: 'Card'
+    click_on t('forms.piv_cac_setup.submit')
+    follow_piv_cac_redirect
 
-    click_submit_default
     click_agree_and_continue
     click_submit_default
     expect_successful_saml_redirect

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -405,36 +405,24 @@ RSpec.feature 'Two Factor Authentication', allowed_extra_analytics: [:*] do
     end
 
     scenario 'user uses PIV/CAC as their second factor' do
-      stub_piv_cac_service
-
       user = user_with_piv_cac
       sign_in_before_2fa(user)
+      stub_piv_cac_service(uuid: user.piv_cac_configurations.first.x509_dn_uuid)
 
-      nonce = visit_login_two_factor_piv_cac_and_get_nonce
+      click_on t('forms.piv_cac_mfa.submit')
+      follow_piv_cac_redirect
 
-      visit_piv_cac_service(
-        login_two_factor_piv_cac_path,
-        uuid: user.piv_cac_configurations.first.x509_dn_uuid,
-        dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-        nonce: nonce,
-      )
       expect(current_path).to eq account_path
     end
 
     scenario 'user uses incorrect PIV/CAC as their second factor' do
-      stub_piv_cac_service
-
       user = user_with_piv_cac
       sign_in_before_2fa(user)
+      stub_piv_cac_service(uuid: Random.uuid)
 
-      nonce = visit_login_two_factor_piv_cac_and_get_nonce
+      click_on t('forms.piv_cac_mfa.submit')
+      follow_piv_cac_redirect
 
-      visit_piv_cac_service(
-        login_two_factor_piv_cac_path,
-        uuid: user.piv_cac_configurations.first.x509_dn_uuid + 'X',
-        dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.12345',
-        nonce: nonce,
-      )
       expect(current_path).to eq login_two_factor_piv_cac_path
       expect(page).to have_content(t('two_factor_authentication.invalid_piv_cac'))
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -132,14 +132,8 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
     allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
 
     stub_piv_cac_service
-    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
-    visit_piv_cac_service(
-      current_url,
-      nonce: nonce,
-      dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-      uuid: SecureRandom.uuid,
-      subject: 'SomeIgnoredSubject',
-    )
+    click_on t('forms.piv_cac_login.submit')
+    follow_piv_cac_redirect
 
     expect(page).to have_current_path(login_piv_cac_error_path(error: 'user.not_found'))
     visit sign_up_email_path

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -64,21 +64,14 @@ module Features
     end
 
     def signin_with_piv_error(error)
-      user = user_with_piv_cac
       visit new_user_session_path
       click_on t('account.login.piv_cac')
 
       allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
 
-      stub_piv_cac_service
-      nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
-      visit_piv_cac_service(
-        current_url,
-        nonce: nonce,
-        uuid: user.piv_cac_configurations.first.x509_dn_uuid,
-        subject: 'SomeIgnoredSubject',
-        error: error,
-      )
+      stub_piv_cac_service(error:)
+      click_on t('forms.piv_cac_login.submit')
+      follow_piv_cac_redirect
     end
 
     def signin_with_bad_piv
@@ -93,14 +86,9 @@ module Features
                                                  piv_cac_configurations&.first&.x509_dn_uuid)
       allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
 
-      stub_piv_cac_service
-      nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
-      visit_piv_cac_service(
-        current_url,
-        nonce: nonce,
-        uuid: uuid,
-        subject: 'SomeIgnoredSubject',
-      )
+      stub_piv_cac_service(uuid:)
+      click_on t('forms.piv_cac_login.submit')
+      follow_piv_cac_redirect
     end
 
     def fill_in_bad_piv_cac_credentials_and_submit
@@ -537,16 +525,9 @@ module Features
     def set_up_2fa_with_piv_cac
       stub_piv_cac_service
       select_2fa_option('piv_cac')
-
-      expect(page).to have_current_path setup_piv_cac_path
-
-      nonce = piv_cac_nonce_from_form_action
-      visit_piv_cac_service(
-        setup_piv_cac_url,
-        nonce: nonce,
-        uuid: SecureRandom.uuid,
-        subject: 'SomeIgnoredSubject',
-      )
+      fill_in t('instructions.mfa.piv_cac.step_1'), with: 'Card'
+      click_on t('forms.piv_cac_setup.submit')
+      follow_piv_cac_redirect
     end
 
     def skip_second_mfa_prompt
@@ -559,7 +540,7 @@ module Features
       click_submit_default
     end
 
-    def stub_piv_cac_service(error: nil)
+    def stub_piv_cac_service(error: nil, uuid: Random.uuid)
       allow(IdentityConfig.store).to receive(:identity_pki_disabled).and_return(false)
       allow(IdentityConfig.store).to receive(:piv_cac_service_url).
         and_return('http://piv.example.com/')
@@ -582,7 +563,7 @@ module Features
                 query['redirect_uri'],
                 token: {
                   dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-                  uuid: SecureRandom.uuid,
+                  uuid:,
                   subject: 'SomeIgnoredSubject',
                   nonce: query['nonce'],
                   error:,
@@ -598,36 +579,6 @@ module Features
       # submit a request to the `current_url` and get the redirect header.
       redirect_url = Faraday.post(current_url).headers['location']
       visit redirect_url
-    end
-
-    def visit_piv_cac_service(idp_url, token_data)
-      visit(idp_url + '?token=' + CGI.escape(token_data.to_json))
-    end
-
-    def visit_login_two_factor_piv_cac_and_get_nonce
-      visit login_two_factor_piv_cac_path
-      get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_mfa.submit')))
-    end
-
-    # This is a bit convoluted because we generate a nonce when we visit the
-    # link. The link provides a redirect to the piv/cac service with the nonce.
-    # This way, even if JavaScript fetches the link to grab the nonce, a new nonce
-    # is generated when the user clicks on the link.
-    def get_piv_cac_nonce_from_link(link)
-      go_back = current_path
-      visit link['href']
-      nonce = Rack::Utils.parse_nested_query(URI(current_url).query)['nonce']
-      visit go_back
-      nonce
-    end
-
-    def piv_cac_nonce_from_form_action
-      go_back = current_path
-      fill_in 'name', with: 'Card ' + SecureRandom.uuid
-      click_button t('forms.piv_cac_setup.submit')
-      nonce = Rack::Utils.parse_nested_query(URI(current_url).query)['nonce']
-      visit go_back
-      nonce
     end
 
     def link_identity(user, service_provider, ial = nil)


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-13477](https://cm-jira.usa.gov/browse/LG-13477) (https://github.com/18F/identity-idp/pull/10918)

## 🛠 Summary of changes

Builds upon the changes in #10939 to use the new `stub_piv_cac_service` enhancements consistently throughout existing specs, removing the `visit_piv_cac_service` method and related spec helpers.

As mentioned in #10939, the goal is to have this behave more realistically to the live implementation, and to have the tests interact with the page in the same way a user would. Previously, we relied heavily on visiting specific URLs that don't necessarily follow from interactions on the page.

## 📜 Testing Plan

Verify build passes.