### PR TITLE
Use aria-hidden for decorative SVG images

### DIFF
--- a/app/views/mfa_confirmation/show.html.erb
+++ b/app/views/mfa_confirmation/show.html.erb
@@ -1,6 +1,6 @@
 <% self.title = @content.heading %>
 
-<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'img' %>
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', aria: { hidden: true } %>
 
 <%= render PageHeadingComponent.new.with_content(@content.heading) %>
 

--- a/app/views/openid_connect/logout/confirm_logout.html.erb
+++ b/app/views/openid_connect/logout/confirm_logout.html.erb
@@ -1,7 +1,7 @@
 <% self.title = t('openid_connect.logout.heading', app_name: APP_NAME) %>
 
 <div class='text-center'>
-  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'img') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', aria: { hidden: true }) %>
   <% if @service_provider_name.present? %>
     <%= render PageHeadingComponent.new.with_content(t('openid_connect.logout.heading_with_sp', app_name: APP_NAME, service_provider_name: @service_provider_name)) %>
   <% else %>

--- a/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
+++ b/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
@@ -17,7 +17,7 @@
       "two_factor_options_form_selection_#{option.type}",
       class: 'usa-checkbox__label usa-checkbox__label--illustrated',
     ) do %>
-  <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: '', class: 'usa-checkbox__image', role: 'img') %>
+  <%= image_tag(asset_url("mfa-options/#{option.type}.svg"), alt: '', class: 'usa-checkbox__image', aria: { hidden: true }) %>
   <div class="usa-checkbox__label--text">
     <span class="margin-right-2"><%= option.label %></span>
     <%= content_tag(

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -28,7 +28,6 @@
                   asset_url('icon-dot-gov.svg'),
                   size: 40,
                   alt: '',
-                  role: 'img',
                   aria: { hidden: true },
                   class: 'usa-banner__icon usa-media-block__img',
                 ) %>
@@ -44,7 +43,6 @@
                   asset_url('icon-https.svg'),
                   size: 40,
                   alt: '',
-                  role: 'img',
                   aria: { hidden: true },
                   class: 'usa-banner__icon usa-media-block__img',
                 ) %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,6 +1,6 @@
 <footer class="footer">
   <%= new_tab_link_to('https://www.gsa.gov', class: 'footer__agency-logo') do %>
-    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'margin-right-05', role: 'img') %>
+    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'margin-right-05', aria: { hidden: true }) %>
     <%= t('shared.footer_lite.gsa') %>
   <% end %>
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>
@@ -12,7 +12,7 @@
   </div>
   <div class="footer__links">
     <%= new_tab_link_to('https://www.gsa.gov', class: 'footer__agency-logo') do %>
-      <%= image_tag(asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: '', class: 'margin-right-05', role: 'img') %>
+      <%= image_tag(asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: '', class: 'margin-right-05', aria: { hidden: true }) %>
       <%= t('shared.footer_lite.gsa') %>
     <% end %>
   </div>

--- a/app/views/sign_up/registrations/_sp_registration_heading.html.erb
+++ b/app/views/sign_up/registrations/_sp_registration_heading.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', role: 'img') %>
+  <%= image_tag(asset_url('user-access.svg'), width: '280', height: '91', alt: '', aria: { hidden: true }) %>
   <h1 class="margin-bottom-4 text-primary text-normal">
     <strong><%= decorated_sp_session.sp_name %></strong>
     <%= t('headings.create_account_with_sp.sp_text', app_name: APP_NAME) %>

--- a/app/views/users/backup_code_setup/reminder.html.erb
+++ b/app/views/users/backup_code_setup/reminder.html.erb
@@ -1,6 +1,6 @@
 <% self.title = t('forms.backup_code.title') %>
 
