### PR TITLE
WIP changelog: Internal, In-person proofing, make sponser_id on in_person…

### DIFF
--- a/db/primary_migrate/20240801155943_change_in_person_enrollment_sponsor_id_to_non_nullable.rb
+++ b/db/primary_migrate/20240801155943_change_in_person_enrollment_sponsor_id_to_non_nullable.rb
@@ -1,0 +1,5 @@
+class ChangeInPersonEnrollmentSponsorIdToNonNullable < ActiveRecord::Migration[7.1]
+  def change
+    add_check_constraint :in_person_enrollments, "sponsor_id IS NOT NULL", name: "in_person_enrollments_sponsor_id_null", validate: false
+  end
+end

--- a/db/primary_migrate/20240801183410_validate_change_in_person_enrollment_sponsor_id_to_non_nullable.rb
+++ b/db/primary_migrate/20240801183410_validate_change_in_person_enrollment_sponsor_id_to_non_nullable.rb
@@ -1,0 +1,12 @@
+class ValidateChangeInPersonEnrollmentSponsorIdToNonNullable < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :in_person_enrollments, name: "in_person_enrollments_sponsor_id_null"
+    change_column_null :in_person_enrollments, :sponsor_id, false
+    remove_check_constraint :in_person_enrollments, name: "in_person_enrollments_sponsor_id_null"
+  end
+
+  def down
+    add_check_constraint :in_person_enrollments, "sponsor_id IS NOT NULL", name: "in_person_enrollments_sponser_id_null", validate: false
+    change_column_null :in_person_enrollments, :sponsor_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_08_183211) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_01_183410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -318,7 +318,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_183211) do
     t.boolean "ready_for_status_check", default: false
     t.datetime "notification_sent_at", comment: "The time a notification was sent"
     t.datetime "last_batch_claimed_at"
-    t.string "sponsor_id"
+    t.string "sponsor_id", null: false
     t.string "doc_auth_result"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["ready_for_status_check"], name: "index_in_person_enrollments_on_ready_for_status_check", where: "(ready_for_status_check = true)"

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -82,6 +82,7 @@ namespace :dev do
   desc 'Create in-person enrollments for N random users'
   task random_in_person_users: [:environment, :random_users] do
     is_enhanced_ipp = false
+    sponsor_id = IdentityConfig.store.usps_ipp_sponsor_id
     usps_request_delay_ms = (ENV['USPS_REQUEST_DELAY_MS'] || 0).to_i
     num_users = (ENV['NUM_USERS'] || 100).to_i
     pw = 'salty pickles'
@@ -140,6 +141,7 @@ namespace :dev do
                 user: user,
                 status: :establishing,
                 profile: profile,
+                sponsor_id: sponsor_id,
               )
               enrollment.save!
 
@@ -170,6 +172,7 @@ namespace :dev do
                 enrollment_established_at: Time.zone.now - random.rand(0..5).days,
                 unique_id: SecureRandom.hex(9),
                 enrollment_code: SecureRandom.hex(16),
+                sponsor_id: sponsor_id,
               )
 
               if raw_enrollment_status == InPersonEnrollment::STATUS_PASSED
@@ -182,6 +185,7 @@ namespace :dev do
           InPersonEnrollment.create!(
             user: user,
             status: enrollment_status,
+            sponsor_id: sponsor_id,
           )
         end
         progress&.increment

--- a/spec/lib/tasks/backfill_sponsor_id_rake_spec.rb
+++ b/spec/lib/tasks/backfill_sponsor_id_rake_spec.rb
@@ -21,21 +21,16 @@ RSpec.describe 'in_person_enrollments:backfill_sponsor_id rake task' do
     end
   end
 
-  let(:pending_enrollment) { create(:in_person_enrollment, :pending, :with_nil_sponsor_id) }
-  let(:expired_enrollment) { create(:in_person_enrollment, :expired, :with_nil_sponsor_id) }
-  let(:failed_enrollment) { create(:in_person_enrollment, :failed, :with_nil_sponsor_id) }
+  let(:pending_enrollment) { create(:in_person_enrollment, :pending) }
+  let(:expired_enrollment) { create(:in_person_enrollment, :expired) }
+  let(:failed_enrollment) { create(:in_person_enrollment, :failed) }
   let(:enrollment_with_service_provider) do
