### PR TITLE
Adding tests to assert AAL values

### DIFF
--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe AttributeAsserter do
   include SamlAuthHelper
 
-  let(:ial1_user) { create(:user, :fully_registered) }
   let(:user) { create(:profile, :active, :verified).user }
   let(:biometric_verified_user) { create(:profile, :active, :verified, idv_level: :in_person).user }
   let(:user_session) { {} }
@@ -26,134 +25,22 @@ RSpec.describe AttributeAsserter do
       metadata: {},
     )
   end
-  let(:raw_sp1_authn_request) do
-    sp1_authnrequest = saml_authn_request_url(overrides: { issuer: sp1_issuer })
-    CGI.unescape sp1_authnrequest.split('SAMLRequest').last
-  end
-  let(:raw_aal3_sp1_authn_request) do
-    ial1_aal3_authnrequest = saml_authn_request_url(
+
+  let(:options) { {} }
+  let(:raw_authn_request) do
+    raw = saml_authn_request_url(
       overrides: {
         issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
-        ],
-      },
+      }.merge(options)
     )
-    CGI.unescape ial1_aal3_authnrequest.split('SAMLRequest').last
+
+    CGI.unescape raw.split('SAMLRequest').last
   end
-  let(:raw_ial1_authn_request) do
-    ial1_authn_request_url = saml_authn_request_url(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-      },
-    )
-    CGI.unescape ial1_authn_request_url.split('SAMLRequest').last
+
+  let(:authn_request) do
+    SamlIdp::Request.from_deflated_request(raw_authn_request)
   end
-  let(:raw_vtr_no_proofing_authn_request) do
-    vtr_proofing_authn_request = saml_authn_request_url(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: 'C1.C2',
-      },
-    )
-    CGI.unescape vtr_proofing_authn_request.split('SAMLRequest').last
-  end
-  let(:raw_ial2_authn_request) do
-    ial2_authnrequest = saml_authn_request_url(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-      },
-    )
-    CGI.unescape ial2_authnrequest.split('SAMLRequest').last
-  end
-  let(:raw_vtr_proofing_authn_request) do
-    vtr_proofing_authn_request = saml_authn_request_url(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: 'C1.C2.P1',
-      },
-    )
-    CGI.unescape vtr_proofing_authn_request.split('SAMLRequest').last
-  end
-  let(:raw_ial1_aal3_authn_request) do
-    ial1_aal3_authnrequest = saml_authn_request_url(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
-        ],
-      },
-    )
-    CGI.unescape ial1_aal3_authnrequest.split('SAMLRequest').last
-  end
-  let(:raw_ialmax_authn_request) do
-    ialmax_authnrequest = saml_authn_request_url(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-        ],
-        authn_context_comparison: 'minimum',
-      },
-    )
-    CGI.unescape ialmax_authnrequest.split('SAMLRequest').last
-  end
-  let(:raw_biometric_preferred_ial_authn_request) do
-    biometric_preferred_ial_authnrequest = saml_authn_request_url(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF,
-        ],
-      },
-    )
-    CGI.unescape biometric_preferred_ial_authnrequest.split('SAMLRequest').last
-  end
-  let(:raw_biometric_required_ial_authn_request) do
-    biometric_preferred_ial_authnrequest = saml_authn_request_url(
-      overrides: {
-        issuer: sp1_issuer,
-        authn_context: [
-          Saml::Idp::Constants::IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF,
-        ],
-      },
-    )
-    CGI.unescape biometric_preferred_ial_authnrequest.split('SAMLRequest').last
-  end
-  let(:sp1_authn_request) do
-    SamlIdp::Request.from_deflated_request(raw_sp1_authn_request)
-  end
-  let(:aal3_sp1_authn_request) do
-    SamlIdp::Request.from_deflated_request(raw_aal3_sp1_authn_request)
-  end
-  let(:ial1_authn_request) do
-    SamlIdp::Request.from_deflated_request(raw_ial1_authn_request)
-  end
-  let(:ial2_authn_request) do
-    SamlIdp::Request.from_deflated_request(raw_ial2_authn_request)
-  end
-  let(:vtr_proofing_authn_request) do
-    SamlIdp::Request.from_deflated_request(raw_vtr_proofing_authn_request)
-  end
-  let(:vtr_no_proofing_authn_request) do
-    SamlIdp::Request.from_deflated_request(raw_vtr_no_proofing_authn_request)
-  end
-  let(:ial1_aal3_authn_request) do
-    SamlIdp::Request.from_deflated_request(raw_ial1_aal3_authn_request)
-  end
-  let(:ialmax_authn_request) do
-    SamlIdp::Request.from_deflated_request(raw_ialmax_authn_request)
-  end
-  let(:biometric_preferred_ial_authnrequest) do
-    SamlIdp::Request.from_deflated_request(raw_biometric_preferred_ial_authn_request)
-  end
-  let(:biometric_required_ial_authnrequest) do
-    SamlIdp::Request.from_deflated_request(raw_biometric_required_ial_authn_request)
-  end
+
   let(:decrypted_pii) do
     Pii::Attributes.new_from_hash(
       first_name: 'Jåné',
@@ -163,18 +50,27 @@ RSpec.describe AttributeAsserter do
     )
   end
 
