### PR TITLE
Assert logged events using have_logged_event (simple cases)

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -138,6 +138,7 @@ module AnalyticsEvents
 
   # @identity.idp.previous_event_name Account Reset
   # @param [Boolean] success
+  # @param [Hash] errors Errors resulting from form validation
   # @param [Boolean] sms_phone does the user have a phone factor configured?
   # @param [Boolean] totp does the user have an authentication app as a 2FA option?
   # @param [Boolean] piv_cac does the user have PIV/CAC as a 2FA option?
@@ -147,6 +148,7 @@ module AnalyticsEvents
   # An account reset has been requested
   def account_reset_request(
     success:,
+    errors:,
     sms_phone:,
     totp:,
     piv_cac:,
@@ -159,6 +161,7 @@ module AnalyticsEvents
       'Account Reset: request',
       {
         success: success,
+        errors:,
         sms_phone: sms_phone,
         totp: totp,
         piv_cac: piv_cac,
@@ -190,13 +193,15 @@ module AnalyticsEvents
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+  # @param [String] domain_name Domain name of email address submitted
   # Tracks request for adding new emails to an account
-  def add_email_request(success:, errors:, error_details: nil, **extra)
+  def add_email_request(success:, errors:, domain_name:, error_details: nil, **extra)
     track_event(
       'Add Email Requested',
       success:,
       errors:,
       error_details:,
+      domain_name:,
       **extra,
     )
   end

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AccountReset::CancelController, allowed_extra_analytics: [:*] do
         request_id: 'fake-message-request-id',
       }
 
-      expect(@analytics).to receive(:track_event).with('Account Reset: cancel', analytics_hash)
+      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
 
       post :create
     end
@@ -35,7 +35,7 @@ RSpec.describe AccountReset::CancelController, allowed_extra_analytics: [:*] do
         user_id: 'anonymous-uuid',
       }
 
-      expect(@analytics).to receive(:track_event).with('Account Reset: cancel', analytics_hash)
+      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
       session[:cancel_token] = 'FOO'
 
       post :create
@@ -50,7 +50,7 @@ RSpec.describe AccountReset::CancelController, allowed_extra_analytics: [:*] do
         user_id: 'anonymous-uuid',
       }
 
-      expect(@analytics).to receive(:track_event).with('Account Reset: cancel', analytics_hash)
+      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
 
       post :create
     end
@@ -94,8 +94,7 @@ RSpec.describe AccountReset::CancelController, allowed_extra_analytics: [:*] do
           token: { cancel_token_invalid: true },
         },
       }
-      expect(@analytics).to receive(:track_event).
-        with('Account Reset: cancel token validation', properties)
+      expect(@analytics).to have_logged_event('Account Reset: cancel token validation', properties)
 
       get :show, params: { token: 'FOO' }
 

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe AccountReset::CancelController, allowed_extra_analytics: [:*] do
         request_id: 'fake-message-request-id',
       }
 
-      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
-
       post :create
+
+      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
     end
 
     it 'logs a bad token to the analytics' do
@@ -35,10 +35,11 @@ RSpec.describe AccountReset::CancelController, allowed_extra_analytics: [:*] do
         user_id: 'anonymous-uuid',
       }
 
-      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
       session[:cancel_token] = 'FOO'
 
       post :create
+
+      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
     end
 
     it 'logs a missing token to the analytics' do
@@ -94,10 +95,10 @@ RSpec.describe AccountReset::CancelController, allowed_extra_analytics: [:*] do
           token: { cancel_token_invalid: true },
         },
       }
-      expect(@analytics).to have_logged_event('Account Reset: cancel token validation', properties)
 
       get :show, params: { token: 'FOO' }
 
+      expect(@analytics).to have_logged_event('Account Reset: cancel token validation', properties)
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq t('errors.account_reset.cancel_token_invalid', app_name: APP_NAME)
     end

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe AccountReset::CancelController, allowed_extra_analytics: [:*] do
         user_id: 'anonymous-uuid',
       }
 
-      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
-
       post :create
+
+      expect(@analytics).to have_logged_event('Account Reset: cancel', analytics_hash)
     end
 
     it 'redirects to the root without a flash message when the token is missing or invalid' do

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -32,11 +32,10 @@ RSpec.describe AccountReset::DeleteAccountController do
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       }
-      expect(@analytics).
-        to have_logged_event('Account Reset: delete', properties)
 
       delete :delete
 
+      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
       expect(response).to redirect_to account_reset_confirm_delete_account_url
     end
 
@@ -52,10 +51,10 @@ RSpec.describe AccountReset::DeleteAccountController do
         account_age_in_days: 0,
         account_confirmed_at: kind_of(Time),
       }
-      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
 
       delete :delete
 
+      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq(invalid_token_message)
     end
@@ -71,10 +70,10 @@ RSpec.describe AccountReset::DeleteAccountController do
         account_age_in_days: 0,
         account_confirmed_at: kind_of(Time),
       }
-      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
 
       delete :delete
 
+      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq t(
         'errors.account_reset.granted_token_missing',
@@ -97,13 +96,13 @@ RSpec.describe AccountReset::DeleteAccountController do
         account_age_in_days: 2,
         account_confirmed_at: kind_of(Time),
       }
-      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
 
       travel_to(Time.zone.now + 2.days) do
         session[:granted_token] = AccountResetRequest.first.granted_token
         delete :delete
       end
 
+      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq(
         t('errors.account_reset.granted_token_expired', app_name: APP_NAME),
@@ -119,10 +118,10 @@ RSpec.describe AccountReset::DeleteAccountController do
         errors: invalid_token_error,
         error_details: { token: { granted_token_invalid: true } },
       }
-      expect(@analytics).to have_logged_event('Account Reset: granted token validation', properties)
 
       get :show, params: { token: 'FOO' }
 
+      expect(@analytics).to have_logged_event('Account Reset: granted token validation', properties)
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq(invalid_token_message)
     end
@@ -138,12 +137,12 @@ RSpec.describe AccountReset::DeleteAccountController do
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
         error_details: { token: { granted_token_expired: true } },
       }
-      expect(@analytics).to have_logged_event('Account Reset: granted token validation', properties)
 
       travel_to(Time.zone.now + 2.days) do
         get :show, params: { token: AccountResetRequest.first.granted_token }
       end
 
+      expect(@analytics).to have_logged_event('Account Reset: granted token validation', properties)
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq(
         t('errors.account_reset.granted_token_expired', app_name: APP_NAME),

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         account_confirmed_at: user.confirmed_at,
       }
       expect(@analytics).
-        to receive(:track_event).with('Account Reset: delete', properties)
+        to have_logged_event('Account Reset: delete', properties)
 
       delete :delete
 
@@ -52,7 +52,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         account_age_in_days: 0,
         account_confirmed_at: kind_of(Time),
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset: delete', properties)
+      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
 
       delete :delete
 
@@ -71,7 +71,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         account_age_in_days: 0,
         account_confirmed_at: kind_of(Time),
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset: delete', properties)
+      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
 
       delete :delete
 
@@ -97,7 +97,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         account_age_in_days: 2,
         account_confirmed_at: kind_of(Time),
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset: delete', properties)
+      expect(@analytics).to have_logged_event('Account Reset: delete', properties)
 
       travel_to(Time.zone.now + 2.days) do
         session[:granted_token] = AccountResetRequest.first.granted_token
@@ -119,8 +119,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         errors: invalid_token_error,
         error_details: { token: { granted_token_invalid: true } },
       }
-      expect(@analytics).to receive(:track_event).
-        with('Account Reset: granted token validation', properties)
+      expect(@analytics).to have_logged_event('Account Reset: granted token validation', properties)
 
       get :show, params: { token: 'FOO' }
 
@@ -139,8 +138,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
         error_details: { token: { granted_token_expired: true } },
       }
-      expect(@analytics).to receive(:track_event).
-        with('Account Reset: granted token validation', properties)
+      expect(@analytics).to have_logged_event('Account Reset: granted token validation', properties)
 
       travel_to(Time.zone.now + 2.days) do
         get :show, params: { token: AccountResetRequest.first.granted_token }

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe AccountReset::DeleteAccountController do
           webauthn: 2,
           phone: 2,
         },
-        pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       }
@@ -47,7 +46,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         errors: invalid_token_error,
         error_details: { token: { granted_token_invalid: true } },
         mfa_method_counts: {},
-        pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
         account_confirmed_at: kind_of(Time),
       }
@@ -66,7 +64,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         errors: { token: [t('errors.account_reset.granted_token_missing', app_name: APP_NAME)] },
         error_details: { token: { blank: true } },
         mfa_method_counts: {},
-        pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 0,
         account_confirmed_at: kind_of(Time),
       }
@@ -92,7 +89,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         errors: { token: [t('errors.account_reset.granted_token_expired', app_name: APP_NAME)] },
         error_details: { token: { granted_token_expired: true } },
         mfa_method_counts: {},
-        pii_like_keypaths: [[:mfa_method_counts, :phone]],
         account_age_in_days: 2,
         account_confirmed_at: kind_of(Time),
       }

--- a/spec/controllers/account_reset/recovery_options_controller_spec.rb
+++ b/spec/controllers/account_reset/recovery_options_controller_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe AccountReset::RecoveryOptionsController do
       stub_sign_in_before_2fa(user)
       stub_analytics
 
-      expect(@analytics).to have_logged_event('Account Reset: Recovery Options Visited')
-
       get :show
+
+      expect(@analytics).to have_logged_event('Account Reset: Recovery Options Visited')
     end
   end
 
@@ -40,9 +40,9 @@ RSpec.describe AccountReset::RecoveryOptionsController do
       stub_sign_in_before_2fa(user)
       stub_analytics
 
-      expect(@analytics).to have_logged_event('Account Reset: Cancel Account Recovery Options')
-
       post :cancel
+
+      expect(@analytics).to have_logged_event('Account Reset: Cancel Account Recovery Options')
     end
   end
 end

--- a/spec/controllers/account_reset/recovery_options_controller_spec.rb
+++ b/spec/controllers/account_reset/recovery_options_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AccountReset::RecoveryOptionsController do
       stub_sign_in_before_2fa(user)
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with('Account Reset: Recovery Options Visited')
+      expect(@analytics).to have_logged_event('Account Reset: Recovery Options Visited')
 
       get :show
     end
@@ -40,8 +40,7 @@ RSpec.describe AccountReset::RecoveryOptionsController do
       stub_sign_in_before_2fa(user)
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).
-        with('Account Reset: Cancel Account Recovery Options')
+      expect(@analytics).to have_logged_event('Account Reset: Cancel Account Recovery Options')
 
       post :cancel
     end

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe AccountReset::RequestController do
       stub_sign_in_before_2fa(user)
       stub_analytics
 
-      expect(@analytics).to have_logged_event('Account deletion and reset visited')
-
       get :show
+
+      expect(@analytics).to have_logged_event('Account deletion and reset visited')
     end
 
     context 'non-fraud user' do
@@ -106,9 +106,10 @@ RSpec.describe AccountReset::RequestController do
         email_addresses: 1,
         errors: {},
       }
-      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
 
       post :create
+
+      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
     end
 
     it 'logs sms user in the analytics' do
@@ -126,9 +127,10 @@ RSpec.describe AccountReset::RequestController do
         message_id: 'fake-message-id',
         errors: {},
       }
-      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
 
       post :create
+
+      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
     end
 
     it 'logs PIV/CAC user in the analytics' do
@@ -144,9 +146,10 @@ RSpec.describe AccountReset::RequestController do
         email_addresses: 1,
         errors: {},
       }
-      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
 
       post :create
+
+      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
     end
 
     it 'redirects to root if user not signed in' do

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AccountReset::RequestController do
       stub_sign_in_before_2fa(user)
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with('Account deletion and reset visited')
+      expect(@analytics).to have_logged_event('Account deletion and reset visited')
 
       get :show
     end
@@ -106,7 +106,7 @@ RSpec.describe AccountReset::RequestController do
         email_addresses: 1,
         errors: {},
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset: request', attributes)
+      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
 
       post :create
     end
@@ -126,7 +126,7 @@ RSpec.describe AccountReset::RequestController do
         message_id: 'fake-message-id',
         errors: {},
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset: request', attributes)
+      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
 
       post :create
     end
@@ -144,7 +144,7 @@ RSpec.describe AccountReset::RequestController do
         email_addresses: 1,
         errors: {},
       }
-      expect(@analytics).to receive(:track_event).with('Account Reset: request', attributes)
+      expect(@analytics).to have_logged_event('Account Reset: request', attributes)
 
       post :create
     end

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Accounts::PersonalKeysController, allowed_extra_analytics: [:*] d
       stub_sign_in(create(:user, :with_phone))
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with('Profile: Visited new personal key')
+      expect(@analytics).to have_logged_event('Profile: Visited new personal key')
 
       get :new
     end
@@ -32,8 +32,8 @@ RSpec.describe Accounts::PersonalKeysController, allowed_extra_analytics: [:*] d
         with(subject.current_user).and_return(generator)
 
       expect(generator).to receive(:create)
-      expect(@analytics).to receive(:track_event).with('Profile: Created new personal key')
-      expect(@analytics).to receive(:track_event).with(
+      expect(@analytics).to have_logged_event('Profile: Created new personal key')
+      expect(@analytics).to have_logged_event(
         'Profile: Created new personal key notifications',
         hash_including(emails: 1, sms_message_ids: ['fake-message-id']),
       )
@@ -53,8 +53,7 @@ RSpec.describe Accounts::PersonalKeysController, allowed_extra_analytics: [:*] d
       }
       allow(controller).to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
 
-      expect(@analytics).to receive(:track_event).
-        with('Invalid Authenticity Token', analytics_hash)
+      expect(@analytics).to have_logged_event('Invalid Authenticity Token', analytics_hash)
 
       post :create
 

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Accounts::PersonalKeysController, allowed_extra_analytics: [:*] d
       stub_sign_in(create(:user, :with_phone))
       stub_analytics
 
-      expect(@analytics).to have_logged_event('Profile: Visited new personal key')
-
       get :new
+
+      expect(@analytics).to have_logged_event('Profile: Visited new personal key')
     end
   end
 
@@ -32,14 +32,14 @@ RSpec.describe Accounts::PersonalKeysController, allowed_extra_analytics: [:*] d
         with(subject.current_user).and_return(generator)
 
       expect(generator).to receive(:create)
+
+      post :create
+
       expect(@analytics).to have_logged_event('Profile: Created new personal key')
       expect(@analytics).to have_logged_event(
         'Profile: Created new personal key notifications',
         hash_including(emails: 1, sms_message_ids: ['fake-message-id']),
       )
-
-      post :create
-
       expect(response).to redirect_to manage_personal_key_path
       expect(flash[:info]).to eq(t('account.personal_key.old_key_will_not_work'))
     end
@@ -53,10 +53,9 @@ RSpec.describe Accounts::PersonalKeysController, allowed_extra_analytics: [:*] d
       }
       allow(controller).to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
 
-      expect(@analytics).to have_logged_event('Invalid Authenticity Token', analytics_hash)
-
       post :create
 
