### PR TITLE
[DRAFT] Experiment with speeding up the i18n test

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -3,146 +3,9 @@
 require 'rails_helper'
 require 'i18n/tasks'
 
-# List of keys allowed to contain different interpolation arguments across locales
-ALLOWED_INTERPOLATION_MISMATCH_KEYS = [
-  'time.formats.event_timestamp_js',
-].freeze
-
-ALLOWED_LEADING_OR_TRAILING_SPACE_KEYS = [
-  'datetime.dotiw.last_word_connector',
-  'datetime.dotiw.two_words_connector',
-  'datetime.dotiw.words_connector',
-].sort.freeze
-
-# These are keys with mismatch interpolation for specific locales
-ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS = [].freeze
-
-PUNCTUATION_PAIRS = {
-  '{' => '}',
-  '[' => ']',
-  '(' => ')',
-  '<' => '>',
-  '（' => '）',
-  '“' => '”',
-}.freeze
-
-# A set of patterns which are expected to only occur within specific locales. This is an imperfect
-# solution based on current content, intended to help prevent accidents when adding new translated
-# content. If you are having issues with new content, it would be reasonable to remove or modify
-# the parts of the pattern which are valid for the content you're adding.
-LOCALE_SPECIFIC_CONTENT = {
-  fr: / [nd]’|à/i,
-  es: /¿|ó/,
-}.freeze
-
-# Regex patterns for commonly misspelled words by locale. Match on word boundaries ignoring case.
-# The current design should be adequate for a small number of words in each language.
-# If we encounter false positives we should come up with a scheme to ignore those cases.
-# Add additional words using the regex union operator '|'.
-COMMONLY_MISSPELLED_WORDS = {
-  en: /\b(cancelled|occured|seperated?)\b/i,
-}.freeze
-
-module I18n
-  module Tasks
-    class BaseTask
-      # List of keys allowed to be untranslated or are the same as English
-      # rubocop:disable Layout/LineLength
-      ALLOWED_UNTRANSLATED_KEYS = [
-        { key: 'i18n.locale.en', locales: %i[es fr zh] },
-        { key: 'i18n.locale.es', locales: %i[es fr zh] },
-        { key: 'i18n.locale.fr', locales: %i[es fr zh] },
-        { key: 'i18n.locale.zh', locales: %i[es fr zh] },
-        { key: 'account.email_language.name.en', locales: %i[es fr zh] },
-        { key: 'account.email_language.name.es', locales: %i[es fr zh] },
-        { key: 'account.email_language.name.fr', locales: %i[es fr zh] },
-        { key: 'account.email_language.name.zh', locales: %i[es fr zh] },
-        { key: 'account.navigation.menu', locales: %i[fr] }, # "Menu" is "Menu" in French
-        { key: /^countries/ }, # Some countries have the same name across languages
-        { key: 'date.formats.long', locales: %i[es zh] },
-        { key: 'date.formats.short', locales: %i[es zh] },
-        { key: 'datetime.dotiw.minutes.one' }, # "minute is minute" in French and English
-        { key: 'datetime.dotiw.minutes.other' }, # "minute is minute" in French and English
-        { key: 'datetime.dotiw.words_connector' }, # " , " is only punctuation and not translated
-        { key: 'in_person_proofing.process.eipp_bring_id.image_alt_text', locales: %i[fr es zh] }, # Real ID is considered a proper noun in this context, ID translated to ID Card in Chinese
-        { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
-        { key: 'saml_idp.auth.error.title', locales: %i[es] }, # "Error" is "Error" in Spanish
-        { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
-        { key: 'telephony.format_length.six', locales: %i[zh] }, # numeral is not translated
-        { key: 'telephony.format_length.ten', locales: %i[zh] }, # numeral is not translated
-        { key: 'time.formats.event_date', locales: %i[es zh] },
-        { key: 'time.formats.event_time', locales: %i[es zh] },
-        { key: 'time.formats.event_timestamp', locales: %i[zh] },
-        { key: 'time.formats.full_date', locales: %i[es] }, # format is the same in Spanish and English
-        { key: 'time.formats.sms_date' }, # for us date format
-      ].freeze
-      # rubocop:enable Layout/LineLength
-
-      def leading_or_trailing_whitespace_keys
-        self.locales.each_with_object([]) do |locale, result|
-          data[locale].key_values.each_with_object(result) do |key_value, result|
-            key, value = key_value
-            next if ALLOWED_LEADING_OR_TRAILING_SPACE_KEYS.include?(key)
-
-            leading_or_trailing_whitespace =
-              if value.is_a?(String)
-                leading_or_trailing_whitespace?(value)
-              elsif value.is_a?(Array)
-                value.compact.any? { |x| leading_or_trailing_whitespace?(x) }
-              end
-
-            if leading_or_trailing_whitespace
-              result << "#{locale}.#{key}"
-            end
-
-            result
-          end
-        end
-      end
-
-      def leading_or_trailing_whitespace?(value)
-        value.match?(/\A\s|\s\z/)
-      end
-
-      def untranslated_keys
-        data[base_locale].key_values.each_with_object([]) do |key_value, result|
-          key, value = key_value
-
-          result << key if untranslated_key?(key, value)
-          result
-        end
-      end
-
-      def untranslated_key?(key, base_locale_value)
-        locales = self.locales - [base_locale]
-        locales.any? do |current_locale|
-          node = data[current_locale].first.children[key]
-          next unless node&.value&.is_a?(String)
-          next if node.value.empty?
-          next unless node.value == base_locale_value
-          true unless allowed_untranslated_key?(current_locale, key)
-        end
-      end
-
-      def allowed_untranslated_key?(locale, key)
-        ALLOWED_UNTRANSLATED_KEYS.any? do |entry|
-          next if entry[:key].is_a?(Regexp) && !key.match?(entry[:key])
-          next if entry[:key].is_a?(String) && key != entry[:key]
-
-          if !entry.key?(:locales) || entry[:locales].include?(locale.to_sym)
-            entry[:used] = true
-
-            true
-          end
-        end
-      end
-    end
-  end
-end
-
 i18n = I18n::Tasks::BaseTask.new
 missing_keys = i18n.missing_keys
-unused_keys = i18n.unused_keys
+unused_keys  = i18n.unused_keys
 untranslated_keys = i18n.untranslated_keys
 leading_or_trailing_whitespace_keys = i18n.leading_or_trailing_whitespace_keys
 
@@ -151,7 +14,7 @@ RSpec.describe 'I18n' do
     mismatched_punctuation_pairs = {}
     i18n.locales.each do |locale|
       i18n.data[locale].key_values.each do |key, value|
-        PUNCTUATION_PAIRS.each do |item1, item2|
+        I18n::PUNCTUATION_PAIRS.each do |item1, item2|
           Array(value).each do |value|
             next if value.nil?
             if value.count(item1) != value.count(item2)
@@ -226,7 +89,7 @@ RSpec.describe 'I18n' do
 
       next if interpolation_arguments.blank?
       next if interpolation_arguments.values.uniq.length == 1
-      if ALLOWED_INTERPOLATION_MISMATCH_KEYS.include?(key)
+      if I18n::ALLOWED_INTERPOLATION_MISMATCH_KEYS.include?(key)
         missing_interpolation_argument_keys.push(key)
         next
       end
@@ -246,7 +109,7 @@ RSpec.describe 'I18n' do
     end
 
     unallowed_interpolation_mismatch_locale_keys =
-      missing_interpolation_argument_locale_keys - ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS
+      missing_interpolation_argument_locale_keys - I18n::ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS
 
     expect(unallowed_interpolation_mismatch_locale_keys).to(
       be_empty,
@@ -257,7 +120,7 @@ RSpec.describe 'I18n' do
     )
 
     unused_allowed_interpolation_mismatch_keys =
-      ALLOWED_INTERPOLATION_MISMATCH_KEYS - missing_interpolation_argument_keys
+      I18n::ALLOWED_INTERPOLATION_MISMATCH_KEYS - missing_interpolation_argument_keys
     expect(unused_allowed_interpolation_mismatch_keys).to(
       be_empty,
       <<~EOS,
@@ -268,7 +131,7 @@ RSpec.describe 'I18n' do
     )
 
     unused_allowed_interpolation_mismatch_locale_keys =
-      ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS - missing_interpolation_argument_locale_keys
+      I18n::ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS - missing_interpolation_argument_locale_keys
     expect(unused_allowed_interpolation_mismatch_locale_keys).to(
       be_empty,
       <<~EOS,
@@ -367,16 +230,16 @@ RSpec.describe 'I18n' do
 
       it 'does not contain content from another language' do
         flattened_yaml_data.each do |_key, value|
-          other_locales = LOCALE_SPECIFIC_CONTENT.keys - [locale]
+          other_locales = I18n::LOCALE_SPECIFIC_CONTENT.keys - [locale]
           expect(value).not_to match(
-            Regexp.union(*LOCALE_SPECIFIC_CONTENT.slice(*other_locales).values),
+            Regexp.union(*I18n::LOCALE_SPECIFIC_CONTENT.slice(*other_locales).values),
           )
         end
       end
 
-      it 'does not contain common misspellings', if: COMMONLY_MISSPELLED_WORDS.key?(locale) do
+      it 'does not contain common misspellings', if: I18n::COMMONLY_MISSPELLED_WORDS.key?(locale) do
         flattened_yaml_data.each do |_key, value|
-          expect(value).not_to match(COMMONLY_MISSPELLED_WORDS[locale])
+          expect(value).not_to match(I18n::COMMONLY_MISSPELLED_WORDS[locale])
         end
       end
     end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -140,15 +140,13 @@ module I18n
   end
 end
 
-RSpec.describe 'I18n' do
-  let(:i18n) { I18n::Tasks::BaseTask.new }
-  let(:missing_keys) { i18n.missing_keys }
-  let(:unused_keys) { i18n.unused_keys }
-  let(:untranslated_keys) { i18n.untranslated_keys }
-  let(:leading_or_trailing_whitespace_keys) do
-    i18n.leading_or_trailing_whitespace_keys
-  end
+i18n = I18n::Tasks::BaseTask.new
+missing_keys = i18n.missing_keys
+unused_keys = i18n.unused_keys
+untranslated_keys = i18n.untranslated_keys
+leading_or_trailing_whitespace_keys = i18n.leading_or_trailing_whitespace_keys
 
+RSpec.describe 'I18n' do
   it 'has matching pairs of punctuation' do
     mismatched_punctuation_pairs = {}
     i18n.locales.each do |locale|

--- a/spec/support/i18n_helper.rb
+++ b/spec/support/i18n_helper.rb
@@ -10,4 +10,139 @@ module I18n
       end,
     )
   end
+
+  # List of keys allowed to contain different interpolation arguments across locales
+  ALLOWED_INTERPOLATION_MISMATCH_KEYS = [
+    'time.formats.event_timestamp_js',
+  ].freeze
+
+  ALLOWED_LEADING_OR_TRAILING_SPACE_KEYS = [
+    'datetime.dotiw.last_word_connector',
+    'datetime.dotiw.two_words_connector',
+    'datetime.dotiw.words_connector',
+  ].sort.freeze
+
+  # These are keys with mismatch interpolation for specific locales
+  ALLOWED_INTERPOLATION_MISMATCH_LOCALE_KEYS = [].freeze
+
+  PUNCTUATION_PAIRS = {
+    '{' => '}',
+    '[' => ']',
+    '(' => ')',
+    '<' => '>',
+    '（' => '）',
+    '“' => '”',
+  }.freeze
+
+  # A set of patterns which are expected to only occur within specific locales. This is an imperfect
+  # solution based on current content, intended to help prevent accidents when adding new translated
+  # content. If you are having issues with new content, it would be reasonable to remove or modify
+  # the parts of the pattern which are valid for the content you're adding.
+  LOCALE_SPECIFIC_CONTENT = {
+    fr: / [nd]’|à/i,
+    es: /¿|ó/,
+  }.freeze
+
+  # Regex patterns for commonly misspelled words by locale. Match on word boundaries ignoring case.
+  # The current design should be adequate for a small number of words in each language.
+  # If we encounter false positives we should come up with a scheme to ignore those cases.
+  # Add additional words using the regex union operator '|'.
+  COMMONLY_MISSPELLED_WORDS = {
+    en: /\b(cancelled|occured|seperated?)\b/i,
+  }.freeze
+
+  module Tasks
+    class BaseTask
+      # List of keys allowed to be untranslated or are the same as English
+      # rubocop:disable Layout/LineLength
+      ALLOWED_UNTRANSLATED_KEYS = [
+        { key: 'i18n.locale.en', locales: %i[es fr zh] },
+        { key: 'i18n.locale.es', locales: %i[es fr zh] },
+        { key: 'i18n.locale.fr', locales: %i[es fr zh] },
+        { key: 'i18n.locale.zh', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.en', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.es', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.fr', locales: %i[es fr zh] },
+        { key: 'account.email_language.name.zh', locales: %i[es fr zh] },
+        { key: 'account.navigation.menu', locales: %i[fr] }, # "Menu" is "Menu" in French
+        { key: /^countries/ }, # Some countries have the same name across languages
+        { key: 'date.formats.long', locales: %i[es zh] },
+        { key: 'date.formats.short', locales: %i[es zh] },
+        { key: 'datetime.dotiw.minutes.one' }, # "minute is minute" in French and English
+        { key: 'datetime.dotiw.minutes.other' }, # "minute is minute" in French and English
+        { key: 'datetime.dotiw.words_connector' }, # " , " is only punctuation and not translated
+        { key: 'in_person_proofing.process.eipp_bring_id.image_alt_text', locales: %i[fr es zh] }, # Real ID is considered a proper noun in this context, ID translated to ID Card in Chinese
+        { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
+        { key: 'saml_idp.auth.error.title', locales: %i[es] }, # "Error" is "Error" in Spanish
+        { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
+        { key: 'telephony.format_length.six', locales: %i[zh] }, # numeral is not translated
+        { key: 'telephony.format_length.ten', locales: %i[zh] }, # numeral is not translated
+        { key: 'time.formats.event_date', locales: %i[es zh] },
+        { key: 'time.formats.event_time', locales: %i[es zh] },
+        { key: 'time.formats.event_timestamp', locales: %i[zh] },
+        { key: 'time.formats.full_date', locales: %i[es] }, # format is the same in Spanish and English
+        { key: 'time.formats.sms_date' }, # for us date format
+      ].freeze
+      # rubocop:enable Layout/LineLength
+
+      def leading_or_trailing_whitespace_keys
+        self.locales.each_with_object([]) do |locale, result|
+          data[locale].key_values.each_with_object(result) do |key_value, result|
+            key, value = key_value
+            next if ALLOWED_LEADING_OR_TRAILING_SPACE_KEYS.include?(key)
+
+            leading_or_trailing_whitespace =
+              if value.is_a?(String)
+                leading_or_trailing_whitespace?(value)
+              elsif value.is_a?(Array)
+                value.compact.any? { |x| leading_or_trailing_whitespace?(x) }
+              end
+
+            if leading_or_trailing_whitespace
+              result << "#{locale}.#{key}"
+            end
+
+            result
+          end
+        end
+      end
+
+      def leading_or_trailing_whitespace?(value)
+        value.match?(/\A\s|\s\z/)
+      end
+
+      def untranslated_keys
+        data[base_locale].key_values.each_with_object([]) do |key_value, result|
+          key, value = key_value
+
+          result << key if untranslated_key?(key, value)
+          result
+        end
+      end
+
+      def untranslated_key?(key, base_locale_value)
+        locales = self.locales - [base_locale]
+        locales.any? do |current_locale|
+          node = data[current_locale].first.children[key]
+          next unless node&.value&.is_a?(String)
+          next if node.value.empty?
+          next unless node.value == base_locale_value
+          true unless allowed_untranslated_key?(current_locale, key)
+        end
+      end
+
+      def allowed_untranslated_key?(locale, key)
+        ALLOWED_UNTRANSLATED_KEYS.any? do |entry|
+          next if entry[:key].is_a?(Regexp) && !key.match?(entry[:key])
+          next if entry[:key].is_a?(String) && key != entry[:key]
+
+          if !entry.key?(:locales) || entry[:locales].include?(locale.to_sym)
+            entry[:used] = true
+
+            true
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

This was prompted by an internal discussion

## 🛠 Summary of changes

### This should not be merged yet. I have not yet checked if it invalidates any of the tests

Locally this change appears to be a 90% speed improvement. I suspect there's probably also a more Rspec-idiomatic way to write this then throwing some barewords in the middle of the file

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots

rbspy flamegraphs on an M3 Mac running `bundle exec rspec ./spec/i18n_spec.rb `

before:
![2024-07-26-ok4CqFPK4Y flamegraph](https://github.com/user-attachments/assets/848afc3e-8040-49a6-b2a4-af544902af32)

after:

![2024-07-26-RSAEsiJRsq flamegraph](https://github.com/user-attachments/assets/6e67ef24-0c54-4f50-9c64-a58c30362660)
