### PR TITLE
Deploy RC 400 to Production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -227,9 +227,9 @@ class ApplicationController < ActionController::Base
     return user_please_call_url if current_user.suspended?
     return user_password_compromised_url if session[:redirect_to_password_compromised].present?
     return authentication_methods_setup_url if user_needs_sp_auth_method_setup?
-    return login_add_piv_cac_prompt_url if session[:needs_to_setup_piv_cac_after_sign_in].present?
     return fix_broken_personal_key_url if current_user.broken_personal_key?
     return user_session.delete(:stored_location) if user_session.key?(:stored_location)
+    return login_add_piv_cac_prompt_url if session[:needs_to_setup_piv_cac_after_sign_in].present?
     return reactivate_account_url if user_needs_to_reactivate_account?
     return login_piv_cac_recommended_path if user_recommended_for_piv_cac?
     return second_mfa_reminder_url if user_needs_second_mfa_reminder?

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -89,6 +89,11 @@ module SignUp
         needs_completion_screen_reason: needs_completion_screen_reason,
       }
 
+      if (last_enrollment = current_user.in_person_enrollments.last)
+        attributes[:in_person_proofing_status] = last_enrollment.status
+        attributes[:doc_auth_result] = last_enrollment.doc_auth_result
+      end
+
       if page_occurence.present? && DisposableEmailDomain.disposable?(email_domain)
         attributes[:disposable_email_domain] = email_domain
       end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -72,7 +72,7 @@ module Users
     end
 
     def process_locked_out_session
-      warden.logout(:user)
+      sign_out(:user)
       warden.lock!
 
       flash[:error] = t(
@@ -100,7 +100,7 @@ module Users
 
     def process_failed_captcha
       flash[:error] = t('errors.messages.invalid_recaptcha_token')
-      warden.logout(:user)
+      sign_out(:user)
       warden.lock!
       redirect_to root_url
     end
@@ -176,6 +176,7 @@ module Users
         bad_password_count: session[:bad_password_count].to_i,
         sp_request_url_present: sp_session[:request_url].present?,
         remember_device: remember_device_cookie.present?,
+        new_device: success ? new_device? : nil,
       )
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -38,6 +38,10 @@ module Idv
       if form_response.success?
         client_response = post_images_to_client
 
+        document_capture_session.update!(
+          last_doc_auth_result: client_response.extra[:doc_auth_result],
+        )
+
         if client_response.success?
           doc_pii_response = validate_pii_from_doc(client_response)
         end

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -5,7 +5,7 @@ class OpenidConnectTokenForm
   include ActionView::Helpers::TranslationHelper
   include Rails.application.routes.url_helpers
 
