### PR TITLE
Refactor backup code verification to follow conventional form pattern

### DIFF
--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -46,10 +46,10 @@ module TwoFactorAuthentication
       )
     end
 
-    def handle_invalid_backup_code
+    def handle_invalid_backup_code(result)
       update_invalid_user
 
-      flash.now[:error] = t('two_factor_authentication.invalid_backup_code')
+      flash.now[:error] = result.first_error_message
 
       if current_user.locked_out?
         handle_second_factor_locked_user(type: 'backup_code')
@@ -69,7 +69,7 @@ module TwoFactorAuthentication
         return handle_last_code if all_codes_used?
         handle_valid_backup_code
       else
-        handle_invalid_backup_code
+        handle_invalid_backup_code(result)
       end
     end
 

--- a/app/forms/backup_code_verification_form.rb
+++ b/app/forms/backup_code_verification_form.rb
@@ -2,6 +2,9 @@
 
 class BackupCodeVerificationForm
   include ActiveModel::Model
+  include ActionView::Helpers::TranslationHelper
+
+  validate :validate_and_consume_backup_code!
 
   def initialize(user)
     @user = user
@@ -11,12 +14,19 @@ class BackupCodeVerificationForm
   def submit(params)
     @backup_code = params[:backup_code]
     FormResponse.new(
-      success: valid_backup_code?,
+      success: valid?,
+      errors:,
       extra: extra_analytics_attributes,
+      serialize_error_details_only: true,
     )
   end
 
   attr_reader :user, :backup_code
+
+  def validate_and_consume_backup_code!
+    return if valid_backup_code?
+    errors.add(:backup_code, :invalid, message: t('two_factor_authentication.invalid_backup_code'))
+  end
 
   def valid_backup_code?
     valid_backup_code_config_created_at.present?
@@ -24,7 +34,7 @@ class BackupCodeVerificationForm
 
   def valid_backup_code_config_created_at
     return @valid_backup_code_config_created_at if defined?(@valid_backup_code_config_created_at)
-    @valid_backup_code_config_created_at = BackupCodeGenerator.new(@user).
+    @valid_backup_code_config_created_at = BackupCodeGenerator.new(user).
       if_valid_consume_code_return_config_created_at(backup_code)
   end
 

--- a/app/services/backup_code_generator.rb
+++ b/app/services/backup_code_generator.rb
@@ -23,11 +23,6 @@ class BackupCodeGenerator
     codes
   end
 
-  # @return [Boolean]
-  def verify(plaintext_code)
-    if_valid_consume_code_return_config_created_at(plaintext_code).present?
-  end
-
   # @return [BackupCodeConfiguration, nil]
   def if_valid_consume_code_return_config_created_at(plaintext_code)
     return unless plaintext_code.present?

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
           expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication',
             success: true,
-            errors: {},
             multi_factor_auth_method: 'backup_code',
             multi_factor_auth_method_created_at: Time.zone.now.strftime('%s%L'),
             enabled_mfa_methods_count: 1,
@@ -94,7 +93,6 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
           expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication',
             success: true,
-            errors: {},
             multi_factor_auth_method: 'backup_code',
             multi_factor_auth_method_created_at: Time.zone.now.strftime('%s%L'),
             enabled_mfa_methods_count: 1,
