### PR TITLE
Consolidated doc auth error messages.

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -197,7 +197,7 @@ module Idv
         limiter_type: :idv_send_link,
       )
       message = I18n.t(
-        'errors.doc_auth.send_link_limited',
+        'doc_auth.errors.send_link_limited',
         timeout: distance_of_time_in_words(
           Time.zone.now,
           [rate_limiter.expires_at, Time.zone.now].compact.max,

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -73,11 +73,11 @@ module Idv
     def render_document_capture_cancelled
       redirect_to idv_hybrid_handoff_url
       idv_session.flow_path = nil
-      failure(I18n.t('errors.doc_auth.document_capture_canceled'))
+      failure(I18n.t('doc_auth.errors.document_capture_canceled'))
     end
 
     def render_step_incomplete_error
-      failure(I18n.t('errors.doc_auth.phone_step_incomplete'))
+      failure(I18n.t('doc_auth.errors.phone_step_incomplete'))
     end
 
     def take_photo_with_phone_successful?

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -298,7 +298,7 @@ module Idv
     def limit_if_rate_limited
       return unless rate_limited?
 
-      errors.add(:limit, t('errors.doc_auth.rate_limited_heading'), type: :rate_limited)
+      errors.add(:limit, t('doc_auth.errors.rate_limited_heading'), type: :rate_limited)
     end
 
     def track_rate_limited

--- a/app/forms/idv/consent_form.rb
+++ b/app/forms/idv/consent_form.rb
@@ -7,7 +7,7 @@ module Idv
     attr_reader :idv_consent_given
 
     validates :idv_consent_given,
-              acceptance: { message: proc { I18n.t('errors.doc_auth.consent_form') } }
+              acceptance: { message: proc { I18n.t('doc_auth.errors.consent_form') } }
 
     def initialize(idv_consent_given: false)
       @idv_consent_given = idv_consent_given

--- a/app/forms/idv/how_to_verify_form.rb
+++ b/app/forms/idv/how_to_verify_form.rb
@@ -10,11 +10,11 @@ module Idv
     attr_reader :selection
 
     validates :selection, presence: {
-      message: proc { I18n.t('errors.doc_auth.how_to_verify_form') },
+      message: proc { I18n.t('doc_auth.errors.how_to_verify_form') },
     }
     validates :selection, inclusion: {
       in: [REMOTE, IPP],
-      message: proc { I18n.t('errors.doc_auth.how_to_verify_form') },
+      message: proc { I18n.t('doc_auth.errors.how_to_verify_form') },
     }
 
     def initialize(selection: nil)

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -37,25 +37,25 @@ function getHeading({
   t,
 }: GetHeadingArguments) {
   if (isFailedDocType) {
-    return t('errors.doc_auth.doc_type_not_supported_heading');
+    return t('doc_auth.errors.doc_type_not_supported_heading');
   }
   if (isResultCodeInvalid) {
-    return t('errors.doc_auth.rate_limited_heading');
+    return t('doc_auth.errors.rate_limited_heading');
   }
   if (isFailedSelfieLivenessOrQuality) {
-    return t('errors.doc_auth.selfie_not_live_or_poor_quality_heading');
+    return t('doc_auth.errors.selfie_not_live_or_poor_quality_heading');
   }
   if (isFailedSelfie) {
-    return t('errors.doc_auth.selfie_fail_heading');
+    return t('doc_auth.errors.selfie_fail_heading');
   }
-  return t('errors.doc_auth.rate_limited_heading');
+  return t('doc_auth.errors.rate_limited_heading');
 }
 
 function getSubheading({ nonIppOrFailedResult, t }) {
   const showSubheading = !nonIppOrFailedResult;
 
   if (showSubheading) {
-    return <h2>{t('errors.doc_auth.rate_limited_subheading')}</h2>;
+    return <h2>{t('doc_auth.errors.rate_limited_subheading')}</h2>;
   }
   return undefined;
 }

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -125,7 +125,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
                     failedImageFingerprints: submissionError.failed_image_fingerprints,
                   })(ReviewIssuesStep)
                 : ReviewIssuesStep,
-            title: t('errors.doc_auth.rate_limited_heading'),
+            title: t('doc_auth.errors.rate_limited_heading'),
           },
         ] as FormStep[]
       ).concat(inPersonSteps)

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -39,7 +39,7 @@ module Idv
         redirect_to rate_limited_url
         DocAuth::Response.new(
           success: false,
-          errors: { limit: I18n.t('errors.doc_auth.rate_limited_heading') },
+          errors: { limit: I18n.t('doc_auth.errors.rate_limited_heading') },
         )
       end
 