+      expect(@analytics).to have_logged_event('Invalid Authenticity Token', analytics_hash)
       expect(response).to redirect_to new_user_session_url
       expect(flash[:error]).to eq t('errors.general')
     end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe AccountsController do
 
         sign_in user
 
-        expect(@analytics).to receive(:track_event).with('Account Page Visited')
+        expect(@analytics).to have_logged_event('Account Page Visited')
 
         get :show
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -73,10 +73,9 @@ RSpec.describe AccountsController do
 
         sign_in user
 
-        expect(@analytics).to have_logged_event('Account Page Visited')
-
         get :show
 
+        expect(@analytics).to have_logged_event('Account Page Visited')
         expect(response).to_not be_redirect
       end
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -93,8 +93,7 @@ RSpec.describe ApplicationController do
 
       stub_analytics
       event_properties = { controller: 'anonymous#index', user_signed_in: true }
-      expect(@analytics).to receive(:track_event).
-        with('Invalid Authenticity Token', event_properties)
+      expect(@analytics).to have_logged_event('Invalid Authenticity Token', event_properties)
 
       get :index
 
@@ -149,8 +148,7 @@ RSpec.describe ApplicationController do
 
       stub_analytics
       event_properties = { controller: 'anonymous#index', user_signed_in: true, referer: referer }
-      expect(@analytics).to receive(:track_event).
-        with('Unsafe Redirect', event_properties)
+      expect(@analytics).to have_logged_event('Unsafe Redirect', event_properties)
 
       get :index
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -93,10 +93,10 @@ RSpec.describe ApplicationController do
 
       stub_analytics
       event_properties = { controller: 'anonymous#index', user_signed_in: true }
-      expect(@analytics).to have_logged_event('Invalid Authenticity Token', event_properties)
 
       get :index
 
+      expect(@analytics).to have_logged_event('Invalid Authenticity Token', event_properties)
       expect(flash[:error]).to eq t('errors.general')
       expect(response).to redirect_to(root_url)
       expect(subject.current_user).to be_present
@@ -148,10 +148,10 @@ RSpec.describe ApplicationController do
 
       stub_analytics
       event_properties = { controller: 'anonymous#index', user_signed_in: true, referer: referer }
-      expect(@analytics).to have_logged_event('Unsafe Redirect', event_properties)
 
       get :index
 
+      expect(@analytics).to have_logged_event('Unsafe Redirect', event_properties)
       expect(flash[:error]).to eq t('errors.general')
       expect(response).to redirect_to(root_url)
       expect(subject.current_user).to be_present

--- a/spec/controllers/concerns/reauthentication_required_concern_spec.rb
+++ b/spec/controllers/concerns/reauthentication_required_concern_spec.rb
@@ -62,12 +62,14 @@ RSpec.describe ReauthenticationRequiredConcern, type: :controller do
 
       it 'records analytics' do
         stub_analytics
+
+        get :index
+
         expect(@analytics).to have_logged_event(
           'User 2FA Reauthentication Required',
           authenticated_at: travel_time.ago,
           auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,
         )
-        get :index
       end
     end
   end

--- a/spec/controllers/concerns/reauthentication_required_concern_spec.rb
+++ b/spec/controllers/concerns/reauthentication_required_concern_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ReauthenticationRequiredConcern, type: :controller do
 
       it 'records analytics' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'User 2FA Reauthentication Required',
           authenticated_at: travel_time.ago,
           auth_method: TwoFactorAuthenticatable::AuthMethod::TOTP,

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EventDisavowalController do
   let(:disavowal_token) { 'asdf1234' }
-  let(:event) do
+  let!(:event) do
     create(
       :event,
       disavowal_token_fingerprint: Pii::Fingerprinter.fingerprint(disavowal_token),

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -16,22 +16,21 @@ RSpec.describe EventDisavowalController do
   describe '#new' do
     context 'with a valid disavowal_token' do
       it 'tracks an analytics event' do
+        get :new, params: { disavowal_token: disavowal_token }
+
         expect(@analytics).to have_logged_event(
           'Event disavowal visited',
           build_analytics_hash,
         )
-
-        get :new, params: { disavowal_token: disavowal_token }
       end
 
       it 'assigns forbidden passwords' do
+        get :new, params: { disavowal_token: disavowal_token }
+
         expect(@analytics).to have_logged_event(
           'Event disavowal visited',
           build_analytics_hash,
         )
-
-        get :new, params: { disavowal_token: disavowal_token }
-
         expect(assigns(:forbidden_passwords)).to all(be_a(String))
       end
     end
@@ -40,6 +39,8 @@ RSpec.describe EventDisavowalController do
       it 'tracks an analytics event' do
         event.update!(disavowed_at: Time.zone.now)
 
+        get :new, params: { disavowal_token: disavowal_token }
+
         expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
@@ -47,13 +48,13 @@ RSpec.describe EventDisavowalController do
             errors: { event: [t('event_disavowals.errors.event_already_disavowed')] },
           ),
         )
-
-        get :new, params: { disavowal_token: disavowal_token }
       end
 
       it 'does not assign forbidden passwords' do
         event.update!(disavowed_at: Time.zone.now)
 
+        get :new, params: { disavowal_token: disavowal_token }
+
         expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
@@ -61,9 +62,6 @@ RSpec.describe EventDisavowalController do
             errors: { event: [t('event_disavowals.errors.event_already_disavowed')] },
           ),
         )
-
-        get :new, params: { disavowal_token: disavowal_token }
-
         expect(assigns(:forbidden_passwords)).to be_nil
       end
     end
@@ -72,20 +70,27 @@ RSpec.describe EventDisavowalController do
   describe '#create' do
     context 'with a valid password' do
       it 'tracks an analytics event' do
-        expect(@analytics).to have_logged_event(
-          'Event disavowal password reset',
-          build_analytics_hash,
-        )
-
         post :create, params: {
           disavowal_token: disavowal_token,
           event_disavowal_password_reset_from_disavowal_form: { password: 'salty pickles' },
         }
+
+        expect(@analytics).to have_logged_event(
+          'Event disavowal password reset',
+          build_analytics_hash,
+        )
       end
     end
 
     context 'with an invalid password' do
       it 'tracks an analytics event' do
+        params = {
+          disavowal_token: disavowal_token,
+          event_disavowal_password_reset_from_disavowal_form: { password: 'too short' },
+        }
+
+        post :create, params: params
+
         expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
           build_analytics_hash(
@@ -99,16 +104,16 @@ RSpec.describe EventDisavowalController do
             },
           ),
         )
+      end
 
+      it 'assigns forbidden passwords' do
         params = {
           disavowal_token: disavowal_token,
           event_disavowal_password_reset_from_disavowal_form: { password: 'too short' },
         }
 
         post :create, params: params
-      end
 
-      it 'assigns forbidden passwords' do
         expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
           build_analytics_hash(
@@ -116,14 +121,6 @@ RSpec.describe EventDisavowalController do
             errors: { password: ['Password must be at least 12 characters long'] },
           ),
         )
-
-        params = {
-          disavowal_token: disavowal_token,
-          event_disavowal_password_reset_from_disavowal_form: { password: 'too short' },
-        }
-
-        post :create, params: params
-
         expect(assigns(:forbidden_passwords)).to all(be_a(String))
       end
     end
@@ -132,6 +129,13 @@ RSpec.describe EventDisavowalController do
       it 'tracks an analytics event' do
         event.update!(disavowed_at: Time.zone.now)
 
+        params = {
+          disavowal_token: disavowal_token,
+          event_disavowal_password_reset_from_disavowal_form: { password: 'salty pickles' },
+        }
+
+        post :create, params: params
+
         expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
@@ -139,13 +143,6 @@ RSpec.describe EventDisavowalController do
             errors: { event: [t('event_disavowals.errors.event_already_disavowed')] },
           ),
         )
-
-        params = {
-          disavowal_token: disavowal_token,
-          event_disavowal_password_reset_from_disavowal_form: { password: 'salty pickles' },
-        }
-
-        post :create, params: params
       end
     end
 
@@ -155,6 +152,11 @@ RSpec.describe EventDisavowalController do
       end
 
       it 'errors' do
+        post :create, params: {
+          disavowal_token: disavowal_token,
+          event_disavowal_password_reset_from_disavowal_form: { password: 'salty pickles' },
+        }
+
         expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
@@ -164,11 +166,6 @@ RSpec.describe EventDisavowalController do
             },
           ),
         )
-
-        post :create, params: {
-          disavowal_token: disavowal_token,
-          event_disavowal_password_reset_from_disavowal_form: { password: 'salty pickles' },
-        }
       end
     end
   end

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe EventDisavowalController do
   describe '#new' do
     context 'with a valid disavowal_token' do
       it 'tracks an analytics event' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal visited',
           build_analytics_hash,
         )
@@ -25,7 +25,7 @@ RSpec.describe EventDisavowalController do
       end
 
       it 'assigns forbidden passwords' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal visited',
           build_analytics_hash,
         )
@@ -40,7 +40,7 @@ RSpec.describe EventDisavowalController do
       it 'tracks an analytics event' do
         event.update!(disavowed_at: Time.zone.now)
 
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
             success: false,
@@ -54,7 +54,7 @@ RSpec.describe EventDisavowalController do
       it 'does not assign forbidden passwords' do
         event.update!(disavowed_at: Time.zone.now)
 
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
             success: false,
@@ -72,7 +72,7 @@ RSpec.describe EventDisavowalController do
   describe '#create' do
     context 'with a valid password' do
       it 'tracks an analytics event' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
           build_analytics_hash,
         )
@@ -86,7 +86,7 @@ RSpec.describe EventDisavowalController do
 
     context 'with an invalid password' do
       it 'tracks an analytics event' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
           build_analytics_hash(
             success: false,
@@ -109,7 +109,7 @@ RSpec.describe EventDisavowalController do
       end
 
       it 'assigns forbidden passwords' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
           build_analytics_hash(
             success: false,
@@ -132,7 +132,7 @@ RSpec.describe EventDisavowalController do
       it 'tracks an analytics event' do
         event.update!(disavowed_at: Time.zone.now)
 
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
             success: false,
@@ -155,7 +155,7 @@ RSpec.describe EventDisavowalController do
       end
 
       it 'errors' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
             success: false,

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -177,6 +177,8 @@ RSpec.describe FrontendLogController do
         end
 
         it 'logs the analytics event' do
+          action
+
           expect(fake_analytics).to have_logged_event(
             'IdV: Native camera forced after failed attempts',
             field: field,
@@ -184,9 +186,6 @@ RSpec.describe FrontendLogController do
             failed_submission_attempts: failed_submission_attempts,
             flow_path: flow_path,
           )
-
-          action
-
           expect(response).to have_http_status(:ok)
           expect(json[:success]).to eq(true)
         end

--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe FrontendLogController do
         end
 
         it 'logs the analytics event' do
-          expect(fake_analytics).to receive(:track_event).with(
+          expect(fake_analytics).to have_logged_event(
             'IdV: Native camera forced after failed attempts',
             field: field,
             failed_capture_attempts: failed_capture_attempts,

--- a/spec/controllers/idv/by_mail/enter_code_rate_limited_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_rate_limited_controller_spec.rb
@@ -19,14 +19,13 @@ RSpec.describe Idv::ByMail::EnterCodeRateLimitedController do
 
   describe '#index' do
     it 'renders the rate limited page' do
-      expect(@analytics).to have_logged_event(
-        'Rate Limit Reached',
-        limiter_type: :verify_gpo_key,
-      ).once
-
       get :index
 
       expect(response).to render_template :index
+      expect(@analytics).to have_logged_event(
+        'Rate Limit Reached',
+        limiter_type: :verify_gpo_key,
+      )
     end
   end
 end

--- a/spec/controllers/idv/by_mail/enter_code_rate_limited_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_rate_limited_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Idv::ByMail::EnterCodeRateLimitedController do
 
   describe '#index' do
     it 'renders the rate limited page' do
-      expect(@analytics).to receive(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'Rate Limit Reached',
         limiter_type: :verify_gpo_key,
       ).once

--- a/spec/controllers/idv/not_verified_controller_spec.rb
+++ b/spec/controllers/idv/not_verified_controller_spec.rb
@@ -10,12 +10,11 @@ RSpec.describe Idv::NotVerifiedController do
   it 'renders the show template' do
     stub_analytics
 
+    get :show
+
     expect(@analytics).to have_logged_event(
       'IdV: Not verified visited',
     )
-
-    get :show
-
     expect(response).to render_template :show
   end
 end

--- a/spec/controllers/idv/not_verified_controller_spec.rb
+++ b/spec/controllers/idv/not_verified_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Idv::NotVerifiedController do
   it 'renders the show template' do
     stub_analytics
 
-    expect(@analytics).to receive(:track_event).with(
+    expect(@analytics).to have_logged_event(
       'IdV: Not verified visited',
     )
 

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event' do
+        get action
+
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(type: action.to_s),
-        ).once
-        get action
+        )
       end
 
       context 'fetch() request from form-steps-wait JS' do
@@ -44,11 +45,12 @@ RSpec.describe Idv::SessionErrorsController do
         expect(response).to redirect_to(idv_phone_url)
       end
       it 'does not log an event' do
+        get action
+
         expect(@analytics).not_to have_logged_event(
           'IdV: session error visited',
           hash_including(type: action.to_s),
         )
-        get action
       end
     end
   end
@@ -64,11 +66,12 @@ RSpec.describe Idv::SessionErrorsController do
         expect(response).to render_template(template)
       end
       it 'logs an event' do
+        get action
+
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(type: action.to_s),
-        ).once
-        get action
+        )
       end
 
       context 'fetch() request from form-steps-wait JS' do
@@ -81,8 +84,9 @@ RSpec.describe Idv::SessionErrorsController do
           expect(response).to have_http_status(204)
         end
         it 'does not log an event' do
-          expect(@analytics).not_to have_logged_event('IdV: session error visited', anything)
           get action
+
+          expect(@analytics).not_to have_logged_event('IdV: session error visited', anything)
         end
       end
     end
@@ -94,11 +98,12 @@ RSpec.describe Idv::SessionErrorsController do
         expect(response).to redirect_to(new_user_session_url)
       end
       it 'does not log an event' do
+        get action
+
         expect(@analytics).not_to have_logged_event(
           'IdV: session error visited',
           hash_including(type: action.to_s),
         )
-        get action
       end
     end
 
@@ -179,6 +184,8 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event with attempts remaining' do
+        response
+
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(
@@ -186,7 +193,6 @@ RSpec.describe Idv::SessionErrorsController do
             submit_attempts_remaining: IdentityConfig.store.idv_max_attempts - 1,
           ),
         )
-        response
       end
 
       context 'in in-person proofing flow' do
@@ -259,6 +265,8 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event with attempts remaining' do
+        get action
+
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(
@@ -266,7 +274,6 @@ RSpec.describe Idv::SessionErrorsController do
             submit_attempts_remaining: 0,
           ),
         )
-        get action
       end
     end
   end
@@ -300,6 +307,8 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event with attempts remaining' do
+        get action
+
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(
@@ -307,7 +316,6 @@ RSpec.describe Idv::SessionErrorsController do
             submit_attempts_remaining: 0,
           ),
         )
-        get action
       end
     end
   end
