### PR TITLE
Add AAL3 usage to protocols report

### DIFF
--- a/spec/lib/reporting/protocols_report_spec.rb
+++ b/spec/lib/reporting/protocols_report_spec.rb
@@ -72,11 +72,20 @@ RSpec.describe Reporting::ProtocolsReport do
         'issuer' => 'Issuer3',
       },
     ]
+    aal3_issuers_query_response = [
+      {
+        'issuer' => 'Issuer1',
+      },
+      {
+        'issuer' => 'Issuer3',
+      },
+    ]
 
     stub_multiple_cloudwatch_logs(
       protocol_query_response,
       saml_signature_query_response,
       loa_issuers_query_response,
+      aal3_issuers_query_response,
     )
   end
 
@@ -202,10 +211,20 @@ RSpec.describe Reporting::ProtocolsReport do
         ['Incorrectly signing SAML authentication requests', string_or_num(strings, 1), 'Issuer1'],
       ],
       [
-        ['Count of issuers using LOA', 'List of issuers with the issue'],
         [
+          'Deprecated Parameter',
+          'Count of issuers using the parameter',
+          'List of issuers using the parameter',
+        ],
+        [
+          'LOA',
           string_or_num(strings, 3),
           'Issuer1, Issuer2, Issuer3',
+        ],
+        [
+          'AAL3',
+          string_or_num(strings, 2),
+          'Issuer1, Issuer3',
         ],
       ],
     ]


### PR DESCRIPTION
We would like to know who is using the deprecated AAL3 ACR parameter.

See
https://gitlab.login.gov/lg-people/lg-people-appdev/Melba/backlog-fy24/-/issues/10

changelog: Internal, Reporting, Add AAL3 usage to protocols report

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
