### PR TITLE
LG 13001 Implementation: Select email to share with partner

### DIFF
--- a/app/components/icon_list_item_component.html.erb
+++ b/app/components/icon_list_item_component.html.erb
@@ -2,5 +2,5 @@
   <%= content_tag(:div, class: icon_css_class) do %>
     <%= render IconComponent.new(icon: icon) %>
   <% end %>
-  <div class="usa-icon-list__content flex-2"><%= content %></div>
+  <div class="usa-icon-list__content grid-col-fill"><%= content %></div>
 <% end %>

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -150,7 +150,7 @@ module SamlIdpAuthConcern
     identity = current_user.identities.where(service_provider: sp)
     email_id = identity.pluck('email_address_id')[0]
     return email_id if email_id.is_a? Integer
-    return current_user.email_addresses.take.id
+    return EmailContext.new(current_user).last_sign_in_email_address.id
   end
 
   def identity_needs_verification?

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -147,9 +147,8 @@ module SamlIdpAuthConcern
   def email_address_id
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
     return session[:sp_email_id] if session[:sp_email_id].present?
-    sp = sp_session['issuer']
-    identity = current_user.identities.where(service_provider: sp)
-    email_id = identity.email_address.id if identity.respond_to? :email_address
+    identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
+    email_id = identity&.email_address_id
     return email_id if email_id.is_a? Integer
     return EmailContext.new(current_user).last_sign_in_email_address.id
   end

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -146,7 +146,7 @@ module SamlIdpAuthConcern
 
   def email_address_id
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
-    return session[:sp_email_id] if session[:sp_email_id].present?
+    return session[:selected_email_id] if session[:selected_email_id].present?
     identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
     email_id = identity&.email_address_id
     return email_id if email_id.is_a? Integer

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -150,7 +150,6 @@ module SamlIdpAuthConcern
     identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
     email_id = identity&.email_address_id
     return email_id if email_id.is_a? Integer
-    # EmailContext.new(current_user).last_sign_in_email_address.id
   end
 
   def identity_needs_verification?

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -146,11 +146,11 @@ module SamlIdpAuthConcern
 
   def email_address_id
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
-    return session[:selected_email_id] if session[:selected_email_id].present?
+    return user_session[:selected_email_id] if user_session[:selected_email_id].present?
     identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
     email_id = identity&.email_address_id
     return email_id if email_id.is_a? Integer
-    return EmailContext.new(current_user).last_sign_in_email_address.id
+    EmailContext.new(current_user).last_sign_in_email_address.id
   end
 
   def identity_needs_verification?

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -150,7 +150,7 @@ module SamlIdpAuthConcern
     identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
     email_id = identity&.email_address_id
     return email_id if email_id.is_a? Integer
-    EmailContext.new(current_user).last_sign_in_email_address.id
+    # EmailContext.new(current_user).last_sign_in_email_address.id
   end
 
   def identity_needs_verification?

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -149,7 +149,7 @@ module SamlIdpAuthConcern
     return session[:sp_email_id] if session[:sp_email_id].present?
     sp = sp_session['issuer']
     identity = current_user.identities.where(service_provider: sp)
-    email_id = identity.pluck('email_address_id')[0]
+    email_id = identity.email_address.id if identity.respond_to? :email_address
     return email_id if email_id.is_a? Integer
     return EmailContext.new(current_user).last_sign_in_email_address.id
   end

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -145,6 +145,7 @@ module SamlIdpAuthConcern
   end
 
   def email_address_id
+    return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
     return session[:sp_email_id] if session[:sp_email_id].present?
     sp = sp_session['issuer']
     identity = current_user.identities.where(service_provider: sp)

--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -28,7 +28,6 @@ module VerifySpAttributesConcern
       verified_attributes: sp_session[:requested_attributes],
       last_consented_at: Time.zone.now,
       clear_deleted_at: true,
-      email_address_id: user_session[:selected_email_id],
     )
   end
 

--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -28,7 +28,7 @@ module VerifySpAttributesConcern
       verified_attributes: sp_session[:requested_attributes],
       last_consented_at: Time.zone.now,
       clear_deleted_at: true,
-      email_address_id: session[:sp_email_id],
+      email_address_id: session[:selected_email_id],
     )
   end
 

--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -28,7 +28,7 @@ module VerifySpAttributesConcern
       verified_attributes: sp_session[:requested_attributes],
       last_consented_at: Time.zone.now,
       clear_deleted_at: true,
-      email_address_id: session[:selected_email_id],
+      email_address_id: user_session[:selected_email_id],
     )
   end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -89,6 +89,7 @@ module OpenidConnect
     end
 
     def email_address_id
+      return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
       return session[:sp_email_id] if session[:sp_email_id].present?
       sp = sp_session['issuer']
       identity = current_user.identities.where(service_provider: sp)

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -90,7 +90,9 @@ module OpenidConnect
 
     def email_address_id
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
-      return session[:selected_email_id] if session[:selected_email_id].present?
+      return user_session[:selected_email_id] if user_session[:selected_email_id].present?
+      identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
+      identity&.email_address_id || EmailContext.new(current_user).last_sign_in_email_address.id
     end
 
     def ial_context

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -90,7 +90,7 @@ module OpenidConnect
 
     def email_address_id
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
-      return session[:sp_email_id] if session[:sp_email_id].present?
+      return session[:selected_email_id] if session[:selected_email_id].present?
       identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
       email_id = identity&.email_address_id
       return email_id if email_id.is_a? Integer

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -92,7 +92,7 @@ module OpenidConnect
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
       return user_session[:selected_email_id] if user_session[:selected_email_id].present?
       identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
-      identity&.email_address_id || EmailContext.new(current_user).last_sign_in_email_address.id
+      identity&.email_address_id
     end
 
     def ial_context

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -94,7 +94,7 @@ module OpenidConnect
       identity = current_user.identities.where(service_provider: sp)
       email_id = identity.pick('email_address_id')
       return email_id if email_id.is_a? Integer
-      return current_user.email_addresses.take.id
+      return EmailContext.new(current_user).last_sign_in_email_address.id
     end
 
     def ial_context

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -93,7 +93,7 @@ module OpenidConnect
       return session[:sp_email_id] if session[:sp_email_id].present?
       sp = sp_session['issuer']
       identity = current_user.identities.where(service_provider: sp)
-      email_id = identity.pick('email_address_id')
+      email_id = identity.email_address.id if identity.respond_to? :email_address
       return email_id if email_id.is_a? Integer
       return EmailContext.new(current_user).last_sign_in_email_address.id
     end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -91,8 +91,6 @@ module OpenidConnect
     def email_address_id
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
       return session[:selected_email_id] if session[:selected_email_id].present?
-      identity = current_user.active_identity_for(@authorize_form.service_provider)
-      identity&.email_address_id || EmailContext.new(current_user).last_sign_in_email_address.id
     end
 
     def ial_context

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -91,9 +91,8 @@ module OpenidConnect
     def email_address_id
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
       return session[:sp_email_id] if session[:sp_email_id].present?
-      sp = sp_session['issuer']
-      identity = current_user.identities.where(service_provider: sp)
-      email_id = identity.email_address.id if identity.respond_to? :email_address
+      identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
+      email_id = identity&.email_address_id
       return email_id if email_id.is_a? Integer
       return EmailContext.new(current_user).last_sign_in_email_address.id
     end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -92,7 +92,7 @@ module OpenidConnect
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
       return session[:selected_email_id] if session[:selected_email_id].present?
       identity = current_user.active_identity_for(@authorize_form.service_provider)
-      identity.email_address_id || EmailContext.new(current_user).last_sign_in_email_address.id
+      identity&.email_address_id || EmailContext.new(current_user).last_sign_in_email_address.id
     end
 
     def ial_context

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -89,7 +89,7 @@ module OpenidConnect
     end
 
     def email_address_id
-      return session[:sp_email_id] unless session[:sp_email_id].nil?
+      return session[:sp_email_id] if session[:sp_email_id].present?
       sp = sp_session['issuer']
       identity = current_user.identities.where(service_provider: sp)
       email_id = identity.pick('email_address_id')

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -91,10 +91,8 @@ module OpenidConnect
     def email_address_id
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
       return session[:selected_email_id] if session[:selected_email_id].present?
-      identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
-      email_id = identity&.email_address_id
-      return email_id if email_id.is_a? Integer
-      return EmailContext.new(current_user).last_sign_in_email_address.id
+      identity = current_user.active_identity_for(@authorize_form.service_provider)
+      identity.email_address_id || EmailContext.new(current_user).last_sign_in_email_address.id
     end
 
     def ial_context

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -49,6 +49,7 @@ module SignUp
         requested_attributes: decorated_sp_session.requested_attributes.map(&:to_sym),
         ial2_requested: ial2_requested?,
         completion_context: needs_completion_screen_reason,
+        selected_email_id: session[:selected_email_id],
       )
     end
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -21,8 +21,10 @@ module SignUp
       track_completion_event('agency-page')
       update_verified_attributes
       send_in_person_completion_survey
-      user_session[:selected_email_id] = EmailContext.new(current_user).
-        last_sign_in_email_address.id
+      if user_session[:selected_email_id].nil?
+        user_session[:selected_email_id] = EmailContext.new(current_user).
+          last_sign_in_email_address.id
+      end
       if decider.go_back_to_mobile_app?
         sign_user_out_and_instruct_to_go_back_to_mobile_app
       else

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -21,6 +21,8 @@ module SignUp
       track_completion_event('agency-page')
       update_verified_attributes
       send_in_person_completion_survey
+      user_session[:selected_email_id] = EmailContext.new(current_user).
+        last_sign_in_email_address.id
       if decider.go_back_to_mobile_app?
         sign_user_out_and_instruct_to_go_back_to_mobile_app
       else

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -49,7 +49,7 @@ module SignUp
         requested_attributes: decorated_sp_session.requested_attributes.map(&:to_sym),
         ial2_requested: ial2_requested?,
         completion_context: needs_completion_screen_reason,