@@ -333,6 +341,8 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event with attempts remaining' do
+        get action
+
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(
@@ -340,8 +350,6 @@ RSpec.describe Idv::SessionErrorsController do
             submit_attempts_remaining: 0,
           ),
         )
-
-        get action
       end
     end
   end

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(type: action.to_s),
         ).once
@@ -28,8 +28,7 @@ RSpec.describe Idv::SessionErrorsController do
           expect(response).to have_http_status(204)
         end
         it 'does not log an event' do
-          expect(@analytics).not_to receive(:track_event).
-            with('IdV: session error visited', anything)
+          expect(@analytics).not_to have_logged_event('IdV: session error visited', anything)
           get action
         end
       end
@@ -45,7 +44,7 @@ RSpec.describe Idv::SessionErrorsController do
         expect(response).to redirect_to(idv_phone_url)
       end
       it 'does not log an event' do
-        expect(@analytics).not_to receive(:track_event).with(
+        expect(@analytics).not_to have_logged_event(
           'IdV: session error visited',
           hash_including(type: action.to_s),
         )
@@ -65,7 +64,7 @@ RSpec.describe Idv::SessionErrorsController do
         expect(response).to render_template(template)
       end
       it 'logs an event' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(type: action.to_s),
         ).once
@@ -82,8 +81,7 @@ RSpec.describe Idv::SessionErrorsController do
           expect(response).to have_http_status(204)
         end
         it 'does not log an event' do
-          expect(@analytics).not_to receive(:track_event).
-            with('IdV: session error visited', anything)
+          expect(@analytics).not_to have_logged_event('IdV: session error visited', anything)
           get action
         end
       end
@@ -96,7 +94,7 @@ RSpec.describe Idv::SessionErrorsController do
         expect(response).to redirect_to(new_user_session_url)
       end
       it 'does not log an event' do
-        expect(@analytics).not_to receive(:track_event).with(
+        expect(@analytics).not_to have_logged_event(
           'IdV: session error visited',
           hash_including(type: action.to_s),
         )
@@ -181,7 +179,7 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event with attempts remaining' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(
             type: action.to_s,
@@ -261,7 +259,7 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event with attempts remaining' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(
             type: action.to_s,
@@ -302,7 +300,7 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event with attempts remaining' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(
             type: 'ssn_failure',
@@ -335,7 +333,7 @@ RSpec.describe Idv::SessionErrorsController do
       end
 
       it 'logs an event with attempts remaining' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'IdV: session error visited',
           hash_including(
             type: action.to_s,

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -149,6 +149,9 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'tracks events' do
             stub_analytics
+
+            action
+
             expect(@analytics).to have_logged_event(
               'OIDC Logout Requested',
               hash_including(
@@ -173,8 +176,6 @@ RSpec.describe OpenidConnect::LogoutController do
                 oidc: true,
               ),
             )
-
-            action
           end
         end
 
@@ -213,8 +214,6 @@ RSpec.describe OpenidConnect::LogoutController do
                 saml_request_valid: nil,
               ),
             )
-
-            action
           end
         end
 
@@ -223,6 +222,8 @@ RSpec.describe OpenidConnect::LogoutController do
           it 'tracks events' do
             stub_analytics
             errors_keys = [:id_token_hint]
+
+            action
 
             expect(@analytics).to have_logged_event(
               'OIDC Logout Requested',
@@ -238,7 +239,6 @@ RSpec.describe OpenidConnect::LogoutController do
                 saml_request_valid: nil,
               ),
             )
-            action
           end
         end
       end
@@ -291,6 +291,9 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'renders logout confirmation page' do
             stub_analytics
+
+            action
+
             expect(@analytics).to have_logged_event(
               'OIDC Logout Requested',
               hash_including(
@@ -315,8 +318,6 @@ RSpec.describe OpenidConnect::LogoutController do
                 oidc: true,
               ),
             )
-
-            action
             expect(response).to render_template(:confirm_logout)
             expect(response.body).to include service_provider.friendly_name
           end
@@ -340,6 +341,8 @@ RSpec.describe OpenidConnect::LogoutController do
           it 'tracks events' do
             stub_analytics
 
+            action
+
             errors = {
               redirect_uri: [t('openid_connect.authorization.errors.redirect_uri_no_match')],
             }
@@ -357,8 +360,6 @@ RSpec.describe OpenidConnect::LogoutController do
                 saml_request_valid: nil,
               ),
             )
-
-            action
           end
         end
       end
@@ -418,6 +419,9 @@ RSpec.describe OpenidConnect::LogoutController do
 
         it 'tracks events' do
           stub_analytics
+
+          action
+
           expect(@analytics).to have_logged_event(
             'OIDC Logout Requested',
             hash_including(
@@ -430,7 +434,6 @@ RSpec.describe OpenidConnect::LogoutController do
               oidc: true,
             ),
           )
-
           expect(@analytics).to have_logged_event(
             'OIDC Logout Page Visited',
             hash_including(
@@ -443,8 +446,6 @@ RSpec.describe OpenidConnect::LogoutController do
               oidc: true,
             ),
           )
-
-          action
         end
       end
 
@@ -466,6 +467,8 @@ RSpec.describe OpenidConnect::LogoutController do
         it 'tracks events' do
           stub_analytics
 
+          action
+
           errors = {
             id_token_hint: [t('openid_connect.logout.errors.id_token_hint_present')],
           }
@@ -483,8 +486,6 @@ RSpec.describe OpenidConnect::LogoutController do
               saml_request_valid: nil,
             ),
           )
-
-          action
         end
       end
 
@@ -506,6 +507,8 @@ RSpec.describe OpenidConnect::LogoutController do
         it 'tracks events' do
           stub_analytics
 
+          action
+
           errors = {
             redirect_uri: [t('openid_connect.authorization.errors.redirect_uri_no_match')],
           }
@@ -523,8 +526,6 @@ RSpec.describe OpenidConnect::LogoutController do
               saml_request_valid: nil,
             ),
           )
-
-          action
         end
       end
     end
@@ -776,6 +777,8 @@ RSpec.describe OpenidConnect::LogoutController do
           it 'tracks events' do
             stub_analytics
 
+            action
+
             expect(@analytics).to have_logged_event(
               'OIDC Logout Submitted',
               success: true,
@@ -802,8 +805,6 @@ RSpec.describe OpenidConnect::LogoutController do
               method: nil,
               saml_request_valid: nil,
             )
-
-            action
           end
         end
 

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -197,6 +197,8 @@ RSpec.describe OpenidConnect::LogoutController do
           it 'tracks events' do
             stub_analytics
 
+            action
+
             errors = {
               redirect_uri: [t('openid_connect.authorization.errors.redirect_uri_no_match')],
             }

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -149,32 +149,30 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'tracks events' do
             stub_analytics
-            expect(@analytics).to receive(:track_event).
-              with(
-                'OIDC Logout Requested',
-                hash_including(
-                  success: true,
-                  client_id: service_provider.issuer,
-                  client_id_parameter_present: false,
-                  id_token_hint_parameter_present: true,
-                  errors: {},
-                  sp_initiated: true,
-                  oidc: true,
-                ),
-              )
-            expect(@analytics).to receive(:track_event).
-              with(
-                'Logout Initiated',
-                hash_including(
-                  success: true,
-                  client_id: service_provider.issuer,
-                  client_id_parameter_present: false,
-                  id_token_hint_parameter_present: true,
-                  errors: {},
-                  sp_initiated: true,
-                  oidc: true,
-                ),
-              )
+            expect(@analytics).to have_logged_event(
+              'OIDC Logout Requested',
+              hash_including(
+                success: true,
+                client_id: service_provider.issuer,
+                client_id_parameter_present: false,
+                id_token_hint_parameter_present: true,
+                errors: {},
+                sp_initiated: true,
+                oidc: true,
+              ),
+            )
+            expect(@analytics).to have_logged_event(
+              'Logout Initiated',
+              hash_including(
+                success: true,
+                client_id: service_provider.issuer,
+                client_id_parameter_present: false,
+                id_token_hint_parameter_present: true,
+                errors: {},
+                sp_initiated: true,
+                oidc: true,
+              ),
+            )
 
             action
           end
@@ -201,21 +199,20 @@ RSpec.describe OpenidConnect::LogoutController do
             errors = {
               redirect_uri: [t('openid_connect.authorization.errors.redirect_uri_no_match')],
             }
-            expect(@analytics).to receive(:track_event).
-              with(
-                'OIDC Logout Requested',
-                hash_including(
-                  success: false,
-                  client_id: service_provider.issuer,
-                  client_id_parameter_present: false,
-                  id_token_hint_parameter_present: true,
-                  errors: errors,
-                  error_details: hash_including(*errors.keys),
-                  sp_initiated: true,
-                  oidc: true,
-                  saml_request_valid: nil,
-                ),
-              )
+            expect(@analytics).to have_logged_event(
+              'OIDC Logout Requested',
+              hash_including(
+                success: false,
+                client_id: service_provider.issuer,
+                client_id_parameter_present: false,
+                id_token_hint_parameter_present: true,
+                errors: errors,
+                error_details: hash_including(*errors.keys),
+                sp_initiated: true,
+                oidc: true,
+                saml_request_valid: nil,
+              ),
+            )
 
             action
           end
@@ -227,21 +224,20 @@ RSpec.describe OpenidConnect::LogoutController do
             stub_analytics
             errors_keys = [:id_token_hint]
 
-            expect(@analytics).to receive(:track_event).
-              with(
-                'OIDC Logout Requested',
-                hash_including(
-                  success: false,
-                  client_id: nil,
-                  client_id_parameter_present: false,
-                  id_token_hint_parameter_present: true,
-                  errors: hash_including(*errors_keys),
-                  error_details: hash_including(*errors_keys),
-                  sp_initiated: true,
-                  oidc: true,
-                  saml_request_valid: nil,
-                ),
-              )
+            expect(@analytics).to have_logged_event(
+              'OIDC Logout Requested',
+              hash_including(
+                success: false,
+                client_id: nil,
+                client_id_parameter_present: false,
+                id_token_hint_parameter_present: true,
+                errors: hash_including(*errors_keys),
+                error_details: hash_including(*errors_keys),
+                sp_initiated: true,
+                oidc: true,
+                saml_request_valid: nil,
+              ),
+            )
             action
           end
         end
@@ -295,32 +291,30 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'renders logout confirmation page' do
             stub_analytics
-            expect(@analytics).to receive(:track_event).
-              with(
-                'OIDC Logout Requested',
-                hash_including(
-                  success: true,
-                  client_id: service_provider.issuer,
-                  client_id_parameter_present: true,
-                  id_token_hint_parameter_present: false,
-                  errors: {},
-                  sp_initiated: true,
-                  oidc: true,
-                ),
-              )
-            expect(@analytics).to receive(:track_event).
-              with(
-                'OIDC Logout Page Visited',
-                hash_including(
-                  success: true,
-                  client_id: service_provider.issuer,
-                  client_id_parameter_present: true,
-                  id_token_hint_parameter_present: false,
-                  errors: {},
-                  sp_initiated: true,
-                  oidc: true,
-                ),
-              )
+            expect(@analytics).to have_logged_event(
+              'OIDC Logout Requested',
+              hash_including(
+                success: true,
+                client_id: service_provider.issuer,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: false,
+                errors: {},
+                sp_initiated: true,
+                oidc: true,
+              ),
+            )
+            expect(@analytics).to have_logged_event(
+              'OIDC Logout Page Visited',
+              hash_including(
+                success: true,
+                client_id: service_provider.issuer,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: false,
+                errors: {},
+                sp_initiated: true,
+                oidc: true,
+              ),
+            )
 
             action
             expect(response).to render_template(:confirm_logout)
@@ -349,21 +343,20 @@ RSpec.describe OpenidConnect::LogoutController do
             errors = {
               redirect_uri: [t('openid_connect.authorization.errors.redirect_uri_no_match')],
             }
-            expect(@analytics).to receive(:track_event).
-              with(
-                'OIDC Logout Requested',
-                hash_including(
-                  success: false,
-                  client_id: service_provider.issuer,
-                  client_id_parameter_present: true,
-                  id_token_hint_parameter_present: false,
-                  errors: errors,
-                  error_details: hash_including(*errors.keys),
-                  sp_initiated: true,
-                  oidc: true,
-                  saml_request_valid: nil,
-                ),
-              )
+            expect(@analytics).to have_logged_event(
+              'OIDC Logout Requested',
+              hash_including(
+                success: false,
+                client_id: service_provider.issuer,
+                client_id_parameter_present: true,
+                id_token_hint_parameter_present: false,
+                errors: errors,
+                error_details: hash_including(*errors.keys),
+                sp_initiated: true,
+                oidc: true,
+                saml_request_valid: nil,
+              ),
+            )
 
             action
           end
@@ -425,33 +418,31 @@ RSpec.describe OpenidConnect::LogoutController do
 
         it 'tracks events' do
           stub_analytics
-          expect(@analytics).to receive(:track_event).
-            with(
-              'OIDC Logout Requested',
-              hash_including(
-                success: true,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: true,
-                id_token_hint_parameter_present: false,
-                errors: {},
-                sp_initiated: true,
-                oidc: true,
-              ),
-            )
+          expect(@analytics).to have_logged_event(
+            'OIDC Logout Requested',
+            hash_including(
+              success: true,
+              client_id: service_provider.issuer,
+              client_id_parameter_present: true,
+              id_token_hint_parameter_present: false,
+              errors: {},
+              sp_initiated: true,
+              oidc: true,
+            ),
+          )
 
-          expect(@analytics).to receive(:track_event).
-            with(
-              'OIDC Logout Page Visited',
-              hash_including(
-                success: true,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: true,
-                id_token_hint_parameter_present: false,
-                errors: {},
-                sp_initiated: true,
-                oidc: true,
-              ),
-            )
+          expect(@analytics).to have_logged_event(
+            'OIDC Logout Page Visited',
+            hash_including(
+              success: true,
+              client_id: service_provider.issuer,
+              client_id_parameter_present: true,
+              id_token_hint_parameter_present: false,
+              errors: {},
+              sp_initiated: true,
+              oidc: true,
+            ),
+          )
 
           action
         end
@@ -478,21 +469,20 @@ RSpec.describe OpenidConnect::LogoutController do
           errors = {
             id_token_hint: [t('openid_connect.logout.errors.id_token_hint_present')],
           }
-          expect(@analytics).to receive(:track_event).
-            with(
-              'OIDC Logout Requested',
-              hash_including(
-                success: false,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: true,
-                id_token_hint_parameter_present: true,
-                errors: errors,
-                error_details: hash_including(*errors.keys),
-                sp_initiated: true,
-                oidc: true,
-                saml_request_valid: nil,
-              ),
-            )
+          expect(@analytics).to have_logged_event(
+            'OIDC Logout Requested',
+            hash_including(
+              success: false,
+              client_id: service_provider.issuer,
+              client_id_parameter_present: true,
+              id_token_hint_parameter_present: true,
+              errors: errors,
+              error_details: hash_including(*errors.keys),
+              sp_initiated: true,
+              oidc: true,
+              saml_request_valid: nil,
+            ),
+          )
 
           action
         end
