### PR TITLE
Fixed broken link to help center.

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
@@ -49,7 +49,7 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
       'idv.troubleshooting.options.supported_documentslinks.new_tab',
     );
     expect(links[1].getAttribute('href')).to.equal(
-      'https://example.com/redirect/?category=verify-your-identity&article=accepted-state-issued-identification&location=document_capture_troubleshooting_options',
+      'https://example.com/redirect/?category=verify-your-identity&article=accepted-identification-documents&location=document_capture_troubleshooting_options',
     );
     expect(links[1].target).to.equal('_blank');
   });

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -57,7 +57,7 @@ function DocumentCaptureTroubleshootingOptions({
             showDocumentTips && {
               url: getHelpCenterURL({
                 category: 'verify-your-identity',
-                article: 'accepted-state-issued-identification',
+                article: 'accepted-identification-documents',
                 location,
               }),
               text: t('idv.troubleshooting.options.supported_documents'),

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -11,7 +11,6 @@ class MarketingSite
     manage-your-account/personal-key
     trouble-signing-in/face-or-touch-unlock
     verify-your-identity/accepted-identification-documents
-    verify-your-identity/accepted-state-issued-identification
     verify-your-identity/how-to-add-images-of-your-state-issued-id
     verify-your-identity/verify-your-identity-in-person
     verify-your-identity/phone-number

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -28,7 +28,7 @@
   <%= link_to(
         MarketingSite.help_center_article_url(
           category: 'verify-your-identity',
-          article: 'accepted-state-identification-documents',
+          article: 'accepted-identification-documents',
         ),
         class: 'display-inline',
       ) do %>

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -28,7 +28,7 @@
   <%= link_to(
         MarketingSite.help_center_article_url(
           category: 'verify-your-identity',
-          article: 'accepted-state-issued-identification',
+          article: 'accepted-state-identification-documents',
         ),
         class: 'display-inline',
       ) do %>

--- a/spec/controllers/redirect/help_center_controller_spec.rb
+++ b/spec/controllers/redirect/help_center_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Redirect::HelpCenterController do
 
     context 'with valid help center article' do
       let(:category) { 'verify-your-identity' }
-      let(:article) { 'accepted-state-issued-identification' }
+      let(:article) { 'accepted-identification-documents' }
       let(:params) { super().merge(category:, article:) }
 
       it 'redirects to the help center article and logs' do

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -170,20 +170,20 @@ RSpec.describe MarketingSite do
 
     context 'with valid article' do
       let(:category) { 'verify-your-identity' }
-      let(:article) { 'accepted-state-issued-identification' }
+      let(:article) { 'accepted-identification-documents' }
 
       it_behaves_like 'a marketing site URL'
 
       it 'returns article URL' do
         expect(url).to eq(
-          'https://www.login.gov/help/verify-your-identity/accepted-state-issued-identification/',
+          'https://www.login.gov/help/verify-your-identity/accepted-identification-documents/',
         )
       end
     end
 
     context 'with anchor' do
       let(:category) { 'verify-your-identity' }
-      let(:article) { 'accepted-state-issued-identification' }
+      let(:article) { 'accepted-identification-documents' }
       let(:article_anchor) { 'test-anchor-url' }
       let(:url) do
         MarketingSite.help_center_article_url(category:, article:, article_anchor:)
@@ -193,7 +193,7 @@ RSpec.describe MarketingSite do
 
       it 'returns article URL' do
         expect(url).to eq(
-          'https://www.login.gov/help/verify-your-identity/accepted-state-issued-identification/#test-anchor-url',
+          'https://www.login.gov/help/verify-your-identity/accepted-identification-documents/#test-anchor-url',
         )
       end
     end
@@ -213,7 +213,7 @@ RSpec.describe MarketingSite do
 
     context 'with valid article' do
       let(:category) { 'verify-your-identity' }
-      let(:article) { 'accepted-state-issued-identification' }
+      let(:article) { 'accepted-identification-documents' }
 
       it { expect(result).to eq(true) }
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13945](https://cm-jira.usa.gov/browse/LG-13945)

## 🛠 Summary of changes

Fixed a broken link on the document capture page. We were pointing them to a non-existent help center page.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Bring up the server, create an account, and enter IdV
- [ ] Use the attached YAML file to force a failure when uploading your ID images
- [ ] Click on the 'Learn more about accepted IDs' link, and verify that you are taken to a help center article, not to a 404 error page.

### Yaml file for ID upload

```
failed_alerts:
  - name: Document Classification
    result: Attention
```

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Upload Your ID</summary>

![Upload_your_ID](https://github.com/user-attachments/assets/a7107b61-ce50-4542-b11c-bf20402ca893)

</details>

<details>
<summary>Error Page</summary>

![Error_page](https://github.com/user-attachments/assets/1dce467f-c9a6-48d1-9575-d0ecef264526)

</details>

<details>
<summary>Help Center</summary>

![Help_Center](https://github.com/user-attachments/assets/d5ee2951-3622-4bdf-b79f-523e431b7dd6)

</details>