### PR TITLE
Limit analytics CSP revisions to necessary entries

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -241,23 +241,17 @@ module Users
 
     def override_csp_for_google_analytics
       return unless IdentityConfig.store.participate_in_dap
+      # See: https://github.com/digital-analytics-program/gov-wide-code#content-security-policy
       policy = current_content_security_policy
       policy.script_src(
         *policy.script_src,
         'dap.digitalgov.gov',
         'www.google-analytics.com',
-        '*.googletagmanager.com',
+        'www.googletagmanager.com',
       )
       policy.connect_src(
         *policy.connect_src,
-        '*.google-analytics.com',
-        '*.analytics.google.com',
-        '*.googletagmanager.com',
-      )
-      policy.img_src(
-        *policy.img_src,
-        '*.google-analytics.com',
-        '*.googletagmanager.com',
+        'www.google-analytics.com',
       )
       request.content_security_policy = policy
     end

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -19,7 +19,6 @@ production:
   recaptcha_mock_validator: true
   redis_throttle_url: ['env', 'REDIS_THROTTLE_URL']
   redis_url: ['env', 'REDIS_URL']
-  participate_in_dap: true
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   phone_recaptcha_score_threshold: 0.5

--- a/config/application.yml.default.docker
+++ b/config/application.yml.default.docker
@@ -19,6 +19,7 @@ production:
   recaptcha_mock_validator: true
   redis_throttle_url: ['env', 'REDIS_THROTTLE_URL']
   redis_url: ['env', 'REDIS_URL']
+  participate_in_dap: true
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   phone_recaptcha_score_threshold: 0.5

--- a/spec/requests/csp_spec.rb
+++ b/spec/requests/csp_spec.rb
@@ -228,16 +228,11 @@ RSpec.describe 'content security policy' do
 
         content_security_policy = parse_content_security_policy
 
-        # see GA4 docs for directives
-        # https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics
-        expect(content_security_policy['script-src']).to include('*.googletagmanager.com')
-
-        expect(content_security_policy['img-src']).to include('*.google-analytics.com')
-        expect(content_security_policy['img-src']).to include('*.googletagmanager.com')
-
-        expect(content_security_policy['connect-src']).to include('*.google-analytics.com')
-        expect(content_security_policy['connect-src']).to include('*.analytics.google.com')
-        expect(content_security_policy['connect-src']).to include('*.googletagmanager.com')
+        # See: https://github.com/digital-analytics-program/gov-wide-code#content-security-policy
+        expect(content_security_policy['script-src']).to include('dap.digitalgov.gov')
+        expect(content_security_policy['script-src']).to include('www.google-analytics.com')
+        expect(content_security_policy['script-src']).to include('www.googletagmanager.com')
+        expect(content_security_policy['connect-src']).to include('www.google-analytics.com')
       end
     end
 
@@ -247,14 +242,11 @@ RSpec.describe 'content security policy' do
 
         content_security_policy = parse_content_security_policy
 
-        expect(content_security_policy['script-src']).to_not include('*.googletagmanager.com')
-
-        expect(content_security_policy['img-src']).to_not include('*.google-analytics.com')
-        expect(content_security_policy['img-src']).to_not include('*.googletagmanager.com')
-
-        expect(content_security_policy['connect-src']).to_not include('*.google-analytics.com')
-        expect(content_security_policy['connect-src']).to_not include('*.analytics.google.com')
-        expect(content_security_policy['connect-src']).to_not include('*.googletagmanager.com')
+        # See: https://github.com/digital-analytics-program/gov-wide-code#content-security-policy
+        expect(content_security_policy['script-src']).not_to include('dap.digitalgov.gov')
+        expect(content_security_policy['script-src']).not_to include('www.google-analytics.com')
+        expect(content_security_policy['script-src']).not_to include('www.googletagmanager.com')
+        expect(content_security_policy['connect-src']).not_to include('www.google-analytics.com')
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates content security policy to limit directives to only those strictly necessary for Digital Analytics Program.

See documentation: https://github.com/digital-analytics-program/gov-wide-code#content-security-policy

Since these conflicted with the [recommendations from Google for Google Analytics](https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics), I had reached out to the DAP support team to clarify that their documented recommendations are sufficient. I'll also plan to monitor this after the changes go live to ensure there are no issues.

## 📜 Testing Plan

Verify that there are no errors in browser developer tools console when loading the preview site for this branch:

TBD

(It's enabled temporarily in preview environments, but this will be removed prior to merging)