-        selected_email_id: session[:selected_email_id],
+        selected_email_id: user_session[:selected_email_id],
       )
     end
 

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -43,7 +43,7 @@ module SignUp
     end
 
     def form_params
-      params.fetch(:select_email_form, {}).permit(:selection)
+      params.fetch(:select_email_form, {}).permit(:selected_email_id)
     end
   end
 end

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -41,7 +41,7 @@ module SignUp
 
     def last_email
       if user_session[:selected_email_id]
-        EmailAddress.find(user_session[:selected_email_id]).email
+        user_emails.find(user_session[:selected_email_id]).email
       else
         EmailContext.new(current_user).last_sign_in_email_address.email
       end

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -38,7 +38,7 @@ module SignUp
     end
 
     def user_emails
-      @user_emails = current_user.email_addresses.map { |e| e.email }
+      @user_emails = current_user.confirmed_email_addresses.map { |e| e.email }
     end
 
     private

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -8,11 +8,11 @@ module SignUp
       @sp_name = sp_name
       @user_emails = user_emails
       @last_sign_in_email_address = EmailContext.new(current_user).last_sign_in_email_address.email
-      @select_email_form = new_select_email_form
+      @select_email_form = build_select_email_form
     end
 
     def create
-      @select_email_form = new_select_email_form
+      @select_email_form = build_select_email_form
 
       result = @select_email_form.submit(form_params)
       if result.success?
@@ -43,7 +43,7 @@ module SignUp
 
     private
 
-    def new_select_email_form
+    def build_select_email_form
       SelectEmailForm.new(current_user)
     end
 

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -50,6 +50,5 @@ module SignUp
     def form_params
       params.fetch(:select_email_form, {}).permit(:selection)
     end
-    ## method to update user selected sp email
   end
 end

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -3,6 +3,7 @@
 module SignUp
   class SelectEmailController < ApplicationController
     before_action :confirm_two_factor_authenticated
+    before_action :verify_needs_completions_screen
 
     def show
       @sp_name = sp_name
@@ -19,7 +20,7 @@ module SignUp
         session[:selected_email_id] = form_params[:selected_email_id]
         redirect_to sign_up_completed_path
       else
-        flash[:error] = t('anonymous_mailer.password_reset_missing_user.subject')
+        flash[:error] = result.first_error_message
         redirect_to sign_up_select_email_path
       end
     end
@@ -50,6 +51,10 @@ module SignUp
       session_selected_email_id = session[:selected_email_id] ||
                                   EmailContext.new(current_user).last_sign_in_email_address.id
       EmailAddress.find(session_selected_email_id).email
+    end
+
+    def verify_needs_completions_screen
+      redirect_to account_url unless needs_completion_screen_reason
     end
   end
 end

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -17,7 +17,7 @@ module SignUp
 
       result = @select_email_form.submit(form_params)
       if result.success?
-        session[:selected_email_id] = form_params[:selected_email_id]
+        user_session[:selected_email_id] = form_params[:selected_email_id]
         redirect_to sign_up_completed_path
       else
         flash[:error] = result.first_error_message
@@ -40,9 +40,11 @@ module SignUp
     end
 
     def last_email
-      session_selected_email_id = session[:selected_email_id] ||
-                                  EmailContext.new(current_user).last_sign_in_email_address.id
-      EmailAddress.find(session_selected_email_id).email
+      if user_session[:selected_email_id]
+        EmailAddress.find(user_session[:selected_email_id]).email
+      else
+        EmailContext.new(current_user).last_sign_in_email_address.email
+      end
     end
 
     def verify_needs_completions_screen

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -16,16 +16,11 @@ module SignUp
 
       result = @select_email_form.submit(form_params)
       if result.success?
-
-        EmailAddress.update_last_sign_in_at_on_user_id_and_email(
-          user_id: current_user.id,
-          email: form_params[:selection],
-        )
-
         session[:sp_email_id] = EmailContext.new(current_user).last_sign_in_email_address.id
         redirect_to sign_up_completed_path
       else
-        render :show
+        flash[:error] = t('anonymous_mailer.password_reset_missing_user.subject')
+        redirect_to sign_up_select_email_path
       end
     end
 

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -48,9 +48,11 @@ module SignUp
     end
 
     def last_email
-      session_selected_email_id = session[:selected_email_id] ||
-                                  EmailContext.new(current_user).last_sign_in_email_address.id
-      EmailAddress.find(session_selected_email_id).email
+      begin
+        EmailAddress.find(session[:selected_email_id])
+      rescue ActiveRecord::RecordNotFound
+        EmailContext.new(current_user).last_sign_in_email_address.email
+      end
     end
 
     def verify_needs_completions_screen

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -33,7 +33,7 @@ module SignUp
     end
 
     def user_emails
-      @user_emails = current_user.confirmed_email_addresses.map { |e| e.email }
+      @user_emails = current_user.confirmed_email_addresses
     end
 
     private

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -6,7 +6,7 @@ module SignUp
     before_action :verify_needs_completions_screen
 
     def show
-      @sp_name = sp_name
+      @sp_name = current_sp.friendly_name || sp.agency&.name
       @user_emails = user_emails
       @last_sign_in_email_address = last_email
       @select_email_form = build_select_email_form
@@ -22,14 +22,6 @@ module SignUp
       else
         flash[:error] = result.first_error_message
         redirect_to sign_up_select_email_path
-      end
-    end
-
-    def sp_name
-      if current_sp
-        @sp_name ||= current_sp.friendly_name || sp.agency&.name
-      else
-        @sp_name = APP_NAME
       end
     end
 

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -7,7 +7,7 @@ module SignUp
     def show
       @sp_name = sp_name
       @user_emails = user_emails
-      @last_sign_in_email_address = EmailContext.new(current_user).last_sign_in_email_address.email
+      @last_sign_in_email_address = last_email
       @select_email_form = build_select_email_form
     end
 
@@ -16,7 +16,7 @@ module SignUp
 
       result = @select_email_form.submit(form_params)
       if result.success?
-        session[:sp_email_id] = EmailContext.new(current_user).last_sign_in_email_address.id
+        session[:selected_email_id] = form_params[:selected_email_id]
         redirect_to sign_up_completed_path
       else
         flash[:error] = t('anonymous_mailer.password_reset_missing_user.subject')
@@ -44,6 +44,12 @@ module SignUp
 
     def form_params
       params.fetch(:select_email_form, {}).permit(:selected_email_id)
+    end
+
+    def last_email
+      session_selected_email_id = session[:selected_email_id] ||
+                                  EmailContext.new(current_user).last_sign_in_email_address.id
+      EmailAddress.find(session_selected_email_id).email
     end
   end
 end

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -48,11 +48,9 @@ module SignUp
     end
 
     def last_email
-      begin
-        EmailAddress.find(session[:selected_email_id])
-      rescue ActiveRecord::RecordNotFound
-        EmailContext.new(current_user).last_sign_in_email_address.email
-      end
+      session_selected_email_id = session[:selected_email_id] ||
+                                  EmailContext.new(current_user).last_sign_in_email_address.id
+      EmailAddress.find(session_selected_email_id).email
     end
 
     def verify_needs_completions_screen

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -176,6 +176,7 @@ module Users
     end
 
     def last_email_from_sp
+      return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
       sp = sp_session['issuer']
       if sp.present?
         identity = current_user.identities.where(service_provider: sp)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -178,7 +178,6 @@ module Users
     def last_email_from_sp
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
       if sp_session['issuer'].present?
-        # identity = current_user.identities.where(service_provider: sp)
         identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
         email_id = identity&.email_address_id
         return current_user.email_addresses.find(email_id).email if email_id.is_a? Integer

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -177,10 +177,10 @@ module Users
 
     def last_email_from_sp
       return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
-      sp = sp_session['issuer']
-      if sp.present?
-        identity = current_user.identities.where(service_provider: sp)
-        email_id = identity.pick('email_address_id')
+      if sp_session['issuer'].present?
+        # identity = current_user.identities.where(service_provider: sp)
+        identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
+        email_id = identity&.email_address_id
         return current_user.email_addresses.find(email_id).email if email_id.is_a? Integer
       end
       return auth_params[:email]

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -167,22 +167,12 @@ module Users
       UserAlerts::AlertUserAboutNewDevice.schedule_alert(event:) if new_device?
       EmailAddress.update_last_sign_in_at_on_user_id_and_email(
         user_id: current_user.id,
-        email: last_email_from_sp,
+        email: auth_params[:email],
       )
       user_session[:platform_authenticator_available] =
         params[:platform_authenticator_available] == 'true'
       check_password_compromised
       redirect_to next_url_after_valid_authentication
-    end
-
-    def last_email_from_sp
-      return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
-      if sp_session['issuer'].present?
-        identity = current_user.identities.find_by(service_provider: sp_session['issuer'])
-        email_id = identity&.email_address_id
-        return current_user.email_addresses.find(email_id).email if email_id.is_a? Integer
-      end
-      return auth_params[:email]
     end
 
     def track_authentication_attempt(email)

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -15,7 +15,6 @@ class DeleteUserEmailForm
   def submit
     success = valid? && email_address_destroyed
     notify_subscribers if success
-    delete_identity_email_id if success
     FormResponse.new(success: success, errors: errors)
   end
 
@@ -36,14 +35,5 @@ class DeleteUserEmailForm
     PushNotification::HttpPush.deliver(email_changed)
     recovery_information_changed = PushNotification::RecoveryInformationChangedEvent.new(user: user)
     PushNotification::HttpPush.deliver(recovery_information_changed)
-  end
-
-  def delete_identity_email_id
-    if user.identities.present?
-      user.identities.where(email_address_id: email_address.id).each do |identity|
-        identity.email_address_id = nil
-        identity.save
-      end
-    end
   end
 end

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -15,6 +15,7 @@ class DeleteUserEmailForm
   def submit
     success = valid? && email_address_destroyed
     notify_subscribers if success
+    delete_identity_email_id if success
     FormResponse.new(success: success, errors: errors)
   end
 
@@ -35,5 +36,14 @@ class DeleteUserEmailForm
     PushNotification::HttpPush.deliver(email_changed)
     recovery_information_changed = PushNotification::RecoveryInformationChangedEvent.new(user: user)
     PushNotification::HttpPush.deliver(recovery_information_changed)
