### PR TITLE
LG-13970 Log document issue year with uploads

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -348,6 +348,7 @@ module Idv
       update_funnel(client_response)
       birth_year = client_response.pii_from_doc&.dob&.to_date&.year
       zip_code = client_response.pii_from_doc&.zipcode&.to_s&.strip&.slice(0, 5)
+      issue_year = client_response.pii_from_doc&.state_id_issued&.slice(0, 4)
       analytics.idv_doc_auth_submitted_image_upload_vendor(
         **client_response.to_h.merge(
           birth_year: birth_year,
@@ -356,6 +357,7 @@ module Idv
           flow_path: params[:flow_path],
           vendor_request_time_in_ms: vendor_request_time_in_ms,
           zip_code: zip_code,
+          issue_year: issue_year,
         ).except(:classification_info).
         merge(acuant_sdk_upgrade_ab_test_data),
       )

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -405,6 +405,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
           workflow: an_instance_of(String),
           birth_year: 1938,
           zip_code: '59010',
+          issue_year: '2019',
         )
 
         expect(@analytics).to have_logged_event(
@@ -550,6 +551,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
               vendor: nil,
               birth_year: 1938,
               zip_code: '12345',
+              issue_year: nil,
             )
 
             expect(@analytics).to have_logged_event(
@@ -648,6 +650,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
               vendor: nil,
               birth_year: 1938,
               zip_code: '12345',
+              issue_year: nil,
             )
 
             expect(@analytics).to have_logged_event(
@@ -746,6 +749,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
               vendor: nil,
               birth_year: 1938,
               zip_code: '12345',
+              issue_year: nil,
             )
 
             expect(@analytics).to have_logged_event(
@@ -841,6 +845,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
               vendor: nil,
               birth_year: nil,
               zip_code: '12345',
+              issue_year: nil,
             )
 
             expect(@analytics).to have_logged_event(
@@ -962,6 +967,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
           vendor: nil,
           birth_year: nil,
           zip_code: nil,
+          issue_year: nil,
         )
 
         expect_funnel_update_counts(user, 1)
@@ -1056,6 +1062,7 @@ RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
           workflow: an_instance_of(String),
           birth_year: nil,
           zip_code: nil,
+          issue_year: nil,
         )
 
         expect_funnel_update_counts(user, 1)

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -238,6 +238,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
           workflow: 'test_non_liveness_workflow',
           birth_year: 1938,
           zip_code: '59010',
+          issue_year: '2019',
         )
       end
 
@@ -343,6 +344,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
             workflow: 'test_liveness_workflow',
             birth_year: 1938,
             zip_code: '59010',
+            issue_year: '2019',
           )
         end
 


### PR DESCRIPTION
Add the year of issue of the applicant's ID to 'IdV: doc auth image upload vendor submitted'

## 🎫 Ticket

Link to the relevant ticket:
[LG-13970](https://cm-jira.usa.gov/browse/LG-13970)

## 🛠 Summary of changes

Added the year that the applicant's ID was issued to our log message.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify that all existing tests pass running locally.
- [ ] Inspect the events log and verify that all instances of 'IdV: doc auth image upload vendor submitted' include the new 'issue_year' field. It may be nil for some test cases, but should not be nil for all of them.