### PR TITLE
Stub proofed user for PIV IdV sign-in spec

### DIFF
--- a/app/views/openid_connect/shared/redirect_js.html.erb
+++ b/app/views/openid_connect/shared/redirect_js.html.erb
@@ -10,7 +10,7 @@
           <%= t('saml_idp.shared.saml_post_binding.no_js') %>
         </p>
 
-        <%= link_to(t('forms.buttons.continue'), @oidc_redirect_uri, class: 'usa-button usa-button--wide usa-button--big', data: { click_immediate: '' }) %>
+        <%= link_to(t('forms.buttons.submit.default'), @oidc_redirect_uri, class: 'usa-button usa-button--wide usa-button--big', data: { click_immediate: '' }) %>
       </div>
     </div>
   </div>

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -263,7 +263,7 @@ module Features
     end
 
     def click_submit_default
-      click_button t('forms.buttons.submit.default')
+      click_on t('forms.buttons.submit.default')
     end
 
     def click_submit_default_twice

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -11,26 +11,6 @@ module SpAuthHelper
     User.find_with_email(email)
   end
 
-  def create_ial2_account_go_back_to_sp_and_sign_out(sp)
-    user = create(:user, :fully_registered)
-    visit_idp_from_sp_with_ial2(sp)
-    fill_in_credentials_and_submit(user.email, user.password)
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-    complete_all_doc_auth_steps
-    fill_out_phone_form_ok
-    choose_idv_otp_delivery_method_sms
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-    fill_in t('idv.form.password'), with: user.password
-    click_continue
-    acknowledge_and_confirm_personal_key
-    expect(page).to have_current_path(sign_up_completed_path)
-    click_agree_and_continue
-    visit sign_out_url
-    user.reload
-  end
-
   def create_in_person_ial2_account_go_back_to_sp_and_sign_out(sp)
     user = user_with_totp_2fa
     ServiceProvider.find_by(issuer: service_provider_issuer(sp)).


### PR DESCRIPTION
## 🛠 Summary of changes

Updates sign-in feature specs for verification of PIV sign-in for proofed user to avoid running through the entire proofing process, since this is slow and requires JavaScript, and the intent of the spec is to verify that the user would be prompted for their password before being returned to the service provider.

Follow-up from #10966: 

>Separately, it may be worth revisiting whether it's necessary for sign-in specs to go through the complete IdV flow, or if it would be fine to stub an already-IdV'd user instead (see [sign_in.rb shared examples](https://github.com/18F/identity-idp/blob/main/spec/support/shared_examples/sign_in.rb), specifically [use of create_ial2_account_go_back_to_sp_and_sign_out](https://github.com/18F/identity-idp/blob/c02f05010d324b121f5ba7e33e22ea6a39af8c68/spec/support/shared_examples/sign_in.rb#L358))

## 📜 Testing Plan

```
rspec './spec/features/users/sign_in_spec.rb[1:40:1]' './spec/features/users/sign_in_spec.rb[1:39:1]' './spec/features/users/sign_in_spec.rb[1:39:2:1]'
```