### PR TITLE
Integrate SAML validation namespace fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.21.6-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.21.8-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,10 +35,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 512ad9b1609884781034773f6c4ccd53e7036a82
-  tag: 0.21.6-18f
+  revision: e52d679ab060531e12c19a27357aec4cd9b63546
+  tag: 0.21.8-18f
   specs:
-    saml_idp (0.21.6.pre.18f)
+    saml_idp (0.21.8.pre.18f)
       activesupport
       builder
       faraday

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -204,7 +204,7 @@ module SamlIdpAuthConcern
   end
 
   def encryption_cert
-    saml_request.service_provider.matching_cert ||
+    saml_request.matching_cert ||
       saml_request_service_provider&.ssl_certs&.first
   end
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -134,22 +134,10 @@ class SamlIdpController < ApplicationController
     )
 
     if result.success? && saml_request.signed?
-      # Logging to indicate if a validation bug fix will create a potentially breaking change
-      analytics_payload[:encryption_cert_matches_matching_cert] =
-        encryption_cert_matches_matching_cert?
       analytics_payload[:cert_error_details] = saml_request.cert_errors
     end
 
     analytics.saml_auth(**analytics_payload)
-  end
-
-  def matching_cert
-    saml_request.matching_cert
-  rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
-  end
-
-  def encryption_cert_matches_matching_cert?
-    (matching_cert || saml_request_service_provider&.ssl_certs&.first) == encryption_cert
   end
 
   def log_external_saml_auth_request

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5343,7 +5343,6 @@ module AnalyticsEvents
   # @param [Integer] requested_ial
   # @param [Boolean] request_signed
   # @param [String] matching_cert_serial
-  # @param [Boolean|nil] encryption_cert_matches_matching_cert If the encryption certificate
   # matches the request certificate in a successful, signed request
   # @param [Hash] cert_error_details Details for errors that occurred because of an invalid
   # signature
@@ -5361,7 +5360,6 @@ module AnalyticsEvents
     requested_ial:,
     request_signed:,
     matching_cert_serial:,
-    encryption_cert_matches_matching_cert: nil,
     error_details: nil,
     cert_error_details: nil,
     **extra
@@ -5382,7 +5380,6 @@ module AnalyticsEvents
       requested_ial:,
       request_signed:,
       matching_cert_serial:,
-      encryption_cert_matches_matching_cert:,
       cert_error_details:,
       **extra,
     )

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -792,7 +792,6 @@ RSpec.describe SamlIdpController do
             finish_profile: false,
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
-            encryption_cert_matches_matching_cert: true,
           ),
         )
         expect(@analytics).to have_logged_event(
@@ -944,7 +943,6 @@ RSpec.describe SamlIdpController do
             finish_profile: false,
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
-            encryption_cert_matches_matching_cert: true,
           ),
         )
         expect(@analytics).to have_logged_event(
@@ -1424,7 +1422,6 @@ RSpec.describe SamlIdpController do
 
     describe 'SAML signature behavior' do
       let(:authn_requests_signed) { false }
-      let(:encryption_cert_matches_matching_cert) { nil }
       let(:matching_cert_serial) { nil }
       let(:service_provider) { ServiceProvider.find_by(issuer: auth_settings.issuer) }
       let(:user) { create(:user, :fully_registered) }
@@ -1471,7 +1468,6 @@ RSpec.describe SamlIdpController do
               'SAML Auth', hash_including(
                 request_signed: authn_requests_signed,
                 matching_cert_serial: saml_test_sp_cert_serial,
-                encryption_cert_matches_matching_cert: true,
               )
             )
           end
@@ -1494,7 +1490,6 @@ RSpec.describe SamlIdpController do
               expect(@analytics).to have_logged_event(
                 'SAML Auth', hash_including(
                   request_signed: authn_requests_signed,
-                  encryption_cert_matches_matching_cert: false,
                 )
               )
             end
@@ -1540,7 +1535,6 @@ RSpec.describe SamlIdpController do
             expect(@analytics).to have_logged_event(
               'SAML Auth', hash_including(
                 request_signed: authn_requests_signed,
-                encryption_cert_matches_matching_cert: true,
                 cert_error_details:,
               )
             )
@@ -1664,7 +1658,6 @@ RSpec.describe SamlIdpController do
           finish_profile: false,
           request_signed: true,
           matching_cert_serial: saml_test_sp_cert_serial,
-          encryption_cert_matches_matching_cert: true,
         }
 
         expect(@analytics).to have_logged_event('SAML Auth', hash_including(analytics_hash))
@@ -2378,7 +2371,6 @@ RSpec.describe SamlIdpController do
           finish_profile: false,
           request_signed: true,
           matching_cert_serial: saml_test_sp_cert_serial,
-          encryption_cert_matches_matching_cert: true,
         }
 
         generate_saml_response(user)
@@ -2432,7 +2424,6 @@ RSpec.describe SamlIdpController do
           finish_profile: true,
           request_signed: true,
           matching_cert_serial: saml_test_sp_cert_serial,
-          encryption_cert_matches_matching_cert: true,
         }
 
         generate_saml_response(user)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/90

## 🛠 Summary of changes
This change updates the saml_idp version to include two fixes that will improve our SAML signature validation.

* Allows the implementation to identity non-namespaced Signature blocks, therefore indicating that they are signed
* It allows our SAML validation code to correctly identify the DigestMethod node, and not sometimes incorreclty default to SHA1
* Removes analytics logging that was used to validate that these changes would have minimal impact