--- a/app/views/idv/session_errors/rate_limited.html.erb
+++ b/app/views/idv/session_errors/rate_limited.html.erb
@@ -1,6 +1,6 @@
 <%= render(
       'idv/shared/error',
-      heading: t('errors.doc_auth.rate_limited_heading'),
+      heading: t('doc_auth.errors.rate_limited_heading'),
       options: [
         {
           url: MarketingSite.contact_url,
@@ -11,7 +11,7 @@
     ) do %>
       <p>
         <%= t(
-              'errors.doc_auth.rate_limited_text_html',
+              'doc_auth.errors.rate_limited_text_html',
               timeout: distance_of_time_in_words(
                 Time.zone.now,
                 [@expires_at, Time.zone.now].compact.max,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,9 +523,12 @@ doc_auth.errors.camera.blocked: Your camera is blocked
 doc_auth.errors.camera.blocked_detail_html: '<strong>Allow access to your camera to take photos for %{app_name}.</strong><span>Try taking photos again and allowing permission. If that doesn’t work, you may need to check your device settings to allow access.</span>'
 doc_auth.errors.camera.failed: Camera failed to start, please try again.
 doc_auth.errors.card_type: Try again with your driver’s license or state ID card.
+doc_auth.errors.consent_form: Before you can continue, you must give us permission. Please check the box below and then click continue.
+doc_auth.errors.doc_type_not_supported_heading: We only accept a driver’s license or a state ID
 doc_auth.errors.doc.doc_type_check: Your driver’s license or state ID must be issued by a U.S. state or territory. We do not accept other forms of ID, like passports or military IDs.
 doc_auth.errors.doc.resubmit_failed_image: You already tried this image, and it failed. Please try adding a different image.
 doc_auth.errors.doc.wrong_id_type_html: We only accept a driver’s license or a state ID issued by a U.S. state or territory. We do not accept other forms of ID, like passports or military IDs. <a>Learn more about accepted IDs</a>
+doc_auth.errors.document_capture_canceled: You have canceled uploading photos of your ID on your phone.
 doc_auth.errors.dpi.failed_short: Image is too small or blurry, please try again.
 doc_auth.errors.dpi.top_msg: We couldn’t read your ID. Your image size may be too small, or your ID is too small or blurry in the photo. Make sure your ID is large within the image frame and try taking a new picture.
 doc_auth.errors.dpi.top_msg_plural: We couldn’t read your ID. Your image sizes may be too small, or your ID is too small or blurry in the photos. Make sure your ID is large within the image frame and try taking new pictures.
@@ -540,6 +543,7 @@ doc_auth.errors.general.selfie_failure_help_link_text: Review more tips for taki
 doc_auth.errors.glare.failed_short: Image has glare, please try again.
 doc_auth.errors.glare.top_msg: We couldn’t read your ID. Your photo may have glare. Make sure that the flash on your camera is off and try taking a new picture.
 doc_auth.errors.glare.top_msg_plural: We couldn’t read your ID. Your photos may have glare. Make sure that the flash on your camera is off and try taking new pictures.
+doc_auth.errors.how_to_verify_form: Select a way to verify your identity.
 doc_auth.errors.http.image_load.failed_short: Image file is not supported, please try again.
 doc_auth.errors.http.image_load.top_msg: The image file that you added is not supported. Please take new photos of your ID and try again.
 doc_auth.errors.http.image_size.failed_short: Image file is not supported, please try again.
@@ -547,7 +551,14 @@ doc_auth.errors.http.image_size.top_msg: Your image size is too large or too sma
 doc_auth.errors.http.pixel_depth.failed_short: Image file is not supported, please try again.
 doc_auth.errors.http.pixel_depth.top_msg: The pixel depth of your image file is not supported. Please take new photos of your ID and try again. Supported image pixel depth is 24-bit RGB.
 doc_auth.errors.not_a_file: The selection was not a valid file.
+doc_auth.errors.phone_step_incomplete: You must go to your phone and upload photos of your ID before continuing. We sent you a link with instructions.
 doc_auth.errors.pii.birth_date_min_age: Your birthday does not meet the minimum age requirement.
+doc_auth.errors.rate_limited_heading: We couldn’t verify your ID
+doc_auth.errors.rate_limited_subheading: Try taking new pictures
+doc_auth.errors.rate_limited_text_html: For your security, we limit the number of times you can attempt to verify a document online. <strong>Try again in %{timeout}.</strong>
+doc_auth.errors.selfie_fail_heading: We couldn’t match the photo of yourself to your ID
+doc_auth.errors.selfie_not_live_or_poor_quality_heading: We could not verify the photo of yourself
+doc_auth.errors.send_link_limited: You tried too many times, please try again in %{timeout}. You can also go back and choose to use your computer instead.
 doc_auth.errors.sharpness.failed_short: Image is blurry, please try again.
 doc_auth.errors.sharpness.top_msg: We couldn’t read your ID. Your photo may be too blurry or dark. Try taking a new picture in a bright area.
 doc_auth.errors.sharpness.top_msg_plural: We couldn’t read your ID. Your photos may be too blurry or dark. Try taking new pictures in a bright area.
@@ -696,17 +707,6 @@ errors.attributes.password.too_short.one: Password must be at least one characte
 errors.attributes.password.too_short.other: Password must be at least %{count} characters long
 errors.capture_doc.invalid_link: This link is expired or not valid. Please request another link to verify your identity on a mobile phone.
 errors.confirm_password_incorrect: Incorrect password.
-errors.doc_auth.consent_form: Before you can continue, you must give us permission. Please check the box below and then click continue.
-errors.doc_auth.doc_type_not_supported_heading: We only accept a driver’s license or a state ID
-errors.doc_auth.document_capture_canceled: You have canceled uploading photos of your ID on your phone.
-errors.doc_auth.how_to_verify_form: Select a way to verify your identity.
-errors.doc_auth.phone_step_incomplete: You must go to your phone and upload photos of your ID before continuing. We sent you a link with instructions.
-errors.doc_auth.rate_limited_heading: We couldn’t verify your ID
-errors.doc_auth.rate_limited_subheading: Try taking new pictures
-errors.doc_auth.rate_limited_text_html: For your security, we limit the number of times you can attempt to verify a document online. <strong>Try again in %{timeout}.</strong>
-errors.doc_auth.selfie_fail_heading: We couldn’t match the photo of yourself to your ID
-errors.doc_auth.selfie_not_live_or_poor_quality_heading: We could not verify the photo of yourself
-errors.doc_auth.send_link_limited: You tried too many times, please try again in %{timeout}. You can also go back and choose to use your computer instead.
 errors.enter_code.rate_limited_html: You entered an incorrect verification code too many times. <strong>Try again in %{timeout}.</strong>
 errors.general: Oops, something went wrong. Please try again.
 errors.invalid_totp: Invalid code. Please try again.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -534,9 +534,12 @@ doc_auth.errors.camera.blocked: Su cámara está bloqueada
 doc_auth.errors.camera.blocked_detail_html: '<strong>Permita el acceso a su cámara para tomar las fotografías de %{app_name}.</strong><span>Intente tomar las fotografías de nuevo permitiendo el acceso. Si eso no funciona, tal vez necesite revisar la configuración de su dispositivo para permitir el acceso.</span>'
 doc_auth.errors.camera.failed: No se pudo activar la cámara; inténtelo de nuevo.
 doc_auth.errors.card_type: Inténtelo de nuevo con su licencia de conducir o tarjeta de identificación estatal.
+doc_auth.errors.consent_form: Antes de continuar, debe darnos permiso. Marque la casilla a continuación y luego haga clic en continuar.
+doc_auth.errors.doc_type_not_supported_heading: Solo aceptamos una licencia de conducir o una identificación estatal.
 doc_auth.errors.doc.doc_type_check: Su licencia de conducir o identificación estatal debe ser emitida por un estado o territorio de los EE. UU. No aceptamos otras formas de identificación, como pasaportes o identificaciones militares.
 doc_auth.errors.doc.resubmit_failed_image: Ya intentó con esta imagen y no funcionó. Intente añadir una imagen diferente.
 doc_auth.errors.doc.wrong_id_type_html: Solo aceptamos una licencia de conducir o una identificación estatal emitida por un estado o territorio de los EE. UU. No aceptamos otras formas de identificación, como pasaportes o identificaciones militares. <a>Obtenga más información sobre las identificaciones aceptadas</a>
+doc_auth.errors.document_capture_canceled: Ha cancelado la carga de fotos de su identificación en este teléfono.
 doc_auth.errors.dpi.failed_short: La imagen es demasiado pequeña o está borrosa; inténtelo de nuevo.
 doc_auth.errors.dpi.top_msg: No pudimos leer su identificación. Es posible que el tamaño de su imagen o de su identificación sea demasiado pequeño o que la foto esté borrosa. Asegúrese de que su identificación se vea más grande dentro del marco de la imagen e intente tomar una nueva foto.
 doc_auth.errors.dpi.top_msg_plural: No pudimos leer su identificación. Es posible que el tamaño de sus imágenes o de su identificación sea demasiado pequeño o que las fotos estén borrosas. Asegúrese de que su identificación se vea grande dentro del marco de la imagen e intente tomar nuevas fotos.
@@ -551,6 +554,7 @@ doc_auth.errors.general.selfie_failure_help_link_text: Consulte más consejos pa
 doc_auth.errors.glare.failed_short: La imagen tiene reflejos; inténtelo de nuevo.
 doc_auth.errors.glare.top_msg: No pudimos leer su identificación. Es posible que su foto tenga reflejos. Asegúrese de que el flash de su cámara esté apagado e intente tomar una nueva foto.
 doc_auth.errors.glare.top_msg_plural: No pudimos leer su identificación. Es posible que sus fotos tengan reflejos. Asegúrese de que el flash de su cámara esté apagado e intente tomar nuevas fotos.
+doc_auth.errors.how_to_verify_form: Seleccione una forma de verificar su identidad.
 doc_auth.errors.http.image_load.failed_short: El archivo de la imagen no es compatible; inténtelo de nuevo.
 doc_auth.errors.http.image_load.top_msg: El archivo de imagen que añadió no es compatible. Tome nuevas fotos de su identificación e inténtelo de nuevo.
 doc_auth.errors.http.image_size.failed_short: El archivo de la imagen no es compatible; inténtelo de nuevo.
@@ -558,7 +562,14 @@ doc_auth.errors.http.image_size.top_msg: El tamaño de la imagen es demasiado gr
 doc_auth.errors.http.pixel_depth.failed_short: El archivo de la imagen no es compatible; inténtelo de nuevo.
 doc_auth.errors.http.pixel_depth.top_msg: La profundidad de píxel de su archivo de imagen no es compatible. Tome nuevas fotos de su identificación e inténtelo de nuevo. La profundidad de píxel de la imagen admitida es RGB de 24 bits.
 doc_auth.errors.not_a_file: La selección no era un archivo válido.
+doc_auth.errors.phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación antes de continuar. Le enviamos un vínculo con instrucciones.
 doc_auth.errors.pii.birth_date_min_age: Su fecha de nacimiento no cumple con el requisito de edad mínima.
+doc_auth.errors.rate_limited_heading: No pudimos verificar su identificación
+doc_auth.errors.rate_limited_subheading: Intente tomar nuevas fotos
+doc_auth.errors.rate_limited_text_html: Por su seguridad, limitamos el número de veces que puede intentar verificar un documento en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
+doc_auth.errors.selfie_fail_heading: No hemos podido cotejar su foto con su identificación.
+doc_auth.errors.selfie_not_live_or_poor_quality_heading: No pudimos verificar su foto
+doc_auth.errors.send_link_limited: Lo intentó demasiadas veces; vuelva a intentarlo en %{timeout}. También puede volver atrás y elegir utilizar su computadora.
 doc_auth.errors.sharpness.failed_short: La imagen está borrosa; inténtelo de nuevo.
 doc_auth.errors.sharpness.top_msg: No pudimos leer su identificación. Es posible que su foto esté demasiado borrosa u oscura. Intente tomar una nueva foto en un lugar iluminado.
 doc_auth.errors.sharpness.top_msg_plural: No pudimos leer su identificación. Es posible que sus fotos estén demasiado borrosas u oscuras. Intente tomar nuevas fotos en un lugar iluminado.
@@ -707,17 +718,6 @@ errors.attributes.password.too_short.one: La contraseña debe tener al menos un 
 errors.attributes.password.too_short.other: La contraseña debe tener al menos %{count} caracteres.
 errors.capture_doc.invalid_link: Este enlace ha caducado o no es válido. Solicite otro enlace para verificar su identidad en un teléfono móvil.
 errors.confirm_password_incorrect: La contraseña es incorrecta.
-errors.doc_auth.consent_form: Antes de continuar, debe darnos permiso. Marque la casilla a continuación y luego haga clic en continuar.
-errors.doc_auth.doc_type_not_supported_heading: Solo aceptamos una licencia de conducir o una identificación estatal.
-errors.doc_auth.document_capture_canceled: Ha cancelado la carga de fotos de su identificación en este teléfono.
-errors.doc_auth.how_to_verify_form: Seleccione una forma de verificar su identidad.
-errors.doc_auth.phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación antes de continuar. Le enviamos un vínculo con instrucciones.
-errors.doc_auth.rate_limited_heading: No pudimos verificar su identificación
-errors.doc_auth.rate_limited_subheading: Intente tomar nuevas fotos
-errors.doc_auth.rate_limited_text_html: Por su seguridad, limitamos el número de veces que puede intentar verificar un documento en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
-errors.doc_auth.selfie_fail_heading: No hemos podido cotejar su foto con su identificación.
-errors.doc_auth.selfie_not_live_or_poor_quality_heading: No pudimos verificar su foto
-errors.doc_auth.send_link_limited: Lo intentó demasiadas veces; vuelva a intentarlo en %{timeout}. También puede volver atrás y elegir utilizar su computadora.
 errors.enter_code.rate_limited_html: Ingresó un código de verificación incorrecto demasiadas veces. <strong>Vuelva a intentarlo en %{timeout}.</strong>
 errors.general: Algo salió mal. Vuelva a intentarlo.
 errors.invalid_totp: El código no es válido. Vuelva a intentarlo.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -523,9 +523,12 @@ doc_auth.errors.camera.blocked: Votre appareil photo est bloqué
 doc_auth.errors.camera.blocked_detail_html: '<strong>Autorisez l’accès à votre caméra pour prendre des photos pour %{app_name}.</strong><span>Essayez à nouveau de prendre des photos en autorisant %{app_name} à accéder à votre appareil. Si cela ne marche pas, pensez à vérifier les paramètres de votre appareil en matière d’autorisations d’accès.</span>'
 doc_auth.errors.camera.failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
 doc_auth.errors.card_type: Réessayez avec votre permis de conduire ou carte d’identité d’un État.
+doc_auth.errors.consent_form: Avant de pouvoir continuer, vous devez nous donner la permission. Veuillez cocher la case ci-dessous, puis cliquez sur Suite.
+doc_auth.errors.doc_type_not_supported_heading: Nous n’acceptons que les permis de conduire ou les cartes d’identité délivrées par un État
 doc_auth.errors.doc.doc_type_check: Votre permis de conduire ou votre carte d’identité doit être délivré par un État ou un territoire des États-Unis. Nous n’acceptons pas d’autres pièces d’identité, comme les passeports ou les cartes d’identité militaires.
 doc_auth.errors.doc.resubmit_failed_image: Vous avez déjà essayé cette image et elle a échoué. Veuillez essayer d’ajouter une image différente.
 doc_auth.errors.doc.wrong_id_type_html: Nous n’acceptons qu’un permis de conduire ou une carte d’identité délivré par un État ou un territoire des États-Unis. Nous n’acceptons pas d’autres pièces d’identité, comme les passeports ou les cartes d’identité militaires. <a>En savoir plus sur les pièces d’identité acceptées</a>
+doc_auth.errors.document_capture_canceled: Vous avez annulé le téléchargement de vos photos d’identité sur votre téléphone.
 doc_auth.errors.dpi.failed_short: Image trop petite ou floue, veuillez réessayer.
 doc_auth.errors.dpi.top_msg: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre image soit de trop petite taille ou que votre pièce d’identité soit trop petite ou floue sur la photo. Assurez-vous que votre pièce d’identité remplisse le cadre de l’image, puis essayez de prendre une nouvelle photo.
 doc_auth.errors.dpi.top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre image soit de trop petite taille ou que votre pièce d’identité soit trop petite ou floue sur les photos. Assurez-vous que votre pièce d’identité remplisse le cadre de l’image, puis essayez de prendre une nouvelle photo.
@@ -540,6 +543,7 @@ doc_auth.errors.general.selfie_failure_help_link_text: Consultez plus de conseil
 doc_auth.errors.glare.failed_short: L’image a des reflets, veuillez réessayer.
 doc_auth.errors.glare.top_msg: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre photo présente des reflets. Assurez-vous que le flash de votre appareil photo soit désactivé, puis essayez de prendre une nouvelle photo.
 doc_auth.errors.glare.top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre photo présente des reflets. Assurez-vous que le flash de votre appareil photo soit désactivé, puis essayez de prendre une nouvelle photo.
+doc_auth.errors.how_to_verify_form: Sélectionnez un moyen de vérifier votre identité.
 doc_auth.errors.http.image_load.failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
 doc_auth.errors.http.image_load.top_msg: Le fichier image que vous avez ajouté n’est pas pris en charge. Veuillez prendre de nouvelles photos de votre pièce d’identité et réessayer.
 doc_auth.errors.http.image_size.failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
@@ -547,7 +551,14 @@ doc_auth.errors.http.image_size.top_msg: La taille de votre image est trop grand
 doc_auth.errors.http.pixel_depth.failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
 doc_auth.errors.http.pixel_depth.top_msg: La profondeur de pixel de votre fichier image n’est pas prise en charge. Veuillez prendre de nouvelles photos de votre pièce d’identité et réessayer. La profondeur de pixel de l’image prise en charge est de 24 bits RGB.
 doc_auth.errors.not_a_file: La sélection n’était pas un fichier valide.
+doc_auth.errors.phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des photos de votre pièce d’identité avant de continuer. Nous vous avons envoyé un lien avec des instructions.
 doc_auth.errors.pii.birth_date_min_age: Votre anniversaire ne correspond pas à l’âge minimum requis.
+doc_auth.errors.rate_limited_heading: Nous n’avons pas pu vérifier votre pièce d’identité.
+doc_auth.errors.rate_limited_subheading: Essayez de prendre de nouvelles photos.
+doc_auth.errors.rate_limited_text_html: Pour votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier un document en ligne. <strong>Réessayez dans %{timeout}.</strong>
+doc_auth.errors.selfie_fail_heading: Nous n’avons pas pu faire correspondre votre photo à celle figurant sur votre pièce d’identité.
+doc_auth.errors.selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
+doc_auth.errors.send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans %{timeout}. Vous pouvez également revenir en arrière et choisir d’utiliser votre ordinateur à la place.
 doc_auth.errors.sharpness.failed_short: L’image est floue, veuillez réessayer.
 doc_auth.errors.sharpness.top_msg: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre photo soit trop floue ou trop sombre. Essayez de prendre une nouvelle photo dans un endroit bien éclairé.
 doc_auth.errors.sharpness.top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que vos photos soient trop floues ou trop sombres. Essayez de prendre de nouvelles photos dans un endroit bien éclairé.
@@ -696,17 +707,6 @@ errors.attributes.password.too_short.one: Le mot de passe doit comporter au moin
 errors.attributes.password.too_short.other: Le mot de passe doit comporter au moins %{count} caractères
 errors.capture_doc.invalid_link: Ce lien a expiré ou n’est pas valide. Veuillez demander un autre lien pour vérifier votre identité sur un téléphone mobile.
 errors.confirm_password_incorrect: Mot de passe incorrect.
-errors.doc_auth.consent_form: Avant de pouvoir continuer, vous devez nous donner la permission. Veuillez cocher la case ci-dessous, puis cliquez sur Suite.
-errors.doc_auth.doc_type_not_supported_heading: Nous n’acceptons que les permis de conduire ou les cartes d’identité délivrées par un État
-errors.doc_auth.document_capture_canceled: Vous avez annulé le téléchargement de vos photos d’identité sur votre téléphone.
-errors.doc_auth.how_to_verify_form: Sélectionnez un moyen de vérifier votre identité.
-errors.doc_auth.phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des photos de votre pièce d’identité avant de continuer. Nous vous avons envoyé un lien avec des instructions.
-errors.doc_auth.rate_limited_heading: Nous n’avons pas pu vérifier votre pièce d’identité.
-errors.doc_auth.rate_limited_subheading: Essayez de prendre de nouvelles photos.
-errors.doc_auth.rate_limited_text_html: Pour votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier un document en ligne. <strong>Réessayez dans %{timeout}.</strong>
-errors.doc_auth.selfie_fail_heading: Nous n’avons pas pu faire correspondre votre photo à celle figurant sur votre pièce d’identité.
-errors.doc_auth.selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
-errors.doc_auth.send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans %{timeout}. Vous pouvez également revenir en arrière et choisir d’utiliser votre ordinateur à la place.
 errors.enter_code.rate_limited_html: Vous avez saisi un code de vérification inexact à trop de reprises. <strong>Réessayez dans %{timeout}.</strong>
 errors.general: Oups, une erreur s’est produite. Veuillez réessayer.
 errors.invalid_totp: Code non valide. Veuillez réessayer.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -534,9 +534,12 @@ doc_auth.errors.camera.blocked: 你的镜头被遮住了。
 doc_auth.errors.camera.blocked_detail_html: '<strong>允许 %{app_name} 进入你的相机来拍照。</strong><span>尝试再次拍照并给予许可。如果还不行，你可能需要检查自己设备的设置来给予许可。</span>'
 doc_auth.errors.camera.failed: 相机未开启，请再试一次。
 doc_auth.errors.card_type: 再用你的驾照或州政府颁发的身份证件试一次。
+doc_auth.errors.consent_form: 在你能继续之前，你必须授予我们你的同意。请在下面的框打勾然后点击继续。
+doc_auth.errors.doc_type_not_supported_heading: 我们只接受驾照或州政府颁发的 ID。
 doc_auth.errors.doc.doc_type_check: 你的驾照或身份证件必须是美国一个州或属地颁发的。我们不接受任何其他形式的身份证件，比如护照和军队身份证件。
 doc_auth.errors.doc.resubmit_failed_image: 你已经试过这张图像，该图像不行。请尝试添加一个不同的图像。
 doc_auth.errors.doc.wrong_id_type_html: 我们只接受由美国的一个州或属地颁发的驾照或身份证件。我们不接受任何其他形式的身份证件，比如护照和军队身份证件。<a> 了解更多有关我们接受的身份证件的信息 </a>
+doc_auth.errors.document_capture_canceled: 你已取消了用手机上传身份证件照片。
 doc_auth.errors.dpi.failed_short: 图像太小或模糊，请再试一次。
 doc_auth.errors.dpi.top_msg: 我们无法辨认你的身份证件。你的图像尺寸可能太小，或者照片中你的身份证件太小或太模糊。确保你的身份证件在图框中比较大，然后试着重拍一下。
 doc_auth.errors.dpi.top_msg_plural: 我们无法读取你的身份证件。你的图像尺寸可能太小，或者照片中你的身份证件太小或模糊。确保你的身份证件在图片框中很大，然后试着拍一张新照片。
@@ -551,6 +554,7 @@ doc_auth.errors.general.selfie_failure_help_link_text: 查看更多有关拍摄�
 doc_auth.errors.glare.failed_short: 图像有炫光，请再试一次。
 doc_auth.errors.glare.top_msg: 我们无法读取你的身份证件。你的照片可能有炫光。确保你相机上的闪光是关掉的，然后再尝试重拍张。
 doc_auth.errors.glare.top_msg_plural: 我们无法读取你的身份证件。你的照片可能有炫光。确保你相机上的闪光是关掉的，然后再尝试重拍。
+doc_auth.errors.how_to_verify_form: 选择一个验证身份的方法。
 doc_auth.errors.http.image_load.failed_short: 系统不支持图像文件，请再试一次。
 doc_auth.errors.http.image_load.top_msg: 你添加的图像文件系统不支持。请重拍你的身份证件并再试一次。
 doc_auth.errors.http.image_size.failed_short: 系统不支持图像文件，请再试一次。
@@ -558,7 +562,14 @@ doc_auth.errors.http.image_size.top_msg: 你的图像尺寸太大或太小。请
 doc_auth.errors.http.pixel_depth.failed_short: 系统不支持图像文件，请再试一次。
 doc_auth.errors.http.pixel_depth.top_msg: 你图像文件的像素深度系统不支持。请重拍你的身份证件并再试一次。系统支持的图像像素深度为 24位 RGB。
 doc_auth.errors.not_a_file: 你选择的不是一个正确的文件。
+doc_auth.errors.phone_step_incomplete: 在继续之前你必须使用手机上传你身份证件的图片。我们已给你发了带有说明的链接。
 doc_auth.errors.pii.birth_date_min_age: 你的生日不满足最低年龄要求。
+doc_auth.errors.rate_limited_heading: 我们无法验证你的身份证件。
+doc_auth.errors.rate_limited_subheading: 尝试再拍照片
+doc_auth.errors.rate_limited_text_html: 为了你的安全，我们限制你在网上尝试验证文件的次数。<strong> %{timeout} 后再试。</strong>
+doc_auth.errors.selfie_fail_heading: 我们无法把你自己的照片与你的身份证件匹配
+doc_auth.errors.selfie_not_live_or_poor_quality_heading: 我们无法验证你自己的照片
+doc_auth.errors.send_link_limited: 你尝试了太多次。请在 %{timeout}后再试。你也可以返回并选择使用电脑。
 doc_auth.errors.sharpness.failed_short: 图像模糊，请再试一次。
 doc_auth.errors.sharpness.top_msg: 我们无法读取你的身份证件。你的照片可能太模糊或太暗。尝试在明亮的地方重拍一张。
 doc_auth.errors.sharpness.top_msg_plural: 我们无法读取你的身份证件。你的照片可能太模糊或太暗。尝试在明亮的地方重拍一张。
@@ -707,17 +718,6 @@ errors.attributes.password.too_short.one: 密码必须至少有一个字符
 errors.attributes.password.too_short.other: 密码必须至少有%{count}个字符
 errors.capture_doc.invalid_link: 链接已过期或有误。 请要求另外一个在手机上验证身份的链接。
 errors.confirm_password_incorrect: 密码不对。
-errors.doc_auth.consent_form: 在你能继续之前，你必须授予我们你的同意。请在下面的框打勾然后点击继续。
-errors.doc_auth.doc_type_not_supported_heading: 我们只接受驾照或州政府颁发的 ID。
-errors.doc_auth.document_capture_canceled: 你已取消了用手机上传身份证件照片。
-errors.doc_auth.how_to_verify_form: 选择一个验证身份的方法。
-errors.doc_auth.phone_step_incomplete: 在继续之前你必须使用手机上传你身份证件的图片。我们已给你发了带有说明的链接。
-errors.doc_auth.rate_limited_heading: 我们无法验证你的身份证件。
-errors.doc_auth.rate_limited_subheading: 尝试再拍照片
-errors.doc_auth.rate_limited_text_html: 为了你的安全，我们限制你在网上尝试验证文件的次数。<strong> %{timeout} 后再试。</strong>
-errors.doc_auth.selfie_fail_heading: 我们无法把你自己的照片与你的身份证件匹配
-errors.doc_auth.selfie_not_live_or_poor_quality_heading: 我们无法验证你自己的照片
-errors.doc_auth.send_link_limited: 你尝试了太多次。请在 %{timeout}后再试。你也可以返回并选择使用电脑。
 errors.enter_code.rate_limited_html: 你输入错误验证码太多次。<strong> %{timeout} 后再试。</strong>
 errors.general: 哎呀，出错了。请再试一次。
 errors.invalid_totp: 代码有误。请再试一次。

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
           'IdV: doc auth image upload form submitted',
           success: false,
           errors: {
-            limit: [I18n.t('errors.doc_auth.rate_limited_heading')],
+            limit: [I18n.t('doc_auth.errors.rate_limited_heading')],
           },
           error_details: {
             limit: { rate_limited: true },

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Idv::LinkSentController do
             it 'flashes an error and does not redirect' do
               put :update
 
-              expect(flash[:error]).to eq t('errors.doc_auth.phone_step_incomplete')
+              expect(flash[:error]).to eq t('doc_auth.errors.phone_step_incomplete')
               expect(response.status).to eq(204)
             end
           end
@@ -204,7 +204,7 @@ RSpec.describe Idv::LinkSentController do
 
       context 'document capture session canceled' do
         let(:session_canceled_at) { Time.zone.now }
-        let(:error_message) { t('errors.doc_auth.document_capture_canceled') }
+        let(:error_message) { t('doc_auth.errors.document_capture_canceled') }
 
         before do
           expect(FormResponse).to receive(:new).with(
@@ -228,7 +228,7 @@ RSpec.describe Idv::LinkSentController do
           put :update
 
           expect(response).to have_http_status(204)
-          expect(flash[:error]).to eq(t('errors.doc_auth.phone_step_incomplete'))
+          expect(flash[:error]).to eq(t('doc_auth.errors.phone_step_incomplete'))
         end
       end
     end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
           ),
         )
         submit_images
-        message = strip_tags(t('errors.doc_auth.doc_type_not_supported_heading'))
+        message = strip_tags(t('doc_auth.errors.doc_type_not_supported_heading'))
         expect(page).to have_content(message)
         detail_message = strip_tags(t('doc_auth.errors.doc.doc_type_check'))
         security_message = strip_tags(
@@ -108,7 +108,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
           timeout = distance_of_time_in_words(
             RateLimiter.attempt_window_in_minutes(:idv_doc_auth).minutes,
           )
-          message = strip_tags(t('errors.doc_auth.rate_limited_text_html', timeout: timeout))
+          message = strip_tags(t('doc_auth.errors.rate_limited_text_html', timeout: timeout))
           expect(page).to have_content(message)
           expect(page).to have_current_path(idv_session_errors_rate_limited_path)
         end
@@ -320,10 +320,10 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_issues_h1_heading = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_issues_h1_heading)
 
-                review_issues_subheading = strip_tags(t('errors.doc_auth.rate_limited_subheading'))
+                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
                 expect(page).not_to have_selector('h2', text: review_issues_subheading)
 
                 review_issues_body_message = strip_tags(t('doc_auth.errors.general.no_liveness'))
@@ -373,10 +373,10 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_issues_h1_heading = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_issues_h1_heading)
 
-                review_issues_subheading = strip_tags(t('errors.doc_auth.rate_limited_subheading'))
+                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
                 expect(page).not_to have_selector('h2', text: review_issues_subheading)
 
                 review_issues_body_message = strip_tags(
@@ -427,10 +427,10 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_issues_h1_heading = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_issues_h1_heading)
 
-                review_issues_subheading = strip_tags(t('errors.doc_auth.rate_limited_subheading'))
+                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
                 expect(page).not_to have_selector('h2', text: review_issues_subheading)
 
                 review_issues_body_message = strip_tags(
@@ -496,7 +496,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
@@ -547,7 +547,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 submit_images
 
                 review_page_h1_copy = strip_tags(
-                  t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+                  t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
                 )
                 expect(page).to have_content(review_page_h1_copy)
 
@@ -594,7 +594,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
@@ -638,7 +638,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
@@ -682,7 +682,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
@@ -728,7 +728,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(
@@ -776,7 +776,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(
@@ -824,7 +824,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.no_liveness'))
@@ -869,7 +869,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 submit_images
 
                 review_page_h1_copy = strip_tags(
-                  t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+                  t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
                 )
                 expect(page).to have_content(review_page_h1_copy)
 
@@ -916,7 +916,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.alerts.address_check'))
@@ -962,7 +962,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
@@ -1011,7 +1011,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               ),
             )
             submit_images
-            message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+            message = strip_tags(t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
             detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
@@ -1022,7 +1022,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             )
             expect(page).to have_content(detail_message << "\n" << security_message)
             review_issues_header = strip_tags(
-              t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+              t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
             )
             expect(page).to have_content(review_issues_header)
             expect(page).to have_current_path(idv_document_capture_path)
@@ -1049,7 +1049,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               ),
             )
             submit_images
-            message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+            message = strip_tags(t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
             detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
@@ -1060,7 +1060,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             )
             expect(page).to have_content(detail_message << "\n" << security_message)
             review_issues_header = strip_tags(
-              t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+              t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
             )
             expect(page).to have_content(review_issues_header)
             expect(page).to have_current_path(idv_document_capture_path)
@@ -1087,7 +1087,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               ),
             )
             submit_images
