### PR TITLE
Assert logged events using have_logged_event (part 2)

### DIFF
--- a/spec/controllers/frontend_log_controller_spec.rb
+++ b/spec/controllers/frontend_log_controller_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe FrontendLogController do
   describe '#create' do
     subject(:action) { post :create, params: params, as: :json }
 
-    let(:fake_analytics) { FakeAnalytics.new }
     let(:user) { create(:user, :with_phone, with: { phone: '+1 (202) 555-1212' }) }
     let(:event) { 'Custom Event' }
     let(:payload) { { 'message' => 'To be logged...' } }
@@ -27,7 +26,7 @@ RSpec.describe FrontendLogController do
     context 'user is signed in' do
       before do
         sign_in user
-        allow(controller).to receive(:analytics).and_return(fake_analytics)
+        stub_analytics
       end
 
       context 'with invalid event name' do
@@ -51,7 +50,7 @@ RSpec.describe FrontendLogController do
         it 'succeeds' do
           action
 
-          expect(fake_analytics).to have_logged_event('IdV: personal key downloaded')
+          expect(@analytics).to have_logged_event('IdV: personal key downloaded')
           expect(response).to have_http_status(:ok)
           expect(json[:success]).to eq(true)
         end
@@ -69,7 +68,7 @@ RSpec.describe FrontendLogController do
           it 'succeeds' do
             action
 
