### PR TITLE
Add test coverage for expected reCAPTCHA sign-in logging

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -914,6 +914,7 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
     it 'redirects user to security check failed page' do
       visit new_user_session_path
 
+      asserted_expected_user = false
       fake_analytics = FakeAnalytics.new
       allow_any_instance_of(ApplicationController).to receive(:analytics).
         and_wrap_original do |original|
@@ -921,6 +922,7 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
           if original_analytics.request.params[:controller] == 'users/sessions' &&
              original_analytics.request.params[:action] == 'create'
             expect(original_analytics.user).to eq(user)
+            asserted_expected_user = true
           end
 
           fake_analytics
@@ -928,6 +930,7 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
 
       fill_in :user_recaptcha_mock_score, with: '0.1'
       fill_in_credentials_and_submit(user.email, user.password)
+      expect(asserted_expected_user).to eq(true)
       expect(fake_analytics).to have_logged_event(
         'reCAPTCHA verify result received',
         recaptcha_result: {

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -918,7 +918,7 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
       allow_any_instance_of(ApplicationController).to receive(:analytics).
         and_wrap_original do |original|
           original_analytics = original.call
-          if original_analytics.request.params[:controller] == 'users/sesson' &&
+          if original_analytics.request.params[:controller] == 'users/sessions' &&
              original_analytics.request.params[:action] == 'create'
             expect(original_analytics.user).to eq(user)
           end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -902,8 +902,9 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
     end
   end
 
-  context 'Recaptcha check fails' do
+  context 'reCAPTCHA check fails' do
     let(:user) { create(:user, :fully_registered) }
+
     before do
       allow(FeatureManagement).to receive(:sign_in_recaptcha_enabled?).and_return(true)
       allow(IdentityConfig.store).to receive(:recaptcha_mock_validator).and_return(true)
@@ -912,9 +913,34 @@ RSpec.feature 'Sign in', allowed_extra_analytics: [:*] do
 
     it 'redirects user to security check failed page' do
       visit new_user_session_path
+
+      fake_analytics = FakeAnalytics.new
+      allow_any_instance_of(ApplicationController).to receive(:analytics).
+        and_wrap_original do |original|
+          original_analytics = original.call
+          if original_analytics.request.params[:controller] == 'users/sesson' &&
+             original_analytics.request.params[:action] == 'create'
+            expect(original_analytics.user).to eq(user)
+          end
+
+          fake_analytics
+        end
+
       fill_in :user_recaptcha_mock_score, with: '0.1'
       fill_in_credentials_and_submit(user.email, user.password)
-
+      expect(fake_analytics).to have_logged_event(
+        'reCAPTCHA verify result received',
+        recaptcha_result: {
+          assessment_id: kind_of(String),
+          success: true,
+          score: 0.1,
+          errors: [],
+          reasons: [],
+        },
+        evaluated_as_valid: false,
+        score_threshold: 0.2,
+        form_class: 'RecaptchaMockForm',
+      )
       expect(current_path).to eq sign_in_security_check_failed_path
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates reCAPTCHA sign-in failure specs to include coverage for expected logging:

- Expected logging properties
- Expected user_id associated with attempted user

## 📜 Testing Plan

```
rspec spec/features/users/sign_in_spec.rb:905
```