### PR TITLE
Deploy RC 399 to Production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt ## Runs the developme
 normalize_yaml: ## Normalizes YAML files (alphabetizes keys, fixes line length, smart quotes)
 	yarn normalize-yaml .rubocop.yml --disable-sort-keys --disable-smart-punctuation
 	find ./config/locales/transliterate -type f -name '*.yml' -exec yarn normalize-yaml --disable-sort-keys --disable-smart-punctuation {} \;
+	yarn normalize-yaml --disable-sort-keys --disable-smart-punctuation config/application.yml.default
 	find ./config/locales/telephony -type f -name '*.yml' | xargs yarn normalize-yaml --disable-smart-punctuation
 	find ./config/locales -not \( -path "./config/locales/telephony*" -o -path "./config/locales/transliterate/*" \) -type f -name '*.yml' | \
 	xargs yarn normalize-yaml \

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -197,7 +197,7 @@ module Idv
         limiter_type: :idv_send_link,
       )
       message = I18n.t(
-        'errors.doc_auth.send_link_limited',
+        'doc_auth.errors.send_link_limited',
         timeout: distance_of_time_in_words(
           Time.zone.now,
           [rate_limiter.expires_at, Time.zone.now].compact.max,

--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -18,17 +18,24 @@ module Idv
           )
           locations = proofer.request_facilities(candidate, false)
 
-          render json: locations.to_json
+          render json: localized_locations(locations).to_json
         end
 
         def options
           head :ok
         end
 
-        protected
+        private
 
         def proofer
           @proofer ||= UspsInPersonProofing::EnrollmentHelper.usps_proofer
+        end
+
+        def localized_locations(locations)
+          return nil if locations.nil?
+          locations.map do |location|
+            UspsInPersonProofing::EnrollmentHelper.localized_location(location)
+          end
         end
 
         def enabled?

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -27,18 +27,18 @@ module Idv
           zip_code: search_params['zip_code']
         )
         is_enhanced_ipp = resolved_authn_context_result.enhanced_ipp?
-        response = proofer.request_facilities(candidate, is_enhanced_ipp)
-        if response.length > 0
+        locations = proofer.request_facilities(candidate, is_enhanced_ipp)
+        if locations.length > 0
           analytics.idv_in_person_locations_searched(
             success: true,
-            result_total: response.length,
+            result_total: locations.length,
           )
         else
           analytics.idv_in_person_locations_searched(
             success: false, errors: 'No USPS locations found',
           )
         end
-        render json: response.to_json
+        render json: localized_locations(locations).to_json
       end
 
       # save the Post Office location the user selected to an enrollment
@@ -62,6 +62,13 @@ module Idv
         ProofingComponent.
           create_or_find_by(user: current_or_hybrid_user).
           update(document_check: Idp::Constants::Vendors::USPS)
+      end
+
+      def localized_locations(locations)
+        return nil if locations.nil?
+        locations.map do |location|
+          EnrollmentHelper.localized_location(location)
+        end
       end
 
       def handle_error(err)

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -73,11 +73,11 @@ module Idv
     def render_document_capture_cancelled
       redirect_to idv_hybrid_handoff_url
       idv_session.flow_path = nil
-      failure(I18n.t('errors.doc_auth.document_capture_canceled'))
+      failure(I18n.t('doc_auth.errors.document_capture_canceled'))
     end
 
     def render_step_incomplete_error
-      failure(I18n.t('errors.doc_auth.phone_step_incomplete'))
+      failure(I18n.t('doc_auth.errors.phone_step_incomplete'))
     end
 
     def take_photo_with_phone_successful?

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -54,7 +54,7 @@ module Users
       else
         process_invalid_submission
       end
-      analytics.piv_cac_login(**result.to_h)
+      analytics.piv_cac_login(**result.to_h, new_device: @new_device)
     end
 
     def piv_cac_login_form
@@ -75,7 +75,7 @@ module Users
         presented: true,
       )
 
-      set_new_device_session(nil)
+      @new_device = set_new_device_session(nil)
       handle_verification_for_authentication_context(
         result:,
         auth_method: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -176,7 +176,6 @@ module Users
         bad_password_count: session[:bad_password_count].to_i,
         sp_request_url_present: sp_session[:request_url].present?,
         remember_device: remember_device_cookie.present?,
-        new_device: success ? new_device? : nil,
       )
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -298,7 +298,7 @@ module Idv
     def limit_if_rate_limited
       return unless rate_limited?
 
-      errors.add(:limit, t('errors.doc_auth.rate_limited_heading'), type: :rate_limited)
+      errors.add(:limit, t('doc_auth.errors.rate_limited_heading'), type: :rate_limited)
     end
 
     def track_rate_limited

--- a/app/forms/idv/consent_form.rb
+++ b/app/forms/idv/consent_form.rb
@@ -7,7 +7,7 @@ module Idv
     attr_reader :idv_consent_given
 
     validates :idv_consent_given,
-              acceptance: { message: proc { I18n.t('errors.doc_auth.consent_form') } }
+              acceptance: { message: proc { I18n.t('doc_auth.errors.consent_form') } }
 
     def initialize(idv_consent_given: false)
       @idv_consent_given = idv_consent_given

--- a/app/forms/idv/how_to_verify_form.rb
+++ b/app/forms/idv/how_to_verify_form.rb
@@ -10,11 +10,11 @@ module Idv
     attr_reader :selection
 
     validates :selection, presence: {
-      message: proc { I18n.t('errors.doc_auth.how_to_verify_form') },
+      message: proc { I18n.t('doc_auth.errors.how_to_verify_form') },
     }
     validates :selection, inclusion: {
       in: [REMOTE, IPP],
-      message: proc { I18n.t('errors.doc_auth.how_to_verify_form') },
+      message: proc { I18n.t('doc_auth.errors.how_to_verify_form') },
     }
 
     def initialize(selection: nil)

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -37,25 +37,25 @@ function getHeading({
   t,
 }: GetHeadingArguments) {
   if (isFailedDocType) {
-    return t('errors.doc_auth.doc_type_not_supported_heading');
+    return t('doc_auth.errors.doc_type_not_supported_heading');
   }
   if (isResultCodeInvalid) {
-    return t('errors.doc_auth.rate_limited_heading');
+    return t('doc_auth.errors.rate_limited_heading');
   }
   if (isFailedSelfieLivenessOrQuality) {
-    return t('errors.doc_auth.selfie_not_live_or_poor_quality_heading');
+    return t('doc_auth.errors.selfie_not_live_or_poor_quality_heading');
   }
   if (isFailedSelfie) {
-    return t('errors.doc_auth.selfie_fail_heading');
+    return t('doc_auth.errors.selfie_fail_heading');
   }
-  return t('errors.doc_auth.rate_limited_heading');
+  return t('doc_auth.errors.rate_limited_heading');
 }
 
 function getSubheading({ nonIppOrFailedResult, t }) {
   const showSubheading = !nonIppOrFailedResult;
 
   if (showSubheading) {
-    return <h2>{t('errors.doc_auth.rate_limited_subheading')}</h2>;
+    return <h2>{t('doc_auth.errors.rate_limited_subheading')}</h2>;
   }
   return undefined;
 }

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -125,7 +125,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
                     failedImageFingerprints: submissionError.failed_image_fingerprints,
                   })(ReviewIssuesStep)
                 : ReviewIssuesStep,
-            title: t('errors.doc_auth.rate_limited_heading'),
+            title: t('doc_auth.errors.rate_limited_heading'),
           },
         ] as FormStep[]
       ).concat(inPersonSteps)

--- a/app/jobs/reports/drop_off_report.rb
+++ b/app/jobs/reports/drop_off_report.rb
@@ -8,6 +8,8 @@ module Reports
 
     attr_accessor :report_date
 
+    # Generate a drop off report for the week including the passed timestamp
+    # @param [DateTime]
     def perform(report_date)
       self.report_date = report_date
 

--- a/app/jobs/reports/protocols_report.rb
+++ b/app/jobs/reports/protocols_report.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'reporting/protocols_report'
+
+module Reports
+  class ProtocolsReport < BaseReport
+    REPORT_NAME = 'protocols-report'
+
+    attr_accessor :report_date
+
+    def perform(report_date)
+      return unless IdentityConfig.store.s3_reports_enabled
+
+      self.report_date = report_date
+      message = "Report: #{REPORT_NAME} #{report_date}"
+      subject = "Weekly Protocols Report - #{report_date}"
+
+      report_configs.each do |report_hash|
+        reports = weekly_protocols_emailable_reports
+
+        report_hash['emails'].each do |email|
+          ReportMailer.tables_report(
+            email:,
+            subject:,
+            message:,
+            reports:,
+            attachment_format: :csv,
+          ).deliver_now
+        end
+      end
+    end
+
+    private
+
+    def weekly_protocols_emailable_reports
+      Reporting::ProtocolsReport.new(
+        issuers: nil,
+        time_range: report_date.all_week,
+      ).as_emailable_reports
+    end
+
+    def report_configs
+      IdentityConfig.store.protocols_report_config
+    end
+  end
+end

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -31,7 +31,7 @@ module Idv
       def selected_location_hours(prefix)
         return unless selected_location_details
         hours = selected_location_details["#{prefix}_hours"]
-        localized_hours(hours)
+        UspsInPersonProofing::EnrollmentHelper.localized_hours(hours)
       end
 
       def service_provider
