### PR TITLE
LG-13944 Add sponsor_id to initial IPP in-person enrollment creation

### DIFF
--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -26,8 +26,7 @@ module Idv
           city: search_params['city'], state: search_params['state'],
           zip_code: search_params['zip_code']
         )
-        is_enhanced_ipp = resolved_authn_context_result.enhanced_ipp?
-        locations = proofer.request_facilities(candidate, is_enhanced_ipp)
+        locations = proofer.request_facilities(candidate, is_authn_context_enhanced_ipp?)
         if locations.length > 0
           analytics.idv_in_person_locations_searched(
             success: true,
@@ -47,6 +46,7 @@ module Idv
           selected_location_details: update_params.as_json,
           issuer: current_sp&.issuer,
           doc_auth_result: document_capture_session&.last_doc_auth_result,
+          sponsor_id: enrollment_sponsor_id,
         )
 
         add_proofing_component
@@ -121,6 +121,16 @@ module Idv
           status: :establishing,
           profile: nil,
         )
+      end
+
+      def enrollment_sponsor_id
+        is_authn_context_enhanced_ipp? ?
+          IdentityConfig.store.usps_eipp_sponsor_id :
+          IdentityConfig.store.usps_ipp_sponsor_id
+      end
+
+      def is_authn_context_enhanced_ipp?
+        resolved_authn_context_result.enhanced_ipp?
       end
 
       def search_params

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -8,6 +8,13 @@ module UspsInPersonProofing
         return unless enrollment
 
         enrollment.current_address_matches_id = pii['same_address_as_id']
+
+        if enrollment.sponsor_id.nil?
+          enrollment.sponsor_id = is_enhanced_ipp ?
+            IdentityConfig.store.usps_eipp_sponsor_id :
+            IdentityConfig.store.usps_ipp_sponsor_id
+        end
+
         enrollment.save!
 
         # Send state ID address to USPS
@@ -19,12 +26,6 @@ module UspsInPersonProofing
 
         enrollment_code = create_usps_enrollment(enrollment, pii, is_enhanced_ipp)
         return unless enrollment_code
-
-        if is_enhanced_ipp
-          enrollment.sponsor_id = IdentityConfig.store.usps_eipp_sponsor_id
-        else
-          enrollment.sponsor_id = IdentityConfig.store.usps_ipp_sponsor_id
-        end
 
         # update the enrollment to status pending
         enrollment.enrollment_code = enrollment_code

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -267,23 +267,60 @@ RSpec.describe Idv::InPerson::UspsLocationsController, allowed_extra_analytics: 
   end
 
   describe '#update' do
+    let(:enrollment) { InPersonEnrollment.last }
+    let(:sp) { create(:service_provider, ial: 2) }
     subject(:response) { put :update, params: selected_location }
 
-    it 'writes the passed location to in-person enrollment' do
-      response
+    context 'when the user is going through ID-IPP' do
+      it 'creates an in person enrollment' do
+        expect { response }.to change { InPersonEnrollment.count }.from(0).to(1)
+        expect(enrollment.user).to eq(user)
+        expect(enrollment.status).to eq('establishing')
+        expect(enrollment.profile).to be_nil
+        expect(enrollment.sponsor_id).to eq(IdentityConfig.store.usps_ipp_sponsor_id)
+        expect(enrollment.selected_location_details).to eq(
+          selected_location[:usps_location].as_json,
+        )
+        expect(enrollment.service_provider).to eq(sp)
+      end
 
-      enrollment = user.reload.establishing_in_person_enrollment
+      it 'updates proofing component vendor' do
+        expect(user.proofing_component&.document_check).to be_nil
 
-      expect(enrollment.selected_location_details).to eq(selected_location[:usps_location].as_json)
-      expect(enrollment.service_provider).to be_nil
+        response
+
+        expect(user.proofing_component.document_check).to eq Idp::Constants::Vendors::USPS
+      end
     end
 
-    it 'updates proofing component vendor' do
-      expect(user.proofing_component&.document_check).to be_nil
+    context 'when the user is going through EIPP' do
+      let(:vtr) { ['C1.C2.P1.Pe'] }
+      let(:enhanced_ipp_sp_session) { { vtr: vtr, acr_values: nil } }
 
-      response
+      before do
+        allow(controller).to receive(:sp_session).and_return(enhanced_ipp_sp_session)
+        allow(controller).to receive(:sp_from_sp_session).and_return(sp)
+      end
 
