### PR TITLE
Use redirect logging controller for Privacy Act links

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -88,7 +88,11 @@
   <p class="margin-y-1">
     <%= new_tab_link_to(
           t('notices.privacy.privacy_act_statement'),
-          MarketingSite.privacy_act_statement_url,
+          policy_redirect_url(
+            policy: :privacy_act_statement,
+            flow: :sign_in,
+            step: :sign_in,
+          ),
         ) %>
   </p>
 <% end %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -50,13 +50,21 @@
 <p class='margin-top-2'>
   <%= new_tab_link_to(
         t('notices.privacy.security_and_privacy_practices'),
-        MarketingSite.security_and_privacy_practices_url,
+        policy_redirect_url(
+          policy: :security_and_privacy_practices,
+          flow: :create_account,
+          step: :enter_email,
+        ),
       ) %>
 </p>
 
 <p>
   <%= new_tab_link_to(
         t('notices.privacy.privacy_act_statement'),
-        MarketingSite.privacy_act_statement_url,
+        policy_redirect_url(
+          policy: :privacy_act_statement,
+          flow: :create_account,
+          step: :enter_email,
+        ),
       ) %>
 </p>

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -63,7 +63,11 @@ RSpec.describe 'devise/sessions/new.html.erb' do
 
     expect(rendered).to have_link(
       t('notices.privacy.privacy_act_statement'),
-      href: MarketingSite.privacy_act_statement_url,
+      href: policy_redirect_url(
+        policy: :privacy_act_statement,
+        flow: :sign_in,
+        step: :sign_in,
+      ),
     ) { |link| link[:target] == '_blank' && link[:rel] == 'noopener noreferrer' }
   end
 

--- a/spec/views/sign_up/registrations/new.html.erb_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.erb_spec.rb
@@ -73,15 +73,22 @@ RSpec.describe 'sign_up/registrations/new.html.erb' do
   it 'includes a link to security / privacy page and privacy statement act' do
     render
 
-    expect(rendered).
-      to have_link(
-        t('notices.privacy.security_and_privacy_practices'),
-        href: MarketingSite.security_and_privacy_practices_url,
-      )
-    expect(rendered).
-      to have_selector(
-        "a[href='#{MarketingSite.security_and_privacy_practices_url}']\
-[target='_blank'][rel='noopener noreferrer']",
-      )
+    expect(rendered).to have_link(
+      t('notices.privacy.security_and_privacy_practices'),
+      href: policy_redirect_url(
+        policy: :security_and_privacy_practices,
+        flow: :create_account,
+        step: :enter_email,
+      ),
+    ) { |link| link[:target] == '_blank' && link[:rel] == 'noopener noreferrer' }
+
+    expect(rendered).to have_link(
+      t('notices.privacy.privacy_act_statement'),
+      href: policy_redirect_url(
+        policy: :privacy_act_statement,
+        flow: :create_account,
+        step: :enter_email,
+      ),
+    ) { |link| link[:target] == '_blank' && link[:rel] == 'noopener noreferrer' }
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Privacy Act links to use the policy redirect controller, which was updated in #11031 (RC 404) to support this link.

Follows #11031

## 📜 Testing Plan

1. In a separate terminal process, run make watch_events
2. Go to http://localhost:3000/
3. Click "Privacy Act Statement"
4. See "Policy Page Redirect" event in events logging with redirect_url of https://www.login.gov/policy/our-privacy-act-statement/