### PR TITLE
[Blocked] Return correct AAL value in user_info JWT

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -140,8 +140,7 @@ class OpenidConnectAuthorizeForm
   end
 
   def requested_aal_value
-    highest_level_aal(aal_values) ||
-      Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
+    highest_level_aal(aal_values) || default_aal_acr
   end
 
   private
@@ -365,5 +364,15 @@ class OpenidConnectAuthorizeForm
 
   def semantic_authn_contexts_requested?
     Saml::Idp::Constants::SEMANTIC_ACRS.intersect?(acr_values)
+  end
+
+  def default_aal_acr
+    ctx = AuthnContextResolver.new(
+      service_provider: service_provider,
+      user: nil,
+      vtr: nil,
+      acr_values: nil,
+    )
+    ctx.asserted_aal_value
   end
 end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -373,6 +373,6 @@ class OpenidConnectAuthorizeForm
       vtr: nil,
       acr_values: nil,
     )
-    ctx.asserted_aal_value
+    ctx.asserted_aal_acr
   end
 end

--- a/app/models/federated_protocols/oidc.rb
+++ b/app/models/federated_protocols/oidc.rb
@@ -2,6 +2,7 @@
 
 module FederatedProtocols
   class Oidc
+    # @param request [OpenidConnectAuthorizeForm]
     def initialize(request)
       @request = request
     end

--- a/app/models/federated_protocols/oidc.rb
+++ b/app/models/federated_protocols/oidc.rb
@@ -37,6 +37,7 @@ module FederatedProtocols
 
     private
 
+    # @return [OpenidConnectAuthorizeForm]
     attr_reader :request
   end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -41,7 +41,6 @@ class OpenidConnectUserInfoPresenter
   private
 
   def asserted_ial_value
-    return Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF unless active_profile.present?
     authn_context_resolver.asserted_ial_acr
   end
 

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -24,8 +24,8 @@ class OpenidConnectUserInfoPresenter
     info.merge!(x509_attributes) if scoper.x509_scopes_requested?
     info[:verified_at] = verified_at if scoper.verified_at_requested?
     if identity.vtr.nil?
-      info[:ial] = authn_context_resolver.asserted_ial_acr
-      info[:aal] = identity.requested_aal_value
+      info[:ial] = asserted_ial_value
+      info[:aal] = asserted_aal_value
     else
       info[:vot] = vot_values
       info[:vtm] = IdentityConfig.store.vtm_url
@@ -39,6 +39,15 @@ class OpenidConnectUserInfoPresenter
   end
 
   private
+
+  def asserted_ial_value
+    return Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF unless active_profile.present?
+    authn_context_resolver.asserted_ial_acr
+  end
+
+  def asserted_aal_value
+    identity.requested_aal_value.presence || authn_context_resolver.asserted_aal_acr
+  end
 
   def vot_values
     AuthnContextResolver.new(

--- a/app/services/vot/acr_component_values.rb
+++ b/app/services/vot/acr_component_values.rb
@@ -77,7 +77,7 @@ module Vot
     ).freeze
 
     ## Authentication ACR values
