### PR TITLE
Adds a comment to usps_auth_token_refresh config

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -182,6 +182,7 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.yesterday] },
       },
+      # Refresh USPS auth tokens
       usps_auth_token_refresh: (if IdentityConfig.store.usps_auth_token_refresh_job_enabled
                                   {
                                     class: 'UspsAuthTokenRefreshJob',


### PR DESCRIPTION
## 🎫 Ticket

Nuisance papercut discovered while working on [LG-14022](https://cm-jira.usa.gov/browse/LG-14022). (Not tagging in the title so the Jira state doesn't get erroneously updated.)

## 🛠 Summary of changes

Nearly every job has a comment above it explaining what it's for. While working on a story for `identity_verification_report`, I noticed that the completely unrelated `usps_auth_token_refresh` job directly underneath it looked as if it was a confusing continuation because it didn't follow the pattern.

This is not an earth-shatteringly informative comment, but it makes the file less visually-confusing by not being a weird outlier, and "What if I reformatted the whole file so this wasn't an issue?" is way too big of a distraction.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
