### PR TITLE
Add biometric acr_values for OIDC protocol

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -169,7 +169,7 @@ class SamlIdpController < ApplicationController
 
   def requested_ial
     requested_ial_acr = FederatedProtocols::Saml.new(saml_request).ial
-    requested_ial_component = Vot::LegacyComponentValues.by_name[requested_ial_acr]
+    requested_ial_component = Vot::AcrComponentValues.by_name[requested_ial_acr]
     return 'ialmax' if requested_ial_component&.requirements&.include?(:ialmax)
 
     saml_request&.requested_ial_authn_context || 'none'

--- a/app/models/federated_protocols/saml.rb
+++ b/app/models/federated_protocols/saml.rb
@@ -81,7 +81,7 @@ module FederatedProtocols
     def ialmax_requested_with_authn_context_comparison?
       return unless (current_service_provider&.ial || 1) > 1
 
-      acr_component_value = Vot::LegacyComponentValues.by_name[request.requested_ial_authn_context]
+      acr_component_value = Vot::AcrComponentValues.by_name[request.requested_ial_authn_context]
       return unless acr_component_value.present?
 
       !acr_component_value.requirements.include?(:identity_proofing) &&

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -46,7 +46,7 @@ class OpenidConnectUserInfoPresenter
     if resolved_authn_context_result.biometric_comparison?
       Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
     elsif resolved_authn_context_result.identity_proofing? ||
-      resolved_authn_context_result.ialmax?
+          resolved_authn_context_result.ialmax?
       Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
     else
       Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -24,11 +24,7 @@ class OpenidConnectUserInfoPresenter
     info.merge!(x509_attributes) if scoper.x509_scopes_requested?
     info[:verified_at] = verified_at if scoper.verified_at_requested?
     if identity.vtr.nil?
-      info[:ial] = if identity_proofing_requested_for_verified_user?
-                     Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
-                   else
-                     Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-                   end
+      info[:ial] = asserted_ial_value
       info[:aal] = identity.requested_aal_value
     else
       info[:vot] = vot_values
@@ -43,6 +39,19 @@ class OpenidConnectUserInfoPresenter
   end
 
   private
