### PR TITLE
LG-13726 update verify info controller to redirect when pii is missing

### DIFF
--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -10,6 +10,7 @@ module Idv
       include VerifyInfoConcern
 
       before_action :confirm_not_rate_limited_after_doc_auth, except: [:show]
+      before_action :confirm_pii_data_present
       before_action :confirm_ssn_step_complete
 
       def show
@@ -73,7 +74,8 @@ module Idv
       end
 
       def pii
-        user_session.dig('idv/in_person', :pii_from_user).merge(ssn: idv_session.ssn)
+        pii_from_user = user_session.dig('idv/in_person', :pii_from_user) || {}
+        pii_from_user.merge(ssn: idv_session.ssn)
       end
 
       # override IdvSessionConcern
@@ -93,6 +95,12 @@ module Idv
       def confirm_ssn_step_complete
         return if pii.present? && idv_session.ssn.present?
         redirect_to prev_url
+      end
+
+      def confirm_pii_data_present
+        unless user_session.dig('idv/in_person').present?
+          redirect_to idv_path
+        end
       end
     end
   end

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
         :confirm_ssn_step_complete,
       )
     end
+
+    it 'confirms idv/in_person data is present' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_pii_data_present,
+      )
+    end
   end
 
   before do
@@ -169,6 +176,29 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
         expect(response).to render_template :show
         expect(controller.flash[:error]).to eq(I18n.t('idv.failure.timeout'))
         expect(@analytics).to have_logged_event('IdV: proofing resolution result missing')
+      end
+    end
+
+    context 'when idv/in_person data is present' do
+      before do
+        subject.user_session['idv/in_person'] = flow_session
+      end
+
+      it 'renders the show template without errors' do
+        get :show
+
+        expect(response).to render_template :show
+      end
+    end
+
+    context 'when idv/in_person data is missing' do
+      before do
+        subject.user_session['idv/in_person'] = {}
+      end
+
+      it 'redirects to idv_path' do
+        get :show
+        expect(response).to redirect_to(idv_path)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13726](https://cm-jira.usa.gov/browse/LG-13726)


## 🛠 Summary of changes

An error recently surfaced in NewRelic: `undefined method 'merge' for nil` occurring in the verify info controller. This error would occur because a possibly nil "pii_from_user "object was being called "merge" upon. This updates the code to check for missing PII before rendering the verify info controller, as well as handle that nil object gracefully and prevent such an the error from breaking the app.


## 📜 Testing Plan

- [x] Reproduce the error:
   - [x] On the main branch (without this fix) complete the IPP flow to the point of the 'verify/in_person/verify_info' page (after you've entered SSN). 
   - [x] Hit the 'Cancel' link near the bottom of the page
   - [x] Choose "Exit Login.gov"
   - [x] Hit the back button in your browser to return to Login.gov
   - [x] Choose "Keep going"
   - [x] Observe the application breaks with `undefined method 'merge' for nil`   error 
   
   

https://github.com/user-attachments/assets/c801c977-6b9c-46b6-a604-71b298136e9b


 
 - [x] Perform the same actions to confirm the fix on this branch:
    - [x] Checkout this branch (jverdeyen/LG-13726-fix-nil-merge-error) and complete the IPP flow to the point of the 'verify/in_person/verify_info' page (after you've entered SSN). 
    - [x] Hit the 'Cancel' link near the bottom of the page
    - [x] Choose "Exit Login.gov"
    - [x] Hit the back button in your browser to return to Login.gov
    - [x] Choose "Keep going"
    - [x]  Observe that it redirects to the /verify/welcome page without error
    
    https://github.com/user-attachments/assets/03a14af3-8d69-4fe1-bb24-cc253918bbe3

- [x] Confirm the tests are passing (spec/controllers/idv/in_person/verify_info_controller_spec.rb) ✅ 