-      expect(user.proofing_component.document_check).to eq Idp::Constants::Vendors::USPS
+      it 'creates an in person enrollment' do
+        expect { response }.to change { InPersonEnrollment.count }.from(0).to(1)
+        expect(enrollment.user).to eq(user)
+        expect(enrollment.status).to eq('establishing')
+        expect(enrollment.profile).to be_nil
+        expect(enrollment.sponsor_id).to eq(IdentityConfig.store.usps_eipp_sponsor_id)
+        expect(enrollment.selected_location_details).to eq(
+          selected_location[:usps_location].as_json,
+        )
+        expect(enrollment.service_provider).to eq(sp)
+      end
+
+      it 'updates proofing component vendor' do
+        expect(user.proofing_component&.document_check).to be_nil
+
+        response
+
+        expect(user.proofing_component.document_check).to eq Idp::Constants::Vendors::USPS
+      end
     end
 
     context 'when unauthenticated' do
@@ -322,7 +359,7 @@ RSpec.describe Idv::InPerson::UspsLocationsController, allowed_extra_analytics: 
         expect(enrollment.selected_location_details).to eq(
           selected_location[:usps_location].as_json,
         )
-        expect(enrollment.service_provider).to be_nil
+        expect(enrollment.service_provider).to eq(sp)
       end
     end
 

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -43,198 +43,225 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
   end
 
   describe '#schedule_in_person_enrollment' do
-    let!(:enrollment) do
-      create(
-        :in_person_enrollment,
-        user: user,
-        service_provider: service_provider,
-        status: :establishing,
-        profile: nil,
-      )
-    end
+    context 'when the user does not have a establishing in person enrollment' do
+      let(:user) { double('user', establishing_in_person_enrollment: nil) }
 
-    context 'when in-person mocking is enabled' do
-      let(:usps_mock_fallback) { true }
-
-      it 'uses a mock proofer' do
-        expect(UspsInPersonProofing::Mock::Proofer).to receive(:new).and_call_original
-
-        subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+      it 'returns without error' do
+        expect do
+          subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp: false)
+        end.not_to raise_error
       end
     end
 
-    context 'an establishing enrollment record exists for the user' do
-      before do
-        allow(Rails).to receive(:cache).and_return(
-          ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
+    context 'when the user has an establishing in person enrollment' do
+      let!(:enrollment) do
+        create(
+          :in_person_enrollment,
+          user: user,
+          service_provider: service_provider,
+          status: :establishing,
+          current_address_matches_id: nil,
+          profile: nil,
         )
-        allow(subject).to receive(:usps_proofer).and_return(proofer)
       end
 
-      it 'updates the existing enrollment record' do
-        expect(user.in_person_enrollments.length).to eq(1)
+      context 'when in-person mocking is enabled' do
+        let(:usps_mock_fallback) { true }
 
-        subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-        enrollment.reload
-
-        # tests that the value of current_address_matches_id on the enrollment corresponds
-        # to the value of same_address_as_id in the session
-        expect(enrollment.current_address_matches_id).to eq(current_address_matches_id)
-      end
-
-      context 'transliteration disabled' do
-        let(:usps_ipp_transliteration_enabled) { false }
-
-        it 'creates usps enrollment without using transliteration' do
-          expect(transliterator).not_to receive(:transliterate)
-          expect(proofer).to receive(:request_enroll) do |applicant|
-            expect(applicant.first_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
-            expect(applicant.last_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:last_name])
-            expect(applicant.address).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:address1])
-            expect(applicant.city).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:city])
-            expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
-            expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
-            expect(applicant.unique_id).to eq(enrollment.unique_id)
-
-            UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
-          end
+        it 'uses a mock proofer' do
+          expect(UspsInPersonProofing::Mock::Proofer).to receive(:new).and_call_original
 
           subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
         end
+      end
 
-        context 'same address as id is false' do
-          let(:pii) do
-            Pii::Attributes.new_from_hash(
-              Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.
-                merge(same_address_as_id: current_address_matches_id ? 'true' : 'false').
-                merge(Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS).
-                transform_keys(&:to_s),
-            )
+      context 'when the enrollment sponsor_id is not set' do
+        let!(:enrollment) do
+          create(
+            :in_person_enrollment,
+            user: user,
+            service_provider: service_provider,
+            status: :establishing,
+            current_address_matches_id: nil,
+            profile: nil,
+            sponsor_id: nil,
+          )
+        end
+
+        context 'when the usps enrollment fails' do
+          before do
+            stub_request_enroll_bad_request_response
           end
 
