### PR TITLE
Retire `no_verify_by_mail_for_biometric_comparison_enabled` feature flag

### DIFF
--- a/app/policies/idv/gpo_verify_by_mail_policy.rb
+++ b/app/policies/idv/gpo_verify_by_mail_policy.rb
@@ -38,14 +38,10 @@ module Idv
     private
 
     def disabled_for_biometric_comparison?
-      return false unless IdentityConfig.store.no_verify_by_mail_for_biometric_comparison_enabled
-
       resolved_authn_context_result.two_pieces_of_fair_evidence?
     end
 
     def disabled_for_ipp?
-      return false unless IdentityConfig.store.no_verify_by_mail_for_biometric_comparison_enabled
-
       user.has_in_person_enrollment?
     end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -201,7 +201,6 @@ min_password_score: 3
 minimum_wait_before_another_usps_letter_in_hours: 24
 mx_timeout: 3
 new_device_alert_delay_in_minutes: 5
-no_verify_by_mail_for_biometric_comparison_enabled: true
 openid_connect_redirect: client_side_js
 openid_connect_content_security_form_action_enabled: false
 openid_connect_redirect_uuid_override_map: '{}'
@@ -474,7 +473,6 @@ production:
   logins_per_ip_period: 20
   logins_per_ip_track_only_mode: true
   newrelic_license_key: ''
-  no_verify_by_mail_for_biometric_comparison_enabled: false
   openid_connect_redirect: server_side
   openid_connect_content_security_form_action_enabled: true
   otp_delivery_blocklist_findtime: 5

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -241,7 +241,6 @@ module IdentityConfig
     config.add(:mx_timeout, type: :integer)
     config.add(:new_device_alert_delay_in_minutes, type: :integer)
     config.add(:newrelic_license_key, type: :string)
