### PR TITLE
Document all analytics logged through sign_in_spec

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1068,7 +1068,7 @@ module AnalyticsEvents
     step:,
     analytics_id:,
     acuant_sdk_upgrade_ab_test_bucket:,
-    skip_hybrid_handoff:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1093,7 +1093,7 @@ module AnalyticsEvents
     step:,
     analytics_id:,
     acuant_sdk_upgrade_ab_test_bucket:,
-    skip_hybrid_handoff:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1117,23 +1117,23 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_document_capture_submitted(
     success:,
     errors:,
     step:,
     analytics_id:,
     redo_document_capture:,
-    skip_hybrid_handoff:,
     liveness_checking_required:,
     selfie_check_required:,
     acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1157,21 +1157,21 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_document_capture_visited(
     step:,
     analytics_id:,
     redo_document_capture:,
-    skip_hybrid_handoff:,
     liveness_checking_required:,
     selfie_check_required:,
     acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1228,23 +1228,23 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param ["document_capture","send_link"] destination Where user is sent after submission
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_hybrid_handoff_submitted(
     success:,
     errors:,
     step:,
     analytics_id:,
     redo_document_capture:,
-    skip_hybrid_handoff:,
     selfie_check_required:,
     acuant_sdk_upgrade_ab_test_bucket:,
     destination:,
     flow_path:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1269,17 +1269,17 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_hybrid_handoff_visited(
     step:,
     analytics_id:,
     redo_document_capture:,
-    skip_hybrid_handoff:,
     selfie_check_required:,
     acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1321,17 +1321,17 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_ssn_submitted(
     success:,
     errors:,
     step:,
     analytics_id:,
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1351,15 +1351,15 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name IdV: in person proofing ssn visited
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_ssn_visited(
     step:,
     analytics_id:,
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1727,15 +1727,15 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name IdV: in person proofing verify submitted
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_verify_submitted(
     step:,
     analytics_id:,
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1753,15 +1753,15 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name IdV: in person proofing verify visited
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_verify_visited(
     step:,
     analytics_id:,
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    skip_hybrid_handoff: nil,
     **extra
   )
     track_event(
@@ -1791,7 +1791,7 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
-  def idv_doc_auth_welcome_submitted(step:, analytics_id:, skip_hybrid_handoff:, **extra)
+  def idv_doc_auth_welcome_submitted(step:, analytics_id:, skip_hybrid_handoff: nil, **extra)
     track_event(
       'IdV: doc auth welcome submitted',
       step:,
@@ -1805,7 +1805,7 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
-  def idv_doc_auth_welcome_visited(step:, analytics_id:, skip_hybrid_handoff:, **extra)
+  def idv_doc_auth_welcome_visited(step:, analytics_id:, skip_hybrid_handoff: nil, **extra)
     track_event(
       'IdV: doc auth welcome visited',
       step:,
@@ -1821,8 +1821,8 @@ module AnalyticsEvents
   # @param [Boolean] fraud_rejection
   # @param [Boolean] gpo_verification_pending
   # @param [Boolean] in_person_verification_pending
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -1841,8 +1841,8 @@ module AnalyticsEvents
     fraud_rejection:,
     gpo_verification_pending:,
     in_person_verification_pending:,
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff: nil,
     deactivation_reason: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -1866,8 +1866,8 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -1883,8 +1883,8 @@ module AnalyticsEvents
   # User visited IDV password confirm page
   # @identity.idp.previous_event_name  IdV: review info visited
   def idv_enter_password_visited(
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff: nil,
     proofing_components: nil,
     address_verification_method: nil,
     active_profile_idv_level: nil,
@@ -1909,8 +1909,8 @@ module AnalyticsEvents
   # @param [Boolean] fraud_rejection Profile is rejected due to fraud
   # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verification
   # @param [Boolean] in_person_verification_pending Profile is awaiting in person verification
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -1931,8 +1931,8 @@ module AnalyticsEvents
     fraud_rejection:,
     gpo_verification_pending:,
     in_person_verification_pending:,
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff: nil,
     deactivation_reason: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -3366,8 +3366,8 @@ module AnalyticsEvents
   # @param [String] carrier Pinpoint detected phone carrier
   # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] area_code Area code of phone number
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -3388,8 +3388,8 @@ module AnalyticsEvents
     carrier:,
     country_code:,
     area_code:,
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff: nil,
     error_details: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -3614,8 +3614,8 @@ module AnalyticsEvents
   # @param [:sms,:voice] otp_delivery_preference
   # @param [Integer] second_factor_attempts_count number of attempts to confirm this phone
   # @param [Time, nil] second_factor_locked_at timestamp when the phone was locked out
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -3635,8 +3635,8 @@ module AnalyticsEvents
     otp_delivery_preference:,
     second_factor_attempts_count:,
     second_factor_locked_at:,
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff: nil,
     error_details: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -3776,8 +3776,8 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -3790,8 +3790,8 @@ module AnalyticsEvents
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User visited idv phone of record
   def idv_phone_of_record_visited(
-    skip_hybrid_handoff:,
     acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
     pending_profile_idv_level: nil,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5117,9 +5117,30 @@ module AnalyticsEvents
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+  # @param [Boolean] active_profile_present Whether active profile existed at time of change
+  # @param [Boolean] pending_profile_present Whether pending profile existed at time of change
+  # @param [Boolean] required_password_change Whether password change was forced due to compromised
+  # password
   # The user updated their password
-  def password_changed(success:, errors:, error_details: nil, **extra)
-    track_event('Password Changed', success:, errors:, error_details:, **extra)
+  def password_changed(
+    success:,
+    errors:,
+    active_profile_present:,
+    pending_profile_present:,
+    required_password_change:,
+    error_details: nil,
+    **extra
+  )
+    track_event(
+      'Password Changed',
+      success:,
+      errors:,
+      error_details:,
+      active_profile_present:,
+      pending_profile_present:,
+      required_password_change:,
+      **extra,
+    )
   end
 
   # @param [Boolean] success Whether form validation was successful

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -282,7 +282,7 @@ module AnalyticsEvents
   end
 
   # Tracks when the user creates a set of backup mfa codes.
-  # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Boolean] in_account_creation_flow Whether user is going through creation flow
   def backup_code_created(enabled_mfa_methods_count:, in_account_creation_flow:, **extra)
     track_event(
@@ -302,7 +302,7 @@ module AnalyticsEvents
   # Track user creating new BackupCodeSetupForm, record form submission Hash
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account
-  # @param [Number] enabled_mfa_methods_count Number of enabled MFA methods on the account
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Boolean] in_account_creation_flow Whether page is visited as part of account creation
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
@@ -704,7 +704,7 @@ module AnalyticsEvents
 
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
-  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] isCameraSupported
   # @param [Boolean] success
   # @param [Boolean] use_alternate_sdk
@@ -854,7 +854,7 @@ module AnalyticsEvents
 
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
-  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] isDrop
   # @param [Boolean] source
   # @param [Boolean] use_alternate_sdk
@@ -909,7 +909,7 @@ module AnalyticsEvents
     track_event(:idv_camera_info_error, error: error)
   end
 
-  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Array] camera_info Information on the users cameras max resolution
   # as  captured by the browser
   def idv_camera_info_logged(flow_path:, camera_info:, **_extra)
@@ -1020,7 +1020,7 @@ module AnalyticsEvents
 
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
-  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] use_alternate_sdk
   # @param [Boolean] liveness_checking_required
   def idv_capture_troubleshooting_dismissed(
@@ -1055,24 +1055,139 @@ module AnalyticsEvents
 
   # User has consented to share information with document upload and may
   # view the "hybrid handoff" step next unless "skip_hybrid_handoff" param is true
-  def idv_doc_auth_agreement_submitted(**extra)
-    track_event('IdV: doc auth agreement submitted', **extra)
+  # @param [Boolean] success Whether form validation was successful
+  # @param [Hash] errors Errors resulting from form validation
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  def idv_doc_auth_agreement_submitted(
+    success:,
+    errors:,
+    step:,
+    analytics_id:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth agreement submitted',
+      success:,
+      errors:,
+      step:,
+      analytics_id:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      skip_hybrid_handoff:,
+      **extra,
+    )
   end
 
-  def idv_doc_auth_agreement_visited(**extra)
-    track_event('IdV: doc auth agreement visited', **extra)
+  # User visits IdV agreement step
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  def idv_doc_auth_agreement_visited(
+    step:,
+    analytics_id:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    skip_hybrid_handoff:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth agreement visited',
+      step:,
+      analytics_id:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      skip_hybrid_handoff:,
+      **extra,
+    )
   end
 
   def idv_doc_auth_capture_complete_visited(**extra)
     track_event('IdV: doc auth capture_complete visited', **extra)
   end
 
-  def idv_doc_auth_document_capture_submitted(**extra)
-    track_event('IdV: doc auth document_capture submitted', **extra)
+  # User submits IdV document capture step
+  # @param [Boolean] success Whether form validation was successful
+  # @param [Hash] errors Errors resulting from form validation
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
+  # warning
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
+  # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
+  # @param ["document_capture","send_link"] destination Where user is sent after submission
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  def idv_doc_auth_document_capture_submitted(
+    success:,
+    errors:,
+    step:,
+    analytics_id:,
+    redo_document_capture:,
+    skip_hybrid_handoff:,
+    liveness_checking_required:,
+    selfie_check_required:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth document_capture submitted',
+      success:,
+      errors:,
+      step:,
+      analytics_id:,
+      redo_document_capture:,
+      skip_hybrid_handoff:,
+      liveness_checking_required:,
+      selfie_check_required:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      flow_path:,
+      **extra,
+    )
   end
 
-  def idv_doc_auth_document_capture_visited(**extra)
-    track_event('IdV: doc auth document_capture visited', **extra)
+  # User visits IdV document capture step
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
+  # warning
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
+  # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
+  # @param ["document_capture","send_link"] destination Where user is sent after submission
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  def idv_doc_auth_document_capture_visited(
+    step:,
+    analytics_id:,
+    redo_document_capture:,
+    skip_hybrid_handoff:,
+    liveness_checking_required:,
+    selfie_check_required:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth document_capture visited',
+      flow_path:,
+      step:,
+      analytics_id:,
+      redo_document_capture:,
+      skip_hybrid_handoff:,
+      liveness_checking_required:,
+      selfie_check_required:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      **extra,
+    )
   end
 
   # @param [String] step_name which step the user was on
@@ -1109,14 +1224,76 @@ module AnalyticsEvents
   # either continue via desktop ("document_capture" destination) or switch
   # to mobile phone ("send_link" destination) to perform document upload.
   # @identity.idp.previous_event_name IdV: doc auth upload submitted
-  def idv_doc_auth_hybrid_handoff_submitted(**extra)
-    track_event('IdV: doc auth hybrid handoff submitted', **extra)
+  # @param [Boolean] success Whether form validation was successful
+  # @param [Hash] errors Errors resulting from form validation
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
+  # warning
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
+  # @param ["document_capture","send_link"] destination Where user is sent after submission
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  def idv_doc_auth_hybrid_handoff_submitted(
+    success:,
+    errors:,
+    step:,
+    analytics_id:,
+    redo_document_capture:,
+    skip_hybrid_handoff:,
+    selfie_check_required:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    destination:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth hybrid handoff submitted',
+      success:,
+      errors:,
+      step:,
+      analytics_id:,
+      redo_document_capture:,
+      skip_hybrid_handoff:,
+      selfie_check_required:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      destination:,
+      flow_path:,
+      **extra,
+    )
   end
 
   # Desktop user has reached the above "hybrid handoff" view
   # @identity.idp.previous_event_name IdV: doc auth upload visited
-  def idv_doc_auth_hybrid_handoff_visited(**extra)
-    track_event('IdV: doc auth hybrid handoff visited', **extra)
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
+  # warning
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
+  def idv_doc_auth_hybrid_handoff_visited(
+    step:,
+    analytics_id:,
+    redo_document_capture:,
+    skip_hybrid_handoff:,
+    selfie_check_required:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth hybrid handoff visited',
+      step:,
+      analytics_id:,
+      redo_document_capture:,
+      skip_hybrid_handoff:,
+      selfie_check_required:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      **extra,
+    )
   end
 
   # @identity.idp.previous_event_name IdV: doc auth send_link submitted
@@ -1140,26 +1317,76 @@ module AnalyticsEvents
     track_event('IdV: doc auth redo_ssn submitted', **extra)
   end
 
+  # User submits IdV Social Security number step
   # @identity.idp.previous_event_name IdV: in person proofing ssn submitted
-  def idv_doc_auth_ssn_submitted(**extra)
-    track_event('IdV: doc auth ssn submitted', **extra)
+  # @param [Boolean] success Whether form validation was successful
+  # @param [Hash] errors Errors resulting from form validation
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  def idv_doc_auth_ssn_submitted(
+    success:,
+    errors:,
+    step:,
+    analytics_id:,
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth ssn submitted',
+      success:,
+      errors:,
+      step:,
+      analytics_id:,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      flow_path:,
+      **extra,
+    )
   end
 
+  # User visits IdV Social Security number step
   # @identity.idp.previous_event_name IdV: in person proofing ssn visited
-  def idv_doc_auth_ssn_visited(**extra)
-    track_event('IdV: doc auth ssn visited', **extra)
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  def idv_doc_auth_ssn_visited(
+    step:,
+    analytics_id:,
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth ssn visited',
+      step:,
+      analytics_id:,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      flow_path:,
+      **extra,
+    )
   end
 
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  # @param [Integer] submit_attempts (previously called "attempts")
+  # @param [Integer] submit_attempts Times that user has tried submitting (previously called
+  # "attempts")
   # @param [Integer] remaining_submit_attempts (previously called "remaining_attempts")
   # @param [String] user_id
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] liveness_checking_required Whether or not the selfie is required
   # @param [String] front_image_fingerprint Fingerprint of front image data
   # @param [String] back_image_fingerprint Fingerprint of back image data
+  # @param [String] selfie_image_fingerprint Fingerprint of selfie image data
   # The document capture image uploaded was locally validated during the IDV process
   def idv_doc_auth_submitted_image_upload_form(
     success:,
@@ -1172,6 +1399,7 @@ module AnalyticsEvents
     user_id: nil,
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
+    selfie_image_fingerprint: nil,
     **extra
   )
     track_event(
@@ -1186,6 +1414,7 @@ module AnalyticsEvents
       front_image_fingerprint:,
       back_image_fingerprint:,
       liveness_checking_required:,
+      selfie_image_fingerprint:,
       **extra,
     )
   end
@@ -1198,14 +1427,16 @@ module AnalyticsEvents
   # @param [String] state
   # @param [String] state_id_type
   # @param [Boolean] async
-  # @param [Integer] submit_attempts (previously called "attempts")
+  # @param [Integer] submit_attempts Times that user has tried submitting (previously called
+  # "attempts")
   # @param [Integer] remaining_submit_attempts (previously called "remaining_attempts")
   # @param [Hash] client_image_metrics
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Float] vendor_request_time_in_ms Time it took to upload images & get a response.
   # @param [String] front_image_fingerprint Fingerprint of front image data
   # @param [String] back_image_fingerprint Fingerprint of back image data
-  # @param [Boolean] attention_with_barcode
+  # @param [String] selfie_image_fingerprint Fingerprint of selfie image data
+  # @param [Boolean] attention_with_barcode Whether result was attention with barcode
   # @param [Boolean] doc_type_supported
   # @param [Boolean] doc_auth_success
   # @param [String] liveness_checking_required Whether or not the selfie is required
@@ -1225,6 +1456,10 @@ module AnalyticsEvents
   # @param [Hash] image_metrics
   # @param [Boolean] address_line2_present
   # @param [String] zip_code
+  # @param [Boolean] selfie_live Selfie liveness result
+  # @param [Boolean] selfie_quality_good Selfie quality result
+  # @param [String] workflow LexisNexis TrueID workflow
+  # @param [String] birth_year Birth year from document
   # @option extra [String] 'DocumentName'
   # @option extra [String] 'DocAuthResult'
   # @option extra [String] 'DocIssuerCode'
@@ -1257,6 +1492,7 @@ module AnalyticsEvents
     vendor_request_time_in_ms: nil,
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
+    selfie_image_fingerprint: nil,
     attention_with_barcode: nil,
     doc_type_supported: nil,
     doc_auth_success: nil,
@@ -1276,6 +1512,10 @@ module AnalyticsEvents
     image_metrics: nil,
     address_line2_present: nil,
     zip_code: nil,
+    selfie_live: nil,
+    selfie_quality_good: nil,
+    workflow: nil,
+    birth_year: nil,
     **extra
   )
     track_event(
@@ -1295,6 +1535,7 @@ module AnalyticsEvents
       vendor_request_time_in_ms:,
       front_image_fingerprint:,
       back_image_fingerprint:,
+      selfie_image_fingerprint:,
       attention_with_barcode:,
       doc_type_supported:,
       doc_auth_success:,
@@ -1315,6 +1556,10 @@ module AnalyticsEvents
       address_line2_present:,
       liveness_checking_required:,
       zip_code:,
+      selfie_live:,
+      selfie_quality_good:,
+      workflow:,
+      birth_year:,
       **extra,
     )
   end
@@ -1325,10 +1570,15 @@ module AnalyticsEvents
   # @param [String] user_id
   # @param [Integer] remaining_submit_attempts (previously called "remaining_attempts")
   # @param [Hash] pii_like_keypaths
-  # @param [String] flow_path
-  # @param [String] liveness_checking_required Whether or not the selfie is required
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] liveness_checking_required Whether or not the selfie is required
+  # @param ["present","missing"] id_issued_status Status of state_id_issued field presence
+  # @param ["present","missing"] id_expiration_status Status of state_id_expiration field presence
+  # @param [Boolean] attention_with_barcode Whether result was attention with barcode
+  # @param [Integer] submit_attempts Times that user has tried submitting
   # @param [String] front_image_fingerprint Fingerprint of front image data
   # @param [String] back_image_fingerprint Fingerprint of back image data
+  # @param [String] selfie_image_fingerprint Fingerprint of selfie image data
   # @param [Hash] classification_info document image side information, issuing country and type etc
   # The PII that came back from the document capture vendor was validated
   def idv_doc_auth_submitted_pii_validation(
@@ -1338,10 +1588,15 @@ module AnalyticsEvents
     pii_like_keypaths:,
     flow_path:,
     liveness_checking_required:,
+    attention_with_barcode:,
+    id_issued_status:,
+    id_expiration_status:,
+    submit_attempts:,
     error_details: nil,
     user_id: nil,
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
+    selfie_image_fingerprint: nil,
     classification_info: {},
     **extra
   )
@@ -1351,11 +1606,16 @@ module AnalyticsEvents
       errors:,
       error_details:,
       user_id:,
+      attention_with_barcode:,
+      id_issued_status:,
+      id_expiration_status:,
+      submit_attempts:,
       remaining_submit_attempts:,
       pii_like_keypaths:,
       flow_path:,
       front_image_fingerprint:,
       back_image_fingerprint:,
+      selfie_image_fingerprint:,
       classification_info:,
       liveness_checking_required:,
       **extra,
@@ -1465,14 +1725,56 @@ module AnalyticsEvents
   end
   # rubocop:enable Layout/LineLength
 
+  # User submits IdV verify step
   # @identity.idp.previous_event_name IdV: in person proofing verify submitted
-  def idv_doc_auth_verify_submitted(**extra)
-    track_event('IdV: doc auth verify submitted', **extra)
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  def idv_doc_auth_verify_submitted(
+    step:,
+    analytics_id:,
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth verify submitted',
+      step:,
+      analytics_id:,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      flow_path:,
+      **extra,
+    )
   end
 
+  # User visits IdV verify step
   # @identity.idp.previous_event_name IdV: in person proofing verify visited
-  def idv_doc_auth_verify_visited(**extra)
-    track_event('IdV: doc auth verify visited', **extra)
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  def idv_doc_auth_verify_visited(
+    step:,
+    analytics_id:,
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
+    flow_path:,
+    **extra
+  )
+    track_event(
+      'IdV: doc auth verify visited',
+      step:,
+      analytics_id:,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      flow_path:,
+      **extra,
+    )
   end
 
   # @param [String] step_name
@@ -1487,12 +1789,32 @@ module AnalyticsEvents
     )
   end
 
-  def idv_doc_auth_welcome_submitted(**extra)
-    track_event('IdV: doc auth welcome submitted', **extra)
+  # User submits IdV welcome screen
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  def idv_doc_auth_welcome_submitted(step:, analytics_id:, skip_hybrid_handoff:, **extra)
+    track_event(
+      'IdV: doc auth welcome submitted',
+      step:,
+      analytics_id:,
+      skip_hybrid_handoff:,
+      **extra,
+    )
   end
 
-  def idv_doc_auth_welcome_visited(**extra)
-    track_event('IdV: doc auth welcome visited', **extra)
+  # User visits IdV welcome screen
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  def idv_doc_auth_welcome_visited(step:, analytics_id:, skip_hybrid_handoff:, **extra)
+    track_event(
+      'IdV: doc auth welcome visited',
+      step:,
+      analytics_id:,
+      skip_hybrid_handoff:,
+      **extra,
+    )
   end
 
   # User submitted IDV password confirm page
@@ -1501,6 +1823,8 @@ module AnalyticsEvents
   # @param [Boolean] fraud_rejection
   # @param [Boolean] gpo_verification_pending
   # @param [Boolean] in_person_verification_pending
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -1519,6 +1843,8 @@ module AnalyticsEvents
     fraud_rejection:,
     gpo_verification_pending:,
     in_person_verification_pending:,
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
     deactivation_reason: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -1527,19 +1853,23 @@ module AnalyticsEvents
   )
     track_event(
       :idv_enter_password_submitted,
-      success: success,
-      deactivation_reason: deactivation_reason,
-      fraud_review_pending: fraud_review_pending,
-      gpo_verification_pending: gpo_verification_pending,
-      in_person_verification_pending: in_person_verification_pending,
-      fraud_rejection: fraud_rejection,
-      proofing_components: proofing_components,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
+      success:,
+      deactivation_reason:,
+      fraud_review_pending:,
+      gpo_verification_pending:,
+      in_person_verification_pending:,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      fraud_rejection:,
+      proofing_components:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
       **extra,
     )
   end
 
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -1555,6 +1885,8 @@ module AnalyticsEvents
   # User visited IDV password confirm page
   # @identity.idp.previous_event_name  IdV: review info visited
   def idv_enter_password_visited(
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
     proofing_components: nil,
     address_verification_method: nil,
     active_profile_idv_level: nil,
@@ -1563,10 +1895,12 @@ module AnalyticsEvents
   )
     track_event(
       :idv_enter_password_visited,
-      address_verification_method: address_verification_method,
-      proofing_components: proofing_components,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      address_verification_method:,
+      proofing_components:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
       **extra,
     )
   end
@@ -1577,6 +1911,8 @@ module AnalyticsEvents
   # @param [Boolean] fraud_rejection Profile is rejected due to fraud
   # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verification
   # @param [Boolean] in_person_verification_pending Profile is awaiting in person verification
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -1597,6 +1933,8 @@ module AnalyticsEvents
     fraud_rejection:,
     gpo_verification_pending:,
     in_person_verification_pending:,
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
     deactivation_reason: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -1606,16 +1944,18 @@ module AnalyticsEvents
   )
     track_event(
       'IdV: final resolution',
-      success: success,
-      fraud_review_pending: fraud_review_pending,
-      fraud_rejection: fraud_rejection,
-      gpo_verification_pending: gpo_verification_pending,
-      in_person_verification_pending: in_person_verification_pending,
-      deactivation_reason: deactivation_reason,
-      proofing_components: proofing_components,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
-      profile_history: profile_history,
+      success:,
+      fraud_review_pending:,
+      fraud_rejection:,
+      gpo_verification_pending:,
+      in_person_verification_pending:,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      deactivation_reason:,
+      proofing_components:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
+      profile_history:,
       **extra,
     )
   end
@@ -1682,7 +2022,7 @@ module AnalyticsEvents
   # @param [Integer] dpi  dots per inch of image
   # @param [Integer] failedImageResubmission
   # @param [String] fingerprint fingerprint of the image added
-  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Integer] glare
   # @param [Integer] glareScoreThreshold
   # @param [Integer] height height of image added in pixels
@@ -1761,7 +2101,7 @@ module AnalyticsEvents
 
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
-  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] isDrop
   # @param [String] source
   # @param [String] use_alternate_sdk