@@ -105,26 +105,6 @@ module Idv
 
       def format_outage_date(date)
         I18n.l(date.to_date, format: :short)
-      end
-
-      def localized_hours(hours)
-        return nil if hours.nil?
-
-        if hours == 'Closed'
-          I18n.t('in_person_proofing.body.barcode.retail_hours_closed')
-        elsif hours.include?(' - ') # Hyphen
-          hours.
-            split(' - '). # Hyphen
-            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
-            join(' – ') # Endash
-        elsif hours.include?(' – ') # Endash
-          hours.
-            split(' – '). # Endash
-            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
-            join(' – ') # Endash
-        else
-          hours
-        end
       end
 
       def sp_return_url_resolver

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -404,8 +404,6 @@ module AnalyticsEvents
   # @param [String] bad_password_count represents number of prior login failures
   # @param [Boolean] sp_request_url_present if was an SP request URL in the session
   # @param [Boolean] remember_device if the remember device cookie was present
-  # @param [Boolean, nil] new_device Whether the user is authenticating from a new device. Nil if
-  # there is the attempt was unsuccessful, since it cannot be known whether it's a new device.
   # Tracks authentication attempts at the email/password screen
   def email_and_password_auth(
     success:,
@@ -415,7 +413,6 @@ module AnalyticsEvents
     bad_password_count:,
     sp_request_url_present:,
     remember_device:,
-    new_device:,
     **extra
   )
     track_event(
@@ -427,7 +424,6 @@ module AnalyticsEvents
       bad_password_count:,
       sp_request_url_present:,
       remember_device:,
-      new_device:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4991,14 +4991,16 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name PIV/CAC login
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
-  # @param [String,nil] key_id
+  # @param [String,nil] key_id PIV/CAC key_id from PKI service
+  # @param [Boolean] new_device Whether the user is authenticating from a new device
   # tracks piv cac login event
-  def piv_cac_login(success:, errors:, key_id:, **extra)
+  def piv_cac_login(success:, errors:, key_id:, new_device:, **extra)
     track_event(
       :piv_cac_login,
       success:,
       errors:,
       key_id:,
+      new_device:,
       **extra,
     )
   end

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -39,7 +39,7 @@ module Idv
         redirect_to rate_limited_url
         DocAuth::Response.new(
           success: false,
-          errors: { limit: I18n.t('errors.doc_auth.rate_limited_heading') },
+          errors: { limit: I18n.t('doc_auth.errors.rate_limited_heading') },
         )
       end
 

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -102,6 +102,42 @@ module UspsInPersonProofing
         end
       end
 
+      def localized_location(location)
+        {
+          address: location.address,
+          city: location.city,
+          distance: location.distance,
+          name: location.name,
+          saturday_hours: EnrollmentHelper.localized_hours(location.saturday_hours),
+          state: location.state,
+          sunday_hours: EnrollmentHelper.localized_hours(location.sunday_hours),
+          weekday_hours: EnrollmentHelper.localized_hours(location.weekday_hours),
+          zip_code_4: location.zip_code_4,
+          zip_code_5: location.zip_code_5,
+          is_pilot: location.is_pilot,
+        }
+      end
+
+      def localized_hours(hours)
+        return nil if hours.nil?
+
+        if hours == 'Closed'
+          I18n.t('in_person_proofing.body.barcode.retail_hours_closed')
+        elsif hours.include?(' - ') # Hyphen
+          hours.
+            split(' - '). # Hyphen
+            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
+            join(' – ') # Endash
+        elsif hours.include?(' – ') # Endash
+          hours.
+            split(' – '). # Endash
+            map { |time| Time.zone.parse(time).strftime(I18n.t('time.formats.event_time')) }.
+            join(' – ') # Endash
+        else
+          hours
+        end
+      end
+
       private
 
       SECONDARY_ID_ADDRESS_MAP = {

--- a/app/views/idv/session_errors/rate_limited.html.erb
+++ b/app/views/idv/session_errors/rate_limited.html.erb
@@ -1,6 +1,6 @@
 <%= render(
       'idv/shared/error',
-      heading: t('errors.doc_auth.rate_limited_heading'),
+      heading: t('doc_auth.errors.rate_limited_heading'),
       options: [
         {
           url: MarketingSite.contact_url,
@@ -11,7 +11,7 @@
     ) do %>
       <p>
         <%= t(
-              'errors.doc_auth.rate_limited_text_html',
+              'doc_auth.errors.rate_limited_text_html',
               timeout: distance_of_time_in_words(
                 Time.zone.now,
                 [@expires_at, Time.zone.now].compact.max,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -423,7 +423,7 @@ development:
   usps_eipp_sponsor_id: '222222222222222'
   usps_ipp_sponsor_id: '111111111111111'
   usps_ipp_transliteration_enabled: true
-  usps_upload_sftp_directory: "/gsa_order"
+  usps_upload_sftp_directory: '/gsa_order'
   usps_upload_sftp_host: localhost
   usps_upload_sftp_password: test
   usps_upload_sftp_username: brady
@@ -592,8 +592,7 @@ test:
   usps_eipp_sponsor_id: '222222222222222'
   usps_ipp_root_url: 'http://localhost:1000'
   usps_ipp_sponsor_id: '111111111111111'
-  usps_upload_sftp_directory: "/directory"
+  usps_upload_sftp_directory: '/directory'
   usps_upload_sftp_host: example.com
   usps_upload_sftp_password: pass
   usps_upload_sftp_username: user
-  

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -219,6 +219,7 @@ participate_in_dap: false
 password_max_attempts: 3
 personal_key_retired: true
 phone_carrier_registration_blocklist_array: '[]'
+protocols_report_config: '[]'
 short_term_phone_otp_max_attempt_window_in_seconds: 10
 short_term_phone_otp_max_attempts: 2
 phone_confirmation_max_attempts: 20

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -229,6 +229,12 @@ else
         cron: cron_every_monday,
         args: -> { [Time.zone.yesterday] },
       },
+      # Previous week's protocols report
+      weekly_protocols_report: {
+        class: 'Reports::ProtocolsReport',
+        cron: cron_every_monday,
+        args: -> { [Time.zone.yesterday] },
+      },
     }.compact
   end
   # rubocop:enable Metrics/BlockLength

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -215,7 +215,7 @@ else
       weekly_authentication_report: {
         class: 'Reports::AuthenticationReport',
         cron: cron_every_monday,
-        args: -> { [Time.zone.yesterday] },
+        args: -> { [Time.zone.yesterday.end_of_day] },
       },
       # Send fraud metrics to Team Judy
       fraud_metrics_report: {
@@ -227,7 +227,7 @@ else
       weekly_drop_off_report: {
         class: 'Reports::DropOffReport',
         cron: cron_every_monday,
-        args: -> { [Time.zone.yesterday] },
+        args: -> { [Time.zone.yesterday.end_of_day] },
       },
       # Previous week's protocols report
       weekly_protocols_report: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1823,7 +1823,7 @@ user_mailer.in_person_failed_suspected_fraud.body.help_center_html: If you need 
 user_mailer.in_person_failed_suspected_fraud.body.intro: We understand that you were attempting to verify your identity through %{app_name}, however your identity could not be verified at the %{location} Post Office on %{date}.
 user_mailer.in_person_failed_suspected_fraud.greeting: Hello,
 user_mailer.in_person_failed_suspected_fraud.subject: Your identity could not be verified in person
-user_mailer.in_person_failed.body.with_cta: Click the button or copy the link below to try verifying your identity online again through %{sp_or_app_name}. If you are still experiencing issues, please contact the agency you are trying to access.
+user_mailer.in_person_failed.body.with_cta: Click the button or copy the link below to try verifying your identity again through %{sp_or_app_name}. If you are still experiencing issues, please contact the agency you are trying to access.
 user_mailer.in_person_failed.body.without_cta: Please try verifying your identity again from %{sp_name}’s website. If you are still experiencing issues, please contact the agency you are trying to access.
 user_mailer.in_person_failed.intro: Your identity could not be verified at the %{location} Post Office on %{date}.
 user_mailer.in_person_failed.subject: Your identity could not be verified in person

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,9 +523,12 @@ doc_auth.errors.camera.blocked: Your camera is blocked
 doc_auth.errors.camera.blocked_detail_html: '<strong>Allow access to your camera to take photos for %{app_name}.</strong><span>Try taking photos again and allowing permission. If that doesn’t work, you may need to check your device settings to allow access.</span>'
 doc_auth.errors.camera.failed: Camera failed to start, please try again.
 doc_auth.errors.card_type: Try again with your driver’s license or state ID card.
+doc_auth.errors.consent_form: Before you can continue, you must give us permission. Please check the box below and then click continue.
+doc_auth.errors.doc_type_not_supported_heading: We only accept a driver’s license or a state ID
 doc_auth.errors.doc.doc_type_check: Your driver’s license or state ID must be issued by a U.S. state or territory. We do not accept other forms of ID, like passports or military IDs.
 doc_auth.errors.doc.resubmit_failed_image: You already tried this image, and it failed. Please try adding a different image.
 doc_auth.errors.doc.wrong_id_type_html: We only accept a driver’s license or a state ID issued by a U.S. state or territory. We do not accept other forms of ID, like passports or military IDs. <a>Learn more about accepted IDs</a>
+doc_auth.errors.document_capture_canceled: You have canceled uploading photos of your ID on your phone.
 doc_auth.errors.dpi.failed_short: Image is too small or blurry, please try again.
 doc_auth.errors.dpi.top_msg: We couldn’t read your ID. Your image size may be too small, or your ID is too small or blurry in the photo. Make sure your ID is large within the image frame and try taking a new picture.
 doc_auth.errors.dpi.top_msg_plural: We couldn’t read your ID. Your image sizes may be too small, or your ID is too small or blurry in the photos. Make sure your ID is large within the image frame and try taking new pictures.
@@ -540,6 +543,7 @@ doc_auth.errors.general.selfie_failure_help_link_text: Review more tips for taki
 doc_auth.errors.glare.failed_short: Image has glare, please try again.
 doc_auth.errors.glare.top_msg: We couldn’t read your ID. Your photo may have glare. Make sure that the flash on your camera is off and try taking a new picture.
 doc_auth.errors.glare.top_msg_plural: We couldn’t read your ID. Your photos may have glare. Make sure that the flash on your camera is off and try taking new pictures.
+doc_auth.errors.how_to_verify_form: Select a way to verify your identity.
 doc_auth.errors.http.image_load.failed_short: Image file is not supported, please try again.
 doc_auth.errors.http.image_load.top_msg: The image file that you added is not supported. Please take new photos of your ID and try again.
 doc_auth.errors.http.image_size.failed_short: Image file is not supported, please try again.
@@ -547,7 +551,14 @@ doc_auth.errors.http.image_size.top_msg: Your image size is too large or too sma
 doc_auth.errors.http.pixel_depth.failed_short: Image file is not supported, please try again.
 doc_auth.errors.http.pixel_depth.top_msg: The pixel depth of your image file is not supported. Please take new photos of your ID and try again. Supported image pixel depth is 24-bit RGB.
 doc_auth.errors.not_a_file: The selection was not a valid file.
+doc_auth.errors.phone_step_incomplete: You must go to your phone and upload photos of your ID before continuing. We sent you a link with instructions.
 doc_auth.errors.pii.birth_date_min_age: Your birthday does not meet the minimum age requirement.
+doc_auth.errors.rate_limited_heading: We couldn’t verify your ID
+doc_auth.errors.rate_limited_subheading: Try taking new pictures
+doc_auth.errors.rate_limited_text_html: For your security, we limit the number of times you can attempt to verify a document online. <strong>Try again in %{timeout}.</strong>
+doc_auth.errors.selfie_fail_heading: We couldn’t match the photo of yourself to your ID
+doc_auth.errors.selfie_not_live_or_poor_quality_heading: We could not verify the photo of yourself
+doc_auth.errors.send_link_limited: You tried too many times, please try again in %{timeout}. You can also go back and choose to use your computer instead.
 doc_auth.errors.sharpness.failed_short: Image is blurry, please try again.
 doc_auth.errors.sharpness.top_msg: We couldn’t read your ID. Your photo may be too blurry or dark. Try taking a new picture in a bright area.
 doc_auth.errors.sharpness.top_msg_plural: We couldn’t read your ID. Your photos may be too blurry or dark. Try taking new pictures in a bright area.
@@ -696,17 +707,6 @@ errors.attributes.password.too_short.one: Password must be at least one characte
 errors.attributes.password.too_short.other: Password must be at least %{count} characters long
 errors.capture_doc.invalid_link: This link is expired or not valid. Please request another link to verify your identity on a mobile phone.
 errors.confirm_password_incorrect: Incorrect password.
-errors.doc_auth.consent_form: Before you can continue, you must give us permission. Please check the box below and then click continue.
-errors.doc_auth.doc_type_not_supported_heading: We only accept a driver’s license or a state ID
-errors.doc_auth.document_capture_canceled: You have canceled uploading photos of your ID on your phone.
-errors.doc_auth.how_to_verify_form: Select a way to verify your identity.
-errors.doc_auth.phone_step_incomplete: You must go to your phone and upload photos of your ID before continuing. We sent you a link with instructions.
-errors.doc_auth.rate_limited_heading: We couldn’t verify your ID
-errors.doc_auth.rate_limited_subheading: Try taking new pictures
-errors.doc_auth.rate_limited_text_html: For your security, we limit the number of times you can attempt to verify a document online. <strong>Try again in %{timeout}.</strong>
-errors.doc_auth.selfie_fail_heading: We couldn’t match the photo of yourself to your ID
-errors.doc_auth.selfie_not_live_or_poor_quality_heading: We could not verify the photo of yourself
-errors.doc_auth.send_link_limited: You tried too many times, please try again in %{timeout}. You can also go back and choose to use your computer instead.
 errors.enter_code.rate_limited_html: You entered an incorrect verification code too many times. <strong>Try again in %{timeout}.</strong>
 errors.general: Oops, something went wrong. Please try again.
 errors.invalid_totp: Invalid code. Please try again.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1835,7 +1835,7 @@ user_mailer.in_person_failed_suspected_fraud.body.help_center_html: Si necesita 
 user_mailer.in_person_failed_suspected_fraud.body.intro: Entendemos que estaba intentando verificar su identidad usando %{app_name}; sin embargo, su identidad no pudo ser verificada en la oficina de correos de %{location} el %{date}.
 user_mailer.in_person_failed_suspected_fraud.greeting: 'Hola:'
 user_mailer.in_person_failed_suspected_fraud.subject: No se pudo verificar su identidad en persona
-user_mailer.in_person_failed.body.with_cta: Haga clic en el botón o copie el vínculo siguiente para volver a intentar verificar su identidad en línea con %{sp_or_app_name}. Si sigue teniendo problemas, contacte con la agencia a la que está intentando acceder.
+user_mailer.in_person_failed.body.with_cta: Haga clic en el botón o copie el vínculo siguiente para volver a intentar verificar su identidad con %{sp_or_app_name}. Si sigue teniendo problemas, póngase en contacto con la agencia a la que intenta acceder.
 user_mailer.in_person_failed.body.without_cta: Vuelva a intentar verificar su identidad en el sitio web de %{sp_name}. Si sigue teniendo problemas, contacte con la agencia a la que está intentando acceder.
 user_mailer.in_person_failed.intro: No se pudo verificar su identidad en la oficina de correos de %{location} el %{date}.
 user_mailer.in_person_failed.subject: No se pudo verificar su identidad en persona

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -534,9 +534,12 @@ doc_auth.errors.camera.blocked: Su cámara está bloqueada
 doc_auth.errors.camera.blocked_detail_html: '<strong>Permita el acceso a su cámara para tomar las fotografías de %{app_name}.</strong><span>Intente tomar las fotografías de nuevo permitiendo el acceso. Si eso no funciona, tal vez necesite revisar la configuración de su dispositivo para permitir el acceso.</span>'
 doc_auth.errors.camera.failed: No se pudo activar la cámara; inténtelo de nuevo.
 doc_auth.errors.card_type: Inténtelo de nuevo con su licencia de conducir o tarjeta de identificación estatal.
+doc_auth.errors.consent_form: Antes de continuar, debe darnos permiso. Marque la casilla a continuación y luego haga clic en continuar.
+doc_auth.errors.doc_type_not_supported_heading: Solo aceptamos una licencia de conducir o una identificación estatal.
 doc_auth.errors.doc.doc_type_check: Su licencia de conducir o identificación estatal debe ser emitida por un estado o territorio de los EE. UU. No aceptamos otras formas de identificación, como pasaportes o identificaciones militares.
 doc_auth.errors.doc.resubmit_failed_image: Ya intentó con esta imagen y no funcionó. Intente añadir una imagen diferente.
 doc_auth.errors.doc.wrong_id_type_html: Solo aceptamos una licencia de conducir o una identificación estatal emitida por un estado o territorio de los EE. UU. No aceptamos otras formas de identificación, como pasaportes o identificaciones militares. <a>Obtenga más información sobre las identificaciones aceptadas</a>
+doc_auth.errors.document_capture_canceled: Ha cancelado la carga de fotos de su identificación en este teléfono.
 doc_auth.errors.dpi.failed_short: La imagen es demasiado pequeña o está borrosa; inténtelo de nuevo.
 doc_auth.errors.dpi.top_msg: No pudimos leer su identificación. Es posible que el tamaño de su imagen o de su identificación sea demasiado pequeño o que la foto esté borrosa. Asegúrese de que su identificación se vea más grande dentro del marco de la imagen e intente tomar una nueva foto.
 doc_auth.errors.dpi.top_msg_plural: No pudimos leer su identificación. Es posible que el tamaño de sus imágenes o de su identificación sea demasiado pequeño o que las fotos estén borrosas. Asegúrese de que su identificación se vea grande dentro del marco de la imagen e intente tomar nuevas fotos.
@@ -551,6 +554,7 @@ doc_auth.errors.general.selfie_failure_help_link_text: Consulte más consejos pa
 doc_auth.errors.glare.failed_short: La imagen tiene reflejos; inténtelo de nuevo.
 doc_auth.errors.glare.top_msg: No pudimos leer su identificación. Es posible que su foto tenga reflejos. Asegúrese de que el flash de su cámara esté apagado e intente tomar una nueva foto.
 doc_auth.errors.glare.top_msg_plural: No pudimos leer su identificación. Es posible que sus fotos tengan reflejos. Asegúrese de que el flash de su cámara esté apagado e intente tomar nuevas fotos.
+doc_auth.errors.how_to_verify_form: Seleccione una forma de verificar su identidad.
 doc_auth.errors.http.image_load.failed_short: El archivo de la imagen no es compatible; inténtelo de nuevo.
 doc_auth.errors.http.image_load.top_msg: El archivo de imagen que añadió no es compatible. Tome nuevas fotos de su identificación e inténtelo de nuevo.
 doc_auth.errors.http.image_size.failed_short: El archivo de la imagen no es compatible; inténtelo de nuevo.
@@ -558,7 +562,14 @@ doc_auth.errors.http.image_size.top_msg: El tamaño de la imagen es demasiado gr
 doc_auth.errors.http.pixel_depth.failed_short: El archivo de la imagen no es compatible; inténtelo de nuevo.
 doc_auth.errors.http.pixel_depth.top_msg: La profundidad de píxel de su archivo de imagen no es compatible. Tome nuevas fotos de su identificación e inténtelo de nuevo. La profundidad de píxel de la imagen admitida es RGB de 24 bits.
 doc_auth.errors.not_a_file: La selección no era un archivo válido.
+doc_auth.errors.phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación antes de continuar. Le enviamos un vínculo con instrucciones.
 doc_auth.errors.pii.birth_date_min_age: Su fecha de nacimiento no cumple con el requisito de edad mínima.
+doc_auth.errors.rate_limited_heading: No pudimos verificar su identificación
+doc_auth.errors.rate_limited_subheading: Intente tomar nuevas fotos
+doc_auth.errors.rate_limited_text_html: Por su seguridad, limitamos el número de veces que puede intentar verificar un documento en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
+doc_auth.errors.selfie_fail_heading: No hemos podido cotejar su foto con su identificación.
+doc_auth.errors.selfie_not_live_or_poor_quality_heading: No pudimos verificar su foto
+doc_auth.errors.send_link_limited: Lo intentó demasiadas veces; vuelva a intentarlo en %{timeout}. También puede volver atrás y elegir utilizar su computadora.
 doc_auth.errors.sharpness.failed_short: La imagen está borrosa; inténtelo de nuevo.
 doc_auth.errors.sharpness.top_msg: No pudimos leer su identificación. Es posible que su foto esté demasiado borrosa u oscura. Intente tomar una nueva foto en un lugar iluminado.
 doc_auth.errors.sharpness.top_msg_plural: No pudimos leer su identificación. Es posible que sus fotos estén demasiado borrosas u oscuras. Intente tomar nuevas fotos en un lugar iluminado.
@@ -707,17 +718,6 @@ errors.attributes.password.too_short.one: La contraseña debe tener al menos un 
 errors.attributes.password.too_short.other: La contraseña debe tener al menos %{count} caracteres.
 errors.capture_doc.invalid_link: Este enlace ha caducado o no es válido. Solicite otro enlace para verificar su identidad en un teléfono móvil.
 errors.confirm_password_incorrect: La contraseña es incorrecta.
-errors.doc_auth.consent_form: Antes de continuar, debe darnos permiso. Marque la casilla a continuación y luego haga clic en continuar.
-errors.doc_auth.doc_type_not_supported_heading: Solo aceptamos una licencia de conducir o una identificación estatal.
-errors.doc_auth.document_capture_canceled: Ha cancelado la carga de fotos de su identificación en este teléfono.
-errors.doc_auth.how_to_verify_form: Seleccione una forma de verificar su identidad.
-errors.doc_auth.phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación antes de continuar. Le enviamos un vínculo con instrucciones.
-errors.doc_auth.rate_limited_heading: No pudimos verificar su identificación
-errors.doc_auth.rate_limited_subheading: Intente tomar nuevas fotos
-errors.doc_auth.rate_limited_text_html: Por su seguridad, limitamos el número de veces que puede intentar verificar un documento en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
-errors.doc_auth.selfie_fail_heading: No hemos podido cotejar su foto con su identificación.
-errors.doc_auth.selfie_not_live_or_poor_quality_heading: No pudimos verificar su foto
-errors.doc_auth.send_link_limited: Lo intentó demasiadas veces; vuelva a intentarlo en %{timeout}. También puede volver atrás y elegir utilizar su computadora.
 errors.enter_code.rate_limited_html: Ingresó un código de verificación incorrecto demasiadas veces. <strong>Vuelva a intentarlo en %{timeout}.</strong>
 errors.general: Algo salió mal. Vuelva a intentarlo.
 errors.invalid_totp: El código no es válido. Vuelva a intentarlo.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1823,7 +1823,7 @@ user_mailer.in_person_failed_suspected_fraud.body.help_center_html: Si vous avez
 user_mailer.in_person_failed_suspected_fraud.body.intro: Vous avez tenté de confirmer votre identité par le biais de %{app_name}, mais votre identité n’a pas pu être confirmée au bureau de poste de %{location} le %{date}.
 user_mailer.in_person_failed_suspected_fraud.greeting: Bonjour,
 user_mailer.in_person_failed_suspected_fraud.subject: Votre identité n’a pas pu être vérifiée en personne
-user_mailer.in_person_failed.body.with_cta: Cliquez sur le bouton ou copiez le lien ci-dessous pour réessayer de confirmer votre identité en ligne par le biais de %{sp_or_app_name}. Si vous rencontrez toujours des difficultés, veuillez contacter l’organisme auquel vous essayez d’accéder.
+user_mailer.in_person_failed.body.with_cta: Cliquez sur le bouton ou copiez le lien ci-dessous pour réessayer de confirmer votre identité par le biais de %{sp_or_app_name}. Si vous rencontrez toujours des difficultés, veuillez contacter l’organisme auquel vous essayez d’accéder.
 user_mailer.in_person_failed.body.without_cta: Veuillez réessayer de confirmer votre identité sur le site Web de %{sp_name}. Si vous rencontrez toujours des difficultés, veuillez contacter l’organisme auquel vous essayez d’accéder.
 user_mailer.in_person_failed.intro: Votre identité n’a pas pu être vérifiée au bureau de poste de %{location} le %{date}.
 user_mailer.in_person_failed.subject: Votre identité n’a pas pu être vérifiée en personne

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -523,9 +523,12 @@ doc_auth.errors.camera.blocked: Votre appareil photo est bloqué
 doc_auth.errors.camera.blocked_detail_html: '<strong>Autorisez l’accès à votre caméra pour prendre des photos pour %{app_name}.</strong><span>Essayez à nouveau de prendre des photos en autorisant %{app_name} à accéder à votre appareil. Si cela ne marche pas, pensez à vérifier les paramètres de votre appareil en matière d’autorisations d’accès.</span>'
 doc_auth.errors.camera.failed: L’appareil photo n’a pas réussi à démarrer, veuillez réessayer.
 doc_auth.errors.card_type: Réessayez avec votre permis de conduire ou carte d’identité d’un État.
+doc_auth.errors.consent_form: Avant de pouvoir continuer, vous devez nous donner la permission. Veuillez cocher la case ci-dessous, puis cliquez sur Suite.
+doc_auth.errors.doc_type_not_supported_heading: Nous n’acceptons que les permis de conduire ou les cartes d’identité délivrées par un État
 doc_auth.errors.doc.doc_type_check: Votre permis de conduire ou votre carte d’identité doit être délivré par un État ou un territoire des États-Unis. Nous n’acceptons pas d’autres pièces d’identité, comme les passeports ou les cartes d’identité militaires.
 doc_auth.errors.doc.resubmit_failed_image: Vous avez déjà essayé cette image et elle a échoué. Veuillez essayer d’ajouter une image différente.
 doc_auth.errors.doc.wrong_id_type_html: Nous n’acceptons qu’un permis de conduire ou une carte d’identité délivré par un État ou un territoire des États-Unis. Nous n’acceptons pas d’autres pièces d’identité, comme les passeports ou les cartes d’identité militaires. <a>En savoir plus sur les pièces d’identité acceptées</a>
+doc_auth.errors.document_capture_canceled: Vous avez annulé le téléchargement de vos photos d’identité sur votre téléphone.
 doc_auth.errors.dpi.failed_short: Image trop petite ou floue, veuillez réessayer.
 doc_auth.errors.dpi.top_msg: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre image soit de trop petite taille ou que votre pièce d’identité soit trop petite ou floue sur la photo. Assurez-vous que votre pièce d’identité remplisse le cadre de l’image, puis essayez de prendre une nouvelle photo.
 doc_auth.errors.dpi.top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre image soit de trop petite taille ou que votre pièce d’identité soit trop petite ou floue sur les photos. Assurez-vous que votre pièce d’identité remplisse le cadre de l’image, puis essayez de prendre une nouvelle photo.
@@ -540,6 +543,7 @@ doc_auth.errors.general.selfie_failure_help_link_text: Consultez plus de conseil
 doc_auth.errors.glare.failed_short: L’image a des reflets, veuillez réessayer.
 doc_auth.errors.glare.top_msg: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre photo présente des reflets. Assurez-vous que le flash de votre appareil photo soit désactivé, puis essayez de prendre une nouvelle photo.
 doc_auth.errors.glare.top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre photo présente des reflets. Assurez-vous que le flash de votre appareil photo soit désactivé, puis essayez de prendre une nouvelle photo.
+doc_auth.errors.how_to_verify_form: Sélectionnez un moyen de vérifier votre identité.
 doc_auth.errors.http.image_load.failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
 doc_auth.errors.http.image_load.top_msg: Le fichier image que vous avez ajouté n’est pas pris en charge. Veuillez prendre de nouvelles photos de votre pièce d’identité et réessayer.
 doc_auth.errors.http.image_size.failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
@@ -547,7 +551,14 @@ doc_auth.errors.http.image_size.top_msg: La taille de votre image est trop grand
 doc_auth.errors.http.pixel_depth.failed_short: Le fichier image n’est pas pris en charge, veuillez réessayer.
 doc_auth.errors.http.pixel_depth.top_msg: La profondeur de pixel de votre fichier image n’est pas prise en charge. Veuillez prendre de nouvelles photos de votre pièce d’identité et réessayer. La profondeur de pixel de l’image prise en charge est de 24 bits RGB.
 doc_auth.errors.not_a_file: La sélection n’était pas un fichier valide.
+doc_auth.errors.phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des photos de votre pièce d’identité avant de continuer. Nous vous avons envoyé un lien avec des instructions.
 doc_auth.errors.pii.birth_date_min_age: Votre anniversaire ne correspond pas à l’âge minimum requis.
+doc_auth.errors.rate_limited_heading: Nous n’avons pas pu vérifier votre pièce d’identité.
+doc_auth.errors.rate_limited_subheading: Essayez de prendre de nouvelles photos.
+doc_auth.errors.rate_limited_text_html: Pour votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier un document en ligne. <strong>Réessayez dans %{timeout}.</strong>
+doc_auth.errors.selfie_fail_heading: Nous n’avons pas pu faire correspondre votre photo à celle figurant sur votre pièce d’identité.
+doc_auth.errors.selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
+doc_auth.errors.send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans %{timeout}. Vous pouvez également revenir en arrière et choisir d’utiliser votre ordinateur à la place.
 doc_auth.errors.sharpness.failed_short: L’image est floue, veuillez réessayer.
 doc_auth.errors.sharpness.top_msg: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre photo soit trop floue ou trop sombre. Essayez de prendre une nouvelle photo dans un endroit bien éclairé.
 doc_auth.errors.sharpness.top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que vos photos soient trop floues ou trop sombres. Essayez de prendre de nouvelles photos dans un endroit bien éclairé.
@@ -696,17 +707,6 @@ errors.attributes.password.too_short.one: Le mot de passe doit comporter au moin
 errors.attributes.password.too_short.other: Le mot de passe doit comporter au moins %{count} caractères
 errors.capture_doc.invalid_link: Ce lien a expiré ou n’est pas valide. Veuillez demander un autre lien pour vérifier votre identité sur un téléphone mobile.
 errors.confirm_password_incorrect: Mot de passe incorrect.
-errors.doc_auth.consent_form: Avant de pouvoir continuer, vous devez nous donner la permission. Veuillez cocher la case ci-dessous, puis cliquez sur Suite.
-errors.doc_auth.doc_type_not_supported_heading: Nous n’acceptons que les permis de conduire ou les cartes d’identité délivrées par un État
-errors.doc_auth.document_capture_canceled: Vous avez annulé le téléchargement de vos photos d’identité sur votre téléphone.
-errors.doc_auth.how_to_verify_form: Sélectionnez un moyen de vérifier votre identité.
-errors.doc_auth.phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des photos de votre pièce d’identité avant de continuer. Nous vous avons envoyé un lien avec des instructions.
-errors.doc_auth.rate_limited_heading: Nous n’avons pas pu vérifier votre pièce d’identité.
-errors.doc_auth.rate_limited_subheading: Essayez de prendre de nouvelles photos.
-errors.doc_auth.rate_limited_text_html: Pour votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier un document en ligne. <strong>Réessayez dans %{timeout}.</strong>
-errors.doc_auth.selfie_fail_heading: Nous n’avons pas pu faire correspondre votre photo à celle figurant sur votre pièce d’identité.
-errors.doc_auth.selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
-errors.doc_auth.send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans %{timeout}. Vous pouvez également revenir en arrière et choisir d’utiliser votre ordinateur à la place.
 errors.enter_code.rate_limited_html: Vous avez saisi un code de vérification inexact à trop de reprises. <strong>Réessayez dans %{timeout}.</strong>
 errors.general: Oups, une erreur s’est produite. Veuillez réessayer.
 errors.invalid_totp: Code non valide. Veuillez réessayer.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -534,9 +534,12 @@ doc_auth.errors.camera.blocked: 你的镜头被遮住了。
 doc_auth.errors.camera.blocked_detail_html: '<strong>允许 %{app_name} 进入你的相机来拍照。</strong><span>尝试再次拍照并给予许可。如果还不行，你可能需要检查自己设备的设置来给予许可。</span>'
 doc_auth.errors.camera.failed: 相机未开启，请再试一次。
 doc_auth.errors.card_type: 再用你的驾照或州政府颁发的身份证件试一次。
+doc_auth.errors.consent_form: 在你能继续之前，你必须授予我们你的同意。请在下面的框打勾然后点击继续。
+doc_auth.errors.doc_type_not_supported_heading: 我们只接受驾照或州政府颁发的 ID。
 doc_auth.errors.doc.doc_type_check: 你的驾照或身份证件必须是美国一个州或属地颁发的。我们不接受任何其他形式的身份证件，比如护照和军队身份证件。
 doc_auth.errors.doc.resubmit_failed_image: 你已经试过这张图像，该图像不行。请尝试添加一个不同的图像。
 doc_auth.errors.doc.wrong_id_type_html: 我们只接受由美国的一个州或属地颁发的驾照或身份证件。我们不接受任何其他形式的身份证件，比如护照和军队身份证件。<a> 了解更多有关我们接受的身份证件的信息 </a>
+doc_auth.errors.document_capture_canceled: 你已取消了用手机上传身份证件照片。
 doc_auth.errors.dpi.failed_short: 图像太小或模糊，请再试一次。
 doc_auth.errors.dpi.top_msg: 我们无法辨认你的身份证件。你的图像尺寸可能太小，或者照片中你的身份证件太小或太模糊。确保你的身份证件在图框中比较大，然后试着重拍一下。
 doc_auth.errors.dpi.top_msg_plural: 我们无法读取你的身份证件。你的图像尺寸可能太小，或者照片中你的身份证件太小或模糊。确保你的身份证件在图片框中很大，然后试着拍一张新照片。
@@ -551,6 +554,7 @@ doc_auth.errors.general.selfie_failure_help_link_text: 查看更多有关拍摄�
 doc_auth.errors.glare.failed_short: 图像有炫光，请再试一次。
 doc_auth.errors.glare.top_msg: 我们无法读取你的身份证件。你的照片可能有炫光。确保你相机上的闪光是关掉的，然后再尝试重拍张。
 doc_auth.errors.glare.top_msg_plural: 我们无法读取你的身份证件。你的照片可能有炫光。确保你相机上的闪光是关掉的，然后再尝试重拍。
+doc_auth.errors.how_to_verify_form: 选择一个验证身份的方法。
 doc_auth.errors.http.image_load.failed_short: 系统不支持图像文件，请再试一次。
 doc_auth.errors.http.image_load.top_msg: 你添加的图像文件系统不支持。请重拍你的身份证件并再试一次。
 doc_auth.errors.http.image_size.failed_short: 系统不支持图像文件，请再试一次。
@@ -558,7 +562,14 @@ doc_auth.errors.http.image_size.top_msg: 你的图像尺寸太大或太小。请
 doc_auth.errors.http.pixel_depth.failed_short: 系统不支持图像文件，请再试一次。
 doc_auth.errors.http.pixel_depth.top_msg: 你图像文件的像素深度系统不支持。请重拍你的身份证件并再试一次。系统支持的图像像素深度为 24位 RGB。
 doc_auth.errors.not_a_file: 你选择的不是一个正确的文件。
+doc_auth.errors.phone_step_incomplete: 在继续之前你必须使用手机上传你身份证件的图片。我们已给你发了带有说明的链接。
 doc_auth.errors.pii.birth_date_min_age: 你的生日不满足最低年龄要求。
+doc_auth.errors.rate_limited_heading: 我们无法验证你的身份证件。
+doc_auth.errors.rate_limited_subheading: 尝试再拍照片
+doc_auth.errors.rate_limited_text_html: 为了你的安全，我们限制你在网上尝试验证文件的次数。<strong> %{timeout} 后再试。</strong>
+doc_auth.errors.selfie_fail_heading: 我们无法把你自己的照片与你的身份证件匹配
+doc_auth.errors.selfie_not_live_or_poor_quality_heading: 我们无法验证你自己的照片
+doc_auth.errors.send_link_limited: 你尝试了太多次。请在 %{timeout}后再试。你也可以返回并选择使用电脑。
 doc_auth.errors.sharpness.failed_short: 图像模糊，请再试一次。
 doc_auth.errors.sharpness.top_msg: 我们无法读取你的身份证件。你的照片可能太模糊或太暗。尝试在明亮的地方重拍一张。
 doc_auth.errors.sharpness.top_msg_plural: 我们无法读取你的身份证件。你的照片可能太模糊或太暗。尝试在明亮的地方重拍一张。
@@ -707,17 +718,6 @@ errors.attributes.password.too_short.one: 密码必须至少有一个字符
 errors.attributes.password.too_short.other: 密码必须至少有%{count}个字符
 errors.capture_doc.invalid_link: 链接已过期或有误。 请要求另外一个在手机上验证身份的链接。
 errors.confirm_password_incorrect: 密码不对。
-errors.doc_auth.consent_form: 在你能继续之前，你必须授予我们你的同意。请在下面的框打勾然后点击继续。
-errors.doc_auth.doc_type_not_supported_heading: 我们只接受驾照或州政府颁发的 ID。
-errors.doc_auth.document_capture_canceled: 你已取消了用手机上传身份证件照片。
-errors.doc_auth.how_to_verify_form: 选择一个验证身份的方法。
-errors.doc_auth.phone_step_incomplete: 在继续之前你必须使用手机上传你身份证件的图片。我们已给你发了带有说明的链接。
-errors.doc_auth.rate_limited_heading: 我们无法验证你的身份证件。
-errors.doc_auth.rate_limited_subheading: 尝试再拍照片
-errors.doc_auth.rate_limited_text_html: 为了你的安全，我们限制你在网上尝试验证文件的次数。<strong> %{timeout} 后再试。</strong>
-errors.doc_auth.selfie_fail_heading: 我们无法把你自己的照片与你的身份证件匹配
-errors.doc_auth.selfie_not_live_or_poor_quality_heading: 我们无法验证你自己的照片
-errors.doc_auth.send_link_limited: 你尝试了太多次。请在 %{timeout}后再试。你也可以返回并选择使用电脑。
 errors.enter_code.rate_limited_html: 你输入错误验证码太多次。<strong> %{timeout} 后再试。</strong>
 errors.general: 哎呀，出错了。请再试一次。
 errors.invalid_totp: 代码有误。请再试一次。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1834,7 +1834,7 @@ user_mailer.in_person_failed_suspected_fraud.body.help_center_html: 如需要更
 user_mailer.in_person_failed_suspected_fraud.body.intro: 我们知道你曾经试图通过 %{app_name} 验证身份，但是你的身份于 %{date}在 %{location} 邮局未能得到验证。
 user_mailer.in_person_failed_suspected_fraud.greeting: 你好，
 user_mailer.in_person_failed_suspected_fraud.subject: 你的身份未能亲身被验证。
-user_mailer.in_person_failed.body.with_cta: 点击按钮或者复制下面的链接来再次在网上通过 %{sp_or_app_name}验证你的身份。如果你仍然遇到问题，请联系你要访问的政府机构。
+user_mailer.in_person_failed.body.with_cta: 点击按钮或复制下面的链接，尝试通过 %{sp_or_app_name} 再次验证你的身份。
 user_mailer.in_person_failed.body.without_cta: 请尝试从 %{sp_name}的网站再次验证你的身份。如果你仍然遇到问题，请联系你要访问的政府机构。
 user_mailer.in_person_failed.intro: 你的身份于 %{date}在 %{location} 邮局未能得到验证。
 user_mailer.in_person_failed.subject: 你的身份未能亲身被验证。

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -305,6 +305,7 @@ module IdentityConfig
       type: :symbol,
       enum: [:disabled, :collect_only, :enabled],
     )
+    config.add(:protocols_report_config, type: :json)
     config.add(:push_notifications_enabled, type: :boolean)
     config.add(:pwned_passwords_file_path, type: :string)
     config.add(:rack_mini_profiler, type: :boolean)

--- a/lib/reporting/cloudwatch_client.rb
+++ b/lib/reporting/cloudwatch_client.rb
@@ -47,7 +47,7 @@ module Reporting
     # @param [#to_s] query
     # @param [Time] from
     # @param [Time] to
-    # @param [Array<Range<Time>>] time_slices Pass an to use specific slices
+    # @param [Array<Range<Time>>] time_slices Pass a list of time ranges to use specific slices
     # @raise [ArgumentError] raised when incorrect time parameters are received
     # @overload fetch(query:, from:, to:)
     #   The block-less form returns the array of *all* results at the end
@@ -250,8 +250,12 @@ module Reporting
       end
 
       if time_slices.present?
-        time_slices
-      elsif slice_interval
+        return time_slices
+      end
+
+      raise ArgumentError, '`:from` must be a Time or equivalent' if !from.respond_to?(:to_i)
+      raise ArgumentError, '`:to` must be a Time or equivalent' if !to.respond_to?(:to_i)
+      if slice_interval
         slices = []
         low = from
         high = to

--- a/spec/config/initializers/job_configurations_spec.rb
+++ b/spec/config/initializers/job_configurations_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'GoodJob.cron' do
 
         freeze_time do
           # Always passes the previous day as the argument
-          expect(report[:args].call).to eq([Time.zone.yesterday])
+          # Our CloudwatchClient requires using DateTime. It won't accept a Date without coercion
+          expect(report[:args].call).to eq([Time.zone.yesterday.end_of_day])
 
           now = Time.zone.now
           next_time = Fugit.parse(report[:cron]).next_time

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
           'IdV: doc auth image upload form submitted',
           success: false,
           errors: {
-            limit: [I18n.t('errors.doc_auth.rate_limited_heading')],
+            limit: [I18n.t('doc_auth.errors.rate_limited_heading')],
           },
           error_details: {
             limit: { rate_limited: true },

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Idv::LinkSentController do
             it 'flashes an error and does not redirect' do
               put :update
 
-              expect(flash[:error]).to eq t('errors.doc_auth.phone_step_incomplete')
+              expect(flash[:error]).to eq t('doc_auth.errors.phone_step_incomplete')
               expect(response.status).to eq(204)
             end
           end
@@ -204,7 +204,7 @@ RSpec.describe Idv::LinkSentController do
 
       context 'document capture session canceled' do
         let(:session_canceled_at) { Time.zone.now }
-        let(:error_message) { t('errors.doc_auth.document_capture_canceled') }
+        let(:error_message) { t('doc_auth.errors.document_capture_canceled') }
 
         before do
           expect(FormResponse).to receive(:new).with(
@@ -228,7 +228,7 @@ RSpec.describe Idv::LinkSentController do
           put :update
 
           expect(response).to have_http_status(204)
-          expect(flash[:error]).to eq(t('errors.doc_auth.phone_step_incomplete'))
+          expect(flash[:error]).to eq(t('doc_auth.errors.phone_step_incomplete'))
         end
       end
     end

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Users::PivCacLoginController do
             errors: {},
             key_id: nil,
             success: false,
+            new_device: nil,
           )
         end
 
@@ -85,6 +86,7 @@ RSpec.describe Users::PivCacLoginController do
               },
               key_id: nil,
               success: false,
+              new_device: nil,
             )
           end
 
@@ -125,6 +127,7 @@ RSpec.describe Users::PivCacLoginController do
               errors: {},
               key_id: nil,
               success: true,
+              new_device: true,
             )
           end
 
@@ -168,6 +171,26 @@ RSpec.describe Users::PivCacLoginController do
               presented: true,
             }
             expect(controller.user_session[:decrypted_x509]).to eq session_info.to_json
+          end
+
+          context 'with authenticated device' do
+            let(:user) { create(:user, :with_authenticated_device) }
+
+            before do
+              cookies[:device] = user.devices.last.cookie_uuid
+            end
+
+            it 'tracks the login attempt' do
+              response
+
+              expect(@analytics).to have_logged_event(
+                :piv_cac_login,
+                errors: {},
+                key_id: nil,
+                success: true,
+                new_device: false,
+              )
+            end
           end
 
           context 'when the user has not accepted the most recent terms of use' do

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
           ),
         )
         submit_images
