### PR TITLE
Log new_device with email and password authentication event

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -176,6 +176,7 @@ module Users
         bad_password_count: session[:bad_password_count].to_i,
         sp_request_url_present: sp_session[:request_url].present?,
         remember_device: remember_device_cookie.present?,
+        new_device: success ? new_device? : nil,
       )
     end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -404,6 +404,8 @@ module AnalyticsEvents
   # @param [String] bad_password_count represents number of prior login failures
   # @param [Boolean] sp_request_url_present if was an SP request URL in the session
   # @param [Boolean] remember_device if the remember device cookie was present
+  # @param [Boolean, nil] new_device Whether the user is authenticating from a new device. Nil if
+  # there is the attempt was unsuccessful, since it cannot be known whether it's a new device.
   # Tracks authentication attempts at the email/password screen
   def email_and_password_auth(
     success:,
@@ -413,6 +415,7 @@ module AnalyticsEvents
     bad_password_count:,
     sp_request_url_present:,
     remember_device:,
+    new_device:,
     **extra
   )
     track_event(
@@ -424,6 +427,7 @@ module AnalyticsEvents
       bad_password_count:,
       sp_request_url_present:,
       remember_device:,
+      new_device:,
       **extra,
     )
   end


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-13904](https://cm-jira.usa.gov/browse/LG-13904)

## 🛠 Summary of changes

Updates "Email and Password Authentication" event to include a new `new_device` property.

This will help support:

- Monitor expected behaviors for deployment of new sign-in email aggregation feature
- With in-progress reCAPTCHA-at-sign-in behaviors, which are expected to only apply for new device sign-ins

## 📜 Testing Plan

1. Have a separate terminal process running `make watch_events`
2. Go to http://localhost:3000
3. Sign in
4. Observe event for "Email and Password Authentication" has expected result for `new_device`

To force `new_device: true`, try in a private browsing window. To force `new_device: false`, first sign-in, sign-out, and start over.
