### PR TITLE
Add in-person proofing successes to the weekly drop-off report

### DIFF
--- a/lib/reporting/drop_off_report.rb
+++ b/lib/reporting/drop_off_report.rb
@@ -56,6 +56,7 @@ module Reporting
     end
 
     module Results
+      IPP_ENROLLMENT_UPDATE = 'GetUspsProofingResultsJob: Enrollment status updated'
       IDV_FINAL_RESOLUTION_VERIFIED = 'IdV: final resolution - Verified'
     end
 
@@ -63,7 +64,7 @@ module Reporting
       [
         Reporting::EmailableReport.new(
           title: 'Step Definitions',
-          table: step_definition_table,
+          table: STEP_DEFINITIONS,
         ),
         Reporting::EmailableReport.new(
           title: 'Overview',
@@ -234,6 +235,10 @@ module Reporting
           'Workflow Complete - Total Pending',
           idv_final_resolution_total_pending,
         ],
+        [
+          'Successfully verified via in-person proofing',
+          ipp_verification_total,
+        ],
       ]
     end
 
@@ -246,59 +251,65 @@ module Reporting
       data[Results::IDV_FINAL_RESOLUTION_VERIFIED].count
     end
 
-    def step_definition_table
-      [
-        ['Step', 'Definition'],
-        [
-          'Welcome (page viewed)',
-          'Start of proofing process',
-        ],
-        [
-          'User agreement (page viewer)',
-          'Users who clicked "Continue" on the welcome page',
-        ],
-        [
-          'Capture Document (page viewed)',
-          'Users who check the consent checkbox and click "Continue"',
-        ],
-        [
-          'Document submitted (event)',
-          'Users who upload a front and back image and click "Submit"	',
-        ],
-        [
-          'SSN (page view)',
-          'Users whose ID is authenticated by Acuant',
-        ],
-        [
-          'Verify Info (page view)',
-          'Users who enter an SSN and continue',
-        ],
-        [
-          'Verify submit (event)',
-          'Users who verify their information and submit it for Identity Verification (LN)',
-        ],
-        [
-          'Phone finder (page view)',
-          'Users who successfuly had their identities verified by LN',
-        ],
-        [
-          'Encrypt account: enter password (page view)',
-          'Users who were able to complete the physicality check using PhoneFinder',
-        ],
-        [
-          'Personal key input (page view)',
-          'Users who enter their password to encrypt their PII',
-        ],
-        [
-          'Verified (event)',
-          'Users who confirm their personal key and complete setting up their verified account',
-        ],
-        [
-          'Workflow Complete - Total Pending',
-          'Total count of users who are pending IDV',
-        ],
-      ]
+    def ipp_verification_total
+      @ipp_verification_total ||= data[Results::IPP_ENROLLMENT_UPDATE].count
     end
+
+    STEP_DEFINITIONS = [
+      ['Step', 'Definition'],
+      [
+        'Welcome (page viewed)',
+        'Start of proofing process',
+      ],
+      [
+        'User agreement (page viewer)',
+        'Users who clicked "Continue" on the welcome page',
+      ],
+      [
+        'Capture Document (page viewed)',
+        'Users who check the consent checkbox and click "Continue"',
+      ],
+      [
+        'Document submitted (event)',
+        'Users who upload a front and back image and click "Submit"	',
+      ],
+      [
+        'SSN (page view)',
+        'Users whose ID is authenticated by Acuant',
+      ],
+      [
+        'Verify Info (page view)',
+        'Users who enter an SSN and continue',
+      ],
+      [
+        'Verify submit (event)',
+        'Users who verify their information and submit it for Identity Verification (LN)',
+      ],
+      [
+        'Phone finder (page view)',
+        'Users who successfuly had their identities verified by LN',
+      ],
+      [
+        'Encrypt account: enter password (page view)',
+        'Users who were able to complete the physicality check using PhoneFinder',
+      ],
+      [
+        'Personal key input (page view)',
+        'Users who enter their password to encrypt their PII',
+      ],
+      [
+        'Verified (event)',
+        'Users who confirm their personal key and complete setting up their verified account',
+      ],
+      [
+        'Workflow Complete - Total Pending',
+        'Total count of users who are pending IDV',
+      ],
+      [
+        'Successfully verified via in-person proofing',
+        'The count of users who successfully verified their identity in-person at a USPS location within the report period',
+      ],
+    ].freeze
 
     def idv_started
       data[Events::IDV_DOC_AUTH_WELCOME].count