-        message = strip_tags(t('errors.doc_auth.doc_type_not_supported_heading'))
+        message = strip_tags(t('doc_auth.errors.doc_type_not_supported_heading'))
         expect(page).to have_content(message)
         detail_message = strip_tags(t('doc_auth.errors.doc.doc_type_check'))
         security_message = strip_tags(
@@ -108,7 +108,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
           timeout = distance_of_time_in_words(
             RateLimiter.attempt_window_in_minutes(:idv_doc_auth).minutes,
           )
-          message = strip_tags(t('errors.doc_auth.rate_limited_text_html', timeout: timeout))
+          message = strip_tags(t('doc_auth.errors.rate_limited_text_html', timeout: timeout))
           expect(page).to have_content(message)
           expect(page).to have_current_path(idv_session_errors_rate_limited_path)
         end
@@ -320,10 +320,10 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_issues_h1_heading = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_issues_h1_heading)
 
-                review_issues_subheading = strip_tags(t('errors.doc_auth.rate_limited_subheading'))
+                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
                 expect(page).not_to have_selector('h2', text: review_issues_subheading)
 
                 review_issues_body_message = strip_tags(t('doc_auth.errors.general.no_liveness'))
@@ -373,10 +373,10 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_issues_h1_heading = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_issues_h1_heading)
 
