### PR TITLE
LG-13870: Update the Account deletion cancel request confirmation page to reflect current Login.gov content and design system standards

### DIFF
--- a/app/views/account_reset/pending/confirm.html.erb
+++ b/app/views/account_reset/pending/confirm.html.erb
@@ -6,6 +6,7 @@
 
 <%= render ButtonComponent.new(
       url: account_reset_pending_cancel_path,
+      method: :post,
       class: 'margin-top-2 margin-bottom-4',
       wide: true,
       big: true,

--- a/app/views/account_reset/pending/confirm.html.erb
+++ b/app/views/account_reset/pending/confirm.html.erb
@@ -1,11 +1,16 @@
 <% self.title = t('account_reset.cancel_request.title') %>
 
+<%= render PageHeadingComponent.new.with_content(t('account_reset.pending.header')) %>
+
 <p><%= t('account_reset.pending.confirm', interval: @account_reset_deletion_period_interval) %></p>
 
-<%= button_to(
-      account_reset_pending_cancel_path,
-      class: 'usa-button usa-button--wide usa-button--big margin-bottom-2',
-      method: :post,
-    ) { t('forms.buttons.continue') } %>
+<%= render ButtonComponent.new(
+      url: account_reset_pending_cancel_path,
+      class: 'margin-top-2 margin-bottom-4',
+      wide: true,
+      big: true,
+    ).with_content(t('account_reset.pending.cancel_request')) %>
 
-<%= link_to(t('links.go_back'), account_reset_pending_path) %>
+  <div>
+    <%= link_to(t('links.go_back'), idv_forgot_password_url, class: 'margin-left-1') %>
+  </div>

--- a/app/views/account_reset/pending/confirm.html.erb
+++ b/app/views/account_reset/pending/confirm.html.erb
@@ -13,5 +13,5 @@
     ).with_content(t('account_reset.pending.cancel_request')) %>
 
   <div>
-    <%= link_to(t('links.go_back'), idv_forgot_password_url) %>
+    <%= link_to(t('links.go_back'), account_reset_pending_path) %>
   </div>

--- a/app/views/account_reset/pending/confirm.html.erb
+++ b/app/views/account_reset/pending/confirm.html.erb
@@ -7,7 +7,7 @@
 <%= render ButtonComponent.new(
       url: account_reset_pending_cancel_path,
       method: :post,
-      class: 'margin-top-2 margin-bottom-4',
+      class: 'margin-top-3 margin-bottom-2',
       wide: true,
       big: true,
     ).with_content(t('account_reset.pending.cancel_request')) %>

--- a/app/views/account_reset/pending/confirm.html.erb
+++ b/app/views/account_reset/pending/confirm.html.erb
@@ -13,5 +13,5 @@
     ).with_content(t('account_reset.pending.cancel_request')) %>
 
   <div>
-    <%= link_to(t('links.go_back'), idv_forgot_password_url, class: 'margin-left-1') %>
+    <%= link_to(t('links.go_back'), idv_forgot_password_url) %>
   </div>

--- a/app/views/account_reset/pending/confirm.html.erb
+++ b/app/views/account_reset/pending/confirm.html.erb
@@ -12,6 +12,6 @@
       big: true,
     ).with_content(t('account_reset.pending.cancel_request')) %>
 
-  <div>
-    <%= link_to(t('links.go_back'), account_reset_pending_path) %>
-  </div>
+<div>
+  <%= link_to(t('links.go_back'), account_reset_pending_path) %>
+</div>

--- a/spec/features/account_reset/pending_request_spec.rb
+++ b/spec/features/account_reset/pending_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Pending account reset request sign in' do
     expect(page).to have_content(t('account_reset.pending.header'))
 
     click_on t('account_reset.pending.cancel_request')
-    click_on t('forms.buttons.continue')
+    click_on t('account_reset.pending.cancel_request')
     expect(page).to have_content(t('account_reset.pending.canceled'))
 
     click_on t('links.continue_sign_in')


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13870](https://cm-jira.usa.gov/browse/LG-13870)

## 🛠 Summary of changes

This PR adds the H1 element to the account reset cancel request confirmation form as well as a more descriptive button explaining the next step in the account reset cancellation process.

## 📜 Testing Plan

Pre-requisites: An existing account with at least 1 MFA method

- [ ] Login to your account
- [ ] On the screen where you are prompted to authenticate, click "Choose another authentication method
- [ ] Scroll down to the bottom of the page and click "deleting your account"
- [ ] Continue with the deletion process by clicking "Yes, continue deletion"
- [ ] Confirm deletion request by clicking "Yes, continue deletion"
- [ ] Receive email stating that your account will be deleted in 24 hours
- [ ] Return to the application and log in to your account
- [ ] Click "Cancel request"
- [ ] See updated screen with the new `h1` element as well as the updated "Cancel request" button

## 👀 Screenshots

<details>
<summary>Before:</summary>

| English | Spanish | French | Chinese |
|--------|--------|--------|--------|
| <img width="767" alt="screenshot of current you requested to delete your account page in english" src="https://github.com/user-attachments/assets/6662bc14-1c65-40f6-9e9b-7f08c7dffc1a"> | <img width="794" alt="screenshot of current you requested to delete your account page in spanish" src="https://github.com/user-attachments/assets/1a9dcff8-37cc-49bb-ad8c-6027748f9754"> | <img width="752" alt="screenshot of current you requested to delete your account page in french" src="https://github.com/user-attachments/assets/f0115a12-bbe9-4bb2-a42f-7182721a0717"> | <img width="800" alt="screenshot of current you requested to delete your account page in chinese" src="https://github.com/user-attachments/assets/8803c567-4345-4095-92a0-c70a77b922d3"> | 
</details>

<details>
<summary>After:</summary>

| English | Spanish | French | Chinese |
|--------|--------|--------|--------|
| ![screenshot of updated you requested to delete your account page in english](https://github.com/user-attachments/assets/a20b7173-14ff-42c0-8992-113420f48277) | ![screenshot of updated you request to delete your account page in spanish](https://github.com/user-attachments/assets/cd7a464d-8774-4695-ae1e-34fb71ebdd97) | <img width="696" alt="screenshot of update you requested to delete your account page in french" src="https://github.com/user-attachments/assets/8c975686-fdb7-4e4d-8951-4b9b73c79b04"> | <img width="758" alt="screenshot of updated you requested to delete your account page in chinese" src="https://github.com/user-attachments/assets/5fb27c92-dfc9-474e-92bd-ee79ae5911c6"> | 

</details>