+  end
+
+  def delete_identity_email_id
+    if user.identities.present?
+      user.identities.where(email_address_id: email_address.id).each do |identity|
+        identity.email_address_id = nil
+        identity.save
+      end
+    end
   end
 end

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -4,15 +4,44 @@ class SelectEmailForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
 
+  attr_reader :user, :selected_email
+
+  validate :owns_selected_email
+
   def initialize(user)
     @user = user
   end
 
-  def submit(params)
-    @selected_email_form = params[:select_email_form]
+  def owns_selected_email
+    user_selected_email = EmailAddress.find_with_email(selected_email)
+    return if @user.id == user_selected_email&.user&.id
 
-    success = valid?
+    errors.add :email, I18n.t(
+      'anonymous_mailer.password_reset_missing_user.subject',
+    ), type: :selected_email
+  end
+
+  def submit(params)
+    @selected_email = params[:selection]
+
+    if valid?
+      process_successful_submission
+    else
+      self.success = false
+    end
 
     FormResponse.new(success: success, errors: errors)
+  end
+
+  private
+
+  attr_accessor :success
+
+  def process_successful_submission
+    self.success = true
+    EmailAddress.update_last_sign_in_at_on_user_id_and_email(
+      user_id: @user.id,
+      email: @selected_email,
+    )
   end
 end

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -16,18 +16,10 @@ class SelectEmailForm
     @selected_email_id = params[:selected_email_id]
 
     success = valid?
-    process_successful_submission if success
     FormResponse.new(success:, errors:)
   end
 
   private
-
-  def process_successful_submission
-    EmailAddress.update_last_sign_in_at_on_user_id_and_email(
-      user_id: @user.id,
-      email: EmailAddress.find(@selected_email_id).email,
-    )
-  end
 
   def validate_owns_selected_email
     return if user.confirmed_email_addresses.exists?(id: selected_email_id)

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -33,7 +33,7 @@ class SelectEmailForm
     return if user.confirmed_email_addresses.exists?(id: selected_email_id)
 
     errors.add :email, I18n.t(
-      'anonymous_mailer.password_reset_missing_user.subject',
+      'email_address.not_found',
     ), type: :selected_email_id
   end
 end

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -6,42 +6,36 @@ class SelectEmailForm
 
   attr_reader :user, :selected_email
 
-  validate :owns_selected_email
+  validate :validate_owns_selected_email
 
   def initialize(user)
     @user = user
   end
 
-  def owns_selected_email
-    user_selected_email = EmailAddress.find_with_email(selected_email)
+  def submit(params)
+    @selected_email = params[:selection]
+
+    success = valid?
+    process_successful_submission if success
+    FormResponse.new(success:, errors:)
+  end
+
+  private
+
+  def process_successful_submission
+    EmailAddress.update_last_sign_in_at_on_user_id_and_email(
+      user_id: @user.id,
+      email: EmailAddress.find(@selected_email).email,
+    )
+  end
+
+  def validate_owns_selected_email
+    user_selected_email = EmailAddress.find(selected_email) if EmailAddress.
+      exists? id: selected_email
     return if @user.id == user_selected_email&.user&.id
 
     errors.add :email, I18n.t(
       'anonymous_mailer.password_reset_missing_user.subject',
     ), type: :selected_email
-  end
-
-  def submit(params)
-    @selected_email = params[:selection]
-
-    if valid?
-      process_successful_submission
-    else
-      self.success = false
-    end
-
-    FormResponse.new(success: success, errors: errors)
-  end
-
-  private
-
-  attr_accessor :success
-
-  def process_successful_submission
-    self.success = true
-    EmailAddress.update_last_sign_in_at_on_user_id_and_email(
-      user_id: @user.id,
-      email: @selected_email,
-    )
   end
 end

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -30,8 +30,11 @@ class SelectEmailForm
   end
 
   def validate_owns_selected_email
-    user_selected_email = EmailAddress.find(selected_email) if EmailAddress.
-      exists? id: selected_email
+    if EmailAddress.exists? id: selected_email
+      if EmailAddress.find(selected_email).confirmed?
+        user_selected_email = EmailAddress.find(selected_email)
+      end
+    end
     return if @user.id == user_selected_email&.user&.id
 
     errors.add :email, I18n.t(

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -4,7 +4,7 @@ class SelectEmailForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :user, :selected_email
+  attr_reader :user, :selected_email_id
 
   validate :validate_owns_selected_email
 
@@ -13,7 +13,7 @@ class SelectEmailForm
   end
 
   def submit(params)
-    @selected_email = params[:selection]
+    @selected_email_id = params[:selected_email_id]
 
     success = valid?
     process_successful_submission if success
@@ -25,15 +25,15 @@ class SelectEmailForm
   def process_successful_submission
     EmailAddress.update_last_sign_in_at_on_user_id_and_email(
       user_id: @user.id,
-      email: EmailAddress.find(@selected_email).email,
+      email: EmailAddress.find(@selected_email_id).email,
     )
   end
 
   def validate_owns_selected_email
-    return if user.confirmed_email_addresses.exists?(id: selected_email)
+    return if user.confirmed_email_addresses.exists?(id: selected_email_id)
 
     errors.add :email, I18n.t(
       'anonymous_mailer.password_reset_missing_user.subject',
-    ), type: :selected_email
+    ), type: :selected_email_id
   end
 end

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -30,12 +30,7 @@ class SelectEmailForm
   end
 
   def validate_owns_selected_email
