### PR TITLE
Sort keys in application.yml.default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ run-https: tmp/$(HOST)-$(PORT).key tmp/$(HOST)-$(PORT).crt ## Runs the developme
 normalize_yaml: ## Normalizes YAML files (alphabetizes keys, fixes line length, smart quotes)
 	yarn normalize-yaml .rubocop.yml --disable-sort-keys --disable-smart-punctuation
 	find ./config/locales/transliterate -type f -name '*.yml' -exec yarn normalize-yaml --disable-sort-keys --disable-smart-punctuation {} \;
-	yarn normalize-yaml --disable-sort-keys --disable-smart-punctuation config/application.yml.default
+	yarn normalize-yaml --disable-smart-punctuation --ignore-key-sort development,production,test config/application.yml.default
 	find ./config/locales/telephony -type f -name '*.yml' | xargs yarn normalize-yaml --disable-smart-punctuation
 	find ./config/locales -not \( -path "./config/locales/telephony*" -o -path "./config/locales/transliterate/*" \) -type f -name '*.yml' | \
 	xargs yarn normalize-yaml \

--- a/app/javascript/packages/normalize-yaml/CHANGELOG.md
+++ b/app/javascript/packages/normalize-yaml/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features
 
 - Added new punctuation formatter to collapse multiple spaces to a single space.
+- Added new option `--ignore-key-sort` to preserve ordering of keys.
 
 ## v2.0.0
 

--- a/app/javascript/packages/normalize-yaml/README.md
+++ b/app/javascript/packages/normalize-yaml/README.md
@@ -29,11 +29,12 @@ yarn add @18f/identity-normalize-yaml prettier
 
 ### CLI
 
-The included `normalize-yaml` binary receives files as an argument, with optional flags:
+The included `normalize-yaml` binary receives files as an argument, with optional configuration:
 
 - `--disable-sort-keys`: Disable the default behavior to sort keys.
 - `--disable-smart-punctuation`: Disable the default behavior to apply smart punctuation.
 - `--disable-collapse-spacing`: Disable the default behavior to collapse multiple spaces to a single space.
+- `--ignore-key-sort`: Specify key(s) whose ordering should be preserved as-is.
 
 **Example:**
 

--- a/app/javascript/packages/normalize-yaml/README.md
+++ b/app/javascript/packages/normalize-yaml/README.md
@@ -34,7 +34,7 @@ The included `normalize-yaml` binary receives files as an argument, with optiona
 - `--disable-sort-keys`: Disable the default behavior to sort keys.
 - `--disable-smart-punctuation`: Disable the default behavior to apply smart punctuation.
 - `--disable-collapse-spacing`: Disable the default behavior to collapse multiple spaces to a single space.
-- `--ignore-key-sort`: Specify key(s) whose ordering should be preserved as-is.
+- `--ignore-key-sort`: Specify key(s) whose ordering should be preserved as-is. This can be passed multiple times, or as a comma-separated value.
 
 **Example:**
 
@@ -60,6 +60,7 @@ Given an input YAML string and optional options, resolves to a normalized YAML s
 
 - `prettierConfig` (`Record<string, any>`): Optional Prettier configuration object.
 - `exclude` (`Formatter[]`) Formatters to exclude.
+- `ignoreKeySort` (`string[]`) Keys whose order should be preserved in sorting.
 
 ## License
 

--- a/app/javascript/packages/normalize-yaml/cli.js
+++ b/app/javascript/packages/normalize-yaml/cli.js
@@ -2,8 +2,9 @@
 
 /* eslint-disable no-console */
 
-import { promises as fsPromises } from 'fs';
-import { join } from 'path';
+import { parseArgs } from 'node:util';
+import { promises as fsPromises } from 'node:fs';
+import { join } from 'node:path';
 import prettier from 'prettier';
 import normalize from './index.js';
 
@@ -12,20 +13,32 @@ const { readFile, writeFile } = fsPromises;
 /** @type {Record<string,any>=} */
 const prettierConfig = (await prettier.resolveConfig(process.cwd())) || undefined;
 
-const args = process.argv.slice(2);
-const files = args.filter((arg) => !arg.startsWith('-'));
-const flags = args.filter((arg) => arg.startsWith('-'));
+const { values: config, positionals: files } = parseArgs({
+  allowPositionals: true,
+  options: {
+    'disable-collapse-spacing': { type: 'boolean' },
+    'disable-sort-keys': { type: 'boolean' },
+    'disable-smart-punctuation': { type: 'boolean' },
+    'ignore-key-sort': { type: 'string', multiple: true },
+  },
+});
+
+let ignoreKeySort = config['ignore-key-sort'];
+if (ignoreKeySort) {
+  ignoreKeySort = ignoreKeySort.flatMap((value) => value.split(','));
+}
 
 /** @type {import('./index').NormalizeOptions} */
 const options = {
   prettierConfig,
   exclude: /** @type {import('./index').Formatter[]} */ (
     [
-      flags.includes('--disable-sort-keys') && 'sortKeys',
-      flags.includes('--disable-smart-punctuation') && 'smartPunctuation',
-      flags.includes('--disable-collapse-spacing') && 'collapseSpacing',
+      config['disable-collapse-spacing'] && 'collapseSpacing',
+      config['disable-sort-keys'] && 'sortKeys',
+      config['disable-smart-punctuation'] && 'smartPunctuation',
     ].filter(Boolean)
   ),
+  ignoreKeySort,
 };
 
 let exitCode = 0;