+  let(:subject) do
+    described_class.new(
+      user:,
+      name_id_format:,
+      service_provider:,
+      authn_request:,
+      decrypted_pii:,
+      user_session:,
+    )
+  end
+
   describe '#build' do
     context 'when an IAL2 request is made' do
-      let(:subject) do
-        described_class.new(
-          user: user,
-          name_id_format: name_id_format,
-          service_provider: service_provider,
-          authn_request: ial2_authn_request,
-          decrypted_pii: decrypted_pii,
-          user_session: user_session,
-        )
+      let(:options) do
+        {
+          authn_context: [
+            Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+          ],
+        }
       end
+
       context 'when the user has been proofed without biometric' do
         context 'custom bundle includes email, phone, and first_name' do
           before do
@@ -261,20 +157,14 @@ RSpec.describe AttributeAsserter do
 
           context 'authn request specifies bundle' do
             # rubocop:disable Layout/LineLength
-            let(:raw_ial2_authn_request) do
-              request_url = saml_authn_request_url(
-                overrides: {
-                  issuer: sp1_issuer,
-                  authn_context: [
-                    Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-                    "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-                    "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-                  ],
-                },
-              )
-              CGI.unescape(
-                request_url.split('SAMLRequest').last,
-              )
+            let(:options) do
+              {
+                authn_context: [
+                  Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+                ],
+              }
             end
             # rubocop:enable Layout/LineLength
 
@@ -346,8 +236,9 @@ RSpec.describe AttributeAsserter do
           end
         end
       end
+
       context 'when the user has been proofed with biometric' do
-        let(:user) { biometric_verified_user }
+        let(:user) { create(:profile, :active, :verified, idv_level: :in_person).user }
         before do
           user.identities << identity
           subject.build
@@ -361,16 +252,7 @@ RSpec.describe AttributeAsserter do
     end
 
     context 'verified user and proofing VTR request' do
-      let(:subject) do
-        described_class.new(
-          user: user,
-          name_id_format: name_id_format,
-          service_provider: service_provider,
-          authn_request: vtr_proofing_authn_request,
-          decrypted_pii: decrypted_pii,
-          user_session: user_session,
-        )
-      end
+      let(:options) { { authn_context: 'C1.C2.P1' } }
 
       before do
         user.identities << identity
@@ -389,17 +271,6 @@ RSpec.describe AttributeAsserter do
     end
 
     context 'when an IAL1 request is made' do
-      let(:subject) do
-        described_class.new(
-          user: user,
-          name_id_format: name_id_format,
-          service_provider: service_provider,
-          authn_request: sp1_authn_request,
-          decrypted_pii: decrypted_pii,
-          user_session: user_session,
-        )
-      end
-
       context 'when the user has been proofed without biometric comparison' do
         context 'custom bundle includes email, phone, and first_name' do
           before do
@@ -419,7 +290,8 @@ RSpec.describe AttributeAsserter do
           end
 
           it 'gets UUID (MBUN) from Service Provider' do