-    DEFAULT = ComponentValue.new(
+    DEFAULT_AAL = ComponentValue.new(
       name: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
       description: 'Legacy default authentication',
       implied_component_values: [],
@@ -117,7 +117,7 @@ module Vot
       name: Saml::Idp::Constants::AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF,
       description: 'Legacy AAL3 with HSPD12',
       implied_component_values: [],
-      requirements: [:aal2, :hspd12],
+      requirements: [:aal2, :hspd12, :phishing_resistant],
     ).freeze
 
     NAME_HASH = constants.map do |constant|

--- a/app/services/vot/acr_component_values.rb
+++ b/app/services/vot/acr_component_values.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
 module Vot
   module AcrComponentValues
     ## Identity proofing ACR values
@@ -79,54 +80,111 @@ module Vot
     ## Authentication ACR values
     DEFAULT_AAL = ComponentValue.new(
       name: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-      description: 'Legacy default authentication',
+      description:
+        'Default - MFA required + remember device up to 30 days (AAL1, NIST SP 800-63B-3)',
       implied_component_values: [],
       requirements: [],
     ).freeze
     AAL1 = ComponentValue.new(
       name: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
-      description: 'Legacy AAL1',
+      description:
+        '(defunct) MFA required + remember device up to 30 days. (AAL1, NIST SP 800-63B-3)',
       implied_component_values: [],
       requirements: [],
     ).freeze
     AAL2 = ComponentValue.new(
       name: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
-      description: 'Legacy AAL2',
+      description: 'MFA required, remember device disallowed. (AAL2, NIST SP 800-63B-3)',
       implied_component_values: [],
       requirements: [:aal2],
     ).freeze
     AAL2_PHISHING_RESISTANT = ComponentValue.new(
       name: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
-      description: 'Legacy AAL2 with phishing resistance',
+      description: %{Phishing-resistant MFA required (e.g., WebAuthn or PIV/CAC cards),
+      remember device disallowed. (AAL2, NIST SP 800-63B-3)},
       implied_component_values: [],
       requirements: [:aal2, :phishing_resistant],
     ).freeze
     AAL2_HSPD12 = ComponentValue.new(
       name: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
-      description: 'Legacy AAL2 with HSPD12',
+      description: 'HSPD12-compliant MFA required (i.e., PIV/CAC only), remember device disallowed. (AAL2, NIST SP 800-63B-3)',
       implied_component_values: [],
-      requirements: [:aal2, :hspd12],
+      requirements: [:aal2, :phishing_resistant, :hspd12],
     ).freeze
     AAL3 = ComponentValue.new(
       name: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
-      description: 'Legacy AAL3',
+      description: 'Unsupported. (AAL3, NIST SP 800-63B-3)',
       implied_component_values: [],
       requirements: [:aal2, :phishing_resistant],
     ).freeze
     AAL3_HSPD12 = ComponentValue.new(
       name: Saml::Idp::Constants::AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF,
-      description: 'Legacy AAL3 with HSPD12',
+      description: 'Unsupported. (AAL3, NIST SP 800-63B-3)',
       implied_component_values: [],
       requirements: [:aal2, :hspd12, :phishing_resistant],
     ).freeze
 
-    NAME_HASH = constants.map do |constant|
-      component_value = const_get(constant)
-      [component_value.name, component_value]
-    end.to_h.freeze
+    # @type [Hash]
+    NAME_HASH = constants(false).
+      map { |c| const_get(c, false) }.
+      filter { |c| c.is_a?(ComponentValue) }.
+      index_by(&:name).freeze
+
+    VALUES = NAME_HASH.values.freeze
 
     DELIM = ' '
 
+    IAL_COMPONENTS = [
+      LOA1,
+      LOA3,
+      IAL1,
+      IALMAX,
+      IAL2,
+      IAL2_BIO_PREFERRED,
+      IAL2_BIO_REQUIRED,
+    ].freeze
+    IAL_COMPONENTS_BY_PRIORITY = [
+      IAL2_BIO_REQUIRED,
+      IAL2_BIO_PREFERRED,
+      IAL2,
+      LOA3,
+      IALMAX,
+      IAL1,
+      LOA1,
+    ].freeze
+    IALS_BY_PRIORITY = IAL_COMPONENTS_BY_PRIORITY.map(&:name).freeze
+
+    DELIM = ' '
+
+    AAL_COMPONENTS = [
+      DEFAULT_AAL,
+      AAL1,
+      AAL2,
+      AAL2_PHISHING_RESISTANT,
+      AAL2_HSPD12,
+      AAL3,
+      AAL3_HSPD12,
+    ].freeze
+    AAL_COMPONENTS_BY_PRIORITY = [
+      AAL2_HSPD12,
+      AAL3_HSPD12,
+      AAL2_PHISHING_RESISTANT,
+      AAL3,
+      AAL2,
+      AAL1,
+      DEFAULT_AAL,
+    ].freeze
+
+    AALS_BY_PRIORITY = AAL_COMPONENTS_BY_PRIORITY.map(&:name).freeze
+
+    ACR_COMPONENTS_BY_PRIORITY = [
+      *IAL_COMPONENTS_BY_PRIORITY,
+      *AAL_COMPONENTS_BY_PRIORITY,
+    ].freeze
+
+    ACRS_BY_PRIORITY = ACR_COMPONENTS_BY_PRIORITY.map(&:name).freeze
+
+    # @return [Hash{String=>Vot::ComponentValue}]
     def self.by_name
       NAME_HASH
     end
@@ -142,5 +200,79 @@ module Vot
                ).to_a
       Saml::Idp::Constants::SEMANTIC_ACRS.intersect?(values)
     end
