### PR TITLE
change cert bundle to the new global bundle

### DIFF
--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -123,7 +123,7 @@ RUN echo "{\"branch\":\"$ARG_CI_COMMIT_BRANCH\",\"git_sha\":\"$ARG_CI_COMMIT_SHA
 
 # Download RDS Combined CA Bundle
 RUN mkdir -p /usr/local/share/aws \
-  && curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem > /usr/local/share/aws/rds-combined-ca-bundle.pem \
+  && curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem > /usr/local/share/aws/rds-combined-ca-bundle.pem  \
   && chmod 644 /usr/local/share/aws/rds-combined-ca-bundle.pem
 
 # Generate and place SSL certificates for puma

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -123,7 +123,7 @@ RUN echo "{\"branch\":\"$ARG_CI_COMMIT_BRANCH\",\"git_sha\":\"$ARG_CI_COMMIT_SHA
 
 # Download RDS Combined CA Bundle
 RUN mkdir -p /usr/local/share/aws \
-  && curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem > /usr/local/share/aws/rds-combined-ca-bundle.pem \
+  && curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem > /usr/local/share/aws/rds-combined-ca-bundle.pem \
   && chmod 644 /usr/local/share/aws/rds-combined-ca-bundle.pem
 
 # Generate and place SSL certificates for puma

--- a/dockerfiles/idp_review_app.Dockerfile
+++ b/dockerfiles/idp_review_app.Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y yarn=1.22.5-1
 
 # Download RDS Combined CA Bundle
 RUN mkdir -p /usr/local/share/aws \
-  && curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem > /usr/local/share/aws/rds-combined-ca-bundle.pem \
+  && curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem > /usr/local/share/aws/rds-combined-ca-bundle.pem \
   && chmod 644 /usr/local/share/aws/rds-combined-ca-bundle.pem
 
 # Create a new user and set up the working directory


### PR DESCRIPTION
## 🛠 Summary of changes

Update the old rds combined cert bundle with the new global cert bundle, required for the new encryption policy that is on our databases.

## 📜 Testing Plan

- [ ] Make sure it builds in the PR
- [ ] install the image in the tstest cluster and make sure it comes up OK.