### PR TITLE
Avoid new device email for reauthentication from new account

### DIFF
--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -217,6 +217,24 @@ RSpec.describe 'New device tracking' do
         expect_delivered_email_count(0)
       end
     end
+
+    context 'reauthenticating after new account creation' do
+      before do
+        sign_up_and_2fa_ial1_user
+        reset_email
+        expire_reauthn_window
+      end
+
+      it 'does not send a second user notification' do
+        within('.sidenav') { click_on t('account.navigation.add_phone_number') }
+        expect(page).to have_current_path(login_two_factor_options_path)
+        click_on t('forms.buttons.continue')
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect_delivered_email_count(0)
+      end
+    end
   end
 
   context 'user does not have existing devices' do


### PR DESCRIPTION
## 🎫 Ticket

TBD

## 🛠 Summary of changes

Fixes an issue with aggregated new device sign-in email notifications to avoid sending an email when a user reauthenticates during the same session they created their account.

**Draft:** Currently only implements failing feature spec.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create an account
3. Wait for reauthentication window to lapse, keeping your session active (reload page if neccessary)
    - Set `reauthn_window` to a low value in `config/application.yml` to facilitate testing
4. From account dashboard, take an action that requires reauthentication (e.g. add a phone number, delete account)
5. Finish reauthentication

Before: "New sign-in and authentication with your Login.gov account" email is sent
After: "New sign-in and authentication with your Login.gov account" email is not sent