### PR TITLE
LG-12532 Add 50/50 tests for IPP state id page

### DIFF
--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -36,7 +36,7 @@
   <%= link_to(
         MarketingSite.help_center_article_url(
           category: 'verify-your-identity',
-          article: 'accepted-state-issued-identification',
+          article: 'accepted-identification-documents',
         ),
         class: 'display-inline',
       ) do %>

--- a/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
@@ -1,0 +1,380 @@
+require 'rails_helper'
+
+RSpec.describe 'state id 50/50 state', js: true, allowed_extra_analytics: [:*],
+                                       allow_browser_log: true do
+  include IdvStepHelper
+  include InPersonHelper
+
+  let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
+  let(:user) { user_with_2fa }
+
+  before do
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+  end
+
+  context 'when navigating to state id page from PO search location page' do
+    context 'when the controller is switched from enabled to disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(true)
+        visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+        sign_in_via_branded_page(user)
+        begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+        complete_prepare_step(user)
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(false)
+        complete_location_step
+      end
+
+      it 'navigates to the FSM state_id route' do
+        expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+      end
+    end
+
+    context 'when the controller is switched from disabled to enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(false)
+        visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+        sign_in_via_branded_page(user)
+        begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+        complete_prepare_step(user)
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(true)
+        complete_location_step
+      end
+
+      it 'navigates to the controller state_id route' do
+        expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
+      end
+    end
+  end
+
+  context 'when refreshing the state id page' do
+    context 'when the controller is switched from enabled to disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(true)
+        visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+        sign_in_via_branded_page(user)
+        begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+        complete_prepare_step(user)
+        complete_location_step
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(false)
+        page.refresh
+      end
+
+      it 'renders the 404 page' do
+        expect(page).to have_content(
+          "The page you were looking for doesn’t exist.\nYou might want to double-check your link" \
+          " and try again. (404)",
+        )
+      end
+    end
+
+    context 'when the controller is switched from disabled to enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(false)
+        visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+        sign_in_via_branded_page(user)
+        begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+        complete_prepare_step(user)
+        complete_location_step
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(true)
+        page.refresh
+      end
+
+      it 'renders the FSM state_id page' do
+        expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+      end
+    end
+  end
+
+  context 'when navigating to state id page from verify info page' do
+    context 'when the controller is switched from enabled to disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(true)
+        visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+        sign_in_via_branded_page(user)
+        begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+        complete_prepare_step(user)
+        complete_location_step
+        complete_state_id_controller(user, same_address_as_id: true)
+        complete_ssn_step(user)
+        expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(false)
+        click_button t('idv.buttons.change_state_id_label')
+      end
+
+      it 'navigates to the FSM state_id route' do
+        expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+        # state id page has fields that are pre-populated
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.first_name'),
+          with: InPersonHelper::GOOD_FIRST_NAME,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.last_name'),
+          with: InPersonHelper::GOOD_LAST_NAME,
+        )
+        expect(page).to have_field(t('components.memorable_date.month'), with: '10')
+        expect(page).to have_field(t('components.memorable_date.day'), with: '6')
+        expect(page).to have_field(t('components.memorable_date.year'), with: '1938')
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.state_id_jurisdiction'),
+          with: Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.state_id_number'),
+          with: InPersonHelper::GOOD_STATE_ID_NUMBER,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.address1'),
+          with: InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.address2'),
+          with: InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.city'),
+          with: InPersonHelper::GOOD_IDENTITY_DOC_CITY,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.zipcode'),
+          with: InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.identity_doc_address_state'),
+          with: Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        )
+        expect(page).to have_checked_field(
+          t('in_person_proofing.form.state_id.same_address_as_id_yes'),
+          visible: false,
+        )
+      end
+    end
+
+    context 'when the controller is switched from disabled to enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(false)
+        visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+        sign_in_via_branded_page(user)
+        begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+        complete_prepare_step(user)
+        complete_location_step
+        complete_state_id_step(user, same_address_as_id: true)
+        complete_ssn_step(user)
+        expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(true)
+        click_button t('idv.buttons.change_state_id_label')
+      end
+
+      it 'navigates to the controller state_id route' do
+        expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
+        # state id page has fields that are pre-populated
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.first_name'),
+          with: InPersonHelper::GOOD_FIRST_NAME,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.last_name'),
+          with: InPersonHelper::GOOD_LAST_NAME,
+        )
+        expect(page).to have_field(t('components.memorable_date.month'), with: '10')
+        expect(page).to have_field(t('components.memorable_date.day'), with: '6')
+        expect(page).to have_field(t('components.memorable_date.year'), with: '1938')
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.state_id_jurisdiction'),
+          with: Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.state_id_number'),
+          with: InPersonHelper::GOOD_STATE_ID_NUMBER,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.address1'),
+          with: InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.address2'),
+          with: InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.city'),
+          with: InPersonHelper::GOOD_IDENTITY_DOC_CITY,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.zipcode'),
+          with: InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE,
+        )
+        expect(page).to have_field(
+          t('in_person_proofing.form.state_id.identity_doc_address_state'),
+          with: Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        )
+        expect(page).to have_checked_field(
+          t('in_person_proofing.form.state_id.same_address_as_id_yes'),
+          visible: false,
+        )
+      end
+    end
+  end
+
+  context 'when updating state id info from the verify info page' do
+    let(:first_name_update) { 'Natalya' }
+
+    context 'when the controller is switched from enabled to disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(true)
+        visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+        sign_in_via_branded_page(user)
+        begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+        complete_prepare_step(user)
+        complete_location_step
+        complete_state_id_controller(user, same_address_as_id: true)
+        complete_ssn_step(user)
+        expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(false)
+        click_button t('idv.buttons.change_state_id_label')
+        fill_in t('in_person_proofing.form.state_id.first_name'), with: first_name_update
+        click_button t('forms.buttons.submit.update')
+      end
+
+      it 'navigates back to the verify_info page' do
+        expect(page).to have_current_path(idv_in_person_verify_info_path)
+        expect(page).to have_text(first_name_update)
+      end
+    end
+
+    context 'when the controller is switched from disabled to enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(false)
+        visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+        sign_in_via_branded_page(user)
+        begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+        complete_prepare_step(user)
+        complete_location_step
+        complete_state_id_step(user, same_address_as_id: true)
+        complete_ssn_step(user)
+        expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+        allow(IdentityConfig.store).to receive(
+          :in_person_state_id_controller_enabled,
+        ).and_return(true)
+        click_button t('idv.buttons.change_state_id_label')
+        fill_in t('in_person_proofing.form.state_id.first_name'), with: first_name_update
+        click_button t('forms.buttons.submit.update')
+      end
+
+      it 'navigates back to the verify_info page' do
+        expect(page).to have_current_path(idv_in_person_verify_info_path)
+        expect(page).to have_text(first_name_update)
+      end
+    end
+  end
+
+  context 'when navigating to state id page from hybrid PO search location page' do
+    let(:phone_number) { '415-555-0199' }
+
+    before do
+      allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
+      allow(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
+        @sms_link = config[:link]
+        impl.call(**config)
+      end.at_least(1).times
+    end
+
+    context 'when the controller is switched from enabled to disabled' do
+      before do
+        perform_in_browser(:desktop) do
+          allow(IdentityConfig.store).to receive(
+            :in_person_state_id_controller_enabled,
+          ).and_return(true)
+          visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+          sign_in_via_branded_page(user)
+          complete_doc_auth_steps_before_hybrid_handoff_step
+          click_on t('forms.buttons.continue_remote')
+          clear_and_fill_in(:doc_auth_phone, phone_number)
+          click_send_link
+        end
+
+        perform_in_browser(:mobile) do
+          visit @sms_link
+          mock_doc_auth_fail_face_match_fail
+          attach_and_submit_images
+          click_button t('in_person_proofing.body.cta.button')
+          click_idv_continue
+          allow(IdentityConfig.store).to receive(
+            :in_person_state_id_controller_enabled,
+          ).and_return(false)
+          complete_location_step
+        end
+      end
+
+      it 'navigates to the FSM state_id route' do
+        perform_in_browser(:desktop) do
+          expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+        end
+      end
+    end
+
+    context 'when the controller is switched from disabled to enabled' do
+      before do
+        perform_in_browser(:desktop) do
+          allow(IdentityConfig.store).to receive(
+            :in_person_state_id_controller_enabled,
+          ).and_return(false)
+          visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+          sign_in_via_branded_page(user)
+          complete_doc_auth_steps_before_hybrid_handoff_step
+          click_on t('forms.buttons.continue_remote')
+          clear_and_fill_in(:doc_auth_phone, phone_number)
+          click_send_link
+        end
+
+        perform_in_browser(:mobile) do
+          visit @sms_link
+          mock_doc_auth_fail_face_match_fail
+          attach_and_submit_images
+          click_button t('in_person_proofing.body.cta.button')
+          click_idv_continue
+          allow(IdentityConfig.store).to receive(
+            :in_person_state_id_controller_enabled,
+          ).and_return(true)
+          complete_location_step
+        end
+      end
+
+      it 'navigates to the controller state_id route' do
+        perform_in_browser(:desktop) do
+          expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/idv/steps/in_person/state_id_controller_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_controller_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
-RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: [:*] do
+RSpec.describe 'state id controller enabled', js: true, allowed_extra_analytics: [:*] do
   include IdvStepHelper
   include InPersonHelper
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-    allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).and_return(false)
+    allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).and_return(true)
   end
 
   context 'when visiting state id for the first time' do
     it 'displays correct heading and button text', allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       expect(page).to have_content(t('forms.buttons.continue'))
       expect(page).to have_content(
@@ -22,7 +22,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
     end
 
     it 'allows the user to cancel and start over', allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       expect(page).not_to have_content('forms.buttons.back')
 
@@ -32,17 +32,17 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
     end
 
     it 'allows the user to cancel and return', allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       expect(page).not_to have_content('forms.buttons.back')
 
       click_link t('links.cancel')
       click_on t('idv.cancel.actions.keep_going')
-      expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+      expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
     end
 
     it 'allows user to submit valid inputs on form', allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
       fill_out_state_id_form_ok(same_address_as_id: true)
       click_idv_continue
 
@@ -64,7 +64,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
 
   context 'updating state id page' do
     it 'has form fields that are pre-populated', allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       fill_out_state_id_form_ok(same_address_as_id: true)
       click_idv_continue
@@ -74,7 +74,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
       click_button t('idv.buttons.change_state_id_label')
 
       # state id page has fields that are pre-populated
-      expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+      expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
       expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
       expect(page).to have_field(
         t('in_person_proofing.form.state_id.first_name'),
@@ -134,7 +134,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
 
       it 'does not update their previous selection of "Yes,
         I live at the address on my state-issued ID"' do
-        complete_state_id_step(user, same_address_as_id: true)
+        complete_state_id_controller(user, same_address_as_id: true)
         # skip address step
         complete_ssn_step(user)
         # expect to be on verify page
@@ -166,7 +166,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
       end
 
       it 'does not update their previous selection of "No, I live at a different address"' do
-        complete_state_id_step(user, same_address_as_id: false)
+        complete_state_id_controller(user, same_address_as_id: false)
         # expect to be on address page
         expect(page).to have_content(t('in_person_proofing.headings.address'))
         # complete address step
@@ -200,7 +200,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
       end
 
       it 'updates their previous selection from "Yes" TO "No, I live at a different address"' do
-        complete_state_id_step(user, same_address_as_id: true)
+        complete_state_id_controller(user, same_address_as_id: true)
         # skip address step
         complete_ssn_step(user)
         # click update state ID button on the verify page
@@ -235,7 +235,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
 
       it 'updates their previous selection from "No" TO "Yes,
         I live at the address on my state-issued ID"' do
-        complete_state_id_step(user, same_address_as_id: false)
+        complete_state_id_controller(user, same_address_as_id: false)
         # expect to be on address page
         expect(page).to have_content(t('in_person_proofing.headings.address'))
         # complete address step
@@ -273,7 +273,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
 
   context 'Validation' do
     it 'validates zip code input', allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       fill_out_state_id_form_ok(same_address_as_id: true)
       fill_in t('in_person_proofing.form.state_id.zipcode'), with: ''
@@ -299,7 +299,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
     end
 
     it 'shows error for dob under minimum age', allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       fill_in t('components.memorable_date.month'), with: '1'
       fill_in t('components.memorable_date.day'), with: '1'
@@ -332,7 +332,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
 
     it 'shows validation errors',
        allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       fill_out_state_id_form_ok
       fill_in t('in_person_proofing.form.state_id.first_name'), with: 'T0mmy "Lee"'
@@ -396,7 +396,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
   context 'State selection' do
     it 'shows address hint when user selects state that has a specific hint',
        allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       # state id page
       select 'Puerto Rico',
@@ -433,7 +433,7 @@ RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: 
 
     it 'shows id number hint when user selects issuing state that has a specific hint',
        allow_browser_log: true do
-      complete_steps_before_state_id_step
+      complete_steps_before_state_id_controller
 
       # expect default hint to be present
       expect(page).to have_content(t('in_person_proofing.form.state_id.state_id_number_hint'))

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -131,6 +131,18 @@ module InPersonHelper
     end
   end
 
+  def complete_state_id_controller(_user = nil, same_address_as_id: true,
+                                   first_name: GOOD_FIRST_NAME)
+    # Wait for page to load before attempting to fill out form
+    expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
+    fill_out_state_id_form_ok(same_address_as_id: same_address_as_id, first_name:)
+    click_idv_continue
+    unless same_address_as_id
+      expect(page).to have_current_path(idv_in_person_address_path, wait: 10)
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+    end
+  end
+
   def complete_address_step(_user = nil, same_address_as_id: true)
     fill_out_address_form_ok(same_address_as_id: same_address_as_id)
     click_idv_continue
@@ -153,6 +165,15 @@ module InPersonHelper
     complete_location_step
 
     expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+  end
+
+  def complete_steps_before_state_id_controller
+    sign_in_and_2fa_user
+    begin_in_person_proofing
+    complete_prepare_step
+    complete_location_step
+
+    expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
   end
 
   def complete_all_in_person_proofing_steps(user = user_with_2fa, tmx_status = nil,


### PR DESCRIPTION
## 🎫 Ticket

[LG-12532](https://cm-jira.usa.gov/browse/LG-12532)

## 🛠 Summary of changes

Added integration tests for covering 50/50 state for the state ID page FSM and Controller.
Added integration tests for the state ID page controller.