@@ -1917,7 +2257,7 @@ module AnalyticsEvents
   # @param [String] error
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] use_alternate_sdk
   # rubocop:disable Naming/VariableName,Naming/MethodParameterName
   def idv_image_capture_failed(
@@ -1980,7 +2320,7 @@ module AnalyticsEvents
   end
 
   # @param [String] selected_location Selected in-person location
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # The user submitted the in person proofing location step
   def idv_in_person_location_submitted(
@@ -1998,7 +2338,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # The user visited the in person proofing location step
   def idv_in_person_location_visited(flow_path:, opted_in_to_in_person_proofing:, **extra)
@@ -2063,7 +2403,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # The user submitted the in person proofing prepare step
   def idv_in_person_prepare_submitted(flow_path:, opted_in_to_in_person_proofing:, **extra)
@@ -2075,7 +2415,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # The user visited the in person proofing prepare step
   def idv_in_person_prepare_visited(flow_path:, opted_in_to_in_person_proofing:, **extra)
@@ -2087,7 +2427,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] step
   # @param [String] analytics_id
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
@@ -2109,7 +2449,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] step
   # @param [String] analytics_id
   # @param [Boolean] success Whether form validation was successful
@@ -2209,7 +2549,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] step
   # @param [String] analytics_id
   # @param [Boolean] success Whether form validation was successful
