### PR TITLE
Use ActiveModel validations for components

### DIFF
--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 class AlertComponent < BaseComponent
-  VALID_TYPES = [nil, :info, :success, :warning, :error, :emergency].freeze
-
   attr_reader :type, :message, :tag_options, :text_tag
 
-  def initialize(type: nil, text_tag: 'p', message: nil, **tag_options)
-    if !VALID_TYPES.include?(type)
-      raise ArgumentError, "`type` #{type} is invalid, expected one of #{VALID_TYPES}"
-    end
+  validates_inclusion_of :type, in: [nil, :info, :success, :warning, :error, :emergency]
 
+  def initialize(type: nil, text_tag: 'p', message: nil, **tag_options)
     @type = type
     @message = message
     @tag_options = tag_options

--- a/app/components/alert_icon_component.rb
+++ b/app/components/alert_icon_component.rb
@@ -14,11 +14,9 @@ class AlertIconComponent < BaseComponent
 
   attr_reader :tag_options, :icon_name
 
+  validates_inclusion_of :icon_name, in: ICON_SOURCE.keys
+
   def initialize(icon_name: :warning, **tag_options)
-    if !ICON_SOURCE.key?(icon_name)
-      raise ArgumentError,
-            "`icon_name` #{icon_name} is invalid, expected one of #{ICON_SOURCE.keys}"
-    end
     @icon_name = icon_name
     @tag_options = tag_options
   end

--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 class BadgeComponent < BaseComponent
-  ICONS = %i[
+  attr_reader :icon, :tag_options
+
+  validates_inclusion_of :icon, in: %i[
     lock
     check_circle
     warning
     info
-  ].to_set.freeze
-
-  attr_reader :icon, :tag_options
+  ]
 
   def initialize(icon:, **tag_options)
-    raise ArgumentError, "invalid icon #{icon}, expected one of #{ICONS}" if !ICONS.include?(icon)
     @icon = icon
     @tag_options = tag_options
   end

--- a/app/components/base_component.rb
+++ b/app/components/base_component.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class BaseComponent < ViewComponent::Base
+  include ActiveModel::Model
+
   def before_render
+    raise_validation_errors
     render_assets unless rendered_assets?
   end
 
@@ -46,5 +49,10 @@ class BaseComponent < ViewComponent::Base
     end
 
     @rendered_assets = true
+  end
+
+  def raise_validation_errors
+    return unless IdentityConfig.store.raise_on_component_validation_error
+    validate!
   end
 end

--- a/app/components/icon_component.rb
+++ b/app/components/icon_component.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class IconComponent < BaseComponent
+  attr_reader :icon, :size, :tag_options
+
   # See: https://github.com/uswds/uswds/tree/develop/src/img/usa-icons