--- a/app/javascript/packages/normalize-yaml/index.js
+++ b/app/javascript/packages/normalize-yaml/index.js
@@ -9,6 +9,7 @@ import { getUnifiedVisitor } from './visitors/index.js';
  *
  * @prop {Record<string,any>=} prettierConfig Optional Prettier configuration object.
  * @prop {Array<Formatter>=} exclude Formatters to exclude.
+ * @prop {Array<string>=} ignoreKeySort Keys to ignore for sorting.
  */
 
 /**
@@ -19,9 +20,10 @@ import { getUnifiedVisitor } from './visitors/index.js';
  *
  * @return {Promise<string>} Normalized content.
  */
-function normalize(content, { prettierConfig, exclude } = {}) {
+function normalize(content, options = {}) {
+  const { prettierConfig } = options;
   const document = YAML.parseDocument(content);
-  YAML.visit(document, getUnifiedVisitor({ exclude }));
+  YAML.visit(document, getUnifiedVisitor(options));
   return prettier.format(document.toString(), { ...prettierConfig, parser: 'yaml' });
 }
 

--- a/app/javascript/packages/normalize-yaml/index.spec.js
+++ b/app/javascript/packages/normalize-yaml/index.spec.js
@@ -53,8 +53,17 @@ describe('normalize', () => {
   });
 
   it('allows ignoring specific keys for sorting', async () => {
-    const original = '---\na: 1\nc: 3\nd: 4\nb: 2';
-    const expected = '---\na: 1\nc: 3\nb: 2\nd: 4\n';
+    const original = `---
+a: 1
+c: 3
+d: 4
+b: 2`;
+    const expected = `---
+a: 1
+c: 3
+b: 2
+d: 4
+`;
 
     expect(await normalize(original, { ignoreKeySort: ['c'] })).to.equal(expected);
   });

--- a/app/javascript/packages/normalize-yaml/index.spec.js
+++ b/app/javascript/packages/normalize-yaml/index.spec.js
@@ -51,4 +51,11 @@ describe('normalize', () => {
 
     expect(await normalize(original, { exclude: ['smartPunctuation'] })).to.equal(expected);
   });
+
+  it('allows ignoring specific keys for sorting', async () => {
+    const original = '---\na: 1\nc: 3\nd: 4\nb: 2';
+    const expected = '---\na: 1\nc: 3\nb: 2\nd: 4\n';
+
+    expect(await normalize(original, { ignoreKeySort: ['c'] })).to.equal(expected);
+  });
 });