@@ -352,7 +363,7 @@ module Reporting
 
     def as_tables
       [
-        step_definition_table,
+        STEP_DEFINITIONS,
         overview_table,
         dropoff_metrics_table,
       ]
@@ -370,10 +381,12 @@ module Reporting
 
     # @return [Float]
     def percent(numerator:, denominator:)
-      (numerator.to_f / denominator.to_f)
+      result = (numerator.to_f / denominator.to_f)
+      result.nan? ? 0 : result
     end
 
-    def fetch_results
+    def fetch_results(query: nil)
+      query ||= self.query
       cloudwatch_client.fetch(query:, from: time_range.begin, to: time_range.end)
     end
 
@@ -399,6 +412,21 @@ module Reporting
       QUERY
     end
 
+    def ipp_query
+      params = {
+        issuers: issuers.present? && quote(issuers),
+        event_names: quote(Results::IPP_ENROLLMENT_UPDATE),
+      }
+      format(<<~QUERY, params)
+        name
+        , properties.user_id AS user_id
+        #{issuers.present? ? '| filter properties.service_provider IN %{issuers}' : ''}
+        | filter name in %{event_names}
+        | filter properties.event_properties.passed or properties.event_properties.success
+        | limit 10000
+      QUERY
+    end
+
     # event name => set(user ids)
     # @return Hash<String,Set<String>>
     def data
@@ -407,7 +435,9 @@ module Reporting
           h[uuid] = Set.new
         end
 
-        fetch_results.each do |row|
+        # Splitting out the `ipp_query` is hopefully temporary until we can get the events
+        # to use similar schema
+        (fetch_results + fetch_results(query: ipp_query)).each do |row|
           event = row['name']
           user_id = row['user_id']
           event_users[event] << user_id

--- a/spec/lib/reporting/drop_off_report_spec.rb
+++ b/spec/lib/reporting/drop_off_report_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reporting::DropOffReport do
   subject(:report) { Reporting::DropOffReport.new(issuers: [issuer], time_range:) }
 
   before do