-          it 'maps enrollment address fields' do
+          context 'when an EIPP enrollment is scheduled' do
+            let(:is_enhanced_ipp) { true }
+            let(:usps_eipp_sponsor_id) { '6543211' }
+
+            before do
+              allow(
+                IdentityConfig.store,
+              ).to receive(:usps_eipp_sponsor_id).and_return(usps_eipp_sponsor_id)
+              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+            rescue StandardError
+            ensure
+              enrollment.reload
+            end
+
+            it 'sets the sponsor_id to the configured EIPP sponsor_id' do
+              expect(enrollment.sponsor_id).to eq(usps_eipp_sponsor_id)
+            end
+          end
+
+          context 'when an ID-IPP enrollment scheduled' do
+            let(:is_enhanced_ipp) { false }
+
+            before do
+              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+            rescue StandardError
+            ensure
+              enrollment.reload
+            end
+
+            it 'sets the sponsor_id to the configured ID-IPP sponsor_id' do
+              expect(enrollment.sponsor_id).to eq(usps_ipp_sponsor_id)
+            end
+          end
+        end
+      end
+
+      context 'an establishing enrollment record exists for the user' do
+        before do
+          allow(Rails).to receive(:cache).and_return(
+            ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
+          )
+          allow(subject).to receive(:usps_proofer).and_return(proofer)
+        end
+
+        it 'updates the existing enrollment record' do
+          expect(user.in_person_enrollments.length).to eq(1)
+
+          subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+          enrollment.reload
+
+          # tests that the value of current_address_matches_id on the enrollment corresponds
+          # to the value of same_address_as_id in the session
+          expect(enrollment.current_address_matches_id).to eq(current_address_matches_id)
+        end
+
+        context 'transliteration disabled' do
+          let(:usps_ipp_transliteration_enabled) { false }
+
+          it 'creates usps enrollment without using transliteration' do
+            expect(transliterator).not_to receive(:transliterate)
             expect(proofer).to receive(:request_enroll) do |applicant|
-              expect(applicant).to have_attributes(
-                address: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
-                  :identity_doc_address1
-                ],
-                city: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city],
-                state: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
-                  :identity_doc_address_state
-                ],
-                zip_code:
-                  Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode],
+              expect(applicant.first_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
+              expect(applicant.last_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:last_name])
+              expect(applicant.address).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:address1])
+              expect(applicant.city).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:city])
+              expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
+              expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
+              expect(applicant.unique_id).to eq(enrollment.unique_id)
+
+              UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
+            end
+
+            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+          end
+
+          context 'same address as id is false' do
+            let(:pii) do
+              Pii::Attributes.new_from_hash(
+                Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.
+                  merge(same_address_as_id: current_address_matches_id ? 'true' : 'false').
+                  merge(Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS).
+                  transform_keys(&:to_s),
               )
+            end
+
+            it 'maps enrollment address fields' do
+              expect(proofer).to receive(:request_enroll) do |applicant|
+                expect(applicant).to have_attributes(
+                  address: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
+                    :identity_doc_address1
+                  ],
+                  city: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city],
+                  state: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
+                    :identity_doc_address_state
+                  ],
+                  zip_code:
+                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode],
+                )
+                UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
+              end
+
+              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+            end
+          end
+        end
+
+        context 'transliteration enabled' do
+          let(:usps_ipp_transliteration_enabled) { true }
+
+          it 'creates usps enrollment while using transliteration' do
+            first_name = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
+            last_name = Idp::Constants::MOCK_IDV_APPLICANT[:last_name]
+            address = Idp::Constants::MOCK_IDV_APPLICANT[:address1]
+            city = Idp::Constants::MOCK_IDV_APPLICANT[:city]
+
+            expect(transliterator).to receive(:transliterate).
+              with(first_name).and_return(transliterated_without_change(first_name))
+            expect(transliterator).to receive(:transliterate).
+              with(last_name).and_return(transliterated(last_name))
+            expect(transliterator).to receive(:transliterate).
+              with(address).and_return(transliterated_with_failure(address))
+            expect(transliterator).to receive(:transliterate).
+              with(city).and_return(transliterated(city))
+
+            expect(proofer).to receive(:request_enroll) do |applicant|
+              expect(applicant.first_name).to eq(first_name)
+              expect(applicant.last_name).to eq("transliterated_#{last_name}")
+              expect(applicant.address).to eq(address)
+              expect(applicant.city).to eq("transliterated_#{city}")
+              expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
+              expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
+              expect(applicant.email).to eq(usps_ipp_enrollment_status_update_email_address)
+              expect(applicant.unique_id).to eq(enrollment.unique_id)
+
               UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
             end
 
             subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
           end
         end
