### PR TITLE
Clean up unnecessary methods 

### DIFF
--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -18,7 +18,6 @@ module VerifyProfileConcern
     @pending_profile_policy ||= PendingProfilePolicy.new(
       user: current_user,
       resolved_authn_context_result: resolved_authn_context_result,
-      biometric_comparison_requested: nil,
     )
   end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -52,12 +52,7 @@ module OpenidConnect
       @pending_profile_policy ||= PendingProfilePolicy.new(
         user: current_user,
         resolved_authn_context_result: resolved_authn_context_result,
-        biometric_comparison_requested: biometric_comparison_requested?,
       )
-    end
-
-    def biometric_comparison_requested?
-      @authorize_form.biometric_comparison_requested?
     end
 
     def check_sp_active

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -129,18 +129,6 @@ class OpenidConnectAuthorizeForm
       Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
   end
 
-  def parsed_vectors_of_trust
-    return @parsed_vectors_of_trust if defined?(@parsed_vectors_of_trust)
-
-    @parsed_vectors_of_trust = begin
-      if vtr.is_a?(Array) && !vtr.empty?
-        vtr.map { |vot| Vot::Parser.new(vector_of_trust: vot).parse }
-      end
-    rescue Vot::Parser::ParseException
-      nil
-    end
-  end
-
   private
 
   attr_reader :identity, :success
@@ -154,6 +142,18 @@ class OpenidConnectAuthorizeForm
     return false if identity_proofing_requested_or_default? || param_value.blank?
     return true if verified_at_requested? && !identity_proofing_service_provider?
     @scope != param_value.split(' ').compact
+  end
+
+  def parsed_vectors_of_trust
+    return @parsed_vectors_of_trust if defined?(@parsed_vectors_of_trust)
+
+    @parsed_vectors_of_trust = begin
+      if vtr.is_a?(Array) && !vtr.empty?
+        vtr.map { |vot| Vot::Parser.new(vector_of_trust: vot).parse }
+      end
+    rescue Vot::Parser::ParseException
+      nil
+    end
   end
 
   def parse_to_values(param_value, possible_values)

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -129,10 +129,6 @@ class OpenidConnectAuthorizeForm
       Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
   end
 
-  def biometric_comparison_requested?
-    !!parsed_vectors_of_trust&.any?(&:biometric_comparison?)
-  end
-
   def parsed_vectors_of_trust
     return @parsed_vectors_of_trust if defined?(@parsed_vectors_of_trust)
 

--- a/app/policies/pending_profile_policy.rb
+++ b/app/policies/pending_profile_policy.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class PendingProfilePolicy
-  def initialize(user:, resolved_authn_context_result:, biometric_comparison_requested:)
+  def initialize(user:, resolved_authn_context_result:)
     @user = user
     @resolved_authn_context_result = resolved_authn_context_result
-    @biometric_comparison_requested = biometric_comparison_requested
   end
 
   def user_has_pending_profile?
@@ -19,14 +18,14 @@ class PendingProfilePolicy
 
   private
 
-  attr_reader :user, :resolved_authn_context_result, :biometric_comparison_requested
+  attr_reader :user, :resolved_authn_context_result
 
   def pending_biometric_profile?
     user.pending_profile&.idv_level == 'unsupervised_with_selfie'
   end
 
   def biometric_comparison_requested?
-    resolved_authn_context_result.biometric_comparison? || biometric_comparison_requested
+    resolved_authn_context_result.biometric_comparison?
   end
 
   def pending_legacy_profile?

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -22,10 +22,6 @@ class SamlRequestValidator
     FormResponse.new(success: valid?, errors: errors, extra: extra_analytics_attributes)
   end
 
-  def biometric_comparison_requested?
-    !!parsed_vectors_of_trust&.any?(&:biometric_comparison?)
-  end
-
   private
 
   attr_accessor :service_provider, :authn_context, :authn_context_comparison, :nameid_format

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -707,37 +707,4 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
   end
-
-  describe '#biometric_comparison_requested?' do
-    it 'returns false by default' do
-      expect(subject.biometric_comparison_requested?).to eql(false)
-    end
-
-    context 'biometric requested via VTR' do
-      let(:acr_values) { nil }
-      let(:vtr) { ['C1.P1.Pb'].to_json }
-
-      it 'returns true' do
-        expect(subject.biometric_comparison_requested?).to eql(true)
-      end
-    end
-
-    context 'VTR used but biometric not requested' do
-      let(:acr_values) { nil }
-      let(:vtr) { ['C1.P1'].to_json }
-
-      it 'returns false' do
-        expect(subject.biometric_comparison_requested?).to eql(false)
-      end
-    end
-
-    context 'multiple VTR including biometric comparison' do
-      let(:acr_values) { nil }
-      let(:vtr) { ['C1.P1', 'C1.P1.Pb'].to_json }
-
-      it 'returns false' do
-        expect(subject.biometric_comparison_requested?).to eql(true)
-      end
-    end
-  end
 end

--- a/spec/policies/pending_profile_policy_spec.rb
+++ b/spec/policies/pending_profile_policy_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe PendingProfilePolicy do
       acr_values: acr_values,
     ).resolve
   end
-  let(:biometric_comparison_requested) { nil }
   let(:vtr) { nil }
   let(:acr_values) { nil }
 
@@ -18,7 +17,6 @@ RSpec.describe PendingProfilePolicy do
     described_class.new(
       user: user,
       resolved_authn_context_result: resolved_authn_context_result,
-      biometric_comparison_requested: biometric_comparison_requested,
     )
   end
 
@@ -38,9 +36,8 @@ RSpec.describe PendingProfilePolicy do
         end
       end
 
-      context 'with biometric_comparison_requested param set to true' do
-        let(:biometric_comparison_requested) { true }
-        let(:acr_values) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
+      context 'with biometric comparison requested ACR value' do
+        let(:acr_values) { Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF }
 
         it 'has a usable pending profile' do
           expect(policy.user_has_pending_profile?).to eq(true)

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -402,38 +402,4 @@ RSpec.describe SamlRequestValidator do
       end
     end
   end
-
-  describe '#biometric_comparison_requested?' do
-    let(:sp) { ServiceProvider.find_by(issuer: 'http://localhost:3000') }
-    let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT }
-    let(:authn_context) { [] }
-
-    subject(:validator) do
-      validator = SamlRequestValidator.new
-      validator.call(
-        service_provider: sp,
-        authn_context: authn_context,
-        nameid_format: name_id_format,
-      )
-      validator
-    end
-
-    context 'biometric comparison was requested' do
-      let(:authn_context) { ['C1.C2.P1.Pb'] }
-
-      it { expect(subject.biometric_comparison_requested?).to eq(true) }
-    end
-
-    context 'biometric comparison was not requested' do
-      let(:authn_context) { ['C1.C2.P1'] }
-
-      it { expect(subject.biometric_comparison_requested?).to eq(false) }
-    end
-
-    context 'biometric comparison requested with multiple vectors of trust' do
-      let(:authn_context) { ['C1.C2.P1', 'C1.C2.P1.Pb'] }
-
-      it { expect(subject.biometric_comparison_requested?).to eq(true) }
-    end
-  end
 end


### PR DESCRIPTION
## 🎫 Ticket
https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/43

## 🛠 Summary of changes
This is some cleanup for the ticket adding new biometric comparison ACR values for OIDC. 

Several methods that had been used to determine whether biometric comparison (I think) are no longer necessary,  as the resolved authn context object is available at the moment of consumption. One other similarly named method was no longer in use. 