@@ -2244,7 +2584,7 @@ module AnalyticsEvents
     track_event('IdV: in person proofing residential address submitted', **extra)
   end
 
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] step
   # @param [String] analytics_id
   # @param [Boolean] success Whether form validation was successful
@@ -2278,7 +2618,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] step
   # @param [String] analytics_id
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
@@ -2437,13 +2777,13 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # The user submitted the in person proofing switch_back step
   def idv_in_person_switch_back_submitted(flow_path:, **extra)
     track_event('IdV: in person proofing switch_back submitted', flow_path: flow_path, **extra)
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # The user visited the in person proofing switch_back step
   def idv_in_person_switch_back_visited(flow_path:, **extra)
     track_event('IdV: in person proofing switch_back visited', flow_path: flow_path, **extra)
@@ -2859,7 +3199,7 @@ module AnalyticsEvents
   # @param [Integer] failed_capture_attempts Number of failed Acuant SDK attempts
   # @param [Integer] failed_submission_attempts Number of failed Acuant doc submissions
   # @param [String] field Image form field
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # The number of acceptable failed attempts (maxFailedAttemptsBeforeNativeCamera) has been met
   # or exceeded, and the system has forced the use of the native camera, rather than Acuant's
   # camera, on mobile devices.
@@ -3023,6 +3363,13 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["sms", "voice"] otp_delivery_preference
+  # @param [String] phone_type Pinpoint phone classification type
+  # @param [Array<String>] types Phonelib parsed phone types
+  # @param [String] carrier Pinpoint detected phone carrier
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
+  # @param [String] area_code Area code of phone number
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -3038,6 +3385,13 @@ module AnalyticsEvents
     success:,
     otp_delivery_preference:,
     errors:,
