### PR TITLE
LG-13715 Add enhanced_ipp to enrollment updated event

### DIFF
--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:,
                                                             email_type:,
                                                             enrollment_status:,
-                                                            response_json:|
+                                                            response_json:,
+                                                            enhanced_ipp_enrollment: false|
 
-  it 'logs a message with common attributes' do
+  it 'logs an enrollment status update analytics event' do
     date_far_from_daylight_savings_changes = Time.zone.parse('2023-11-30T10:00:00Z')
     travel_to date_far_from_daylight_savings_changes do
       pending_enrollment.update(
@@ -45,6 +46,7 @@ RSpec.shared_examples 'enrollment_with_a_status_update' do |passed:,
         transaction_start_date_time: anything,
         job_name: 'GetUspsProofingResultsJob',
         tmx_status: :threatmetrix_pass,
+        enhanced_ipp: enhanced_ipp_enrollment,
       )
     end
   end
@@ -689,6 +691,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                   reason: 'Successful status update',
                   passed: true,
                   job_name: 'GetUspsProofingResultsJob',
+                  enhanced_ipp: false,
                 ),
               )
               expect(job_analytics).to have_logged_event(
@@ -732,6 +735,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                   passed: false,
                   reason: 'Failed status',
                   job_name: 'GetUspsProofingResultsJob',
+                  enhanced_ipp: false,
                 ),
               )
               expect(job_analytics).to have_logged_event(
@@ -776,6 +780,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                   passed: false,
                   reason: 'Failed status',
                   job_name: 'GetUspsProofingResultsJob',
+                  enhanced_ipp: false,
                 ),
               )
               expect(job_analytics).to have_logged_event(
@@ -819,6 +824,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                   passed: false,
                   reason: 'Unsupported ID type',
                   job_name: 'GetUspsProofingResultsJob',
+                  enhanced_ipp: false,
                 ),
               )
 
@@ -859,6 +865,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                   transaction_end_date_time: nil,
                   transaction_start_date_time: nil,
                   job_name: 'GetUspsProofingResultsJob',
+                  enhanced_ipp: false,
                 ),
               )
             end
@@ -912,6 +919,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                   passed: false,
                   reason: 'Enrollment has expired',
                   job_name: 'GetUspsProofingResultsJob',
+                  enhanced_ipp: false,
                 ),
               )
 
@@ -1306,6 +1314,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                       passed: true,
                       reason: 'Passed with fraud pending',
                       job_name: 'GetUspsProofingResultsJob',
+                      enhanced_ipp: false,
                     ),
                   )
                 end
@@ -1397,6 +1406,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                   passed: false,
                   reason: 'Provided secondary proof of address',
                   job_name: 'GetUspsProofingResultsJob',
+                  enhanced_ipp: false,
                 ),
               )
             end
@@ -1530,6 +1540,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
             enrollment_status: InPersonEnrollment::STATUS_PASSED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
               request_passed_proofing_unsupported_id_results_response,
+            enhanced_ipp_enrollment: true,
           )
 
           it 'invokes the SendProofingNotificationJob and logs details about the success' do
@@ -1552,6 +1563,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                 reason: 'Successful status update',
                 passed: true,
                 job_name: 'GetUspsProofingResultsJob',