@@ -173,7 +171,7 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
         expect(@analytics).to have_logged_event(
           'Multi-Factor Authentication',
           success: false,
-          errors: {},
+          error_details: { backup_code: { invalid: true } },
           multi_factor_auth_method: 'backup_code',
           enabled_mfa_methods_count: 1,
           new_device: true,

--- a/spec/forms/backup_code_verification_form_spec.rb
+++ b/spec/forms/backup_code_verification_form_spec.rb
@@ -10,45 +10,35 @@ RSpec.describe BackupCodeVerificationForm do
   end
 
   describe '#submit' do
-    let(:params) do
-      {
-        backup_code: code,
-      }
-    end
+    let(:params) { { backup_code: code } }
 
     context 'with a valid backup code' do
       let(:code) { backup_codes.first }
-      let(:expected_response) do
-        {
-          success: true,
-          errors: {},
-          multi_factor_auth_method_created_at: backup_code_config.created_at.strftime('%s%L'),
-        }
-      end
 
-      it 'returns succcess' do
-        expect(result).to eq(expected_response)
+      it 'returns success' do
+        expect(result).to eq(
+          success: true,
+          multi_factor_auth_method_created_at: backup_code_config.created_at.strftime('%s%L'),
+        )
       end
 
       it 'marks code as used' do
-        expect { subject }.to change {
-                                backup_code_config.reload.used_at
-                              }.from(nil).to kind_of(Time)
+        expect { subject }.
+          to change { backup_code_config.reload.used_at }.
+          from(nil).
+          to kind_of(Time)
       end
     end
 
     context 'with an invalid backup code' do
       let(:code) { 'invalid' }
-      let(:expected_response) do
-        {
-          success: false,
-          errors: {},
-          multi_factor_auth_method_created_at: nil,
-        }
-      end
 
       it 'returns failure' do
-        expect(result).to eq(expected_response)
+        expect(result).to eq(
+          success: false,
+          error_details: { backup_code: { invalid: true } },
+          multi_factor_auth_method_created_at: nil,
+        )
       end
     end
   end

--- a/spec/services/backup_code_generator_spec.rb
+++ b/spec/services/backup_code_generator_spec.rb
@@ -5,70 +5,90 @@ RSpec.describe BackupCodeGenerator do
 
   subject(:generator) { BackupCodeGenerator.new(user) }
 
-  it 'should generate backup codes and be able to verify them' do
-    codes = generator.delete_and_regenerate
+  describe '#delete_and_regenerate' do
+    subject(:codes) { generator.delete_and_regenerate }
 
-    codes.each do |code|
-      expect(generator.verify(code)).to eq(true)
+    it 'generates backup codes' do
+      expect { codes }.
+        to change { user.reload.backup_code_configurations.count }.
+        from(0).
+        to(BackupCodeGenerator::NUMBER_OF_CODES)
+    end
+
+    it 'returns valid 12-character codes via base32 crockford' do
+      expect(Base32::Crockford).to receive(:encode).
+        and_call_original.at_least(BackupCodeGenerator::NUMBER_OF_CODES).times
+
+      expect(codes).to be_present
+      codes.each do |code|
+        expect(code).to match(/\A[a-z0-9]{12}\Z/i)
+        expect(generator.if_valid_consume_code_return_config_created_at(code)).not_to eq(nil)
+      end
+    end
+
+    it 'should generate backup codes and be able to verify them' do
+      codes.each do |code|
+        expect(generator.if_valid_consume_code_return_config_created_at(code)).not_to eq(nil)
+      end
+    end
+
+    it 'creates codes with the same salt for that batch' do
+      codes
+
+      salts = user.backup_code_configurations.map(&:code_salt).uniq
+      expect(salts.size).to eq(1)
+      expect(salts.first).to_not be_empty
+
+      costs = user.backup_code_configurations.map(&:code_cost).uniq
+      expect(costs.size).to eq(1)
+      expect(costs.first).to_not be_empty
+    end
+
+    it 'creates different salts for different batches' do
+      user1 = create(:user)
+      user2 = create(:user)
+
+      [user1, user2].each { |user| BackupCodeGenerator.new(user).delete_and_regenerate }
+
+      user1_salt = user1.backup_code_configurations.map(&:code_salt).uniq.first
+      user2_salt = user2.backup_code_configurations.map(&:code_salt).uniq.first
+
+      expect(user1_salt).to_not eq(user2_salt)
+    end
+
+    it 'filters out profanity' do
+      profane = Base32::Crockford.decode('FART')
+      not_profane = Base32::Crockford.decode('ABCD')
+
+      expect(SecureRandom).to receive(:random_number).
+        and_return(profane, not_profane)
+
+      code = generator.send(:backup_code)
+
+      expect(code).to eq('00000000ABCD')
     end
   end
 
-  it 'generates 12-letter/digit codes via base32 crockford' do
-    expect(Base32::Crockford).to receive(:encode).
-      and_call_original.at_least(BackupCodeGenerator::NUMBER_OF_CODES).times
+  describe '#if_valid_consume_code_return_config_created_at' do
+    let(:code) {}
+    subject(:result) { generator.if_valid_consume_code_return_config_created_at(code) }
 
-    codes = generator.delete_and_regenerate
+    context 'invalid code' do
+      let(:code) { 'invalid' }
 
-    codes.each do |code|
-      expect(code).to match(/\A[a-z0-9]{12}\Z/i)
+      it { is_expected.to eq(nil) }
     end
-  end
 
-  it 'should reject invalid codes' do
-    generator.delete_and_regenerate
+    context 'nil code' do
+      let(:code) { 'invalid' }
 
-    success = generator.verify 'This is a string which will never result from code generation'
-    expect(success).to eq false
-  end
+      it { is_expected.to eq(nil) }
+    end
 
-  it 'should reject nil codes' do
-    success = generator.verify(nil)
-    expect(success).to eq false
-  end
+    context 'valid code' do
+      let(:code) { generator.delete_and_regenerate.sample }
 
-  it 'creates codes with the same salt for that batch' do
-    generator.delete_and_regenerate
-
-    salts = user.backup_code_configurations.map(&:code_salt).uniq
-    expect(salts.size).to eq(1)
-    expect(salts.first).to_not be_empty
-
-    costs = user.backup_code_configurations.map(&:code_cost).uniq
-    expect(costs.size).to eq(1)
-    expect(costs.first).to_not be_empty
-  end
-
-  it 'creates different salts for different batches' do
-    user1 = create(:user)
-    user2 = create(:user)
-
-    [user1, user2].each { |user| BackupCodeGenerator.new(user).delete_and_regenerate }
-
-    user1_salt = user1.backup_code_configurations.map(&:code_salt).uniq.first
-    user2_salt = user2.backup_code_configurations.map(&:code_salt).uniq.first
-
-    expect(user1_salt).to_not eq(user2_salt)
-  end
-
-  it 'filters out profanity' do
-    profane = Base32::Crockford.decode('FART')
-    not_profane = Base32::Crockford.decode('ABCD')
-
-    expect(SecureRandom).to receive(:random_number).
-      and_return(profane, not_profane)
-
-    code = generator.send(:backup_code)
-
-    expect(code).to eq('00000000ABCD')
+      it { is_expected.to be_instance_of(Time) }
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-14078](https://cm-jira.usa.gov/browse/LG-14078)

## 🛠 Summary of changes

Updates backup code verification to use [the conventional form pattern](https://github.com/18F/identity-idp/blob/main/docs/backend.md#forms-formresponse-analytics-and-controllers):

- Validation should use `ActiveModel#valid?` in combination with validation methods appending errors as relevant
- Include errors in `FormResponse` return value
- Use errors from form response result to display in user interface
- Remove unused `BackupCodeGenerator#verify` method and update specs to ensure coverage for actively-used methods

To simplify review, consider hiding whitespace changes: https://github.com/18F/identity-idp/pull/11089/files?w=1

## 📜 Testing Plan

Verify that you can sign in with backup codes:

1. Prerequisite: Have an account with backup codes where you have a record of a usable code
2. Go to http://localhost:3000
3. SIgn in
4. If not prompted for MFA, click "Forget all browsers" from account dashboard, confirm, sign out, then start from Step 3
5. When prompted for MFA, if prompted for an MFA other than backup codes, select "Choose another authentication method" and select "Backup codes"
6. When prompted for backup codes, enter a valid backup code and submit
7. Observe no regressions in being signed in

Verify that updated specs pass:

```
rspec spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb spec/forms/backup_code_verification_form_spec.rb spec/services/backup_code_generator_spec.rb
```