### PR TITLE
Avoid unnecessary seconds conversion before to_i

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -5,7 +5,7 @@ class OpenidConnectTokenForm
   include ActionView::Helpers::TranslationHelper
   include Rails.application.routes.url_helpers
 
-  ISSUED_AT_LEEWAY_SECONDS = 10.seconds.to_i.freeze
+  ISSUED_AT_LEEWAY_SECONDS = 10
 
   ATTRS = %i[
     client_assertion

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -23,7 +23,7 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.selfie_status = doc_auth_response.selfie_status
     EncryptedRedisStructStorage.store(
       session_result,
-      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.to_i,
+      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.in_seconds,
     )
     self.ocr_confirmation_pending = doc_auth_response.attention_with_barcode?
     save!
@@ -45,7 +45,7 @@ class DocumentCaptureSession < ApplicationRecord
 
     EncryptedRedisStructStorage.store(
       session_result,
-      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.to_i,
+      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.in_seconds,
     )
     save!
   end

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -23,7 +23,7 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.selfie_status = doc_auth_response.selfie_status
     EncryptedRedisStructStorage.store(
       session_result,
-      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.seconds.to_i,
+      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.to_i,
     )
     self.ocr_confirmation_pending = doc_auth_response.attention_with_barcode?
     save!
@@ -45,7 +45,7 @@ class DocumentCaptureSession < ApplicationRecord
 
     EncryptedRedisStructStorage.store(
       session_result,
-      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.seconds.to_i,
+      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.to_i,
     )
     save!
   end

--- a/app/services/rate_limiter.rb
+++ b/app/services/rate_limiter.rb
@@ -79,7 +79,7 @@ class RateLimiter
         multi.incr(key)
         multi.expireat(
           key,
-          now + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.seconds.to_i,
+          now + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.to_i,
         )
       end
     end
@@ -132,8 +132,7 @@ class RateLimiter
       client.set(
         key,
         value,
-        exat: now.to_i +
-          RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.seconds.to_i,
+        exat: now.to_i + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.to_i,
       )
     end
 

--- a/app/services/rate_limiter.rb
+++ b/app/services/rate_limiter.rb
@@ -79,7 +79,7 @@ class RateLimiter
         multi.incr(key)
         multi.expireat(
           key,
-          now + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.to_i,
+          now + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.in_seconds,
         )
       end
     end
@@ -132,7 +132,7 @@ class RateLimiter
       client.set(
         key,
         value,
-        exat: now.to_i + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.to_i,
+        exat: now.to_i + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.in_seconds,
       )
     end
 

--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -70,7 +70,7 @@ class ServiceProviderRequestProxy
     REDIS_POOL.with do |client|
       client.setex(
         key(uuid),
-        IdentityConfig.store.service_provider_request_ttl_hours.hours.to_i,
+        IdentityConfig.store.service_provider_request_ttl_hours.hours.in_seconds,
         obj.to_json,
       )
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      Rack::CACHE_CONTROL => "public, max-age=#{2.days.to_i}",
+      Rack::CACHE_CONTROL => "public, max-age=#{2.days.in_seconds}",
     }
   else
     config.action_controller.perform_caching = false

--- a/spec/controllers/country_support_controller_spec.rb
+++ b/spec/controllers/country_support_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CountrySupportController do
     it 'sets HTTP headers to cache for 15 minutes' do
       get :index
 
-      expect(response['Cache-Control']).to eq("max-age=#{15.minutes.to_i}, public")
+      expect(response['Cache-Control']).to eq("max-age=#{15.minutes.in_seconds}, public")
     end
 
     context 'renders when passing in different locale' do

