### PR TITLE
Fix WebAuthn hints to pass on public key credential options

### DIFF
--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -85,10 +85,10 @@ describe('enrollWebauthnDevice', () => {
           ],
           timeout: 800000,
           attestation: 'none',
+          hints: ['security-key'],
           authenticatorSelection: {
             userVerification: 'discouraged',
             authenticatorAttachment: 'cross-platform',
-            hints: ['security-key'],
           },
           excludeCredentials: [
             {
@@ -139,9 +139,9 @@ describe('enrollWebauthnDevice', () => {
 
         expect(navigator.credentials.create).to.have.been.calledWithMatch({
           publicKey: {
+            hints: ['client-device'],
             authenticatorSelection: {
               authenticatorAttachment: 'platform',
-              hints: ['client-device'],
             },
           },
         });

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -41,7 +41,7 @@ interface EnrollResult {
   transports?: string[];
 }
 
-interface AuthenticatorSelectionCriteriaWithHints extends AuthenticatorSelectionCriteria {
+interface PublicKeyCredentialCreationOptionsWithHints extends PublicKeyCredentialCreationOptions {
   hints?: Array<PublicKeyCredentialHintType>;
 }
 
@@ -94,14 +94,14 @@ async function enrollWebauthnDevice({
       pubKeyCredParams: SUPPORTED_ALGORITHMS.map((alg) => ({ alg, type: 'public-key' })),
       timeout: 800000,
       attestation: 'none',
+      hints,
       authenticatorSelection: {
         // Prevents user from needing to use PIN with Security Key
         userVerification: 'discouraged',
         authenticatorAttachment,
-        hints,
-      } as AuthenticatorSelectionCriteriaWithHints,
+      },
       excludeCredentials,
-    },
+    } as PublicKeyCredentialCreationOptionsWithHints,
   })) as PublicKeyCredential;
 
   const response = credential.response as AuthenticatorAttestationResponseBrowserSupport;


### PR DESCRIPTION
## 🛠 Summary of changes

Updates WebAuthn enrollment to pass the `hints` property on the correct nesting level of the configuration.

Previously, it was passed as a property of `authenticatorSelection`, but it is a sibling option of `authenticatorSelection`.

Specification: https://w3c.github.io/webauthn/#sctn-parseCreationOptionsFromJSON

Related Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1723054132991659

## 📜 Testing Plan

If you have Chrome 128 available ([currently beta, stable release planned for 8/14/24](https://chromestatus.com/roadmap)), you can verify that you are prompted for a security key when choosing to add a security key to your account. Previously, you would see a QR code prompting for a passkey, with small text mentioning the ability to use a security key.

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/987b132f-ac88-4a94-b6ac-7d7f4a2dfc7f)|![image](https://github.com/user-attachments/assets/2f8f99f3-d997-447a-a85f-e4240c4f0796)
