### PR TITLE
Move Docker image builds earlier in CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ install:
 # Build a container image async, and don't block CI tests
 # Cache intermediate images for 1 week (168 hours)
 build-review-image:
-  stage: review
+  stage: build
   needs: []
   environment:
     name: review/$CI_COMMIT_REF_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,7 +143,7 @@ build-review-image:
       --build-arg "ARG_CI_COMMIT_SHA=${CI_COMMIT_SHA}"
 
 build-idp-image:
-  stage: review
+  stage: build
   needs: []
   interruptible: true
   variables:


### PR DESCRIPTION
There are two CI jobs, `build-idp-image` and `build-review-image` that currently run after the `build` and `test` stages. This PR moves them to the `build` stage so they can get started earlier and reduce the duration of the complete CI pipeline.