### PR TITLE
Log unused_identity_config_keys event as JSON

### DIFF
--- a/config/initializers/unused_identity_config_keys.rb
+++ b/config/initializers/unused_identity_config_keys.rb
@@ -3,6 +3,6 @@
 if Identity::Hostdata.config_builder.unused_keys.present?
   Rails.logger.warn(
     { name: 'unused_identity_config_keys',
-      keys: Identity::Hostdata.config_builder.unused_keys },
+      keys: Identity::Hostdata.config_builder.unused_keys }.to_json,
   )
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Currently we log a hash, which gets turned into a string via `inspect`, which results in a format that can't be parsed by Cloudwatch and makes it difficult to filter via `name`. This PR changes the log output to be JSON so that it can be.

Before:
```
{:name=>"unused_identity_config_keys", :keys=>[:my_key]}
```

After
```
{"name":"unused_identity_config_keys","keys":["my_key"]}
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