-      end
 
-      context 'transliteration enabled' do
-        let(:usps_ipp_transliteration_enabled) { true }
+        context 'when the enrollment does not have a unique ID' do
+          it 'generates a usps_unique_id value to create the enrollment' do
+            enrollment.update(unique_id: nil)
+            expect(proofer).to receive(:request_enroll) do |applicant|
+              # The InPersonEnrollment#usps_unique_id method is deprecated
+              expect(applicant.unique_id).to eq(enrollment.usps_unique_id)
 
-        it 'creates usps enrollment while using transliteration' do
-          first_name = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
-          last_name = Idp::Constants::MOCK_IDV_APPLICANT[:last_name]
-          address = Idp::Constants::MOCK_IDV_APPLICANT[:address1]
-          city = Idp::Constants::MOCK_IDV_APPLICANT[:city]
-
-          expect(transliterator).to receive(:transliterate).
-            with(first_name).and_return(transliterated_without_change(first_name))
-          expect(transliterator).to receive(:transliterate).
-            with(last_name).and_return(transliterated(last_name))
-          expect(transliterator).to receive(:transliterate).
-            with(address).and_return(transliterated_with_failure(address))
-          expect(transliterator).to receive(:transliterate).
-            with(city).and_return(transliterated(city))
-
-          expect(proofer).to receive(:request_enroll) do |applicant|
-            expect(applicant.first_name).to eq(first_name)
-            expect(applicant.last_name).to eq("transliterated_#{last_name}")
-            expect(applicant.address).to eq(address)
-            expect(applicant.city).to eq("transliterated_#{city}")
-            expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
-            expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
-            expect(applicant.email).to eq(usps_ipp_enrollment_status_update_email_address)
-            expect(applicant.unique_id).to eq(enrollment.unique_id)
-
-            UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
-          end
-
-          subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-        end
-      end
-
-      context 'when the enrollment does not have a unique ID' do
-        it 'uses the deprecated InPersonEnrollment#usps_unique_id value to create the enrollment' do
-          enrollment.update(unique_id: nil)
-          expect(proofer).to receive(:request_enroll) do |applicant|
-            expect(applicant.unique_id).to eq(enrollment.usps_unique_id)
-
-            UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
-          end
-
-          subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-        end
-      end
-
-      it <<~STR.squish do
-        sets enrollment status to pending, sponsor_id to usps_ipp_sponsor_id,
-        and sets established at date and unique id
-      STR
-        subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-
-        expect(user.in_person_enrollments.first.status).to eq(InPersonEnrollment::STATUS_PENDING)
-        expect(user.in_person_enrollments.first.sponsor_id).to eq(usps_ipp_sponsor_id)
-        expect(user.in_person_enrollments.first.enrollment_established_at).to_not be_nil
-        expect(user.in_person_enrollments.first.unique_id).to_not be_nil
-      end
-
-      context 'event logging' do
-        context 'with no service provider' do
-          it 'logs event' do
-            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-
-            expect(subject_analytics).to have_logged_event(
-              'USPS IPPaaS enrollment created',
-              enrollment_code: user.in_person_enrollments.first.enrollment_code,
-              enrollment_id: user.in_person_enrollments.first.id,
-              opted_in_to_in_person_proofing: nil,
-              second_address_line_present: false,
-              service_provider: nil,
-              tmx_status: nil,
-              enhanced_ipp: false,
-            )
-          end
-        end
-
-        context 'with a service provider' do
-          let(:issuer) { 'this-is-an-issuer' }
-          let(:service_provider) { build(:service_provider, issuer: issuer) }
-
-          context 'when the enrollment is enhanced_ipp' do
-            let(:is_enhanced_ipp) { true }
-
-            it 'logs event' do
-              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-
-              expect(subject_analytics).to have_logged_event(
-                'USPS IPPaaS enrollment created',
-                enrollment_code: user.in_person_enrollments.first.enrollment_code,
-                enrollment_id: user.in_person_enrollments.first.id,
-                opted_in_to_in_person_proofing: nil,
-                second_address_line_present: false,
-                service_provider: issuer,
-                tmx_status: nil,
-                enhanced_ipp: true,
-              )
+              UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
             end
-          end
 
