### PR TITLE
Reduce threading and increase time slice default values for LG-99 Report

### DIFF
--- a/lib/reporting/fraud_metrics_lg99_report.rb
+++ b/lib/reporting/fraud_metrics_lg99_report.rb
@@ -32,8 +32,8 @@ module Reporting
       time_range:,
       verbose: false,
       progress: false,
-      slice: 3.hours,
-      threads: 5
+      slice: 6.hours,
+      threads: 1
     )
       @time_range = time_range
       @verbose = verbose

--- a/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
@@ -144,9 +144,9 @@ RSpec.describe Reporting::FraudMetricsLg99Report do
     let(:subject) { described_class.new(time_range:, **opts) }
     let(:default_args) do
       {
-        num_threads: 5,
+        num_threads: 1,
         ensure_complete_logs: true,
-        slice_interval: 3.hours,
+        slice_interval: 6.hours,
         progress: false,
         logger: nil,
       }


### PR DESCRIPTION
## 🛠 Summary of changes

We've had some issues with query volume from this report ([thread](https://gsa-tts.slack.com/archives/CMW9H0RFX/p1722271455385999)), and this proposes a couple changes to reduce the rate at which it makes requests.

The time slice shouldn't be an issue until there are more than 10,000 events in each one (I picked 6 hours).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