@@ -519,21 +509,20 @@ RSpec.describe OpenidConnect::LogoutController do
           errors = {
             redirect_uri: [t('openid_connect.authorization.errors.redirect_uri_no_match')],
           }
-          expect(@analytics).to receive(:track_event).
-            with(
-              'OIDC Logout Requested',
-              hash_including(
-                success: false,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: true,
-                id_token_hint_parameter_present: false,
-                errors: errors,
-                error_details: hash_including(*errors.keys),
-                sp_initiated: true,
-                oidc: true,
-                saml_request_valid: nil,
-              ),
-            )
+          expect(@analytics).to have_logged_event(
+            'OIDC Logout Requested',
+            hash_including(
+              success: false,
+              client_id: service_provider.issuer,
+              client_id_parameter_present: true,
+              id_token_hint_parameter_present: false,
+              errors: errors,
+              error_details: hash_including(*errors.keys),
+              sp_initiated: true,
+              oidc: true,
+              saml_request_valid: nil,
+            ),
+          )
 
           action
         end
@@ -787,34 +776,32 @@ RSpec.describe OpenidConnect::LogoutController do
           it 'tracks events' do
             stub_analytics
 
-            expect(@analytics).to receive(:track_event).
-              with(
-                'OIDC Logout Submitted',
-                success: true,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: true,
-                id_token_hint_parameter_present: false,
-                errors: {},
-                error_details: nil,
-                sp_initiated: true,
-                oidc: true,
-                method: nil,
-                saml_request_valid: nil,
-              )
-            expect(@analytics).to receive(:track_event).
-              with(
-                'Logout Initiated',
-                success: true,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: true,
-                id_token_hint_parameter_present: false,
-                errors: {},
-                error_details: nil,
-                sp_initiated: true,
-                oidc: true,
-                method: nil,
-                saml_request_valid: nil,
-              )
+            expect(@analytics).to have_logged_event(
+              'OIDC Logout Submitted',
+              success: true,
+              client_id: service_provider.issuer,
+              client_id_parameter_present: true,
+              id_token_hint_parameter_present: false,
+              errors: {},
+              error_details: nil,
+              sp_initiated: true,
+              oidc: true,
+              method: nil,
+              saml_request_valid: nil,
+            )
+            expect(@analytics).to have_logged_event(
+              'Logout Initiated',
+              success: true,
+              client_id: service_provider.issuer,
+              client_id_parameter_present: true,
+              id_token_hint_parameter_present: false,
+              errors: {},
+              error_details: nil,
+              sp_initiated: true,
+              oidc: true,
+              method: nil,
+              saml_request_valid: nil,
+            )
 
             action
           end

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -52,6 +52,9 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
 
       it 'tracks a successful event in analytics' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'OpenID Connect: token', {
             success: true,
@@ -65,7 +68,6 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
             ial: 1,
           }
         )
-        action
       end
     end
 
@@ -83,6 +85,9 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
 
       it 'tracks an unsuccessful event in analytics' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'OpenID Connect: token', {
             success: false,
@@ -97,8 +102,6 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
             ial: 1,
           }
         )
-
-        action
       end
     end
 

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
 
       it 'tracks a successful event in analytics' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('OpenID Connect: token', {
+        expect(@analytics).to have_logged_event(
+          'OpenID Connect: token', {
             success: true,
             client_id: client_id,
             user_id: user.uuid,
@@ -63,7 +63,8 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
             service_provider_pkce: nil,
             expires_in: 0,
             ial: 1,
-          })
+          }
+        )
         action
       end
     end
@@ -82,8 +83,8 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
 
       it 'tracks an unsuccessful event in analytics' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('OpenID Connect: token', {
+        expect(@analytics).to have_logged_event(
+          'OpenID Connect: token', {
             success: false,
             client_id: client_id,
             user_id: user.uuid,
@@ -94,7 +95,8 @@ RSpec.describe OpenidConnect::TokenController, allowed_extra_analytics: [:*] do
             error_details: hash_including(:grant_type),
             expires_in: nil,
             ial: 1,
-          })
+          }
+        )
 
         action
       end

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -19,13 +19,14 @@ RSpec.describe OpenidConnect::UserInfoController do
 
       it 'tracks analytics' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('OpenID Connect: bearer token authentication',
-               success: false,
-               client_id: nil,
-               ial: nil,
-               errors: hash_including(:access_token),
-               error_details: hash_including(:access_token))
+        expect(@analytics).to have_logged_event(
+          'OpenID Connect: bearer token authentication',
+          success: false,
+          client_id: nil,
+          ial: nil,
+          errors: hash_including(:access_token),
+          error_details: hash_including(:access_token),
+        )
 
         action
       end
@@ -43,13 +44,14 @@ RSpec.describe OpenidConnect::UserInfoController do
 
       it 'tracks analytics' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('OpenID Connect: bearer token authentication',
-               success: false,
-               client_id: nil,
-               ial: nil,
-               errors: hash_including(:access_token),
-               error_details: hash_including(:access_token))
+        expect(@analytics).to have_logged_event(
+          'OpenID Connect: bearer token authentication',
+          success: false,
+          client_id: nil,
+          ial: nil,
+          errors: hash_including(:access_token),
+          error_details: hash_including(:access_token),
+        )
 
         action
       end
@@ -66,13 +68,14 @@ RSpec.describe OpenidConnect::UserInfoController do
 
       it 'tracks analytics' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('OpenID Connect: bearer token authentication',
-               success: false,
-               errors: hash_including(:access_token),
-               client_id: nil,
-               ial: nil,
-               error_details: hash_including(:access_token))
+        expect(@analytics).to have_logged_event(
+          'OpenID Connect: bearer token authentication',
+          success: false,
+          errors: hash_including(:access_token),
+          client_id: nil,
+          ial: nil,
+          error_details: hash_including(:access_token),
+        )
 
         action
       end
@@ -127,7 +130,7 @@ RSpec.describe OpenidConnect::UserInfoController do
 
       it 'tracks analytics' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'OpenID Connect: bearer token authentication',
           success: true,
           client_id: identity.service_provider,

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe OpenidConnect::UserInfoController do
 
       it 'tracks analytics' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'OpenID Connect: bearer token authentication',
           success: false,
@@ -27,8 +30,6 @@ RSpec.describe OpenidConnect::UserInfoController do
           errors: hash_including(:access_token),
           error_details: hash_including(:access_token),
         )
-
-        action
       end
     end
 
@@ -44,6 +45,9 @@ RSpec.describe OpenidConnect::UserInfoController do
 
       it 'tracks analytics' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'OpenID Connect: bearer token authentication',
           success: false,
@@ -52,8 +56,6 @@ RSpec.describe OpenidConnect::UserInfoController do
           errors: hash_including(:access_token),
           error_details: hash_including(:access_token),
         )
-
-        action
       end
     end
 
@@ -68,6 +70,9 @@ RSpec.describe OpenidConnect::UserInfoController do
 
       it 'tracks analytics' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'OpenID Connect: bearer token authentication',
           success: false,
@@ -76,8 +81,6 @@ RSpec.describe OpenidConnect::UserInfoController do
           ial: nil,
           error_details: hash_including(:access_token),
         )
-
-        action
       end
     end
 
@@ -130,6 +133,9 @@ RSpec.describe OpenidConnect::UserInfoController do
 
       it 'tracks analytics' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'OpenID Connect: bearer token authentication',
           success: true,
@@ -138,8 +144,6 @@ RSpec.describe OpenidConnect::UserInfoController do
           errors: {},
           error_details: nil,
         )
-
-        action
       end
 
       it 'only changes the paths visited in session' do

--- a/spec/controllers/reactivate_account_controller_spec.rb
+++ b/spec/controllers/reactivate_account_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ReactivateAccountController do
 
       it 'renders the index template' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with('Reactivate Account Visited')
+        expect(@analytics).to have_logged_event('Reactivate Account Visited')
 
         get :index
 
@@ -41,7 +41,7 @@ RSpec.describe ReactivateAccountController do
 
     it 'redirects user to idv_url' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).with('Reactivate Account Submitted')
+      expect(@analytics).to have_logged_event('Reactivate Account Submitted')
       put :update
 
       expect(subject.user_session[:acknowledge_personal_key]).to be_nil

--- a/spec/controllers/reactivate_account_controller_spec.rb
+++ b/spec/controllers/reactivate_account_controller_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe ReactivateAccountController do
 
       it 'renders the index template' do
         stub_analytics
-        expect(@analytics).to have_logged_event('Reactivate Account Visited')
 
         get :index
 
+        expect(@analytics).to have_logged_event('Reactivate Account Visited')
         expect(subject).to render_template(:index)
       end
     end
@@ -41,9 +41,9 @@ RSpec.describe ReactivateAccountController do
 
     it 'redirects user to idv_url' do
       stub_analytics
-      expect(@analytics).to have_logged_event('Reactivate Account Submitted')
       put :update
 
+      expect(@analytics).to have_logged_event('Reactivate Account Submitted')
       expect(subject.user_session[:acknowledge_personal_key]).to be_nil
       expect(response).to redirect_to idv_url
     end

--- a/spec/controllers/risc/security_events_controller_spec.rb
+++ b/spec/controllers/risc/security_events_controller_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe Risc::SecurityEventsController, allowed_extra_analytics: [:*] do
 
     it 'tracks an successful in analytics' do
       stub_analytics
+
+      action
+
       expect(@analytics).to have_logged_event(
         'RISC: Security event received',
         client_id: service_provider.issuer,
@@ -58,8 +61,6 @@ RSpec.describe Risc::SecurityEventsController, allowed_extra_analytics: [:*] do
         success: true,
         user_id: user.uuid,
       )
-
-      action
     end
 
     context 'with a bad request' do
@@ -79,6 +80,9 @@ RSpec.describe Risc::SecurityEventsController, allowed_extra_analytics: [:*] do
 
       it 'tracks an error event in analytics' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'RISC: Security event received',
           client_id: service_provider.issuer,
@@ -90,8 +94,6 @@ RSpec.describe Risc::SecurityEventsController, allowed_extra_analytics: [:*] do
           success: false,
           user_id: user.uuid,
         )
-
-        action
       end
     end
   end

--- a/spec/controllers/risc/security_events_controller_spec.rb
+++ b/spec/controllers/risc/security_events_controller_spec.rb
@@ -47,16 +47,17 @@ RSpec.describe Risc::SecurityEventsController, allowed_extra_analytics: [:*] do
 
     it 'tracks an successful in analytics' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).
-        with('RISC: Security event received',
-             client_id: service_provider.issuer,
-             event_type: event_type,
-             error_code: nil,
-             errors: {},
-             error_details: nil,
-             jti: jti,
-             success: true,
-             user_id: user.uuid)
+      expect(@analytics).to have_logged_event(
+        'RISC: Security event received',
+        client_id: service_provider.issuer,
+        event_type: event_type,
+        error_code: nil,
+        errors: {},
+        error_details: nil,
+        jti: jti,
+        success: true,
+        user_id: user.uuid,
+      )
 
       action
     end
@@ -78,16 +79,17 @@ RSpec.describe Risc::SecurityEventsController, allowed_extra_analytics: [:*] do
 
       it 'tracks an error event in analytics' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('RISC: Security event received',
-               client_id: service_provider.issuer,
-               event_type: event_type,
-               error_code: SecurityEventForm::ErrorCodes::JWT_AUD,
-               errors: kind_of(Hash),
-               error_details: kind_of(Hash),
-               jti: jti,
-               success: false,
-               user_id: user.uuid)
+        expect(@analytics).to have_logged_event(
+          'RISC: Security event received',
+          client_id: service_provider.issuer,
+          event_type: event_type,
+          error_code: SecurityEventForm::ErrorCodes::JWT_AUD,
+          errors: kind_of(Hash),
+          error_details: kind_of(Hash),
+          jti: jti,
+          success: false,
+          user_id: user.uuid,
+        )
 
         action
       end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SamlIdpController do
       stub_analytics
 
       result = { sp_initiated: false, oidc: false, saml_request_valid: true }
-      expect(@analytics).to receive(:track_event).with('Logout Initiated', hash_including(result))
+      expect(@analytics).to have_logged_event('Logout Initiated', hash_including(result))
 
       delete :logout, params: { path_year: path_year }
     end
@@ -28,7 +28,7 @@ RSpec.describe SamlIdpController do
       stub_analytics
 
       result = { sp_initiated: true, oidc: false, saml_request_valid: true }
-      expect(@analytics).to receive(:track_event).with('Logout Initiated', hash_including(result))
+      expect(@analytics).to have_logged_event('Logout Initiated', hash_including(result))
 
       delete :logout, params: { SAMLRequest: 'foo', path_year: path_year }
     end
@@ -37,7 +37,7 @@ RSpec.describe SamlIdpController do
       stub_analytics
 
       result = { sp_initiated: true, oidc: false, saml_request_valid: false }
-      expect(@analytics).to receive(:track_event).with('Logout Initiated', hash_including(result))
+      expect(@analytics).to have_logged_event('Logout Initiated', hash_including(result))
 
       delete :logout, params: { SAMLRequest: 'foo', path_year: path_year }
     end
@@ -175,7 +175,7 @@ RSpec.describe SamlIdpController do
       stub_analytics
 
       result = { service_provider: nil, saml_request_valid: false }
-      expect(@analytics).to receive(:track_event).with('Remote Logout initiated', result)
+      expect(@analytics).to have_logged_event('Remote Logout initiated', result)
 
       post :remotelogout, params: { SAMLRequest: 'foo', path_year: path_year }
     end
