### PR TITLE
LG-14219: Arrange email as first item in IdV consent screen

### DIFF
--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -4,11 +4,11 @@ class CompletionsPresenter
   attr_reader :current_user, :current_sp, :decrypted_pii, :requested_attributes, :completion_context
 
   SORTED_IAL2_ATTRIBUTE_MAPPING = [
+    [[:email], :email],
+    [[:all_emails], :all_emails],
     [%i[given_name family_name], :full_name],
     [[:address], :address],
     [[:phone], :phone],
-    [[:email], :email],
-    [[:all_emails], :all_emails],
     [[:birthdate], :birthdate],
     [[:social_security_number], :social_security_number],
     [[:x509_subject], :x509_subject],

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -265,16 +265,14 @@ RSpec.describe CompletionsPresenter do
   end
 
   describe '#pii' do
+    subject(:pii) { presenter.pii }
+
     context 'ial1' do
       context 'with a subset of attributes requested' do
         let(:requested_attributes) { [:email] }
 
         it 'properly scopes and resolve attributes' do
-          expect(presenter.pii).to eq(
-            {
-              email: current_user.email,
-            },
-          )
+          expect(pii).to eq(email: current_user.email)
         end
       end
 
@@ -282,24 +280,27 @@ RSpec.describe CompletionsPresenter do
         let(:requested_attributes) { [:email, :all_emails] }
 
         it 'only displays all_emails' do
-          expect(presenter.pii).to eq(
-            {
-              all_emails: [current_user.email],
-            },
-          )
+          expect(pii).to eq(all_emails: [current_user.email])
         end
       end
 
       context 'with all attributes requested' do
         it 'properly scopes and resolve attributes' do
-          expect(presenter.pii).to eq(
-            {
-              all_emails: [current_user.email],
-              verified_at: nil,
-              x509_issuer: nil,
-              x509_subject: nil,
-            },
+          expect(pii).to eq(
+            all_emails: [current_user.email],
+            verified_at: nil,
+            x509_issuer: nil,
+            x509_subject: nil,
           )
+        end
+
+        it 'builds hash with sorted keys' do
+          expect(pii.keys).to eq %i[
+            all_emails
+            x509_subject
+            x509_issuer
+            verified_at
+          ]
         end
       end
     end
@@ -311,31 +312,49 @@ RSpec.describe CompletionsPresenter do
         let(:requested_attributes) { [:email, :given_name, :phone] }
 
         it 'properly scopes and resolve attributes' do
-          expect(presenter.pii).to eq(
-            {
-              email: current_user.email,
-              full_name: 'Testy Testerson',
-              phone: '+1 202-212-1000',
-            },
+          expect(pii).to eq(
+            email: current_user.email,
+            full_name: 'Testy Testerson',
+            phone: '+1 202-212-1000',
           )
+        end
+
+        it 'builds hash with sorted keys' do
+          expect(pii.keys).to eq %i[
+            full_name
+            phone
+            email
+          ]
         end
       end
 
       context 'with all attributes requested' do
         it 'properly scopes and resolve attributes' do
-          expect(presenter.pii).to eq(
-            {
-              full_name: 'Testy Testerson',
-              address: '123 main st apt 123 Washington, DC 20405',
-              phone: '+1 202-212-1000',
-              all_emails: [current_user.email],
-              birthdate: 'January 1, 1990',
-              social_security_number: '900-12-3456',
-              verified_at: nil,
-              x509_subject: nil,
-              x509_issuer: nil,
-            },
+          expect(pii).to eq(
+            full_name: 'Testy Testerson',
+            address: '123 main st apt 123 Washington, DC 20405',
+            phone: '+1 202-212-1000',
+            all_emails: [current_user.email],
+            birthdate: 'January 1, 1990',
+            social_security_number: '900-12-3456',
+            verified_at: nil,
+            x509_subject: nil,
+            x509_issuer: nil,
           )
+        end
+
+        it 'builds hash with sorted keys' do
+          expect(pii.keys).to eq %i[
+            full_name
+            address
+            phone
+            all_emails
+            birthdate
+            social_security_number
+            x509_subject
+            x509_issuer
+            verified_at
+          ]
         end
       end
     end

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -321,9 +321,9 @@ RSpec.describe CompletionsPresenter do
 
         it 'builds hash with sorted keys' do
           expect(pii.keys).to eq %i[
+            email
             full_name
             phone
-            email
           ]
         end
       end
@@ -345,10 +345,10 @@ RSpec.describe CompletionsPresenter do
 
         it 'builds hash with sorted keys' do
           expect(pii.keys).to eq %i[
+            all_emails
             full_name
             address
             phone
-            all_emails
             birthdate
             social_security_number
             x509_subject


### PR DESCRIPTION
## 🎫 Ticket

[LG-14219](https://cm-jira.usa.gov/browse/LG-14219)

## 🛠 Summary of changes

Updates the consent screen to show email address as the first item when consenting to a partner requesting a verified identity.

This brings consistency with how it behaves for IAL1 authentications, and prepares for updates allowing a user to add or change their preferred email address when consenting to share information with a partner (LG-13001).

The changes also include test coverage for expected sort order of keys in the consent screen. This behavior had already been implemented, but there was no test coverage.

## 📜 Testing Plan

Verify that email address is shown first when consenting to share identity-verified information with a partner:

1. Have both the IdP and [sample application](https://github.com/18f/identity-oidc-sinatra) running simultaneously.
2. Go to http://localhost:9292/?ial=2
3. Click "Sign in"
4. Sign in or create an account
5. When prompted to consent to share information, note order of "Email" attribute as first item

## 👀 Screenshots

Before|After
---|---
![before](https://github.com/user-attachments/assets/99691bd2-f35c-41b7-b6c2-043d7eebca68)|![after](https://github.com/user-attachments/assets/18ca0e2e-2d4a-43ee-9246-5c5950417975)
