### PR TITLE
Remove reference to frontend interest group team in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,12 +90,7 @@ commits together, merges it, then deletes the branch.
 
 Everyone is encouraged to participate in code review. To solicit feedback from specific people,
 consider adding individuals or groups as requested reviewers on your pull request. Most internal
-product teams have a team handle which can be used to notify everyone on that team, or you can
-request reviews from one of the available interest group teams:
-
-- `18f/identity-frontend` for developers interested in frontend development
-
-To request to join any of these teams, you can contact any existing member and ask to be added.
+product teams have a team handle which can be used to notify everyone on that team.
 
 ## Public domain
 


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a reference to `@18f/identity-frontend` frontend development interest group team.

This was an earlier experiment of creating focus area-specific interest groups, which was discontinued due to lack of usage and participation.

## 📜 Testing Plan

Verify that documentation still makes sense after removals.