-  ISSUED_AT_LEEWAY_SECONDS = 10.seconds.to_i.freeze
+  ISSUED_AT_LEEWAY_SECONDS = 10
 
   ATTRS = %i[
     client_assertion

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
@@ -49,7 +49,7 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
       'idv.troubleshooting.options.supported_documentslinks.new_tab',
     );
     expect(links[1].getAttribute('href')).to.equal(
-      'https://example.com/redirect/?category=verify-your-identity&article=accepted-state-issued-identification&location=document_capture_troubleshooting_options',
+      'https://example.com/redirect/?category=verify-your-identity&article=accepted-identification-documents&location=document_capture_troubleshooting_options',
     );
     expect(links[1].target).to.equal('_blank');
   });

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -57,7 +57,7 @@ function DocumentCaptureTroubleshootingOptions({
             showDocumentTips && {
               url: getHelpCenterURL({
                 category: 'verify-your-identity',
-                article: 'accepted-state-issued-identification',
+                article: 'accepted-identification-documents',
                 location,
               }),
               text: t('idv.troubleshooting.options.supported_documents'),

--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -39,14 +39,59 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
   const { trackSubmitEvent, trackVisitEvent } = useContext(AnalyticsContext);
   const { inPersonFullAddressEntryEnabled, inPersonURL, skipDocAuth, skipDocAuthFromHandoff } =
     useContext(InPersonContext);
-  const appName = getConfigValue('appName');
-
   useDidUpdateEffect(onStepChange, [stepName]);
   useEffect(() => {
     if (stepName) {
       trackVisitEvent(stepName);
     }
   }, [stepName]);
+  const appName = getConfigValue('appName');
+  const inPersonLocationPostOfficeSearchForm = inPersonFullAddressEntryEnabled
+    ? InPersonLocationFullAddressEntryPostOfficeSearchStep
+    : InPersonLocationPostOfficeSearchStep;
+
+  // Define different states to be used in human readable array declaration
+  const documentFormStep: FormStep = {
+    name: 'documents',
+    form: DocumentsStep,
+    title: t('doc_auth.headings.document_capture'),
+  };
+  const reviewFormStep: FormStep = {
+    name: 'review',
+    form:
+      submissionError instanceof UploadFormEntriesError
+        ? withProps({
+            remainingSubmitAttempts: submissionError.remainingSubmitAttempts,
+            isResultCodeInvalid: submissionError.isResultCodeInvalid,
+            isFailedResult: submissionError.isFailedResult,
+            isFailedDocType: submissionError.isFailedDocType,
+            isFailedSelfie: submissionError.isFailedSelfie,
+            isFailedSelfieLivenessOrQuality:
+              submissionError.selfieNotLive || submissionError.selfieNotGoodQuality,
+            captureHints: submissionError.hints,
+            pii: submissionError.pii,
+            failedImageFingerprints: submissionError.failed_image_fingerprints,
+          })(ReviewIssuesStep)
+        : ReviewIssuesStep,
+    title: t('doc_auth.errors.rate_limited_heading'),
+  };
+
+  // In Person Steps
+  const prepareFormStep: FormStep = {
+    name: 'prepare',
+    form: InPersonPrepareStep,
+    title: t('in_person_proofing.headings.prepare'),
+  };
+  const locationFormStep: FormStep = {
+    name: 'location',
+    form: inPersonLocationPostOfficeSearchForm,
+    title: t('in_person_proofing.headings.po_search.location'),
+  };
+  const hybridFormStep: FormStep = {
+    name: 'switch_back',
+    form: InPersonSwitchBackStep,
+    title: t('in_person_proofing.headings.switch_back'),
+  };
 
   /**
    * Clears error state and sets form values for submission.
@@ -80,62 +125,16 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
     initialValues = formValues;
   }
 
-  const inPersonLocationPostOfficeSearchForm = inPersonFullAddressEntryEnabled
-    ? InPersonLocationFullAddressEntryPostOfficeSearchStep
-    : InPersonLocationPostOfficeSearchStep;
-
   const inPersonSteps: FormStep[] =
     inPersonURL === undefined
       ? []
-      : ([
-          {
-            name: 'prepare',
-            form: InPersonPrepareStep,
-            title: t('in_person_proofing.headings.prepare'),
-          },
-          {
-            name: 'location',
-            form: inPersonLocationPostOfficeSearchForm,
-            title: t('in_person_proofing.headings.po_search.location'),
-          },
-          flowPath === 'hybrid' && {
-            name: 'switch_back',
-            form: InPersonSwitchBackStep,
-            title: t('in_person_proofing.headings.switch_back'),
-          },
-        ].filter(Boolean) as FormStep[]);
+      : ([prepareFormStep, locationFormStep, flowPath === 'hybrid' && hybridFormStep].filter(
+          Boolean,
+        ) as FormStep[]);
 
   const defaultSteps: FormStep[] = submissionError
-    ? (
-        [
-          {
-            name: 'review',
-            form:
-              submissionError instanceof UploadFormEntriesError
-                ? withProps({
-                    remainingSubmitAttempts: submissionError.remainingSubmitAttempts,
-                    isResultCodeInvalid: submissionError.isResultCodeInvalid,
-                    isFailedResult: submissionError.isFailedResult,
-                    isFailedDocType: submissionError.isFailedDocType,
-                    isFailedSelfie: submissionError.isFailedSelfie,
-                    isFailedSelfieLivenessOrQuality:
-                      submissionError.selfieNotLive || submissionError.selfieNotGoodQuality,
-                    captureHints: submissionError.hints,
-                    pii: submissionError.pii,
-                    failedImageFingerprints: submissionError.failed_image_fingerprints,
-                  })(ReviewIssuesStep)
-                : ReviewIssuesStep,
-            title: t('doc_auth.errors.rate_limited_heading'),
-          },
-        ] as FormStep[]
-      ).concat(inPersonSteps)
-    : ([
-        {
-          name: 'documents',
-          form: DocumentsStep,
-          title: t('doc_auth.headings.document_capture'),
-        },
-      ].filter(Boolean) as FormStep[]);
+    ? ([reviewFormStep] as FormStep[]).concat(inPersonSteps)
+    : ([documentFormStep] as FormStep[]);
 
   // If the user got here by opting-in to in-person proofing, when skipDocAuth === true,
   // then set steps to inPersonSteps

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -121,9 +121,11 @@ class GetUspsProofingResultsJob < ApplicationJob
     enrollment.update(status_check_attempted_at: status_check_attempted_at)
   end
 
-  def passed_with_unsupported_secondary_id_type?(response)
-    return response['secondaryIdType'].present? &&
-           SUPPORTED_SECONDARY_ID_TYPES.exclude?(response['secondaryIdType'])
+  def passed_with_unsupported_secondary_id_type?(enrollment, response)
+    return false if enrollment.enhanced_ipp?
+
+    response['secondaryIdType'].present? &&
+      SUPPORTED_SECONDARY_ID_TYPES.exclude?(response['secondaryIdType'])
   end
 
   def analytics(user: AnonymousUser.new)
@@ -483,7 +485,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     when IPP_STATUS_PASSED
       if fraud_result_pending?(enrollment)
         handle_passed_with_fraud_review_pending(enrollment, response)
-      elsif passed_with_unsupported_secondary_id_type?(response)
+      elsif passed_with_unsupported_secondary_id_type?(enrollment, response)
         handle_unsupported_secondary_id(enrollment, response)
       elsif passed_with_primary_id_check?(enrollment, response)
         handle_successful_status_update(enrollment, response)

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -23,7 +23,7 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.selfie_status = doc_auth_response.selfie_status
     EncryptedRedisStructStorage.store(
       session_result,
-      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.seconds.to_i,
+      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.in_seconds,
     )
     self.ocr_confirmation_pending = doc_auth_response.attention_with_barcode?
     save!
@@ -45,7 +45,7 @@ class DocumentCaptureSession < ApplicationRecord
 
     EncryptedRedisStructStorage.store(
       session_result,
-      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.seconds.to_i,
+      expires_in: IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes.in_seconds,
     )
     save!
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5818,6 +5818,8 @@ module AnalyticsEvents
   # @param [Array] sp_session_requested_attributes Attributes requested by the service provider
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation flow
   # @param [String, nil] disposable_email_domain Disposable email domain used for registration
+  # @param [String, nil] in_person_proofing_status In person proofing status
+  # @param [String, nil] doc_auth_result The doc auth result
   def user_registration_complete(
     ial2:,
     service_provider_name:,
@@ -5827,6 +5829,8 @@ module AnalyticsEvents
     sp_session_requested_attributes:,
     ialmax: nil,
     disposable_email_domain: nil,
+    in_person_proofing_status: nil,
+    doc_auth_result: nil,
     **extra
   )
     track_event(
@@ -5839,6 +5843,8 @@ module AnalyticsEvents
       needs_completion_screen_reason:,
       sp_session_requested_attributes:,
       disposable_email_domain:,
+      in_person_proofing_status:,
+      doc_auth_result:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -404,6 +404,8 @@ module AnalyticsEvents
   # @param [String] bad_password_count represents number of prior login failures
   # @param [Boolean] sp_request_url_present if was an SP request URL in the session
   # @param [Boolean] remember_device if the remember device cookie was present
+  # @param [Boolean, nil] new_device Whether the user is authenticating from a new device. Nil if
+  # there is the attempt was unsuccessful, since it cannot be known whether it's a new device.
   # Tracks authentication attempts at the email/password screen
   def email_and_password_auth(
     success:,
@@ -413,6 +415,7 @@ module AnalyticsEvents
     bad_password_count:,
     sp_request_url_present:,
     remember_device:,
+    new_device:,
     **extra
   )
     track_event(
@@ -424,6 +427,7 @@ module AnalyticsEvents
       bad_password_count:,
       sp_request_url_present:,
       remember_device:,
+      new_device:,
       **extra,
     )
   end

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -11,7 +11,6 @@ class MarketingSite
     manage-your-account/personal-key
     trouble-signing-in/face-or-touch-unlock
     verify-your-identity/accepted-identification-documents
-    verify-your-identity/accepted-state-issued-identification
     verify-your-identity/how-to-add-images-of-your-state-issued-id
     verify-your-identity/verify-your-identity-in-person
     verify-your-identity/phone-number

--- a/app/services/rate_limiter.rb
+++ b/app/services/rate_limiter.rb
@@ -79,7 +79,7 @@ class RateLimiter
         multi.incr(key)
         multi.expireat(
           key,
-          now + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.seconds.to_i,
+          now + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.in_seconds,
         )
       end
     end
@@ -132,8 +132,7 @@ class RateLimiter
       client.set(
         key,
         value,
-        exat: now.to_i +
-          RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.seconds.to_i,
+        exat: now.to_i + RateLimiter.attempt_window_in_minutes(rate_limit_type).minutes.in_seconds,
       )
     end
 

--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -70,7 +70,7 @@ class ServiceProviderRequestProxy
     REDIS_POOL.with do |client|
       client.setex(
         key(uuid),
-        IdentityConfig.store.service_provider_request_ttl_hours.hours.to_i,
+        IdentityConfig.store.service_provider_request_ttl_hours.hours.in_seconds,
         obj.to_json,
       )
     end

--- a/app/services/usps_in_person_proofing/mock/fixtures.rb
+++ b/app/services/usps_in_person_proofing/mock/fixtures.rb
@@ -77,6 +77,12 @@ module UspsInPersonProofing
         )
       end
 
+      def self.request_passed_proofing_secondary_id_type_results_response_ial_2
+        load_response_fixture(
+          'request_passed_proofing_secondary_id_type_results_response_ial_2.json',
+        )
+      end
+
       def self.request_expired_proofing_results_response
         load_response_fixture('request_expired_proofing_results_response.json')
       end

--- a/app/services/usps_in_person_proofing/mock/responses/request_passed_proofing_secondary_id_type_results_response_ial_2.json
+++ b/app/services/usps_in_person_proofing/mock/responses/request_passed_proofing_secondary_id_type_results_response_ial_2.json
@@ -1,0 +1,14 @@
+{
+  "status": "In-person passed",
+  "proofingPostOffice": "WILKES BARRE",
+  "proofingCity": "WILKES BARRE",
+  "proofingState": "PA",
+  "enrollmentCode": "2090002197504352",
+  "primaryIdType": "State driver's license",
+  "transactionStartDateTime": "12/17/2020 033855",
+  "transactionEndDateTime": "12/17/2020 034055",
+  "secondaryIdType": "State driver's license",
+  "fraudSuspected": false,
+  "proofingConfirmationNumber": "350040248346701",
+  "ippAssuranceLevel": "2.0"
+}

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -28,7 +28,7 @@
   <%= link_to(
         MarketingSite.help_center_article_url(
           category: 'verify-your-identity',
-          article: 'accepted-state-issued-identification',
+          article: 'accepted-identification-documents',
         ),
         class: 'display-inline',
       ) do %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      Rack::CACHE_CONTROL => "public, max-age=#{2.days.to_i}",
+      Rack::CACHE_CONTROL => "public, max-age=#{2.days.in_seconds}",
     }
   else
     config.action_controller.perform_caching = false

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -233,7 +233,7 @@ else
       weekly_protocols_report: {
         class: 'Reports::ProtocolsReport',
         cron: cron_every_monday,
-        args: -> { [Time.zone.yesterday] },
+        args: -> { [Time.zone.yesterday.end_of_day] },
       },
     }.compact
   end

--- a/db/primary_migrate/20240708183211_add_doc_auth_result_to_in_person_enrollments.rb
+++ b/db/primary_migrate/20240708183211_add_doc_auth_result_to_in_person_enrollments.rb
@@ -1,0 +1,6 @@
+class AddDocAuthResultToInPersonEnrollments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :in_person_enrollments, :doc_auth_result, :string
+    add_column :document_capture_sessions, :last_doc_auth_result, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_04_173515) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_08_183211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -191,6 +191,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_173515) do
     t.string "issuer"
     t.datetime "cancelled_at", precision: nil
     t.boolean "ocr_confirmation_pending", default: false
+    t.string "last_doc_auth_result"
     t.index ["result_id"], name: "index_document_capture_sessions_on_result_id"
     t.index ["user_id"], name: "index_document_capture_sessions_on_user_id"
     t.index ["uuid"], name: "index_document_capture_sessions_on_uuid"
@@ -318,6 +319,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_173515) do
     t.datetime "notification_sent_at", comment: "The time a notification was sent"
     t.datetime "last_batch_claimed_at"
     t.string "sponsor_id"
+    t.string "doc_auth_result"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["ready_for_status_check"], name: "index_in_person_enrollments_on_ready_for_status_check", where: "(ready_for_status_check = true)"
     t.index ["status_check_attempted_at"], name: "index_in_person_enrollments_on_status_check_attempted_at", where: "(status = 1)"

--- a/spec/controllers/country_support_controller_spec.rb
+++ b/spec/controllers/country_support_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CountrySupportController do
     it 'sets HTTP headers to cache for 15 minutes' do
       get :index
 
-      expect(response['Cache-Control']).to eq("max-age=#{15.minutes.to_i}, public")
+      expect(response['Cache-Control']).to eq("max-age=#{15.minutes.in_seconds}, public")
     end
 
     context 'renders when passing in different locale' do

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
   let(:back_image) { DocAuthImageFixtures.document_back_image_multipart }
   let(:selfie_img) { nil }
   let(:state_id_number) { 'S59397998' }
+  let(:user) { create(:user) }
+
+  before do
+    stub_sign_in(user) if user
+  end
 
   describe '#create' do
     subject(:action) do
       post :create, params: params
     end
 
-    let(:user) { create(:user) }
     let!(:document_capture_session) { user.document_capture_sessions.create!(user: user) }
     let(:flow_path) { 'standard' }
     let(:params) do

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -326,6 +326,23 @@ RSpec.describe Idv::InPerson::UspsLocationsController, allowed_extra_analytics: 
       end
     end
 
+    context 'with failed doc_auth_result' do
+      before do
+        allow(controller).to receive(:document_capture_session).and_return(
+          OpenStruct.new({ last_doc_auth_result: 'Failed' }),
+        )
+      end
+
+      it 'updates the doc_auth_result in the enrollment' do
+        response
+
+        enrollment = user.reload.establishing_in_person_enrollment
+
+        expect(enrollment.selected_location_details).to_not be_nil
+        expect(enrollment.doc_auth_result).to eq('Failed')
+      end
+    end
+
     context 'with feature disabled' do
       let(:in_person_proofing_enabled) { false }
 

--- a/spec/controllers/redirect/help_center_controller_spec.rb
+++ b/spec/controllers/redirect/help_center_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Redirect::HelpCenterController do
 
     context 'with valid help center article' do
       let(:category) { 'verify-your-identity' }
-      let(:article) { 'accepted-state-issued-identification' }
+      let(:article) { 'accepted-identification-documents' }
       let(:params) { super().merge(category:, article:) }
 
       it 'redirects to the help center article and logs' do

--- a/spec/controllers/sign_up/cancellations_controller_spec.rb
+++ b/spec/controllers/sign_up/cancellations_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SignUp::CancellationsController do
     it 'redirects if confirmation_token is expired' do
       confirmation_token = '1'
       invalid_confirmation_sent_at =
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
 
       create(
         :user, email_addresses: [

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -236,6 +236,8 @@ RSpec.describe SignUp::CompletionsController do
           sp_session_requested_attributes: nil,
           in_account_creation_flow: true,
           disposable_email_domain: nil,
+          in_person_proofing_status: nil,
+          doc_auth_result: nil,
         )
       end
 
@@ -296,6 +298,8 @@ RSpec.describe SignUp::CompletionsController do
             sp_session_requested_attributes: nil,
             in_account_creation_flow: true,
             disposable_email_domain: 'temporary.com',
+            doc_auth_result: nil,
+            in_person_proofing_status: nil,
           )
         end
       end
@@ -312,6 +316,7 @@ RSpec.describe SignUp::CompletionsController do
         )
         stub_sign_in(user)
         sp = create(:service_provider, issuer: 'https://awesome')
+        create(:in_person_enrollment, status: 'passed', doc_auth_result: 'Passed', user: user)
         subject.session[:sp] = {
           issuer: sp.issuer,
           acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
@@ -332,6 +337,8 @@ RSpec.describe SignUp::CompletionsController do
           sp_session_requested_attributes: ['email'],
           in_account_creation_flow: true,
           disposable_email_domain: 'temporary.com',
+          in_person_proofing_status: 'passed',
+          doc_auth_result: 'Passed',
         )
       end
 

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SignUp::EmailConfirmationsController do
 
     it 'tracks expired token' do
       invalid_confirmation_sent_at =
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
       email_address = create(
         :email_address,
         :unconfirmed,

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe SignUp::PasswordsController do
     context 'with an with an invalid confirmation_token' do
       let(:token) { 'new token' }
       let(:invalid_confirmation_sent_at) do
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
       end
       let!(:user) do
         create(
@@ -161,7 +161,7 @@ RSpec.describe SignUp::PasswordsController do
 
     it 'rejects when confirmation_token is invalid' do
       invalid_confirmation_sent_at =
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
       create(
         :user,
         :unconfirmed,

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe OpenidConnectTokenForm do
         OutOfBandSessionAccessor.new(
           identity.rails_session_id,
         ).put_empty_user_session(
-          5.minutes.to_i,
+          5.minutes.in_seconds,
         )
       end
 

--- a/spec/jobs/reports/protocols_report_spec.rb
+++ b/spec/jobs/reports/protocols_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::ProtocolsReport do
-  let(:report_date) { Date.new(2024, 7, 5) }
+  let(:report_date) { Date.new(2024, 7, 5).in_time_zone('UTC') }
   let(:email) { 'team@example.com' }
 
   let(:report_configs) do
@@ -38,6 +38,18 @@ RSpec.describe Reports::ProtocolsReport do
       ).and_call_original
 
       subject.perform(report_date)
+    end
+  end
+
+  describe 'with empty logs' do
+    before do
+      stub_cloudwatch_logs([])
+    end
+
+    it 'sends an email with at least 1 attachment' do
+      subject.perform(report_date)
+      sent_mail = ActionMailer::Base.deliveries.last
+      expect(sent_mail.parts.attachments.count).to be >= 1
     end
   end
 end

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe DocumentCaptureSession do
         zipcode: '12345',
         issuing_country_code: 'USA',
       ),
+      extra: {
+        doc_auth_result: 'Passed',
+      },
     )
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1000,7 +1000,7 @@ RSpec.describe User do
           OutOfBandSessionAccessor.new(mock_session_id).put_pii(
             profile_id: 123,
             pii: { first_name: 'Mario' },
-            expiration: 5.minutes.to_i,
+            expiration: 5.minutes.in_seconds,
           )
 
           expect(OutOfBandSessionAccessor.new(mock_session_id).exists?).to eq true

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
         OutOfBandSessionAccessor.new(rails_session_id).put_pii(
           profile_id: profile.id,
           pii: pii,
-          expiration: 5.minutes.to_i,
+          expiration: 5.minutes.in_seconds,
         )
       end
     end
@@ -284,7 +284,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
 
       context 'when the piv/cac was used as a second factor' do
         before do
-          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.to_i)
+          OutOfBandSessionAccessor.new(rails_session_id).put_x509(x509, 5.minutes.in_seconds)
         end
 
         it 'includes the x509 claims' do

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -170,20 +170,20 @@ RSpec.describe MarketingSite do
 
     context 'with valid article' do
       let(:category) { 'verify-your-identity' }
-      let(:article) { 'accepted-state-issued-identification' }
+      let(:article) { 'accepted-identification-documents' }
 
       it_behaves_like 'a marketing site URL'
 
       it 'returns article URL' do
         expect(url).to eq(
-          'https://www.login.gov/help/verify-your-identity/accepted-state-issued-identification/',
+          'https://www.login.gov/help/verify-your-identity/accepted-identification-documents/',
         )
       end
     end
 
     context 'with anchor' do
       let(:category) { 'verify-your-identity' }
-      let(:article) { 'accepted-state-issued-identification' }
+      let(:article) { 'accepted-identification-documents' }
       let(:article_anchor) { 'test-anchor-url' }
       let(:url) do
         MarketingSite.help_center_article_url(category:, article:, article_anchor:)
@@ -193,7 +193,7 @@ RSpec.describe MarketingSite do
 
       it 'returns article URL' do
         expect(url).to eq(
-          'https://www.login.gov/help/verify-your-identity/accepted-state-issued-identification/#test-anchor-url',
+          'https://www.login.gov/help/verify-your-identity/accepted-identification-documents/#test-anchor-url',
         )
       end
     end
@@ -213,7 +213,7 @@ RSpec.describe MarketingSite do
 
     context 'with valid article' do
       let(:category) { 'verify-your-identity' }
-      let(:article) { 'accepted-state-issued-identification' }
+      let(:article) { 'accepted-identification-documents' }
 
       it { expect(result).to eq(true) }
 

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe OutOfBandSessionAccessor do
       store.put_pii(
         profile_id: profile_id,
         pii: { first_name: 'Fakey' },
-        expiration: 5.minutes.to_i,
+        expiration: 5.minutes.in_seconds,
       )
 
-      expect(store.ttl).to be_within(1).of(5.minutes.to_i)
+      expect(store.ttl).to be_within(1).of(5.minutes.in_seconds)
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe OutOfBandSessionAccessor do
       store.put_pii(
         profile_id: profile_id,
         pii: { dob: '1970-01-01' },
-        expiration: 5.minutes.to_i,
+        expiration: 5.minutes.in_seconds,
       )
 
       pii = store.load_pii(profile_id)
@@ -40,7 +40,7 @@ RSpec.describe OutOfBandSessionAccessor do
 
   describe '#load_x509' do
     it 'loads X509 attributes from the session' do
-      store.put_x509({ subject: 'O=US, OU=DoD, CN=John.Doe.1234' }, 5.minutes.to_i)
+      store.put_x509({ subject: 'O=US, OU=DoD, CN=John.Doe.1234' }, 5.minutes.in_seconds)
 
       x509 = store.load_x509
       expect(x509).to be_kind_of(X509::Attributes)
@@ -53,7 +53,7 @@ RSpec.describe OutOfBandSessionAccessor do
       store.put_pii(
         profile_id: profile_id,
         pii: { first_name: 'Fakey' },
-        expiration: 5.minutes.to_i,
+        expiration: 5.minutes.in_seconds,
       )
       store.destroy
 

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SendSignUpEmailConfirmation do
     context 'when the user already has a confirmation token' do
       let(:email_address) do
         invalid_confirmation_sent_at =
-          Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.to_i + 1)
+          Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
 
         create(
           :email_address,

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -239,6 +239,15 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_passed_proofing_secondary_id_type_results_ial_2
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
+      status: 200,
+      body: UspsInPersonProofing::Mock::
+        Fixtures.request_passed_proofing_secondary_id_type_results_response_ial_2,
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_passed_proofing_unsupported_status_results
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults}).to_return(
       status: 200,


### PR DESCRIPTION
## Bug Fixes
- Help Links: Fixed a broken link on the document capture page ([#10968](https://github.com/18F/identity-idp/pull/10968))
- PIV Enrollment: Fix reprompt when reauthenticating to add PIV after sign-in ([#10918](https://github.com/18F/identity-idp/pull/10918))

## Internal
- Analytics: Log new_device with email and password authentication event ([#10965](https://github.com/18F/identity-idp/pull/10965))
- IdV: Add doc_auth_result to in_person enrollments table ([#10950](https://github.com/18F/identity-idp/pull/10950))
- Performance: Avoid unnecessary seconds conversion before to_i ([#10979](https://github.com/18F/identity-idp/pull/10979))
- Reporting: Ensure parameter correctness ([#10973](https://github.com/18F/identity-idp/pull/10973))
- doc-capture: Refactored step code in doc capture ([#10933](https://github.com/18F/identity-idp/pull/10933))

## Upcoming Features
- Enhanced In-person proofing: Bypass secondary id check for EIPP ([#10934](https://github.com/18F/identity-idp/pull/10934))