-    config.add(:no_verify_by_mail_for_biometric_comparison_enabled, type: :boolean)
     config.add(
       :openid_connect_redirect,
       type: :string,

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
       complete_all_in_person_proofing_steps(user)
       test_restart_in_person_flow(user)
       complete_otp_verification_page(user)
-      
+
       test_go_back_in_person_flow
 
       complete_enter_password_step(user)

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -87,6 +87,38 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
     validate_return_to_sp
   end
 
+  scenario 'Verify by mail' do
+    visit_idp_from_sp_with_ial2(sp)
+    user = sign_up_and_2fa_ial1_user
+    complete_all_doc_auth_steps
+
+    enter_gpo_flow
+    test_go_back_from_request_letter
+    complete_request_letter
+    complete_enter_password_step(user)
+
+    try_to_go_back_from_letter_enqueued
+    validate_letter_enqueued_page
+    complete_letter_enqueued
+    validate_return_to_sp
+
+    visit sign_out_url
+    user.reload
+
+    visit_idp_from_sp_with_ial2(sp)
+
+    sign_in_live_with_2fa(user)
+
+    complete_gpo_verification(user)
+    expect(user.identity_verified?).to be(true)
+
+    acknowledge_and_confirm_personal_key
+    validate_idv_completed_page(user)
+    click_agree_and_continue
+
+    validate_return_to_sp
+  end
+
   context 'with an sp that allows in person proofing' do
     before do
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
@@ -95,61 +127,36 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
         update(in_person_proofing_enabled: true)
     end
 
-    context 'when gpo is allowed for verify by mail' do
-      before do
-        allow(IdentityConfig.store).to receive(:no_verify_by_mail_for_biometric_comparison_enabled).
-          and_return(false)
-      end
+    scenario 'In person proofing', allow_browser_log: true do
+      visit_idp_from_sp_with_ial2(sp)
+      user = sign_up_and_2fa_ial1_user
 
-      scenario 'In person proofing verify by mail', allow_browser_log: true do
-        visit_idp_from_sp_with_ial2(sp)
-        user = sign_up_and_2fa_ial1_user
+      begin_in_person_proofing
+      complete_all_in_person_proofing_steps(user)
+      test_restart_in_person_flow(user)
+      complete_otp_verification_page(user)
+      
+      test_go_back_in_person_flow
 
-        begin_in_person_proofing
-        complete_all_in_person_proofing_steps(user)
-        test_restart_in_person_flow(user)
+      complete_enter_password_step(user)
+      acknowledge_and_confirm_personal_key
 
-        enter_gpo_flow
-        test_go_back_from_request_letter
-        complete_request_letter
+      expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
+      visit_sp_from_in_person_ready_to_verify
 
-        test_go_back_in_person_flow
-        complete_enter_password_step(user)
+      visit sign_out_url
+      user.reload
 
-        try_to_go_back_from_letter_enqueued
-        validate_letter_enqueued_page
-        complete_letter_enqueued
-        validate_return_to_sp
+      mark_in_person_enrollment_passed(user)
 
-        visit sign_out_url
-        user.reload
+      # sign in
+      visit_idp_from_sp_with_ial2(sp)
+      sign_in_live_with_2fa(user)
 
-        visit_idp_from_sp_with_ial2(sp)
+      validate_idv_completed_page(user)
+      click_agree_and_continue
 
-        sign_in_live_with_2fa(user)
-
-        complete_gpo_verification(user)
-        expect(user.identity_verified?).to be(false)
-
-        acknowledge_and_confirm_personal_key
-
-        expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
-        visit_sp_from_in_person_ready_to_verify
-
-        visit sign_out_url
-        user.reload
-
-        mark_in_person_enrollment_passed(user)
-
-        # sign in
-        visit_idp_from_sp_with_ial2(sp)
-        sign_in_live_with_2fa(user)
-
-        validate_idv_completed_page(user)
-        click_agree_and_continue
-
-        validate_return_to_sp
-      end
+      validate_return_to_sp
     end
   end
 
@@ -329,7 +336,7 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
 
   def validate_letter_enqueued_page
     expect(page).to have_current_path(idv_letter_enqueued_path)
-    expect_in_person_gpo_step_indicator_current_step(t('step_indicator.flows.idv.verify_address'))
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_address'))
     expect(page).to have_content(t('idv.titles.come_back_later'))
     expect(page).not_to have_content(t('step_indicator.flows.idv.verify_phone'))
   end
@@ -494,7 +501,7 @@ RSpec.describe 'Identity verification', :js, allowed_extra_analytics: [:*] do
     go_back
     expect(page).to have_current_path(idv_phone_path)
     go_back
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
+    expect(page).to have_current_path(idv_verify_info_path)
     2.times { go_forward }
     expect(page).to have_current_path(idv_request_letter_path)
   end

--- a/spec/features/idv/gpo_disabled_spec.rb
+++ b/spec/features/idv/gpo_disabled_spec.rb
@@ -37,10 +37,8 @@ RSpec.feature 'disabling GPO address verification', allowed_extra_analytics: [:*
     end
   end
 
-  context 'with GPO address verification disallowed for biometric comparison' do
+  context 'GPO address verification disallowed for biometric comparison' do
     before do
-      allow(IdentityConfig.store).to receive(:no_verify_by_mail_for_biometric_comparison_enabled).
-        and_return(true)
       allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
     end
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -265,7 +265,6 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     end
   end
 
-
   context 'verify by mail not allowed for in-person' do
     it 'does not present gpo as an option', allow_browser_log: true do
       sign_in_and_2fa_user

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -265,90 +265,14 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     end
   end
 
-  context 'verify address by mail (GPO letter)' do
-    before do
-      allow(FeatureManagement).to receive(:reveal_gpo_code?).and_return(true)
-    end
 
-    context 'verify by mail not allowed for biometric' do
-      before do
-        allow(IdentityConfig.store).to receive(:no_verify_by_mail_for_biometric_comparison_enabled).
-          and_return(true)
-      end
-
-      it 'does not present gpo as an option', allow_browser_log: true do
-        sign_in_and_2fa_user
-        begin_in_person_proofing
-        complete_all_in_person_proofing_steps
-        expect(page).to have_current_path(idv_phone_path)
-        expect(page).not_to have_content(t('idv.troubleshooting.options.verify_by_mail'))
-      end
-    end
-
-    context 'verify by mail allowed for biometric' do
-      before do
-        allow(IdentityConfig.store).to receive(:no_verify_by_mail_for_biometric_comparison_enabled).
-          and_return(false)
-      end
-
-      it 'requires address verification before showing instructions', allow_browser_log: true do
-        sign_in_and_2fa_user
-        begin_in_person_proofing
-        complete_all_in_person_proofing_steps
-        click_on t('idv.troubleshooting.options.verify_by_mail')
-        expect_in_person_gpo_step_indicator_current_step(
-          t('step_indicator.flows.idv.verify_address'),
-        )
-        click_on t('idv.buttons.mail.send')
-        expect_in_person_gpo_step_indicator_current_step(
-          t('step_indicator.flows.idv.verify_address'),
-        )
-        complete_enter_password_step
-
-        expect_in_person_gpo_step_indicator_current_step(
-          t('step_indicator.flows.idv.verify_address'),
-        )
-        expect(page).to have_content(t('idv.titles.come_back_later'))
-        expect(page).to have_current_path(idv_letter_enqueued_path)
-
-        click_idv_continue
-        expect(page).to have_current_path(account_path)
-        expect(page).not_to have_content(t('account.index.verification.verified_badge'))
-        click_on t('account.index.verification.reactivate_button')
-        expect_in_person_gpo_step_indicator_current_step(
-          t('step_indicator.flows.idv.verify_address'),
-        )
-        click_button t('idv.gpo.form.submit')
-
-        # personal key
-        expect_in_person_gpo_step_indicator_current_step(
-          t('step_indicator.flows.idv.secure_account'),
-        )
-        expect(page).to have_content(t('titles.idv.personal_key'))
-        acknowledge_and_confirm_personal_key
-
-        expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
-        expect_in_person_gpo_step_indicator_current_step(
-          t('step_indicator.flows.idv.go_to_the_post_office'),
-        )
-        expect(page).not_to have_content(t('account.index.verification.success'))
-      end
-
-      it 'lets the user clear and start over from gpo confirmation', allow_browser_log: true do
-        sign_in_and_2fa_user
-        begin_in_person_proofing
-        complete_all_in_person_proofing_steps
-        click_on t('idv.troubleshooting.options.verify_by_mail')
-        click_on t('idv.buttons.mail.send')
-        complete_enter_password_step
-        click_idv_continue
-        click_on t('account.index.verification.reactivate_button')
-        click_on t('idv.gpo.address_accordion.title')
-        click_on t('idv.gpo.address_accordion.cta_link')
-        click_idv_continue
-
-        expect(page).to have_current_path(idv_welcome_path)
-      end
+  context 'verify by mail not allowed for in-person' do
+    it 'does not present gpo as an option', allow_browser_log: true do
+      sign_in_and_2fa_user
+      begin_in_person_proofing
+      complete_all_in_person_proofing_steps
+      expect(page).to have_current_path(idv_phone_path)
+      expect(page).not_to have_content(t('idv.troubleshooting.options.verify_by_mail'))
     end
   end
 

--- a/spec/policies/idv/gpo_verify_by_mail_policy_spec.rb
+++ b/spec/policies/idv/gpo_verify_by_mail_policy_spec.rb
@@ -90,60 +90,24 @@ RSpec.describe Idv::GpoVerifyByMailPolicy do
       context 'the 2 pieces of fair evidence requirement is present' do
         let(:two_pieces_of_fair_evidence) { true }
 
-        it 'returns false when the feature flag is enabled' do
-          allow(IdentityConfig.store).to receive(
-            :no_verify_by_mail_for_biometric_comparison_enabled,
-          ).and_return(true)
-
+        it 'returns false' do
           expect(subject.send_letter_available?).to eq(false)
-        end
-
-        it 'returns true when the feature flag is disabled' do
-          allow(IdentityConfig.store).to receive(
-            :no_verify_by_mail_for_biometric_comparison_enabled,
-          ).and_return(false)
-
-          expect(subject.send_letter_available?).to eq(true)
         end
       end
 
       context 'user has a pending in-person enrollment' do
         let!(:in_person_enrollment) { create(:in_person_enrollment, :pending, user: user) }
 
-        it 'returns false when the feature flag is enabled' do
-          allow(IdentityConfig.store).to receive(
-            :no_verify_by_mail_for_biometric_comparison_enabled,
-          ).and_return(true)
-
+        it 'returns false' do
           expect(subject.send_letter_available?).to eq(false)
-        end
-
-        it 'returns true when the feature flag is disabled' do
-          allow(IdentityConfig.store).to receive(
-            :no_verify_by_mail_for_biometric_comparison_enabled,
-          ).and_return(false)
-
-          expect(subject.send_letter_available?).to eq(true)
         end
       end
 
       context 'user has an establishing in-person enrollment' do
         let!(:in_person_enrollment) { create(:in_person_enrollment, :establishing, user: user) }
 
-        it 'returns false when the feature flag is enabled' do
-          allow(IdentityConfig.store).to receive(
-            :no_verify_by_mail_for_biometric_comparison_enabled,
-          ).and_return(true)
-
+        it 'returns false' do
           expect(subject.send_letter_available?).to eq(false)
-        end
-
-        it 'returns true when the feature flag is disabled' do
-          allow(IdentityConfig.store).to receive(
-            :no_verify_by_mail_for_biometric_comparison_enabled,
-          ).and_return(false)
-
-          expect(subject.send_letter_available?).to eq(true)
         end
       end
     end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -191,16 +191,6 @@ module InPersonHelper
     )
   end
 
-  def expect_in_person_gpo_step_indicator_current_step(text)
-    # Ensure that GPO letter step is shown in the step indicator.
-    expect(page).to have_css(
-      '.step-indicator__step',
-      text: t('step_indicator.flows.idv.verify_address'),
-    )
-
-    expect_in_person_step_indicator_current_step(text)
-  end
-
   def make_pii(same_address_as_id: 'true')
     pii_from_user[:same_address_as_id] = same_address_as_id
     pii_from_user[:identity_doc_address1] = identity_doc_address1


### PR DESCRIPTION
The `no_verify_by_mail_for_biometric_comparison_enabled` was used to control whether the GPO option was available for users performing a biometric comparison. We have enabled the feature flag in production and will be moving forward with this feature. This commit retires the feature flag.