@@ -764,35 +764,35 @@ RSpec.describe SamlIdpController do
 
       it 'tracks IAL2 authentication events' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('SAML Auth Request', {
+        expect(@analytics).to have_logged_event(
+          'SAML Auth Request', {
             authn_context: [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF],
             requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
             service_provider: sp1_issuer,
             force_authn: false,
             user_fully_authenticated: true,
-          })
-        expect(@analytics).to receive(:track_event).
-          with(
-            'SAML Auth',
-            hash_including(
-              success: true,
-              errors: {},
-              error_details: nil,
-              nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-              authn_context: [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF],
-              authn_context_comparison: 'exact',
-              requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-              service_provider: sp1_issuer,
-              endpoint: "/api/saml/auth#{path_year}",
-              idv: false,
-              finish_profile: false,
-              request_signed: true,
-              matching_cert_serial: saml_test_sp_cert_serial,
-              encryption_cert_matches_matching_cert: true,
-            ),
-          )
-        expect(@analytics).to receive(:track_event).with(
+          }
+        )
+        expect(@analytics).to have_logged_event(
+          'SAML Auth',
+          hash_including(
+            success: true,
+            errors: {},
+            error_details: nil,
+            nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+            authn_context: [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF],
+            authn_context_comparison: 'exact',
+            requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+            service_provider: sp1_issuer,
+            endpoint: "/api/saml/auth#{path_year}",
+            idv: false,
+            finish_profile: false,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
+            encryption_cert_matches_matching_cert: true,
+          ),
+        )
+        expect(@analytics).to have_logged_event(
           'SP redirect initiated',
           ial: Idp::Constants::IAL2,
           sign_in_duration_seconds: nil,
@@ -918,35 +918,35 @@ RSpec.describe SamlIdpController do
 
       it 'tracks IAL2 authentication events' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('SAML Auth Request', {
+        expect(@analytics).to have_logged_event(
+          'SAML Auth Request', {
             authn_context: [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF],
             requested_ial: 'ialmax',
             service_provider: sp1_issuer,
             force_authn: false,
             user_fully_authenticated: true,
-          })
-        expect(@analytics).to receive(:track_event).
-          with(
-            'SAML Auth',
-            hash_including(
-              success: true,
-              errors: {},
-              error_details: nil,
-              nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-              authn_context: ['http://idmanagement.gov/ns/assurance/ial/1'],
-              authn_context_comparison: 'minimum',
-              requested_ial: 'ialmax',
-              service_provider: sp1_issuer,
-              endpoint: "/api/saml/auth#{path_year}",
-              idv: false,
-              finish_profile: false,
-              request_signed: true,
-              matching_cert_serial: saml_test_sp_cert_serial,
-              encryption_cert_matches_matching_cert: true,
-            ),
-          )
-        expect(@analytics).to receive(:track_event).with(
+          }
+        )
+        expect(@analytics).to have_logged_event(
+          'SAML Auth',
+          hash_including(
+            success: true,
+            errors: {},
+            error_details: nil,
+            nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+            authn_context: ['http://idmanagement.gov/ns/assurance/ial/1'],
+            authn_context_comparison: 'minimum',
+            requested_ial: 'ialmax',
+            service_provider: sp1_issuer,
+            endpoint: "/api/saml/auth#{path_year}",
+            idv: false,
+            finish_profile: false,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
+            encryption_cert_matches_matching_cert: true,
+          ),
+        )
+        expect(@analytics).to have_logged_event(
           'SP redirect initiated',
           ial: 0,
           sign_in_duration_seconds: nil,
@@ -1168,15 +1168,16 @@ RSpec.describe SamlIdpController do
 
       it 'logs SAML Auth Request' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('SAML Auth Request', {
+        expect(@analytics).to have_logged_event(
+          'SAML Auth Request', {
             authn_context: request_authn_contexts,
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: true,
             user_fully_authenticated: false,
-          })
+          }
+        )
 
         saml_get_auth(saml_settings(overrides: { force_authn: true }))
       end
@@ -1901,15 +1902,16 @@ RSpec.describe SamlIdpController do
 
       it 'logs SAML Auth Request but does not log SAML Auth' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('SAML Auth Request', {
+        expect(@analytics).to have_logged_event(
+          'SAML Auth Request', {
             authn_context: request_authn_contexts,
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
             user_fully_authenticated: false,
-          })
+          }
+        )
 
         saml_get_auth(saml_settings)
       end
@@ -2349,8 +2351,8 @@ RSpec.describe SamlIdpController do
           matching_cert_serial: nil,
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('SAML Auth Request', {
+        expect(@analytics).to have_logged_event(
+          'SAML Auth Request', {
             authn_context: [
               Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
               Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
@@ -2360,9 +2362,9 @@ RSpec.describe SamlIdpController do
             requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
             user_fully_authenticated: true,
-          })
-        expect(@analytics).to receive(:track_event).
-          with('SAML Auth', hash_including(analytics_hash))
+          }
+        )
+        expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
 
         get :auth, params: { path_year: path_year }
       end
@@ -2403,20 +2405,21 @@ RSpec.describe SamlIdpController do
           encryption_cert_matches_matching_cert: true,
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('SAML Auth Request', {
+        expect(@analytics).to have_logged_event(
+          'SAML Auth Request', {
             authn_context: request_authn_contexts,
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
             user_fully_authenticated: true,
-          })
-        expect(@analytics).to receive(:track_event).with(
+          }
+        )
+        expect(@analytics).to have_logged_event(
           'SAML Auth',
           hash_including(analytics_hash),
         )
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'SP redirect initiated',
           ial: 1,
           sign_in_duration_seconds: nil,
@@ -2459,20 +2462,21 @@ RSpec.describe SamlIdpController do
           encryption_cert_matches_matching_cert: true,
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('SAML Auth Request', {
+        expect(@analytics).to have_logged_event(
+          'SAML Auth Request', {
             authn_context: request_authn_contexts,
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
             user_fully_authenticated: true,
-          })
-        expect(@analytics).to receive(:track_event).with(
+          }
+        )
+        expect(@analytics).to have_logged_event(
           'SAML Auth',
           hash_including(analytics_hash),
         )
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'SP redirect initiated',
           ial: 1,
           sign_in_duration_seconds: nil,

--- a/spec/controllers/sign_out_controller_spec.rb
+++ b/spec/controllers/sign_out_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SignOutController do
       allow(controller.decorated_sp_session).to receive(:cancel_link_url).and_return('foo')
 
       expect(@analytics).
-        to receive(:track_event).with('Logout Initiated', hash_including(method: 'cancel link'))
+        to have_logged_event('Logout Initiated', hash_including(method: 'cancel link'))
 
       get :destroy
     end

--- a/spec/controllers/sign_out_controller_spec.rb
+++ b/spec/controllers/sign_out_controller_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe SignOutController do
       stub_analytics
       allow(controller.decorated_sp_session).to receive(:cancel_link_url).and_return('foo')
 
+      get :destroy
+
       expect(@analytics).
         to have_logged_event('Logout Initiated', hash_including(method: 'cancel link'))
-
-      get :destroy
     end
   end
 end

--- a/spec/controllers/sign_up/cancellations_controller_spec.rb
+++ b/spec/controllers/sign_up/cancellations_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SignUp::CancellationsController do
       stub_analytics
       properties = { request_came_from: 'no referer' }
 
-      expect(@analytics).to receive(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'User registration: cancellation visited', properties
       )
 
@@ -20,7 +20,7 @@ RSpec.describe SignUp::CancellationsController do
       request.env['HTTP_REFERER'] = 'http://example.com/'
       properties = { request_came_from: 'users/sessions#new' }
 
-      expect(@analytics).to receive(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'User registration: cancellation visited', properties
       )
 
@@ -110,7 +110,7 @@ RSpec.describe SignUp::CancellationsController do
       stub_analytics
       properties = { request_came_from: 'no referer' }
 
-      expect(@analytics).to receive(:track_event).with('Account Deletion Requested', properties)
+      expect(@analytics).to have_logged_event('Account Deletion Requested', properties)
 
       delete :destroy
     end
@@ -122,7 +122,7 @@ RSpec.describe SignUp::CancellationsController do
       request.env['HTTP_REFERER'] = 'http://example.com/'
       properties = { request_came_from: 'users/sessions#new' }
 
-      expect(@analytics).to receive(:track_event).with('Account Deletion Requested', properties)
+      expect(@analytics).to have_logged_event('Account Deletion Requested', properties)
 
       delete :destroy
     end

--- a/spec/controllers/sign_up/cancellations_controller_spec.rb
+++ b/spec/controllers/sign_up/cancellations_controller_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe SignUp::CancellationsController do
       stub_analytics
       properties = { request_came_from: 'no referer' }
 
-      expect(@analytics).to have_logged_event('Account Deletion Requested', properties)
-
       delete :destroy
+
+      expect(@analytics).to have_logged_event('Account Deletion Requested', properties)
     end
 
     it 'tracks the event in analytics when referer is present' do

--- a/spec/controllers/sign_up/cancellations_controller_spec.rb
+++ b/spec/controllers/sign_up/cancellations_controller_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe SignUp::CancellationsController do
       stub_analytics
       properties = { request_came_from: 'no referer' }
 
+      get :new
+
       expect(@analytics).to have_logged_event(
         'User registration: cancellation visited', properties
       )
-
-      get :new
     end
 
     it 'tracks the event in analytics when referer is present' do
@@ -20,11 +20,11 @@ RSpec.describe SignUp::CancellationsController do
       request.env['HTTP_REFERER'] = 'http://example.com/'
       properties = { request_came_from: 'users/sessions#new' }
 
+      get :new
+
       expect(@analytics).to have_logged_event(
         'User registration: cancellation visited', properties
       )
-
-      get :new
     end
   end
 
@@ -122,17 +122,18 @@ RSpec.describe SignUp::CancellationsController do
       request.env['HTTP_REFERER'] = 'http://example.com/'
       properties = { request_came_from: 'users/sessions#new' }
 
-      expect(@analytics).to have_logged_event('Account Deletion Requested', properties)
-
       delete :destroy
+
+      expect(@analytics).to have_logged_event('Account Deletion Requested', properties)
     end
 
     it 'calls ParseControllerFromReferer' do
       user = create(:user)
-      stub_sign_in_before_2fa(user)
-      expect_any_instance_of(ParseControllerFromReferer).to receive(:call).and_call_original
 
       delete :destroy
+
+      stub_sign_in_before_2fa(user)
+      expect_any_instance_of(ParseControllerFromReferer).to receive(:call).and_call_original
     end
   end
 end

--- a/spec/controllers/sign_up/cancellations_controller_spec.rb
+++ b/spec/controllers/sign_up/cancellations_controller_spec.rb
@@ -130,10 +130,10 @@ RSpec.describe SignUp::CancellationsController do
     it 'calls ParseControllerFromReferer' do
       user = create(:user)
 
-      delete :destroy
-
       stub_sign_in_before_2fa(user)
       expect_any_instance_of(ParseControllerFromReferer).to receive(:call).and_call_original
+
+      delete :destroy
     end
   end
 end

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -16,49 +16,45 @@ RSpec.describe SignUp::EmailConfirmationsController do
     end
 
     it 'tracks nil email confirmation token' do
+      get :create, params: { confirmation_token: nil }
+
       expect(@analytics).to have_logged_event(
         'User Registration: Email Confirmation',
         analytics_token_error_hash,
       )
-
-      get :create, params: { confirmation_token: nil }
-
       expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
       expect(response).to redirect_to sign_up_register_url
     end
 
     it 'tracks blank email confirmation token' do
+      get :create, params: { confirmation_token: '' }
+
       expect(@analytics).to have_logged_event(
         'User Registration: Email Confirmation',
         analytics_token_error_hash,
       )
-
-      get :create, params: { confirmation_token: '' }
-
       expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
       expect(response).to redirect_to sign_up_register_url
     end
 
     it 'tracks confirmation token as a single-quoted empty string' do
+      get :create, params: { confirmation_token: "''" }
+
       expect(@analytics).to have_logged_event(
         'User Registration: Email Confirmation',
         analytics_token_error_hash,
       )
-
-      get :create, params: { confirmation_token: "''" }
-
       expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
       expect(response).to redirect_to sign_up_register_url
     end
 
     it 'tracks confirmation token as a double-quoted empty string' do
+      get :create, params: { confirmation_token: '""' }
+
       expect(@analytics).to have_logged_event(
         'User Registration: Email Confirmation',
         analytics_token_error_hash,
       )
-
-      get :create, params: { confirmation_token: '""' }
-
       expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
       expect(response).to redirect_to sign_up_register_url
     end
@@ -73,12 +69,12 @@ RSpec.describe SignUp::EmailConfirmationsController do
         user_id: email_address.user.uuid,
       }
 
+      get :create, params: { confirmation_token: 'foo' }
+
       expect(@analytics).to have_logged_event(
         'User Registration: Email Confirmation',
         analytics_hash,
       )
-
-      get :create, params: { confirmation_token: 'foo' }
     end
 
     it 'tracks expired token' do
@@ -99,13 +95,12 @@ RSpec.describe SignUp::EmailConfirmationsController do
         user_id: email_address.user.uuid,
       }
 
+      get :create, params: { confirmation_token: 'foo' }
+
       expect(@analytics).to have_logged_event(
         'User Registration: Email Confirmation',
         analytics_hash,
       )
-
-      get :create, params: { confirmation_token: 'foo' }
-
       expect(flash[:error]).to eq t('errors.messages.confirmation_period_expired')
       expect(response).to redirect_to sign_up_register_url
     end
@@ -127,13 +122,12 @@ RSpec.describe SignUp::EmailConfirmationsController do
         user_id: user.uuid,
       }
 
+      get :create, params: { confirmation_token: 'foo' }
+
       expect(@analytics).to have_logged_event(
         'User Registration: Email Confirmation',
         analytics_hash,
       )
-
-      get :create, params: { confirmation_token: 'foo' }
-
       expect(flash[:error]).to eq t('errors.messages.confirmation_period_expired')
       expect(response).to redirect_to sign_up_register_url
     end
@@ -197,12 +191,12 @@ RSpec.describe SignUp::EmailConfirmationsController do
         user_id: user.uuid,
       }
 
+      get :create, params: { confirmation_token: 'foo' }
+
       expect(@analytics).to have_logged_event(
         'User Registration: Email Confirmation',
         analytics_hash,
       )
-
-      get :create, params: { confirmation_token: 'foo' }
     end
   end
 

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe SignUp::EmailConfirmationsController do
     end
 
     it 'tracks nil email confirmation token' do
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Confirmation', analytics_token_error_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Confirmation',
+        analytics_token_error_hash,
+      )
 
       get :create, params: { confirmation_token: nil }
 
@@ -26,8 +28,10 @@ RSpec.describe SignUp::EmailConfirmationsController do
     end
 
     it 'tracks blank email confirmation token' do
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Confirmation', analytics_token_error_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Confirmation',
+        analytics_token_error_hash,
+      )
 
       get :create, params: { confirmation_token: '' }
 
@@ -36,8 +40,10 @@ RSpec.describe SignUp::EmailConfirmationsController do
     end
 
     it 'tracks confirmation token as a single-quoted empty string' do
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Confirmation', analytics_token_error_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Confirmation',
+        analytics_token_error_hash,
+      )
 
       get :create, params: { confirmation_token: "''" }
 
@@ -46,8 +52,10 @@ RSpec.describe SignUp::EmailConfirmationsController do
     end
 
     it 'tracks confirmation token as a double-quoted empty string' do
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Confirmation', analytics_token_error_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Confirmation',
+        analytics_token_error_hash,
+      )
 
       get :create, params: { confirmation_token: '""' }
 
@@ -65,8 +73,10 @@ RSpec.describe SignUp::EmailConfirmationsController do
         user_id: email_address.user.uuid,
       }
 
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Confirmation', analytics_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Confirmation',
+        analytics_hash,
+      )
 
       get :create, params: { confirmation_token: 'foo' }
     end
@@ -89,8 +99,10 @@ RSpec.describe SignUp::EmailConfirmationsController do
         user_id: email_address.user.uuid,
       }
 
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Confirmation', analytics_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Confirmation',
+        analytics_hash,
+      )
 
       get :create, params: { confirmation_token: 'foo' }
 
@@ -115,8 +127,10 @@ RSpec.describe SignUp::EmailConfirmationsController do
         user_id: user.uuid,
       }
 
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Confirmation', analytics_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Confirmation',
+        analytics_hash,
+      )
 
       get :create, params: { confirmation_token: 'foo' }
 
