### PR TITLE
Fix flakey IAA Agreements spec

### DIFF
--- a/spec/models/agreements/iaa_spec.rb
+++ b/spec/models/agreements/iaa_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Agreements::Iaa do
     end
 
     it 'returns false when the order does not match' do
-      other_order = create(:iaa_order, iaa_gtc: gtc)
+      other_order = create(:iaa_order, order_number: 2, iaa_gtc: gtc)
       other = described_class.new(gtc: gtc, order: other_order)
       expect(iaa).not_to eq(other)
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the spec for `Agreements::Iaa` to fix flakey test failures.

Example failure: https://gitlab.login.gov/lg/identity-idp/-/jobs/1326656

The issue is that the spec in question compares a [factory-created record with a randomized order number](https://github.com/18F/identity-idp/blob/5a01dc3425ca8b2a7bfd5cc8894c3c3c86c37891/spec/models/agreements/iaa_spec.rb#L69) with [a record that has a set order number](https://github.com/18F/identity-idp/blob/5a01dc3425ca8b2a7bfd5cc8894c3c3c86c37891/spec/models/agreements/iaa_spec.rb#L5). And because [the randomized order number is between 1 and 1000](https://github.com/18F/identity-idp/blob/5a01dc3425ca8b2a7bfd5cc8894c3c3c86c37891/spec/factories/agreements.rb#L28), this leaves a 1 in 1000 chance that the number conflicts.

The fix is to assign a unique, known `order_number` to the "other" record. Another option is to use a dynamically-generated order number for both and use Faker's `.unique` option, but this adds some complexity to how other specs in this file assert their expected result ([example](https://github.com/18F/identity-idp/blob/5a01dc3425ca8b2a7bfd5cc8894c3c3c86c37891/spec/models/agreements/iaa_spec.rb#L45)).

## 📜 Testing Plan

Verify build passes.