-            expect(get_asserted_attribute(user, :uuid)).to eq user.last_identity.uuid
+            uuid_getter = user.asserted_attributes[:uuid][:getter]
+            expect(uuid_getter.call(user)).to eq user.last_identity.uuid
           end
         end
 
@@ -437,11 +309,19 @@ RSpec.describe AttributeAsserter do
             it 'only includes uuid, email, aal, and ial (no verified_at)' do
               expect(user.asserted_attributes.keys).to eq %i[uuid email aal ial]
             end
+
+            it 'does not create a getter function for IAL1 attributes' do
+              expected_email = EmailContext.new(user).last_sign_in_email_address.email
+              expect(get_asserted_attribute(user, :email)).to eq expected_email
+            end
+
+            it 'gets UUID (MBUN) from Service Provider' do
+              expect(get_asserted_attribute(user, :uuid)).to eq user.last_identity.uuid
+            end
           end
 
           context 'the service provider is ial2' do
             let(:service_provider_ial) { 2 }
-
             it 'includes verified_at' do
               expect(user.asserted_attributes.keys).to eq %i[uuid email verified_at aal ial]
             end
@@ -463,23 +343,16 @@ RSpec.describe AttributeAsserter do
 
           context 'authn request specifies bundle with first_name, last_name, email, ssn, phone' do
             # rubocop:disable Layout/LineLength
-            let(:raw_sp1_authn_request) do
-              request_url = saml_authn_request_url(
-                overrides: {
-                  issuer: sp1_issuer,
-                  authn_context: [
-                    Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-                    Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
-                    "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-                    "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-                  ],
-                },
-              )
-              CGI.unescape(
-                request_url.split('SAMLRequest').last,
-              )
+            let(:options) do
+              {
+                authn_context: [
+                  Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+                  Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+                ]
+              }
             end
-            # rubocop:enable Layout/LineLength
 
             it 'only includes uuid, email, aal, and ial' do
               expect(user.asserted_attributes.keys).to eq(%i[uuid email aal ial])
@@ -549,16 +422,7 @@ RSpec.describe AttributeAsserter do
         end
 
         context 'request made with a VTR param' do
-          let(:subject) do
-            described_class.new(
-              user: user,
-              name_id_format: name_id_format,
-              service_provider: service_provider,
-              authn_request: vtr_no_proofing_authn_request,
-              decrypted_pii: decrypted_pii,
-              user_session: user_session,
-            )
-          end
+          let(:options) { { authn_context: 'C1.C2' } }
 
           before do
             user.identities << identity
@@ -575,8 +439,10 @@ RSpec.describe AttributeAsserter do
           end
         end
       end
+
       context 'when the user has been proofed with biometric comparison' do
-        let(:user) { biometric_verified_user }
+        let(:user) { create(:profile, :active, :verified, idv_level: :in_person).user }
+
         before do
           user.identities << identity
           subject.build
@@ -592,15 +458,13 @@ RSpec.describe AttributeAsserter do
     context 'verified user and IAL1 AAL3 request' do
       context 'service provider configured for AAL3' do
         let(:service_provider_aal) { 3 }
-        let(:subject) do
-          described_class.new(
-            user: user,
-            name_id_format: name_id_format,
-            service_provider: service_provider,
-            authn_request: aal3_sp1_authn_request,
-            decrypted_pii: decrypted_pii,
-            user_session: user_session,
-          )
+        let(:options) do
+          {
+            authn_context: [
+              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+              Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+            ]
+          }
         end
 
         before do
@@ -617,15 +481,13 @@ RSpec.describe AttributeAsserter do
       end
 
       context 'service provider requests AAL3' do
-        let(:subject) do
-          described_class.new(
-            user: user,
-            name_id_format: name_id_format,
-            service_provider: service_provider,
-            authn_request: ial1_aal3_authn_request,
-            decrypted_pii: decrypted_pii,
-            user_session: user_session,
-          )
+        let(:options) do
+          {
+            authn_context: [
+              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+              Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+            ],
+          }
         end
 
         before do
@@ -645,15 +507,13 @@ RSpec.describe AttributeAsserter do
     context 'IALMAX' do
       context 'service provider requests IALMAX with IAL1 user' do
         let(:service_provider_ial) { 2 }