-          context 'when the enrollment is not enhanced_ipp' do
+            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+          end
+        end
+
+        it <<~STR.squish do
+          sets enrollment status to pending, sponsor_id to usps_ipp_sponsor_id,
+          and sets established at date and unique id
+        STR
+          subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+
+          expect(user.in_person_enrollments.first.status).to eq(InPersonEnrollment::STATUS_PENDING)
+          expect(user.in_person_enrollments.first.sponsor_id).to eq(usps_ipp_sponsor_id)
+          expect(user.in_person_enrollments.first.enrollment_established_at).to_not be_nil
+          expect(user.in_person_enrollments.first.unique_id).to_not be_nil
+        end
+
+        context 'event logging' do
+          context 'with no service provider' do
             it 'logs event' do
               subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
 
@@ -244,47 +271,77 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
                 enrollment_id: user.in_person_enrollments.first.id,
                 opted_in_to_in_person_proofing: nil,
                 second_address_line_present: false,
-                service_provider: issuer,
+                service_provider: nil,
                 tmx_status: nil,
                 enhanced_ipp: false,
               )
             end
           end
-        end
 
-        context 'with address line 2 present' do
-          before { pii['address2'] = 'Apartment 227' }
+          context 'with a service provider' do
+            let(:issuer) { 'this-is-an-issuer' }
+            let(:service_provider) { build(:service_provider, issuer: issuer) }
 
-          # this is a pii bundle that adds identity_doc_* values
-          let(:pii) do
-            Pii::Attributes.new_from_hash(
-              Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS.transform_keys(&:to_s),
-            )
+            context 'when the enrollment is enhanced_ipp' do
+              let!(:enrollment) do
+                create(
+                  :in_person_enrollment,
+                  :enhanced_ipp,
+                  user: user,
+                  service_provider: service_provider,
+                  status: :establishing,
+                  current_address_matches_id: nil,
+                  profile: nil,
+                )
+              end
+              let(:is_enhanced_ipp) { true }
+
+              it 'logs event' do
+                subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+
+                expect(subject_analytics).to have_logged_event(
+                  'USPS IPPaaS enrollment created',
+                  enrollment_code: user.in_person_enrollments.first.enrollment_code,
+                  enrollment_id: user.in_person_enrollments.first.id,
+                  opted_in_to_in_person_proofing: nil,
+                  second_address_line_present: false,
+                  service_provider: issuer,
+                  tmx_status: nil,
+                  enhanced_ipp: true,
+                )
+              end
+            end
+
+            context 'when the enrollment is not enhanced_ipp' do
+              it 'logs event' do
+                subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+
+                expect(subject_analytics).to have_logged_event(
+                  'USPS IPPaaS enrollment created',
+                  enrollment_code: user.in_person_enrollments.first.enrollment_code,
+                  enrollment_id: user.in_person_enrollments.first.id,
+                  opted_in_to_in_person_proofing: nil,
+                  second_address_line_present: false,
+                  service_provider: issuer,
+                  tmx_status: nil,
+                  enhanced_ipp: false,
+                )
+              end
+            end
           end
 
-          it 'does not log the presence of address line 2 only in residential address' do
-            pii['identity_doc_address2'] = nil
+          context 'with address line 2 present' do
+            before { pii['address2'] = 'Apartment 227' }
 
-            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+            # this is a pii bundle that adds identity_doc_* values
+            let(:pii) do
+              Pii::Attributes.new_from_hash(
+                Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS.transform_keys(&:to_s),
+              )
+            end
 
-            expect(subject_analytics).to have_logged_event(
-              'USPS IPPaaS enrollment created',
-              enrollment_code: user.in_person_enrollments.first.enrollment_code,
-              enrollment_id: user.in_person_enrollments.first.id,
-              opted_in_to_in_person_proofing: nil,
-              second_address_line_present: false,
-              service_provider: nil,
-              tmx_status: nil,
-              enhanced_ipp: false,
-            )
-          end
-
-          context 'with address line 2 present in state ID address' do
-            it 'logs the presence of address line 2' do
-              expect(pii['identity_doc_address2'].present?).to eq(true)
-
-              pii['same_address_as_id'] = false
-              pii['address2'] = nil
+            it 'does not log the presence of address line 2 only in residential address' do
+              pii['identity_doc_address2'] = nil
 
               subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
 
@@ -293,7 +350,48 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
                 enrollment_code: user.in_person_enrollments.first.enrollment_code,
                 enrollment_id: user.in_person_enrollments.first.id,
                 opted_in_to_in_person_proofing: nil,