+    phone_type:,
+    types:,
+    carrier:,
+    country_code:,
+    area_code:,
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
     error_details: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -3049,6 +3403,13 @@ module AnalyticsEvents
       success:,
       errors:,
       error_details:,
+      phone_type:,
+      types:,
+      carrier:,
+      country_code:,
+      area_code:,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
       otp_delivery_preference:,
       proofing_components:,
       active_profile_idv_level:,
@@ -3139,7 +3500,7 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["sms","voice"] otp_delivery_preference which channel the OTP was delivered by
-  # @param [String] country_code country code of phone number
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] area_code area code of phone number
   # @param [Boolean] rate_limit_exceeded whether or not the rate limit was exceeded by this attempt
   # @param [Hash] telephony_response response from Telephony gem
@@ -3195,7 +3556,7 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["sms","voice"] otp_delivery_preference which channel the OTP was delivered by
-  # @param [String] country_code country code of phone number
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] area_code area code of phone number
   # @param [Boolean] rate_limit_exceeded whether or not the rate limit was exceeded by this attempt
   # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
@@ -3255,6 +3616,8 @@ module AnalyticsEvents
   # @param [:sms,:voice] otp_delivery_preference
   # @param [Integer] second_factor_attempts_count number of attempts to confirm this phone
   # @param [Time, nil] second_factor_locked_at timestamp when the phone was locked out
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -3274,6 +3637,8 @@ module AnalyticsEvents
     otp_delivery_preference:,
     second_factor_attempts_count:,
     second_factor_locked_at:,
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
     error_details: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -3290,6 +3655,8 @@ module AnalyticsEvents
       otp_delivery_preference:,
       second_factor_attempts_count:,
       second_factor_locked_at:,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
       proofing_components:,
       active_profile_idv_level:,
       pending_profile_idv_level:,