-    if EmailAddress.exists? id: selected_email
-      if EmailAddress.find(selected_email).confirmed?
-        user_selected_email = EmailAddress.find(selected_email)
-      end
-    end
-    return if @user.id == user_selected_email&.user&.id
+    return if user.confirmed_email_addresses.exists?(id: selected_email)
 
     errors.add :email, I18n.t(
       'anonymous_mailer.password_reset_missing_user.subject',

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -11,6 +11,7 @@ class EmailAddress < ApplicationRecord
   # rubocop:disable Rails/HasManyOrHasOneDependent
   has_one :suspended_email
   # rubocop:enable Rails/HasManyOrHasOneDependent
+  has_many :identities, class_name: 'ServiceProviderIdentity', dependent: :nullify
 
   scope :confirmed, -> { where('confirmed_at IS NOT NULL') }
 

--- a/app/models/service_provider_identity.rb
+++ b/app/models/service_provider_identity.rb
@@ -19,6 +19,9 @@ class ServiceProviderIdentity < ApplicationRecord
   # rubocop:enable Rails/InverseOf
   has_one :agency, through: :service_provider_record
 
+  has_one :email_address,
+          dependent: nil
+
   scope :not_deleted, -> { where(deleted_at: nil) }
 
   CONSENT_EXPIRATION = 1.year.freeze

--- a/app/models/service_provider_identity.rb
+++ b/app/models/service_provider_identity.rb
@@ -20,7 +20,7 @@ class ServiceProviderIdentity < ApplicationRecord
   has_one :agency, through: :service_provider_record
 
   has_one :email_address,
-          dependent: nil
+          dependent: :nullify
 
   scope :not_deleted, -> { where(deleted_at: nil) }
 

--- a/app/models/service_provider_identity.rb
+++ b/app/models/service_provider_identity.rb
@@ -19,8 +19,7 @@ class ServiceProviderIdentity < ApplicationRecord
   # rubocop:enable Rails/InverseOf
   has_one :agency, through: :service_provider_record
 
-  has_one :email_address,
-          dependent: :nullify
+  belongs_to :email_address
 
   scope :not_deleted, -> { where(deleted_at: nil) }
 

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -106,7 +106,7 @@ class CompletionsPresenter
   end
 
   def multiple_emails?
-    current_user.confirmed_email_addresses.count > 1
+    current_user.confirmed_email_addresses.any?
   end
 
   private

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -103,7 +103,7 @@ class CompletionsPresenter
   end
 
   def multiple_emails?
-    current_user.confirmed_email_addresses.any?
+    current_user.confirmed_email_addresses.count > 1
   end
 
   private

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -106,7 +106,7 @@ class CompletionsPresenter
   end
 
   def multiple_emails?
-    current_user.confirmed_email_addresses.count > 1
+    current_user.confirmed_email_addresses.many?
   end
 
   private

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -4,7 +4,8 @@ class CompletionsPresenter
   include ActionView::Helpers::TranslationHelper
   include ActionView::Helpers::TagHelper
 
-  attr_reader :current_user, :current_sp, :decrypted_pii, :requested_attributes, :completion_context
+  attr_reader :current_user, :current_sp, :decrypted_pii, :requested_attributes,
+              :completion_context, :selected_email_id
 
   SORTED_IAL2_ATTRIBUTE_MAPPING = [
     [[:email], :email],
@@ -33,7 +34,8 @@ class CompletionsPresenter
     decrypted_pii:,
     requested_attributes:,
     ial2_requested:,
-    completion_context:
+    completion_context:,
+    selected_email_id:
   )
     @current_user = current_user
     @current_sp = current_sp
@@ -41,6 +43,7 @@ class CompletionsPresenter
     @requested_attributes = requested_attributes
     @ial2_requested = ial2_requested
     @completion_context = completion_context
+    @selected_email_id = selected_email_id
   end
 
   def ial2_requested?
@@ -116,6 +119,7 @@ class CompletionsPresenter
     @displayable_pii ||= DisplayablePiiFormatter.new(
       current_user: current_user,
       pii: decrypted_pii,
+      selected_email_id: @selected_email_id,
     ).format
   end
 

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -103,7 +103,7 @@ class CompletionsPresenter
   end
 
   def multiple_emails?
-    current_user.email_addresses.count > 1
+    current_user.confirmed_email_addresses.any?
   end
 
   private

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -106,7 +106,7 @@ class CompletionsPresenter
   end
 
   def multiple_emails?
-    current_user.confirmed_email_addresses.any?
+    current_user.confirmed_email_addresses.count > 1
   end
 
   private

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -189,13 +189,4 @@ class OpenidConnectUserInfoPresenter
   def out_of_band_session_accessor
     @out_of_band_session_accessor ||= OutOfBandSessionAccessor.new(identity.rails_session_id)
   end
-
-  def find_email_address
-    begin
-      @email_address = EmailAddress.find(identity.email_address_id)
-    rescue ActiveRecord::RecordNotFound
-      @email_address = nil
-    end
-    @email_address
-  end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -54,7 +54,8 @@ class OpenidConnectUserInfoPresenter
   end
 
   def email_from_sp_identity
-    email_context.last_sign_in_email_address.email
+    EmailAddress.find(identity.email_address_id).email ||
+      email_context.last_sign_in_email_address.email
   end
 
   def all_emails_from_sp_identity(identity)

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -54,7 +54,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def email_from_sp_identity
-    if identity.email_address_id
+    if identity.email_address_id && validate_saved_email_id?
       return EmailAddress.find(identity.email_address_id).email
     end
     email_context.last_sign_in_email_address.email
@@ -187,5 +187,10 @@ class OpenidConnectUserInfoPresenter
 
   def out_of_band_session_accessor
     @out_of_band_session_accessor ||= OutOfBandSessionAccessor.new(identity.rails_session_id)
+  end
+
+  def validate_saved_email_id?
+    saved_email = identity.email_address_id
+    EmailAddress.exists?(saved_email)
   end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -60,15 +60,6 @@ class OpenidConnectUserInfoPresenter
     email_context.last_sign_in_email_address.email
   end
 
-  def find_email_address
-    begin
-      @email_address = EmailAddress.find(identity.email_address_id)
-    rescue ActiveRecord::RecordNotFound
-      @email_address = nil
-    end
-    @email_address
-  end
-
   def all_emails_from_sp_identity(identity)
     identity.user.confirmed_email_addresses.map(&:email)
   end
@@ -196,5 +187,14 @@ class OpenidConnectUserInfoPresenter
 
   def out_of_band_session_accessor
     @out_of_band_session_accessor ||= OutOfBandSessionAccessor.new(identity.rails_session_id)
+  end
+
+  def find_email_address
+    begin
+      @email_address = EmailAddress.find(identity.email_address_id)
+    rescue ActiveRecord::RecordNotFound
+      @email_address = nil
+    end
+    @email_address
   end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -54,8 +54,10 @@ class OpenidConnectUserInfoPresenter
   end
 
   def email_from_sp_identity
-    EmailAddress.find(identity.email_address_id).email ||
-      email_context.last_sign_in_email_address.email
+    if identity.email_address_id
+      return EmailAddress.find(identity.email_address_id).email
+    end
+    email_context.last_sign_in_email_address.email
   end
 
   def all_emails_from_sp_identity(identity)

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -54,10 +54,19 @@ class OpenidConnectUserInfoPresenter
   end
 
   def email_from_sp_identity
-    if identity.email_address_id && validate_saved_email_id?
-      return EmailAddress.find(identity.email_address_id).email
+    if identity.email_address_id && find_email_address.present?
+      return email_address.email
     end
     email_context.last_sign_in_email_address.email
+  end
+
+  def find_email_address
+    begin
+      email_address = EmailAddress.find(identity.email_address_id)
+    rescue ActiveRecord::RecordNotFound
+      email_address = nil
+    end
+    email_address
   end
 
   def all_emails_from_sp_identity(identity)
@@ -187,10 +196,5 @@ class OpenidConnectUserInfoPresenter
 
   def out_of_band_session_accessor
     @out_of_band_session_accessor ||= OutOfBandSessionAccessor.new(identity.rails_session_id)
-  end
-
-  def validate_saved_email_id?
-    saved_email = identity.email_address_id
-    EmailAddress.exists?(saved_email)
   end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -54,11 +54,10 @@ class OpenidConnectUserInfoPresenter
   end
 
   def email_from_sp_identity
-    if identity.email_address_id && (email_address = EmailAddress.find(identity.email_address_id))
-      email_address.email
-    else
-      email_context.last_sign_in_email_address.email
+    if identity.email_address_id && find_email_address.present?
+      return @email_address.email
     end
+    email_context.last_sign_in_email_address.email
   end
 
   def all_emails_from_sp_identity(identity)
@@ -191,6 +190,11 @@ class OpenidConnectUserInfoPresenter
   end
 
   def find_email_address
-    @email_address = EmailAddress.find(identity.email_address_id)
+    begin
+      @email_address = EmailAddress.find(identity.email_address_id)
+    rescue ActiveRecord::RecordNotFound
+      @email_address = nil
+    end
+    @email_address
   end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -55,18 +55,18 @@ class OpenidConnectUserInfoPresenter
 
   def email_from_sp_identity
     if identity.email_address_id && find_email_address.present?
-      return email_address.email
+      return @email_address.email
     end
     email_context.last_sign_in_email_address.email
   end
 
   def find_email_address
     begin
-      email_address = EmailAddress.find(identity.email_address_id)
+      @email_address = EmailAddress.find(identity.email_address_id)
     rescue ActiveRecord::RecordNotFound
-      email_address = nil
+      @email_address = nil
     end
-    email_address
+    @email_address
   end
 
   def all_emails_from_sp_identity(identity)

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -54,11 +54,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def email_from_sp_identity
-    if identity.email_address_id &&
-       (email_address = EmailAddress.find_by(id: identity.email_address_id))
-      return email_address.email
-    end
-    email_context.last_sign_in_email_address.email
+    identity.email_address&.email || email_context.last_sign_in_email_address.email
   end
 
   def all_emails_from_sp_identity(identity)

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -54,10 +54,11 @@ class OpenidConnectUserInfoPresenter
   end
 
   def email_from_sp_identity
-    if identity.email_address_id && find_email_address.present?
-      return @email_address.email
+    if identity.email_address_id && (email_address = EmailAddress.find(identity.email_address_id))
+      email_address.email
+    else
+      email_context.last_sign_in_email_address.email
     end
-    email_context.last_sign_in_email_address.email
   end
 
   def all_emails_from_sp_identity(identity)
@@ -190,11 +191,6 @@ class OpenidConnectUserInfoPresenter
   end
 
   def find_email_address
-    begin
-      @email_address = EmailAddress.find(identity.email_address_id)
-    rescue ActiveRecord::RecordNotFound
-      @email_address = nil
-    end
-    @email_address
+    @email_address = EmailAddress.find(identity.email_address_id)
   end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -54,8 +54,9 @@ class OpenidConnectUserInfoPresenter
   end
 
   def email_from_sp_identity
-    if identity.email_address_id && find_email_address.present?
-      return @email_address.email
+    if identity.email_address_id &&
+       (email_address = EmailAddress.find_by(id: identity.email_address_id))
+      return email_address.email
     end
     email_context.last_sign_in_email_address.email
   end

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -221,7 +221,7 @@ class AttributeAsserter
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
     identity = principal.active_identity_for(service_provider)
     email_id = identity&.email_address_id
-    principal.confirmed_email_addresses.find_by(id: email_id)&.email if identity.email_address_id
+    principal.confirmed_email_addresses.find_by(id: email_id)&.email if email_id
   end
 
   def bundle

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -220,8 +220,9 @@ class AttributeAsserter
   def last_email_from_sp
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
     sp = service_provider.issuer
-    identity = user.identities.where(service_provider: sp)
-    email_id = identity.pick('email_address_id')
+    # identity = user.identities.where(service_provider: sp)
+    identity = user.identities.find_by(service_provider: sp)
+    email_id = identity&.email_address_id
     return user.email_addresses.find(email_id).email if email_id.is_a? Integer
   end
 

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -220,7 +220,6 @@ class AttributeAsserter
   def last_email_from_sp
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
     sp = service_provider.issuer
-    # identity = user.identities.where(service_provider: sp)
     identity = user.identities.find_by(service_provider: sp)
     email_id = identity&.email_address_id
     return user.email_addresses.find(email_id).email if email_id.is_a? Integer

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -221,11 +221,7 @@ class AttributeAsserter
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
     identity = principal.active_identity_for(service_provider)
     email_id = identity&.email_address_id
-    begin
-      principal.confirmed_email_addresses.find(email_id)&.email if identity.email_address_id
-    rescue
-      nil
-    end
+    principal.confirmed_email_addresses.find_by(id: email_id)&.email if identity.email_address_id
   end
 
   def bundle

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -221,6 +221,7 @@ class AttributeAsserter
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
     sp = service_provider.issuer
     identity = user.identities.find_by(service_provider: sp)
+    return nil unless EmailAddress.exists?(identity.email_address_id)
     email_id = identity&.email_address_id
     return user.email_addresses.find(email_id).email if email_id.is_a? Integer
   end

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -221,7 +221,11 @@ class AttributeAsserter
     return nil unless IdentityConfig.store.feature_select_email_to_share_enabled
     identity = principal.active_identity_for(service_provider)
     email_id = identity&.email_address_id
-    principal.confirmed_email_addresses.find(email_id)&.email if identity.email_address_id
+    begin
+      principal.confirmed_email_addresses.find(email_id)&.email if identity.email_address_id
+    rescue
+      nil
+    end
   end
 
   def bundle

--- a/app/services/displayable_pii_formatter.rb
+++ b/app/services/displayable_pii_formatter.rb
@@ -8,10 +8,12 @@ class DisplayablePiiFormatter
 
   attr_reader :current_user
   attr_reader :pii
+  attr_reader :selected_email_id
 
-  def initialize(current_user:, pii:)
+  def initialize(current_user:, pii:, selected_email_id:)
     @current_user = current_user
     @pii = pii
+    @selected_email_id = selected_email_id
   end
 
   # @return [FormattedPii]
@@ -36,7 +38,9 @@ class DisplayablePiiFormatter
   private
 
   def email
-    EmailContext.new(current_user).last_sign_in_email_address.email
+    session_selected_email_id = @selected_email_id ||
+                                EmailContext.new(current_user).last_sign_in_email_address.id
+    EmailAddress.find(session_selected_email_id).email
   end
 
   def all_emails

--- a/app/services/displayable_pii_formatter.rb
+++ b/app/services/displayable_pii_formatter.rb
@@ -38,9 +38,11 @@ class DisplayablePiiFormatter
   private
 
   def email
-    session_selected_email_id = @selected_email_id ||
-                                EmailContext.new(current_user).last_sign_in_email_address.id
-    EmailAddress.find(session_selected_email_id).email
+    if @selected_email_id
+      current_user.confirmed_email_addresses.find(@selected_email_id).email
+    else
+      EmailContext.new(current_user).last_sign_in_email_address.email
+    end
   end
 
   def all_emails

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -45,11 +45,13 @@
       <% elsif attribute_key == :email && IdentityConfig.store.feature_select_email_to_share_enabled %>
         <div class="display-flex flex-justify">
           <%= attribute_value.to_s %>
+          <p class='font-body-2xs text-right'>
             <% if @presenter.multiple_emails? %>
-              <p class='font-body-2xs text-right'><%= link_to t('help_text.requested_attributes.change_email_link'), sign_up_select_email_path %></p>
+              <%= link_to t('help_text.requested_attributes.change_email_link'), sign_up_select_email_path %>\
             <% else %>
-              <p class='font-body-2xs text-right'><%= link_to t('account.index.email_add'), add_email_path %></p>
+              <%= link_to t('account.index.email_add'), add_email_path %>
             <% end %>
+          </p>
         </div>
       <% else %>
         <%= attribute_value.to_s %>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -42,17 +42,17 @@
                 last_number: attribute_value[-1],
               ),
             ) %>
