### PR TITLE
Log new_device for piv_cac_login event

### DIFF
--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -54,7 +54,7 @@ module Users
       else
         process_invalid_submission
       end
-      analytics.piv_cac_login(**result.to_h)
+      analytics.piv_cac_login(**result.to_h, new_device: @new_device)
     end
 
     def piv_cac_login_form
@@ -75,7 +75,7 @@ module Users
         presented: true,
       )
 
-      set_new_device_session(nil)
+      @new_device = set_new_device_session(nil)
       handle_verification_for_authentication_context(
         result:,
         auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4991,14 +4991,16 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name PIV/CAC login
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
-  # @param [String,nil] key_id
+  # @param [String,nil] key_id PIV/CAC key_id from PKI service
+  # @param [Boolean] new_device Whether the user is authenticating from a new device
   # tracks piv cac login event
-  def piv_cac_login(success:, errors:, key_id:, **extra)
+  def piv_cac_login(success:, errors:, key_id:, new_device:, **extra)
     track_event(
       :piv_cac_login,
       success:,
       errors:,
       key_id:,
+      new_device:,
       **extra,
     )
   end

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Users::PivCacLoginController do
             errors: {},
             key_id: nil,
             success: false,
+            new_device: nil,
           )
         end
 
@@ -85,6 +86,7 @@ RSpec.describe Users::PivCacLoginController do
               },
               key_id: nil,
               success: false,
+              new_device: nil,
             )
           end
 
@@ -125,6 +127,7 @@ RSpec.describe Users::PivCacLoginController do
               errors: {},
               key_id: nil,
               success: true,
+              new_device: true,
             )
           end
 
@@ -168,6 +171,26 @@ RSpec.describe Users::PivCacLoginController do
               presented: true,
             }
             expect(controller.user_session[:decrypted_x509]).to eq session_info.to_json
+          end
+
+          context 'with authenticated device' do
+            let(:user) { create(:user, :with_authenticated_device) }
+
+            before do
+              cookies[:device] = user.devices.last.cookie_uuid
+            end
+
+            it 'tracks the login attempt' do
+              response
+
+              expect(@analytics).to have_logged_event(
+                :piv_cac_login,
+                errors: {},
+                key_id: nil,
+                success: true,
+                new_device: false,
+              )
+            end
           end
 
           context 'when the user has not accepted the most recent terms of use' do


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-13904](https://cm-jira.usa.gov/browse/LG-13904)

## 🛠 Summary of changes

Updates `piv_cac_login` event to include a new `new_device` property.

This is similar to #10957, except applying for users who sign-in using PIV.

## 📜 Testing Plan

1. Have a separate terminal process running `make watch_events`
2. Go to http://localhost:3000
3. Click "Sign in with your government employee ID"
4. Click "Insert your PIV/CAC"
5. Authenticate with your PIV
6. Observe event for `piv_cac_login` has expected result for `new_device`

To force `new_device: true`, try in a private browsing window. To force `new_device: false`, first sign-in, sign-out, and start over.