-    stub_cloudwatch_logs(
+    stub_multiple_cloudwatch_logs(
       [
         # finishes funnel
         { 'user_id' => 'user1', 'name' => 'IdV: doc auth welcome visited' },
@@ -99,6 +99,21 @@ RSpec.describe Reporting::DropOffReport do
         { 'user_id' => 'user8', 'name' => 'IdV: personal key submitted' },
         { 'user_id' => 'user8', 'name' => 'IdV: final resolution' },
       ],
+      [
+        # IPP successes
+        { 'user_id' => 'user9',
+          'name' => 'GetUspsProofingResultsJob: Enrollment status updated',
+          'success' => '1' },
+        { 'user_id' => 'user10',
+          'name' => 'GetUspsProofingResultsJob: Enrollment status updated',
+          'success' => '1' },
+        { 'user_id' => 'user11',
+          'name' => 'GetUspsProofingResultsJob: Enrollment status updated',
+          'success' => '1' },
+        { 'user_id' => 'user12',
+          'name' => 'GetUspsProofingResultsJob: Enrollment status updated',
+          'success' => '1' },
+      ],
     )
   end
 
@@ -178,10 +193,41 @@ RSpec.describe Reporting::DropOffReport do
     end
   end
 
-  def expected_tables(strings: false)
+  context 'no available events' do
+    before do
+      stub_multiple_cloudwatch_logs([], [])
+    end
+
+    it 'tries its best' do
+      expect(report.as_tables).to eq(empty_tables)
+      expect(report.as_emailable_reports.map(&:table)).to eq(empty_tables)
+    end
+  end
+
+  def empty_tables(strings: false)
+    data = [
+      [0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0],
+      [0],
+    ]
+    expected_tables(strings:, values: data)
+  end
+
+  def expected_tables(strings: false, values: nil)
+    iterator = values&.each
     [
-      # these two tables are static
-      report.step_definition_table,
+      # the first two tables are relatively static
+      Reporting::DropOffReport::STEP_DEFINITIONS,
       [
         ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
         ['Report Generated', Date.today.to_s], # rubocop:disable Rails/Date
@@ -190,18 +236,55 @@ RSpec.describe Reporting::DropOffReport do
       [
         ['Step', 'Unique user count', 'Users lost', 'Dropoff from last step',
          'Users left from start'],
-        ['Welcome (page viewed)'] + string_or_num(strings, 8),
-        ['User agreement (page viewed)'] + string_or_num(strings, 8, 0, 0.0, 1.0),
-        ['Capture Document (page viewed)'] + string_or_num(strings, 7, 1, 0.125, 0.875),
-        ['Document submitted (event)'] + string_or_num(strings, 7, 0, 0.0, 0.875),
-        ['SSN (page view)'] + string_or_num(strings, 6, 1, 1.0 / 7, 0.75),
-        ['Verify Info (page view)'] + string_or_num(strings, 5, 1, 1.0 / 6, 0.625),
-        ['Verify submit (event)'] + string_or_num(strings, 5, 0, 0.0, 0.625),
-        ['Phone finder (page view)'] + string_or_num(strings, 5, 0, 0.0, 0.625),
-        ['Encrypt account: enter password (page view)'] + string_or_num(strings, 4, 1, 0.2, 0.5),
-        ['Personal key input (page view)'] + string_or_num(strings, 4, 0, 0.0, 0.5),
-        ['Verified (event)'] + string_or_num(strings, 4, 0, 0.0, 0.5),
-        ['Workflow Complete - Total Pending'] + string_or_num(strings, 3),
+        ['Welcome (page viewed)'] + string_or_num(strings, *(values ? iterator.next : [8])),
+        ['User agreement (page viewed)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [8, 0, 0.0, 1.0]),
+        ),
+        ['Capture Document (page viewed)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [7, 1, 0.125, 0.875]),
+        ),
+        ['Document submitted (event)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [7, 0, 0.0, 0.875]),
+        ),
+        ['SSN (page view)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [6, 1, 1.0 / 7, 0.75]),
+        ),
+        ['Verify Info (page view)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [5, 1, 1.0 / 6, 0.625]),
+        ),
+        ['Verify submit (event)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [5, 0, 0.0, 0.625]),
+        ),
+        ['Phone finder (page view)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [5, 0, 0.0, 0.625]),
+        ),
+        ['Encrypt account: enter password (page view)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [4, 1, 0.2, 0.5]),
+        ),
+        ['Personal key input (page view)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [4, 0, 0.0, 0.5]),
+        ),
+        ['Verified (event)'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [4, 0, 0.0, 0.5]),
+        ),
+        ['Workflow Complete - Total Pending'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [3]),
+        ),
+        ['Successfully verified via in-person proofing'] + string_or_num(
+          strings,
+          *(values ? iterator.next : [4]),
+        ),
       ],
     ]
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
https://cm-jira.usa.gov/browse/LG-14117


## 🛠 Summary of changes

This code queries Cloudwatch for the relevant IPP success events and adds them to the report.

I was hoping that we could include the new event addition in the list with the other events we query for, but the structure/schema does not match up. I'm still chasing down our options there, see [this thread](https://gsa-tts.slack.com/archives/C04GA9WQ85B/p1723564151026709?thread_ts=1723482960.667779&cid=C04GA9WQ85B). Meanwhile, I've tried to write code where simplifying the query would require a minimal rewrite if we can arrange for it.

## 📜 Testing Plan

* Try and trigger some fake data in staging
* Run the report in staging

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