+
+  def asserted_ial_value
+    return Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF unless active_profile.present?
+
+    if resolved_authn_context_result.biometric_comparison?
+      Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
+    elsif resolved_authn_context_result.identity_proofing? ||
+      resolved_authn_context_result.ialmax?
+      Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+    else
+      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+    end
+  end
 
   def vot_values
     AuthnContextResolver.new(

--- a/app/presenters/saml_requested_attributes_presenter.rb
+++ b/app/presenters/saml_requested_attributes_presenter.rb
@@ -43,14 +43,14 @@ class SamlRequestedAttributesPresenter
     if vtr.present?
       parsed_vectors_of_trust.any? { |vot_result| vot_result.identity_proofing? }
     else
-      Vot::LegacyComponentValues.by_name[ial]&.requirements&.include?(
+      Vot::AcrComponentValues.by_name[ial]&.requirements&.include?(
         :identity_proofing,
       )
     end
   end
 
   def ialmax_requested?
-    Vot::LegacyComponentValues.by_name[ial]&.requirements&.include?(:ialmax)
+    Vot::AcrComponentValues.by_name[ial]&.requirements&.include?(:ialmax)
   end
 
   def parsed_vectors_of_trust

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -88,7 +88,7 @@ class AuthnContextResolver
     return result unless result.biometric_comparison?
 
     return result if user&.identity_verified_with_biometric_comparison? ||
-      biometric_is_required?(result)
+                     biometric_is_required?(result)
 
     if user&.identity_verified?
       result.with(biometric_comparison?: false, two_pieces_of_fair_evidence?: false)

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -87,7 +87,8 @@ class AuthnContextResolver
   def decorate_acr_result_with_user_context(result)
     return result unless result.biometric_comparison?
 
-    return result if user&.identity_verified_with_biometric_comparison?
+    return result if user&.identity_verified_with_biometric_comparison? ||
+      result.component_values.map(&:name).include?(Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF)
 
     if user&.identity_verified?
       result.with(biometric_comparison?: false, two_pieces_of_fair_evidence?: false)

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -88,7 +88,7 @@ class AuthnContextResolver
     return result unless result.biometric_comparison?
 
     return result if user&.identity_verified_with_biometric_comparison? ||
-      result.component_values.map(&:name).include?(Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF)
+      biometric_is_required?(result)
 
     if user&.identity_verified?
       result.with(biometric_comparison?: false, two_pieces_of_fair_evidence?: false)
@@ -118,5 +118,12 @@ class AuthnContextResolver
     acr_result_without_sp_defaults.component_values.filter do |component_value|
       component_value.name.include?('ial') || component_value.name.include?('loa')
     end
+  end
+
+  def biometric_is_required?(result)
+    result.
+      component_values.
+      map(&:name).
+      include?(Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF)
   end
 end

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -67,9 +67,9 @@ class IdTokenBuilder
     if resolved_authn_context_result.ialmax?
       determine_ial_max_acr.name
     elsif resolved_authn_context_result.identity_proofing?
-      Vot::LegacyComponentValues::IAL2.name
+      Vot::AcrComponentValues::IAL2.name
     else
-      Vot::LegacyComponentValues::IAL1.name
+      Vot::AcrComponentValues::IAL1.name
     end
   end
 
@@ -85,9 +85,9 @@ class IdTokenBuilder
 
   def determine_ial_max_acr
     if identity.user.identity_verified?
-      Vot::LegacyComponentValues::IAL2
+      Vot::AcrComponentValues::IAL2
     else
-      Vot::LegacyComponentValues::IAL1
+      Vot::AcrComponentValues::IAL1
     end
   end
 

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -64,7 +64,9 @@ class IdTokenBuilder
   def acr
     return nil unless identity.acr_values.present?
 
-    if resolved_authn_context_result.ialmax?
+    if resolved_authn_context_result.biometric_comparison?
+      Vot::AcrComponentValues::IAL2_BIO_REQUIRED.name
+    elsif resolved_authn_context_result.ialmax?
       determine_ial_max_acr.name
     elsif resolved_authn_context_result.identity_proofing?
       Vot::AcrComponentValues::IAL2.name

--- a/app/services/vot/acr_component_values.rb
+++ b/app/services/vot/acr_component_values.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Vot
-  module LegacyComponentValues
+  module AcrComponentValues
     ## Identity proofing ACR values
     LOA1 = ComponentValue.new(
       name: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
@@ -26,6 +26,21 @@ module Vot
       description: 'Legacy IAL2',
       implied_component_values: [],
       requirements: [:aal2, :identity_proofing],
+    ).freeze
+    IAL2_BIO_REQUIRED = ComponentValue.new(
+      name: Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF,
+      description: 'IAL2 - require identity proofing with biometric comparison (NIST SP 800-63-3)',
+      implied_component_values: [],
+      requirements: [:aal2, :identity_proofing, :biometric_comparison,
+                     :two_pieces_of_fair_evidence],
+    ).freeze
+    IAL2_BIO_PREFERRED = ComponentValue.new(
+      name: Saml::Idp::Constants::IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF,
+      description:
+        'IAL2 - use identity proofing with biometric comparison if completed (NIST SP 800-63-3)',
+      implied_component_values: [],
+      requirements: [:aal2, :identity_proofing, :biometric_comparison,
+                     :two_pieces_of_fair_evidence],
     ).freeze
     IALMAX = ComponentValue.new(
       name: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,

--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -6,6 +6,7 @@ module Vot
 
     Result = Data.define(
       :component_values,
+      :component_separator,
       :aal2?,
       :phishing_resistant?,
       :hspd12?,
@@ -18,6 +19,7 @@ module Vot
       def self.no_sp_result
         self.new(
           component_values: [],
+          component_separator: ' ',
           aal2?: false,
           phishing_resistant?: false,
           hspd12?: false,
@@ -34,7 +36,7 @@ module Vot
       end
 
       def expanded_component_values
-        component_values.map(&:name).join('.')
+        component_values.map(&:name).join(component_separator)
       end
     end.freeze
 
@@ -56,6 +58,7 @@ module Vot
       requirement_list = expanded_components.flat_map(&:requirements)
       Result.new(
         component_values: expanded_components,
+        component_separator:,
         aal2?: requirement_list.include?(:aal2),
         phishing_resistant?: requirement_list.include?(:phishing_resistant),
         hspd12?: requirement_list.include?(:hspd12),
@@ -92,7 +95,7 @@ module Vot
       if vector_of_trust.present?
         SupportedComponentValues.by_name
       else
-        LegacyComponentValues.by_name
+        AcrComponentValues.by_name
       end
     end
 

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -47,6 +47,8 @@ module Saml
         LOA3_AUTHN_CONTEXT_CLASSREF => ::Idp::Constants::IAL2,
         IAL1_AUTHN_CONTEXT_CLASSREF => ::Idp::Constants::IAL1,
         IAL2_AUTHN_CONTEXT_CLASSREF => ::Idp::Constants::IAL2,
+        IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF => ::Idp::Constants::IAL2,
+        IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF => ::Idp::Constants::IAL2,
         IALMAX_AUTHN_CONTEXT_CLASSREF => ::Idp::Constants::IAL_MAX,
       }.freeze
 

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe SignUp::EmailConfirmationsController do
         get :create, params: {
           confirmation_token:,
           _request_id: request_id_param,
-          acr_values: Vot::LegacyComponentValues::IAL1,
+          acr_values: Vot::AcrComponentValues::IAL1,
         }
       end
 

--- a/spec/policies/service_provider_mfa_policy_spec.rb
+++ b/spec/policies/service_provider_mfa_policy_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ServiceProviderMfaPolicy do
   let(:resolved_authn_context_result) do
     Vot::Parser::Result.new(
       component_values: [],
+      component_separator: ' ',
       aal2?: aal2,
       hspd12?: hspd12,
       phishing_resistant?: phishing_resistant,

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -183,6 +183,49 @@ RSpec.describe OpenidConnectUserInfoPresenter do
             expect(user_info[:social_security_number]).to eq('666661234')
           end
         end
+
+        context 'with biometric comparison' do
+          let(:acr_values) do
+            [
+              Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+              Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF,
+            ].join(' ')
+          end
+
+          it 'includes the correct non-proofed attributes' do
+            aggregate_failures do
+              expect(user_info[:sub]).to eq(identity.uuid)
+              expect(user_info[:iss]).to eq(root_url)
+              expect(user_info[:email]).to eq(identity.user.email_addresses.first.email)
+              expect(user_info[:email_verified]).to eq(true)
+              expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
+              expect(user_info[:ial]).to eq(
+                Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
+              )
+              expect(user_info[:aal]).to eq(Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF)
+              expect(user_info).to_not have_key(:vot)
+            end
+          end
+
+          it 'includes the proofed attributes' do
+            aggregate_failures do
+              expect(user_info[:given_name]).to eq('John')
+              expect(user_info[:family_name]).to eq('Smith')
+              expect(user_info[:birthdate]).to eq('1970-12-31')
+              expect(user_info[:phone]).to eq('+17035555555')
+              expect(user_info[:phone_verified]).to eq(true)
+              expect(user_info[:address]).to eq(
+                formatted: "123 Fake St\nApt 456\nWashington, DC 12345",
+                street_address: "123 Fake St\nApt 456",
+                locality: 'Washington',
+                region: 'DC',
+                postal_code: '12345',
+              )
+              expect(user_info[:verified_at]).to eq(profile.verified_at.to_i)
+              expect(user_info[:social_security_number]).to eq('666661234')
+            end
+          end
+        end
       end
 
       context 'IALMax' do

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
               expect(user_info[:email_verified]).to eq(true)
               expect(user_info[:all_emails]).to eq([identity.user.email_addresses.first.email])
               expect(user_info[:ial]).to eq(
-                Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
+                Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF,
               )
               expect(user_info[:aal]).to eq(Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF)
               expect(user_info).to_not have_key(:vot)

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -257,7 +257,9 @@ RSpec.describe Analytics do
     end
 
     context 'IAL2 with biometric' do
-      let(:session) { { sp: { acr_values: Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF } } }
+      let(:session) do
+        { sp: { acr_values: Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF } }
+      end
       let(:expected_attributes) do
         {
           sp_request: {

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -148,8 +148,8 @@ RSpec.describe AuthnContextResolver do
     end
   end
 
-  context 'when users uses an acr_values param' do
-    context 'no service provider' do
+  context 'when resolving acr_values' do
+    context 'with no service provider' do
       it 'parses an ACR value into requirements' do
         acr_values = [
           'http://idmanagement.gov/ns/assurance/aal/2',
@@ -218,7 +218,7 @@ RSpec.describe AuthnContextResolver do
       end
     end
 
-    context 'AAL2 service provider' do
+    context 'with an AAL2 service provider' do
       it 'uses the AAL ACR if one is present' do
         service_provider = build(:service_provider, default_aal: 2)
 
@@ -291,42 +291,112 @@ RSpec.describe AuthnContextResolver do
       end
     end
 
-    context 'IAL2 service provider' do
-      it 'uses the IAL ACR if one is present' do
-        service_provider = build(:service_provider, ial: 2)
-
-        acr_values = [
-          'http://idmanagement.gov/ns/assurance/aal/1',
-          'http://idmanagement.gov/ns/assurance/ial/1',
-        ].join(' ')
-
-        result = AuthnContextResolver.new(
+    context 'with an IAL2 service provider' do
+      let(:service_provider) { build(:service_provider, ial: 2) }
+      subject do
+        AuthnContextResolver.new(
           user: user,
           service_provider: service_provider,
           vtr: nil,
           acr_values: acr_values,
-        ).resolve
+        )
+      end
+      let(:result) { subject.resolve }
 
-        expect(result.identity_proofing?).to eq(false)
-        expect(result.aal2?).to eq(false)
+      context 'if IAL ACR value is present' do
+        let(:acr_values) do
+          [
+            'http://idmanagement.gov/ns/assurance/ial/1',
+            'http://idmanagement.gov/ns/assurance/aal/1',
+          ].join(' ')
+        end
+
+        it 'uses the IAL ACR if one is present' do
+          expect(result.identity_proofing?).to be false
+          expect(result.aal2?).to be false
+        end
       end
 
-      it 'uses the defaul IAL if no IAL ACR is present' do
-        service_provider = build(:service_provider, ial: 2)
+      context 'if multiple IAL ACR values are present' do
+        let(:acr_values) do
+          [
+            'http://idmanagement.gov/ns/assurance/ial/1',
+            'http://idmanagement.gov/ns/assurance/ial/2',
+            'http://idmanagement.gov/ns/assurance/aal/1',
+          ].join(' ')
+        end
 
-        acr_values = [
-          'http://idmanagement.gov/ns/assurance/aal/1',
-        ].join(' ')
+        it 'uses the highest IAL ACR if one is present' do
+          expect(result.identity_proofing?).to be true
+          expect(result.aal2?).to be true
+        end
+      end
 
-        result = AuthnContextResolver.new(
-          user: user,
-          service_provider: service_provider,
-          vtr: nil,
-          acr_values: acr_values,
-        ).resolve
+      context 'if No IAL ACR is present' do
+        let(:acr_values) do
+          [
+            'http://idmanagement.gov/ns/assurance/aal/1',
+          ].join(' ')
+        end
 
-        expect(result.identity_proofing?).to eq(true)
-        expect(result.aal2?).to eq(true)
+        it 'uses the defaul IAL' do
+          expect(result.identity_proofing?).to be true
+          expect(result.aal2?).to be true
+        end
+      end
+
+      context 'if requesting biometric comparison' do
+        let(:bio_value) { 'required' }
+        let(:acr_values) do
+          [
+            "http://idmanagement.gov/ns/assurance/ial/2?bio=#{bio_value}",
+            'http://idmanagement.gov/ns/assurance/aal/1',
+          ].join(' ')
+        end
+
+        context 'with biometric comparison is required' do
+          it 'sets biometric_comparison to true' do
+            expect(result.identity_proofing?).to be true
+            expect(result.biometric_comparison?).to be true
+            expect(result.aal2?).to be true
+            expect(result.two_pieces_of_fair_evidence?).to be true
+          end
+        end
+
+        context 'with biometric comparison is preferred' do
+          let(:bio_value) { 'preferred' }
+
+          context 'when the user is already verified' do
+            context 'without biometric comparison' do
+              let(:user) { build(:user, :proofed) }
+
+              it 'falls back on proofing without biometric comparison' do
+                expect(result.identity_proofing?).to be true
+                expect(result.biometric_comparison?).to be false
+                expect(result.aal2?).to be true
+              end
+            end
+
+            context 'with biometric comparison' do
+              let(:user) { build(:user, :proofed_with_selfie) }
+
+              it 'asserts biometric comparison' do
+                expect(result.identity_proofing?).to be true
+                expect(result.biometric_comparison?).to be true
+                expect(result.aal2?).to be true
+              end
+            end
+          end
+
+          context 'when the user has not yet been verified' do
+            let(:user) { build(:user) }
+            it 'asserts biometric comparison' do
+              expect(result.identity_proofing?).to be true
+              expect(result.biometric_comparison?).to be true
+              expect(result.aal2?).to be true
+            end
+          end
+        end
       end
     end
   end

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -355,11 +355,37 @@ RSpec.describe AuthnContextResolver do
         end
 
         context 'with biometric comparison is required' do
-          it 'sets biometric_comparison to true' do
-            expect(result.identity_proofing?).to be true
-            expect(result.biometric_comparison?).to be true
-            expect(result.aal2?).to be true
-            expect(result.two_pieces_of_fair_evidence?).to be true
+          context 'when user is not verified' do
+            it 'sets biometric_comparison to true' do
+              expect(result.identity_proofing?).to be true
+              expect(result.biometric_comparison?).to be true
+              expect(result.aal2?).to be true
+              expect(result.two_pieces_of_fair_evidence?).to be true
+            end
+          end
+
+          context 'when the user is already verified' do
+            context 'without biometric comparison' do
+              let(:user) { build(:user, :proofed) }
+
+              it 'asserts biometric_comparison as true' do
+                expect(result.identity_proofing?).to be true
+                expect(result.biometric_comparison?).to be true
+                expect(result.aal2?).to be true
+                expect(result.two_pieces_of_fair_evidence?).to be true
+              end
+            end
+
+            context 'with biometric comparison' do
+              let(:user) { build(:user, :proofed_with_selfie) }
+
+              it 'asserts biometric comparison' do
+                expect(result.identity_proofing?).to be true
+                expect(result.biometric_comparison?).to be true
+                expect(result.two_pieces_of_fair_evidence?).to be true
+                expect(result.aal2?).to be true
+              end
+            end
           end
         end
 
@@ -373,6 +399,7 @@ RSpec.describe AuthnContextResolver do
               it 'falls back on proofing without biometric comparison' do
                 expect(result.identity_proofing?).to be true
                 expect(result.biometric_comparison?).to be false
+                expect(result.two_pieces_of_fair_evidence?).to be false
                 expect(result.aal2?).to be true
               end
             end

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -115,7 +115,9 @@ RSpec.describe IdTokenBuilder do
         end
 
         it 'sets the acr to the ial2 constant' do
-          expect(decoded_payload[:acr]).to eq(Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF)
+          expect(decoded_payload[:acr]).to eq(
+            Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF,
+          )
         end
       end
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -108,6 +108,17 @@ RSpec.describe IdTokenBuilder do
         end
       end
 
+      context 'ial2 with biometric comparison required' do
+        before do
+          identity.ial = 2
+          identity.acr_values = Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
+        end
+
+        it 'sets the acr to the ial2 constant' do
+          expect(decoded_payload[:acr]).to eq(Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF)
+        end
+      end
+
       context 'ial1 request' do
         before do
           identity.ial = 1


### PR DESCRIPTION
## 🎫 Ticket
https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/43

This change builds off the changes in https://github.com/18F/identity-idp/pull/10948

## 🛠 Summary of changes
This is the initial work to replace our public-facing Vectors of Trust (VOT) API interface(s) with acr_values. This work is focused on the OIDC implementation; we will follow up with whatever changes we need to make for SAML in the next week.

This change:

- Maintains the current VoT implementation and API for current SPs
- Adds support for selecting proofing with biometric comparison using new Authentication Context Class Reference values (ACR values) in our OIDC API
- Does not change other ACR implementations

## 📜 Testing Plan
Acceptance testing detailed [here](https://docs.google.com/document/d/1_TJBdEiErT460qoJh-jiw9E3mlPCffguMn28--4LJK8/edit)
Release plan details [here](https://docs.google.com/document/d/1BNDWm9IeyYl9adRga2Tv-5pRNewOg74zfEHUi6mEAsk/edit#heading=h.9zotfk2fxoh6)