-  ICONS = %i[
+  validates_inclusion_of :icon, in: %i[
     accessibility_new
     accessible_forward
     account_balance
@@ -246,11 +248,7 @@ class IconComponent < BaseComponent
     zoom_out_map
   ].to_set.freeze
 
-  attr_reader :icon, :size, :tag_options
-
   def initialize(icon:, size: nil, **tag_options)
-    raise ArgumentError, "`icon` #{icon} is not a valid icon" if !ICONS.include?(icon)
-
     @icon = icon
     @size = size
     @tag_options = tag_options

--- a/app/components/login_button_component.rb
+++ b/app/components/login_button_component.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 class LoginButtonComponent < BaseComponent
-  VALID_COLORS = ['primary', 'primary-darker', 'primary-lighter'].freeze
-
   attr_reader :color, :big, :width, :height, :tag_options
 
+  validates_inclusion_of :color, in: ['primary', 'primary-darker', 'primary-lighter']
+
   def initialize(color: 'primary', big: false, **tag_options)
-    if !VALID_COLORS.include?(color)
-      raise ArgumentError, "`color` #{color}} is invalid, expected one of #{VALID_COLORS}"
-    end
     @big = big
     @width = big ? '11.1rem' : '7.4rem'
     @height = big ? '1.5rem' : '1rem'

--- a/app/components/manageable_authenticator_component.rb
+++ b/app/components/manageable_authenticator_component.rb
@@ -8,6 +8,8 @@ class ManageableAuthenticatorComponent < BaseComponent
               :custom_strings,
               :tag_options
 
+  validate :validate_configuration_methods
+
   def initialize(
     configuration:,
     user_session:,
@@ -16,10 +18,6 @@ class ManageableAuthenticatorComponent < BaseComponent
     custom_strings: {},
     **tag_options
   )
-    if ![:name, :id, :created_at].all? { |method| configuration.respond_to?(method) }
-      raise ArgumentError, '`configuration` must respond to `name`, `id`, `created_at`'
-    end
-
     @configuration = configuration
     @user_session = user_session
     @manage_api_url = manage_api_url
@@ -43,6 +41,17 @@ class ManageableAuthenticatorComponent < BaseComponent
   delegate :reauthenticate_at, to: :auth_methods_session
 
   private
+
+  def validate_configuration_methods
+    [:name, :id, :created_at].all? do |method|
+      next if configuration.respond_to?(method)
+      errors.add(
+        :configuration,
+        :missing_method,
+        message: "`configuration` must respond to `#{method}`",
+      )
+    end
+  end
 
   def auth_methods_session
     @auth_methods_session ||= AuthMethodsSession.new(user_session:)

--- a/app/components/manageable_authenticator_component.rb
+++ b/app/components/manageable_authenticator_component.rb
@@ -43,7 +43,7 @@ class ManageableAuthenticatorComponent < BaseComponent
   private
 
   def validate_configuration_methods
-    [:name, :id, :created_at].all? do |method|
+    [:name, :id, :created_at].each do |method|
       next if configuration.respond_to?(method)
       errors.add(
         :configuration,

--- a/app/components/status_page_component.rb
+++ b/app/components/status_page_component.rb
@@ -7,8 +7,6 @@ class StatusPageComponent < BaseComponent
     error: [nil, :lock],
   }.freeze
 
-  VALID_STATUS = %i[info error warning].freeze
-
   renders_one :header, ::PageHeadingComponent
   renders_many :action_buttons, ->(**button_options) do
     ButtonComponent.new(**button_options, big: true, wide: true)
@@ -17,15 +15,10 @@ class StatusPageComponent < BaseComponent
 
   attr_reader :status, :icon
 
+  validates_inclusion_of :status, in: %i[info error warning]
+  validate :validate_status_icon
+
   def initialize(status: :error, icon: nil)
-    if !VALID_STATUS.include?(status)
-      raise ArgumentError, "`status` #{status} is invalid, expected one of #{VALID_STATUS}"
-    end
-
-    if !ICONS[status].include?(icon)
-      raise ArgumentError, "`icon` #{icon} is invalid, expected one of #{ICONS[status]}"
-    end
-
     @icon = icon
     @status = status
   end
@@ -36,5 +29,16 @@ class StatusPageComponent < BaseComponent
     else
       status.to_sym
     end
+  end
+
+  private
+
+  def validate_status_icon
+    return if ICONS[status]&.include?(icon)
+    errors.add(
+      :icon,
+      :invalid,
+      message: "`icon` #{icon} is invalid, expected one of #{ICONS[status]}",
+    )
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -254,6 +254,7 @@ pwned_passwords_file_path: 'pwned_passwords/pwned_passwords.txt'
 rack_mini_profiler: false
 rack_timeout_service_timeout_seconds: 15
 rails_mailer_previews_enabled: false
+raise_on_component_validation_error: true
 raise_on_missing_title: false
 reauthn_window: 1200
 recaptcha_enterprise_api_key: ''
@@ -479,6 +480,7 @@ production:
   participate_in_dap: true
   password_pepper:
   piv_cac_verify_token_secret:
+  raise_on_component_validation_error: false
   recaptcha_mock_validator: false
   redis_throttle_url: redis://redis.login.gov.internal:6379/1
   redis_url: redis://redis.login.gov.internal:6379

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -310,6 +310,7 @@ module IdentityConfig
     config.add(:rack_mini_profiler, type: :boolean)
     config.add(:rack_timeout_service_timeout_seconds, type: :integer)
     config.add(:rails_mailer_previews_enabled, type: :boolean)
+    config.add(:raise_on_component_validation_error, type: :boolean)
     config.add(:raise_on_missing_title, type: :boolean)
     config.add(:reauthn_window, type: :integer)
     config.add(:recaptcha_enterprise_api_key, type: :string)

--- a/spec/components/alert_component_spec.rb
+++ b/spec/components/alert_component_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe AlertComponent, type: :component do
     expect(rendered).to have_selector('.usa-alert[role="alert"]')
   end
 
-  it 'raises error for unknown type' do
+  it 'validates type' do
     expect do
       render_inline AlertComponent.new(type: 'alert', message: 'Attention!')
-    end.to raise_error(ArgumentError)
+    end.to raise_error(ActiveModel::ValidationError)
   end
 end

--- a/spec/components/alert_icon_component_spec.rb
+++ b/spec/components/alert_icon_component_spec.rb
@@ -24,8 +24,10 @@ RSpec.describe AlertIconComponent, type: :component do
     expect(rendered).to have_css('[alt="custom alt text"]')
   end
 
-  it 'raises an ArgumentError if an invalid icon name is given' do
-    expect { described_class.new(icon_name: :invalid_icon_name) }.to raise_error(ArgumentError)
+  it 'validates icon name' do
+    expect do
+      render_inline(described_class.new(icon_name: :invalid_icon_name))
+    end.to raise_error(ActiveModel::ValidationError)
   end
 
   it 'renders with the explicitly passed in width and height values' do

--- a/spec/components/badge_component_spec.rb
+++ b/spec/components/badge_component_spec.rb
@@ -12,17 +12,13 @@ RSpec.describe BadgeComponent, type: :component do
   context 'without icon' do
     let(:icon) { nil }
 
-    it 'raises an exception' do
-      expect { rendered }.to raise_error(ArgumentError)
-    end
+    it { expect { rendered }.to raise_error(ActiveModel::ValidationError) }
   end
 
   context 'with invalid icon' do
     let(:icon) { :invalid }
 
-    it 'raises an exception' do
-      expect { rendered }.to raise_error(ArgumentError)
-    end
+    it { expect { rendered }.to raise_error(ActiveModel::ValidationError) }
   end
 
   context 'with valid icon' do

--- a/spec/components/block_link_component_spec.rb
+++ b/spec/components/block_link_component_spec.rb
@@ -32,11 +32,18 @@ RSpec.describe BlockLinkComponent, type: :component do
   context 'with a component' do
     before do
       stub_const(
-        'TestComponent', Class.new(BaseComponent) do
-                           def call
-                             content_tag(:div, 'from test component', class: 'style')
-                           end
-                         end
+        'TestComponent',
+        Class.new(BaseComponent) do
+          attr_reader :tag_options
+
+          def initialize(**tag_options)
+            @tag_options = tag_options
+          end
+
+          def call
+            content_tag(:div, 'from test component', class: 'style')
+          end
+        end,
       )
     end
 

--- a/spec/components/icon_component_spec.rb
+++ b/spec/components/icon_component_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe IconComponent, type: :component do
   end
 
   context 'with invalid icon' do
-    it 'raises an error' do
-      expect { render_inline IconComponent.new(icon: :foo) }.to raise_error(ArgumentError)
-    end
+    subject(:rendered) { render_inline IconComponent.new(icon: :foo) }
+
+    it { expect { rendered }.to raise_error(ActiveModel::ValidationError) }
   end
 
   context 'with size' do

--- a/spec/components/login_button_component_spec.rb
+++ b/spec/components/login_button_component_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe LoginButtonComponent, type: :component do
     end
   end
 
-  it 'raises error for unknown color' do
+  it 'validates color' do
     expect do
       render_inline LoginButtonComponent.new(color: 'foo')
-    end.to raise_error(ArgumentError)
+    end.to raise_error(ActiveModel::ValidationError)
   end
 
   context 'with tag options' do

--- a/spec/components/status_page_component_spec.rb
+++ b/spec/components/status_page_component_spec.rb
@@ -59,21 +59,21 @@ RSpec.describe StatusPageComponent, type: :component do
     expect(rendered).to have_link('Option', href: '/')
   end
 
-  it 'raises error for unknown status' do
+  it 'validates status' do
     expect do
       render_inline StatusPageComponent.new(status: :foo)
-    end.to raise_error(ArgumentError)
+    end.to raise_error(ActiveModel::ValidationError)
   end
 
-  it 'raises error for unknown status icon' do
+  it 'validates status icon' do
     expect do
       render_inline StatusPageComponent.new(status: :warning, icon: :foo)
-    end.to raise_error(ArgumentError)
+    end.to raise_error(ActiveModel::ValidationError)
   end
 
-  it 'raises error if no default icon associated with status' do
+  it 'validates missing default icon associated with status' do
     expect do
       render_inline StatusPageComponent.new(status: :info)
-    end.to raise_error(ArgumentError)
+    end.to raise_error(ActiveModel::ValidationError)
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds support to `BaseComponent` to use `ActiveModel::Model` validation helpers.

**Why?**

- We already perform validation in a number of our components, and this helps align to Rails conventions in place of ad hoc error raising
- Makes available a number of new helpers to help with common use-cases
   - Simplifies code
- Should improve performance, since validation is not performed in production

## 📜 Testing Plan

1. Update usage of an affected component to try passing an invalid constructor option value
   - e.g. change [this line](https://github.com/18F/identity-idp/blob/6c484f6f25c91d0385912c2453a74c3bb0cff6a7/spec/components/previews/alert_component_preview.rb#L8) to pass `type: :wrong`
2. View page with rendering of the component usage you updated
   - e.g. http://localhost:3000/components/inspect/alert/preview if you updated line example above
3. Observe error
    - e.g. `Validation failed: Type is not included in the list` if you updated line example above