### PR TITLE
Document analytics methods properties in primary IdV flow

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1478,6 +1478,7 @@ module AnalyticsEvents
   # @param [Boolean] selfie_quality_good Selfie quality result
   # @param [String] workflow LexisNexis TrueID workflow
   # @param [String] birth_year Birth year from document
+  # @param [Integer] issue_year Year document was issued
   # @option extra [String] 'DocumentName'
   # @option extra [String] 'DocAuthResult'
   # @option extra [String] 'DocIssuerCode'
@@ -1505,6 +1506,7 @@ module AnalyticsEvents
     client_image_metrics:,
     flow_path:,
     liveness_checking_required:,
+    issue_year:,
     billed: nil,
     doc_auth_result: nil,
     vendor_request_time_in_ms: nil,
@@ -1578,6 +1580,7 @@ module AnalyticsEvents
       selfie_quality_good:,
       workflow:,
       birth_year:,
+      issue_year:,
       **extra,
     )
   end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::ImageUploadsController, allowed_extra_analytics: [:*] do
+RSpec.describe Idv::ImageUploadsController do
   include DocPiiHelper
 
   let(:document_filename_regex) { /^[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\.[a-z]+$/ }

--- a/spec/features/idv/account_creation_spec.rb
+++ b/spec/features/idv/account_creation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'IAL2 account creation', allowed_extra_analytics: [:*] do
+RSpec.describe 'IAL2 account creation' do
   include IdvHelper
   include DocAuthHelper
   include SamlAuthHelper

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'cancel IdV', allowed_extra_analytics: [:*] do
+RSpec.describe 'cancel IdV' do
   include IdvStepHelper
   include DocAuthHelper
   include InteractionHelper

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'ssn step mock proofer', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'ssn step mock proofer', :js do
   include IdvStepHelper
   include DocAuthHelper
 

--- a/spec/features/idv/gpo_disabled_spec.rb
+++ b/spec/features/idv/gpo_disabled_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'disabling GPO address verification', allowed_extra_analytics: [:*] do
+RSpec.feature 'disabling GPO address verification' do
   include IdvStepHelper
 
   context 'with GPO address verification disabled' do

--- a/spec/features/idv/phone_input_spec.rb
+++ b/spec/features/idv/phone_input_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'IdV phone number input', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'IdV phone number input', :js do
   include IdvStepHelper
 
   before do

--- a/spec/features/idv/proofing_components_spec.rb
+++ b/spec/features/idv/proofing_components_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'proofing components', allowed_extra_analytics: [:*] do
+RSpec.describe 'proofing components' do
   include DocAuthHelper
   include IdvHelper
   include SamlAuthHelper

--- a/spec/features/idv/sp_requested_attributes_spec.rb
+++ b/spec/features/idv/sp_requested_attributes_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'sp requested IdV attributes', :email, allowed_extra_analytics: [:*] do
+RSpec.feature 'sp requested IdV attributes', :email do
   context 'oidc' do
     it_behaves_like 'sp requesting attributes', :oidc
   end

--- a/spec/features/idv/step_up_spec.rb
+++ b/spec/features/idv/step_up_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'IdV step up flow', allowed_extra_analytics: [:*] do
+RSpec.describe 'IdV step up flow' do
   include IdvStepHelper
   include InPersonHelper
 

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'phone otp verification step spec', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'phone otp verification step spec', :js do
   include IdvStepHelper
 
   it 'requires the user to enter the correct otp before continuing' do

--- a/spec/features/idv/threat_metrix_pending_spec.rb
+++ b/spec/features/idv/threat_metrix_pending_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Users pending ThreatMetrix review', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'Users pending ThreatMetrix review', :js do
   include IdvStepHelper
   include OidcAuthHelper
   include DocAuthHelper

--- a/spec/features/idv/uak_password_spec.rb
+++ b/spec/features/idv/uak_password_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A user with a UAK passwords attempts IdV', allowed_extra_analytics: [:*] do
+RSpec.feature 'A user with a UAK passwords attempts IdV' do
   include IdvStepHelper
 
   it 'allows the user to continue to the SP', js: true do

--- a/spec/features/sp_cost_tracking_spec.rb
+++ b/spec/features/sp_cost_tracking_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'SP Costing', :email, allowed_extra_analytics: [:*] do
+RSpec.feature 'SP Costing', :email do
   include SpAuthHelper
   include SamlAuthHelper
   include IdvHelper

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Password recovery via personal key', allowed_extra_analytics: [:*] do
+RSpec.feature 'Password recovery via personal key' do
   include PersonalKeyHelper
   include IdvStepHelper
   include SamlAuthHelper

--- a/spec/support/fake_analytics_spec.rb
+++ b/spec/support/fake_analytics_spec.rb
@@ -621,6 +621,7 @@ RSpec.describe FakeAnalytics do
         client_image_metrics: nil,
         flow_path: nil,
         liveness_checking_required: nil,
+        issue_year: nil,
         'DocumentName' => 'some_name',
       )
 


### PR DESCRIPTION
## 🛠 Summary of changes

Adds missing analytics methods property documentation for happy path identity verification.

Turns out I already did most of the work for this in #10966, and there was only one property left to be documented.

**Why?**

- Move toward full documentation coverage for analytics methods

## 📜 Testing Plan

Verify build passes.