### PR TITLE
Fix spacing on PIV/CAC login screen

### DIFF
--- a/app/views/users/piv_cac_login/new.html.erb
+++ b/app/views/users/piv_cac_login/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
-<p class='margin-top-2 margin-bottom-2'>
+<p class="margin-bottom-5">
   <%= @presenter.info %>
 </p>
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates margins on the PIV/CAC login screen to use standard page layout margins. Buttons are intended to have 2.5rem margin between itself and the preceding page content.

This has been an issue that's bugged me for several years now, so finally taking care of it now that content has been updated recently 😅 

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Click "Sign in with your government employee ID"
3. See corrected layout

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/acf40323-71bd-4a8d-a0e2-ad895e00e4db)|![image](https://github.com/user-attachments/assets/9a9783d0-6675-4379-8b52-13655d189b70)
