### PR TITLE
LG-13725 Remove old hybrid flow columns from `DocAuthLog` model

### DIFF
--- a/app/models/doc_auth_log.rb
+++ b/app/models/doc_auth_log.rb
@@ -9,13 +9,7 @@ class DocAuthLog < ApplicationRecord
              primary_key: 'issuer'
   # rubocop:enable Rails/InverseOf
 
-  # rubocop:disable Rails/UnusedIgnoredColumns
   self.ignored_columns = [
     :aamva,
-    :email_sent_view_at,
-    :email_sent_view_count,
-    :send_link_view_at,
-    :send_link_view_count,
   ]
-  # rubocop:enable Rails/UnusedIgnoredColumns
 end


### PR DESCRIPTION
The `DocAuthLog` model had the following columns in its ignored columns.

- `email_sent_view_at`
- `email_sent_view_count`
- `send_link_view_at`
- `send_link_view_count`

These columns were dropped by a migration added in f24fb015d0d. This commit follows up on that by removed the reference to these in the ignored columns list.