+
+    # Get the highest priority ACR value
+    # @return [String, nil]
+    def self.find_highest_priority(values)
+      AcrComponentValues.order_by_priority(values).first
+    end
+
+    # Sort ACR values by priority, highest to lowest
+    # @param values [Array<String,ComponentValue>, String]
+    def self.order_by_priority(values)
+      order_by_priority_with(values, series: ACRS_BY_PRIORITY)
+    end
+
+    # Order a list of ACR values by priority, highest to lowest
+    # Returns a new {Array} of {String} values where the order has been by set by the +series+,
+    # based on the index of the objects from the original  in the series.
+    #
+    # If the +series+ includes values that have no corresponding element in the Enumerable,
+    # these are ignored.
+    # If the Enumerable has additional elements that aren't named in the +series+,
+    # these are not included in the result.
+    # @param values [Array<String, ComponentValue>, String]
+    # @param series [Array<String>,nil] Defaults to #ACRS_BY_PRIORITY
+    def self.order_by_priority_with(values, series: nil)
+      rankings = series.presence || ACRS_BY_PRIORITY
+      to_names(values).
+        filter { |acr| AcrComponentValues.acr?(acr) && rankings.include?(acr) }.
+        sort_by { |acr| rankings.index(acr) }
+    end
+
+    def self.ial_values(values)
+      to_names(values).filter { |acr| AcrComponentValues.ial?(acr) }
+    end
+
+    def self.aal_values(values)
+      to_names(values).filter { |acr| AcrComponentValues.aal?(acr) }
+    end
+
+    # Convert list of strings or {Vot::ComponentValue} to ACR values
+    # @return [Array<String>]
+    def self.to_names(values)
+      [] unless values.present? &&
+                !(values.is_a?(String) || values.is_a?(Enumerable))
+      names =
+        if values.is_a?(Enumerable)
+          values.
+            map { |v| AcrComponentValues.to_name(v) }.
+            to_a
+        else
+          values.split(DELIM)
+        end
+      names.compact_blank.uniq
+    end
+
+    def self.to_name(value)
+      value.is_a?(ComponentValue) ? value.name : value.to_s
+    end
+
+    def self.join(values)
+      to_names(values).join(DELIM)
+    end
+
+    def self.ial?(value)
+      Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL.include?(AcrComponentValues.to_name(value))
+    end
+
+    def self.aal?(value)
+      Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_AAL.include?(AcrComponentValues.to_name(value))
+    end
+
+    def self.acr?(value)
+      AcrComponentValues.ial?(value) || AcrComponentValues.aal?(value)
+    end
   end
 end
+# rubocop:enable Layout/LineLength

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'idp/constants'
+
 # rubocop:disable Layout/LineLength
 # Global constants used by the SAML IdP
 module Saml
   module Idp
     module Constants
+      DELIM = ' '
       LOA1_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/1'
       LOA3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/3'
 
@@ -30,11 +32,17 @@ module Saml
 
       DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF = 'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo'
       AAL_AUTHN_CONTEXT_PREFIX = 'http://idmanagement.gov/ns/assurance/aal'
+
+      # @deprecated Use {#DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF}
       AAL1_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/1".freeze
       AAL2_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/2".freeze
       AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/2?phishing_resistant=true".freeze
       AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/2?hspd12=true".freeze
+
+      # @deprecated We do not support NIST SP 800-63-3 AAL3
       AAL3_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/3".freeze
