### PR TITLE
LG-13820 Redirect from request letter controller when letter send is not available

### DIFF
--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -10,6 +10,7 @@ module Idv
 
       before_action :confirm_mail_not_rate_limited
       before_action :confirm_step_allowed
+      before_action :confirm_letter_sends_allowed
 
       def index
         @applicant = idv_session.applicant
@@ -33,7 +34,7 @@ module Idv
           action: :index,
           next_steps: [:enter_password],
           preconditions: ->(idv_session:, user:) do
-            idv_session.verify_info_step_complete? || user.gpo_verification_pending_profile?
+            idv_session.verify_info_step_complete?
           end,
           undo_step: ->(idv_session:, user:) { idv_session.address_verification_mechanism = nil },
         )
@@ -53,6 +54,10 @@ module Idv
 
       def confirm_mail_not_rate_limited
         redirect_to idv_enter_password_url if gpo_verify_by_mail_policy.rate_limited?
+      end
+
+      def confirm_letter_sends_allowed
+        redirect_to idv_enter_password_url if !gpo_verify_by_mail_policy.send_letter_available?
       end
 
       def step_indicator_steps

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe Idv::ByMail::RequestLetterController,
 
       expect(response).to redirect_to idv_enter_password_path
     end
+
+    it 'redirects if the user is not allowed to send mail' do
+      allow(controller.gpo_verify_by_mail_policy).to receive(:send_letter_available?).
+        and_return(false)
+
+      get :index
+
+      expect(response).to redirect_to idv_enter_password_path
+    end
   end
 
   describe '#create' do

--- a/spec/features/idv/gpo_disabled_spec.rb
+++ b/spec/features/idv/gpo_disabled_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'disabling GPO address verification', allowed_extra_analytics: [:*
       Rails.application.reload_routes!
     end
 
-    it 'allows verification without the option to confirm address with usps', js: true do
+    it 'allows verification without the option to confirm address with usps', :js do
       user = user_with_2fa
       start_idv_from_sp
       complete_idv_steps_before_phone_step(user)
@@ -34,6 +34,39 @@ RSpec.feature 'disabling GPO address verification', allowed_extra_analytics: [:*
       acknowledge_and_confirm_personal_key
 
       expect(page).to have_current_path(sign_up_completed_path)
+    end
+  end
+
+  context 'with GPO address verification disallowed for biometric comparison' do
+    before do
+      allow(IdentityConfig.store).to receive(:no_verify_by_mail_for_biometric_comparison_enabled).
+        and_return(true)
+      allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
+    end
+
+    it 'does not allow verify by mail with biometric comparison', :js do
+      user = user_with_2fa
+      start_idv_from_sp(:oidc, biometric_comparison_required: true)
+      sign_in_and_2fa_user(user)
+      complete_all_doc_auth_steps(with_selfie: true)
+
+      # Link to the GPO flow should not be visible
+      expect(page).to_not have_content(t('idv.troubleshooting.options.verify_by_mail'))
+
+      # Directly visiting the verify my mail path does not allow the user to request a letter
+      visit idv_request_letter_path
+      expect(page).to have_current_path(idv_phone_path)
+    end
+
+    it 'does allow verify by mail without biometric comparison', :js do
+      user = user_with_2fa
+      start_idv_from_sp(:oidc, biometric_comparison_required: false)
+      sign_in_and_2fa_user(user)
+      complete_all_doc_auth_steps(with_selfie: false)
+      click_on t('idv.troubleshooting.options.verify_by_mail')
+
+      # The user is allowed to visit the request letter path
+      expect(page).to have_current_path(idv_request_letter_path)
     end
   end
 end


### PR DESCRIPTION
This commit fixes a bug where the `RequestLetterController` was not respecting `GpoVerifyByMailPolicy#send_letter_available?`. If that method returned false then links would be hidden but users could still visit the controller directly and request letters.

This commit adds a before action to fix the issue and adds tests.
