### PR TITLE
Update fugit dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     cose (1.3.0)
       cbor (~> 0.5.9)
@@ -314,7 +314,7 @@ GEM
       smart_properties
     errbase (0.2.1)
     erubi (1.13.0)
-    et-orbi (1.2.7)
+    et-orbi (1.2.11)
       tzinfo
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -335,8 +335,8 @@ GEM
       ffi (>= 1.0.0)
       rake
     foundation_emails (2.2.1.0)
-    fugit (1.10.1)
-      et-orbi (~> 1, >= 1.2.7)
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     geocoder (1.7.0)
     get_process_mem (0.2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,7 +335,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     foundation_emails (2.2.1.0)
-    fugit (1.9.0)
+    fugit (1.10.1)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     geocoder (1.7.0)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the `fugit` gem to resolve a security advisory.

See: https://github.com/floraison/fugit/security/advisories/GHSA-2m96-52r3-2f3g

Updated via: `bundle update fugit`

## 📜 Testing Plan

Verify `make audit` produces no security advisories.