### PR TITLE
LG-14094 Stop logging extra “IdV: doc auth verify visited” events

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -135,6 +135,7 @@ module Idv
       end
 
       if current_async_state.in_progress?
+        analytics.idv_doc_auth_verify_polling_wait_visited
         render 'shared/wait'
         return
       end
@@ -142,6 +143,7 @@ module Idv
       return if confirm_not_rate_limited_after_doc_auth
 
       if current_async_state.none?
+        analytics.idv_doc_auth_verify_visited(**analytics_arguments)
         render :show
       elsif current_async_state.missing?
         analytics.idv_proofing_resolution_result_missing

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -17,7 +17,6 @@ module Idv
         @ssn = idv_session.ssn
         @pii = pii
 
-        analytics.idv_doc_auth_verify_visited(**analytics_arguments)
         Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
           call('verify', :view, true) # specify in_person?
 

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -16,7 +16,6 @@ module Idv
       @ssn = idv_session.ssn
       @pii = pii
 
-      analytics.idv_doc_auth_verify_visited(**analytics_arguments)
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('verify', :view, true)
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1640,6 +1640,12 @@ module AnalyticsEvents
     )
   end
 
+  # User visits IdV verify step waiting on a resolution proofing job result
+  # @identity.idp.previous_event_name IdV: doc auth verify visited
+  def idv_doc_auth_verify_polling_wait_visited(**extra)
+    track_event(:idv_doc_auth_verify_polling_wait_visited, **extra)
+  end
+
   # rubocop:disable Layout/LineLength
   # @param ab_tests [Hash] Object that holds A/B test data (legacy A/B tests may include attributes outside the scope of this object)
   # @param acuant_sdk_upgrade_ab_test_bucket [String] A/B test bucket for Acuant document capture SDK upgrades

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1642,8 +1642,8 @@ module AnalyticsEvents
 
   # User visits IdV verify step waiting on a resolution proofing job result
   # @identity.idp.previous_event_name IdV: doc auth verify visited
-  def idv_doc_auth_verify_polling_wait_visited(**extra)
-    track_event(:idv_doc_auth_verify_polling_wait_visited, **extra)
+  def idv_doc_auth_verify_polling_wait_visited
+    track_event(:idv_doc_auth_verify_polling_wait_visited)
   end
 
   # rubocop:disable Layout/LineLength

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
       end
     end
 
-    context 'when the reolution proofing job result is missing' do
+    context 'when the resolution proofing job result is missing' do
       let(:async_state) do
         ProofingSessionAsyncResult.new(status: ProofingSessionAsyncResult::MISSING)
       end

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -55,15 +55,6 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
   end
 
   describe '#show' do
-    let(:analytics_name) { 'IdV: doc auth verify visited' }
-    let(:analytics_args) do
-      {
-        analytics_id: 'In Person Proofing',
-        flow_path: 'standard',
-        step: 'verify',
-      }.merge(ab_test_args)
-    end
-
     it 'renders the show template' do
       get :show
 
@@ -75,8 +66,30 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
 
       expect(@analytics).to have_logged_event(
         'IdV: doc auth verify visited',
-        hash_including(**analytics_args, same_address_as_id: true),
+        {
+          analytics_id: 'In Person Proofing',
+          flow_path: 'standard',
+          step: 'verify',
+          same_address_as_id: true,
+        }.merge(ab_test_args),
       )
+    end
+
+    context 'when the user is rate limited' do
+      before do
+        RateLimiter.new(
+          user: subject.current_user,
+          rate_limit_type: :idv_resolution,
+        ).increment_to_limited!
+      end
+
+      it 'redirects to rate limited url' do
+        get :show
+
+        expect(response).to redirect_to idv_session_errors_failure_url
+
+        expect(@analytics).to have_logged_event('Rate Limit Reached', limiter_type: :idv_resolution)
+      end
     end
 
     context 'when done' do