+                enhanced_ipp: true,
               ),
             )
             expect(job_analytics).to have_logged_event(
@@ -1578,6 +1590,7 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
             enrollment_status: InPersonEnrollment::STATUS_PASSED,
             response_json: UspsInPersonProofing::Mock::Fixtures.
             request_passed_proofing_secondary_id_type_results_response_ial_2,
+            enhanced_ipp_enrollment: true,
           )
         end
       end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13715](https://cm-jira.usa.gov/browse/LG-13715)

## 🛠 Summary of changes

* Added `enhanced_ipp` to the `properties.event_properties` of the `GetUspsProofingResultsJob: Enrollment status updated` event.

## 📜 Testing Plan

Scenario:

EIPP -> USPS Proofing Passed -> Passed with unsupported Secondary ID - Logged
- [x] Login through the oidc sinatra application selecting the *Enhanced In-person Proofing* level of service.
- [x] Use an exisiting account or create an account
- [x] Follow the flow for creating an enrollment.
- [x] Once on the Verify view (/verify/in_person/ready_to_verify), open a new terminal and run: rails c
- [x] Grab the enrollment: `e = InPersonEnrollment.last`
- [x] Mock a passed response: `json = JSON.parse(UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_secondary_id_type_results_response)`
- [x] Create a new job instance: `job = GetUspsProofingResultsJob.new`
- [x] Set the enrollment_outcomes class variable `job.instance_variable_set('@enrollment_outcomes', { enrollments_passed: 0, enrollments_failed: 0 })`
- [x] Send it: `job.send(:process_enrollment_response, e, res)`
- [x] Check the logs for "GetUspsProofingResultsJob: Enrollment status updated" event with `property.event_properties.enhanced_ipp = true`

EIPP -> USPS Proofing Passed -> Passed with Primary ID check - Logged
- [x] Login through the oidc sinatra application selecting the *Enhanced In-person Proofing* level of service.
- [x] Use an exisiting account or create an account
- [x] Follow the flow for creating an enrollment.
- [x] Once on the Verify view (/verify/in_person/ready_to_verify), open a new terminal and run: rails c
- [x] Grab the enrollment: `e = InPersonEnrollment.last`
- [x] Mock a passed response: `json = JSON.parse(UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_results_response)`
- [x] Create a new job instance: `job = GetUspsProofingResultsJob.new`
- [x] Set the enrollment_outcomes class variable `job.instance_variable_set('@enrollment_outcomes', { enrollments_passed: 0, enrollments_failed: 0 })`
- [x] Send it: `job.send(:process_enrollment_response, e, res)`
- [x] Check the logs for "GetUspsProofingResultsJob: Enrollment status updated" event with `property.event_properties.enhanced_ipp = true`


ID IPP -> USPS Proofing Passed -> Passed with unsupported secondary ID - Logged

- [x] Login through the oidc sinatra application selecting the *Biometrics* level of service.
- [x] Use an exisiting account or create an account
- [x] Follow the flow for creating an enrollment.
- [x] Once on the Verify view (/verify/in_person/ready_to_verify), open a new terminal and run: rails c
- [x] Grab the enrollment: `e = InPersonEnrollment.last`
- [x] Mock a passed response: `json = JSON.parse(UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_secondary_id_type_results_response)`
- [x] Create a new job instance: `job = GetUspsProofingResultsJob.new`
- [x] Set the enrollment_outcomes class variable `job.instance_variable_set('@enrollment_outcomes', { enrollments_passed: 0, enrollments_failed: 0 })`
- [x] Send it: `job.send(:process_enrollment_response, e, res)`
- [x] Check the logs for "GetUspsProofingResultsJob: Enrollment status updated" event with `property.event_properties.enhanced_ipp = false`

ID IPP -> USPS Proofing Passed -> Passed with Primary ID check - Logged

- [x] Login through the oidc sinatra application selecting the *Biometrics* level of service.
- [x] Use an exisiting account or create an account
- [x] Follow the flow for creating an enrollment.
- [x] Once on the Verify view (/verify/in_person/ready_to_verify), open a new terminal and run: rails c
- [x] Grab the enrollment: `e = InPersonEnrollment.last`
- [x] Mock a passed response: `json = JSON.parse(UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_results_response)`
- [x] Create a new job instance: `job = GetUspsProofingResultsJob.new`
- [x] Set the enrollment_outcomes class variable `job.instance_variable_set('@enrollment_outcomes', { enrollments_passed: 0, enrollments_failed: 0 })`
- [x] Send it: `job.send(:process_enrollment_response, e, res)`
- [x] Check the logs for "GetUspsProofingResultsJob: Enrollment status updated" event with `property.event_properties.enhanced_ipp = false`



