### PR TITLE
Update uuid-convert script to look up deleted users

### DIFF
--- a/app/models/service_provider_identity.rb
+++ b/app/models/service_provider_identity.rb
@@ -10,11 +10,14 @@ class ServiceProviderIdentity < ApplicationRecord
   validates :service_provider, presence: true
 
   # rubocop:disable Rails/InverseOf
+  belongs_to :deleted_user, foreign_key: 'user_id', primary_key: 'user_id'
+
   belongs_to :service_provider_record,
              class_name: 'ServiceProvider',
              foreign_key: 'service_provider',
              primary_key: 'issuer'
   # rubocop:enable Rails/InverseOf
+  has_one :agency, through: :service_provider_record
 
   scope :not_deleted, -> { where(deleted_at: nil) }
 


### PR DESCRIPTION
I got a ticket to look up some user UUIDs, and found that the script reported 2 users as "missing" when they had been deleted, and we still had tombstoned data for them. 

- `AgencyIdentity` rows are deleted via `dependent: :destroy` when a user is deleted
- `ServiceProviderIdentity` rows stay around when users are deleted (to prevent UUID reuse) so we can use that to look up users
- `DeletedUser` table keeps the internal UUIDs around as well
