### PR TITLE
Update the verify-by-phone rate limit screen in no-GPO case

### DIFF
--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -14,22 +14,33 @@
       <p>
         <%= t('idv.failure.phone.rate_limited.body') %>
       </p>
-      <%= t('idv.failure.phone.rate_limited.options_header') %>
-      <ul>
-        <% if @gpo_letter_available %>
+      <% if @gpo_letter_available %>
+        <%= t('idv.failure.phone.rate_limited.options_header') %>
+        <ul>
           <li><%= t('idv.failure.phone.rate_limited.option_verify_by_mail_html') %></li>
-        <% end %>
-        <li>
+            <li>
+            <%= t(
+                  'idv.failure.phone.rate_limited.option_try_again_later_html',
+                  time_left: distance_of_time_in_words(
+                    Time.zone.now,
+                    [@expires_at, Time.zone.now].compact.max,
+                    except: :seconds,
+                  ),
+                ) %>
+          </li>
+        </ul>
+      <% else %>
+        <p>
           <%= t(
-                'idv.failure.phone.rate_limited.option_try_again_later_html',
+                'idv.failure.phone.rate_limited.option_try_again_later_no_gpo_html',
                 time_left: distance_of_time_in_words(
                   Time.zone.now,
                   [@expires_at, Time.zone.now].compact.max,
                   except: :seconds,
                 ),
               ) %>
-        </li>
-      </ul>
+        </p>
+      <% end %>
 
       <% if @gpo_letter_available %>
         <div class="margin-y-5">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1028,6 +1028,7 @@ idv.failure.phone.rate_limited.body: For security reasons, we limit the number o
 idv.failure.phone.rate_limited.gpo.button: Verify by mail
 idv.failure.phone.rate_limited.heading: We couldn’t verify your identity by phone
 idv.failure.phone.rate_limited.option_try_again_later_html: Cancel and start over again after <strong>%{time_left}</strong>
+idv.failure.phone.rate_limited.option_try_again_later_no_gpo_html: You can try again after <strong>%{time_left}</strong>.
 idv.failure.phone.rate_limited.option_verify_by_mail_html: Verify by mail, which takes <strong>5 to 10 days</strong>
 idv.failure.phone.rate_limited.options_header: 'You can:'
 idv.failure.phone.timeout: Our request to verify your information timed out. Please try again.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1039,6 +1039,7 @@ idv.failure.phone.rate_limited.body: Por motivos de seguridad, limitamos el núm
 idv.failure.phone.rate_limited.gpo.button: Verificar por correo
 idv.failure.phone.rate_limited.heading: No pudimos verificar su identidad por teléfono
 idv.failure.phone.rate_limited.option_try_again_later_html: Cancelar y empezar de nuevo en <strong>%{time_left}</strong>
+idv.failure.phone.rate_limited.option_try_again_later_no_gpo_html: Puede volver a intentarlo después de <strong>%{time_left}</strong>.
 idv.failure.phone.rate_limited.option_verify_by_mail_html: Verificar por correo, lo que tarda de <strong>5 a 10 días</strong>
 idv.failure.phone.rate_limited.options_header: 'Usted puede:'
 idv.failure.phone.timeout: Terminó el tiempo de nuestra solicitud para verificar su información. Vuelva a intentarlo.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1028,6 +1028,7 @@ idv.failure.phone.rate_limited.body: Pour des raisons de sécurité, nous limito
 idv.failure.phone.rate_limited.gpo.button: Vérifier par courrier
 idv.failure.phone.rate_limited.heading: Nous n’avons pas pu confirmer votre identité par téléphone
 idv.failure.phone.rate_limited.option_try_again_later_html: Annuler et recommencer après <strong>%{time_left}</strong>
+idv.failure.phone.rate_limited.option_try_again_later_no_gpo_html: Vous pourrez réessayer d’ici <strong>%{time_left}</strong>.
 idv.failure.phone.rate_limited.option_verify_by_mail_html: Vérifier par courrier, ce qui prend <strong>5 à 10 jours</strong>.
 idv.failure.phone.rate_limited.options_header: 'Vous pouvez :'
 idv.failure.phone.timeout: Notre demande de vérification de vos renseignements a expiré. Veuillez réessayer.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1039,6 +1039,7 @@ idv.failure.phone.rate_limited.body: 为了你的安全，我们限制你在网�
 idv.failure.phone.rate_limited.gpo.button: 通过普通邮件验证
 idv.failure.phone.rate_limited.heading: 我们无法通过电话验证你的身份。
 idv.failure.phone.rate_limited.option_try_again_later_html: 取消并在 <strong>%{time_left}</strong> 后再试
+idv.failure.phone.rate_limited.option_try_again_later_no_gpo_html: 您可以在<strong>%{time_left}</strong>后重试。
 idv.failure.phone.rate_limited.option_verify_by_mail_html: 通过普通邮件验证，这需要<strong>五到十天</strong>
 idv.failure.phone.rate_limited.options_header: 你可以：
 idv.failure.phone.timeout: 我们请你验证自己信息的请求已过期。请再试一次。


### PR DESCRIPTION
When the GPO option is available the verify-by-phone rate limit screen contains the following:

> For security reasons, we limit the number of times you can attempt to verify your phone number online.
>
> You can:
> - Verify by mail, which takes 5 to 10 days
> - Cancel and start over again after 5 hours and 59 minutes

However, when the verify-by-mail option is not available this list only contains one bullet point. This commit removes the list when there is no verify by mail option. It introduces a paragraph to tell the user to try again after the rate limit expires.

Screenshots:

Verify-by-mail available:
![image](https://github.com/user-attachments/assets/ef08816c-0bb6-431c-a82a-1dd9246d79b2)

Verify-by-mail unavailable:
![image](https://github.com/user-attachments/assets/0cba0191-54ed-4037-9974-19b9299f4625)

