### PR TITLE
Apply YAML normalizations to application.yml.default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt ## Runs the developme
 normalize_yaml: ## Normalizes YAML files (alphabetizes keys, fixes line length, smart quotes)
 	yarn normalize-yaml .rubocop.yml --disable-sort-keys --disable-smart-punctuation
 	find ./config/locales/transliterate -type f -name '*.yml' -exec yarn normalize-yaml --disable-sort-keys --disable-smart-punctuation {} \;
+	yarn normalize-yaml --disable-sort-keys --disable-smart-punctuation config/application.yml.default
 	find ./config/locales/telephony -type f -name '*.yml' | xargs yarn normalize-yaml --disable-smart-punctuation
 	find ./config/locales -not \( -path "./config/locales/telephony*" -o -path "./config/locales/transliterate/*" \) -type f -name '*.yml' | \
 	xargs yarn normalize-yaml \

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -423,7 +423,7 @@ development:
   usps_eipp_sponsor_id: '222222222222222'
   usps_ipp_sponsor_id: '111111111111111'
   usps_ipp_transliteration_enabled: true
-  usps_upload_sftp_directory: "/gsa_order"
+  usps_upload_sftp_directory: '/gsa_order'
   usps_upload_sftp_host: localhost
   usps_upload_sftp_password: test
   usps_upload_sftp_username: brady
@@ -592,8 +592,7 @@ test:
   usps_eipp_sponsor_id: '222222222222222'
   usps_ipp_root_url: 'http://localhost:1000'
   usps_ipp_sponsor_id: '111111111111111'
-  usps_upload_sftp_directory: "/directory"
+  usps_upload_sftp_directory: '/directory'
   usps_upload_sftp_host: example.com
   usps_upload_sftp_password: pass
   usps_upload_sftp_username: user
-  


### PR DESCRIPTION
## 🛠 Summary of changes

Includes `config/application.yml.default` in YAML normalizations.

**Why?**

- Avoid inconsistent line spacing and quoting

## 📜 Testing Plan

Verify `make lint_yaml` passes.