-<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', role: 'img' %>
+<%= image_tag asset_url('user-signup-ial1.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', aria: { hidden: true } %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code_reminder.heading')) %>
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -1,7 +1,7 @@
 <% self.title = @presenter.page_title %>
 
 <% if @platform_authenticator %>
-  <%= image_tag asset_url('platform-authenticator.svg'), alt: '', width: 84, height: 95, class: 'margin-left-1 margin-bottom-2', role: 'img' %>
+  <%= image_tag asset_url('platform-authenticator.svg'), alt: '', width: 84, height: 95, class: 'margin-left-1 margin-bottom-2', aria: { hidden: true } %>
 <% end %>
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -193,11 +193,11 @@ RSpec::Matchers.define :tag_decorative_svgs_with_role do
   end
 
   match do |page|
-    expect(decorative_svgs(page)).to all satisfy { |img| img.key?(:'aria-hidden') }
+    expect(decorative_svgs(page)).to all satisfy { |img| !img[:'aria-hidden'].nil? }
   end
 
   failure_message do |page|
-    img_tags = decorative_svgs(page).reject { |img| img.key?(:'aria-hidden') }.
+    img_tags = decorative_svgs(page).reject { |img| !img[:'aria-hidden'].nil? }.
       map { |img| %(<img alt="#{img[:alt]}" src="#{img[:src]}" class="#{img[:class]}">) }.
       join("\n")
 

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -187,7 +187,7 @@ RSpec::Matchers.define :have_unique_ids do
   end
 end
 
-RSpec::Matchers.define :tag_decorative_svgs_with_role do
+RSpec::Matchers.define :tag_decorative_svgs_with_aria_hidden do
   # VoiceOver on Safari will erroneously announce SVG <img> elements with a null text alternative,
   # even with `role="presentation"` (see LG-12465). Assigning `aria-hidden` is equivalent to
   # `role="presentation"` for image elements, and prevents the images from being announced. This
@@ -342,7 +342,7 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
   expect(page).to have_valid_idrefs
   expect(page).to label_required_fields
   expect(page).to have_valid_markup if validate_markup
-  expect(page).to tag_decorative_svgs_with_role
+  expect(page).to tag_decorative_svgs_with_aria_hidden
 end
 
 def activate_skip_link

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -193,16 +193,16 @@ RSpec::Matchers.define :tag_decorative_svgs_with_role do
   end
 
   match do |page|
-    expect(decorative_svgs(page)).to all satisfy { |img| img[:role] == 'img' }
+    expect(decorative_svgs(page)).to all satisfy { |img| img.key?(:'aria-hidden') }
   end
 
   failure_message do |page|
-    img_tags = decorative_svgs(page).reject { |img| img[:role] == 'img' }.
+    img_tags = decorative_svgs(page).reject { |img| img.key?(:'aria-hidden') }.
       map { |img| %(<img alt="#{img[:alt]}" src="#{img[:src]}" class="#{img[:class]}">) }.
       join("\n")
 
     <<~STR
-      Expect all decorative SVGs to have role="img", but found ones without:
+      Expect all decorative SVGs to have aria-hidden, but found ones without:
       #{img_tags}
     STR
   end
@@ -327,10 +327,7 @@ class AccessibleName
 end
 
 def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
-  expect(page).to be_axe_clean.according_to(:wcag22aa, :"best-practice").
-    # Axe flags redundant img role on img elements, but is necessary for a Safari bug
-    # See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#identifying_svg_as_an_image
-    excluding('img[alt=""][src$=".svg" i]')
+  expect(page).to be_axe_clean.according_to(:wcag22aa, :"best-practice")
   expect(page).to have_unique_ids
   expect(page).to have_valid_idrefs
   expect(page).to label_required_fields

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -197,7 +197,7 @@ RSpec::Matchers.define :tag_decorative_svgs_with_role do
   end
 
   failure_message do |page|
-    img_tags = decorative_svgs(page).reject { |img| !img[:'aria-hidden'].nil? }.
+    img_tags = decorative_svgs(page).select { |img| img[:'aria-hidden'].nil? }.
       map { |img| %(<img alt="#{img[:alt]}" src="#{img[:src]}" class="#{img[:class]}">) }.
       join("\n")
 

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -188,6 +188,16 @@ RSpec::Matchers.define :have_unique_ids do
 end
 
 RSpec::Matchers.define :tag_decorative_svgs_with_role do
+  # VoiceOver on Safari will erroneously announce SVG <img> elements with a null text alternative,
+  # even with `role="presentation"` (see LG-12465). Assigning `aria-hidden` is equivalent to
+  # `role="presentation"` for image elements, and prevents the images from being announced. This
+  # should be removed if and when the bug is fixed in a future version of Safari.
+  #
+  # "Consequently, using role="presentation" or role="none" on an HTML img is equivalent to using
+  # aria-hidden="true"."
+  #
+  # See: https://www.w3.org/TR/wai-aria-1.2/#presentation
+
   def decorative_svgs(page)
     page.all(:css, 'img[alt=""][src$=".svg" i]')
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates decorative SVG images to use `aria-hidden` instead of `role="img"`.

This builds upon #10200, and seeks to address the original issue while avoiding some incompatibilities between the role and  expectations around decorative images.

This is partly motivated by errors surfaced by automated checking tools, e.g. [Axe's `aria-allowed-role`](https://dequeuniversity.com/rules/axe/4.9/aria-allowed-role) or [PageSpeed Insights](https://pagespeed.web.dev/).

Some background investigation leading to this:

- Originally spotted a [recommendation in a blog post by a well-known accessibility engineer](https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html#image-elements-that-are-decorative), not directly related to this issue, though similarly recommending `aria-hidden` for decoratives images
- More authoritatively through specifications:
    - `role="presentation"` has an intended use-case for decorative images: ["An element whose content is completely presentational (like a [...] decorative graphic"](https://www.w3.org/TR/wai-aria-1.2/#presentation)
   - However, the original bug persists with this implementation
   - Further into the description for this role is the following: "Consequently, using `role="presentation"` or `role="none"` on an HTML `img` is equivalent to using `aria-hidden="true"`."
   - Using `aria-hidden` addresses the original bug

## 📜 Testing Plan

Repeat testing plan from #10200 

Optionally, run a scan using an accessibility tool like Axe to verify there are no errors.