### PR TITLE
Use defer for non-critical scripts

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -102,7 +102,7 @@
   <!-- <%= t('notices.dap_participation') %> -->
   <%= javascript_packs_tag_once(
         'https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS',
-        async: true,
+        defer: true,
         id: '_fed_an_ua_tag',
         preload_links_header: false,
       ) %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -71,7 +71,7 @@
         { type: 'application/json', data: { config: '' } },
         false,
       ) %>
-  <%= javascript_packs_tag_once('track-errors', async: true, preload_links_header: false) if BrowserSupport.supported?(request.user_agent) %>
+  <%= javascript_packs_tag_once('track-errors', defer: true, preload_links_header: false) if BrowserSupport.supported?(request.user_agent) %>
   <%= render_javascript_pack_once_tags %>
 <% end %>
 

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ScriptHelper do
 
       context 'with attributes' do
         before do
-          javascript_packs_tag_once('track-errors', async: true)
+          javascript_packs_tag_once('track-errors', defer: true)
           allow(Rails.application.config.asset_sources).to receive(:get_sources).
             with('track-errors').and_return(['/track-errors.js'])
           allow(Rails.application.config.asset_sources).to receive(:get_assets).
@@ -121,7 +121,7 @@ RSpec.describe ScriptHelper do
           output = render_javascript_pack_once_tags
 
           expect(output).to have_css(
-            "script[src^='/track-errors.js'][async]",
+            "script[src^='/track-errors.js'][defer]",
             count: 1,
             visible: :all,
           )

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
       it 'does not render DAP analytics' do
         allow(view).to receive(:javascript_packs_tag_once)
         expect(view).not_to receive(:javascript_packs_tag_once).
-          with(a_string_matching('https://dap.digitalgov.gov/'), async: true, id: '_fed_an_ua_tag')
+          with(a_string_matching('https://dap.digitalgov.gov/'), defer: true, id: '_fed_an_ua_tag')
 
         render
       end
@@ -195,7 +195,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
         allow(view).to receive(:javascript_packs_tag_once)
         expect(view).to receive(:javascript_packs_tag_once).with(
           a_string_matching('https://dap.digitalgov.gov/'),
-          async: true,
+          defer: true,
           preload_links_header: false,
           id: '_fed_an_ua_tag',
         )


### PR DESCRIPTION
## 🛠 Summary of changes

Updates non-critical scripts to use `defer` instead of `async`.

While both `async` and `defer` _load_ scripts without blocking the parser, `async` will block the parser to execute the script as soon as it's loaded, which may block parsing if it happens before parsing is complete. `defer` will instead wait for parsing to complete before executing the script, which is acceptable behavior for the scripts affected by the changes in this pull request.

The [HTML specification includes helpful diagrams illustrating the difference](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-async:~:text=This%20is%20all%20summarized%20in%20the%20following%20schematic%20diagram%3A):

![image](https://github.com/user-attachments/assets/62a7687d-5415-4899-a6ff-23300e6326cf)

Related resource: https://web.dev/articles/optimizing-content-efficiency-loading-third-party-javascript#async-defer

While this resource includes analytics scripts as an example of `async` usage, it does so under the premise that these are "important for the script to run earlier in the loading process". It's not clear to me that it's important for these to run early.

## 📜 Testing Plan

Verify there is no regression in the loading of scripts marked as `defer`, particularly `track-errors.js` on http://localhost:3000 should load successfully in default development environments.