### PR TITLE
LG-13725 Remove `aamva` from `DocAuthLog` ignored columns

### DIFF
--- a/app/models/doc_auth_log.rb
+++ b/app/models/doc_auth_log.rb
@@ -8,10 +8,4 @@ class DocAuthLog < ApplicationRecord
              foreign_key: 'issuer',
              primary_key: 'issuer'
   # rubocop:enable Rails/InverseOf
-
-  # rubocop:disable Rails/UnusedIgnoredColumns
-  self.ignored_columns = [
-    :aamva,
-  ]
-  # rubocop:enable Rails/UnusedIgnoredColumns
 end


### PR DESCRIPTION
The `aamva` column was dropped in #11052. This commit follows-up on that by removing it from the `ignored_columns` list on the model.

This commit should be merged after changes in #11052 are deployed.