### PR TITLE
Add support for Privacy Act brochure site redirect logging

### DIFF
--- a/app/controllers/redirect/policy_controller.rb
+++ b/app/controllers/redirect/policy_controller.rb
@@ -3,10 +3,18 @@
 module Redirect
   class PolicyController < RedirectController
     def show
-      redirect_to_and_log(
-        MarketingSite.security_and_privacy_practices_url,
-        tracker_method: analytics.method(:policy_redirect),
-      )
+      redirect_to_and_log(policy_url, tracker_method: analytics.method(:policy_redirect))
+    end
+
+    private
+
+    def policy_url
+      case params[:policy]
+      when 'privacy_act_statement'
+        MarketingSite.privacy_act_statement_url
+      else
+        MarketingSite.security_and_privacy_practices_url
+      end
     end
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -77,7 +77,11 @@
   <p class="margin-y-1">
     <%= new_tab_link_to(
           t('notices.privacy.security_and_privacy_practices'),
-          MarketingSite.security_and_privacy_practices_url,
+          policy_redirect_url(
+            policy: :security_and_privacy_practices,
+            flow: :sign_in,
+            step: :sign_in,
+          ),
         ) %>
   </p>
 

--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -35,7 +35,12 @@
   <p class="margin-top-2">
     <%= new_tab_link_to(
           t('doc_auth.instructions.learn_more'),
-          policy_redirect_url(flow: :idv, step: :agreement, location: :consent),
+          policy_redirect_url(
+            policy: :security_and_privacy_practices,
+            flow: :idv,
+            step: :agreement,
+            location: :consent,
+          ),
         ) %>
   </p>
   <div class="margin-top-4">

--- a/spec/controllers/redirect/policy_controller_spec.rb
+++ b/spec/controllers/redirect/policy_controller_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Redirect::PolicyController do
 
   describe '#show' do
     let(:location_params) { { flow: 'flow', step: 'step', location: 'location', foo: 'bar' } }
-    it 'redirects to policy page' do
+
+    it 'redirects to security and privacy practices policy page' do
       redirect_url = MarketingSite.security_and_privacy_practices_url
 
       get :show, params: location_params
@@ -20,6 +21,44 @@ RSpec.describe Redirect::PolicyController do
         redirect_url: redirect_url,
         step: 'step',
       )
+    end
+
+    context 'with security_and_privacy_practices policy parameter' do
+      let(:params) { location_params.merge(policy: :security_and_privacy_practices) }
+
+      it 'redirects to security and privacy practices policy page' do
+        redirect_url = MarketingSite.security_and_privacy_practices_url
+
+        get :show, params: location_params
+
+        expect(response).to redirect_to redirect_url
+        expect(@analytics).to have_logged_event(
+          'Policy Page Redirect',
+          flow: 'flow',
+          location: 'location',
+          redirect_url: redirect_url,
+          step: 'step',
+        )
+      end
+    end
+
+    context 'with privacy_act_statement policy parameter' do
+      let(:params) { location_params.merge(policy: :privacy_act_statement) }
+
+      it 'redirects to privacy act statement policy page' do
+        redirect_url = MarketingSite.privacy_act_statement_url
+
+        get :show, params: params
+
+        expect(response).to redirect_to redirect_url
+        expect(@analytics).to have_logged_event(
+          'Policy Page Redirect',
+          flow: 'flow',
+          location: 'location',
+          redirect_url: redirect_url,
+          step: 'step',
+        )
+      end
     end
   end
 end

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -52,26 +52,19 @@ RSpec.describe 'devise/sessions/new.html.erb' do
   it 'includes a link to security / privacy page and privacy statement act' do
     render
 
-    expect(rendered).
-      to have_link(
-        t('notices.privacy.security_and_privacy_practices'),
-        href: MarketingSite.security_and_privacy_practices_url,
-      )
-    expect(rendered).
-      to have_selector(
-        "a[href='#{MarketingSite.security_and_privacy_practices_url}']\
-[target='_blank'][rel='noopener noreferrer']",
-      )
+    expect(rendered).to have_link(
+      t('notices.privacy.security_and_privacy_practices'),
+      href: policy_redirect_url(
+        policy: :security_and_privacy_practices,
+        flow: :sign_in,
+        step: :sign_in,
+      ),
+    ) { |link| link[:target] == '_blank' && link[:rel] == 'noopener noreferrer' }
 
-    expect(rendered).
-      to have_link(
-        t('notices.privacy.privacy_act_statement'),
-        href: MarketingSite.privacy_act_statement_url,
-      )
-    expect(rendered).to have_selector(
-      "a[href='#{MarketingSite.privacy_act_statement_url}']\
-[target='_blank'][rel='noopener noreferrer']",
-    )
+    expect(rendered).to have_link(
+      t('notices.privacy.privacy_act_statement'),
+      href: MarketingSite.privacy_act_statement_url,
+    ) { |link| link[:target] == '_blank' && link[:rel] == 'noopener noreferrer' }
   end
 
   context 'when SP is present' do

--- a/spec/views/idv/agreement/show.html.erb_spec.rb
+++ b/spec/views/idv/agreement/show.html.erb_spec.rb
@@ -28,7 +28,12 @@ RSpec.describe 'idv/agreement/show' do
   it 'renders a link to the privacy & security page' do
     expect(rendered).to have_link(
       t('doc_auth.instructions.learn_more'),
-      href: policy_redirect_url(flow: :idv, step: :agreement, location: :consent),
+      href: policy_redirect_url(
+        policy: :security_and_privacy_practices,
+        flow: :idv,
+        step: :agreement,
+        location: :consent,
+      ),
     )
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-14093](https://cm-jira.usa.gov/browse/LG-14093)

## 🛠 Summary of changes

Adds support for the `Redirect::PolicyController` to redirect with logging to https://login.gov/policy/our-privacy-act-statement/ 

This is meant to help support [LG-14093](https://cm-jira.usa.gov/browse/LG-14093), which will help identify how many users may exit sign-in using one of the available brochure site links on the Sign In page. Currently, we have no logging insights to clicks on these links.

This updates the "Security Practices and Privacy Act Statement" link to use the redirect controller since support already existed for this, but does not yet update the "Privacy Act Statement" link. That link will be updated in a separate pull request to avoid [issues with 50/50 deploy state](https://handbook.login.gov/articles/manage-50-50-state.html).

## 📜 Testing Plan

1. In a separate terminal process, run `make watch_events`
2. Go to http://localhost:3000
3. Click "Security Practices and Privacy Act Statement"
4. See "Policy Page Redirect" event in events logging with `redirect_url` of https://www.login.gov/policy/
5. Go to http://localhost:3000/redirect/policy?policy=privacy_act_statement
6. See "Policy Page Redirect" event in events logging with `redirect_url` of https://www.login.gov/policy/our-privacy-act-statement/