### PR TITLE
Update highline to remove dependency on abbrev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby "~> #{File.read(File.join(__dir__, '.ruby-version')).strip}"
 
 gem 'rails', '~> 7.1.3'
 
-gem 'abbrev'
 gem 'ahoy_matey', '~> 3.0'
 # pod identity requires 3.188.0
 # https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "~> #{File.read(File.join(__dir__, '.ruby-version')).strip}"
 
 gem 'rails', '~> 7.1.3'
 
+gem 'abbrev'
 gem 'ahoy_matey', '~> 3.0'
 # pod identity requires 3.188.0
 # https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    abbrev (0.1.2)
     actioncable (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -751,6 +752,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  abbrev
   ahoy_matey (~> 3.0)
   aws-sdk-cloudwatchlogs
   aws-sdk-core (>= 3.188.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    abbrev (0.1.2)
     actioncable (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -355,7 +354,8 @@ GEM
     hashdiff (1.1.0)
     heapy (0.2.0)
       thor
-    highline (2.1.0)
+    highline (3.1.0)
+      reline
     htmlbeautifier (1.4.3)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
@@ -752,7 +752,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  abbrev
   ahoy_matey (~> 3.0)
   aws-sdk-cloudwatchlogs
   aws-sdk-core (>= 3.188.0)


### PR DESCRIPTION
**Why**: Fixes warning:

> warning: abbrev was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add abbrev to your Gemfile or gemspec. Also contact author of highline-2.1.0 to add abbrev into its gemspec.

