### PR TITLE
LG-13725 Drop `aamva` column from `doc_auth_logs`

### DIFF
--- a/db/primary_migrate/20240807202012_drop_aamva_from_doc_auth_logs.rb
+++ b/db/primary_migrate/20240807202012_drop_aamva_from_doc_auth_logs.rb
@@ -1,0 +1,7 @@
+class DropAamvaFromDocAuthLogs < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :doc_auth_logs, :aamva, :boolean
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_01_183410) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_07_202012) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -168,7 +168,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_183410) do
     t.datetime "agreement_view_at", precision: nil
     t.integer "agreement_view_count", default: 0
     t.string "state"
-    t.boolean "aamva"
     t.datetime "verify_submit_at", precision: nil
     t.integer "verify_phone_submit_count", default: 0
     t.datetime "verify_phone_submit_at", precision: nil


### PR DESCRIPTION
This column was added to the `ignored_columns` list in https://github.com/18F/identity-idp/commit/85da36e3a4f9515e585782e37a79b5036845f42c. This commit follows up on that by adding a migration to drop the column.