@@ -3327,6 +3694,11 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Hash,nil] proofing_components User's current proofing components
+  # @param [Hash] vendor Vendor response payload
+  # @param [Boolean] new_phone_added Whether phone number was added to account in submission
+  # @param [String] area_code Area code of phone number
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
+  # @param [String] phone_fingerprint Fingerprint of submitted phone number
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
   # @option proofing_components [String,nil] 'source_check' Source used to verify user's PII
@@ -3340,6 +3712,12 @@ module AnalyticsEvents
   def idv_phone_confirmation_vendor_submitted(
     success:,
     errors:,
+    vendor:,
+    area_code:,
+    country_code:,
+    phone_fingerprint:,
+    new_phone_added:,
+    hybrid_handoff_phone_used:,
     error_details: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -3351,6 +3729,12 @@ module AnalyticsEvents
       success:,
       errors:,
       error_details:,
+      vendor:,
+      area_code:,
+      country_code:,
+      phone_fingerprint:,
+      new_phone_added:,
+      hybrid_handoff_phone_used:,
       proofing_components:,
       active_profile_idv_level:,
       pending_profile_idv_level:,
@@ -3394,6 +3778,8 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
@@ -3406,6 +3792,8 @@ module AnalyticsEvents
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User visited idv phone of record
   def idv_phone_of_record_visited(
+    skip_hybrid_handoff:,
+    acuant_sdk_upgrade_ab_test_bucket:,
     proofing_components: nil,
     active_profile_idv_level: nil,
     pending_profile_idv_level: nil,
@@ -3413,9 +3801,11 @@ module AnalyticsEvents
   )
     track_event(
       'IdV: phone of record visited',
-      proofing_components: proofing_components,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
+      skip_hybrid_handoff:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      proofing_components:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
       **extra,
     )
   end
@@ -3680,7 +4070,7 @@ module AnalyticsEvents
   # @param [Integer] selfie_attempts number of times SDK captured selfie, user may decide to retake
   # @param [Integer] failedImageResubmission
   # @param [String] fingerprint fingerprint of the image added
-  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Integer] height height of image added in pixels
   # @param [String] mimeType MIME type of image added
   # @param [Integer] size size of image added in bytes
