### PR TITLE
Use printf to format newlines correctly in bash

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -832,7 +832,7 @@ pinpoint_check_scheduled:
           --channel "#login-appdev" \
           --webhook "${SLACK_WEBHOOK}" \
           --raise \
-          --text "Pinpoint supported countries check in GitLab failed.\nBuild Results: ${CI_JOB_URL}.\nCheck results locally with 'make lint_country_dialing_codes'"
+          --text "$(printf "Pinpoint supported countries check in GitLab failed.\nBuild Results: ${CI_JOB_URL}.\nCheck results locally with 'make lint_country_dialing_codes'")""
       fi
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
@@ -856,7 +856,7 @@ audit_packages_scheduled:
           --channel "#login-appdev" \
           --webhook "${SLACK_WEBHOOK}" \
           --raise \
-          --text "Dependencies audit in GitLab failed.\nBuild Results: ${CI_JOB_URL}\nCheck results locally with 'make audit'"
+          --text "$(printf "Dependencies audit in GitLab failed.\nBuild Results: ${CI_JOB_URL}\nCheck results locally with 'make audit'")"
       fi
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"


### PR DESCRIPTION
**Bug**: Literal `\n`

<img width="428" alt="Screenshot 2024-08-02 at 9 35 37 AM" src="https://github.com/user-attachments/assets/84a943c1-a0df-4d5a-ad93-127f6b9f3444">

**Solution**: Use `printf`