-    create(:in_person_enrollment, :with_service_provider, :with_nil_sponsor_id)
+    create(:in_person_enrollment, :with_service_provider)
   end
   let(:enrollment_with_sponsor_id) { create(:in_person_enrollment) }
 
   before do
     allow(IdentityConfig.store).to receive(:usps_ipp_sponsor_id).and_return('31459')
-    expect(pending_enrollment.sponsor_id).to be_nil
-    expect(expired_enrollment.sponsor_id).to be_nil
-    expect(failed_enrollment.sponsor_id).to be_nil
-    expect(enrollment_with_service_provider.sponsor_id).to be_nil
-    expect(enrollment_with_sponsor_id.sponsor_id).not_to be_nil
   end
 
   it 'does not change the value of an existing sponsor id' do
@@ -44,30 +39,11 @@ RSpec.describe 'in_person_enrollments:backfill_sponsor_id rake task' do
     expect(enrollment_with_sponsor_id.sponsor_id).to eq(original_sponsor_id)
   end
 
-  it 'sets a sponsor id for every enrollment with a nil sponsor id' do
-    enrollments_with_nil_sponsor_id_count = InPersonEnrollment.where(sponsor_id: nil).count
-    expect(enrollments_with_nil_sponsor_id_count).to eq(4)
-    subject
-    enrollments_with_nil_sponsor_id_count = InPersonEnrollment.where(sponsor_id: nil).count
-    expect(enrollments_with_nil_sponsor_id_count).to eq(0)
-  end
-
   it 'sets a sponsor id that is a string' do
     subject
     enrollments = InPersonEnrollment.all
     enrollments.each do |enrollment|
       expect(enrollment.sponsor_id).to be_a String
     end
-  end
-
-  it 'outputs what it did' do
-    expect(invoke_task.to_s).to eql(
-      <<~END,
-        Found 4 in_person_enrollments needing backfill
-        set sponsor_id for 4 in_person_enrollments
-        COMPLETE: Updated 4 in_person_enrollments
-        0 enrollments without a sponsor id
-      END
-    )
   end
 end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -75,60 +75,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper, allowed_extra_analytics: 
         end
       end
 
-      context 'when the enrollment sponsor_id is not set' do
-        let!(:enrollment) do
-          create(
-            :in_person_enrollment,
-            user: user,
-            service_provider: service_provider,
-            status: :establishing,
-            current_address_matches_id: nil,
-            profile: nil,
-            sponsor_id: nil,
-          )
-        end
-
-        context 'when the usps enrollment fails' do
-          before do
-            stub_request_enroll_bad_request_response
-          end
-
-          context 'when an EIPP enrollment is scheduled' do
-            let(:is_enhanced_ipp) { true }
-            let(:usps_eipp_sponsor_id) { '6543211' }
-
-            before do
-              allow(
-                IdentityConfig.store,
-              ).to receive(:usps_eipp_sponsor_id).and_return(usps_eipp_sponsor_id)
-              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-            rescue StandardError
-            ensure
-              enrollment.reload
-            end
-
-            it 'sets the sponsor_id to the configured EIPP sponsor_id' do
-              expect(enrollment.sponsor_id).to eq(usps_eipp_sponsor_id)
-            end
-          end
-
-          context 'when an ID-IPP enrollment scheduled' do
-            let(:is_enhanced_ipp) { false }
-
-            before do
-              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-            rescue StandardError
-            ensure
-              enrollment.reload
-            end
-
-            it 'sets the sponsor_id to the configured ID-IPP sponsor_id' do
-              expect(enrollment.sponsor_id).to eq(usps_ipp_sponsor_id)
-            end
-          end
-        end
-      end
-
       context 'an establishing enrollment record exists for the user' do
         before do
           allow(Rails).to receive(:cache).and_return(


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13733](https://cm-jira.usa.gov/browse/LG-13733)

## 🛠 Summary of changes

`sponser_id` column on `in_person_enrollments` made non-nullable via two migrations

## 📜 Testing Plan
- [x] Step 1: Run migration via `make update`
- [x] Step 2: Ensure nil check is in schema for `in_person_enrollments`

