### PR TITLE
LG-13672 Update barcode page to add alert and remove a line

### DIFF
--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -15,6 +15,10 @@
   <% end %>
 <% end %>
 
+<%= render AlertComponent.new(type: :success, class: 'margin-bottom-4') do %>
+  <%= t('in_person_proofing.body.barcode.email_sent') %>
+<% end %>
+
 <%= render PageHeadingComponent.new(class: 'text-center') do %>
   <%= @presenter.barcode_heading_text %>
 <% end %>
@@ -189,8 +193,6 @@
 
 <h2 class="margin-bottom-2"><%= t('in_person_proofing.body.expect.heading') %></h2>
 <p><%= t('in_person_proofing.body.expect.info') %></p>
-
-<p class="margin-top-4"><strong><%= t('in_person_proofing.body.barcode.email_sent') %></strong></p>
 
 <p class="margin-top-3 margin-bottom-4">
   <% if @presenter.service_provider_homepage_url.present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1179,7 +1179,7 @@ in_person_proofing.body.barcode.close_window: You may now close this window.
 in_person_proofing.body.barcode.deadline: You must visit any participating Post Office by %{deadline}.
 in_person_proofing.body.barcode.deadline_restart: If you go after this deadline, your information will not be saved and you will need to restart the process.
 in_person_proofing.body.barcode.eipp_what_to_bring: 'Depending on your ID, you may need to show supporting documents. Review the following options carefully:'
-in_person_proofing.body.barcode.email_sent: We have sent this information to the email you used to sign in.
+in_person_proofing.body.barcode.email_sent: We have sent your barcode and the information below to the email you used to sign in
 in_person_proofing.body.barcode.learn_more: Learn more about what to bring
 in_person_proofing.body.barcode.location_details: Location details
 in_person_proofing.body.barcode.questions: Questions?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1190,7 +1190,7 @@ in_person_proofing.body.barcode.close_window: Ya puede cerrar esta ventana.
 in_person_proofing.body.barcode.deadline: Debe acudir a cualquier oficina de correos participante antes del %{deadline}
 in_person_proofing.body.barcode.deadline_restart: Si vence el plazo, su información no se guardará y tendrá que reiniciar el proceso.
 in_person_proofing.body.barcode.eipp_what_to_bring: 'Según el tipo de identificación que tenga, es posible que deba presentar documentos comprobatorios. Lea con atención las opciones siguientes:'
-in_person_proofing.body.barcode.email_sent: Enviamos esta información al correo electrónico que usó para iniciar sesión.
+in_person_proofing.body.barcode.email_sent: Enviamos el código de barras y la información más abajo al correo electrónico que usó para iniciar sesión
 in_person_proofing.body.barcode.learn_more: Obtenga más información sobre lo que debe llevar
 in_person_proofing.body.barcode.location_details: Detalles del lugar
 in_person_proofing.body.barcode.questions: '¿Tiene alguna pregunta?'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1179,7 +1179,7 @@ in_person_proofing.body.barcode.close_window: Vous pouvez maintenant fermer cett
 in_person_proofing.body.barcode.deadline: Vous devez vous rendre dans un bureau de poste participant avant le %{deadline}
 in_person_proofing.body.barcode.deadline_restart: Si vous y allez après cette date limite, vos informations ne seront pas sauvegardées et vous devrez recommencer le processus.
 in_person_proofing.body.barcode.eipp_what_to_bring: 'Selon la pièce d’identité dont vous disposez, il pourra vous être demandé de présenter des documents complémentaires. Étudiez attentivement les options suivantes:'
-in_person_proofing.body.barcode.email_sent: Nous avons envoyé ces informations à l’adresse e-mail que vous avez utilisée pour vous connecter.
+in_person_proofing.body.barcode.email_sent: Nous avons envoyé votre code-barre et les informations ci-dessous à l’adresse e-mail que vous avez utilisée pour vous connecter
 in_person_proofing.body.barcode.learn_more: En savoir davantage sur ce qu’il faut apporter.
 in_person_proofing.body.barcode.location_details: Détails de l’emplacement
 in_person_proofing.body.barcode.questions: Des questions ?

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1190,7 +1190,7 @@ in_person_proofing.body.barcode.close_window: 你现在可以关闭这一窗口�
 in_person_proofing.body.barcode.deadline: 你必须在 %{deadline}之前去任何参与邮局。
 in_person_proofing.body.barcode.deadline_restart: 如果你在截止日期后才去邮局，你的信息不会被存储，你又得从头开始这一过程。
 in_person_proofing.body.barcode.eipp_what_to_bring: 取决于您身份证件类型，您也许需要显示支持文件。请仔细阅读以下选项：