--- a/app/javascript/packages/normalize-yaml/visitors/collapse-spacing.js
+++ b/app/javascript/packages/normalize-yaml/visitors/collapse-spacing.js
@@ -1,4 +1,4 @@
-export default /** @type {import('yaml').visitor} */ ({
+export default /** @type {import('./').Visitor} */ (_options) => ({
   Scalar(_key, node) {
     if (typeof node.value === 'string') {
       node.value = node.value.replace(/ {2,}/g, ' ');

--- a/app/javascript/packages/normalize-yaml/visitors/smart-punctuation.js
+++ b/app/javascript/packages/normalize-yaml/visitors/smart-punctuation.js
@@ -23,7 +23,7 @@ export function replaceInHTMLContent(html, replacer) {
  */
 export const ellipses = (string) => string.replace(/\.\.\./g, '…');
 
-export default /** @type {import('yaml').visitor} */ ({
+export default /** @type {import('./').Visitor} */ (_options) => ({
   Scalar(_key, node) {
     if (typeof node.value === 'string') {
       node.value = replaceInHTMLContent(node.value, (string) => ellipses(smartquotes(string)));

--- a/app/javascript/packages/normalize-yaml/visitors/sort-keys.js
+++ b/app/javascript/packages/normalize-yaml/visitors/sort-keys.js
@@ -1,4 +1,4 @@
-export default /** @type {import('./').Visitor} */ (options) => ({
+export default /** @type {import('./').Visitor} */ ({ ignoreKeySort }) => ({
   Map(_key, node) {
     node.items.sort(
       /**
@@ -7,11 +7,14 @@ export default /** @type {import('./').Visitor} */ (options) => ({
        * @return {number}
        */
       (a, b) => {
-        if (options.ignoreKeySort && options.ignoreKeySort.includes(a.key.toString())) {
+        const aKey = a.key.toString();
+        const bKey = b.key.toString();
+
+        if (ignoreKeySort && (ignoreKeySort.includes(aKey) || ignoreKeySort.includes(bKey))) {
           return 0;
         }
 
-        return a.key.toString().localeCompare(b.key.toString());
+        return aKey.localeCompare(bKey);
       },
     );
   },

--- a/app/javascript/packages/normalize-yaml/visitors/sort-keys.js
+++ b/app/javascript/packages/normalize-yaml/visitors/sort-keys.js
@@ -1,4 +1,4 @@
-export default /** @type {import('yaml').visitor} */ ({
+export default /** @type {import('./').Visitor} */ (options) => ({
   Map(_key, node) {
     node.items.sort(
       /**
@@ -6,7 +6,13 @@ export default /** @type {import('yaml').visitor} */ ({
        * @param {import('yaml').Pair<any>} b
        * @return {number}
        */
-      (a, b) => a.key.toString().localeCompare(b.key.toString()),
+      (a, b) => {
+        if (options.ignoreKeySort && options.ignoreKeySort.includes(a.key.toString())) {
+          return 0;
+        }
+
+        return a.key.toString().localeCompare(b.key.toString());
+      },
     );
   },
 });

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -152,9 +152,9 @@ in_person_send_proofing_notifications_enabled: false
 in_person_state_id_controller_enabled: false
 in_person_stop_expiring_enrollments: false
 invalid_gpo_confirmation_zipcode: '00001'
+# LexisNexis #####################################################
 # Instant Verify and Phone Finder Integrations
 lexisnexis_account_id: test_account
-# LexisNexis #####################################################
 lexisnexis_base_url: https://www.example.com
 lexisnexis_hmac_auth_enabled: false
 lexisnexis_hmac_key_id: pf_iv_hmac_key_id
@@ -165,9 +165,9 @@ lexisnexis_password: test_password
 lexisnexis_phone_finder_timeout: 1.0
 lexisnexis_phone_finder_workflow: customers.gsa2.phonefinder.workflow
 lexisnexis_request_mode: testing
-lexisnexis_threatmetrix_js_signing_cert: ''
 ###################################################################
 # LexisNexis DDP/ThreatMetrix #####################################
+lexisnexis_threatmetrix_js_signing_cert: ''
 lexisnexis_threatmetrix_mock_enabled: true
 lexisnexis_threatmetrix_support_code: ABCD
 lexisnexis_threatmetrix_timeout: 1.0

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -20,13 +20,8 @@ aamva_cert_enabled: true
 aamva_supported_jurisdictions: '["AL","AR","AZ","CO","CT","DC","DE","FL","GA","HI","IA","ID","IL","IN","KS","KY","MA","MD","ME","MI","MO","MS","MT","NC","ND","NE","NJ","NM","NV","OH","OR","PA","RI","SC","SD","TN","TX","VA","VT","WA","WI","WV","WY"]'
 aamva_verification_request_timeout: 5.0
 aamva_verification_url: https://example.org:12345/verification/url
-all_redirect_uris_cache_duration_minutes: 2
-allowed_biometric_ial_providers: '[]'
-allowed_ialmax_providers: '[]'
-allowed_verified_within_providers: '[]'
-available_locales: 'en,es,fr,zh'
-account_reset_token_valid_for_days: 1
 account_reset_fraud_user_wait_period_days:
+account_reset_token_valid_for_days: 1
 account_reset_wait_period_days: 1
 account_suspended_support_code: EFGHI
 # These are publicly available credentials used to initialize the client-side Acuant SDK
@@ -34,28 +29,33 @@ acuant_sdk_initialization_creds: 'aWRzY2FuZ293ZWJAYWN1YW50Y29ycC5jb206NVZLcm81Z0
 acuant_sdk_initialization_endpoint: 'https://us.acas.acuant.net'
 add_email_link_valid_for_hours: 24
 address_identity_proofing_supported_country_codes: '["AS", "GU", "MP", "PR", "US", "VI"]'
+all_redirect_uris_cache_duration_minutes: 2
+allowed_biometric_ial_providers: '[]'
+allowed_ialmax_providers: '[]'
+allowed_verified_within_providers: '[]'
 asset_host: ''
-async_wait_timeout_seconds: 60
 async_stale_job_timeout_seconds: 300
-aws_http_timeout: 5
+async_wait_timeout_seconds: 60
+available_locales: 'en,es,fr,zh'
 aws_http_retry_limit: 2
 aws_http_retry_max_delay: 1
-aws_kms_key_id: alias/login-dot-gov-test-keymaker
+aws_http_timeout: 5
 aws_kms_client_contextless_pool_size: 5
 aws_kms_client_multi_pool_size: 5
+aws_kms_key_id: alias/login-dot-gov-test-keymaker
 aws_kms_multi_region_key_id: alias/login-dot-gov-keymaker-multi-region
 aws_kms_session_key_id: alias/login-dot-gov-test-keymaker
 aws_logo_bucket: ''
 aws_region: 'us-west-2'
 backup_code_cost: '2000$8$1$'
 biometric_ial_enabled: true
-broken_personal_key_window_start: '2021-07-29T00:00:00Z'
 broken_personal_key_window_finish: '2021-09-22T00:00:00Z'
-component_previews_enabled: false
-component_previews_embed_frame_ancestors: '[]'
-compromised_password_randomizer_value: 1000
-compromised_password_randomizer_threshold: 900
+broken_personal_key_window_start: '2021-07-29T00:00:00Z'
 check_user_password_compromised_enabled: false
+component_previews_embed_frame_ancestors: '[]'
+component_previews_enabled: false
+compromised_password_randomizer_threshold: 900
+compromised_password_randomizer_value: 1000
 country_phone_number_overrides: '{}'
 database_pool_idp: 5
 database_socket: ''
@@ -63,14 +63,13 @@ database_sslmode: 'verify-full'
 database_statement_timeout: 2_500
 database_timeout: 5_000
 database_worker_jobs_sslmode: 'verify-full'
-deliver_mail_async: false
 deleted_user_accounts_report_configs: '[]'
+deliver_mail_async: false
 development_mailer_deliver_method: letter_opener
 disable_email_sending: true
 disable_logout_get_request: true
 disposable_email_services: '[]'
 doc_auth_attempt_window_in_minutes: 360
-doc_capture_polling_enabled: true
 doc_auth_check_failed_image_resubmission_enabled: true
 doc_auth_client_glare_threshold: 50
 doc_auth_client_sharpness_threshold: 50
@@ -82,6 +81,7 @@ doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_selfie_desktop_test_mode: false
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
+doc_capture_polling_enabled: true
 doc_capture_request_valid_for_minutes: 15
 drop_off_report_config: '[{"emails":["ursula@example.com"],"issuers": ["urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"]}]'
 email_from: no-reply@login.gov
@@ -99,86 +99,90 @@ feature_idv_force_gpo_verification_enabled: false
 feature_idv_hybrid_flow_enabled: true
 feature_new_device_alert_aggregation_enabled: true
 geo_data_file_path: 'geo_data/GeoLite2-City.mmdb'
+get_usps_proofing_results_job_cron: '0/30 * * * *'
+get_usps_proofing_results_job_reprocess_delay_minutes: 5
+get_usps_proofing_results_job_request_delay_milliseconds: 1000
+get_usps_ready_proofing_results_job_cron: '0/10 * * * *'
+get_usps_waiting_proofing_results_job_cron: '0/30 * * * *'
 good_job_max_threads: 5
-good_job_queues: 'default:5;low:1;*'
 good_job_queue_select_limit: 5_000
+good_job_queues: 'default:5;low:1;*'
 gpo_designated_receiver_pii: '{}'
 gpo_max_profile_age_to_send_letter_in_days: 30
 hide_phone_mfa_signup: false
 identity_pki_disabled: false
 identity_pki_local_dev: false
+idv_acuant_sdk_upgrade_a_b_testing_enabled: false
+idv_acuant_sdk_upgrade_a_b_testing_percent: 50
+idv_acuant_sdk_version_alternate: '11.9.2'
+idv_acuant_sdk_version_default: '11.9.3'
 idv_attempt_window_in_hours: 6
 idv_available: true
 idv_contact_phone_number: (844) 555-5555
 idv_max_attempts: 5
 idv_min_age_years: 13
-idv_acuant_sdk_version_default: '11.9.3'
-idv_acuant_sdk_version_alternate: '11.9.2'
-idv_acuant_sdk_upgrade_a_b_testing_enabled: false
-idv_acuant_sdk_upgrade_a_b_testing_percent: 50
 idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 idv_sp_required: false
-in_person_public_address_search_enabled: false
+in_person_completion_survey_url: 'https://login.gov'
 in_person_doc_auth_button_enabled: true
 in_person_email_reminder_early_benchmark_in_days: 11
 in_person_email_reminder_final_benchmark_in_days: 1
 in_person_email_reminder_late_benchmark_in_days: 4
-in_person_proofing_enabled: false
-in_person_proofing_enforce_tmx: false
-in_person_proofing_opt_in_enabled: false
-in_person_state_id_controller_enabled: false
 in_person_enrollment_validity_in_days: 30
-in_person_enrollments_ready_job_email_body_pattern: '\A\s*(?<enrollment_code>\d{16})\s*\Z'
 in_person_enrollments_ready_job_cron: '0/10 * * * *'
+in_person_enrollments_ready_job_email_body_pattern: '\A\s*(?<enrollment_code>\d{16})\s*\Z'
 in_person_enrollments_ready_job_enabled: false
-in_person_enrollments_ready_job_queue_url: ''
 in_person_enrollments_ready_job_max_number_of_messages: 10
+in_person_enrollments_ready_job_queue_url: ''
 in_person_enrollments_ready_job_visibility_timeout_seconds: 30
 in_person_enrollments_ready_job_wait_time_seconds: 20
-in_person_results_delay_in_hours: 1
-in_person_completion_survey_url: 'https://login.gov'
 in_person_full_address_entry_enabled: true
-in_person_outage_message_enabled: false
+in_person_outage_emailed_by_date: 'November 1, 2024'
 # in_person_outage_expected_update_date and in_person_outage_emailed_by_date below
 # are strings in the format 'Month day, year'
 in_person_outage_expected_update_date: 'October 31, 2024'
-in_person_outage_emailed_by_date: 'November 1, 2024'
+in_person_outage_message_enabled: false
+in_person_proofing_enabled: false
+in_person_proofing_enforce_tmx: false
+in_person_proofing_opt_in_enabled: false
+in_person_public_address_search_enabled: false
+in_person_results_delay_in_hours: 1
 in_person_send_proofing_notifications_enabled: false
+in_person_state_id_controller_enabled: false
 in_person_stop_expiring_enrollments: false
 invalid_gpo_confirmation_zipcode: '00001'
-logins_per_ip_track_only_mode: false
-# LexisNexis #####################################################
-lexisnexis_base_url: https://www.example.com
-lexisnexis_request_mode: testing
 # Instant Verify and Phone Finder Integrations
 lexisnexis_account_id: test_account
-lexisnexis_username: test_username
-lexisnexis_password: test_password
+# LexisNexis #####################################################
+lexisnexis_base_url: https://www.example.com
 lexisnexis_hmac_auth_enabled: false
 lexisnexis_hmac_key_id: pf_iv_hmac_key_id
 lexisnexis_hmac_secret_key: pf_iv_hmac_secret_key
-lexisnexis_phone_finder_timeout: 1.0
-lexisnexis_phone_finder_workflow: customers.gsa2.phonefinder.workflow
 lexisnexis_instant_verify_timeout: 1.0
 lexisnexis_instant_verify_workflow: gsa2.chk32.test.wf
-# TrueID DocAuth Integration
-lexisnexis_trueid_account_id: '12345'
-lexisnexis_trueid_username: test_username
-lexisnexis_trueid_password: test_password
-lexisnexis_trueid_hmac_key_id: trueid_hmac_key_id
-lexisnexis_trueid_hmac_secret_key: trueid_hmac_secret_key
-lexisnexis_trueid_timeout: 60.0
-lexisnexis_trueid_liveness_cropping_workflow: customers.gsa2.trueid.workflow
-lexisnexis_trueid_liveness_nocropping_workflow: customers.gsa2.trueid.workflow
-lexisnexis_trueid_noliveness_cropping_workflow: customers.gsa2.trueid.workflow
-lexisnexis_trueid_noliveness_nocropping_workflow: customers.gsa2.trueid.workflow
+lexisnexis_password: test_password
+lexisnexis_phone_finder_timeout: 1.0
+lexisnexis_phone_finder_workflow: customers.gsa2.phonefinder.workflow
+lexisnexis_request_mode: testing
+lexisnexis_threatmetrix_js_signing_cert: ''
 ###################################################################
 # LexisNexis DDP/ThreatMetrix #####################################
 lexisnexis_threatmetrix_mock_enabled: true
 lexisnexis_threatmetrix_support_code: ABCD
 lexisnexis_threatmetrix_timeout: 1.0
-lexisnexis_threatmetrix_js_signing_cert: ''
+# TrueID DocAuth Integration
+lexisnexis_trueid_account_id: '12345'
+lexisnexis_trueid_hmac_key_id: trueid_hmac_key_id
+lexisnexis_trueid_hmac_secret_key: trueid_hmac_secret_key
+lexisnexis_trueid_liveness_cropping_workflow: customers.gsa2.trueid.workflow
+lexisnexis_trueid_liveness_nocropping_workflow: customers.gsa2.trueid.workflow
+lexisnexis_trueid_noliveness_cropping_workflow: customers.gsa2.trueid.workflow
+lexisnexis_trueid_noliveness_nocropping_workflow: customers.gsa2.trueid.workflow
+lexisnexis_trueid_password: test_password
+lexisnexis_trueid_timeout: 60.0
+lexisnexis_trueid_username: test_username
+lexisnexis_username: test_username
 ###################################################################
 lockout_period_in_minutes: 10
 log_to_stdout: false
@@ -187,6 +191,7 @@ logins_per_email_and_ip_bantime: 60
 logins_per_email_and_ip_limit: 5
 logins_per_email_and_ip_period: 60
 logins_per_ip_period: 60
+logins_per_ip_track_only_mode: false
 logo_upload_enabled: false
 mailer_domain_name: http://localhost:3000
 max_auth_apps_per_account: 2
@@ -201,13 +206,14 @@ min_password_score: 3
 minimum_wait_before_another_usps_letter_in_hours: 24
 mx_timeout: 3
 new_device_alert_delay_in_minutes: 5
-openid_connect_redirect: client_side_js
 openid_connect_content_security_form_action_enabled: false
-openid_connect_redirect_uuid_override_map: '{}'
+openid_connect_redirect: client_side_js
 openid_connect_redirect_issuer_override_map: '{}'
+openid_connect_redirect_uuid_override_map: '{}'
 otp_delivery_blocklist_maxretry: 10
-otp_valid_for: 10
 otp_expiration_warning_seconds: 150
+otp_min_attempts_remaining_warning_count: 3
+otp_valid_for: 10
 otps_per_ip_limit: 25
 otps_per_ip_period: 300
 otps_per_ip_track_only_mode: true
@@ -218,33 +224,31 @@ participate_in_dap: false
 password_max_attempts: 3
 personal_key_retired: true
 phone_carrier_registration_blocklist_array: '[]'
-protocols_report_config: '[]'
-short_term_phone_otp_max_attempt_window_in_seconds: 10
-short_term_phone_otp_max_attempts: 2
-phone_confirmation_max_attempts: 20
 phone_confirmation_max_attempt_window_in_minutes: 1_440
-phone_service_check: true
-phone_recaptcha_score_threshold: 0.0
+phone_confirmation_max_attempts: 20
 phone_recaptcha_country_score_overrides: '{"AS":0.0,"GU":0.0,"MP":0.0,"PR":0.0,"US":0.0,"VI":0.0,"CA":0.0,"MX":0.0}'
+phone_recaptcha_score_threshold: 0.0
+phone_service_check: true
 phone_setups_per_ip_limit: 25
 phone_setups_per_ip_period: 300
 phone_setups_per_ip_track_only_mode: false
 pii_lock_timeout_in_minutes: 30
-pinpoint_sms_sender_id: 'aaa'
 pinpoint_sms_configs: '[]'
+pinpoint_sms_sender_id: 'aaa'
 pinpoint_voice_configs: '[]'
 pinpoint_voice_pool_size: 5
-piv_cac_service_url: https://localhost:8443/
 piv_cac_service_timeout: 5.0
+piv_cac_service_url: https://localhost:8443/
 piv_cac_verify_token_url: https://localhost:8443/
 poll_rate_for_verify_in_seconds: 3
 prometheus_exporter: false
-proofer_mock_fallback: true
-proof_address_max_attempts: 5
 proof_address_max_attempt_window_in_minutes: 360
-proof_ssn_max_attempts: 10
+proof_address_max_attempts: 5
 proof_ssn_max_attempt_window_in_minutes: 60
+proof_ssn_max_attempts: 10
+proofer_mock_fallback: true
 proofing_device_profiling: enabled
+protocols_report_config: '[]'
 push_notifications_enabled: false
 pwned_passwords_file_path: 'pwned_passwords/pwned_passwords.txt'
 rack_mini_profiler: false
@@ -255,13 +259,13 @@ reauthn_window: 1200
 recaptcha_enterprise_api_key: ''
 recaptcha_enterprise_project_id: ''
 recaptcha_mock_validator: true
-recaptcha_site_key: ''
 recaptcha_secret_key: ''
+recaptcha_site_key: ''
 recovery_code_length: 4
-redis_throttle_url: redis://localhost:6379/1
-redis_url: redis://localhost:6379/0
 redis_pool_size: 10
 redis_throttle_pool_size: 5
+redis_throttle_url: redis://localhost:6379/1
+redis_url: redis://localhost:6379/0
 reg_confirmed_email_max_attempts: 20
 reg_confirmed_email_window_in_minutes: 60
 reg_unconfirmed_email_max_attempts: 20
@@ -293,18 +297,19 @@ second_mfa_reminder_account_age_in_days: 30
 second_mfa_reminder_sign_in_count: 10
 seed_agreements_data: true
 service_provider_request_ttl_hours: 24
+ses_configuration_set_name: ''
 session_check_delay: 30
 session_check_frequency: 30
 session_encryptor_alert_enabled: false
 session_timeout_in_minutes: 15
 session_timeout_warning_seconds: 150
 session_total_duration_timeout_in_minutes: 720
-ses_configuration_set_name: ''
-sign_in_recaptcha_score_threshold: 0.0
-sp_handoff_bounce_max_seconds: 2
+short_term_phone_otp_max_attempt_window_in_seconds: 10
+short_term_phone_otp_max_attempts: 2
 show_unsupported_passkey_platform_authentication_setup: false
 show_user_attribute_deprecation_warnings: false
-otp_min_attempts_remaining_warning_count: 3
+sign_in_recaptcha_score_threshold: 0.0
+sp_handoff_bounce_max_seconds: 2
 sp_issuer_user_counts_report_configs: '[]'
 team_ada_email: ''
 team_all_login_emails: '[]'
@@ -315,45 +320,40 @@ team_ursula_email: ''
 test_ssn_allowed_list: ''
 totp_code_interval: 30
 unauthorized_scope_enabled: false
-usps_upload_enabled: false
-usps_upload_sftp_timeout: 5
-valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3", "http://idmanagement.gov/ns/assurance/ial/1", "http://idmanagement.gov/ns/assurance/ial/2", "http://idmanagement.gov/ns/assurance/ial/0", "http://idmanagement.gov/ns/assurance/ial/2?strict=true", "http://idmanagement.gov/ns/assurance/ial/2?bio=preferred", "http://idmanagement.gov/ns/assurance/ial/2?bio=required", "urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo", "http://idmanagement.gov/ns/assurance/aal/2", "http://idmanagement.gov/ns/assurance/aal/3", "http://idmanagement.gov/ns/assurance/aal/3?hspd12=true","http://idmanagement.gov/ns/assurance/aal/2?phishing_resistant=true","http://idmanagement.gov/ns/assurance/aal/2?hspd12=true"]'
-vendor_status_lexisnexis_instant_verify: 'operational'
-vendor_status_lexisnexis_phone_finder: 'operational'
-vendor_status_lexisnexis_trueid: 'operational'
-vendor_status_sms: 'operational'
-vendor_status_voice: 'operational'
-vendor_status_idv_scheduled_maintenance_start: ''
-vendor_status_idv_scheduled_maintenance_finish: ''
-verification_errors_report_configs: '[]'
-verify_gpo_key_attempt_window_in_minutes: 10
-verify_gpo_key_max_attempts: 5
-verify_personal_key_attempt_window_in_minutes: 15
-verify_personal_key_max_attempts: 5
-version_headers_enabled: false
-vtm_url: 'https://developer.login.gov/vot-trust-framework'
 use_dashboard_service_providers: false
 use_kms: false
 use_vot_in_sp_requests: true
 usps_auth_token_refresh_job_enabled: false
 usps_confirmation_max_days: 30
 usps_eipp_sponsor_id: ''
-usps_ipp_password: ''
 usps_ipp_client_id: ''
-usps_ipp_root_url: ''
+usps_ipp_enrollment_status_update_email_address: 'no-reply@login.gov'
+usps_ipp_password: ''
 usps_ipp_request_timeout: 10
+usps_ipp_root_url: ''
 usps_ipp_sponsor_id: ''
+usps_ipp_transliteration_enabled: false
 usps_ipp_username: ''
 usps_mock_fallback: true
-usps_ipp_transliteration_enabled: false
-usps_ipp_enrollment_status_update_email_address: 'no-reply@login.gov'
-get_usps_ready_proofing_results_job_cron: '0/10 * * * *'
-get_usps_waiting_proofing_results_job_cron: '0/30 * * * *'
-get_usps_proofing_results_job_cron: '0/30 * * * *'
-get_usps_proofing_results_job_reprocess_delay_minutes: 5
-get_usps_proofing_results_job_request_delay_milliseconds: 1000
+usps_upload_enabled: false
+usps_upload_sftp_timeout: 5
+valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3", "http://idmanagement.gov/ns/assurance/ial/1", "http://idmanagement.gov/ns/assurance/ial/2", "http://idmanagement.gov/ns/assurance/ial/0", "http://idmanagement.gov/ns/assurance/ial/2?strict=true", "http://idmanagement.gov/ns/assurance/ial/2?bio=preferred", "http://idmanagement.gov/ns/assurance/ial/2?bio=required", "urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo", "http://idmanagement.gov/ns/assurance/aal/2", "http://idmanagement.gov/ns/assurance/aal/3", "http://idmanagement.gov/ns/assurance/aal/3?hspd12=true","http://idmanagement.gov/ns/assurance/aal/2?phishing_resistant=true","http://idmanagement.gov/ns/assurance/aal/2?hspd12=true"]'
+vendor_status_idv_scheduled_maintenance_finish: ''
+vendor_status_idv_scheduled_maintenance_start: ''
+vendor_status_lexisnexis_instant_verify: 'operational'
+vendor_status_lexisnexis_phone_finder: 'operational'
+vendor_status_lexisnexis_trueid: 'operational'
+vendor_status_sms: 'operational'
+vendor_status_voice: 'operational'
+verification_errors_report_configs: '[]'
+verify_gpo_key_attempt_window_in_minutes: 10
+verify_gpo_key_max_attempts: 5
+verify_personal_key_attempt_window_in_minutes: 15
+verify_personal_key_max_attempts: 5
+version_headers_enabled: false
 voice_otp_pause_time: '0.5s'
 voice_otp_speech_rate: 'slow'
+vtm_url: 'https://developer.login.gov/vot-trust-framework'
 weekly_auth_funnel_report_config: '[]'
 
 development:
@@ -363,10 +363,10 @@ development:
   attribute_encryption_key_queue: '[{ "key": "11111111111111111111111111111111" }, { "key": "22222222222222222222222222222222" }]'
   aws_logo_bucket: ''
   check_user_password_compromised_enabled: true
-  component_previews_enabled: true
   component_previews_embed_frame_ancestors: '["http://localhost:4000"]'
-  compromised_password_randomizer_value: 1
+  component_previews_enabled: true
   compromised_password_randomizer_threshold: 0
+  compromised_password_randomizer_value: 1
   dashboard_api_token: test_token
   dashboard_url: http://localhost:3001/api/service_providers
   database_host: ''
@@ -376,15 +376,15 @@ development:
   database_readonly_password: ''
   database_readonly_username: ''
   database_username: ''
-  database_worker_jobs_name: ''
-  database_worker_jobs_username: ''
   database_worker_jobs_host: ''
+  database_worker_jobs_name: ''
   database_worker_jobs_password: ''
+  database_worker_jobs_username: ''
   doc_auth_selfie_desktop_test_mode: true
   doc_auth_vendor: 'mock'
   doc_auth_vendor_randomize: false
-  doc_auth_vendor_randomize_percent: 0
   doc_auth_vendor_randomize_alternate_vendor: ''
+  doc_auth_vendor_randomize_percent: 0
   domain_name: localhost:3000
   enable_rate_limiting: false
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
@@ -403,8 +403,8 @@ development:
   phone_recaptcha_score_threshold: 0.5
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   push_notifications_enabled: true
-  rails_mailer_previews_enabled: true
   rack_timeout_service_timeout_seconds: 9_999_999_999
+  rails_mailer_previews_enabled: true
   raise_on_missing_title: true
   risc_notifications_local_enabled: true
   s3_report_bucket_prefix: ''
@@ -449,16 +449,16 @@ production:
   database_readonly_password: ''
   database_readonly_username: ''
   database_username: ''
-  database_worker_jobs_name: ''
-  database_worker_jobs_username: ''
   database_worker_jobs_host: ''
+  database_worker_jobs_name: ''
   database_worker_jobs_password: ''
+  database_worker_jobs_username: ''
   disable_email_sending: false
   disable_logout_get_request: false
   doc_auth_vendor: 'acuant'
   doc_auth_vendor_randomize: false
-  doc_auth_vendor_randomize_percent: 0
   doc_auth_vendor_randomize_alternate_vendor: ''
+  doc_auth_vendor_randomize_percent: 0
   domain_name: login.gov
   email_registrations_per_ip_track_only_mode: true
   enable_test_routes: false
@@ -473,8 +473,8 @@ production:
   logins_per_ip_period: 20
   logins_per_ip_track_only_mode: true
   newrelic_license_key: ''
-  openid_connect_redirect: server_side
   openid_connect_content_security_form_action_enabled: true
+  openid_connect_redirect: server_side
   otp_delivery_blocklist_findtime: 5
   participate_in_dap: true
   password_pepper:
@@ -519,18 +519,19 @@ test:
   database_readonly_password: ''
   database_readonly_username: ''
   database_username: ''
-  database_worker_jobs_name: ''
-  database_worker_jobs_username: ''
   database_worker_jobs_host: ''
+  database_worker_jobs_name: ''
   database_worker_jobs_password: ''
+  database_worker_jobs_username: ''
   doc_auth_max_attempts: 4
   doc_auth_selfie_desktop_test_mode: true
   doc_auth_vendor: 'mock'
   doc_auth_vendor_randomize: false
-  doc_auth_vendor_randomize_percent: 0
   doc_auth_vendor_randomize_alternate_vendor: ''
+  doc_auth_vendor_randomize_percent: 0
   doc_capture_polling_enabled: false
   domain_name: www.example.com
+  email_registrations_per_ip_limit: 3
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: true
@@ -538,25 +539,24 @@ test:
   lockout_period_in_minutes: 5
   logins_per_email_and_ip_limit: 2
   logins_per_ip_limit: 3
-  email_registrations_per_ip_limit: 3
   max_bad_passwords: 5
   max_mail_events: 2
-  otp_min_attempts_remaining_warning_count: 1
   newrelic_license_key: ''
   otp_delivery_blocklist_findtime: 1
   otp_delivery_blocklist_maxretry: 2
+  otp_min_attempts_remaining_warning_count: 1
   otps_per_ip_limit: 3
   otps_per_ip_period: 10
   otps_per_ip_track_only_mode: false
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
-  phone_confirmation_max_attempts: 5
   phone_confirmation_max_attempt_window_in_minutes: 10
+  phone_confirmation_max_attempts: 5
   phone_setups_per_ip_limit: 3
   phone_setups_per_ip_period: 10
   phone_setups_per_ip_track_only_mode: false
-  prometheus_exporter: false
   piv_cac_verify_token_secret: 3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f
   poll_rate_for_verify_in_seconds: 0
+  prometheus_exporter: false
   raise_on_missing_title: true
   reg_confirmed_email_max_attempts: 3
   reg_unconfirmed_email_max_attempts: 4
@@ -583,10 +583,6 @@ test:
   telephony_adapter: test
   test_ssn_allowed_list: '999999999'
   totp_code_interval: 3
-  verify_gpo_key_attempt_window_in_minutes: 3
-  verify_gpo_key_max_attempts: 2
-  verify_personal_key_attempt_window_in_minutes: 3
-  verify_personal_key_max_attempts: 2
   usps_eipp_sponsor_id: '222222222222222'
   usps_ipp_root_url: 'http://localhost:1000'
   usps_ipp_sponsor_id: '111111111111111'
@@ -594,3 +590,7 @@ test:
   usps_upload_sftp_host: example.com
   usps_upload_sftp_password: pass
   usps_upload_sftp_username: user
+  verify_gpo_key_attempt_window_in_minutes: 3
+  verify_gpo_key_max_attempts: 2
+  verify_personal_key_attempt_window_in_minutes: 3
+  verify_personal_key_max_attempts: 2


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `normalize-yaml` to support the ability to ignore sorting for specific keys, and applies key sorting to `application.yml.default`.

**Why?**

- So it's easier for a developer to scan the file for a specific key, trusting that the file's keys are ordered alphabetically

## 📜 Testing Plan

1. Reorder or add keys in `application.yml.default`.
2. Run `make normalize_yaml`
3. Verify that keys in `application.yml.default` are sorted