### PR TITLE
Limit analytics CSP revisions to necessary entries

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -214,23 +214,17 @@ module Users
 
     def override_csp_for_google_analytics
       return unless IdentityConfig.store.participate_in_dap
+      # See: https://github.com/digital-analytics-program/gov-wide-code#content-security-policy
       policy = current_content_security_policy
       policy.script_src(
         *policy.script_src,
         'dap.digitalgov.gov',
         'www.google-analytics.com',
-        '*.googletagmanager.com',
+        'www.googletagmanager.com',
       )
       policy.connect_src(
         *policy.connect_src,
-        '*.google-analytics.com',
-        '*.analytics.google.com',
-        '*.googletagmanager.com',
-      )
-      policy.img_src(
-        *policy.img_src,
-        '*.google-analytics.com',
-        '*.googletagmanager.com',
+        'www.google-analytics.com',
       )
       request.content_security_policy = policy
     end

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -19,6 +19,7 @@ production:
   recaptcha_mock_validator: true
   redis_throttle_url: ['env', 'REDIS_THROTTLE_URL']
   redis_url: ['env', 'REDIS_URL']
+  participate_in_dap: true
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   phone_recaptcha_score_threshold: 0.5


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the logic for adding content-security policy exceptions for analytics to only add the necessary documented values.

This should improve security by tightening the policy, reduces the size of response headers on affected pages, and limits the amount of work performed on a critical path page (the sign-in page).

Related resource: https://github.com/digital-analytics-program/gov-wide-code#content-security-policy

## 📜 Testing Plan

1. Go to TBD
2. Open browser developer tools
3. Reload the page
4. Observe no errors in the developer tools console, or failed requests in the Network tab