@@ -183,8 +197,10 @@ RSpec.describe SignUp::EmailConfirmationsController do
         user_id: user.uuid,
       }
 
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: Email Confirmation', analytics_hash)
+      expect(@analytics).to have_logged_event(
+        'User Registration: Email Confirmation',
+        analytics_hash,
+      )
 
       get :create, params: { confirmation_token: 'foo' }
     end

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe SignUp::PasswordsController do
       end
 
       it 'tracks analytics' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'User Registration: Email Confirmation',
           analytics_hash.merge({ error_details: nil }),
         )
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Password Creation',
           analytics_hash.merge({ request_id_present: false }),
         )

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe SignUp::PasswordsController do
       end
 
       it 'tracks analytics' do
+        subject
+
         expect(@analytics).to have_logged_event(
           'User Registration: Email Confirmation',
           analytics_hash.merge({ error_details: nil }),
@@ -42,8 +44,6 @@ RSpec.describe SignUp::PasswordsController do
           'Password Creation',
           analytics_hash.merge({ request_id_present: false }),
         )
-
-        subject
       end
 
       it 'confirms the user' do

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -28,18 +28,19 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
 
     it 'tracks visit event' do
       stub_analytics
-      expect(@analytics).to have_logged_event('User Registration: enter email visited')
 
       get :new
+
+      expect(@analytics).to have_logged_event('User Registration: enter email visited')
     end
 
     context 'with source parameter' do
       it 'tracks visit event' do
         stub_analytics
 
-        expect(@analytics).to have_logged_event('User Registration: enter email visited')
-
         get :new
+
+        expect(@analytics).to have_logged_event('User Registration: enter email visited')
       end
     end
 

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
 
     it 'tracks visit event' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).with('User Registration: enter email visited')
+      expect(@analytics).to have_logged_event('User Registration: enter email visited')
 
       get :new
     end
@@ -37,7 +37,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
       it 'tracks visit event' do
         stub_analytics
 
-        expect(@analytics).to receive(:track_event).with('User Registration: enter email visited')
+        expect(@analytics).to have_logged_event('User Registration: enter email visited')
 
         get :new
       end

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
       stub_analytics
       analytics_hash = { context: 'authentication' }
 
+      get :show
+
       expect(@analytics).to have_logged_event(
         'Multi-Factor Authentication: enter backup code visited', analytics_hash
       )
-
-      get :show
     end
   end
 

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
       stub_analytics
       analytics_hash = { context: 'authentication' }
 
-      expect(@analytics).to receive(:track_event).
-        with('Multi-Factor Authentication: enter backup code visited', analytics_hash)
+      expect(@analytics).to have_logged_event(
+        'Multi-Factor Authentication: enter backup code visited', analytics_hash
+      )
 
       get :show
     end

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe TwoFactorAuthentication::OptionsController do
       sign_in_before_2fa
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).
-        with('Multi-Factor Authentication: option list visited')
+      expect(@analytics).to have_logged_event('Multi-Factor Authentication: option list visited')
 
       get :index
     end

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe TwoFactorAuthentication::OptionsController do
       sign_in_before_2fa
       stub_analytics
 
-      expect(@analytics).to have_logged_event('Multi-Factor Authentication: option list visited')
-
       get :index
+
+      expect(@analytics).to have_logged_event('Multi-Factor Authentication: option list visited')
     end
   end
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -62,8 +62,10 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
         in_account_creation_flow: false,
       }
 
-      expect(@analytics).to receive(:track_event).
-        with('Multi-Factor Authentication: enter OTP visited', analytics_hash)
+      expect(@analytics).to have_logged_event(
+        'Multi-Factor Authentication: enter OTP visited',
+        analytics_hash,
+      )
 
       get :show, params: { otp_delivery_preference: 'sms' }
     end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
         in_account_creation_flow: false,
       }
 
+      get :show, params: { otp_delivery_preference: 'sms' }
+
       expect(@analytics).to have_logged_event(
         'Multi-Factor Authentication: enter OTP visited',
         analytics_hash,
       )
-
-      get :show, params: { otp_delivery_preference: 'sms' }
     end
 
     context 'when the user is registering a new landline phone_number with SMS preference' do

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController,
       stub_analytics
       analytics_hash = { context: 'authentication' }
 
-      expect(@analytics).to receive(:track_event).
-        with('Multi-Factor Authentication: enter personal key visited', analytics_hash)
+      expect(@analytics).to have_logged_event(
+        'Multi-Factor Authentication: enter personal key visited', analytics_hash
+      )
 
       get :show
     end

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController,
       stub_analytics
       analytics_hash = { context: 'authentication' }
 
+      get :show
+
       expect(@analytics).to have_logged_event(
         'Multi-Factor Authentication: enter personal key visited', analytics_hash
       )
-
-      get :show
     end
 
     it 'redirects to the two_factor_options page if user is IAL2' do

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -16,10 +16,9 @@ RSpec.describe Users::DeleteController do
       stub_analytics
       stub_signed_in_user
 
-      expect(@analytics).to have_logged_event('Account Delete visited')
-
       get :show
 
+      expect(@analytics).to have_logged_event('Account Delete visited')
       expect(response).to render_template(:show)
     end
   end

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Users::DeleteController do
       stub_analytics
       stub_signed_in_user
 
-      expect(@analytics).to receive(:track_event).with('Account Delete visited')
+      expect(@analytics).to have_logged_event('Account Delete visited')
 
       get :show
 

--- a/spec/controllers/users/edit_phone_controller_spec.rb
+++ b/spec/controllers/users/edit_phone_controller_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe Users::EditPhoneController do
           phone_configuration_id: phone_configuration.id,
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Phone Number Change: Form submitted', attributes)
+        expect(@analytics).to have_logged_event('Phone Number Change: Form submitted', attributes)
 
         put :update, params: {
           id: phone_configuration.id,
@@ -45,8 +44,7 @@ RSpec.describe Users::EditPhoneController do
           phone_configuration_id: phone_configuration.id,
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Phone Number Change: Form submitted', attributes)
+        expect(@analytics).to have_logged_event('Phone Number Change: Form submitted', attributes)
         put :update, params: {
           id: phone_configuration.id,
           edit_phone_form: { delivery_preference: 'noise' },
@@ -71,8 +69,7 @@ RSpec.describe Users::EditPhoneController do
         phone_configuration_id: phone_configuration.id,
       }
 
-      expect(@analytics).to receive(:track_event).
-        with('Phone Number Deletion: Submitted', attributes)
+      expect(@analytics).to have_logged_event('Phone Number Deletion: Submitted', attributes)
       expect(PushNotification::HttpPush).to receive(:deliver).
         with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
       delete :destroy, params: { id: phone_configuration.id }

--- a/spec/controllers/users/edit_phone_controller_spec.rb
+++ b/spec/controllers/users/edit_phone_controller_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe Users::EditPhoneController do
           phone_configuration_id: phone_configuration.id,
         }
 
-        expect(@analytics).to have_logged_event('Phone Number Change: Form submitted', attributes)
-
         put :update, params: {
           id: phone_configuration.id,
           edit_phone_form: { delivery_preference: 'voice' },
         }
+
+        expect(@analytics).to have_logged_event('Phone Number Change: Form submitted', attributes)
         expect(response).to redirect_to(account_url)
         expect(phone_configuration.reload.delivery_preference).to eq('voice')
       end
@@ -44,12 +44,12 @@ RSpec.describe Users::EditPhoneController do
           phone_configuration_id: phone_configuration.id,
         }
 
-        expect(@analytics).to have_logged_event('Phone Number Change: Form submitted', attributes)
         put :update, params: {
           id: phone_configuration.id,
           edit_phone_form: { delivery_preference: 'noise' },
         }
 
+        expect(@analytics).to have_logged_event('Phone Number Change: Form submitted', attributes)
         expect(response).to render_template(:edit)
         expect(phone_configuration.reload.delivery_preference).to eq('sms')
       end
@@ -69,11 +69,11 @@ RSpec.describe Users::EditPhoneController do
         phone_configuration_id: phone_configuration.id,
       }
 
-      expect(@analytics).to have_logged_event('Phone Number Deletion: Submitted', attributes)
       expect(PushNotification::HttpPush).to receive(:deliver).
         with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
       delete :destroy, params: { id: phone_configuration.id }
 
+      expect(@analytics).to have_logged_event('Phone Number Deletion: Submitted', attributes)
       expect(response).to redirect_to(account_url)
       expect(flash[:success]).to eq(t('two_factor_authentication.phone.delete.success'))
       expect(PhoneConfiguration.find_by(id: phone_configuration.id)).to eq(nil)

--- a/spec/controllers/users/email_language_controller_spec.rb
+++ b/spec/controllers/users/email_language_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Users::EmailLanguageController do
 
     it 'logs an analytics event for visiting' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).with('Email Language: Visited')
+      expect(@analytics).to have_logged_event('Email Language: Visited')
 
       action
     end
@@ -55,8 +55,10 @@ RSpec.describe Users::EmailLanguageController do
 
       it 'logs a successful analytics event' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('Email Language: Updated', hash_including(success: true))
+        expect(@analytics).to have_logged_event(
+          'Email Language: Updated',
+          hash_including(success: true),
+        )
 
         action
       end
@@ -78,8 +80,10 @@ RSpec.describe Users::EmailLanguageController do
 
       it 'logs an unsuccessful analytics event' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('Email Language: Updated', hash_including(success: false))
+        expect(@analytics).to have_logged_event(
+          'Email Language: Updated',
+          hash_including(success: false),
+        )
 
         action
       end

--- a/spec/controllers/users/email_language_controller_spec.rb
+++ b/spec/controllers/users/email_language_controller_spec.rb
@@ -27,9 +27,10 @@ RSpec.describe Users::EmailLanguageController do
 
     it 'logs an analytics event for visiting' do
       stub_analytics
-      expect(@analytics).to have_logged_event('Email Language: Visited')
 
       action
+
+      expect(@analytics).to have_logged_event('Email Language: Visited')
     end
   end
 
@@ -55,12 +56,13 @@ RSpec.describe Users::EmailLanguageController do
 
       it 'logs a successful analytics event' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'Email Language: Updated',
           hash_including(success: true),
         )
-
-        action
       end
     end
 
@@ -80,12 +82,13 @@ RSpec.describe Users::EmailLanguageController do
 
       it 'logs an unsuccessful analytics event' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'Email Language: Updated',
           hash_including(success: false),
         )
-
-        action
       end
     end
   end

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Users::EmailsController do
       stub_analytics
     end
     it 'renders the index view' do
-      expect(@analytics).to have_logged_event('Add Email Address Page Visited')
-
       get :show
+
+      expect(@analytics).to have_logged_event('Add Email Address Page Visited')
     end
   end
 
@@ -66,6 +66,8 @@ RSpec.describe Users::EmailsController do
           domain_name: email.split('@').last,
         )
 
+        post :resend
+
         expect(@analytics).to have_logged_event(
           'Resend Add Email Requested',
           { success: true },
@@ -74,7 +76,6 @@ RSpec.describe Users::EmailsController do
           t('user_mailer.email_confirmation_instructions.subject'),
         )
 
-        post :resend
         expect(response).to redirect_to(add_email_verify_email_url)
         expect(last_email_sent).to have_subject(
           t('user_mailer.email_confirmation_instructions.subject'),

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Users::EmailsController do
       it 'sends email' do
         email = Faker::Internet.safe_email
 
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Add Email Requested',
           success: true,
           errors: {},
@@ -64,7 +64,7 @@ RSpec.describe Users::EmailsController do
           domain_name: email.split('@').last,
         )
 
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Resend Add Email Requested',
           { success: true },
         )
@@ -85,7 +85,7 @@ RSpec.describe Users::EmailsController do
 
     context 'no valid email exists in session' do
       it 'shows an error and redirects to add email page' do
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Resend Add Email Requested',
           { success: false },
         )

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe Users::EmailsController do
       stub_analytics
     end
     it 'renders the index view' do
-      get :show
       expect(@analytics).to have_logged_event('Add Email Address Page Visited')
+
+      get :show
     end
   end
 
@@ -55,6 +56,8 @@ RSpec.describe Users::EmailsController do
       it 'sends email' do
         email = Faker::Internet.safe_email
 
+        post :add, params: { user: { email: email } }
+
         expect(@analytics).to have_logged_event(
           'Add Email Requested',
           success: true,
@@ -68,8 +71,6 @@ RSpec.describe Users::EmailsController do
           'Resend Add Email Requested',
           { success: true },
         )
-
-        post :add, params: { user: { email: email } }
         expect(last_email_sent).to have_subject(
           t('user_mailer.email_confirmation_instructions.subject'),
         )
@@ -85,12 +86,12 @@ RSpec.describe Users::EmailsController do
 
     context 'no valid email exists in session' do
       it 'shows an error and redirects to add email page' do
+        post :resend
+
         expect(@analytics).to have_logged_event(
           'Resend Add Email Requested',
           { success: false },
         )
-
-        post :resend
         expect(flash[:error]).to eq t('errors.general')
         expect(response).to redirect_to(add_email_url)
         expect(ActionMailer::Base.deliveries.count).to eq 0

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Users::EmailsController do
     before do
       stub_sign_in(user)
       stub_analytics
-      allow(@analytics).to receive(:track_event)
     end
 
     context 'valid email exists in session' do

--- a/spec/controllers/users/forget_all_browsers_controller_spec.rb
+++ b/spec/controllers/users/forget_all_browsers_controller_spec.rb
@@ -30,9 +30,10 @@ RSpec.describe Users::ForgetAllBrowsersController do
 
     it 'logs an analytics event for visiting' do
       stub_analytics
-      expect(@analytics).to have_logged_event('Forget All Browsers Visited')
 
       subject
+
+      expect(@analytics).to have_logged_event('Forget All Browsers Visited')
     end
 
     it 'does not change remember_device_revoked_at' do
@@ -58,9 +59,10 @@ RSpec.describe Users::ForgetAllBrowsersController do
 
     it 'logs an analytics event for forgetting' do
       stub_analytics
-      expect(@analytics).to have_logged_event('Forget All Browsers Submitted')
 
       subject
+
+      expect(@analytics).to have_logged_event('Forget All Browsers Submitted')
     end
 
     it 'redirects to the account page' do

--- a/spec/controllers/users/forget_all_browsers_controller_spec.rb
+++ b/spec/controllers/users/forget_all_browsers_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Users::ForgetAllBrowsersController do
 
     it 'logs an analytics event for visiting' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).with('Forget All Browsers Visited')
+      expect(@analytics).to have_logged_event('Forget All Browsers Visited')
 
       subject
     end
@@ -58,7 +58,7 @@ RSpec.describe Users::ForgetAllBrowsersController do
 
     it 'logs an analytics event for forgetting' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).with('Forget All Browsers Submitted')
+      expect(@analytics).to have_logged_event('Forget All Browsers Submitted')
 
       subject
     end

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe Users::PersonalKeysController do
       stub_analytics
       analytics_hash = { personal_key_present: true }
 
-      expect(@analytics).to receive(:track_event).
-        with('Personal key viewed', analytics_hash)
+      expect(@analytics).to have_logged_event('Personal key viewed', analytics_hash)
 
       get :show
     end
@@ -39,8 +38,7 @@ RSpec.describe Users::PersonalKeysController do
       stub_analytics
       analytics_hash = { personal_key_present: false }
 