--- a/spec/controllers/sign_up/cancellations_controller_spec.rb
+++ b/spec/controllers/sign_up/cancellations_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SignUp::CancellationsController do
     it 'redirects if confirmation_token is expired' do
       confirmation_token = '1'
       invalid_confirmation_sent_at =
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
 
       create(
         :user, email_addresses: [

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SignUp::EmailConfirmationsController do
 
     it 'tracks expired token' do
       invalid_confirmation_sent_at =
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
       email_address = create(
         :email_address,
         :unconfirmed,

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe SignUp::PasswordsController do
     context 'with an with an invalid confirmation_token' do
       let(:token) { 'new token' }
       let(:invalid_confirmation_sent_at) do
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
       end
       let!(:user) do
         create(
@@ -161,7 +161,7 @@ RSpec.describe SignUp::PasswordsController do
 
     it 'rejects when confirmation_token is invalid' do
       invalid_confirmation_sent_at =
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
       create(
         :user,
         :unconfirmed,

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe OpenidConnectTokenForm do
         OutOfBandSessionAccessor.new(
           identity.rails_session_id,
         ).put_empty_user_session(
-          5.minutes.to_i,
+          5.minutes.in_seconds,
         )
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1000,7 +1000,7 @@ RSpec.describe User do
           OutOfBandSessionAccessor.new(mock_session_id).put_pii(
             profile_id: 123,
             pii: { first_name: 'Mario' },
-            expiration: 5.minutes.to_i,
+            expiration: 5.minutes.in_seconds,
           )
 
           expect(OutOfBandSessionAccessor.new(mock_session_id).exists?).to eq true

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
         OutOfBandSessionAccessor.new(rails_session_id).put_pii(
           profile_id: profile.id,
           pii: pii,
-          expiration: 5.minutes.to_i,
+          expiration: 5.minutes.in_seconds,
         )
       end
     end
@@ -284,7 +284,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
 
       context 'when the piv/cac was used as a second factor' do
         before do
-          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
+          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.in_seconds)
         end
 
         it 'includes the x509 claims' do

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe OutOfBandSessionAccessor do
       store.put_pii(
         profile_id: profile_id,
         pii: { first_name: 'Fakey' },
-        expiration: 5.minutes.to_i,
+        expiration: 5.minutes.in_seconds,
       )
 
-      expect(store.ttl).to be_within(1).of(5.minutes.to_i)
+      expect(store.ttl).to be_within(1).of(5.minutes.in_seconds)
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe OutOfBandSessionAccessor do
       store.put_pii(
         profile_id: profile_id,
         pii: { dob: '1970-01-01' },
-        expiration: 5.minutes.to_i,
+        expiration: 5.minutes.in_seconds,
       )
 
       pii = store.load_pii(profile_id)
@@ -40,7 +40,7 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#load_x509' do
     it 'loads X509 attributes from the session' do
-      store.put_x509({ subject: 'O=US, OU=DoD, CN=John.Doe.1234' }, 5.minutes.to_i)
+      store.put_x509({ subject: 'O=US, OU=DoD, CN=John.Doe.1234' }, 5.minutes.in_seconds)
 
       x509 = store.load_x509
       expect(x509).to be_kind_of(X509::Attributes)
@@ -53,7 +53,7 @@ RSpec.describe OutOfBandSessionAccessor do
       store.put_pii(
         profile_id: profile_id,
         pii: { first_name: 'Fakey' },
-        expiration: 5.minutes.to_i,
+        expiration: 5.minutes.in_seconds,
       )
       store.destroy
 

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SendSignUpEmailConfirmation do
     context 'when the user already has a confirmation token' do
       let(:email_address) do
         invalid_confirmation_sent_at =
-          Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+          Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
 
         create(
           :email_address,


### PR DESCRIPTION
## 🛠 Summary of changes

`ActiveSupport::Duration#to_i` returns the duration in seconds ([docs](https://api.rubyonrails.org/classes/ActiveSupport/Duration.html#method-i-to_i)), so it's redundant to convert a duration to seconds before calling `.to_i`.

It also has a large impact on performance, relatively speaking.

Instances discovered via project search for `.seconds.to_i`

### Performance Impact

Benchmark code:

```rb
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('before') do
    5.minutes.seconds.to_i
  end

  x.report('after') do
    5.minutes.to_i
  end

  x.compare!
end
```

```
Warming up --------------------------------------
              before   124.827k i/100ms
               after   278.805k i/100ms
Calculating -------------------------------------
              before      1.257M (± 1.1%) i/s -      6.366M in   5.064966s
               after      2.788M (± 0.7%) i/s -     13.940M in   5.001014s

Comparison:
               after:  2787607.3 i/s
              before:  1257057.5 i/s - 2.22x  slower
```

## 📜 Testing Plan

Verify tests pass.