-      <% else %>
+      <% elsif attribute_key == :email && IdentityConfig.store.feature_select_email_to_share_enabled %>
         <div class="display-flex flex-justify">
           <%= attribute_value.to_s %>
-          <% if attribute_key == :email && IdentityConfig.store.feature_select_email_to_share_enabled %>
             <% if @presenter.multiple_emails? %>
               <p class='font-body-2xs text-right'><%= link_to t('help_text.requested_attributes.change_email_link'), sign_up_select_email_path %></p>
             <% else %>
               <p class='font-body-2xs text-right'><%= link_to t('account.index.email_add'), add_email_path %></p>
             <% end %>
-          <% end %>
         </div>
+      <% else %>
+        <%= attribute_value.to_s %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -44,7 +44,7 @@
             ) %>
       <% else %>
         <div class="display-flex flex-justify">
-          <div><%= attribute_value.to_s %></div>
+          <%= attribute_value.to_s %>
           <% if attribute_key == :email && IdentityConfig.store.feature_select_email_to_share_enabled %>
             <% if @presenter.multiple_emails? %>
               <p class='font-body-2xs text-right'><%= link_to t('help_text.requested_attributes.change_email_link'), sign_up_select_email_path %></p>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -47,7 +47,7 @@
           <%= attribute_value.to_s %>
           <p class='font-body-2xs text-right'>
             <% if @presenter.multiple_emails? %>
-              <%= link_to t('help_text.requested_attributes.change_email_link'), sign_up_select_email_path %>\
+              <%= link_to t('help_text.requested_attributes.change_email_link'), sign_up_select_email_path %>
             <% else %>
               <%= link_to t('account.index.email_add'), add_email_path %>
             <% end %>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -3,7 +3,7 @@
 <h1><%= t('titles.select_email') %></h1>
 
 <p class="margin-top-4">
-  <%= I18n.t('help_text.select_preferred_email', sp: @sp_name) %>
+  <%= I18n.t('help_text.select_preferred_email', sp: @sp_name, app_name: APP_NAME) %>
 </p>
 
 <%= simple_form_for(@select_email_form, url: sign_up_select_email_path) do |f| %>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -6,7 +6,7 @@
   <%= I18n.t('help_text.select_preferred_email', sp: @sp_name, app_name: APP_NAME) %>
 </p>
 
-<%= simple_form_for(@select_email_form, url: sign_up_select_email_path) do |f| %>
+<%= simple_form_for('', url: sign_up_select_email_path) do |f| %>
   <% @user_emails.each do |email, index| %>
     <fieldset class="usa-fieldset">
       <div class="usa-radio">

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -11,13 +11,13 @@
       <fieldset class="usa-fieldset">
         <div class="usa-radio">
           <%= radio_button_tag(
-                'select_email_form[selection]',
+                'select_email_form[selected_email_id]',
                 email.id,
                 email.email == @last_sign_in_email_address,
                 class: 'usa-radio__input usa-radio__input--bordered',
               ) %>
               <%= label_tag(
-                    "select_email_form_selection_#{email.id}",
+                    "select_email_form_selected_email_id_#{email.id}",
                     class: 'usa-radio__label width-full',
                   ) do %>
                 <%= email.email %>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -12,15 +12,15 @@
         <div class="usa-radio">
           <%= radio_button_tag(
                 'select_email_form[selection]',
-                email,
-                email == @last_sign_in_email_address,
+                email.id,
+                email.email == @last_sign_in_email_address,
                 class: 'usa-radio__input usa-radio__input--bordered',
               ) %>
               <%= label_tag(
-                    "select_email_form_selection_#{email}",
+                    "select_email_form_selection_#{email.id}",
                     class: 'usa-radio__label width-full',
                   ) do %>
-                <%= email %>
+                <%= email.email %>
               <% end %>
         </div>
       </fieldset>
@@ -28,19 +28,16 @@
     <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-4' %>
   <% end %>
 
-   <div class="grid-row">
-    <div class="grid-col-6">
     <%= render ButtonComponent.new(
           url: add_email_path,
           outline: true,
-          icon: :add,
-          class: 'margin-y-2 usa-button--big usa-button--wide',
-        ).with_content(t('account.index.email_add')) %>        
-    </div>
-  </div>
-
-  <p>
+          big: true,
+          wide: true,
+          class: 'margin-y-2',
+        ).with_content(t('account.index.email_add')) %>
+        
+  <%= render PageFooterComponent.new do %>
     <%= link_to t('forms.buttons.back'), sign_up_completed_path %>
-  </p>
+  <% end %>
 
 <% end %>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -29,6 +29,7 @@
             <% end %>
           </div>
         </div>
+        <div class="grid-col-4 tablet:grid-col-6"></div>
       </div>
     </fieldset>
     <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-4' %>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -2,29 +2,35 @@
 
 <%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
   <% c.with_header { t('titles.select_email') } %>
-  <p class="margin-top-4">
+  <p id="select-email-intro">
     <%= I18n.t('help_text.select_preferred_email', sp: @sp_name, app_name: APP_NAME) %>
   </p>
 
   <%= simple_form_for('', url: sign_up_select_email_path) do |f| %>
-    <% @user_emails.each do |email, index| %>
-      <fieldset class="usa-fieldset">
-        <div class="usa-radio">
-          <%= radio_button_tag(
-                'select_email_form[selected_email_id]',
-                email.id,
-                email.email == @last_sign_in_email_address,
-                class: 'usa-radio__input usa-radio__input--bordered',
-              ) %>
-              <%= label_tag(
-                    "select_email_form_selected_email_id_#{email.id}",
-                    class: 'usa-radio__label width-full',
-                  ) do %>
-                <%= email.email %>
-              <% end %>
+    <fieldset class="usa-fieldset" aria-labelledby="select-email-intro">
+      <div class="grid-row margin-bottom-neg-1">
+        <div class="grid-col-fill">
+          <div class="display-inline-block inw-full">
+          <% @user_emails.each do |email, index| %>
+            <div class="usa-radio">
+              <%= radio_button_tag(
+                    'select_email_form[selected_email_id]',
+                    email.id,
+                    email.email == @last_sign_in_email_address,
+                    class: 'usa-radio__input usa-radio__input--bordered',
+                  ) %>
+                  <%= label_tag(
+                        "select_email_form_selected_email_id_#{email.id}",
+                        class: 'usa-radio__label width-full',
+                      ) do %>
+                    <%= email.email %>
+                  <% end %>
+            </div>
+          <% end %>
+          </div>
         </div>
-      </fieldset>
-    <% end %>
+      </div>
+    </fieldset>
     <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-4' %>
   <% end %>
 
@@ -33,7 +39,7 @@
           outline: true,
           big: true,
           wide: true,
-          class: 'margin-y-2',
+          class: 'margin-top-2',
         ).with_content(t('account.index.email_add')) %>
         
   <%= render PageFooterComponent.new do %>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -1,40 +1,46 @@
 <% self.title = t('titles.select_email') %>
-<%= render AlertIconComponent.new(icon_name: :info_question, class: 'display-block margin-bottom-4', width: 54, height: 54) %>
-<h1><%= t('titles.select_email') %></h1>
 
-<p class="margin-top-4">
-  <%= I18n.t('help_text.select_preferred_email', sp: @sp_name, app_name: APP_NAME) %>
-</p>
+<%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
+  <% c.with_header { t('titles.select_email') } %>
+  <p class="margin-top-4">
+    <%= I18n.t('help_text.select_preferred_email', sp: @sp_name, app_name: APP_NAME) %>
+  </p>
 
-<%= simple_form_for('', url: sign_up_select_email_path) do |f| %>
-  <% @user_emails.each do |email, index| %>
-    <fieldset class="usa-fieldset">
-      <div class="usa-radio">
-        <%= radio_button_tag(
-              'select_email_form[selection]',
-              email,
-              email == @last_sign_in_email_address,
-              class: 'usa-radio__input usa-radio__input--bordered',
-            ) %>
-            <%= label_tag(
-                  "select_email_form_selection_#{email}",
-                  class: 'usa-radio__label width-full',
-                ) do %>
-              <%= email %>
-            <% end %>
-      </div>
-    </fieldset>
+  <%= simple_form_for('', url: sign_up_select_email_path) do |f| %>
+    <% @user_emails.each do |email, index| %>
+      <fieldset class="usa-fieldset">
+        <div class="usa-radio">
+          <%= radio_button_tag(
+                'select_email_form[selection]',
+                email,
+                email == @last_sign_in_email_address,
+                class: 'usa-radio__input usa-radio__input--bordered',
+              ) %>
+              <%= label_tag(
+                    "select_email_form_selection_#{email}",
+                    class: 'usa-radio__label width-full',
+                  ) do %>
+                <%= email %>
+              <% end %>
+        </div>
+      </fieldset>
+    <% end %>
+    <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-4' %>
   <% end %>
