### PR TITLE
LG-13123 Log when `GpoConfirmationUploader` uploads `GpoConfirmations`

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -672,7 +672,7 @@ module AnalyticsEvents
 
   # @param [Boolean] success Whether records were successfully uploaded
   # @param [String] exception The exception that occured if an exception did occur
-  # @param [Number] gpo_confirmation_count The number of GPO Confirmation records uplaoded
+  # @param [Number] gpo_confirmation_count The number of GPO Confirmation records uploaded
   # GPO confirmation records were uploaded for letter sends
   def gpo_confirmation_upload(
     success:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -670,6 +670,25 @@ module AnalyticsEvents
     )
   end
 
+  # @params [Boolean] success Whether records were successfully uploaded
+  # @params [String] exception The exception that occured if an exception did occur
+  # @param [Number] gpo_confirmation_count The number of GPO Confirmation records uplaoded
+  # GPO confirmation records were uploaded for letter sends
+  def gpo_confirmation_upload(
+    success:,
+    exception:,
+    gpo_confirmation_count:,
+    **extra
+  )
+    track_event(
+      :gpo_confirmation_upload,
+      success: success,
+      exception: exception,
+      gpo_confirmation_count: gpo_confirmation_count,
+      **extra,
+    )
+  end
+
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
   # @param [String] flow_path whether the user is in the hybrid or standard flow

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -670,8 +670,8 @@ module AnalyticsEvents
     )
   end
 
-  # @params [Boolean] success Whether records were successfully uploaded
-  # @params [String] exception The exception that occured if an exception did occur
+  # @param [Boolean] success Whether records were successfully uploaded
+  # @param [String] exception The exception that occured if an exception did occur
   # @param [Number] gpo_confirmation_count The number of GPO Confirmation records uplaoded
   # GPO confirmation records were uploaded for letter sends
   def gpo_confirmation_upload(

--- a/app/services/gpo_confirmation_uploader.rb
+++ b/app/services/gpo_confirmation_uploader.rb
@@ -12,7 +12,13 @@ class GpoConfirmationUploader
     upload_export(export)
     LetterRequestsToGpoFtpLog.create(ftp_at: @now, letter_requests_count: confirmations.count)
     clear_confirmations(confirmations)
+    analytics.gpo_confirmation_upload(
+      success: true, exception: nil, gpo_confirmation_count: confirmations.count,
+    )
   rescue StandardError => error
+    analytics.gpo_confirmation_upload(
+      success: false, exception: error.to_s, gpo_confirmation_count: 0,
+    )
     NewRelic::Agent.notice_error(error)
     raise error
   end
@@ -70,5 +76,9 @@ class GpoConfirmationUploader
       password: IdentityConfig.store.usps_upload_sftp_password,
       timeout: IdentityConfig.store.usps_upload_sftp_timeout,
     ]
+  end
+
+  def analytics
+    Analytics.new(user: AnonymousUser.new, request: nil, session: {}, sp: nil)
   end
 end

--- a/spec/services/gpo_confirmation_uploader_spec.rb
+++ b/spec/services/gpo_confirmation_uploader_spec.rb
@@ -23,8 +23,11 @@ RSpec.describe GpoConfirmationUploader do
     ]
   end
 
+  let(:job_analytics) { FakeAnalytics.new }
+
   before do
     allow(IdentityConfig.store).to receive(:usps_upload_enabled).and_return(true)
+    allow(uploader).to receive(:analytics).and_return(job_analytics)
   end
 
   describe '#generate_export' do
@@ -111,13 +114,20 @@ RSpec.describe GpoConfirmationUploader do
         log = logs.first
         expect(log.ftp_at).to be_present
         expect(log.letter_requests_count).to eq(1)
+        expect(job_analytics).to have_logged_event(
+          :gpo_confirmation_upload,
+          success: true,
+          exception: nil,
+          gpo_confirmation_count: confirmations.count,
+        )
       end
     end
 
     context 'when there is an error' do
       it 'notifies NewRelic and does not clear confirmations if SFTP fails' do
         expect(uploader).to receive(:generate_export).with(confirmations).and_return(export)
-        expect(uploader).to receive(:upload_export).with(export).and_raise(StandardError)
+        expect(uploader).to receive(:upload_export).with(export).
+          and_raise(StandardError, 'test error')
         expect(uploader).not_to receive(:clear_confirmations)
 
         expect(NewRelic::Agent).to receive(:notice_error)
@@ -125,6 +135,12 @@ RSpec.describe GpoConfirmationUploader do
         expect { subject }.to raise_error
 
         expect(GpoConfirmation.count).to eq 1
+        expect(job_analytics).to have_logged_event(
+          :gpo_confirmation_upload,
+          success: false,
+          exception: 'test error',
+          gpo_confirmation_count: 0,
+        )
       end
     end
 


### PR DESCRIPTION
We have observed a number of issues with the `GpoConfirmationUploader`. We are adding more visibility to the job to improve our monitoring and alerting to deal with failures.

This commit adds a line to `events.log` when confirmations get uploaded. It includes a count of the confirmations that were uploaded so we can build a metric for that.

This new logging is in addition to the records that get written to the `letter_requests_to_usps_ftp_logs` which are used in monthly reports.