-        let(:subject) do
-          described_class.new(
-            user: user,
-            name_id_format: name_id_format,
-            service_provider: service_provider,
-            authn_request: ialmax_authn_request,
-            decrypted_pii: decrypted_pii,
-            user_session: user_session,
-          )
+        let(:options) do
+          {
+            authn_context: [
+              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            ],
+            authn_context_comparison: 'minimum'
+          }
         end
 
         before do
@@ -674,15 +534,13 @@ RSpec.describe AttributeAsserter do
 
       context 'IAL2 service provider requests IALMAX with IAL2 user' do
         let(:service_provider_ial) { 2 }
-        let(:subject) do
-          described_class.new(
-            user: user,
-            name_id_format: name_id_format,
-            service_provider: service_provider,
-            authn_request: ialmax_authn_request,
-            decrypted_pii: decrypted_pii,
-            user_session: user_session,
-          )
+        let(:options) do
+          {
+            authn_context: [
+              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            ],
+            authn_context_comparison: 'minimum'
+          }
         end
 
         before do
@@ -707,15 +565,13 @@ RSpec.describe AttributeAsserter do
 
     context 'non-IAL2 service provider requests IALMAX with IAL2 user' do
       let(:service_provider_ial) { 1 }
-      let(:subject) do
-        described_class.new(
-          user: user,
-          name_id_format: name_id_format,
-          service_provider: service_provider,
-          authn_request: ialmax_authn_request,
-          decrypted_pii: decrypted_pii,
-          user_session: user_session,
-        )
+      let(:options) do
+        {
+          authn_context: [
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          ],
+          authn_context_comparison: 'minimum'
+        }
       end
 
       before do
@@ -738,15 +594,12 @@ RSpec.describe AttributeAsserter do
     end
 
     context 'when biometric IAL preferred is requested' do
-      let(:subject) do
-        described_class.new(
-          user: user,
-          name_id_format: name_id_format,
-          service_provider: service_provider,
-          authn_request: biometric_preferred_ial_authnrequest,
-          decrypted_pii: decrypted_pii,
-          user_session: user_session,
-        )
+      let(:options) do
+        {
+          authn_context: [
+            Saml::Idp::Constants::IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF,
+          ]
+        }
       end
 
       context 'when the user has been proofed with biometric' do
@@ -776,15 +629,12 @@ RSpec.describe AttributeAsserter do
     end
 
     context 'when biometric IAL required is requested' do
-      let(:subject) do
-        described_class.new(
-          user: user,
-          name_id_format: name_id_format,
-          service_provider: service_provider,
-          authn_request: biometric_required_ial_authnrequest,
-          decrypted_pii: decrypted_pii,
-          user_session: user_session,
-        )
+      let(:options) do
+        {
+          authn_context: [
+            Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF,
+          ]
+        }
       end
 
       context 'when the user has been proofed with biometric comparison' do
@@ -802,6 +652,8 @@ RSpec.describe AttributeAsserter do
     end
 
     shared_examples 'unverified user' do
+      let(:user) { create(:user, :fully_registered) }
+
       context 'custom bundle does not include email, phone' do
         before do
           allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
@@ -811,7 +663,7 @@ RSpec.describe AttributeAsserter do
         end
 
         it 'only includes UUID, aal, and ial' do
-          expect(ial1_user.asserted_attributes.keys).to eq(%i[uuid aal ial])
+          expect(user.asserted_attributes.keys).to eq(%i[uuid aal ial])
         end
       end
 
@@ -825,7 +677,7 @@ RSpec.describe AttributeAsserter do
         end
 
         it 'includes all the user email addresses' do
-          all_emails_getter = ial1_user.asserted_attributes[:all_emails][:getter]
+          all_emails_getter = user.asserted_attributes[:all_emails][:getter]
           emails = all_emails_getter.call(user)
           expect(emails.length).to eq(2)
           expect(emails).to match_array(user.confirmed_email_addresses.map(&:email))
@@ -841,36 +693,33 @@ RSpec.describe AttributeAsserter do
         end
 
         it 'only includes UUID, email, aal, and ial' do
