### PR TITLE
LG-13864 Create profile after USPS enrollment

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,6 +235,11 @@ class User < ApplicationRecord
     pending_in_person_enrollment.present? || establishing_in_person_enrollment.present?
   end
 
+  # @return [Boolean] Whether the user has an establishing in person enrollment.
+  def has_establishing_in_person_enrollment?
+    establishing_in_person_enrollment.present?
+  end
+
   # Trust `pending_profile` rather than enrollment associations
   def has_establishing_in_person_enrollment_safe?
     !!pending_profile&.in_person_enrollment&.establishing?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -394,6 +394,24 @@ RSpec.describe User do
     end
   end
 
+  describe '#has_establishing_in_person_enrollment?' do
+    context 'when the user has an establishing in person enrollment' do
+      before do
+        create(:in_person_enrollment, :establishing, user: subject)
+      end
+
+      it 'returns true' do
+        expect(subject.has_establishing_in_person_enrollment?).to be(true)
+      end
+    end
+
+    context 'when the user does not have an establishing in person enrollment' do
+      it 'returns false' do
+        expect(subject.has_establishing_in_person_enrollment?).to be(false)
+      end
+    end
+  end
+
   describe 'deleting identities' do
     it 'does not delete identities when the user is destroyed preventing uuid reuse' do
       user = create(:user, :fully_registered)

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -32,8 +32,8 @@ module InPersonHelper
   GOOD_IDENTITY_DOC_ZIPCODE =
     (Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode]).freeze
 
-  def fill_out_state_id_form_ok(same_address_as_id: false)
-    fill_in t('in_person_proofing.form.state_id.first_name'), with: GOOD_FIRST_NAME
+  def fill_out_state_id_form_ok(same_address_as_id: false, first_name: GOOD_FIRST_NAME)
+    fill_in t('in_person_proofing.form.state_id.first_name'), with: first_name
     fill_in t('in_person_proofing.form.state_id.last_name'), with: GOOD_LAST_NAME
     year, month, day = GOOD_DOB.split('-')
     fill_in t('components.memorable_date.month'), with: month
@@ -120,10 +120,10 @@ module InPersonHelper
     click_on t('forms.buttons.continue')
   end
 
-  def complete_state_id_step(_user = nil, same_address_as_id: true)
+  def complete_state_id_step(_user = nil, same_address_as_id: true, first_name: GOOD_FIRST_NAME)
     # Wait for page to load before attempting to fill out form
     expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
-    fill_out_state_id_form_ok(same_address_as_id: same_address_as_id)
+    fill_out_state_id_form_ok(same_address_as_id: same_address_as_id, first_name:)
     click_idv_continue
     unless same_address_as_id
       expect(page).to have_current_path(idv_in_person_address_path, wait: 10)


### PR DESCRIPTION

## 🎫 Ticket
[LG-13864](https://cm-jira.usa.gov/browse/LG-13864)

## 🛠 Summary of changes

- Change the order of events when the enter password form is submitted in the IPP flow. The USPS enrollment request will be made before a profile is created. Currently, when the USPS enrollment request fails the following issues occur:

1. Users are no longer about to retry enter password form because the `IdvStepConcern` before action `no_pending_profile` check automatically navigates the user back to the account page.
2. Users are stuck in a loop in account page where they cannot re-attempt verification.

These issues stem from the user having a profile with an enrollment in the `establishing` state after a USPS enrollment failure occurs.

## 📜 Testing Plan

**Scenario: USPS enrollment failure during ID-IPP enrollment**

- [x] Login through the **oidc sinatra** application selecting the `Identity Verified` level of service.
- [x] Create a new account
- [x] Continue through the in-person enrollment flow
- [x] Once on the `/verify/in_person/state_id` page use the first name of `usps client error` when filling out the form and submit
- [x] Continue through the flow until reaching the `/verify/enter_password`
- [x] Re-enter password and submit the form
- [x] Verify that the `There was an internal error processing your request. Please try again.` error message appears on the `/verify/enter_password` page and you are able to re-enter your password.

**Scenario: User drops off after USPS enrollment failure during ID-IPP enrollment**

- [x] Login through the **oidc sinatra** application selecting the `Identity Verified` level of service.
- [x] Create a new account
- [x] Continue through the in-person enrollment flow
- [x] Once on the `/verify/in_person/state_id` page use the first name of `usps client error` when filling out the form and submit
- [x] Continue through the flow until reaching the `/verify/enter_password`
- [x] Re-enter password and submit the form
- [x] Verify that the `There was an internal error processing your request. Please try again.` error message appears on the `/verify/enter_password` page and you are able to re-enter your password.
- [x] Navigate to the `/account` page.
- [x] Click on the `Continue identity verification` link
- [x] Ensure the flow work for in-person verification