### PR TITLE
Avoid Yarn install and trace in Docker assets precompilation

### DIFF
--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -73,8 +73,10 @@ RUN bundle install --jobs $(nproc)
 RUN bundle binstubs --all
 
 # yarn install
-COPY package.json yarn.lock app/javascript/packages .
-RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
+RUN --mount=type=bind,source=package.json,target=. \
+    --mount=type=bind,source=yarn.lock,target=. \
+    --mount=type=bind,source=app/javascript/packages,target=. \
+    yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code
 COPY ./lib ./lib

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -73,9 +73,9 @@ RUN bundle install --jobs $(nproc)
 RUN bundle binstubs --all
 
 # yarn install
-RUN --mount=type=bind,source=package.json,target=. \
-    --mount=type=bind,source=yarn.lock,target=. \
-    --mount=type=bind,source=app/javascript/packages,target=. \
+COPY ./package.json ./package.json
+COPY ./yarn.lock ./yarn.lock
+RUN --mount=type=bind,source=app/javascript/packages,target=. \
     yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -73,8 +73,7 @@ RUN bundle install --jobs $(nproc)
 RUN bundle binstubs --all
 
 # yarn install
-COPY package.json $RAILS_ROOT/package.json
-COPY yarn.lock $RAILS_ROOT/yarn.lock
+COPY package.json yarn.lock app/javascript/packages .
 RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -104,7 +104,7 @@ COPY public/ban-robots.txt $RAILS_ROOT/public/robots.txt
 COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
-RUN --mount=type=bind,source=app/javascript/packages/build-sass,target=node_modules/@18f/identity-build-sass \
+RUN --mount=type=bind,source=./app/javascript/packages/build-sass,target=./node_modules/@18f/identity-build-sass \
     SKIP_YARN_INSTALL=true ls -al node_modules/@18f && bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -105,6 +105,7 @@ COPY public/ban-robots.txt $RAILS_ROOT/public/robots.txt
 COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
+RUN ls -al node_modules/@18f
 RUN SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -104,8 +104,8 @@ COPY public/ban-robots.txt $RAILS_ROOT/public/robots.txt
 COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
-RUN --mount=type=bind,source=./app/javascript/packages/build-sass,target=./node_modules/@18f/identity-build-sass \
-    SKIP_YARN_INSTALL=true ls -al node_modules/@18f && bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
+RUN --mount=type=bind,source=./app/javascript/packages/build-sass,target=$RAILS_ROOT/node_modules/@18f/identity-build-sass \
+    ls -al node_modules/@18f && SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files
 ARG SERVICE_PROVIDERS_KEY

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -104,7 +104,7 @@ COPY public/ban-robots.txt $RAILS_ROOT/public/robots.txt
 COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
-RUN bundle exec rake assets:precompile --trace && rm -r node_modules/ && rm -r .yarn-cache/
+RUN SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files
 ARG SERVICE_PROVIDERS_KEY

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -75,7 +75,7 @@ RUN bundle binstubs --all
 # yarn install
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
-COPY ./app/javascript/packages/build-sass ./app/javascript/packages/build-sass
+COPY ./app/javascript/packages ./app/javascript/packages
 RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache && ls -al node_modules/@18f
 
 # Add the application code

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -76,7 +76,7 @@ RUN bundle binstubs --all
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
 COPY ./app/javascript/packages/build-sass ./app/javascript/packages/build-sass
-RUN ls -al node_modules/@18f && yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
+RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache && ls -al node_modules/@18f
 
 # Add the application code
 COPY ./lib ./lib

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -72,9 +72,10 @@ RUN bundle config set --local without 'deploy development doc test'
 RUN bundle install --jobs $(nproc)
 RUN bundle binstubs --all
 
-# yarn install
+# Yarn install
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
+# Workspace packages are installed by Yarn via symlink to the original source, and need to be present
 COPY ./app/javascript/packages ./app/javascript/packages
 RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -104,8 +104,8 @@ COPY public/ban-robots.txt $RAILS_ROOT/public/robots.txt
 COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
-RUN --mount=type=bind,source=./app/javascript/packages/build-sass,target=$RAILS_ROOT/node_modules/@18f/identity-build-sass \
-    ls -al node_modules/@18f && SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
+COPY ./app/javascript/packages/build-sass $RAILS_ROOT/node_modules/@18f/identity-build-sass
+RUN ls -al node_modules/@18f && SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files
 ARG SERVICE_PROVIDERS_KEY

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -105,7 +105,7 @@ COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
 RUN --mount=type=bind,source=app/javascript/packages/build-sass,target=node_modules/@18f/identity-build-sass \
-    SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
+    SKIP_YARN_INSTALL=true ls -al node_modules/@18f && bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files
 ARG SERVICE_PROVIDERS_KEY

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -105,7 +105,6 @@ COPY public/ban-robots.txt $RAILS_ROOT/public/robots.txt
 COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
-COPY ./app/javascript/packages/build-sass $RAILS_ROOT/node_modules/@18f/identity-build-sass
 RUN SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -75,7 +75,8 @@ RUN bundle binstubs --all
 # yarn install
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
-RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
+COPY ./app/javascript/packages/build-sass ./app/javascript/packages/build-sass
+RUN ls -al node_modules/@18f && yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code
 COPY ./lib ./lib