-          expect(ial1_user.asserted_attributes.keys).to eq(%i[uuid email aal ial])
+          expect(user.asserted_attributes.keys).to eq(%i[uuid email aal ial])
         end
       end
     end
 
     context 'unverified user and IAL2 request' do
-      let(:subject) do
-        described_class.new(
-          user: ial1_user,
-          name_id_format: name_id_format,
-          service_provider: service_provider,
-          authn_request: ial2_authn_request,
-          decrypted_pii: decrypted_pii,
-          user_session: user_session,
-        )
+      let(:user) { create(:user, :fully_registered) }
+      let(:options) do
+        {
+          authn_context: [
+            Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+          ]
+        }
       end
 
       it_behaves_like 'unverified user'
     end
 
     context 'unverified user and LOA1 request' do
-      let(:subject) do
-        described_class.new(
-          user: ial1_user,
-          name_id_format: name_id_format,
-          service_provider: service_provider,
-          authn_request: ial1_authn_request,
-          decrypted_pii: decrypted_pii,
-          user_session: user_session,
-        )
+      let(:user) { create(:user, :fully_registered) }
+
+      let(:options) do
+        {
+          authn_context: [
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          ]
+        }
       end
 
       it_behaves_like 'unverified user'

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -352,6 +352,7 @@ RSpec.describe AttributeAsserter do
                 "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
                 "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
               ]
+              # rubocop:enable Layout/LineLength
             end
 
             it 'only includes uuid, email, aal, and ial' do
@@ -594,7 +595,7 @@ RSpec.describe AttributeAsserter do
         {
           authn_context: [
             Saml::Idp::Constants::IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF,
-          ]
+          ],
         }
       end
 
@@ -629,7 +630,7 @@ RSpec.describe AttributeAsserter do
         {
           authn_context: [
             Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF,
-          ]
+          ],
         }
       end
 
@@ -730,7 +731,7 @@ RSpec.describe AttributeAsserter do
       context 'default_aal is nil' do
         let(:authn_context) { [] }
         it 'asserts default aal' do
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -742,7 +743,7 @@ RSpec.describe AttributeAsserter do
 
         it 'asserts aal1' do
           # we do not enforce aal1, we enforce default aal, so this should be updated
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -753,7 +754,7 @@ RSpec.describe AttributeAsserter do
         let(:authn_context) { [] }
 
         it 'asserts aal2' do
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -766,7 +767,7 @@ RSpec.describe AttributeAsserter do
         it 'asserts aa33' do
           # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
           # so should be updated
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -780,7 +781,7 @@ RSpec.describe AttributeAsserter do
         # We do not support AAL1. when passed in, we enforce our default AAL value.
         # However, we are returning the AAL1 value, which is misleading.
         it 'asserts default aal' do
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -790,7 +791,7 @@ RSpec.describe AttributeAsserter do
         let(:authn_context) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
 
         it 'asserts plain aal2' do
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -801,7 +802,7 @@ RSpec.describe AttributeAsserter do
 
         # we should assert the more specific aal2 value
         it 'asserts plain aal2' do
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -812,7 +813,7 @@ RSpec.describe AttributeAsserter do
 
         # we should assert the more specific aal2 value
         it 'asserts plain aal2' do
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -825,7 +826,7 @@ RSpec.describe AttributeAsserter do
         # when aal3 is requested, we are enforcing aal2 with phishing-resistant mfa.
         # we should update to assert that
         it 'asserts plain aal3' do
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -837,7 +838,7 @@ RSpec.describe AttributeAsserter do
         # when aal3 is requested, we are enforcing aal2 with HSPD12 mfa.
         # we should update to assert that
         it 'asserts plain aal2' do
-          expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+          expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
         end
@@ -855,8 +856,8 @@ RSpec.describe AttributeAsserter do
           end
 
           it 'asserts the default value' do
-            expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
-              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
+            expect(get_asserted_attribute(user, :aal)).to eq(
+              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             )
           end
         end
@@ -870,8 +871,8 @@ RSpec.describe AttributeAsserter do
           end
 
           it 'asserts the aal1 value' do
-            expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
-              Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF
+            expect(get_asserted_attribute(user, :aal)).to eq(
+              Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
             )
           end
         end