-  <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-4' %>
+
+   <div class="grid-row">
+    <div class="grid-col-6">
+    <%= render ButtonComponent.new(
+          url: add_email_path,
+          outline: true,
+          icon: :add,
+          class: 'margin-y-2 usa-button--big usa-button--wide',
+        ).with_content(t('account.index.email_add')) %>        
+    </div>
+  </div>
+
+  <p>
+    <%= link_to t('forms.buttons.back'), sign_up_completed_path %>
+  </p>
+
 <% end %>
-
-<%= render ButtonComponent.new(
-      url: add_email_path,
-      outline: true,
-      icon: :add,
-      class: 'margin-y-2 usa-button--big usa-button--wide',
-    ).with_content(t('account.index.email_add')) %>
-
-<p>
-  <%= link_to t('forms.buttons.back'), sign_up_completed_path %>
-</p>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -11,22 +11,22 @@
       <div class="grid-row margin-bottom-neg-1">
         <div class="grid-col-fill">
           <div class="display-inline-block inw-full">
-          <% @user_emails.each do |email, index| %>
-            <div class="usa-radio">
-              <%= radio_button_tag(
-                    'select_email_form[selected_email_id]',
-                    email.id,
-                    email.email == @last_sign_in_email_address,
-                    class: 'usa-radio__input usa-radio__input--bordered',
-                  ) %>
-                  <%= label_tag(
-                        "select_email_form_selected_email_id_#{email.id}",
-                        class: 'usa-radio__label width-full',
-                      ) do %>
-                    <%= email.email %>
-                  <% end %>
-            </div>
-          <% end %>
+            <% @user_emails.each do |email, index| %>
+              <div class="usa-radio">
+                <%= radio_button_tag(
+                      'select_email_form[selected_email_id]',
+                      email.id,
+                      email.email == @last_sign_in_email_address,
+                      class: 'usa-radio__input usa-radio__input--bordered',
+                    ) %>
+                    <%= label_tag(
+                          "select_email_form_selected_email_id_#{email.id}",
+                          class: 'usa-radio__label width-full',
+                        ) do %>
+                      <%= email.email %>
+                    <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -10,7 +10,7 @@
     <fieldset class="usa-fieldset" aria-labelledby="select-email-intro">
       <div class="grid-row margin-bottom-neg-1">
         <div class="grid-col-fill">
-          <div class="display-inline-block inw-full">
+          <div class="display-inline-block minw-full">
             <% @user_emails.each do |email, index| %>
               <div class="usa-radio">
                 <%= radio_button_tag(

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -401,7 +401,6 @@ development:
   doc_auth_vendor: 'mock'
   domain_name: localhost:3000
   enable_rate_limiting: false
-  feature_select_email_to_share_enabled: true
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   identity_pki_local_dev: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -959,8 +959,8 @@ headings.webauthn_setup.new: Insert your security key
 help_text.requested_attributes.address: Address
 help_text.requested_attributes.all_emails: Email addresses on your account
 help_text.requested_attributes.birthdate: Date of birth
-help_text.requested_attributes.consent_reminder_html: You must consent each year to share your information with %{sp_html}.
 help_text.requested_attributes.change_email_link: Change
+help_text.requested_attributes.consent_reminder_html: You must consent each year to share your information with %{sp_html}.
 help_text.requested_attributes.email: Email address
 help_text.requested_attributes.full_name: Full name
 help_text.requested_attributes.ial2_reverified_consent_info_html: 'Because you verified your identity again, we need your permission to share this information with %{sp_html}:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -692,6 +692,7 @@ doc_auth.tips.review_issues_id_text1: Did you use a dark background?
 doc_auth.tips.review_issues_id_text2: Did you take the photo on a flat surface?
 doc_auth.tips.review_issues_id_text3: Is the flash on your camera off?
 doc_auth.tips.review_issues_id_text4: Are all details sharp and clearly visible?
+email_address.not_found: 'Email not found'
 email_addresses.add.duplicate: This email address is already registered to your account.
 email_addresses.add.limit: You’ve added the maximum number of email addresses.
 email_addresses.delete.bullet1: You won’t be able to sign in to %{app_name} (or any of the government applications linked to your account) using this email address

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -970,8 +970,8 @@ headings.webauthn_setup.new: Inserte su clave de seguridad
 help_text.requested_attributes.address: Dirección
 help_text.requested_attributes.all_emails: Direcciones de correo electrónico en su cuenta
 help_text.requested_attributes.birthdate: Fecha de nacimiento
-help_text.requested_attributes.consent_reminder_html: Debe dar su consentimiento cada año para divulgar su información a %{sp_html}.
 help_text.requested_attributes.change_email_link: Cambiar
+help_text.requested_attributes.consent_reminder_html: Debe dar su consentimiento cada año para divulgar su información a %{sp_html}.
 help_text.requested_attributes.email: Dirección de correo electrónico
 help_text.requested_attributes.full_name: Nombre completo
 help_text.requested_attributes.ial2_reverified_consent_info_html: 'Como volvió a verificar su identidad, necesitamos su permiso para divulgar esta información a %{sp_html}:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -703,6 +703,7 @@ doc_auth.tips.review_issues_id_text1: '¿Usó un fondo de color oscuro?'
 doc_auth.tips.review_issues_id_text2: '¿Tomó la foto en una superficie plana?'
 doc_auth.tips.review_issues_id_text3: '¿Está apagado el flash de su cámara?'
 doc_auth.tips.review_issues_id_text4: '¿Todos los detalles se ven con precisión y claridad?'
+email_address.not_found: El correo electrónico no encontrado
 email_addresses.add.duplicate: Esta dirección de correo electrónico ya está registrada en su cuenta.
 email_addresses.add.limit: Agregó el número máximo de direcciones de correo electrónico.
 email_addresses.delete.bullet1: Si usa esta dirección de correo electrónico, no podrá iniciar sesión en %{app_name} (ni en ninguna de las aplicaciones gubernamentales vinculadas a su cuenta).

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -959,8 +959,8 @@ headings.webauthn_setup.new: Insérer votre clé de sécurité
 help_text.requested_attributes.address: Adresse
 help_text.requested_attributes.all_emails: Adresses e-mail sur votre compte
 help_text.requested_attributes.birthdate: Date de naissance
-help_text.requested_attributes.consent_reminder_html: Vous devez consentir chaque année au partage de vos informations avec %{sp_html}.
 help_text.requested_attributes.change_email_link: Modifier
+help_text.requested_attributes.consent_reminder_html: Vous devez consentir chaque année au partage de vos informations avec %{sp_html}.
 help_text.requested_attributes.email: Adresse e-mail
 help_text.requested_attributes.full_name: Nom complet
 help_text.requested_attributes.ial2_reverified_consent_info_html: 'Étant donné que vous avez revérifié votre identité, nous avons besoin de votre autorisation pour partager ces informations avec %{sp_html} :'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -692,6 +692,7 @@ doc_auth.tips.review_issues_id_text1: Avez-vous utilisé un arrière-plan de cou
 doc_auth.tips.review_issues_id_text2: Avez-vous pris la photo sur une surface plane ?
 doc_auth.tips.review_issues_id_text3: Le flash de votre appareil photo est-il éteint ?
 doc_auth.tips.review_issues_id_text4: Tous les détails sont-ils nets et clairement visibles ?
+email_address.not_found: Email non trouvé
 email_addresses.add.duplicate: Cette adresse e-mail est déjà enregistrée sur votre compte.
 email_addresses.add.limit: Vous avez ajouté le nombre maximum d’adresses e-mail.
 email_addresses.delete.bullet1: Vous ne pourrez pas vous connecter à %{app_name} (ni à aucune des applications de l’administration associées à votre compte) à l’aide de cette adresse e-mail

--- a/db/primary_migrate/20240718180303_add_selected_email_to_identity.rb
+++ b/db/primary_migrate/20240718180303_add_selected_email_to_identity.rb
@@ -1,5 +1,0 @@
-class AddSelectedEmailToIdentity < ActiveRecord::Migration[7.1]
-  def change
-    add_column :identities, :email_address_id, :bigint
-  end
-end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -247,7 +247,6 @@ RSpec.describe SignUp::CompletionsController do
           verified_attributes: ['email'],
           last_consented_at: now,
           clear_deleted_at: true,
-          email_address_id: nil,
         )
         freeze_time do
           travel_to(now)
@@ -347,7 +346,6 @@ RSpec.describe SignUp::CompletionsController do
           verified_attributes: %w[email first_name verified_at],
           last_consented_at: now,
           clear_deleted_at: true,
-          email_address_id: nil,
         )
         allow(Idv::InPerson::CompletionSurveySender).to receive(:send_completion_survey).
           with(user, sp.issuer)

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe SignUp::SelectEmailController do
     end
 
     it 'updates selected email address' do
-      post :create, params: { selection: email2 }
+      post :create, params: { selected_email_id: email2 }
 
       expect(user.email_addresses.last.email).
         to include('michael.motorist2@email.com')
     end
 
-    context 'with a corrupted email selection form' do
+    context 'with a corrupted email selected_email_id form' do
       render_views
       it 'rejects email not belonging to the user' do
         stub_sign_in(user)
-        post :create, params: { selection: email3 }
+        post :create, params: { selected_email_id: email3 }
 
         expect(user.email_addresses.last.email).
           to include('michael.motorist2@email.com')

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe SignUp::SelectEmailController do
   describe '#create' do
     let(:email) { 'michael.motorist@email.com' }
     let(:email2) { 'michael.motorist2@email.com' }
+    let(:email3) { 'david.motorist@email.com' }
     let(:user) { create(:user) }
 
     before do
@@ -17,6 +18,20 @@ RSpec.describe SignUp::SelectEmailController do
 
       expect(user.email_addresses.last.email).
         to include('michael.motorist2@email.com')
