### PR TITLE
Add spec to ensure mailers don't include SVG

### DIFF
--- a/spec/mailers/previews/user_mailer_preview_spec.rb
+++ b/spec/mailers/previews/user_mailer_preview_spec.rb
@@ -4,8 +4,17 @@ require_relative './user_mailer_preview'
 RSpec.describe UserMailerPreview do
   UserMailerPreview.instance_methods(false).each do |mailer_method|
     describe "##{mailer_method}" do
+      subject(:mail) { UserMailerPreview.new.public_send(mailer_method) }
+
       it 'generates a preview without blowing up' do
-        expect { UserMailerPreview.new.public_send(mailer_method).body }.to_not raise_error
+        expect { mail.body }.to_not raise_error
+      end
+
+      it 'does not include any svg images' do
+        # SVGs are typically the preferred format for their high-quality and small file size, but
+        # they are not well-supported in email clients. Instead, store a rasterized version of the
+        # image in `app/assets/images/email` for use in mailer content.
+        expect(mail.html_part.body).not_to have_selector("img[src$='.svg']")
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a test to verify that mailer content doesn't include SVG images. As described in the included inline code comment (and [related folder README](https://github.com/18F/identity-idp/blob/main/app/assets/images/email/README.md)), SVG images are not well supported in mail clients. This is often hard to spot in development, since our HTML previews render correctly in a browser, but the mailer may not always show the expected content when sent in a deployed environment. The intent of the test is to reduce the feedback loop for this issue, and ensure that the issue is caught sooner.

Previously:

- https://github.com/18F/identity-idp/pull/10839#discussion_r1648075095
- https://github.com/18F/identity-idp/pull/6892
- https://github.com/18F/identity-idp/pull/6585#issuecomment-1187577858

## 📜 Testing Plan

Verify that tests pass:

```
rspec spec/mailers/previews/user_mailer_preview_spec.rb
```

For bonus points, modify a file in `app/views/user_mailer` to include an SVG image and verify that the same tests fail.