@@ -111,8 +124,51 @@ RSpec.describe Idv::InPerson::VerifyInfoController, allowed_extra_analytics: [:*
 
         expect(@analytics).to have_logged_event(
           'IdV: doc auth verify proofing results',
-          hash_including(**analytics_args, success: true),
+          hash_including(
+            {
+              success: true,
+              analytics_id: 'In Person Proofing',
+              flow_path: 'standard',
+              step: 'verify',
+              same_address_as_id: true,
+            }.merge(ab_test_args),
+          ),
         )
+      end
+    end
+
+    context 'when the resolution proofing job has not completed' do
+      let(:async_state) do
+        ProofingSessionAsyncResult.new(status: ProofingSessionAsyncResult::IN_PROGRESS)
+      end
+
+      before do
+        allow(controller).to receive(:load_async_state).and_return(async_state)
+      end
+
+      it 'renders the wait template' do
+        get :show
+
+        expect(response).to render_template 'shared/wait'
+        expect(@analytics).to have_logged_event(:idv_doc_auth_verify_polling_wait_visited)
+      end
+    end
+
+    context 'when the reolution proofing job result is missing' do
+      let(:async_state) do
+        ProofingSessionAsyncResult.new(status: ProofingSessionAsyncResult::MISSING)
+      end
+
+      before do
+        allow(controller).to receive(:load_async_state).and_return(async_state)
+      end
+
+      it 'renders a timeout error' do
+        get :show
+
+        expect(response).to render_template :show
+        expect(controller.flash[:error]).to eq(I18n.t('idv.failure.timeout'))
+        expect(@analytics).to have_logged_event('IdV: proofing resolution result missing')
       end
     end
   end


### PR DESCRIPTION
This commit makes changes to the way to `VerifyInfoController#show` logs events in the main IdV and in-person contexts.

This controller action has 2 primary concerns:

1. Rendering the “Verify your information” page
2. Managing the results of the `ResolutionProofingJob` that runs when the “Verify your information” page is submitted

Which concern is active for these actions is controlled by the `async_state` which is a `ProofingSessionAsyncResult`. This is a struct that includes the status of the `ResolutionProofingJob`. This status can have 4 values:

- `NONE`: This means that no job has been submitted. In this state the controller should render the “Verify your information” page.
- `IN_PROGRESS`: This means that the job is running. In this state the controller should render a loading state page that is detected by the `form-steps-wait` tooling on the frontend causing it to render a loading state.
- `DONE`: The job has been completed. In this state the controller should process the results and redirect appropriately.
- `MISSING`: The result is expected but not present. This indicates that the job has timed out. In this state the controller should render the “Verify your information” page with an error.

In addition to these states the controller is aware of rate limits for the purpose of redirecting to a rate limit action when the user has been rate limited.

Prior to this commit, these states had the following associated analytics actions:

- `IdV: doc auth verify visited`: This event was previously logged in all cases. This event is the focus of this change.
- `IdV: doc auth verify proofing results`: This event is logged when `async_state.status` is `DONE`. This event includes a large hash containing the results of running `ResolutionProofingJob`.
- `IdV: proofing resolution result missing`: This event is logged when `async_state.status` is `MISSING`.
- `Rate Limit Reached`: This event is logged by `RateLimitConcern` when a rate-limit is exceeded and the user is being redirected as a result.

Since the `IdV: doc auth verify visited` was logged in all cases there was a lot of double counting of verify step visits. For example, if a user visited the page, submitted it, has 2 polling attempts, and then sees the job complete on the 3rd attempt then they will have 4 `IdV: doc auth verify visited` events in the log. This pattern has led to some confusion since this user has only visited this step once.

This commit makes a change so that the `IdV: doc auth verify visited` is only logged when `async_state.status` is `NONE`, i.e. when the user is viewing the “Verify your information” screen to submit their info.

All of the other values of `async_state.status` are covered by an existing analytics event except for `IN_PROGRESS`. This commit adds a new `idv_doc_auth_verify_polling_wait_visited` to ensure that this state is covered by logging.

