### PR TITLE
idp_prod image build optimization

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,6 +182,7 @@ build-idp-image:
       --cache-repo="${ECR_REGISTRY}/identity-idp/idp/cache"
       --cache-ttl=168h
       --cache=true
+      --single-snapshot
       --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}"
       --build-arg "https_proxy=${https_proxy}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,7 @@ build-idp-image:
       ${BRANCH_TAGGING_STRING}
       --cache-repo="${ECR_REGISTRY}/identity-idp/idp/cache"
       --cache-ttl=168h
-      --cache=false
+      --cache=true
       --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}"
       --build-arg "https_proxy=${https_proxy}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,7 @@ build-idp-image:
       ${BRANCH_TAGGING_STRING}
       --cache-repo="${ECR_REGISTRY}/identity-idp/idp/cache"
       --cache-ttl=168h
-      --cache=true
+      --cache=false
       --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}"
       --build-arg "https_proxy=${https_proxy}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,7 +182,7 @@ build-idp-image:
       --cache-repo="${ECR_REGISTRY}/identity-idp/idp/cache"
       --cache-ttl=168h
       --cache=true
-      --single-snapshot
+      --single-snapshot 
       --compressed-caching=false
       --build-arg "http_proxy=${http_proxy}"
       --build-arg "https_proxy=${https_proxy}"


### PR DESCRIPTION
## 🛠 Summary of changes

Try to speed up idp prod image builds so that they do not delay the overall pipeline completion.

Caching seems to be super slow, so try turning that off.