### PR TITLE
Do not write config file by default on boot

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module Identity
     Identity::Hostdata.load_config!(
       app_root: Rails.root,
       rails_env: Rails.env,
-      write_copy_to: Rails.root.join('tmp', 'application.yml'),
+      write_copy_to: nil,
       &IdentityConfig::BUILDER
     )
 


### PR DESCRIPTION
## 🛠 Summary of changes

Following some discussion [here](https://gsa-tts.slack.com/archives/C0NGESUN5/p1723820108719159), this PR disables writing the merged config file on boot.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