@@ -885,7 +886,7 @@ RSpec.describe AttributeAsserter do
         describe 'no aal is requested via authn_context' do
           context 'default_aal is nil' do
             it 'asserts default aal' do
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+              expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
               )
             end
@@ -896,7 +897,7 @@ RSpec.describe AttributeAsserter do
 
             it 'asserts aal1' do
               # we do not enforce aal1, we enforce default aal, so this should be updated
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+              expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
               )
             end
@@ -907,7 +908,7 @@ RSpec.describe AttributeAsserter do
 
             it 'asserts aal1' do
               # we do not enforce aal1, we enforce default aal, so this should be updated
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+              expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
               )
             end
@@ -918,7 +919,7 @@ RSpec.describe AttributeAsserter do
 
             it 'asserts aal1' do
               # we do not enforce aal1, we enforce default aal, so this should be updated
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+              expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
               )
             end
@@ -933,7 +934,7 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is nil' do
             it 'asserts default aal' do
               # this should be upgraded to AAL2, as we enforce that on an identity-proofing request
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+              expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
               )
             end
@@ -944,7 +945,7 @@ RSpec.describe AttributeAsserter do
 
             it 'asserts aal1' do
               # this should be upgraded to AAL2, as we enforce that on an identity-proofing request
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+              expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
               )
             end
@@ -954,7 +955,7 @@ RSpec.describe AttributeAsserter do
             let(:service_provider_aal) { 2 }
 
             it 'asserts base aal2' do
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+              expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
               )
             end
@@ -965,7 +966,7 @@ RSpec.describe AttributeAsserter do
 
             it 'asserts aal3' do
               # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+              expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
               )
             end
@@ -983,8 +984,8 @@ RSpec.describe AttributeAsserter do
 
             # identity proofing enforces aal2, so that is what should be asserted
             it 'asserts the default value' do
-              expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
-                Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
+              expect(get_asserted_attribute(user, :aal)).to eq(
+                Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
               )
             end
           end
@@ -1012,7 +1013,7 @@ RSpec.describe AttributeAsserter do
             context 'default_aal is nil' do
               it 'asserts default aal' do
                 # this is fine, as we have enforced auth-only
-                expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+                expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
                 )
               end
@@ -1023,7 +1024,7 @@ RSpec.describe AttributeAsserter do
 
               it 'asserts aal1' do
                 # this is fine, as we have enforced auth-only
-                expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+                expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
                 )
               end
@@ -1033,7 +1034,7 @@ RSpec.describe AttributeAsserter do
               let(:service_provider_aal) { 2 }
 
               it 'asserts base aal2' do
-                expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+                expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
                 )
               end
@@ -1044,7 +1045,7 @@ RSpec.describe AttributeAsserter do
 
               it 'asserts aal3' do
                 # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
-                expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+                expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
                 )
               end
@@ -1058,7 +1059,7 @@ RSpec.describe AttributeAsserter do
               it 'asserts default aal' do
                 # this should be upgraded to AAL2, as we enforce that
                 # on an identity-proofing request
-                expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+                expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
                 )
               end
@@ -1070,7 +1071,7 @@ RSpec.describe AttributeAsserter do
               it 'asserts aal1' do
                 # this should be upgraded to AAL2, as we enforce that
                 # on an identity-proofing request
-                expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+                expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
                 )
               end
@@ -1080,7 +1081,7 @@ RSpec.describe AttributeAsserter do
               let(:service_provider_aal) { 2 }
 
               it 'asserts base aal2' do
-                expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+                expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
                 )
               end
@@ -1091,7 +1092,7 @@ RSpec.describe AttributeAsserter do
 
               it 'asserts aal3' do
                 # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
-                expect(user.asserted_attributes[:aal][:getter].call(user)).to eq(
+                expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
                 )
               end

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -26,7 +26,13 @@ RSpec.describe AttributeAsserter do
     )
   end
 