-            message = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
+            message = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
             expect(page).to have_content(message)
             detail_message = strip_tags(t('doc_auth.errors.general.selfie_failure'))
             security_message = strip_tags(
@@ -1098,7 +1098,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             )
             expect(page).to have_content(detail_message << "\n" << security_message)
             review_issues_header = strip_tags(
-              t('errors.doc_auth.selfie_fail_heading'),
+              t('doc_auth.errors.selfie_fail_heading'),
             )
             expect(page).to have_content(review_issues_header)
             expect(page).to have_current_path(idv_document_capture_path)
@@ -1126,7 +1126,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               ),
             )
             submit_images
-            message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+            message = strip_tags(t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
             detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
@@ -1138,7 +1138,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
             expect(page).to have_content(detail_message << "\n" << security_message)
             review_issues_header = strip_tags(
-              t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+              t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
             )
             expect(page).to have_content(review_issues_header)
             expect(page).to have_current_path(idv_document_capture_path)

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -122,7 +122,7 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
       freeze_time do
         idv_send_link_max_attempts.times do
           expect(page).to_not have_content(
-            I18n.t('errors.doc_auth.send_link_limited', timeout: timeout),
+            I18n.t('doc_auth.errors.send_link_limited', timeout: timeout),
           )
 
           fill_in :doc_auth_phone, with: '415-555-0199'
@@ -139,7 +139,7 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
         expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
         expect(page).to have_content(
           I18n.t(
-            'errors.doc_auth.send_link_limited',
+            'doc_auth.errors.send_link_limited',
             timeout: timeout,
           ),
         )

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
         form.submit
 
         expect(form.valid?).to eq(false)
-        expect(form.errors[:limit]).to eq([I18n.t('errors.doc_auth.rate_limited_heading')])
+        expect(form.errors[:limit]).to eq([I18n.t('doc_auth.errors.rate_limited_heading')])
       end
     end
 

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -89,8 +89,8 @@ describe('DocumentCaptureWarning', () => {
 
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
-        heading: 'errors.doc_auth.rate_limited_heading',
-        subheading: 'errors.doc_auth.rate_limited_subheading',
+        heading: 'doc_auth.errors.rate_limited_heading',
+        subheading: 'doc_auth.errors.rate_limited_subheading',
         error_message_displayed: 'general error',
         remaining_submit_attempts: 2,
         liveness_checking_required: false,
@@ -106,8 +106,8 @@ describe('DocumentCaptureWarning', () => {
           inPersonUrl,
         });
 
-        validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
+        validateHeader('doc_auth.errors.rate_limited_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, true);
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -125,8 +125,8 @@ describe('DocumentCaptureWarning', () => {
           inPersonUrl,
         });
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
+        validateHeader('doc_auth.errors.doc_type_not_supported_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, true);
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -148,8 +148,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.rate_limited_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -168,8 +168,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.doc_type_not_supported_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -192,8 +192,8 @@ describe('DocumentCaptureWarning', () => {
       });
 
       // error message section
-      validateHeader('errors.doc_auth.selfie_fail_heading', 1, true);
-      validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
+      validateHeader('doc_auth.errors.selfie_fail_heading', 1, true);
+      validateHeader('doc_auth.errors.rate_limited_subheading', 2, true);
       expect(getByText('general error')).to.be.ok();
       expect(queryByText('idv.failure.attempts_html')).to.be.ok();
       expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -215,8 +215,8 @@ describe('DocumentCaptureWarning', () => {
       });
 
       // error message section
-      validateHeader('errors.doc_auth.selfie_not_live_or_poor_quality_heading', 1, true);
-      validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
+      validateHeader('doc_auth.errors.selfie_not_live_or_poor_quality_heading', 1, true);
+      validateHeader('doc_auth.errors.rate_limited_subheading', 2, true);
       expect(getByText('general error')).to.be.ok();
       expect(queryByText('idv.failure.attempts_html')).to.be.ok();
       expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -238,7 +238,7 @@ describe('DocumentCaptureWarning', () => {
 
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
-        heading: 'errors.doc_auth.doc_type_not_supported_heading',
+        heading: 'doc_auth.errors.doc_type_not_supported_heading',
         subheading: '',
         error_message_displayed: 'general error',
         remaining_submit_attempts: 2,
@@ -257,8 +257,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.rate_limited_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -277,8 +277,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.doc_type_not_supported_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -300,8 +300,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.rate_limited_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -319,8 +319,8 @@ describe('DocumentCaptureWarning', () => {
           inPersonUrl,
         });
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.doc_type_not_supported_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -34,7 +34,7 @@ describe('document-capture/components/review-issues-step', () => {
         value={
           new I18n({
             strings: {
-              'errors.doc_auth.rate_limited_heading': 'We couldn’t verify your ID',
+              'doc_auth.errors.rate_limited_heading': 'We couldn’t verify your ID',
             },
           })
         }
@@ -80,7 +80,7 @@ describe('document-capture/components/review-issues-step', () => {
       </I18nContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
+    expect(getByText('doc_auth.errors.rate_limited_heading')).to.be.ok();
     expect(getByText('3 attempts', { selector: 'strong' })).to.be.ok();
     expect(getByText('remaining')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -114,7 +114,7 @@ describe('document-capture/components/review-issues-step', () => {
       </InPersonContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
+    expect(getByText('doc_auth.errors.rate_limited_heading')).to.be.ok();
     expect(getByText('3 attempts', { selector: 'strong' })).to.be.ok();
     expect(getByText('remaining')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -156,7 +156,7 @@ describe('document-capture/components/review-issues-step', () => {
       </I18nContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
+    expect(getByText('doc_auth.errors.rate_limited_heading')).to.be.ok();
     expect(getByText('One attempt remaining')).to.be.ok();
     expect(getByText('An unknown error occurred')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -234,7 +234,7 @@ describe('document-capture/components/review-issues-step', () => {
                   one: '<strong>One attempt</strong> remaining to add your ID online',
                   other: '<strong>%{count} attempts</strong> remaining to add your ID online',
                 },
-                'errors.doc_auth.doc_type_not_supported_heading': 'doc type not supported',
+                'doc_auth.errors.doc_type_not_supported_heading': 'doc type not supported',
                 'doc_auth.errors.doc.wrong_id_type_html':
                   "We only accept a driver's license or a state ID card at this time.",
               },
@@ -289,7 +289,7 @@ describe('document-capture/components/review-issues-step', () => {
                   one: '<strong>One attempt</strong> remaining to add your ID online',
                   other: '<strong>%{count} attempts</strong> remaining to add your ID online',
                 },
-                'errors.doc_auth.doc_type_not_supported_heading': 'doc type not supported',
+                'doc_auth.errors.doc_type_not_supported_heading': 'doc type not supported',
                 'doc_auth.errors.doc.wrong_id_type_html':
                   "We only accept a driver's license or a state ID card at this time.",
               },

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ImageUploadResponsePresenter do
         FormResponse.new(
           success: false,
           errors: {
-            limit: t('errors.doc_auth.rate_limited_heading'),
+            limit: t('doc_auth.errors.rate_limited_heading'),
           },
         )
       end
@@ -115,7 +115,7 @@ RSpec.describe ImageUploadResponsePresenter do
         FormResponse.new(
           success: false,
           errors: {
-            limit: t('errors.doc_auth.rate_limited_heading'),
+            limit: t('doc_auth.errors.rate_limited_heading'),
           },
           extra: extra_attributes,
         )
@@ -126,7 +126,7 @@ RSpec.describe ImageUploadResponsePresenter do
           success: false,
           result_code_invalid: true,
           result_failed: false,
-          errors: [{ field: :limit, message: t('errors.doc_auth.rate_limited_heading') }],
+          errors: [{ field: :limit, message: t('doc_auth.errors.rate_limited_heading') }],
           redirect: idv_session_errors_rate_limited_url,
           remaining_submit_attempts: 0,
           ocr_pii: nil,
@@ -149,7 +149,7 @@ RSpec.describe ImageUploadResponsePresenter do
             success: false,
             result_code_invalid: true,
             result_failed: false,
-            errors: [{ field: :limit, message: t('errors.doc_auth.rate_limited_heading') }],
+            errors: [{ field: :limit, message: t('doc_auth.errors.rate_limited_heading') }],
             redirect: idv_hybrid_mobile_capture_complete_url,
             remaining_submit_attempts: 0,
             ocr_pii: nil,

--- a/spec/views/idv/session_errors/rate_limited.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/rate_limited.html.erb_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe 'idv/session_errors/rate_limited.html.erb' do
 
   context 'with liveness feature disabled' do
     it 'renders expected heading' do
-      expect(rendered).to have_text(t('errors.doc_auth.rate_limited_heading'))
+      expect(rendered).to have_text(t('doc_auth.errors.rate_limited_heading'))
     end
   end
 
   context 'with liveness feature enabled' do
     it 'renders expected heading' do
-      expect(rendered).to have_text(t('errors.doc_auth.rate_limited_heading'))
+      expect(rendered).to have_text(t('doc_auth.errors.rate_limited_heading'))
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13096](https://cm-jira.usa.gov/browse/LG-13096)

## 🛠 Summary of changes
Moved doc auth error messages in the `.yml` files so all of them are under `doc_auth.errors.` keys (some of them were under `errors.doc_auth.`

## 📜 Testing Plan

Provide a checklist of steps to confirm the change

- [ ] Verify that the translation files (`config/locales/en.yml`, `config/locales/es.yml`, `config/locales/fr.yml`, and `config/locales/cn.yml`) do not contain any `errors.doc_auth` keys.
- [ ] Verify that all existing tests pass, paying particular attention to `spec/i18n_spec.rb`