+    end
+
+    context 'with a corrupted email selection form' do
+      render_views
+      it 'rejects email not belonging to the user' do
+        stub_sign_in(user)
+        post :create, params: { selection: email3 }
+
+        expect(user.email_addresses.last.email).
+          to include('michael.motorist2@email.com')
+        
+        expect(response).to redirect_to(sign_up_select_email_path)
+
+      end
     end
   end
 end

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -28,9 +28,8 @@ RSpec.describe SignUp::SelectEmailController do
 
         expect(user.email_addresses.last.email).
           to include('michael.motorist2@email.com')
-        
-        expect(response).to redirect_to(sign_up_select_email_path)
 
+        expect(response).to redirect_to(sign_up_select_email_path)
       end
     end
   end

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe SignUp::SelectEmailController do
+  describe 'before_actions' do
+    it 'requires the user be logged in and authenticated' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+      )
+    end
+
+    it 'requires the user be in the completions flow' do
+      expect(subject).to have_actions(
+        :before,
+        :verify_needs_completions_screen,
+      )
+    end
+  end
+
   describe '#create' do
     let(:email) { 'michael.motorist@email.com' }
     let(:email2) { 'michael.motorist2@email.com' }

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SignUp::SelectEmailController do
     it 'updates selected email address' do
       post :create, params: { selection: email2 }
 
-      expect(user.email_addresses.last_sign_in_email_address.email).
+      expect(user.email_addresses.last.email).
         to include('michael.motorist2@email.com')
     end
   end

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SignUp::SelectEmailController do
 
     before do
       user.email_addresses = []
-      user.email_addresses.create(email: email, confirmed_at: Time.zone.now)
-      user.email_addresses.create(email: email2, confirmed_at: Time.zone.now)
+      create(:email_address, user:, email: email)
+      create(:email_address, user:, email: email2)
     end
 
     it 'updates selected email address' do
@@ -24,6 +24,7 @@ RSpec.describe SignUp::SelectEmailController do
       render_views
       it 'rejects email not belonging to the user' do
         stub_sign_in(user)
+        allow(controller).to receive(:needs_completion_screen_reason).and_return(true)
         post :create, params: { selected_email_id: email3 }
 
         expect(user.email_addresses.last.email).

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
         click_submit_default
         click_agree_and_continue if current_path == sign_up_completed_path
         decoded_id_token = fetch_oidc_id_token_info
-        expect(decoded_id_token[:email]).to eq(emails.first)
+        expect(decoded_id_token[:email]).to eq(email)
         expect(decoded_id_token[:all_emails]).to be_nil
 
         Capybara.reset_session!

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -28,7 +28,6 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
     scenario 'signing in with OIDC and selecting an alternative email address at first sign in' do
       user = create(:user, :fully_registered, :with_multiple_emails)
       emails = user.reload.email_addresses.map(&:email)
-      puts emails.first
 
       visit_idp_from_oidc_sp(scope: 'openid email')
       signin(emails.first, user.password)

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
         click_submit_default
         click_agree_and_continue if current_path == sign_up_completed_path
         decoded_id_token = fetch_oidc_id_token_info
-        expect(decoded_id_token[:email]).to eq(email)
+        expect(decoded_id_token[:email]).to eq(emails.first)
         expect(decoded_id_token[:all_emails]).to be_nil
 
         Capybara.reset_session!

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -65,9 +65,13 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       # Delete email from account
       visit manage_email_confirm_delete_url(id: email2.id)
       click_button t('forms.email.buttons.delete')
+      logout
 
       # Sign in again to partner application
       visit_idp_from_oidc_sp(scope: 'openid email')
+      signin(email1.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
 
       decoded_id_token = fetch_oidc_id_token_info
       expect(decoded_id_token[:email]).to eq(email1.email)

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
     scenario 'signing in with OIDC and selecting an alternative email address at first sign in' do
       user = create(:user, :fully_registered, :with_multiple_emails)
       emails = user.reload.email_addresses.map(&:email)
+      puts emails.first
 
       visit_idp_from_oidc_sp(scope: 'openid email')
       signin(emails.first, user.password)

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       expect(current_path).to eq(sign_up_completed_path)
       click_agree_and_continue
       decoded_id_token = fetch_oidc_id_token_info
-      expect(decoded_id_token[:email]).to eq(emails.last)
+      expect(decoded_id_token[:email]).to eq(emails.first)
     end
 
     scenario 'signing in with OIDC after deleting email linked to identity' do
@@ -115,7 +115,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
 
       xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
       email_from_saml_response = xmldoc.attribute_value_for('email')
-      expect(email_from_saml_response).to eq(emails.last)
+      expect(email_from_saml_response).to eq(emails.first)
     end
 
     scenario 'signing in with SAML after deleting email linked to identity' do

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -65,13 +65,9 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       # Delete email from account
       visit manage_email_confirm_delete_url(id: email2.id)
       click_button t('forms.email.buttons.delete')
-      logout
 
       # Sign in again to partner application
       visit_idp_from_oidc_sp(scope: 'openid email')
-      signin(email1.email, user.password)
-      fill_in_code_with_last_phone_otp
-      click_submit_default
 
       decoded_id_token = fetch_oidc_id_token_info
       expect(decoded_id_token[:email]).to eq(email1.email)

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       expect(current_path).to eq(sign_up_completed_path)
       click_agree_and_continue
       decoded_id_token = fetch_oidc_id_token_info
-      expect(decoded_id_token[:email]).to eq(emails.first)
+      expect(decoded_id_token[:email]).to eq(emails.second)
     end
 
     scenario 'signing in with OIDC after deleting email linked to identity' do
@@ -115,7 +115,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
 
       xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
       email_from_saml_response = xmldoc.attribute_value_for('email')
-      expect(email_from_saml_response).to eq(emails.first)
+      expect(email_from_saml_response).to eq(emails.second)
     end
 
     scenario 'signing in with SAML after deleting email linked to identity' do

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
         fill_in_code_with_last_phone_otp
         click_submit_default
         click_agree_and_continue if current_path == sign_up_completed_path
-
         decoded_id_token = fetch_oidc_id_token_info
         expect(decoded_id_token[:email]).to eq(emails.first)
         expect(decoded_id_token[:all_emails]).to be_nil
@@ -42,7 +41,6 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
 
         xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
         email_from_saml_response = xmldoc.attribute_value_for('email')
-
         expect(email_from_saml_response).to eq(emails.first)
 
         Capybara.reset_session!

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -60,6 +60,18 @@ RSpec.describe DeleteUserEmailForm do
 
         submit
       end
+
+      it 'removes associated identity email address id' do
+        user.identities << ServiceProviderIdentity.create(
+          service_provider: 'http://localhost:3000',
+          last_authenticated_at: Time.zone.now,
+        )
+        user.identities.last.email_address_id = email_address.id
+
+        submit
+
+        expect(user.identities.last.email_address_id).to be(nil)
+      end
     end
 
     context 'with a email of a different user' do

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe SelectEmailForm do
+  let(:user) { create(:user, :fully_registered, :with_multiple_emails) }
+  describe '#submit' do
+    it 'returns the email successfully' do
+      form = SelectEmailForm.new(user)
+      response = form.submit(selection: user.email_addresses.last.id)
+
+      expect(response.success?).to eq(true)
+    end
+
+    it 'returns an error when submitting an invalid email' do
+      form = SelectEmailForm.new(user)
+      response = form.submit(selection: nil)
+
+      expect(response.success?).to eq(false)
+    end
+
+    context 'with an unconfirmed email address added' do
+      before do
+        create(
+          :email_address,
+          email: 'michael.business@business.com',
+          user: user,
+          confirmed_at: nil,
+          confirmation_sent_at: 1.month.ago,
+        )
+      end
+
+      it 'returns an error' do
+        form = SelectEmailForm.new(user)
+        response = form.submit(selection: user.email_addresses.last.id)
+
+        expect(response.success?).to eq(false)
+      end
+    end
+
+    context 'with another user\'s email' do
+      let(:user2) { create(:user, :fully_registered, :with_multiple_emails) }
+      before do
+        create(
+          :email_address,
+          email: 'michael.business@business.com',
+          user: user2,
+          confirmed_at: nil,
+          confirmation_sent_at: 1.month.ago,
+        )
+        @email2 = user2.email_addresses.last.id
+      end
+
+      it 'returns an error' do
+        form = SelectEmailForm.new(user)
+        response = form.submit(selection: @email2)
+
+        expect(response.success?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe SelectEmailForm do
   describe '#submit' do
     it 'returns the email successfully' do
       form = SelectEmailForm.new(user)
-      response = form.submit(selection: user.email_addresses.last.id)
+      response = form.submit(selected_email_id: user.email_addresses.last.id)
 
       expect(response.success?).to eq(true)
     end
 
     it 'returns an error when submitting an invalid email' do
       form = SelectEmailForm.new(user)
-      response = form.submit(selection: nil)
+      response = form.submit(selected_email_id: nil)
 
       expect(response.success?).to eq(false)
     end
@@ -30,7 +30,7 @@ RSpec.describe SelectEmailForm do
 
       it 'returns an error' do
         form = SelectEmailForm.new(user)
-        response = form.submit(selection: user.email_addresses.last.id)
+        response = form.submit(selected_email_id: user.email_addresses.last.id)
 
         expect(response.success?).to eq(false)
       end
@@ -51,7 +51,7 @@ RSpec.describe SelectEmailForm do
 
       it 'returns an error' do
         form = SelectEmailForm.new(user)
-        response = form.submit(selection: @email2)
+        response = form.submit(selected_email_id: @email2)
 
         expect(response.success?).to eq(false)
       end

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe CompletionsPresenter do
   end
   let(:current_user) { create(:user, :fully_registered, identities: identities) }
   let(:current_sp) { create(:service_provider, friendly_name: 'Friendly service provider') }
+  let(:selected_email_id) { current_user.email_addresses.first.id }
   let(:decrypted_pii) do
     Pii::Attributes.new(
       first_name: 'Testy',
@@ -41,12 +42,13 @@ RSpec.describe CompletionsPresenter do
 
   subject(:presenter) do
     described_class.new(
-      current_user: current_user,
-      current_sp: current_sp,
-      decrypted_pii: decrypted_pii,
-      requested_attributes: requested_attributes,
-      ial2_requested: ial2_requested,
-      completion_context: completion_context,
+      current_user:,
+      current_sp:,
+      decrypted_pii:,
+      requested_attributes:,
+      ial2_requested:,
+      completion_context:,
+      selected_email_id:,
     )
   end
 

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -368,5 +368,28 @@ RSpec.describe OpenidConnectUserInfoPresenter do
         end
       end
     end
+
+    context 'with a deleted email' do
+      let(:identity) do
+        build(
+          :service_provider_identity,
+          rails_session_id: rails_session_id,
+          user: create(:user, :fully_registered, :with_multiple_emails),
+          scope: scope,
+        )
+      end
+
+      before do
+        identity.email_address_id = identity.user.email_addresses.first.id
+        identity.user.email_addresses.first.delete
+      end
+
+      it 'defers to user alternate email' do
+        expect(identity.user.reload.email_addresses.first.id).
+          to_not eq(identity.email_address_id)
+        expect(identity.user.reload.email_addresses.count).to be 1
+        expect(user_info[:email]).to eq(identity.user.email_addresses.last.email)
+      end
+    end
   end
 end

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -391,5 +391,24 @@ RSpec.describe OpenidConnectUserInfoPresenter do
         expect(user_info[:email]).to eq(identity.user.email_addresses.last.email)
       end
     end
+
+    context 'with nil email id' do
+      let(:identity) do
+        build(
+          :service_provider_identity,
+          rails_session_id: rails_session_id,
+          user: create(:user, :fully_registered),
+          scope: scope,
+        )
+      end
+
+      before do
+        identity.email_address_id = nil
+      end
+
+      it 'adds the signed in email id to the identity' do
+        expect(user_info[:email]).to eq(identity.user.email_addresses.last.email)
+      end
+    end
   end
 end

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -100,6 +100,11 @@ RSpec.describe AttributeAsserter do
           it 'gets UUID from Service Provider' do
             expect(get_asserted_attribute(user, :uuid)).to eq user.last_identity.uuid
           end
+
+          it 'gets the user\'s last sign in email' do
+            expect(get_asserted_attribute(user, :email)).
+              to eq EmailContext.new(user).last_sign_in_email_address.email
+          end
         end
 
         context 'custom bundle includes dob' do

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -802,22 +802,22 @@ RSpec.describe AttributeAsserter do
           allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
             and_return(%w[email phone first_name])
           create(:email_address, user:, email: 'email@example.com')
-  
+
           ident = user.identities.last
           ident.email_address_id = user.email_addresses.first.id
           ident.save
           subject.build
-  
+
           user.email_addresses.first.delete
-  
+
           subject.build
         end
-  
+
         it 'defers to user alternate email' do
           expect(get_asserted_attribute(user, :email)).
             to eq 'email@example.com'
         end
-      end  
+      end
 
       context 'with a nil email id' do
         let(:subject) do
@@ -834,13 +834,13 @@ RSpec.describe AttributeAsserter do
           user.identities << identity
           allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
             and_return(%w[email phone first_name])
-  
+
           ident = user.identities.last
           ident.email_address_id = nil
           ident.save
           subject.build
         end
-  
+
         it 'defers to user alternate email' do
           expect(get_asserted_attribute(user, :email)).
             to eq user.email_addresses.last.email

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -724,7 +724,7 @@ RSpec.describe AttributeAsserter do
           user: user,
           name_id_format: name_id_format,
           service_provider: service_provider,
-          authn_request: ial2_authn_request,
+          authn_request: authn_request,
           decrypted_pii: decrypted_pii,
           user_session: user_session,
         )
@@ -748,6 +748,34 @@ RSpec.describe AttributeAsserter do
       it 'defers to user alternate email' do
         expect(get_asserted_attribute(user, :email)).
           to eq 'email@example.com'
+      end
+    end
+
+    context 'with a nil email id' do
+      let(:subject) do
+        described_class.new(
+          user: user,
+          name_id_format: name_id_format,
+          service_provider: service_provider,
+          authn_request: authn_request,
+          decrypted_pii: decrypted_pii,
+          user_session: user_session,
+        )
+      end
+      before do
+        user.identities << identity
+        allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+          and_return(%w[email phone first_name])
+
+        ident = user.identities.last
+        ident.email_address_id = nil
+        ident.save
+        subject.build
+      end
+
+      it 'defers to user alternate email' do
+        expect(get_asserted_attribute(user, :email)).
+          to eq user.email_addresses.last.email
       end
     end
   end

--- a/spec/services/displayable_pii_formatter_spec.rb
+++ b/spec/services/displayable_pii_formatter_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe DisplayablePiiFormatter do
     )
   end
 
+  let(:selected_email_id) { current_user.email_addresses.first.id }
+
   let(:pii) do
     {
       first_name: first_name,
@@ -63,7 +65,13 @@ RSpec.describe DisplayablePiiFormatter do
     }
   end
 
-  subject(:formatter) { described_class.new(current_user: current_user, pii: pii) }
+  subject(:formatter) do
+    described_class.new(
+      current_user:,
+      pii:,
+      selected_email_id:,
+    )
+  end
 
   describe '#format' do
     context 'ial1' do

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -85,13 +85,7 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
     end
   end
 
-  context 'select email to send to partner and select email feature is enabled' do
-    before do
-      allow(IdentityConfig.store).to receive(
-        :feature_select_email_to_share_enabled,
-      ).and_return(true)
-    end
-
+  context 'select email to send to partner' do
     it 'does not show a link to select different email' do
       create(:email_address, user: user)
       user.reload

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'sign_up/completions/show.html.erb' do
   let(:user) { create(:user, :fully_registered) }
   let(:service_provider) { create(:service_provider) }
+  let(:selected_email_id) { user.email_addresses.first.id }
   let(:decrypted_pii) { {} }
   let(:requested_attributes) { [:email] }
   let(:ial2_requested) { false }
@@ -22,10 +23,11 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
     CompletionsPresenter.new(
       current_user: user,
       current_sp: service_provider,
-      decrypted_pii: decrypted_pii,
-      requested_attributes: requested_attributes,
-      ial2_requested: ial2_requested,
-      completion_context: completion_context,
+      decrypted_pii:,
+      requested_attributes:,
+      ial2_requested:,
+      completion_context:,
+      selected_email_id:,
     )
   end
 

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -61,24 +61,50 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
     )
   end
 