+
+      # @deprecated We do not support NIST SP 800-63-3 AAL3
       AAL3_HSPD12_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/3?hspd12=true".freeze
 
       NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -1263,7 +1263,7 @@ RSpec.describe 'OpenID Connect' do
     else
       expect(userinfo_response[:ial]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
       expect(userinfo_response[:aal]).to eq(
-        Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+        Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
       )
       expect(userinfo_response).not_to have_key(:vot)
     end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -455,6 +455,29 @@ RSpec.describe OpenidConnectAuthorizeForm do
   describe '#requested_aal_value' do
     context 'with ACR values' do
       let(:vtr) { nil }
+      context 'when no AAL value is passed' do
+        context 'when identity proofing is requested' do
+          let(:acr_values) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
+
+          it 'returns AAL2' do
+            expect(form.requested_aal_value).to eq(
+              Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            )
+          end
+          context 'when SP default AAL is 3' do
+            before do
+              allow_any_instance_of(ServiceProvider).to receive(:default_aal).
+                and_return(3)
+            end
+
+            it 'returns AAL3' do
+              expect(form.requested_aal_value).to eq(
+                Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+          end
+        end
+      end
       context 'when AAL2 passed' do
         let(:acr_values) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
       let(:vtr) { ['A1.B2.C3'].to_json }
 
       it 'has errors' do
+        raise_error
         expect(valid?).to eq(false)
         expect(form.errors[:vtr]).
           to include(t('openid_connect.authorization.errors.no_valid_vtr'))
@@ -213,6 +214,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
     shared_examples 'allows biometric IAL only if sp is authorized' do |biometric_ial|
       let(:acr_values) { biometric_ial }
+      let(:vtr) { nil }
 
       context "when the IAL requested is #{biometric_ial}" do
         context 'when the service provider is allowed to use biometric ials' do
@@ -472,7 +474,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
             it 'returns AAL3' do
               expect(form.requested_aal_value).to eq(
-                Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+                Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
               )
             end
           end
@@ -604,8 +606,10 @@ RSpec.describe OpenidConnectAuthorizeForm do
         let(:verified_within) { '45d' }
 
         it 'parses the value as a number of days' do
-          expect(form.valid?).to eq(true)
-          expect(form.verified_within).to eq(45.days)
+          aggregate_failures 'verified within verified_within' do
+            expect(form.valid?).to eq(true)
+            expect(form.verified_within).to eq(45.days)
+          end
         end
       end
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe IdTokenBuilder do
         it 'sets the acr to the ial2 constant' do
           expect(decoded_payload[:acr]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
         end
+
+        it 'sets the aal to the AAL2 ACR value' do
+          expect(decoded_payload[:aal]).to eq(Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF)
+        end
       end
 
       context 'ial2 with biometric comparison required' do
@@ -129,6 +133,11 @@ RSpec.describe IdTokenBuilder do
 
         it 'sets the acr to the ial1 constant' do
           expect(decoded_payload[:acr]).to eq(Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF)
+        end
+        it 'sets the aal to the default ACR value' do
+          expect(decoded_payload[:aal]).to eq(
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+          )
         end
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

**Why**

* When no AAL ACR value is selected and the SP requires a higher default AAL level or the request demands identity proofing, the user_info block should return the correct AAL ACR value instead of the default AAL ACR
* Resolves https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/55

**How**
* Map the ServiceProvider.default_aal value to a known ACR value using a new method (AuthnContextResolver.asserted_aal_value)
* Ensure the new asserted AAL ACR value is used as a fallback in the OpenidConnectUserInfoPresenter and OpenidConnectAuthorizeForm so that the JWT built by IdTokenBuilder is correct and doesn't overwrite pre-existing data.

changelog: Bug Fixes, OIDC Authentication, Return correct AAL in JWT

## 🎫 Ticket

Link to the relevant ticket: https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/55

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
1. Navigate to https://int-identity-oidc-sinatra.app.cloud.gov/
2. Select "Identity-verified" from the level of service drop down
3. Click "Sign in"
4. Go through the test verification process

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