-in_person_proofing.body.barcode.email_sent: 我们已将该信息发送到你用来登录的电邮。
+in_person_proofing.body.barcode.email_sent: 我们已将条形码和以下信息发到了您用来登录的电邮地址
 in_person_proofing.body.barcode.learn_more: 了解有关携带物品的更多信息
 in_person_proofing.body.barcode.location_details: 详细地址信息
 in_person_proofing.body.barcode.questions: 有问题吗？

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -180,6 +180,12 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       ).once
     end
 
+    it 'renders the email sent success alert' do
+      render
+
+      expect(rendered).to have_content(t('in_person_proofing.body.barcode.email_sent'))
+    end
+
     it 'template does not display Enhanced In-Person Proofing specific content' do
       render
 
@@ -249,6 +255,12 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
           article: 'verify-your-identity-in-person',
         ),
       ).once
+    end
+
+    it 'renders the email sent success alert' do
+      render
+
+      expect(rendered).to have_content(t('in_person_proofing.body.barcode.email_sent'))
     end
 
     context 'template displays additional (EIPP specific) content' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13672](https://cm-jira.usa.gov/browse/LG-13672)

## 🛠 Summary of changes

Updates IPP and EIPP barcode pages to have a new alert at the top, and removes the line "We have sent this information to the email you used to sign in." from the bottom.

## 📜 Testing Plan

### IPP Barcode page
- [ ] Enter the IPP flow - Through the Sinatra app, select Biometric for level of service and sign in.
- [ ] Complete the IPP flow and arrive at the `verify/in_person/ready_to_verify` page.
- [ ] Verify that there is a success alert at the top of the page that reads:<img width="367" alt="Screenshot 2024-07-30 at 2 20 01 PM" src="https://github.com/user-attachments/assets/53941a9b-3724-4fb4-8b26-84efa7b78f3a">
    - [ ] En: We have sent your barcode and the information below to the email you used to sign in
    - [ ] Es: Enviamos el código de barras y la información más abajo al correo electrónico que usó para iniciar sesión
    - [ ] Fr: Nous avons envoyé votre code-barre et les informations ci-dessous à l’adresse e-mail que vous avez utilisée pour vous connecter
    - [ ] Ch: 我们已将条形码和以下信息发到了您用来登录的电邮地址


- [ ] Verify that there is **no** line near the bottom of the page that reads "We have sent this information to the email you used to sign in" - it used to exist here: 
<img width="586" alt="Screenshot 2024-07-30 at 2 06 22 PM" src="https://github.com/user-attachments/assets/8a0f954a-5ed4-4e77-a255-b176beb11014">


### EIPP Barcode page
- [ ] Enter the EIPP flow - Through the Sinatra app, select Enhanced for level of service and sign in.
- [ ] Complete the EIPP flow and arrive at the `verify/in_person/ready_to_verify` page.
- [ ] Verify that there is a success alert at the top of the page that reads:<img width="367" alt="Screenshot 2024-07-30 at 2 20 01 PM" src="https://github.com/user-attachments/assets/53941a9b-3724-4fb4-8b26-84efa7b78f3a">
    - [ ] En: We have sent your barcode and the information below to the email you used to sign in
    - [ ] Es: Enviamos el código de barras y la información más abajo al correo electrónico que usó para iniciar sesión
    - [ ] Fr: Nous avons envoyé votre code-barre et les informations ci-dessous à l’adresse e-mail que vous avez utilisée pour vous connecter
    - [ ] Ch: 我们已将条形码和以下信息发到了您用来登录的电邮地址
- [ ] Verify that there is **no** line near the bottom of the page that reads "We have sent this information to the email you used to sign in" - it used to exist here: 
<img width="586" alt="Screenshot 2024-07-30 at 2 06 22 PM" src="https://github.com/user-attachments/assets/8a0f954a-5ed4-4e77-a255-b176beb11014">

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.


<details>
<summary>IPP Barcode Page:</summary>

![Barcode page (en)](https://github.com/user-attachments/assets/4757b9be-b902-46a6-949b-cb7a30ca8617)
![Barcode page (es)](https://github.com/user-attachments/assets/794b6ba6-fadc-4b82-b665-b1d3197c1bb0)
![Barcode page (fr)](https://github.com/user-attachments/assets/b03b9d17-9951-4977-a07e-6c3b68b7baaf)
![Barcode page (zh)](https://github.com/user-attachments/assets/bb82a1f1-c273-4478-8e5d-83dfe4abbebe)


</details>


<details>
<summary>EIPP Barcode Page:</summary>

![EIPP Barcode page (en)](https://github.com/user-attachments/assets/3a4571fd-1dfe-4837-bd42-dbecf4523d84)
![EIPP Barcode page (es)](https://github.com/user-attachments/assets/e4443b04-d892-4006-8c31-d6a2e73d2888)
![EIPP Barcode page (fr)](https://github.com/user-attachments/assets/fdf95246-54a8-42c3-bbd5-e324fdcc41b9)
![EIPP Barcode page (zh)](https://github.com/user-attachments/assets/800a0352-5815-4991-a23b-b42d0ad42721)

</details>