@@ -105,7 +106,7 @@ COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
 COPY ./app/javascript/packages/build-sass $RAILS_ROOT/node_modules/@18f/identity-build-sass
-RUN ls -al node_modules/@18f && SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
+RUN SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files
 ARG SERVICE_PROVIDERS_KEY

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -75,8 +75,7 @@ RUN bundle binstubs --all
 # yarn install
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
-RUN --mount=type=bind,source=app/javascript/packages,target=. \
-    yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
+RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code
 COPY ./lib ./lib
@@ -105,8 +104,8 @@ COPY public/ban-robots.txt $RAILS_ROOT/public/robots.txt
 COPY ./config/application.yml.default.prod $RAILS_ROOT/config/application.yml
 
 # Precompile assets
-RUN ls -al node_modules/@18f
-RUN SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
+RUN --mount=type=bind,source=app/javascript/packages/build-sass,target=node_modules/@18f/identity-build-sass \
+    SKIP_YARN_INSTALL=true bundle exec rake assets:precompile && rm -r node_modules/ && rm -r .yarn-cache/
 
 # get service_providers.yml and related files
 ARG SERVICE_PROVIDERS_KEY

--- a/dockerfiles/idp_prod.Dockerfile
+++ b/dockerfiles/idp_prod.Dockerfile
@@ -76,7 +76,7 @@ RUN bundle binstubs --all
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
 COPY ./app/javascript/packages ./app/javascript/packages
-RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache && ls -al node_modules/@18f
+RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code
 COPY ./lib ./lib

--- a/dockerfiles/idp_review_app.Dockerfile
+++ b/dockerfiles/idp_review_app.Dockerfile
@@ -95,9 +95,9 @@ RUN bundle config set --local without 'deploy development doc test'
 RUN bundle install --jobs $(nproc)
 RUN bundle binstubs --all
 
-COPY ./package.json ./package.json
-COPY ./yarn.lock ./yarn.lock
-COPY ./app/javascript/packages ./app/javascript/packages
+COPY --chown=app:app ./package.json ./package.json
+COPY --chown=app:app ./yarn.lock ./yarn.lock
+COPY --chown=app:app ./app/javascript/packages ./app/javascript/packages
 RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code

--- a/dockerfiles/idp_review_app.Dockerfile
+++ b/dockerfiles/idp_review_app.Dockerfile
@@ -95,7 +95,9 @@ RUN bundle config set --local without 'deploy development doc test'
 RUN bundle install --jobs $(nproc)
 RUN bundle binstubs --all
 
-COPY package.json yarn.lock app/javascript/packages .
+COPY ./package.json ./package.json
+COPY ./yarn.lock ./yarn.lock
+COPY ./app/javascript/packages ./app/javascript/packages
 RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code

--- a/dockerfiles/idp_review_app.Dockerfile
+++ b/dockerfiles/idp_review_app.Dockerfile
@@ -141,7 +141,7 @@ COPY --chown=app:app certs.example $RAILS_ROOT/certs
 COPY --chown=app:app config/service_providers.localdev.yml $RAILS_ROOT/config/service_providers.yml
 
 # Precompile assets
-RUN bundle exec rake assets:precompile --trace
+RUN SKIP_YARN_INSTALL=true bundle exec rake assets:precompile
 
 ARG ARG_CI_COMMIT_BRANCH="branch_placeholder"
 ARG ARG_CI_COMMIT_SHA="sha_placeholder"

--- a/dockerfiles/idp_review_app.Dockerfile
+++ b/dockerfiles/idp_review_app.Dockerfile
@@ -95,8 +95,7 @@ RUN bundle config set --local without 'deploy development doc test'
 RUN bundle install --jobs $(nproc)
 RUN bundle binstubs --all
 
-COPY package.json $RAILS_ROOT/package.json
-COPY yarn.lock $RAILS_ROOT/yarn.lock
+COPY package.json yarn.lock app/javascript/packages .
 RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 
 # Add the application code

--- a/dockerfiles/idp_review_app.Dockerfile
+++ b/dockerfiles/idp_review_app.Dockerfile
@@ -95,8 +95,10 @@ RUN bundle config set --local without 'deploy development doc test'
 RUN bundle install --jobs $(nproc)
 RUN bundle binstubs --all
 
+# Yarn install
 COPY --chown=app:app ./package.json ./package.json
 COPY --chown=app:app ./yarn.lock ./yarn.lock
+# Workspace packages are installed by Yarn via symlink to the original source, and need to be present
 COPY --chown=app:app ./app/javascript/packages ./app/javascript/packages
 RUN yarn install --production=true --frozen-lockfile --cache-folder .yarn-cache
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Dockerfiles to avoid unnecessary effort during assets precompilation:

- Yarn installation
- Debugging backtrace

`assets:precompile` will call `yarn install` by default unless disabled by `SKIP_YARN_INSTALL`.

See other references:

https://github.com/18F/identity-idp/blob/0923f956485381438c21d8c1ec62dae19f97c2f1/.gitlab-ci.yml#L79

https://github.com/18F/identity-idp/blob/0923f956485381438c21d8c1ec62dae19f97c2f1/deploy/build-post-config#L21

## 📜 Testing Plan

Verify build passes.

Check logs for "build-idp-image" and "build-review-image" in CI and observe no installation logging during assets precompilation.