@@ -3725,7 +4115,7 @@ module AnalyticsEvents
   # rubocop:disable Naming/VariableName,Naming/MethodParameterName,
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
-  # @param [String] flow_path whether the user is in the hybrid or standard flow
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] isDrop
   # @param [String] source
   # @param [String] use_alternate_sdk
@@ -3913,7 +4303,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] flow_path Document capture path ("hybrid" or "standard")
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # The user clicked the troubleshooting option to start in-person proofing
   def idv_verify_in_person_troubleshooting_option_clicked(
@@ -3931,7 +4321,7 @@ module AnalyticsEvents
 
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] location
   # @param [Boolean] use_alternate_sdk
   def idv_warning_action_triggered(
@@ -3956,7 +4346,7 @@ module AnalyticsEvents
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
   # @param [String] error_message_displayed
-  # @param [String] flow_path
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] heading
   # @param [String] location
   # @param [Integer] remaining_submit_attempts (previously called "remaining_attempts")
@@ -4063,11 +4453,11 @@ module AnalyticsEvents
   # @param [Integer] phone_configuration_id Database ID of phone configuration
   # @param [Boolean] confirmation_for_add_phone Whether authenticating while adding phone
   # @param [String] area_code Area code of phone number
-  # @param [String] country_code Country code associated with phone number
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
   # @param [String] frontend_error Name of error that occurred in frontend during submission
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation flow
-  # @param [Integer] enabled_mfa_methods_count Number of MFAs associated with user
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # Multi-Factor Authentication
   def multi_factor_auth(
     success:,
@@ -4121,7 +4511,7 @@ module AnalyticsEvents
   end
 
   # Tracks when the the user has added the MFA method phone to their account
-  # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # @param [Boolean] in_account_creation_flow whether user is going through creation flow
   # @param ['phone'] method_name Authentication method added
@@ -4144,7 +4534,7 @@ module AnalyticsEvents
 
   # @identity.idp.previous_event_name Multi-Factor Authentication: Added PIV_CAC
   # Tracks when the user has added the MFA method piv_cac to their account
-  # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Boolean] in_account_creation_flow whether user is going through creation flow
   # @param ['piv_cac'] method_name Authentication method added
   def multi_factor_auth_added_piv_cac(
@@ -4163,7 +4553,7 @@ module AnalyticsEvents
   end
 
   # Tracks when the user has added the MFA method TOTP to their account
-  # @param [Integer] enabled_mfa_methods_count number of registered mfa methods for the user
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Boolean] in_account_creation_flow whether user is going through creation flow
   # @param ['totp'] method_name Authentication method added
   def multi_factor_auth_added_totp(
@@ -4204,7 +4594,7 @@ module AnalyticsEvents
   # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] phone_fingerprint Fingerprint hash of phone number
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation flow
-  # @param [Integer] enabled_mfa_methods_count Number of MFAs associated with user
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # Multi-Factor Authentication enter OTP visited
   def multi_factor_auth_enter_otp_visit(
     context:,
@@ -4308,7 +4698,7 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] selection
-  # @param [integer] enabled_mfa_methods_count
+  # @param [integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Hash] mfa_method_counts
   def multi_factor_auth_option_list(
     success:,
@@ -4342,10 +4732,10 @@ module AnalyticsEvents
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] otp_delivery_preference
   # @param [String] area_code
-  # @param [String] carrier
-  # @param [String] country_code
-  # @param [String] phone_type
-  # @param [Hash] types
+  # @param [String] carrier Pinpoint detected phone carrier
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
+  # @param [String] phone_type Pinpoint phone classification type
+  # @param [Array<String>] types Phonelib parsed phone types
   def multi_factor_auth_phone_setup(
       success:,
       errors:,
@@ -4379,12 +4769,12 @@ module AnalyticsEvents
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] multi_factor_auth_method
   # @param [Boolean] in_account_creation_flow whether user is going through account creation flow
-  # @param [integer] enabled_mfa_methods_count
+  # @param [integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [DateTime] multi_factor_auth_method_created_at time auth method was created
   # @param ['authentication','reauthentication','confirmation'] context User session context
   # @param [Boolean] confirmation_for_add_phone Whether authenticating while adding phone
   # @param [String] area_code Area code of phone number
-  # @param [String] country_code Country code associated with phone number
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] phone_fingerprint The hmac fingerprint of the phone number formatted as e164
   # @param [Integer] phone_configuration_id Database ID of phone configuration
   # @param [Integer] auth_app_configuration_id Database ID of authentication app configuration
@@ -4680,7 +5070,7 @@ module AnalyticsEvents
   # @param ["authentication","reauthentication","confirmation"] context User session context
   # @param [String] otp_delivery_preference (sms or voice)
   # @param [Boolean] resend True if the user re-requested a code
-  # @param [String] country_code Country code associated with phone number
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] area_code Area code of phone number
   def otp_delivery_selection(
     success:,
@@ -4854,13 +5244,25 @@ module AnalyticsEvents
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+  # @param [Integer] emails Number of email addresses the notification was sent to
+  # @param [Array<String>] sms_message_ids AWS Pinpoint SMS message IDs for each phone number that
+  # was notified
   # Alert user if a personal key was used to sign in
-  def personal_key_alert_about_sign_in(success:, errors:, error_details: nil, **extra)
+  def personal_key_alert_about_sign_in(
+    success:,
+    errors:,
+    emails:,
+    sms_message_ids:,
+    error_details: nil,
+    **extra
+  )
     track_event(
       'Personal key: Alert user about sign in',
       success:,
       errors:,
       error_details:,
+      emails:,
+      sms_message_ids:,
       **extra,
     )
   end
@@ -5019,11 +5421,13 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name User Registration: piv cac setup visited
   # @identity.idp.previous_event_name PIV CAC setup visited
   # Tracks when user's piv cac setup
-  # @param [Boolean] in_account_creation_flow
-  def piv_cac_setup_visited(in_account_creation_flow:, **extra)
+  # @param [Boolean] in_account_creation_flow Whether user is going through account creation
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
+  def piv_cac_setup_visited(in_account_creation_flow:, enabled_mfa_methods_count:, **extra)
     track_event(
       :piv_cac_setup_visited,
       in_account_creation_flow:,
+      enabled_mfa_methods_count:,
       **extra,
     )
   end
@@ -5076,7 +5480,7 @@ module AnalyticsEvents
   end
 
   # @param [true] success this event always succeeds
-  # @param [Integer] emails number of email addresses the notification was sent to
+  # @param [Integer] emails Number of email addresses the notification was sent to
   # @param [Array<String>] sms_message_ids AWS Pinpoint SMS message IDs for each phone number that
   # was notified
   # User has chosen to receive a new personal key, contains stats about notifications that
@@ -5599,8 +6003,8 @@ module AnalyticsEvents
     )
   end
 