-  context 'select email to send to partner' do
+  context 'select email to send to partner and select email feature is disabled' do
+    before do
+      allow(IdentityConfig.store).to receive(
+        :feature_select_email_to_share_enabled,
+      ).and_return(false)
+    end
+
+    it 'does not show a link to select different email' do
+      create(:email_address, user: user)
+      user.reload
+      render
+
+      expect(rendered).to_not include(t('help_text.requested_attributes.change_email_link'))
+      expect(rendered).to_not include(t('account.index.email_add'))
+    end
+
+    it 'does not show a link to add another email' do
+      render
+
+      expect(rendered).to_not include(t('help_text.requested_attributes.change_email_link'))
+      expect(rendered).to_not include(t('account.index.email_add'))
+    end
+  end
+
+  context 'select email to send to partner and select email feature is enabled' do
     before do
       allow(IdentityConfig.store).to receive(
         :feature_select_email_to_share_enabled,
       ).and_return(true)
     end
 
-    it 'shows a link to select different email' do
+    it 'does not show a link to select different email' do
       create(:email_address, user: user)
       user.reload
       render
 
       expect(rendered).to include(t('help_text.requested_attributes.change_email_link'))
+      expect(rendered).to_not include(t('account.index.email_add'))
     end
 
-    it 'shows a link to add another email' do
+    it 'does not show a link to add another email' do
       render
 
+      expect(rendered).to_not include(t('help_text.requested_attributes.change_email_link'))
       expect(rendered).to include(t('account.index.email_add'))
     end
   end

--- a/spec/views/sign_up/select_email/show.html.erb_spec.rb
+++ b/spec/views/sign_up/select_email/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'sign_up/select_email/show.html.erb' do
     user.email_addresses.create(email: email, confirmed_at: Time.zone.now)
     user.email_addresses.create(email: email2, confirmed_at: Time.zone.now)
     user.reload
-    @user_emails = user.email_addresses.map { |e| e.email }
+    @user_emails = user.email_addresses
     @select_email_form = SelectEmailForm.new(user)
   end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-13001](https://cm-jira.usa.gov/browse/LG-13001)
[LG-13476](https://cm-jira.usa.gov/browse/LG-13476)



## 🛠 Summary of changes

Add a step in Service Provider consent screen to select from existing email address or if there is only one user email add another and send the selected email onto the service provider. Changes exist behind feature flag `feature_select_email_to_share_enabled: true`


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] With either SP mock local environment running and a previously un-associated account go to the sign in path
- [ ] Continue to SP screen should resemble screenshot below.

With more than one email on the account
- [ ] Click "change"
- [ ] Select a different email then click the Change button
- [ ] Click Agree and Continue, etc. through to completion
- [ ] Expect to see the email selected above having been sent on to SP

With only one email on the account
- [ ] Click "Add..." and add another email
- [ ] From the account page now click "continue to 'Service provider'"
- [ ] Click "change" etc. and proceed as above.

## 👀 Screenshots
Add email
![Screenshot 2024-07-17 at 8 14 10 AM (2)](https://github.com/user-attachments/assets/2fbc5316-2e4c-4dd1-b370-1a265a6f01a3)

Change email
![Screenshot 2024-07-17 at 8 14 30 AM (2)](https://github.com/user-attachments/assets/291f10d5-8c19-45af-ae5e-aac8ddf9af34)

Select email
![Screenshot 2024-08-07 at 11 50 12 AM (2)](https://github.com/user-attachments/assets/c776e775-04b9-4744-8357-6c17ef3a8b72)

As seen at SP
![Screenshot 2024-07-17 at 8 14 56 AM (2)](https://github.com/user-attachments/assets/c2a41646-7b7e-4c05-86f9-a801452170de)