-      expect(@analytics).to receive(:track_event).
-        with('Personal key viewed', analytics_hash)
+      expect(@analytics).to have_logged_event('Personal key viewed', analytics_hash)
 
       get :show
     end
@@ -124,8 +122,7 @@ RSpec.describe Users::PersonalKeysController do
       }
       allow(controller).to receive(:update).and_raise(ActionController::InvalidAuthenticityToken)
 
-      expect(@analytics).to receive(:track_event).
-        with('Invalid Authenticity Token', analytics_hash)
+      expect(@analytics).to have_logged_event('Invalid Authenticity Token', analytics_hash)
 
       post :update
 

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Users::PersonalKeysController do
       stub_analytics
       analytics_hash = { personal_key_present: true }
 
-      expect(@analytics).to have_logged_event('Personal key viewed', analytics_hash)
-
       get :show
+
+      expect(@analytics).to have_logged_event('Personal key viewed', analytics_hash)
     end
 
     it 'tracks the page visit when there is no personal key in the user session' do
@@ -38,9 +38,9 @@ RSpec.describe Users::PersonalKeysController do
       stub_analytics
       analytics_hash = { personal_key_present: false }
 
-      expect(@analytics).to have_logged_event('Personal key viewed', analytics_hash)
-
       get :show
+
+      expect(@analytics).to have_logged_event('Personal key viewed', analytics_hash)
     end
 
     it 'does not generate a new personal key to avoid CSRF attacks' do
@@ -122,10 +122,9 @@ RSpec.describe Users::PersonalKeysController do
       }
       allow(controller).to receive(:update).and_raise(ActionController::InvalidAuthenticityToken)
 
-      expect(@analytics).to have_logged_event('Invalid Authenticity Token', analytics_hash)
-
       post :update
 
+      expect(@analytics).to have_logged_event('Invalid Authenticity Token', analytics_hash)
       expect(response).to redirect_to new_user_session_url
       expect(flash[:error]).to eq t('errors.general')
     end

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Users::PhoneSetupController do
         country_code: nil,
         phone_type: :mobile,
         types: [],
-        pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
       }
 
       post :create, params: {
@@ -156,7 +155,6 @@ RSpec.describe Users::PhoneSetupController do
           country_code: 'US',
           phone_type: :mobile,
           types: [:fixed_or_mobile],
-          pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
         post(
@@ -195,7 +193,6 @@ RSpec.describe Users::PhoneSetupController do
           country_code: 'US',
           phone_type: :mobile,
           types: [:fixed_or_mobile],
-          pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
         post(
@@ -233,7 +230,6 @@ RSpec.describe Users::PhoneSetupController do
           country_code: 'US',
           phone_type: :mobile,
           types: [:fixed_or_mobile],
-          pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
         patch(

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -25,16 +25,17 @@ RSpec.describe Users::PhoneSetupController do
       end
 
       it 'renders the index view' do
+        expect(NewPhoneForm).to receive(:new).with(
+          user:,
+          analytics: kind_of(Analytics),
+          setup_voice_preference: false,
+        )
+
         get :index
 
         expect(@analytics).to have_logged_event(
           'User Registration: phone setup visited',
           { enabled_mfa_methods_count: 0 },
-        )
-        expect(NewPhoneForm).to receive(:new).with(
-          user:,
-          analytics: kind_of(Analytics),
-          setup_voice_preference: false,
         )
         expect(response).to render_template(:index)
       end

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Users::PhoneSetupController do
       end
 
       it 'renders the index view' do
+        get :index
+
         expect(@analytics).to have_logged_event(
           'User Registration: phone setup visited',
           { enabled_mfa_methods_count: 0 },
@@ -34,9 +36,6 @@ RSpec.describe Users::PhoneSetupController do
           analytics: kind_of(Analytics),
           setup_voice_preference: false,
         )
-
-        get :index
-
         expect(response).to render_template(:index)
       end
     end
@@ -84,8 +83,6 @@ RSpec.describe Users::PhoneSetupController do
         pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
       }
 
-      expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
-
       post :create, params: {
         new_phone_form: {
           phone: '703-555-010',
@@ -93,6 +90,7 @@ RSpec.describe Users::PhoneSetupController do
         },
       }
 
+      expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
       expect(response).to render_template(:index)
       expect(flash[:error]).to be_blank
     end
@@ -161,8 +159,6 @@ RSpec.describe Users::PhoneSetupController do
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
-        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
-
         post(
           :create,
           params: {
@@ -171,6 +167,7 @@ RSpec.describe Users::PhoneSetupController do
           },
         )
 
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
         expect(response).to redirect_to(
           otp_send_path(
             otp_delivery_selection_form: { otp_delivery_preference: 'voice',
@@ -201,8 +198,6 @@ RSpec.describe Users::PhoneSetupController do
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
-        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
-
         post(
           :create,
           params: {
@@ -211,6 +206,7 @@ RSpec.describe Users::PhoneSetupController do
           },
         )
 
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
         expect(response).to redirect_to(
           otp_send_path(
             otp_delivery_selection_form: { otp_delivery_preference: 'sms',
@@ -240,8 +236,6 @@ RSpec.describe Users::PhoneSetupController do
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
-        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
-
         patch(
           :create,
           params: {
@@ -250,6 +244,7 @@ RSpec.describe Users::PhoneSetupController do
           },
         )
 
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
         expect(response).to redirect_to(
           otp_send_path(
             otp_delivery_selection_form: { otp_delivery_preference: 'sms',

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -25,9 +25,10 @@ RSpec.describe Users::PhoneSetupController do
       end
 
       it 'renders the index view' do
-        expect(@analytics).to receive(:track_event).
-          with('User Registration: phone setup visited',
-               { enabled_mfa_methods_count: 0 })
+        expect(@analytics).to have_logged_event(
+          'User Registration: phone setup visited',
+          { enabled_mfa_methods_count: 0 },
+        )
         expect(NewPhoneForm).to receive(:new).with(
           user:,
           analytics: kind_of(Analytics),
@@ -83,8 +84,7 @@ RSpec.describe Users::PhoneSetupController do
         pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
       }
 
-      expect(@analytics).to receive(:track_event).
-        with('Multi-Factor Authentication: phone setup', result)
+      expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
 
       post :create, params: {
         new_phone_form: {
@@ -161,8 +161,7 @@ RSpec.describe Users::PhoneSetupController do
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Multi-Factor Authentication: phone setup', result)
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
 
         post(
           :create,
@@ -202,8 +201,7 @@ RSpec.describe Users::PhoneSetupController do
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Multi-Factor Authentication: phone setup', result)
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
 
         post(
           :create,
@@ -242,8 +240,7 @@ RSpec.describe Users::PhoneSetupController do
           pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Multi-Factor Authentication: phone setup', result)
+        expect(@analytics).to have_logged_event('Multi-Factor Authentication: phone setup', result)
 
         patch(
           :create,

--- a/spec/controllers/users/please_call_controller_spec.rb
+++ b/spec/controllers/users/please_call_controller_spec.rb
@@ -10,12 +10,11 @@ RSpec.describe Users::PleaseCallController do
   it 'renders the show template' do
     stub_analytics
 
+    get :show
+
     expect(@analytics).to have_logged_event(
       'User Suspension: Please call visited',
     )
-
-    get :show
-
     expect(response).to render_template :show
   end
 end

--- a/spec/controllers/users/please_call_controller_spec.rb
+++ b/spec/controllers/users/please_call_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Users::PleaseCallController do
   it 'renders the show template' do
     stub_analytics
 
-    expect(@analytics).to receive(:track_event).with(
+    expect(@analytics).to have_logged_event(
       'User Suspension: Please call visited',
     )
 

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -256,8 +256,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           pending_profile_pending_reasons: '',
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Password Reset: Password Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event(
+          'Password Reset: Password Submitted',
+          analytics_hash,
+        )
 
         put :update, params: { reset_password_form: form_params }
 
@@ -300,8 +302,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           pending_profile_pending_reasons: '',
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Password Reset: Password Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event(
+          'Password Reset: Password Submitted',
+          analytics_hash,
+        )
 
         put :update, params: { reset_password_form: form_params }
 
@@ -602,8 +606,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           active_profile: true,
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Password Reset: Email Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event('Password Reset: Email Submitted', analytics_hash)
 
         params = { password_reset_email_form: { email: user.email } }
         put :create, params: params
@@ -623,8 +626,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           active_profile: false,
         }
 
-        expect(@analytics).to receive(:track_event).
-          with('Password Reset: Email Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event('Password Reset: Email Submitted', analytics_hash)
 
         params = { password_reset_email_form: { email: 'foo' } }
         expect { put :create, params: params }.
@@ -653,7 +655,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
     it 'logs visit to analytics' do
       stub_analytics
 
-      expect(@analytics).to receive(:track_event).with('Password Reset: Email Form Visited')
+      expect(@analytics).to have_logged_event('Password Reset: Email Form Visited')
 
       get :new
     end

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -256,13 +256,12 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           pending_profile_pending_reasons: '',
         }
 
+        put :update, params: { reset_password_form: form_params }
+
         expect(@analytics).to have_logged_event(
           'Password Reset: Password Submitted',
           analytics_hash,
         )
-
-        put :update, params: { reset_password_form: form_params }
-
         expect(assigns(:forbidden_passwords)).to all(be_a(String))
         expect(response).to render_template(:edit)
       end
@@ -302,13 +301,12 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           pending_profile_pending_reasons: '',
         }
 
+        put :update, params: { reset_password_form: form_params }
+
         expect(@analytics).to have_logged_event(
           'Password Reset: Password Submitted',
           analytics_hash,
         )
-
-        put :update, params: { reset_password_form: form_params }
-
         expect(assigns(:forbidden_passwords)).to all(be_a(String))
         expect(response).to render_template(:edit)
       end
@@ -606,10 +604,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           active_profile: true,
         }
 
-        expect(@analytics).to have_logged_event('Password Reset: Email Submitted', analytics_hash)
-
         params = { password_reset_email_form: { email: user.email } }
         put :create, params: params
+
+        expect(@analytics).to have_logged_event('Password Reset: Email Submitted', analytics_hash)
       end
     end
 
@@ -626,12 +624,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           active_profile: false,
         }
 
-        expect(@analytics).to have_logged_event('Password Reset: Email Submitted', analytics_hash)
-
         params = { password_reset_email_form: { email: 'foo' } }
         expect { put :create, params: params }.
           to change { ActionMailer::Base.deliveries.count }.by(0)
 
+        expect(@analytics).to have_logged_event('Password Reset: Email Submitted', analytics_hash)
         expect(response).to render_template :new
       end
     end
@@ -655,9 +652,9 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
     it 'logs visit to analytics' do
       stub_analytics
 
-      expect(@analytics).to have_logged_event('Password Reset: Email Form Visited')
-
       get :new
+
+      expect(@analytics).to have_logged_event('Password Reset: Email Form Visited')
     end
   end
 

--- a/spec/controllers/users/rules_of_use_controller_spec.rb
+++ b/spec/controllers/users/rules_of_use_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Users::RulesOfUseController do
 
       it 'logs an analytics event for visiting' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with('Rules of Use Visited')
+        expect(@analytics).to have_logged_event('Rules of Use Visited')
 
         action
       end
@@ -64,7 +64,7 @@ RSpec.describe Users::RulesOfUseController do
 
       it 'logs an analytics event for visiting' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with('Rules of Use Visited')
+        expect(@analytics).to have_logged_event('Rules of Use Visited')
 
         action
       end
@@ -116,8 +116,10 @@ RSpec.describe Users::RulesOfUseController do
 
       it 'logs a successful analytics event' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('Rules of Use Submitted', hash_including(success: true))
+        expect(@analytics).to have_logged_event(
+          'Rules of Use Submitted',
+          hash_including(success: true),
+        )
 
         action
       end
@@ -192,8 +194,10 @@ RSpec.describe Users::RulesOfUseController do
 
       it 'logs a failure analytics event' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('Rules of Use Submitted', hash_including(success: false))
+        expect(@analytics).to have_logged_event(
+          'Rules of Use Submitted',
+          hash_including(success: false),
+        )
 
         action
       end

--- a/spec/controllers/users/rules_of_use_controller_spec.rb
+++ b/spec/controllers/users/rules_of_use_controller_spec.rb
@@ -33,9 +33,10 @@ RSpec.describe Users::RulesOfUseController do
 
       it 'logs an analytics event for visiting' do
         stub_analytics
-        expect(@analytics).to have_logged_event('Rules of Use Visited')
 
         action
+
+        expect(@analytics).to have_logged_event('Rules of Use Visited')
       end
     end
 
@@ -64,9 +65,10 @@ RSpec.describe Users::RulesOfUseController do
 
       it 'logs an analytics event for visiting' do
         stub_analytics
-        expect(@analytics).to have_logged_event('Rules of Use Visited')
 
         action
+
+        expect(@analytics).to have_logged_event('Rules of Use Visited')
       end
     end
 
@@ -116,12 +118,13 @@ RSpec.describe Users::RulesOfUseController do
 
       it 'logs a successful analytics event' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'Rules of Use Submitted',
           hash_including(success: true),
         )
-
-        action
       end
 
       it 'includes service provider URIs in form-action CSP header when enabled' do
@@ -194,12 +197,13 @@ RSpec.describe Users::RulesOfUseController do
 
       it 'logs a failure analytics event' do
         stub_analytics
+
+        action
+
         expect(@analytics).to have_logged_event(
           'Rules of Use Submitted',
           hash_including(success: false),
         )
-
-        action
       end
     end
   end

--- a/spec/controllers/users/service_provider_revoke_controller_spec.rb
+++ b/spec/controllers/users/service_provider_revoke_controller_spec.rb
@@ -31,12 +31,13 @@ RSpec.describe Users::ServiceProviderRevokeController do
 
     it 'logs an analytics event for visiting' do
       stub_analytics
+
+      subject
+
       expect(@analytics).to have_logged_event(
         'SP Revoke Consent: Visited',
         issuer: service_provider.issuer,
       )
-
-      subject
     end
 
     context 'when the sp_id is not valid' do
@@ -76,12 +77,13 @@ RSpec.describe Users::ServiceProviderRevokeController do
 
     it 'logs an analytics event for revoking' do
       stub_analytics
+
+      subject
+
       expect(@analytics).to have_logged_event(
         'SP Revoke Consent: Revoked',
         issuer: service_provider.issuer,
       )
-
-      subject
     end
 
     context 'when the sp_id is not valid' do

--- a/spec/controllers/users/service_provider_revoke_controller_spec.rb
+++ b/spec/controllers/users/service_provider_revoke_controller_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe Users::ServiceProviderRevokeController do
 
     it 'logs an analytics event for visiting' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).
-        with('SP Revoke Consent: Visited', issuer: service_provider.issuer)
+      expect(@analytics).to have_logged_event(
+        'SP Revoke Consent: Visited',
+        issuer: service_provider.issuer,
+      )
 
       subject
     end
@@ -74,8 +76,10 @@ RSpec.describe Users::ServiceProviderRevokeController do
 
     it 'logs an analytics event for revoking' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).
-        with('SP Revoke Consent: Revoked', issuer: service_provider.issuer)
+      expect(@analytics).to have_logged_event(
+        'SP Revoke Consent: Revoked',
+        issuer: service_provider.issuer,
+      )
 
       subject
     end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Users::SessionsController, devise: true do
   describe 'DELETE /logout' do
     it 'tracks a logout event' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'Logout Initiated',
         hash_including(
           sp_initiated: false,
@@ -491,8 +491,7 @@ RSpec.describe Users::SessionsController, devise: true do
       analytics_hash = { controller: 'users/sessions#create', user_signed_in: nil }
       allow(controller).to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
 
-      expect(@analytics).to receive(:track_event).
-        with('Invalid Authenticity Token', analytics_hash)
+      expect(@analytics).to have_logged_event('Invalid Authenticity Token', analytics_hash)
 
       post :create, params: { user: { email: user.email, password: user.password } }
 
@@ -506,8 +505,7 @@ RSpec.describe Users::SessionsController, devise: true do
       analytics_hash = { controller: 'users/sessions#create', user_signed_in: nil }
       allow(controller).to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
 
-      expect(@analytics).to receive(:track_event).
-        with('Invalid Authenticity Token', analytics_hash)
+      expect(@analytics).to have_logged_event('Invalid Authenticity Token', analytics_hash)
 
       request.env['HTTP_REFERER'] = '@@@'
       post :create, params: { user: { email: user.email, password: user.password } }
@@ -725,7 +723,7 @@ RSpec.describe Users::SessionsController, devise: true do
         stub_analytics
         allow(controller).to receive(:flash).and_return(alert: 'hello')
 
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Sign in page visited',
           flash: 'hello',
         )

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -121,6 +121,8 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
         }
 
         travel_to(time1 + 1.second) do
+          get :show
+
           expect(@analytics).to have_logged_event(
             'User marked authenticated',
             { authentication_type: :device_remembered },
@@ -129,7 +131,6 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
             'Remembered device used for authentication',
             { cookie_created_at: time1, cookie_age_seconds: 1 },
           )
-          get :show
         end
 
         expect(Telephony::Test::Message.messages.length).to eq(0)

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -121,9 +121,11 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
         }
 
         travel_to(time1 + 1.second) do
-          expect(@analytics).to receive(:track_event).
-            with('User marked authenticated', { authentication_type: :device_remembered })
-          expect(@analytics).to receive(:track_event).with(
+          expect(@analytics).to have_logged_event(
+            'User marked authenticated',
+            { authentication_type: :device_remembered },
+          )
+          expect(@analytics).to have_logged_event(
             'Remembered device used for authentication',
             { cookie_created_at: time1, cookie_age_seconds: 1 },
           )

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -136,8 +136,7 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController do
         errors: {},
       }
 
-      expect(@analytics).to receive(:track_event).
-        with('User Registration: 2FA Setup', result)
+      expect(@analytics).to have_logged_event('User Registration: 2FA Setup', result)
 
       patch :create, params: {
         two_factor_options_form: {

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -136,13 +136,13 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController do
         errors: {},
       }
 
-      expect(@analytics).to have_logged_event('User Registration: 2FA Setup', result)
-
       patch :create, params: {
         two_factor_options_form: {
           selection: ['voice', 'auth_app'],
         },
       }
+
+      expect(@analytics).to have_logged_event('User Registration: 2FA Setup', result)
     end
 
     context 'when multi selection with phone first' do

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -54,16 +54,16 @@ RSpec.describe Users::VerifyPersonalKeyController do
 
       it 'renders rate limited page' do
         stub_analytics
-        expect(@analytics).to have_logged_event(
-          'Personal key reactivation: Personal key form visited',
-        ).once
-        expect(@analytics).to have_logged_event(
-          'Rate Limit Reached',
-          limiter_type: :verify_personal_key,
-        ).once
 
         get :new
 
+        expect(@analytics).to have_logged_event(
+          'Personal key reactivation: Personal key form visited',
+        )
+        expect(@analytics).to have_logged_event(
+          'Rate Limit Reached',
+          limiter_type: :verify_personal_key,
+        )
         expect(response).to render_template(:rate_limited)
       end
     end
@@ -104,20 +104,19 @@ RSpec.describe Users::VerifyPersonalKeyController do
 
       it 'stores that the personal key was entered in the user session' do
         stub_analytics
+
+        post :create, params: { personal_key: profiles.first.personal_key }
+
         expect(@analytics).to have_logged_event(
           'Personal key reactivation: Personal key form submitted',
           errors: {},
           error_details: nil,
           success: true,
           pii_like_keypaths: pii_like_keypaths_errors,
-        ).once
-
+        )
         expect(@analytics).to have_logged_event(
           'Personal key reactivation: Account reactivated with personal key',
-        ).once
-
-        post :create, params: { personal_key: profiles.first.personal_key }
-
+        )
         expect(subject.reactivate_account_session.validated_personal_key?).to eq(true)
       end
     end
@@ -138,21 +137,21 @@ RSpec.describe Users::VerifyPersonalKeyController do
     context 'with rate limit reached' do
       it 'renders rate limited page' do
         stub_analytics
+
+        max_attempts = RateLimiter.max_attempts(:verify_personal_key)
+        max_attempts.times { post :create, params: personal_key_bad_params }
+
         expect(@analytics).to have_logged_event(
           'Personal key reactivation: Personal key form submitted',
           errors: { personal_key: ['Please fill in this field.', error_text] },
           error_details: { personal_key: { blank: true, personal_key: true } },
           success: false,
           pii_like_keypaths: pii_like_keypaths_errors,
-        ).once
+        )
         expect(@analytics).to have_logged_event(
           'Rate Limit Reached',
           limiter_type: :verify_personal_key,
-        ).once
-
-        max_attempts = RateLimiter.max_attempts(:verify_personal_key)
-        max_attempts.times { post :create, params: personal_key_bad_params }
-
+        )
         expect(response).to render_template(:rate_limited)
       end
     end

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -85,13 +85,6 @@ RSpec.describe Users::VerifyPersonalKeyController do
     let(:personal_key_bad_params) { { personal_key: 'baaad' } }
     let(:personal_key_error) { { personal_key: [error_text] } }
     let(:failure_properties) { { success: false } }
-    let(:pii_like_keypaths_errors) do
-      [
-        [:errors, :personal_key],
-        [:error_details, :personal_key],
-        [:error_details, :personal_key, :personal_key],
-      ]
-    end
     let(:response_ok) { FormResponse.new(success: true, errors: {}) }
     let(:response_bad) { FormResponse.new(success: false, errors: personal_key_error, extra: {}) }
 
@@ -112,7 +105,6 @@ RSpec.describe Users::VerifyPersonalKeyController do
           errors: {},
           error_details: nil,
           success: true,
-          pii_like_keypaths: pii_like_keypaths_errors,
         )
         expect(@analytics).to have_logged_event(
           'Personal key reactivation: Account reactivated with personal key',
@@ -146,7 +138,6 @@ RSpec.describe Users::VerifyPersonalKeyController do
           errors: { personal_key: ['Please fill in this field.', error_text] },
           error_details: { personal_key: { blank: true, personal_key: true } },
           success: false,
-          pii_like_keypaths: pii_like_keypaths_errors,
         )
         expect(@analytics).to have_logged_event(
           'Rate Limit Reached',

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe Users::VerifyPersonalKeyController do
 
       it 'renders rate limited page' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Personal key reactivation: Personal key form visited',
         ).once
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Rate Limit Reached',
           limiter_type: :verify_personal_key,
         ).once
@@ -104,7 +104,7 @@ RSpec.describe Users::VerifyPersonalKeyController do
 
       it 'stores that the personal key was entered in the user session' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Personal key reactivation: Personal key form submitted',
           errors: {},
           error_details: nil,
@@ -112,7 +112,7 @@ RSpec.describe Users::VerifyPersonalKeyController do
           pii_like_keypaths: pii_like_keypaths_errors,
         ).once
 
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Personal key reactivation: Account reactivated with personal key',
         ).once
 
@@ -138,14 +138,14 @@ RSpec.describe Users::VerifyPersonalKeyController do
     context 'with rate limit reached' do
       it 'renders rate limited page' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Personal key reactivation: Personal key form submitted',
           errors: { personal_key: ['Please fill in this field.', error_text] },
           error_details: { personal_key: { blank: true, personal_key: true } },
           success: false,
           pii_like_keypaths: pii_like_keypaths_errors,
         ).once
-        expect(@analytics).to receive(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Rate Limit Reached',
           limiter_type: :verify_personal_key,
         ).once

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -47,13 +47,12 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
         stub_sign_in
         stub_analytics
 
-        expect(@analytics).to receive(:track_event).
-          with(
-            'WebAuthn Setup Visited',
-            platform_authenticator: false,
-            enabled_mfa_methods_count: 0,
-            in_account_creation_flow: false,
-          )
+        expect(@analytics).to have_logged_event(
+          'WebAuthn Setup Visited',
+          platform_authenticator: false,
+          enabled_mfa_methods_count: 0,
+          in_account_creation_flow: false,
+        )
 
         expect(controller.send(:mobile?)).to be false
 
@@ -344,7 +343,7 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
           allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
           allow(WebAuthn::AttestationStatement).to receive(:from).and_raise(StandardError)
 
-          expect(@analytics).to receive(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication Setup',
             {
               enabled_mfa_methods_count: 0,

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -356,7 +356,6 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
               in_account_creation_flow: false,
               mfa_method_counts: {},
               multi_factor_auth_method: 'webauthn_platform',
-              pii_like_keypaths: [[:mfa_method_counts, :phone]],
               success: false,
             },
           )

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -47,16 +47,16 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
         stub_sign_in
         stub_analytics
 
+        expect(controller.send(:mobile?)).to be false
+
+        get :new
+
         expect(@analytics).to have_logged_event(
           'WebAuthn Setup Visited',
           platform_authenticator: false,
           enabled_mfa_methods_count: 0,
           in_account_creation_flow: false,
         )
-
-        expect(controller.send(:mobile?)).to be false
-
-        get :new
       end
 
       context 'with a mobile device' do
@@ -343,6 +343,8 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
           allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
           allow(WebAuthn::AttestationStatement).to receive(:from).and_raise(StandardError)
 
+          patch :confirm, params: params
+
           expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication Setup',
             {
@@ -358,8 +360,6 @@ RSpec.describe Users::WebauthnSetupController, allowed_extra_analytics: [:*] do
               success: false,
             },
           )