-  # @param [String] area_code
-  # @param [String] country_code
+  # @param [String] area_code Area code of phone number
+  # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] phone_fingerprint the hmac fingerprint of the phone number formatted as e164
   # @param [String] context the context of the OTP, either "authentication" for confirmed phones
   # or "confirmation" for unconfirmed
@@ -5646,7 +6050,7 @@ module AnalyticsEvents
   # @param [Boolean] user_signed_up
   # @param [Boolean] totp_secret_present
   # @param [Integer] enabled_mfa_methods_count
-  # @param [Boolean] in_account_creation_flow
+  # @param [Boolean] in_account_creation_flow Whether user is going through account creation
   def totp_setup_visit(
     user_signed_up:,
     totp_secret_present:,
@@ -5742,7 +6146,7 @@ module AnalyticsEvents
   end
 
   # Tracks when user visits MFA selection page
-  # @param [Integer] enabled_mfa_methods_count Number of MFAs associated with user at time of visit
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Boolean] gov_or_mil_email Whether registered user has government email
   def user_registration_2fa_setup_visit(
     enabled_mfa_methods_count:,
@@ -5903,7 +6307,7 @@ module AnalyticsEvents
 
   # @param [Boolean] success
   # @param [Hash] mfa_method_counts
-  # @param [Integer] enabled_mfa_methods_count
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Boolean] second_mfa_reminder_conversion Whether it is a result of second MFA reminder.
   # @param [Hash] pii_like_keypaths
   # Tracks when a user has completed MFA setup
