### PR TITLE
Split utilities stylesheet to standalone file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ lint_asset_bundle_size: ## Lints JavaScript and CSS compiled bundle size
 	@# and you have no options to split that from the common bundles. If you need to increase this
 	@# budget and accept the fact that this will force end-users to endure longer load times, you
 	@# should set the new budget to within a few thousand bytes of the production-compiled size.
-	find app/assets/builds/application.css -size -185000c | grep .
+	find app/assets/builds/application.css -size -105000c | grep .
 	find public/packs/application-*.digested.js -size -5000c | grep .
 
 lint_migrations:

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -3,5 +3,3 @@
 @forward 'uswds';
 @forward 'design-system-waiting-room';
 @forward 'components';
-@forward 'uswds-utilities';
-@forward 'utilities';

--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -1,0 +1,3 @@
+@forward 'uswds-core';
+@forward 'uswds-utilities';
+@forward 'utilities';

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -20,8 +20,9 @@
   <% end %>
   <%= preload_link_tag font_path('public-sans/PublicSans-Bold.woff2') %>
   <%= preload_link_tag font_path('public-sans/PublicSans-Regular.woff2') %>
-  <%= render_stylesheet_once_tags %>
   <%= stylesheet_link_tag 'application', nopush: false %>
+  <%= render_stylesheet_once_tags %>
+  <%= stylesheet_link_tag 'utilities', nopush: false %>
   <%= stylesheet_link_tag 'print', media: :print, preload_links_header: false %>
   <%= csrf_meta_tags %>
 

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -2,8 +2,9 @@
 <html>
   <head>
     <title>Component Preview</title>
+    <%= stylesheet_link_tag 'application', nopush: false %>
     <%= render_stylesheet_once_tags %>
-    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= stylesheet_link_tag 'utilties', nopush: false %>
   </head>
   <body class="height-auto padding-2 <%= params.dig(:lookbook, :display, :body_class) %>">
     <% if params.dig(:lookbook, :display, :form) == true %>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -4,7 +4,7 @@
     <title>Component Preview</title>
     <%= stylesheet_link_tag 'application', nopush: false %>
     <%= render_stylesheet_once_tags %>
-    <%= stylesheet_link_tag 'utilties', nopush: false %>
+    <%= stylesheet_link_tag 'utilities', nopush: false %>
   </head>
   <body class="height-auto padding-2 <%= params.dig(:lookbook, :display, :body_class) %>">
     <% if params.dig(:lookbook, :display, :form) == true %>

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -9,7 +9,7 @@
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', nopush: false %>
     <%= render_stylesheet_once_tags %>
-    <%= stylesheet_link_tag 'utilties', nopush: false %>
+    <%= stylesheet_link_tag 'utilities', nopush: false %>
   </head>
   <body>
     <div class="grid-container tablet:padding-y-6 no-js">

--- a/app/views/saml_idp/shared/saml_post_binding.html.erb
+++ b/app/views/saml_idp/shared/saml_post_binding.html.erb
@@ -7,8 +7,9 @@
       document.documentElement.classList.replace('no-js', 'js');
     <% end %>
     <%= csrf_meta_tags %>
-    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= stylesheet_link_tag 'application', nopush: false %>
     <%= render_stylesheet_once_tags %>
+    <%= stylesheet_link_tag 'utilties', nopush: false %>
   </head>
   <body>
     <div class="grid-container tablet:padding-y-6 no-js">


### PR DESCRIPTION
## 🛠 Summary of changes

Splits utilities out of `application.css` to its own standalone stylesheet `utilities.css`.

**Why?**

- **Predictability**. There have been a number of issues ([[1]](https://github.com/18F/identity-idp/pull/10898#discussion_r1662668282) [[2]](https://github.com/18F/identity-idp/pull/10394#issuecomment-2049857818)) related to the load order of stylesheets, and particularly utility classes and the relative ordering of the design system styles and our application-specific styles. This new implementation ensures that the general priority ordering of `utilities > application styles > design system styles` takes effect.
- **Performance**. While there's not expected to be a net reduction in overall page size, splitting the stylesheets into smaller chunks allows parallelized HTTP/2 downloads to finish page load sooner than a single monolithic stylesheet. The current sign-in page asset sizes are primed for this split, where as of today https://secure.login.gov application is the largest first-party asset at 22.4kb (brotli'd), with the second-largest being 15.7kb (brotli'd). These changes bring the largest asset more into equilibrium, with `application.css` at 10.7kb (brotli'd) and `utilities.css` at 8.1kb (brotli'd).

## 📜 Testing Plan

Verify no regressions in the display of components affected by stylesheets, particularly around precedence of application styles vs. design system styles, and vs. utility classes. Refer to [[1]](https://github.com/18F/identity-idp/pull/10898#discussion_r1662668282) [[2]](https://github.com/18F/identity-idp/pull/10394#issuecomment-2049857818) referenced above for examples of edge-cases previously encountered.