-                second_address_line_present: true,
+                second_address_line_present: false,
+                service_provider: nil,
+                tmx_status: nil,
+                enhanced_ipp: false,
+              )
+            end
+
+            context 'with address line 2 present in state ID address' do
+              it 'logs the presence of address line 2' do
+                expect(pii['identity_doc_address2'].present?).to eq(true)
+
+                pii['same_address_as_id'] = false
+                pii['address2'] = nil
+
+                subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+
+                expect(subject_analytics).to have_logged_event(
+                  'USPS IPPaaS enrollment created',
+                  enrollment_code: user.in_person_enrollments.first.enrollment_code,
+                  enrollment_id: user.in_person_enrollments.first.id,
+                  opted_in_to_in_person_proofing: nil,
+                  second_address_line_present: true,
+                  service_provider: nil,
+                  tmx_status: nil,
+                  enhanced_ipp: false,
+                )
+              end
+            end
+          end
+
+          context 'with opt in value' do
+            let(:opt_in) { true }
+
+            it 'logs user\'s opt-in choice' do
+              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:, opt_in:)
+
+              expect(subject_analytics).to have_logged_event(
+                'USPS IPPaaS enrollment created',
+                enrollment_code: user.in_person_enrollments.first.enrollment_code,
+                enrollment_id: user.in_person_enrollments.first.id,
+                opted_in_to_in_person_proofing: true,
+                second_address_line_present: false,
                 service_provider: nil,
                 tmx_status: nil,
                 enhanced_ipp: false,
@@ -302,34 +400,15 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
           end
         end
 
-        context 'with opt in value' do
-          let(:opt_in) { true }
+        it 'sends verification emails' do
+          subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
 
-          it 'logs user\'s opt-in choice' do
-            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:, opt_in:)
-
-            expect(subject_analytics).to have_logged_event(
-              'USPS IPPaaS enrollment created',
-              enrollment_code: user.in_person_enrollments.first.enrollment_code,
-              enrollment_id: user.in_person_enrollments.first.id,
-              opted_in_to_in_person_proofing: true,
-              second_address_line_present: false,
-              service_provider: nil,
-              tmx_status: nil,
-              enhanced_ipp: false,
-            )
-          end
+          expect_delivered_email_count(1)
+          expect_delivered_email(
+            to: [user.email_addresses.first.email],
+            subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
+          )
         end
-      end
-
-      it 'sends verification emails' do
-        subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-
-        expect_delivered_email_count(1)
-        expect_delivered_email(
-          to: [user.email_addresses.first.email],
-          subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
-        )
       end
     end
   end
@@ -366,6 +445,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
       let!(:enrollment) do
         create(
           :in_person_enrollment,
+          :enhanced_ipp,
           user: user,
           service_provider: service_provider,
           status: :establishing,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13944](https://cm-jira.usa.gov/browse/LG-13944)

## 🛠 Summary of changes

- Set the sponsor_id field on in-person enrollments when they are created during the IPP usps location controller update request.
- Updated the `enrollment_helper.schedule_in_person_enrollment` method to check if a sponsor_id exists on the in-person enrollment before attempting to schedule a usps enrollment.

## 📜 Testing Plan

### Scenario: During EIPP flow when the user submits form for selecting a post office the in-person enrollment is saved with the configured EIPP sponsor_id.
- [x] Login through the oidc sinatra application selecting the *Enhanced In-person Proofing* level of service.
- [x] Use an exisiting account or create an account
- [x] Continue through the In-person flow until the `/verify/document_capture#location` page is reached.
- [x] Open the Rails Console 
- [x] Verify that no establishing enrollments exist for the current user `InPersonEnrollment.where(status: "establishing")`
- [x] Search for participating post office and select one
- [x] Verify that the establishing enrollment exists and has the sponsor_id set to the configured EIPP sponsor_id
- [x] Complete the flow and ensure no issues

### Scenario: During ID-IPP flow when the user submits form for selecting a post office the in-person enrollment saved with the configured ID-IPP sponsor_id.
- [x] Login through the oidc sinatra application selecting a non *Enhanced In-person Proofing* level of service.
- [x] Use an exisiting account or create an account
- [x] Continue through the In-person flow until the `/verify/document_capture#location` page is reached.
- [x] Open the Rails Console 
- [x] Verify that no establishing enrollments exist for the current user `InPersonEnrollment.where(status: "establishing")`
- [x] Search for participating post office and select one
- [x] Verify that the establishing enrollment exists and has the sponsor_id set to the configured ID-IPP sponsor_id
- [x] Complete the flow and ensure no issues

