### PR TITLE
LG-13869: Update email languages preference copy

### DIFF
--- a/app/views/shared/_email_languages.html.erb
+++ b/app/views/shared/_email_languages.html.erb
@@ -10,13 +10,7 @@ locals:
       label: t('forms.registration.labels.email_language'),
       hint: local_assigns.fetch(
         :hint,
-        t(
-          'account.email_language.languages_list',
-          app_name: APP_NAME,
-          list: I18n.available_locales.
-            map { |locale| t("account.email_language.name.#{locale}") }.
-            to_sentence(last_word_connector: " #{t('account.email_language.sentence_connector')} "),
-        ),
+        t('account.email_language.languages_list', app_name: APP_NAME),
       ),
       collection: I18n.available_locales.map do |locale|
         label = locale == I18n.locale ?

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -2,14 +2,8 @@
 
 <%= render PageHeadingComponent.new.with_content(t('account.email_language.edit_title')) %>
 
-<p class="margin-bottom-4">
-  <%= t(
-        'account.email_language.languages_list',
-        app_name: APP_NAME,
-        list: I18n.available_locales.
-          map { |locale| t("account.email_language.name.#{locale}") }.
-          to_sentence(last_word_connector: " #{t('account.email_language.sentence_connector')} "),
-      ) %>
+<p>
+  <%= t('account.email_language.languages_list', app_name: APP_NAME) %>
 </p>
 
 <%= simple_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,6 @@ account.email_language.name.en: English
 account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
-account.email_language.sentence_connector: or
 account.email_language.updated: Your email language preference has been updated.
 account.forget_all_browsers.longer_description: Once you choose to ‘forget all browsers,’ we’ll need additional information to know that it’s actually you signing in to your account. We’ll ask for a multi-factor authentication method (such as text/SMS code or a security key) each time you want to access your account.
 account.index.auth_app_add: Add app

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ account.connected_apps.associated: Connected %{timestamp}
 account.connected_apps.description: With your %{app_name} account, you can securely connect to multiple government accounts online. Below is a list of all the accounts you currently have connected.
 account.email_language.default: '%{language} (default)'
 account.email_language.edit_title: Edit email language preference
-account.email_language.languages_list: '%{app_name} allows you to receive your email communication in %{list}.'
+account.email_language.languages_list: You will receive emails from %{app_name} in the language you choose.
 account.email_language.name.en: English
 account.email_language.name.es: Español
 account.email_language.name.fr: Français

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -47,7 +47,6 @@ account.email_language.name.en: English
 account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
-account.email_language.sentence_connector: o
 account.email_language.updated: Se actualizó su preferencia de idioma del correo electrónico.
 account.forget_all_browsers.longer_description: Una vez que elija “Olvidar todos los navegadores”, necesitaremos más información para saber que realmente es usted quien está iniciando sesión en su cuenta. Le pediremos un método de autenticación multifactor (como código de texto o de SMS, o una clave de seguridad) cada vez que desee acceder a su cuenta.
 account.index.auth_app_add: Agregar aplicación

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -42,7 +42,7 @@ account.connected_apps.associated: 'Conectado: %{timestamp}'
 account.connected_apps.description: Con su cuenta de %{app_name}, puede conectarse de manera segura a muchas cuentas del gobierno en línea. Esta es una lista de todas las cuentas que tiene conectadas actualmente.
 account.email_language.default: '%{language} (predeterminado)'
 account.email_language.edit_title: Editar la preferencia de idioma del correo electrónico
-account.email_language.languages_list: '%{app_name} le permite recibir su comunicación por correo electrónico en %{list}.'
+account.email_language.languages_list: Recibirá mensajes de correo electrónico de %{app_name} en el idioma que elija.
 account.email_language.name.en: English
 account.email_language.name.es: Español
 account.email_language.name.fr: Français

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -47,7 +47,6 @@ account.email_language.name.en: English
 account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
-account.email_language.sentence_connector: ou
 account.email_language.updated: Votre langue de préférence pour les e-mails a été mise à jour.
 account.forget_all_browsers.longer_description: Une fois que vous aurez choisi d’« oublier tous les navigateurs », nous aurons besoin d’informations supplémentaires pour savoir que c’est bien vous qui vous connectez à votre compte. Nous vous demanderons une méthode d’authentification multi-facteurs (comme un code SMS/texto ou une clé de sécurité) chaque fois que vous souhaiterez accéder à votre compte.
 account.index.auth_app_add: Ajouter une appli

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -42,7 +42,7 @@ account.connected_apps.associated: Connecté %{timestamp}
 account.connected_apps.description: Avec votre compte %{app_name}, vous pouvez vous connecter en toute sécurité à plusieurs comptes de l’administration en ligne. Vous trouverez ci-dessous une liste de tous vos comptes actuellement connectés.
 account.email_language.default: '%{language} (par défaut)'
 account.email_language.edit_title: Modifier la langue dans laquelle vous préférez recevoir les e-mails
-account.email_language.languages_list: '%{app_name} vous permet de recevoir des communications par e-mail en %{list}.'
+account.email_language.languages_list: Vous recevrez des e-mails de %{app_name} dans la langue de votre choix.
 account.email_language.name.en: English
 account.email_language.name.es: Español
 account.email_language.name.fr: Français

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -42,7 +42,7 @@ account.connected_apps.associated: 已连接 %{timestamp}
 account.connected_apps.description: 使用你的 %{app_name} 账户，你可以安全地连接到网上多个政府账户。以下列出了你目前已连接的所有账户。
 account.email_language.default: '%{language} （默认）'
 account.email_language.edit_title: 编辑电邮语言选择
-account.email_language.languages_list: '%{app_name} 允许你以 %{list}接受电邮沟通。'
+account.email_language.languages_list: 您将收到%{app_name}用您选择的语言发送的电子邮件。
 account.email_language.name.en: English
 account.email_language.name.es: Español
 account.email_language.name.fr: Français

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -47,7 +47,6 @@ account.email_language.name.en: English
 account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
-account.email_language.sentence_connector: 或者
 account.email_language.updated: 你的电邮语言选择已更新。
 account.forget_all_browsers.longer_description: 你选择“忘掉所有浏览器”后，我们将需要额外信息来知道的确是你在登录你自己的账户。每次你要访问自己的账户时，我们都会向你要一个多因素身份证实方法（比如短信/SMS 代码或安全密钥）
 account.index.auth_app_add: 添加应用程序


### PR DESCRIPTION
## 🎫 Ticket

[LG-13869](https://cm-jira.usa.gov/browse/LG-13869)

## 🛠 Summary of changes

Updates email language preference hint text to (a) use active voice, and (b) avoid listing out languages, which indirectly resolves an issue with [WCAG SC 3.1.2 Language of Parts](https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html).

## 📜 Testing Plan

Verify new text on "Create an account" page:

1. Go to http://localhost:3000/
2. Click "Create an account"
3. See new hint text under "Select your email language preference"

Verify new text on account "Email language preference" page:

1. Go to http://localhost:3000
2. Sign in
3. From account page, click "Edit" under "Email preferences" > "Language"
4. See new paragraph text

## 👀 Screenshots

Screen|Before|After
---|---|---
Create account|![image](https://github.com/user-attachments/assets/b138fb6f-c4c1-42b5-9476-5bd5a5b5e621)|![image](https://github.com/user-attachments/assets/6d714e21-1dc7-40c6-96e3-bacefa139595)
Account preference|![image](https://github.com/user-attachments/assets/7a177481-168a-48f8-8803-8839d3a98011)|![image](https://github.com/user-attachments/assets/2d570205-77f0-4d26-a7ad-e8dc58811558)