-                review_issues_subheading = strip_tags(t('errors.doc_auth.rate_limited_subheading'))
+                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
                 expect(page).not_to have_selector('h2', text: review_issues_subheading)
 
                 review_issues_body_message = strip_tags(
@@ -427,10 +427,10 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_issues_h1_heading = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_issues_h1_heading)
 
-                review_issues_subheading = strip_tags(t('errors.doc_auth.rate_limited_subheading'))
+                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
                 expect(page).not_to have_selector('h2', text: review_issues_subheading)
 
                 review_issues_body_message = strip_tags(
@@ -496,7 +496,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
@@ -547,7 +547,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 submit_images
 
                 review_page_h1_copy = strip_tags(
-                  t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+                  t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
                 )
                 expect(page).to have_content(review_page_h1_copy)
 
@@ -594,7 +594,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
@@ -638,7 +638,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
@@ -682,7 +682,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
@@ -728,7 +728,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(
@@ -776,7 +776,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(
@@ -824,7 +824,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.no_liveness'))
@@ -869,7 +869,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 submit_images
 
                 review_page_h1_copy = strip_tags(
-                  t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+                  t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
                 )
                 expect(page).to have_content(review_page_h1_copy)
 
@@ -916,7 +916,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.rate_limited_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.alerts.address_check'))
@@ -962,7 +962,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
+                review_page_h1_copy = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
                 expect(page).to have_content(review_page_h1_copy)
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
@@ -1011,7 +1011,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               ),
             )
             submit_images
-            message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+            message = strip_tags(t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
             detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
@@ -1022,7 +1022,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             )
             expect(page).to have_content(detail_message << "\n" << security_message)
             review_issues_header = strip_tags(
-              t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+              t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
             )
             expect(page).to have_content(review_issues_header)
             expect(page).to have_current_path(idv_document_capture_path)
@@ -1049,7 +1049,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               ),
             )
             submit_images