@@ -5926,7 +6330,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Integer] enabled_mfa_methods_count
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # Tracks when user visits the phone setup step during registration
   def user_registration_phone_setup_visit(enabled_mfa_methods_count:, **extra)
     track_event(
@@ -6055,7 +6459,7 @@ module AnalyticsEvents
   end
 
   # @param [Hash] platform_authenticator
-  # @param [Integer] enabled_mfa_methods_count
+  # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # Tracks when WebAuthn setup is visited
   def webauthn_setup_visit(platform_authenticator:, enabled_mfa_methods_count:, **extra)
     track_event(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3694,6 +3694,8 @@ module AnalyticsEvents
   # @param [Hash,nil] proofing_components User's current proofing components
   # @param [Hash] vendor Vendor response payload
   # @param [Boolean] new_phone_added Whether phone number was added to account in submission
+  # @param [Boolean] hybrid_handoff_phone_used Whether phone is the same as what was used for hybrid
+  # document capture
   # @param [String] area_code Area code of phone number
   # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] phone_fingerprint Fingerprint of submitted phone number

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1122,7 +1122,6 @@ module AnalyticsEvents
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
-  # @param ["document_capture","send_link"] destination Where user is sent after submission
   # @param ["hybrid","standard"] flow_path Document capture user flow
   def idv_doc_auth_document_capture_submitted(
     success:,
@@ -1163,7 +1162,6 @@ module AnalyticsEvents
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
-  # @param ["document_capture","send_link"] destination Where user is sent after submission
   # @param ["hybrid","standard"] flow_path Document capture user flow
   def idv_doc_auth_document_capture_visited(
     step:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1166,10 +1166,10 @@ module AnalyticsEvents
   def idv_doc_auth_document_capture_visited(
     step:,
     analytics_id:,
-    redo_document_capture:,
     liveness_checking_required:,
     selfie_check_required:,
     flow_path:,
+    redo_document_capture: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
@@ -5423,7 +5423,7 @@ module AnalyticsEvents
   # Tracks when user's piv cac setup
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation
   # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
-  def piv_cac_setup_visited(in_account_creation_flow:, enabled_mfa_methods_count:, **extra)
+  def piv_cac_setup_visited(in_account_creation_flow:, enabled_mfa_methods_count: nil, **extra)
     track_event(
       :piv_cac_setup_visited,
       in_account_creation_flow:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1067,7 +1067,7 @@ module AnalyticsEvents
     errors:,
     step:,
     analytics_id:,
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1092,7 +1092,7 @@ module AnalyticsEvents
   def idv_doc_auth_agreement_visited(
     step:,
     analytics_id:,
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1115,24 +1115,24 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
-  # warning
   # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
+  # warning
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
-  # @param ["hybrid","standard"] flow_path Document capture user flow
-  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_document_capture_submitted(
     success:,
     errors:,
     step:,
     analytics_id:,
-    redo_document_capture:,
     liveness_checking_required:,
     selfie_check_required:,
-    acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
+    redo_document_capture: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1159,9 +1159,9 @@ module AnalyticsEvents
   # warning
   # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
-  # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_document_capture_visited(
     step:,
@@ -1169,8 +1169,8 @@ module AnalyticsEvents
     redo_document_capture:,
     liveness_checking_required:,
     selfie_check_required:,
-    acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1229,10 +1229,10 @@ module AnalyticsEvents
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
   # @param [Boolean] selfie_check_required Whether biometric selfie check is required
-  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
   # @param ["document_capture","send_link"] destination Where user is sent after submission
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_hybrid_handoff_submitted(
     success:,
@@ -1241,9 +1241,9 @@ module AnalyticsEvents
     analytics_id:,
     redo_document_capture:,
     selfie_check_required:,
-    acuant_sdk_upgrade_ab_test_bucket:,
     destination:,
     flow_path:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1278,7 +1278,7 @@ module AnalyticsEvents
     analytics_id:,
     redo_document_capture:,
     selfie_check_required:,
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1321,16 +1321,16 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_ssn_submitted(
     success:,
     errors:,
     step:,
     analytics_id:,
-    acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1351,14 +1351,14 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name IdV: in person proofing ssn visited
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_ssn_visited(
     step:,
     analytics_id:,
-    acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1727,14 +1727,14 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name IdV: in person proofing verify submitted
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_verify_submitted(
     step:,
     analytics_id:,
-    acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1753,14 +1753,14 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name IdV: in person proofing verify visited
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   def idv_doc_auth_verify_visited(
     step:,
     analytics_id:,
-    acuant_sdk_upgrade_ab_test_bucket:,
     flow_path:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
   )
@@ -1841,7 +1841,7 @@ module AnalyticsEvents
     fraud_rejection:,
     gpo_verification_pending:,
     in_person_verification_pending:,
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     deactivation_reason: nil,
     proofing_components: nil,
@@ -1883,7 +1883,7 @@ module AnalyticsEvents
   # User visited IDV password confirm page
   # @identity.idp.previous_event_name  IdV: review info visited
   def idv_enter_password_visited(
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     proofing_components: nil,
     address_verification_method: nil,
@@ -1931,7 +1931,7 @@ module AnalyticsEvents
     fraud_rejection:,
     gpo_verification_pending:,
     in_person_verification_pending:,
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     deactivation_reason: nil,
     proofing_components: nil,
@@ -3388,7 +3388,7 @@ module AnalyticsEvents
     carrier:,
     country_code:,
     area_code:,
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     error_details: nil,
     proofing_components: nil,
@@ -3635,7 +3635,7 @@ module AnalyticsEvents
     otp_delivery_preference:,
     second_factor_attempts_count:,
     second_factor_locked_at:,
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     error_details: nil,
     proofing_components: nil,
@@ -3790,7 +3790,7 @@ module AnalyticsEvents
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # User visited idv phone of record
   def idv_phone_of_record_visited(
-    acuant_sdk_upgrade_ab_test_bucket:,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController,
-               allowed_extra_analytics: [:*] do
+RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
   let(:personal_key) { { personal_key: 'foo' } }
   let(:payload) { { personal_key_form: personal_key } }
 

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
+RSpec.describe Users::PasswordsController do
   context 'user visits edit password page' do
     let(:user) { create(:user) }
     before do

--- a/spec/features/account_email_language_spec.rb
+++ b/spec/features/account_email_language_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Account email language', allowed_extra_analytics: [:*] do
+RSpec.describe 'Account email language' do
   let(:user) { user_with_2fa }
 
   let(:original_email_language) { 'es' }

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'disavowing an action', allowed_extra_analytics: [:*] do
+RSpec.feature 'disavowing an action' do
   let(:user) { create(:user, :fully_registered, :with_personal_key) }
 
   context 'with aggregated sign-in notifications enabled' do

--- a/spec/features/idv/doc_auth/agreement_spec.rb
+++ b/spec/features/idv/doc_auth/agreement_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'agreement step error checking', allowed_extra_analytics: [:*] do
+RSpec.feature 'agreement step error checking' do
   include DocAuthHelper
   context 'skipping hybrid_handoff step', :js, driver: :headless_chrome_mobile do
     let(:fake_analytics) { FakeAnalytics.new }

--- a/spec/features/idv/doc_auth/welcome_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'welcome step', allowed_extra_analytics: [:*] do
+RSpec.feature 'welcome step' do
   include IdvHelper
   include DocAuthHelper
 

--- a/spec/features/idv/pending_profile_password_reset_spec.rb
+++ b/spec/features/idv/pending_profile_password_reset_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Resetting password with a pending profile', allowed_extra_analytics: [:*] do
+RSpec.describe 'Resetting password with a pending profile' do
   include OidcAuthHelper
 
   let(:sp_name) { 'Test SP' }

--- a/spec/features/legacy_passwords_spec.rb
+++ b/spec/features/legacy_passwords_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'legacy passwords', allowed_extra_analytics: [:*] do
+RSpec.feature 'legacy passwords' do
   scenario 'signing in with a password digested by the uak verifier updates the digest' do
     user = create(:user, :fully_registered)
     user.update!(

--- a/spec/features/two_factor_authentication/multiple_tabs_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_tabs_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'user interacts with 2FA across multiple browser tabs',
-              allowed_extra_analytics: [:*] do
+RSpec.feature 'user interacts with 2FA across multiple browser tabs' do
   include SpAuthHelper
   include SamlAuthHelper
 

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Signing in via one-time use personal key', allowed_extra_analytics: [:*] do
+RSpec.feature 'Signing in via one-time use personal key' do
   it 'destroys old key, does not offer new one' do
     user = create(
       :user, :fully_registered, :with_phone, :with_personal_key,

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
+RSpec.feature 'Sign in' do
   include SessionTimeoutWarningHelper
   include ActionView::Helpers::DateHelper
   include PersonalKeyHelper

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'User edit', allowed_extra_analytics: [:*] do
+RSpec.feature 'User edit' do
   let(:user) { create(:user, :fully_registered) }
 
   context 'editing password' do

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Internationalization', allowed_extra_analytics: [:*] do
+RSpec.feature 'Internationalization' do
   context 'visit homepage with no locale set' do
     it 'displays a header in the default locale' do
       visit root_path

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -528,6 +528,8 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
           extra: {
             pii_like_keypaths: pii_like_keypaths,
             attention_with_barcode: false,
+            id_issued_status: 'missing',
+            id_expiration_status: 'missing',
           },
         )
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes `allowed_extra_analytics` from `spec/features/users/sign_in_spec.rb` and resolves all flagged issues.

Most of these come from IdV events, documented to the best of my ability.

~Separately, it may be worth revisiting whether it's necessary for sign-in specs to go through the complete IdV flow, or if it would be fine to stub an already-IdV'd user instead (see [`sign_in.rb` shared examples](https://github.com/18F/identity-idp/blob/main/spec/support/shared_examples/sign_in.rb), specifically [use of `create_ial2_account_go_back_to_sp_and_sign_out`](https://github.com/18F/identity-idp/blob/c02f05010d324b121f5ba7e33e22ea6a39af8c68/spec/support/shared_examples/sign_in.rb#L358))~  **Edit:** Addressed separately in #10967.

## 📜 Testing Plan

Validate that tests pass.

In most cases, I added new method arguments as non-optional. Confidence check that these analytics will always be logged is appreciated.