### PR TITLE
Use faster default driver for feature tests not requiring JavaScript

### DIFF
--- a/spec/features/openid_connect/vtr_spec.rb
+++ b/spec/features/openid_connect/vtr_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'OIDC requests using VTR', allowed_extra_analytics: [:*] do
       and_return(true)
   end
 
-  scenario 'sign in with VTR request for authentication', :js do
+  scenario 'sign in with VTR request for authentication' do
     user = create(:user, :fully_registered)
 
     visit_idp_from_oidc_sp_with_vtr(vtr: ['C1'])
@@ -25,10 +25,10 @@ RSpec.feature 'OIDC requests using VTR', allowed_extra_analytics: [:*] do
 
     click_agree_and_continue
 
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
+    expect(oidc_redirect_url).to start_with('http://localhost:7654/auth/result')
   end
 
-  scenario 'sign in with VTR request for AAL2 disables remember device', :js do
+  scenario 'sign in with VTR request for AAL2 disables remember device' do
     user = create(:user, :fully_registered)
 
     # Sign in and remember device
@@ -48,10 +48,10 @@ RSpec.feature 'OIDC requests using VTR', allowed_extra_analytics: [:*] do
 
     click_agree_and_continue
 
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
+    expect(oidc_redirect_url).to start_with('http://localhost:7654/auth/result')
   end
 
-  scenario 'sign in with VTR for phishing-resistance requires phishing-resistanc auth', :js do
+  scenario 'sign in with VTR for phishing-resistance requires phishing-resistanc auth' do
     mock_webauthn_setup_challenge
     user = create(:user, :fully_registered)
 
@@ -69,7 +69,7 @@ RSpec.feature 'OIDC requests using VTR', allowed_extra_analytics: [:*] do
 
     click_agree_and_continue
 
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
+    expect(oidc_redirect_url).to start_with('http://localhost:7654/auth/result')
   end
 
   scenario 'sign in with VTR request for HSDP12 auth requires PIV/CAC setup' do
@@ -94,12 +94,11 @@ RSpec.feature 'OIDC requests using VTR', allowed_extra_analytics: [:*] do
     follow_piv_cac_redirect
 
     click_agree_and_continue
-    click_submit_default
 
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
+    expect(oidc_redirect_url).to start_with('http://localhost:7654/auth/result')
   end
 
-  scenario 'sign in with VTR request for idv requires idv', :js do
+  scenario 'sign in with VTR request for idv requires idv' do
     user = create(:user, :fully_registered)
 
     visit_idp_from_oidc_sp_with_vtr(vtr: ['P1'])

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -241,14 +241,14 @@ RSpec.feature 'Sign Up', allowed_extra_analytics: [:*] do
 
       expect(page).to have_current_path account_path
     end
+  end
 
-    it 'allows a user to sign up with backup codes and add methods without reauthentication' do
-      sign_in_user
-      select_2fa_option('backup_code')
+  it 'allows a user to sign up with backup codes and add methods without reauthentication' do
+    sign_in_user
+    select_2fa_option('backup_code')
 
-      visit phone_setup_path
-      expect(page).to have_current_path phone_setup_path
-    end
+    visit phone_setup_path
+    expect(page).to have_current_path phone_setup_path
   end
 
   context 'user accesses password screen with already confirmed token', email: true do

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -243,14 +243,6 @@ RSpec.feature 'Sign Up', allowed_extra_analytics: [:*] do
     end
   end
 
-  it 'allows a user to sign up with backup codes and add methods without reauthentication' do
-    sign_in_user
-    select_2fa_option('backup_code')
-
-    visit phone_setup_path
-    expect(page).to have_current_path phone_setup_path
-  end
-
   context 'user accesses password screen with already confirmed token', email: true do
     it 'returns them to the home page' do
       create(:user, :fully_registered, confirmation_token: 'foo')

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -15,13 +15,18 @@ RSpec.feature 'webauthn sign in', allowed_extra_analytics: [:*] do
     )
   end
 
-  it 'allows the user to sign in if webauthn is successful' do
-    mock_webauthn_verification_challenge
+  context 'with javascript enabled', :js do
+    # While JavaScript tests are slower to run, these tests provide increased confidence in the
+    # real-world behavior of WebAuthn browser interaction for the critical pathways.
 
-    sign_in_user(user)
-    mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
+    it 'allows the user to sign in if webauthn is successful' do
+      mock_webauthn_verification_challenge
 
-    expect(page).to have_current_path(account_path)
+      sign_in_user(user)
+      mock_successful_webauthn_authentication { click_webauthn_authenticate_button }
+
+      expect(page).to have_current_path(account_path)
+    end
   end
 
   it 'does not allow the user to sign in if the challenge/secret is incorrect' do

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'webauthn sign in', allowed_extra_analytics: [:*] do
     expect(page).to have_current_path(login_two_factor_webauthn_path)
   end
 
-  it 'does not show error after successful challenge/secret reattempt', :js do
+  it 'does not show error after successful challenge/secret reattempt' do
     mock_webauthn_verification_challenge
 
     sign_in_user(user)
@@ -57,7 +57,7 @@ RSpec.feature 'webauthn sign in', allowed_extra_analytics: [:*] do
     expect(page).to_not have_content(general_error)
   end
 
-  it 'maintains correct platform attachment content if cancelled', :js do
+  it 'maintains correct platform attachment content if cancelled' do
     mock_webauthn_verification_challenge
 
     sign_in_user(user)
@@ -71,7 +71,7 @@ RSpec.feature 'webauthn sign in', allowed_extra_analytics: [:*] do
       create(:user, :with_webauthn_platform, with: { credential_id:, credential_public_key: })
     end
 
-    it 'maintains correct platform attachment content if cancelled', :js do
+    it 'maintains correct platform attachment content if cancelled' do
       mock_webauthn_verification_challenge
 
       sign_in_user(user)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates a few feature specs to avoid opting into the JavaScript-enabled driver where not strictly necessary to do so.

**Why?**

- Improve build speed, since the default driver is faster

## 📜 Testing Plan

Verify build passes.