### PR TITLE
Remove OIDC form-action CSP assertions from account creation specs

### DIFF
--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -1,37 +1,8 @@
 RSpec.shared_examples 'creating an account with the site in Spanish' do |sp|
-  it 'redirects to the SP with SP URIs in form-action CSP if enabled', email: true do
-    allow(IdentityConfig.store).to receive(:openid_connect_content_security_form_action_enabled).
-      and_return(true)
+  it 'redirects to the SP', email: true do
     Capybara.current_session.driver.header('Accept-Language', 'es')
     visit_idp_from_sp_with_ial1(sp)
     register_user
-
-    if sp == :oidc
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include('form-action \'self\' http://localhost:7654'))
-    end
-
-    click_agree_and_continue
-    if :sp == :saml
-      expect(current_url).to eq UriService.add_params(@saml_authn_request, locale: :es)
-    elsif sp == :oidc
-      redirect_uri = URI(oidc_redirect_url)
-
-      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
-    end
-  end
-
-  it 'redirects to the SP without SP URIs in form-action CSP if disabled', email: true do
-    allow(IdentityConfig.store).to receive(:openid_connect_content_security_form_action_enabled).
-      and_return(false)
-    Capybara.current_session.driver.header('Accept-Language', 'es')
-    visit_idp_from_sp_with_ial1(sp)
-    register_user
-
-    if sp == :oidc
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include('form-action \'self\''))
-    end
 
     click_agree_and_continue
     if :sp == :saml
@@ -45,37 +16,9 @@ RSpec.shared_examples 'creating an account with the site in Spanish' do |sp|
 end
 
 RSpec.shared_examples 'creating an account using authenticator app for 2FA' do |sp|
-  it 'redirects to the SP with SP URIs in form-action CSP if enabled', email: true do
-    allow(IdentityConfig.store).to receive(:openid_connect_content_security_form_action_enabled).
-      and_return(true)
+  it 'redirects to the SP', email: true do
     visit_idp_from_sp_with_ial1(sp)
     register_user_with_authenticator_app
-
-    if sp == :oidc
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include('form-action \'self\' http://localhost:7654'))
-    end
-
-    click_agree_and_continue
-    expect(current_url).to eq complete_saml_url if sp == :saml
-
-    if sp == :oidc
-      redirect_uri = URI(oidc_redirect_url)
-
-      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
-    end
-  end
-
-  it 'redirects to the SP without SP URIs in form-action CSP if disabled', email: true do
-    allow(IdentityConfig.store).to receive(:openid_connect_content_security_form_action_enabled).
-      and_return(false)
-    visit_idp_from_sp_with_ial1(sp)
-    register_user_with_authenticator_app
-
-    if sp == :oidc
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include('form-action \'self\''))
-    end
 
     click_agree_and_continue
     expect(current_url).to eq complete_saml_url if sp == :saml

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -57,37 +57,9 @@ RSpec.shared_examples 'creating an IAL2 account using authenticator app for 2FA'
 end
 
 RSpec.shared_examples 'creating an account using PIV/CAC for 2FA' do |sp|
-  it 'redirects to the SP with SP URIs in form-action CSP if enabled', email: true do
-    allow(IdentityConfig.store).to receive(:openid_connect_content_security_form_action_enabled).
-      and_return(true)
+  it 'redirects to the SP', email: true do
     visit_idp_from_sp_with_ial1(sp)
     register_user_with_piv_cac
-
-    if sp == :oidc
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include('form-action \'self\' http://localhost:7654'))
-    end
-
-    click_agree_and_continue
-    expect(current_url).to eq complete_saml_url if sp == :saml
-
-    if sp == :oidc
-      redirect_uri = URI(oidc_redirect_url)
-
-      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
-    end
-  end
-
-  it 'redirects to the SP without SP URIs in form-action CSP if disabled', email: true do
-    allow(IdentityConfig.store).to receive(:openid_connect_content_security_form_action_enabled).
-      and_return(false)
-    visit_idp_from_sp_with_ial1(sp)
-    register_user_with_piv_cac
-
-    if sp == :oidc
-      expect(page.response_headers['Content-Security-Policy']).
-        to(include('form-action \'self\''))
-    end
 
     click_agree_and_continue
     expect(current_url).to eq complete_saml_url if sp == :saml


### PR DESCRIPTION
## 🛠 Summary of changes

Updates account creation shared example test cases to remove assertions about CSP expectations.

Since #10997, these assertions have started failing on unrelated pull requests. The assertions are redundant, since they're [already tested in `csp_spec.rb`.](https://github.com/18F/identity-idp/blob/8b736a28f2836c30b6d151990f552a23160d6325/spec/requests/csp_spec.rb#L11-L98). Limiting the amount of work performed in shared examples should also have a multiplicative benefit on runtime of these specs, since there are now 3x2 (6) fewer test cases being run.

## 📜 Testing Plan

Verify that build passes..