-            expect(fake_analytics).to have_logged_event(
+            expect(@analytics).to have_logged_event(
               'IdV: in person proofing location submitted',
               selected_location: selected_location,
               flow_path: flow_path,
@@ -85,7 +84,7 @@ RSpec.describe FrontendLogController do
             it 'gracefully sets the missing values to nil' do
               action
 
-              expect(fake_analytics).to have_logged_event(
+              expect(@analytics).to have_logged_event(
                 'IdV: in person proofing location submitted',
                 flow_path: nil,
                 selected_location: nil,
@@ -112,7 +111,7 @@ RSpec.describe FrontendLogController do
             it 'succeeds' do
               action
 
-              expect(fake_analytics).to have_logged_event(
+              expect(@analytics).to have_logged_event(
                 'IdV: in person proofing location submitted',
                 selected_location: selected_location,
                 flow_path: flow_path,
@@ -127,21 +126,19 @@ RSpec.describe FrontendLogController do
 
       context 'invalid param' do
         it 'rejects a non-hash payload' do
-          expect(fake_analytics).not_to receive(:track_event)
-
           params[:payload] = 'abc'
           action
 
+          expect(@analytics).to_not have_logged_event
           expect(response).to have_http_status(:bad_request)
           expect(json[:success]).to eq(false)
         end
 
         it 'rejects a non-string event' do
-          expect(fake_analytics).not_to receive(:track_event)
-
           params[:event] = { abc: 'abc' }
           action
 
+          expect(@analytics).to_not have_logged_event
           expect(response).to have_http_status(:bad_request)
           expect(json[:success]).to eq(false)
         end
@@ -149,11 +146,10 @@ RSpec.describe FrontendLogController do
 
       context 'missing a parameter' do
         it 'rejects a request without specifying event' do
-          expect(fake_analytics).not_to receive(:track_event)
-
           params.delete('event')
           action
 
+          expect(@analytics).to_not have_logged_event
           expect(response).to have_http_status(:bad_request)
           expect(json[:success]).to eq(false)
         end
@@ -179,7 +175,7 @@ RSpec.describe FrontendLogController do
         it 'logs the analytics event' do
           action
 
-          expect(fake_analytics).to have_logged_event(
+          expect(@analytics).to have_logged_event(
             'IdV: Native camera forced after failed attempts',
             field: field,
             failed_capture_attempts: failed_capture_attempts,
@@ -207,7 +203,6 @@ RSpec.describe FrontendLogController do
         it 'notices the error to NewRelic instead of analytics logger' do
           allow_any_instance_of(FrontendErrorForm).to receive(:submit).
             and_return(FormResponse.new(success: true))
-          expect(fake_analytics).not_to receive(:track_event)
           expect(NewRelic::Agent).to receive(:notice_error).with(
             FrontendErrorLogger::FrontendError.new,
             custom_params: {
@@ -223,6 +218,7 @@ RSpec.describe FrontendLogController do
 
           action
 
+          expect(@analytics).to_not have_logged_event
           expect(response).to have_http_status(:ok)
           expect(json[:success]).to eq(true)
         end
@@ -234,8 +230,17 @@ RSpec.describe FrontendLogController do
 
       before do
         session[:doc_capture_user_id] = user_id
-        allow(Analytics).to receive(:new).and_return(fake_analytics)
-        expect(Analytics).to receive(:new).with(hash_including(user: user))
+        stub_analytics(user:)
+      end
+
+      context 'allowlisted analytics event' do
+        let(:event) { 'IdV: download personal key' }
+
+        it 'logs as the session-associated user' do
+          action
+
+          expect(@analytics).to have_logged_event('IdV: personal key downloaded')
+        end
       end
 
       context 'with invalid event name' do
@@ -249,6 +254,7 @@ RSpec.describe FrontendLogController do
 
         it 'does not commit session' do
           action
+
           expect(request.session_options[:skip]).to eql(true)
         end
       end

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::AddressController, allowed_extra_analytics: [:*] do
+RSpec.describe Idv::AddressController do
   let(:user) { create(:user) }
 
   let(:pii_from_doc) { Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT) }

--- a/spec/controllers/idv/address_controller_spec.rb
+++ b/spec/controllers/idv/address_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::AddressController do
+RSpec.describe Idv::AddressController, allowed_extra_analytics: [:*] do
   let(:user) { create(:user) }
 
   let(:pii_from_doc) { Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT) }

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::HowToVerifyController do
+RSpec.describe Idv::HowToVerifyController, allowed_extra_analytics: [:*] do
   let(:user) { create(:user) }
   let(:enabled) { true }
   let(:ab_test_args) do
@@ -15,7 +15,6 @@ RSpec.describe Idv::HowToVerifyController do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { true }
     stub_sign_in(user)
     stub_analytics
-    allow(@analytics).to receive(:track_event)
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
     allow(subject.idv_session).to receive(:service_provider).and_return(service_provider)
     subject.idv_session.welcome_visited = true
@@ -130,7 +129,7 @@ RSpec.describe Idv::HowToVerifyController do
     it 'sends analytics_visited event' do
       get :show
 
-      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
     context 'agreement step not completed' do
@@ -164,7 +163,7 @@ RSpec.describe Idv::HowToVerifyController do
       it 'logs the invalid value and re-renders the page' do
         put :update, params: params
 
-        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
         expect(response).to render_template :show
       end
 
@@ -236,7 +235,7 @@ RSpec.describe Idv::HowToVerifyController do
       it 'sends analytics_submitted event when remote proofing is selected' do
         put :update, params: params
 
-        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
       end
     end
 
@@ -263,7 +262,7 @@ RSpec.describe Idv::HowToVerifyController do
       it 'sends analytics_submitted event when remote proofing is selected' do
         put :update, params: params
 
-        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
       end
     end
   end

--- a/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::HybridMobile::CaptureCompleteController do
+RSpec.describe Idv::HybridMobile::CaptureCompleteController, allowed_extra_analytics: [:*] do
   let(:user) { create(:user) }
 
   let!(:document_capture_session) do
@@ -28,7 +28,6 @@ RSpec.describe Idv::HybridMobile::CaptureCompleteController do
     session[:doc_capture_user_id] = user&.id
     session[:document_capture_session_uuid] = document_capture_session_uuid
     stub_analytics
-    allow(@analytics).to receive(:track_event)
     allow(subject).to receive(:confirm_document_capture_session_complete).
       and_return(true)
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
@@ -63,7 +62,7 @@ RSpec.describe Idv::HybridMobile::CaptureCompleteController do
     it 'sends analytics_visited event' do
       get :show
 
-      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
     it 'updates DocAuthLog capture_complete_view_count' do

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::InPerson::AddressController do
+RSpec.describe Idv::InPerson::AddressController, allowed_extra_analytics: [:*] do
   include FlowPolicyHelper
   include InPersonHelper
 
@@ -16,7 +16,6 @@ RSpec.describe Idv::InPerson::AddressController do
     }
     subject.idv_session.ssn = nil
     stub_analytics
-    allow(@analytics).to receive(:track_event)
   end
 
   describe '#step_info' do
@@ -77,9 +76,6 @@ RSpec.describe Idv::InPerson::AddressController do
         flow_path: 'standard',
         opted_in_to_in_person_proofing: nil,
         step: 'address',
-        pii_like_keypaths: [[:same_address_as_id],
-                            [:proofing_results, :context, :stages, :state_id,
-                             :state_id_jurisdiction]],
         same_address_as_id: false,
         skip_hybrid_handoff: nil,
       }
@@ -102,9 +98,7 @@ RSpec.describe Idv::InPerson::AddressController do
     it 'logs idv_in_person_proofing_address_visited' do
       get :show
 
-      expect(@analytics).to have_received(
-        :track_event,
-      ).with(analytics_name, analytics_args)
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
     it 'has correct extra_view_variables' do
@@ -148,9 +142,6 @@ RSpec.describe Idv::InPerson::AddressController do
           analytics_id: 'In Person Proofing',
           flow_path: 'standard',
           step: 'address',
-          pii_like_keypaths: [[:same_address_as_id],
-                              [:proofing_results, :context, :stages, :state_id,
-                               :state_id_jurisdiction]],
           same_address_as_id: false,
           skip_hybrid_handoff: nil,
           current_address_zip_code: '59010',
@@ -172,9 +163,7 @@ RSpec.describe Idv::InPerson::AddressController do
       it 'logs idv_in_person_proofing_address_submitted with 5-digit zipcode' do
         put :update, params: params
 
-        expect(@analytics).to have_received(
-          :track_event,
-        ).with(analytics_name, analytics_args)
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
       end
 
       context 'when updating the residential address' do
@@ -236,9 +225,6 @@ RSpec.describe Idv::InPerson::AddressController do
           analytics_id: 'In Person Proofing',
           flow_path: 'standard',
           step: 'address',
-          pii_like_keypaths: [[:same_address_as_id],
-                              [:proofing_results, :context, :stages, :state_id,
-                               :state_id_jurisdiction]],
           same_address_as_id: false,
           skip_hybrid_handoff: nil,
           current_address_zip_code: '59010',
@@ -254,7 +240,7 @@ RSpec.describe Idv::InPerson::AddressController do
       end
 
       it 'logs idv_in_person_proofing_address_submitted without zipcode' do
-        expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
       end
     end
   end

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::InPerson::StateIdController do
+RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] do
   include FlowPolicyHelper
   include InPersonHelper
 
@@ -22,7 +22,6 @@ RSpec.describe Idv::InPerson::StateIdController do
     subject.user_session['idv/in_person'] = { pii_from_user: {} }
     subject.idv_session.ssn = nil # This made specs pass. Might need more investigation.
     stub_analytics
-    allow(@analytics).to receive(:track_event)
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
@@ -78,9 +77,6 @@ RSpec.describe Idv::InPerson::StateIdController do
         flow_path: 'standard',
         opted_in_to_in_person_proofing: nil,
         step: 'state_id',
-        pii_like_keypaths: [[:same_address_as_id],
-                            [:proofing_results, :context, :stages, :state_id,
-                             :state_id_jurisdiction]],
       }.merge(ab_test_args)
     end
 
@@ -107,9 +103,7 @@ RSpec.describe Idv::InPerson::StateIdController do
     it 'logs idv_in_person_proofing_state_id_visited' do
       get :show
 
-      expect(@analytics).to have_received(
-        :track_event,
-      ).with(analytics_name, analytics_args)
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
     it 'has correct extra_view_variables' do
@@ -189,9 +183,6 @@ RSpec.describe Idv::InPerson::StateIdController do
           flow_path: 'standard',
           step: 'state_id',
           opted_in_to_in_person_proofing: nil,
-          pii_like_keypaths: [[:same_address_as_id],
-                              [:proofing_results, :context, :stages, :state_id,
-                               :state_id_jurisdiction]],
           same_address_as_id: true,
           birth_year: dob[:year],
           document_zip_code: identity_doc_zipcode&.slice(0, 5),
@@ -201,9 +192,7 @@ RSpec.describe Idv::InPerson::StateIdController do
       it 'logs idv_in_person_proofing_state_id_submitted' do
         put :update, params: params
 
-        expect(@analytics).to have_received(
-          :track_event,
-        ).with(analytics_name, analytics_args)
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
       end
 
       it 'renders show when validation errors are present when first visiting page' do

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::LinkSentController do
+RSpec.describe Idv::LinkSentController, allowed_extra_analytics: [:*] do
   let(:user) { create(:user) }
 
   let(:ab_test_args) do
@@ -13,7 +13,6 @@ RSpec.describe Idv::LinkSentController do
     subject.idv_session.idv_consent_given = true
     subject.idv_session.flow_path = 'hybrid'
     stub_analytics
-    allow(@analytics).to receive(:track_event)
     allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
@@ -65,7 +64,7 @@ RSpec.describe Idv::LinkSentController do
     it 'sends analytics_visited event' do
       get :show
 
-      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
     it 'updates DocAuthLog link_sent_view_count' do
@@ -129,7 +128,7 @@ RSpec.describe Idv::LinkSentController do
     it 'sends analytics_submitted event' do
       put :update
 
-      expect(@analytics).to have_received(:track_event).with(analytics_name, analytics_args)
+      expect(@analytics).to have_logged_event(analytics_name, analytics_args)
     end
 
     context 'check results' do

--- a/spec/controllers/redirect/return_to_sp_controller_spec.rb
+++ b/spec/controllers/redirect/return_to_sp_controller_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Redirect::ReturnToSpController do
   before do
     allow(subject).to receive(:current_sp).and_return(current_sp)
     stub_analytics
-    allow(@analytics).to receive(:track_event)
   end
 
   describe '#cancel' do
@@ -35,7 +34,7 @@ RSpec.describe Redirect::ReturnToSpController do
           service_provider: current_sp, oidc_state: state, oidc_redirect_uri: redirect_uri,
         ).return_to_sp_url
         expect(response).to redirect_to(expected_redirect_uri)
-        expect(@analytics).to have_received(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Return to SP: Cancelled',
           hash_including(redirect_url: expected_redirect_uri),
         )
@@ -58,7 +57,7 @@ RSpec.describe Redirect::ReturnToSpController do
           service_provider: current_sp, oidc_state: state, oidc_redirect_uri: redirect_uri,
         ).return_to_sp_url
         expect(response).to redirect_to(expected_redirect_uri)
-        expect(@analytics).to have_received(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Return to SP: Cancelled',
           hash_including(redirect_url: expected_redirect_uri),
         )
@@ -72,7 +71,7 @@ RSpec.describe Redirect::ReturnToSpController do
         get 'cancel'
 
         expect(response).to redirect_to('https://sp.gov/return_to_sp')
-        expect(@analytics).to have_received(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Return to SP: Cancelled',
           hash_including(redirect_url: 'https://sp.gov/return_to_sp'),
         )
@@ -98,7 +97,7 @@ RSpec.describe Redirect::ReturnToSpController do
         get 'failure_to_proof'
 
         expect(response).to redirect_to('https://sp.gov/failure_to_proof')
-        expect(@analytics).to have_received(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Return to SP: Failed to proof',
           hash_including(redirect_url: 'https://sp.gov/failure_to_proof'),
         )
@@ -109,7 +108,7 @@ RSpec.describe Redirect::ReturnToSpController do
       it 'logs with extra analytics properties' do
         get 'failure_to_proof', params: { step: 'first', location: 'bottom' }
 
-        expect(@analytics).to have_received(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Return to SP: Failed to proof',
           hash_including(
             redirect_url: a_kind_of(String),

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -975,7 +975,6 @@ RSpec.describe SamlIdpController do
     context 'authn_context is invalid' do
       it 'renders an error page' do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
 
         saml_get_auth(
           saml_settings(
@@ -1003,8 +1002,7 @@ RSpec.describe SamlIdpController do
           matching_cert_serial: saml_test_sp_cert_serial,
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('SAML Auth', hash_including(analytics_hash))
+        expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
       end
     end
 
@@ -1206,7 +1204,6 @@ RSpec.describe SamlIdpController do
         user = create(:user, :fully_registered)
 
         stub_analytics
-        allow(@analytics).to receive(:track_event)
 
         generate_saml_response(user, saml_settings(overrides: { issuer: 'invalid_provider' }))
 
@@ -1230,8 +1227,7 @@ RSpec.describe SamlIdpController do
           matching_cert_serial: nil,
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('SAML Auth', hash_including(analytics_hash))
+        expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
       end
     end
 
@@ -1240,7 +1236,6 @@ RSpec.describe SamlIdpController do
         user = create(:user, :fully_registered)
 
         stub_analytics
-        allow(@analytics).to receive(:track_event)
 
         generate_saml_response(
           user,
@@ -1279,8 +1274,7 @@ RSpec.describe SamlIdpController do
           matching_cert_serial: nil,
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('SAML Auth', hash_including(analytics_hash))
+        expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
       end
     end
 
@@ -1576,7 +1570,6 @@ RSpec.describe SamlIdpController do
 
       before do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
       end
 
       # the RubySAML library won't let us pass an empty string in as the certificate
@@ -1643,8 +1636,7 @@ RSpec.describe SamlIdpController do
           matching_cert_serial: nil,
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('SAML Auth', hash_including(analytics_hash))
+        expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
       end
 
       it 'returns a 400' do
@@ -1660,7 +1652,6 @@ RSpec.describe SamlIdpController do
 
       before do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
       end
 
       it 'notes that in the analytics event' do
@@ -1693,8 +1684,7 @@ RSpec.describe SamlIdpController do
           encryption_cert_matches_matching_cert: true,
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('SAML Auth', hash_including(analytics_hash))
+        expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
       end
     end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe SignUp::CompletionsController do
     context 'user signed in, sp info present' do
       before do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
       end
 
       it 'redirects to account page when SP request URL is not present' do
@@ -40,7 +39,7 @@ RSpec.describe SignUp::CompletionsController do
         end
 
         it 'tracks page visit' do
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'User registration: agency handoff visited',
             ial2: false,
             ialmax: false,
@@ -77,7 +76,7 @@ RSpec.describe SignUp::CompletionsController do
         end
 
         it 'tracks page visit' do
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'User registration: agency handoff visited',
             ial2: true,
             ialmax: false,
@@ -123,7 +122,7 @@ RSpec.describe SignUp::CompletionsController do
         end
 
         it 'tracks page visit' do
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'User registration: agency handoff visited',
             ial2: false,
             ialmax: true,
@@ -207,7 +206,6 @@ RSpec.describe SignUp::CompletionsController do
 
     before do
       stub_analytics
-      allow(@analytics).to receive(:track_event)
       @linker = instance_double(IdentityLinker)
       allow(@linker).to receive(:link_identity).and_return(true)
       allow(IdentityLinker).to receive(:new).and_return(@linker)
@@ -226,7 +224,7 @@ RSpec.describe SignUp::CompletionsController do
 
         patch :update
 
-        expect(@analytics).to have_received(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'User registration: complete',
           ial2: false,
           ialmax: false,
@@ -288,7 +286,7 @@ RSpec.describe SignUp::CompletionsController do
 
           patch :update
 
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'User registration: complete',
             ial2: false,
             ialmax: false,
@@ -327,7 +325,7 @@ RSpec.describe SignUp::CompletionsController do
 
         patch :update
 
-        expect(@analytics).to have_received(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'User registration: complete',
           ial2: true,
           ialmax: false,

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
+RSpec.describe TwoFactorAuthentication::WebauthnVerificationController,
+               allowed_extra_analytics: [:*] do
   include WebAuthnHelper
 
   describe 'when not signed in' do
@@ -39,7 +40,7 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
         let!(:webauthn_configuration) { create(:webauthn_configuration, user:) }
 
         before do
-          allow(@analytics).to receive(:track_event)
+          stub_analytics
         end
 
         it 'tracks an analytics event' do
@@ -50,7 +51,7 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
             webauthn_configuration_id: nil,
             multi_factor_auth_method_created_at: nil,
           }
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication: enter webAuthn authentication visited',
             result,
           )

--- a/spec/controllers/users/authorization_confirmation_controller_spec.rb
+++ b/spec/controllers/users/authorization_confirmation_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Users::AuthorizationConfirmationController do
 
   before do
     stub_analytics
-    allow(@analytics).to receive(:track_event)
     stub_sign_in(user)
     controller.session[:sp] = sp_session
   end
@@ -28,7 +27,7 @@ RSpec.describe Users::AuthorizationConfirmationController do
       get :new
 
       expect(response).to render_template(:new)
-      expect(@analytics).to have_received(:track_event).with('Authentication Confirmation')
+      expect(@analytics).to have_logged_event('Authentication Confirmation')
     end
   end
 
@@ -37,7 +36,7 @@ RSpec.describe Users::AuthorizationConfirmationController do
       post :create
 
       expect(response).to redirect_to(sp_request_url)
-      expect(@analytics).to have_received(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'Authentication Confirmation: Continue selected',
       )
     end
@@ -50,7 +49,7 @@ RSpec.describe Users::AuthorizationConfirmationController do
       delete :destroy
 
       expect(response).to redirect_to(new_user_session_url(request_id: sp_request_id))
-      expect(@analytics).to have_received(:track_event).with(
+      expect(@analytics).to have_logged_event(
         'Authentication Confirmation: Reset selected',
       )
     end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
       it 'redirects to profile and sends a password change email' do
         stub_sign_in
         stub_analytics
-        allow(@analytics).to receive(:track_event)
 
         params = {
           password: 'salty new password',
@@ -47,7 +46,7 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
         }
         patch :update, params: { update_user_password_form: params }
 
-        expect(@analytics).to have_received(:track_event).with(
+        expect(@analytics).to have_logged_event(
           'Password Changed',
           success: true,
           errors: {},
@@ -148,10 +147,10 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
         end
 
         it 'updates the user password and logs analytic event' do
-          allow(@analytics).to receive(:track_event)
+          stub_analytics
           patch :update, params: { update_user_password_form: params }
 
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'Password Changed',
             success: true,
             errors: {},
@@ -166,7 +165,7 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
         end
 
         it 'sends email notifying user of password change' do
-          allow(@analytics).to receive(:track_event)
+          stub_analytics
 
           patch :update, params: { update_user_password_form: params }
           expect_delivered_email_count(1)
@@ -215,10 +214,10 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
         end
 
         it 'renders edit' do
-          allow(@analytics).to receive(:track_event)
+          stub_analytics
           patch :update, params: { update_user_password_form: params }
 
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'Password Changed',
             success: false,
             errors: {
@@ -250,13 +249,13 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
         before do
           stub_sign_in
           stub_analytics
-          allow(@analytics).to receive(:track_event)
+          stub_analytics
         end
 
         it 'renders edit' do
           patch :update, params: { update_user_password_form: params }
 
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'Password Changed',
             success: false,
             errors: {
@@ -298,13 +297,13 @@ RSpec.describe Users::PasswordsController, allowed_extra_analytics: [:*] do
         before do
           stub_sign_in
           stub_analytics
-          allow(@analytics).to receive(:track_event)
+          stub_analytics
         end
 
         it 'renders edit' do
           patch :update, params: { update_user_password_form: params }
 
-          expect(@analytics).to have_received(:track_event).with(
+          expect(@analytics).to have_logged_event(
             'Password Changed',
             success: false,
             errors: {

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -90,13 +90,14 @@ RSpec.describe Users::PivCacAuthenticationSetupController, allowed_extra_analyti
 
           it 'tracks the analytic event of visited' do
             stub_analytics
-            expect(@analytics).to receive(:track_event).
-              with(:piv_cac_setup_visited, {
-                in_account_creation_flow: false,
-                enabled_mfa_methods_count: 1,
-              })
 
             get :new
+
+            expect(@analytics).to have_logged_event(
+              :piv_cac_setup_visited,
+              in_account_creation_flow: false,
+              enabled_mfa_methods_count: 1,
+            )
           end
         end
 

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
     let(:email_address) { instance_double('EmailAddress') }
     before do
       stub_analytics
-      allow(@analytics).to receive(:track_event)
     end
 
     context 'when token isnt stored in session' do
@@ -38,8 +37,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       it 'redirects to page where user enters email for password reset token' do
         get :edit
 
-        expect(@analytics).to have_received(:track_event).
-          with('Password Reset: Token Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event('Password Reset: Token Submitted', analytics_hash)
         expect(response).to redirect_to new_user_password_path
         expect(flash[:error]).to eq t('devise.passwords.invalid_token')
       end
@@ -83,8 +81,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         it 'redirects to page where user enters email for password reset token' do
           get :edit
 
-          expect(@analytics).to have_received(:track_event).
-            with('Password Reset: Token Submitted', analytics_hash)
+          expect(@analytics).to have_logged_event('Password Reset: Token Submitted', analytics_hash)
           expect(response).to redirect_to new_user_password_path
           expect(flash[:error]).to eq t('devise.passwords.invalid_token')
         end
@@ -109,8 +106,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         it 'redirects to page where user enters email for password reset token' do
           get :edit
 
-          expect(@analytics).to have_received(:track_event).
-            with('Password Reset: Token Submitted', analytics_hash)
+          expect(@analytics).to have_logged_event('Password Reset: Token Submitted', analytics_hash)
           expect(response).to redirect_to new_user_password_path
           expect(flash[:error]).to eq t('devise.passwords.token_expired')
         end
@@ -169,7 +165,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
     context 'user submits new password after token expires' do
       it 'redirects to page where user enters email for password reset token' do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
 
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
@@ -210,8 +205,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           pending_profile_pending_reasons: '',
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('Password Reset: Password Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event(
+          'Password Reset: Password Submitted',
+          analytics_hash,
+        )
         expect(response).to redirect_to new_user_password_path
         expect(flash[:error]).to eq t('devise.passwords.token_expired')
       end
@@ -343,7 +340,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
 
       it 'redirects to sign in page' do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
 
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
@@ -382,8 +378,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
             pending_profile_pending_reasons: '',
           }
 
-          expect(@analytics).to have_received(:track_event).
-            with('Password Reset: Password Submitted', analytics_hash)
+          expect(@analytics).to have_logged_event(
+            'Password Reset: Password Submitted',
+            analytics_hash,
+          )
           expect(user.events.password_changed.size).to be 1
 
           expect(response).to redirect_to new_user_session_path
@@ -398,7 +396,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
 
       it 'deactivates the active profile and redirects' do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
 
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
@@ -433,8 +430,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           pending_profile_pending_reasons: '',
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('Password Reset: Password Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event(
+          'Password Reset: Password Submitted',
+          analytics_hash,
+        )
         expect(user.active_profile.present?).to eq false
         expect(response).to redirect_to new_user_session_path
       end
@@ -445,7 +444,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
 
       it 'confirms the user' do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
 
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
@@ -481,8 +479,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           pending_profile_pending_reasons: '',
         }
 
-        expect(@analytics).to have_received(:track_event).
-          with('Password Reset: Password Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event(
+          'Password Reset: Password Submitted',
+          analytics_hash,
+        )
         expect(user.reload.confirmed?).to eq true
         expect(response).to redirect_to new_user_session_path
       end
@@ -536,7 +536,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
 
       before do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
       end
 
       it 'sends password reset email to user and tracks event' do
@@ -544,8 +543,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           put :create, params: { password_reset_email_form: email_param }
         end.to change { ActionMailer::Base.deliveries.count }.by(1)
 
-        expect(@analytics).to have_received(:track_event).
-          with('Password Reset: Email Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event('Password Reset: Email Submitted', analytics_hash)
         expect(response).to redirect_to forgot_password_path
       end
     end
@@ -572,15 +570,13 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
 
       before do
         stub_analytics
-        allow(@analytics).to receive(:track_event)
       end
 
       it 'sends missing user email and tracks event' do
         expect { put :create, params: params }.
           to change { ActionMailer::Base.deliveries.count }.by(1)
 
-        expect(@analytics).to have_received(:track_event).
-          with('Password Reset: Email Submitted', analytics_hash)
+        expect(@analytics).to have_logged_event('Password Reset: Email Submitted', analytics_hash)
 
         expect(ActionMailer::Base.deliveries.last.subject).
           to eq t('anonymous_mailer.password_reset_missing_user.subject')

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -335,22 +335,20 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
           context: 'authentication',
           country_code: 'US',
           area_code: '202',
-          pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
-
-        expect(@analytics).to receive(:track_event).
-          ordered.
-          with('OTP: Delivery Selection', analytics_hash)
-        expect(@analytics).to receive(:track_event).
-          ordered.
-          with('Telephony: OTP sent', hash_including(
-            resend: true, success: true, **otp_preference_sms,
-            adapter: :test
-          ))
 
         get :send_code, params: {
           otp_delivery_selection_form: { **otp_preference_sms, resend: 'true' },
         }
+
+        expect(@analytics).to have_logged_event('OTP: Delivery Selection', analytics_hash)
+        expect(@analytics).to have_logged_event(
+          'Telephony: OTP sent',
+          hash_including(
+            resend: true, success: true, **otp_preference_sms,
+            adapter: :test
+          ),
+        )
       end
 
       it 'calls OtpRateLimiter#exceeded_otp_send_limit? and #increment' do
@@ -504,15 +502,17 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
           context: 'authentication',
           country_code: 'US',
           area_code: '202',
-          pii_like_keypaths: [[:errors, :phone], [:error_details, :phone]],
         }
 
-        expect(@analytics).to receive(:track_event).
-          ordered.
-          with('OTP: Delivery Selection', analytics_hash)
-        expect(@analytics).to receive(:track_event).
-          ordered.
-          with('Telephony: OTP sent', hash_including(
+        get :send_code, params: {
+          otp_delivery_selection_form: { otp_delivery_preference: 'voice',
+                                         otp_make_default_number: nil },
+        }
+
+        expect(@analytics).to have_logged_event('OTP: Delivery Selection', analytics_hash)
+        expect(@analytics).to have_logged_event(
+          'Telephony: OTP sent',
+          hash_including(
             success: true,
             otp_delivery_preference: 'voice',
             adapter: :test,
@@ -520,12 +520,8 @@ RSpec.describe Users::TwoFactorAuthenticationController, allowed_extra_analytics
             telephony_response: hash_including(
               origination_phone_number: Telephony::Test::VoiceSender::ORIGINATION_PHONE_NUMBER,
             ),
-          ))
-
-        get :send_code, params: {
-          otp_delivery_selection_form: { otp_delivery_preference: 'voice',
-                                         otp_make_default_number: nil },
-        }
+          ),
+        )
       end
 
       context 'when selecting specific phone configuration' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -524,18 +524,18 @@ RSpec.describe UserMailer, type: :mailer do
     it 'logs email metadata to analytics' do
       analytics = FakeAnalytics.new
       allow(Analytics).to receive(:new).and_return(analytics)
-      allow(analytics).to receive(:track_event)
 
       user = create(:user)
       email_address = user.email_addresses.first
       mail = UserMailer.with(user: user, email_address: email_address).please_reset_password
       mail.deliver_now
 
-      expect(analytics).
-        to have_received(:track_event).with(
-          'Email Sent',
-          action: 'please_reset_password', ses_message_id: nil, email_address_id: email_address.id,
-        )
+      expect(analytics).to have_logged_event(
+        'Email Sent',
+        action: 'please_reset_password',
+        ses_message_id: nil,
+        email_address_id: email_address.id,
+      )
     end
   end
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe 'throttling requests' do
       it 'throttles with a custom response' do
         analytics = FakeAnalytics.new
         allow(Analytics).to receive(:new).and_return(analytics)
-        allow(analytics).to receive(:track_event)
 
         (requests_per_ip_limit + 1).times do
           get '/', headers: { REMOTE_ADDR: '1.2.3.4' }
@@ -102,8 +101,7 @@ RSpec.describe 'throttling requests' do
         expect(response.body).
           to include('Please wait a few minutes before you try again.')
         expect(response.header['Content-type']).to include('text/html')
-        expect(analytics).
-          to have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
+        expect(analytics).to have_logged_event('Rate Limit Triggered', type: 'req/ip')
       end
 
       it 'does not throttle if the path is in the allowlist' do
@@ -111,7 +109,6 @@ RSpec.describe 'throttling requests' do
           and_return(['/account'])
         analytics = FakeAnalytics.new
         allow(Analytics).to receive(:new).and_return(analytics)
-        allow(analytics).to receive(:track_event)
 
         (requests_per_ip_limit + 1).times do
           get '/account', headers: { REMOTE_ADDR: '1.2.3.4' }
@@ -120,14 +117,12 @@ RSpec.describe 'throttling requests' do
         expect(response.status).to eq(302)
         expect(response.body).
           to_not include('Please wait a few minutes before you try again.')
-        expect(analytics).
-          to_not have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
+        expect(analytics).to_not have_logged_event('Rate Limit Triggered')
       end
 
       it 'does not throttle if the ip is in the CIDR block allowlist' do
         analytics = FakeAnalytics.new
         allow(Analytics).to receive(:new).and_return(analytics)
-        allow(analytics).to receive(:track_event)
 
         (requests_per_ip_limit + 1).times do
           get '/', headers: { REMOTE_ADDR: '172.18.100.100' }
@@ -136,8 +131,7 @@ RSpec.describe 'throttling requests' do
         expect(response.status).to eq(200)
         expect(response.body).
           to_not include('Please wait a few minutes before you try again.')
-        expect(analytics).
-          to_not have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
+        expect(analytics).to_not have_logged_event('Rate Limit Triggered')
       end
     end
 
@@ -149,7 +143,6 @@ RSpec.describe 'throttling requests' do
       it 'logs the user UUID' do
         analytics = FakeAnalytics.new
         allow(Analytics).to receive(:new).and_return(analytics)
-        allow(analytics).to receive(:track_event)
 
         user = create(:user, :fully_registered)
 
@@ -169,8 +162,7 @@ RSpec.describe 'throttling requests' do
         expect(Analytics).to have_received(:new).twice do |arguments|
           expect(arguments[:user]).to eq user
         end
-        expect(analytics).
-          to have_received(:track_event).with('Rate Limit Triggered', type: 'req/ip')
+        expect(analytics).to have_logged_event('Rate Limit Triggered', type: 'req/ip')
       end
 
       it 'logs the service provider' do


### PR DESCRIPTION
## 🛠 Summary of changes

Updates specs to replace `expect(@analytics).to receive(:track_event).with` with equivalent `expect(@analytics).to have_logged_event`.

This follows #11001, and includes updating some of the more involved analytics stubbing.

**Why?**

- Because `have_logged_event` includes a number of additional helpers implemented through the `FakeAnalytics` class:
   - Accidental PII leak detection
   - Undocumented analytics method arguments checking
- Facilitate work in #10987

## 📜 Testing Plan

Verify build passes.

Verify that there are no lingering references to stubbed `:track_event` for `Analytics` class in the `spec/` directory.