### PR TITLE
Disable USWDS default external link screen reader text

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -11,6 +11,7 @@
 @forward 'full-screen';
 @forward 'hr';
 @forward 'language-picker';
+@forward 'link';
 @forward 'header';
 @forward 'page-heading';
 @forward 'profile-section';

--- a/app/assets/stylesheets/components/_link.scss
+++ b/app/assets/stylesheets/components/_link.scss
@@ -1,0 +1,8 @@
+// USWDS link screen reader text needs improvement for placement and lack of localization support,
+// and conflicts with `new_tab_link_to` customizations.
+//
+// See: https://github.com/uswds/uswds/issues/5942
+.usa-link--external::before,
+.usa-link--external[target='_blank']::before {
+  content: '';
+}


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where external links doubly announce to screen readers that they open in a new window.

This addresses a few problems:

- Double announcement
- Lack of translation in non-English locales
- Confusing placement of the text _before_ the link content

This should hopefully be a temporary patch, pending upstream improvements tracked at https://github.com/uswds/uswds/issues/5942 

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Enable screen reader
3. Navigate to "Security Practices and Privacy Act Statement" link
4. Observe that the link only announces that it opens in a new tab a single time, in the page's current locale, and after the link's content is announced

## 👀 Screenshots

Language|Before|After
---|---|---
English|![english-before](https://github.com/user-attachments/assets/cc0e0c08-f921-43a5-ad1f-702029737c54)|![english-after](https://github.com/user-attachments/assets/5e57ac53-b95c-4db7-86de-dc776b77962a)
Chinese|![chinese-before](https://github.com/user-attachments/assets/2302e46b-a906-4b5a-b9fe-63a4a704272a)|![chinese-after](https://github.com/user-attachments/assets/b4434a85-0a1c-401e-8b90-29814a646229)