-  let(:options) { {} }
+  let(:authn_context) do
+    [
+      Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+    ]
+  end
+  let(:options) { { authn_context: } }
   let(:raw_authn_request) do
     raw = saml_authn_request_url(
       overrides: {
@@ -63,12 +69,10 @@ RSpec.describe AttributeAsserter do
 
   describe '#build' do
     context 'when an IAL2 request is made' do
-      let(:options) do
-        {
-          authn_context: [
-            Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
-          ],
-        }
+      let(:authn_context) do
+        [
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+        ]
       end
 
       context 'when the user has been proofed without biometric' do
@@ -157,14 +161,12 @@ RSpec.describe AttributeAsserter do
 
           context 'authn request specifies bundle' do
             # rubocop:disable Layout/LineLength
-            let(:options) do
-              {
-                authn_context: [
-                  Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-                ],
-              }
+            let(:authn_context) do
+              [
+                Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+                "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+              ]
             end
             # rubocop:enable Layout/LineLength
 
@@ -252,7 +254,7 @@ RSpec.describe AttributeAsserter do
     end
 
     context 'verified user and proofing VTR request' do
-      let(:options) { { authn_context: 'C1.C2.P1' } }
+      let(:authn_context) { 'C1.C2.P1' }
 
       before do
         user.identities << identity
@@ -341,17 +343,15 @@ RSpec.describe AttributeAsserter do
             end
           end
 
+          # rubocop:disable Layout/LineLength
           context 'authn request specifies bundle with first_name, last_name, email, ssn, phone' do
-            # rubocop:disable Layout/LineLength
-            let(:options) do
-              {
-                authn_context: [
-                  Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-                  Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
-                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-                ]
-              }
+            let(:authn_context) do
+              [
+                Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+                Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+              ]
             end
 
             it 'only includes uuid, email, aal, and ial' do
@@ -458,13 +458,11 @@ RSpec.describe AttributeAsserter do
     context 'verified user and IAL1 AAL3 request' do
       context 'service provider configured for AAL3' do
         let(:service_provider_aal) { 3 }
-        let(:options) do
-          {
-            authn_context: [
-              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-              Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
-            ]
-          }
+        let(:authn_context) do
+          [
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+          ]
         end
 
         before do
@@ -481,13 +479,11 @@ RSpec.describe AttributeAsserter do
       end
 
       context 'service provider requests AAL3' do
-        let(:options) do
-          {
-            authn_context: [
-              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-              Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
-            ],
-          }
+        let(:authn_context) do
+          [
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+          ]
         end
 
         before do
@@ -700,12 +696,10 @@ RSpec.describe AttributeAsserter do
 
     context 'unverified user and IAL2 request' do
       let(:user) { create(:user, :fully_registered) }
-      let(:options) do
-        {
-          authn_context: [
-            Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
-          ]
-        }
+      let(:authn_context) do
+        [
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+        ]
       end
 
       it_behaves_like 'unverified user'

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe AttributeAsserter do
             expect(get_asserted_attribute(user, :phone)).to eq '+18888675309'
           end
 
-          it 'gets UUID (MBUN) from Service Provider' do
+          it 'gets UUID from Service Provider' do
             expect(get_asserted_attribute(user, :uuid)).to eq user.last_identity.uuid
           end
         end
@@ -291,7 +291,7 @@ RSpec.describe AttributeAsserter do
             expect(get_asserted_attribute(user, :email)).to eq expected_email
           end
 
-          it 'gets UUID (MBUN) from Service Provider' do
+          it 'gets UUID from Service Provider' do
             uuid_getter = user.asserted_attributes[:uuid][:getter]
             expect(uuid_getter.call(user)).to eq user.last_identity.uuid
           end
@@ -317,7 +317,7 @@ RSpec.describe AttributeAsserter do
               expect(get_asserted_attribute(user, :email)).to eq expected_email
             end
 
-            it 'gets UUID (MBUN) from Service Provider' do
+            it 'gets UUID from Service Provider' do
               expect(get_asserted_attribute(user, :uuid)).to eq user.last_identity.uuid
             end
           end


### PR DESCRIPTION
WIP Currently just open so folks can look at the changes made in the attributes_asserter_spec file

 ## 🎫 Ticket
As part of https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/55, we discovered a number of issues with our returned AAL values. I wanted to write some tests to make sure our understanding of the current state vs the expected state was accurate.

This first commit is just a refactor of the spec file in order to make it easier to understand and work with,