-            message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+            message = strip_tags(t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
             detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
@@ -1060,7 +1060,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             )
             expect(page).to have_content(detail_message << "\n" << security_message)
             review_issues_header = strip_tags(
-              t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+              t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
             )
             expect(page).to have_content(review_issues_header)
             expect(page).to have_current_path(idv_document_capture_path)
@@ -1087,7 +1087,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               ),
             )
             submit_images
-            message = strip_tags(t('errors.doc_auth.selfie_fail_heading'))
+            message = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
             expect(page).to have_content(message)
             detail_message = strip_tags(t('doc_auth.errors.general.selfie_failure'))
             security_message = strip_tags(
@@ -1098,7 +1098,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             )
             expect(page).to have_content(detail_message << "\n" << security_message)
             review_issues_header = strip_tags(
-              t('errors.doc_auth.selfie_fail_heading'),
+              t('doc_auth.errors.selfie_fail_heading'),
             )
             expect(page).to have_content(review_issues_header)
             expect(page).to have_current_path(idv_document_capture_path)
@@ -1126,7 +1126,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               ),
             )
             submit_images
-            message = strip_tags(t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'))
+            message = strip_tags(t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'))
             expect(page).to have_content(message)
             detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
             security_message = strip_tags(
@@ -1138,7 +1138,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
             expect(page).to have_content(detail_message << "\n" << security_message)
             review_issues_header = strip_tags(
-              t('errors.doc_auth.selfie_not_live_or_poor_quality_heading'),
+              t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
             )
             expect(page).to have_content(review_issues_header)
             expect(page).to have_current_path(idv_document_capture_path)

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -122,7 +122,7 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
       freeze_time do
         idv_send_link_max_attempts.times do
           expect(page).to_not have_content(
-            I18n.t('errors.doc_auth.send_link_limited', timeout: timeout),
+            I18n.t('doc_auth.errors.send_link_limited', timeout: timeout),
           )
 
           fill_in :doc_auth_phone, with: '415-555-0199'
@@ -139,7 +139,7 @@ RSpec.feature 'hybrid_handoff step send link and errors', allowed_extra_analytic
         expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
         expect(page).to have_content(
           I18n.t(
-            'errors.doc_auth.send_link_limited',
+            'doc_auth.errors.send_link_limited',
             timeout: timeout,
           ),
         )

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
         form.submit
 
         expect(form.valid?).to eq(false)
-        expect(form.errors[:limit]).to eq([I18n.t('errors.doc_auth.rate_limited_heading')])
+        expect(form.errors[:limit]).to eq([I18n.t('doc_auth.errors.rate_limited_heading')])
       end
     end
 

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -89,8 +89,8 @@ describe('DocumentCaptureWarning', () => {
 
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
-        heading: 'errors.doc_auth.rate_limited_heading',
-        subheading: 'errors.doc_auth.rate_limited_subheading',
+        heading: 'doc_auth.errors.rate_limited_heading',
+        subheading: 'doc_auth.errors.rate_limited_subheading',
         error_message_displayed: 'general error',
         remaining_submit_attempts: 2,
         liveness_checking_required: false,
@@ -106,8 +106,8 @@ describe('DocumentCaptureWarning', () => {
           inPersonUrl,
         });
 
-        validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
+        validateHeader('doc_auth.errors.rate_limited_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, true);
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -125,8 +125,8 @@ describe('DocumentCaptureWarning', () => {
           inPersonUrl,
         });
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
+        validateHeader('doc_auth.errors.doc_type_not_supported_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, true);
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -148,8 +148,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.rate_limited_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -168,8 +168,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.doc_type_not_supported_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -192,8 +192,8 @@ describe('DocumentCaptureWarning', () => {
       });
 
       // error message section
-      validateHeader('errors.doc_auth.selfie_fail_heading', 1, true);
-      validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
+      validateHeader('doc_auth.errors.selfie_fail_heading', 1, true);
+      validateHeader('doc_auth.errors.rate_limited_subheading', 2, true);
       expect(getByText('general error')).to.be.ok();
       expect(queryByText('idv.failure.attempts_html')).to.be.ok();
       expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -215,8 +215,8 @@ describe('DocumentCaptureWarning', () => {
       });
 
       // error message section
-      validateHeader('errors.doc_auth.selfie_not_live_or_poor_quality_heading', 1, true);
-      validateHeader('errors.doc_auth.rate_limited_subheading', 2, true);
+      validateHeader('doc_auth.errors.selfie_not_live_or_poor_quality_heading', 1, true);
+      validateHeader('doc_auth.errors.rate_limited_subheading', 2, true);
       expect(getByText('general error')).to.be.ok();
       expect(queryByText('idv.failure.attempts_html')).to.be.ok();
       expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -238,7 +238,7 @@ describe('DocumentCaptureWarning', () => {
 
       expect(trackEvent).to.have.been.calledWith('IdV: warning shown', {
         location: 'doc_auth_review_issues',
-        heading: 'errors.doc_auth.doc_type_not_supported_heading',
+        heading: 'doc_auth.errors.doc_type_not_supported_heading',
         subheading: '',
         error_message_displayed: 'general error',
         remaining_submit_attempts: 2,
@@ -257,8 +257,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.rate_limited_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -277,8 +277,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.doc_type_not_supported_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -300,8 +300,8 @@ describe('DocumentCaptureWarning', () => {
         });
 
         // error message section
-        validateHeader('errors.doc_auth.rate_limited_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.rate_limited_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText('general error')).to.be.ok();
         expect(getByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -319,8 +319,8 @@ describe('DocumentCaptureWarning', () => {
           inPersonUrl,
         });
         // error message section
-        validateHeader('errors.doc_auth.doc_type_not_supported_heading', 1, true);
-        validateHeader('errors.doc_auth.rate_limited_subheading', 2, false);
+        validateHeader('doc_auth.errors.doc_type_not_supported_heading', 1, true);
+        validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
         expect(getByText(/general error/)).to.be.ok();
         expect(queryByText('idv.failure.attempts_html')).to.be.ok();
         expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -34,7 +34,7 @@ describe('document-capture/components/review-issues-step', () => {
         value={
           new I18n({
             strings: {
-              'errors.doc_auth.rate_limited_heading': 'We couldn’t verify your ID',
+              'doc_auth.errors.rate_limited_heading': 'We couldn’t verify your ID',
             },
           })
         }
@@ -80,7 +80,7 @@ describe('document-capture/components/review-issues-step', () => {
       </I18nContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
+    expect(getByText('doc_auth.errors.rate_limited_heading')).to.be.ok();
     expect(getByText('3 attempts', { selector: 'strong' })).to.be.ok();
     expect(getByText('remaining')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -114,7 +114,7 @@ describe('document-capture/components/review-issues-step', () => {
       </InPersonContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
+    expect(getByText('doc_auth.errors.rate_limited_heading')).to.be.ok();
     expect(getByText('3 attempts', { selector: 'strong' })).to.be.ok();
     expect(getByText('remaining')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.try_online' })).to.be.ok();
@@ -156,7 +156,7 @@ describe('document-capture/components/review-issues-step', () => {
       </I18nContext.Provider>,
     );
 
-    expect(getByText('errors.doc_auth.rate_limited_heading')).to.be.ok();
+    expect(getByText('doc_auth.errors.rate_limited_heading')).to.be.ok();
     expect(getByText('One attempt remaining')).to.be.ok();
     expect(getByText('An unknown error occurred')).to.be.ok();
     expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
@@ -234,7 +234,7 @@ describe('document-capture/components/review-issues-step', () => {
                   one: '<strong>One attempt</strong> remaining to add your ID online',
                   other: '<strong>%{count} attempts</strong> remaining to add your ID online',
                 },
-                'errors.doc_auth.doc_type_not_supported_heading': 'doc type not supported',
+                'doc_auth.errors.doc_type_not_supported_heading': 'doc type not supported',
                 'doc_auth.errors.doc.wrong_id_type_html':
                   "We only accept a driver's license or a state ID card at this time.",
               },
@@ -289,7 +289,7 @@ describe('document-capture/components/review-issues-step', () => {
                   one: '<strong>One attempt</strong> remaining to add your ID online',
                   other: '<strong>%{count} attempts</strong> remaining to add your ID online',
                 },
-                'errors.doc_auth.doc_type_not_supported_heading': 'doc type not supported',
+                'doc_auth.errors.doc_type_not_supported_heading': 'doc type not supported',
                 'doc_auth.errors.doc.wrong_id_type_html':
                   "We only accept a driver's license or a state ID card at this time.",
               },

--- a/spec/jobs/reports/protocols_report_spec.rb
+++ b/spec/jobs/reports/protocols_report_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Reports::ProtocolsReport do
+  let(:report_date) { Date.new(2024, 7, 5) }
+  let(:email) { 'team@example.com' }
+
+  let(:report_configs) do
+    [
+      {
+        'emails' => [email],
+      },
+    ]
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:protocols_report_config) { report_configs }
+  end
+
+  describe '#perform' do
+    it 'sends emailable reports to the ReportMailer' do
+      emailable_reports = double('emailable_reports').as_null_object
+      protocols_report = instance_double(
+        Reporting::ProtocolsReport,
+        as_emailable_reports: emailable_reports,
+      )
+
+      expect(Reporting::ProtocolsReport).to receive(:new).with(
+        issuers: nil,
+        time_range: report_date.all_week,
+      ) { protocols_report }
+      expect(ReportMailer).to receive(:tables_report).with(
+        email:,
+        subject: "Weekly Protocols Report - #{report_date}",
+        message: "Report: protocols-report #{report_date}",
+        reports: emailable_reports,
+        attachment_format: :csv,
+      ).and_call_original
+
+      subject.perform(report_date)
+    end
+  end
+end

--- a/spec/lib/reporting/cloudwatch_client_spec.rb
+++ b/spec/lib/reporting/cloudwatch_client_spec.rb
@@ -111,6 +111,29 @@ RSpec.describe Reporting::CloudwatchClient do
       end
     end
 
+    context 'bad time types are passed' do
+      let(:good_datetime) { Time.zone.now }
+      let(:bad_date) { Time.zone.today }
+      it 'raises with an invalid :from' do
+        expect do
+          client.fetch(
+            query:,
+            from: bad_date - 1.day,
+            to: good_datetime,
+          )
+        end.to raise_error(ArgumentError, /\bfrom\b.* must be a Time/)
+      end
+
+      it 'raises with an invalid :to' do
+        expect do
+          client.fetch(
+            query:,
+            from: good_datetime - 1.day,
+            to: bad_date,
+          )
+        end.to raise_error(ArgumentError, /\bto\b.* must be a Time/)
+      end
+    end
     it 'converts results into hashes, without @ptr' do
       stub_single_page
 

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -66,33 +66,44 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
   end
 
   describe '#selected_location_hours' do
-    let(:hours_open) { '8:00 AM - 4:30 PM' }
-    let(:hours_closed) { 'Closed' }
-
-    before do
-      allow(presenter).to receive(:selected_location_details).and_return(
-        {
-          'weekday_hours' => hours_open,
-          'saturday_hours' => hours_open,
-          'sunday_hours' => hours_closed,
-        },
-      )
-    end
-
     it 'returns localized location hours for weekdays and weekends by prefix' do
-      expect(presenter.selected_location_hours(:weekday)).to eq '8:00 AM – 4:30 PM'
-      expect(presenter.selected_location_hours(:saturday)).to eq '8:00 AM – 4:30 PM'
+      expect(presenter.selected_location_hours(:weekday)).to eq '9:00 AM – 5:00 PM'
+      expect(presenter.selected_location_hours(:saturday)).to eq '9:00 AM – 1:00 PM'
       expect(presenter.selected_location_hours(:sunday)).to eq(
         I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
       )
+    end
+
+    context 'with previously localized hours' do
+      let(:enrollment_selected_location_details) do
+        json = JSON.parse(UspsInPersonProofing::Mock::Fixtures.enrollment_selected_location_details)
+        json['weekday_hours'] = UspsInPersonProofing::EnrollmentHelper.localized_hours(
+          json['weekday_hours'],
+        )
+        json['saturday_hours'] = UspsInPersonProofing::EnrollmentHelper.localized_hours(
+          json['saturday_hours'],
+        )
+        json['sunday_hours'] = UspsInPersonProofing::EnrollmentHelper.localized_hours(
+          json['sunday_hours'],
+        )
+        json
+      end
+
+      it 'localizes appropriately' do
+        expect(presenter.selected_location_hours(:weekday)).to eq '9:00 AM – 5:00 PM'
+        expect(presenter.selected_location_hours(:saturday)).to eq '9:00 AM – 1:00 PM'
+        expect(presenter.selected_location_hours(:sunday)).to eq(
+          I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
+        )
+      end
     end
 
     context 'with Spanish locale' do
       before { I18n.locale = :es }
 
       it 'returns localized location hours for weekdays and weekends by prefix' do
-        expect(presenter.selected_location_hours(:weekday)).to eq '8:00 AM – 4:30 PM'
-        expect(presenter.selected_location_hours(:saturday)).to eq '8:00 AM – 4:30 PM'
+        expect(presenter.selected_location_hours(:weekday)).to eq '9:00 AM – 5:00 PM'
+        expect(presenter.selected_location_hours(:saturday)).to eq '9:00 AM – 1:00 PM'
         expect(presenter.selected_location_hours(:sunday)).to eq(
           I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
         )
@@ -103,8 +114,20 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
       before { I18n.locale = :fr }
 
       it 'returns localized location hours for weekdays and weekends by prefix' do
-        expect(presenter.selected_location_hours(:weekday)).to eq '8 h 00 AM – 4 h 30 PM'
-        expect(presenter.selected_location_hours(:saturday)).to eq '8 h 00 AM – 4 h 30 PM'
+        expect(presenter.selected_location_hours(:weekday)).to eq '9 h 00 AM – 5 h 00 PM'
+        expect(presenter.selected_location_hours(:saturday)).to eq '9 h 00 AM – 1 h 00 PM'
+        expect(presenter.selected_location_hours(:sunday)).to eq(
+          I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
+        )
+      end
+    end
+
+    context 'with Chinese locale' do
+      before { I18n.locale = :zh }
+
+      it 'returns localized location hours for weekdays and weekends by prefix' do
+        expect(presenter.selected_location_hours(:weekday)).to eq '9:00 AM – 5:00 PM'
+        expect(presenter.selected_location_hours(:saturday)).to eq '9:00 AM – 1:00 PM'
         expect(presenter.selected_location_hours(:sunday)).to eq(
           I18n.t('in_person_proofing.body.barcode.retail_hours_closed'),
         )

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ImageUploadResponsePresenter do
         FormResponse.new(
           success: false,
           errors: {
-            limit: t('errors.doc_auth.rate_limited_heading'),
+            limit: t('doc_auth.errors.rate_limited_heading'),
           },
         )
       end
@@ -115,7 +115,7 @@ RSpec.describe ImageUploadResponsePresenter do
         FormResponse.new(
           success: false,
           errors: {
-            limit: t('errors.doc_auth.rate_limited_heading'),
+            limit: t('doc_auth.errors.rate_limited_heading'),
           },
           extra: extra_attributes,
         )
@@ -126,7 +126,7 @@ RSpec.describe ImageUploadResponsePresenter do
           success: false,
           result_code_invalid: true,
           result_failed: false,
-          errors: [{ field: :limit, message: t('errors.doc_auth.rate_limited_heading') }],
+          errors: [{ field: :limit, message: t('doc_auth.errors.rate_limited_heading') }],
           redirect: idv_session_errors_rate_limited_url,
           remaining_submit_attempts: 0,
           ocr_pii: nil,
@@ -149,7 +149,7 @@ RSpec.describe ImageUploadResponsePresenter do
             success: false,
             result_code_invalid: true,
             result_failed: false,
-            errors: [{ field: :limit, message: t('errors.doc_auth.rate_limited_heading') }],
+            errors: [{ field: :limit, message: t('doc_auth.errors.rate_limited_heading') }],
             redirect: idv_hybrid_mobile_capture_complete_url,
             remaining_submit_attempts: 0,
             ocr_pii: nil,

--- a/spec/views/idv/session_errors/rate_limited.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/rate_limited.html.erb_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe 'idv/session_errors/rate_limited.html.erb' do
 
   context 'with liveness feature disabled' do
     it 'renders expected heading' do
-      expect(rendered).to have_text(t('errors.doc_auth.rate_limited_heading'))
+      expect(rendered).to have_text(t('doc_auth.errors.rate_limited_heading'))
     end
   end
 
   context 'with liveness feature enabled' do
     it 'renders expected heading' do
-      expect(rendered).to have_text(t('errors.doc_auth.rate_limited_heading'))
+      expect(rendered).to have_text(t('doc_auth.errors.rate_limited_heading'))
     end
   end
 end


### PR DESCRIPTION
## Bug Fixes

- In-person Proofing: Remove the term online from failure CTA body ([#10936](https://github.com/18F/identity-idp/pull/10936))

## Internal

- Analytics: Log new_device for piv_cac_login event ([#10960](https://github.com/18F/identity-idp/pull/10960))
- Bug Fixes: Translate Post Office search results ([#10940](https://github.com/18F/identity-idp/pull/10940))
- Code Quality: Apply YAML normalizations to application.yml.default ([#10972](https://github.com/18F/identity-idp/pull/10972))
- Reporting: Improve `CloudwatchClient` argument errors ([#10937](https://github.com/18F/identity-idp/pull/10937))
- Reporting: Publish Weekly State of Protocols Email ([#10923](https://github.com/18F/identity-idp/pull/10923))
- Translations: Made doc auth error messages all live in the same section of the strings files ([#10956](https://github.com/18F/identity-idp/pull/10956))