### PR TITLE
LG-14127 Stop deleting TMx session ID when undoing SSN step

### DIFF
--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -64,10 +64,7 @@ module Idv
           controller: self,
           next_steps: [:ipp_verify_info],
           preconditions: ->(idv_session:, user:) { idv_session.ipp_document_capture_complete? },
-          undo_step: ->(idv_session:, user:) do
-            idv_session.ssn = nil
-            idv_session.threatmetrix_session_id = nil
-          end,
+          undo_step: ->(idv_session:, user:) { idv_session.ssn = nil },
         )
       end
 

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -62,10 +62,7 @@ module Idv
         controller: self,
         next_steps: [:verify_info],
         preconditions: ->(idv_session:, user:) { idv_session.remote_document_capture_complete? },
-        undo_step: ->(idv_session:, user:) do
-          idv_session.ssn = nil
-          idv_session.threatmetrix_session_id = nil
-        end,
+        undo_step: ->(idv_session:, user:) { idv_session.ssn = nil },
       )
     end
 

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -125,6 +125,22 @@ RSpec.describe Idv::LinkSentController, allowed_extra_analytics: [:*] do
       expect(subject.idv_session.applicant).to be_nil
     end
 
+    # This is a regression spec that was introduced for a bug that occured
+    # when calling `undo_step` on the SSN controller step info caused the
+    # TMx session ID to be deleted when this step was resubmitted
+    #
+    # See https://cm-jira.usa.gov/browse/LG-14127
+    # See https://github.com/18F/identity-idp/pull/11091#discussion_r1718831233
+    it 'does not delete the TMx session ID' do
+      subject.idv_session.ssn = '900-12-1234'
+      subject.idv_session.threatmetrix_session_id
+
+      put :update
+
+      expect(subject.idv_session.ssn).to be_nil
+      expect(subject.idv_session.threatmetrix_session_id).to_not be_nil
+    end
+
     it 'sends analytics_submitted event' do
       put :update
 

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Idv::LinkSentController, allowed_extra_analytics: [:*] do
     # See https://github.com/18F/identity-idp/pull/11091#discussion_r1718831233
     it 'does not delete the TMx session ID' do
       subject.idv_session.ssn = '900-12-1234'
-      subject.idv_session.threatmetrix_session_id
+      subject.idv_session.threatmetrix_session_id = 'super-cool-test-value'
 
       put :update
 

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe 'Idv::FlowPolicy' do
         idv_session.had_barcode_attention_error = true
 
         idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
-        idv_session.threatmetrix_session_id = SecureRandom.uuid
 
         idv_session.address_edited = true
       end
@@ -68,7 +67,6 @@ RSpec.describe 'Idv::FlowPolicy' do
         expect(idv_session.had_barcode_attention_error).to be_nil
 
         expect(idv_session.ssn).to be_nil
-        expect(idv_session.threatmetrix_session_id).to be_nil
 
         expect(idv_session.address_edited).to be_nil
       end
@@ -90,7 +88,6 @@ RSpec.describe 'Idv::FlowPolicy' do
         idv_session.had_barcode_attention_error = true
 
         idv_session.ssn = nil
-        idv_session.threatmetrix_session_id = SecureRandom.uuid
 
         idv_session.address_edited = true
 
@@ -141,8 +138,6 @@ RSpec.describe 'Idv::FlowPolicy' do
 
           idv_session.had_barcode_read_failure
           idv_session.had_barcode_attention_error
-
-          idv_session.threatmetrix_session_id
         }
       end
     end


### PR DESCRIPTION
The SSN show page includes Javascript for device profiling. To identify a device profiling transaction we set `threatmetrix_session_id` and render that alongside the Javascript that performs the device profiling. This UUID is used downstream to fetch device profiling results.

We observed that some users did not have a `threatmetrix_session_id` value in downstream steps. In many cases this appears to be because they submitted the "link sent" step which calls `undo_step` on the SSN step. Then, either due to network issues or an unusual path through the process they were able to submit the SSN form without re-rendering the SSN show page and regenerating a threatmetrix session ID.

Investigating this we questioned why the threatmetrix session id needs to be deleted when the user submits earlier steps. It appears it was added in #9589 which configured the back button functionality from the SSN step back to other steps. It appears that the threatmetrix session id was set to `nil` there in order to return to the state that existed before the step was submitted and not because of a specific concern about stale IDs or anything like that.

In order to prevent the issue where users have a nil ID after viewing the SSN step and submitting ealier steps and proceeding without re-viewing the SSN step, this commit removes the code to reset the threatmetrix session ID. This should be fine since the old ID will represent a device profiling transaction for the current session which is ultimately the goal.
