### PR TITLE
Use defer when loading GTM script via patched DAP

### DIFF
--- a/app/javascript/packages/analytics/digital-analytics-program.patch
+++ b/app/javascript/packages/analytics/digital-analytics-program.patch
@@ -1,5 +1,5 @@
 73a74
-> GA4Object.async = true;
+> GA4Object.defer = true;
 785d785
 < var piiRegex = [];
 900c900


### PR DESCRIPTION
## 🛠 Summary of changes

Modifies DAP (Digital Analytics Program) patch to load Google Tag Manager using `<script defer>` instead of `<script async>`, which should have better performance characteristics in avoiding interrupted page parsing due to execution of an `async` script.

Related Slack discussion: https://gsa-tts.slack.com/archives/C02CZB4G5/p1724265882031569

References:

- https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/defer
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/async
- https://html.spec.whatwg.org/multipage/scripting.html#dom-script-async
- https://calendar.perfplanet.com/2016/prefer-defer-over-async/

Follows #11097

## 📜 Testing Plan

Repeat Testing Plan from #11097, verifying loaded GTM script has `defer` attribute.

Also confirm that `yarn install` creates a new copy of `app/javascript/packages/analytics/digital-analytics-program.js` after checking out the branch. This should happen automatically as designed, due [to `Makefile` dependencies including the patch](https://github.com/18F/identity-idp/blob/83ec71c3912c259be6dc7f93426df5c81a69edb3/app/javascript/packages/analytics/Makefile#L3).
