### PR TITLE
Update rexml to 3.3.4 to resolve security advisory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,7 +578,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     retries (0.0.5)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rotp (6.3.0)
     rouge (4.2.0)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `rexml` gem to resolve a security advisory.

See: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123/

## 📜 Testing Plan

Verify that `make audit` produces no vulnerabilities.