-
-          patch :confirm, params: params
         end
       end
     end

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Account Reset Request: Delete Account', email: true,
-                                                        allowed_extra_analytics: [:*] do
+RSpec.describe 'Account Reset Request: Delete Account', email: true do
   include PushNotificationsHelper
   include OidcAuthHelper
 

--- a/spec/features/account_reset/pending_request_spec.rb
+++ b/spec/features/account_reset/pending_request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Pending account reset request sign in', allowed_extra_analytics: [:*] do
+RSpec.feature 'Pending account reset request sign in' do
   it 'gives the option to cancel the request on sign in' do
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(999)
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -376,7 +376,6 @@ RSpec.describe 'throttling requests' do
       it 'throttles with a custom response' do
         analytics = FakeAnalytics.new
         allow(Analytics).to receive(:new).and_return(analytics)
-        allow(analytics).to receive(:track_event)
 
         Rack::Attack::EMAIL_REGISTRATION_PATHS.each do |path|
           headers = { REMOTE_ADDR: '1.2.3.4' }

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -250,7 +250,6 @@ RSpec.describe 'throttling requests' do
       it 'throttles with a custom response' do
         analytics = FakeAnalytics.new
         allow(Analytics).to receive(:new).and_return(analytics)
-        allow(analytics).to receive(:track_event)
 
         Rack::Attack::SIGN_IN_PATHS.each do |path|
           headers = { REMOTE_ADDR: '1.2.3.4' }
@@ -315,7 +314,6 @@ RSpec.describe 'throttling requests' do
       it 'throttles with a custom response' do
         analytics = FakeAnalytics.new
         allow(Analytics).to receive(:new).and_return(analytics)
-        allow(analytics).to receive(:track_event)
         analytics_hash = { type: 'logins/email+ip' }
 
         Rack::Attack::SIGN_IN_PATHS.each do |path|

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe 'throttling requests' do
 
         Rack::Attack::SIGN_IN_PATHS.each do |path|
           expect(analytics).
-            to receive(:track_event).with('Rate Limit Triggered', type: 'logins/ip').once
+            to have_logged_event('Rate Limit Triggered', type: 'logins/ip').once
           headers = { REMOTE_ADDR: '1.2.3.4' }
           first_email = 'test1@example.com'
           second_email = 'test2@example.com'
@@ -321,7 +321,7 @@ RSpec.describe 'throttling requests' do
 
         Rack::Attack::SIGN_IN_PATHS.each do |path|
           expect(analytics).
-            to receive(:track_event).with('Rate Limit Triggered', analytics_hash).once
+            to have_logged_event('Rate Limit Triggered', analytics_hash).once
           (logins_per_email_and_ip_limit + 1).times do |index|
             post path, params: {
               user: { email: index.even? ? 'test@example.com' : ' test@EXAMPLE.com   ' },
@@ -388,7 +388,7 @@ RSpec.describe 'throttling requests' do
           fourth_email = 'test4@example.com'
 
           expect(analytics).
-            to receive(:track_event).with(
+            to have_logged_event(
               'Rate Limit Triggered',
               type: 'email_registrations/ip',
             )

--- a/spec/services/outage_status_spec.rb
+++ b/spec/services/outage_status_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe OutageStatus do
   describe '#track_event' do
     it 'logs status of all vendors' do
       analytics = FakeAnalytics.new
-      expect(analytics).to receive(:track_event).with(
+      expect(analytics).to have_logged_event(
         'Vendor Outage',
         redirect_from: nil,
         vendor_status: OutageStatus::ALL_VENDORS.index_with do |_vendor|

--- a/spec/services/outage_status_spec.rb
+++ b/spec/services/outage_status_spec.rb
@@ -176,6 +176,9 @@ RSpec.describe OutageStatus do
   describe '#track_event' do
     it 'logs status of all vendors' do
       analytics = FakeAnalytics.new
+
+      vendor_status.track_event(analytics)
+
       expect(analytics).to have_logged_event(
         'Vendor Outage',
         redirect_from: nil,
@@ -183,8 +186,6 @@ RSpec.describe OutageStatus do
           satisfy { |status| IdentityConfig::VENDOR_STATUS_OPTIONS.include?(status) }
         end,
       )
-
-      vendor_status.track_event(analytics)
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates specs to replace `expect(@analytics).to receive(:track_event).with` with equivalent `expect(@analytics).to have_logged_event`.

This includes changes which can be ported over easily using simple pattern replacement (+ Rubocop autocorrection).

Pattern: `receive\(:track_event\).(\n\s+)?with\((\n\s+)?('[^']+')`
Replacement: `have_logged_event($2$3`

Remaining usage includes negated assertions, and assertions not including a specific event name being logged.

**Why?**

- Because `have_logged_event` includes a number of additional helpers implemented through the `FakeAnalytics` class:
   - Accidental PII leak detection
   - Undocumented analytics method arguments checking
- Facilitate work in #10987

## 📜 Testing Plan

Verify build passes.