### PR TITLE
Remove unnecessary use of DOMContentLoaded

### DIFF
--- a/app/javascript/packs/mock-device-profiling.tsx
+++ b/app/javascript/packs/mock-device-profiling.tsx
@@ -113,15 +113,13 @@ function MockDeviceProfilingOptions() {
   );
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  const ssnInput = document.getElementsByName('doc_auth[ssn]')[0];
+const ssnInput = document.getElementsByName('doc_auth[ssn]')[0];
 
-  if (ssnInput) {
-    const passwordToggle = ssnInput.closest('lg-password-toggle');
+if (ssnInput) {
+  const passwordToggle = ssnInput.closest('lg-password-toggle');
 
-    const div = document.createElement('div');
-    passwordToggle?.parentElement?.appendChild(div);
+  const div = document.createElement('div');
+  passwordToggle?.parentElement?.appendChild(div);
 
-    render(<MockDeviceProfilingOptions />, div);
-  }
-});
+  render(<MockDeviceProfilingOptions />, div);
+}

--- a/app/javascript/packs/mock-device-profiling.tsx
+++ b/app/javascript/packs/mock-device-profiling.tsx
@@ -113,13 +113,15 @@ function MockDeviceProfilingOptions() {
   );
 }
 
-const ssnInput = document.getElementsByName('doc_auth[ssn]')[0];
+document.addEventListener('DOMContentLoaded', () => {
+  const ssnInput = document.getElementsByName('doc_auth[ssn]')[0];
 
-if (ssnInput) {
-  const passwordToggle = ssnInput.closest('lg-password-toggle');
+  if (ssnInput) {
+    const passwordToggle = ssnInput.closest('lg-password-toggle');
 
-  const div = document.createElement('div');
-  passwordToggle?.parentElement?.appendChild(div);
+    const div = document.createElement('div');
+    passwordToggle?.parentElement?.appendChild(div);
 
-  render(<MockDeviceProfilingOptions />, div);
-}
+    render(<MockDeviceProfilingOptions />, div);
+  }
+});

--- a/app/javascript/packs/ssn-field.ts
+++ b/app/javascript/packs/ssn-field.ts
@@ -1,49 +1,42 @@
 import Cleave from 'cleave.js';
 
-function formatSSNFieldAndLimitLength() {
-  const inputs = document.querySelectorAll<HTMLInputElement>('input.ssn-toggle[type="password"]');
+const inputs = document.querySelectorAll<HTMLInputElement>('input.ssn-toggle[type="password"]');
+inputs.forEach((input) => {
+  const toggle = document.querySelector<HTMLInputElement>(`[aria-controls="${input.id}"]`)!;
 
-  if (inputs) {
-    inputs.forEach((input) => {
-      const toggle = document.querySelector<HTMLInputElement>(`[aria-controls="${input.id}"]`)!;
+  let cleave: Cleave | undefined;
 
-      let cleave: Cleave | undefined;
-
-      function sync() {
-        const { value } = input;
-        cleave?.destroy();
-        if (toggle.checked) {
-          cleave = new Cleave(input, {
-            numericOnly: true,
-            blocks: [3, 2, 4],
-            delimiter: '-',
-          });
-        } else {
-          const nextValue = value.replace(/-/g, '');
-          if (nextValue !== value) {
-            input.value = nextValue;
-          }
-        }
-        const didFormat = input.value !== value;
-        if (didFormat) {
-          input.checkValidity();
-        }
+  function sync() {
+    const { value } = input;
+    cleave?.destroy();
+    if (toggle.checked) {
+      cleave = new Cleave(input, {
+        numericOnly: true,
+        blocks: [3, 2, 4],
+        delimiter: '-',
+      });
+    } else {
+      const nextValue = value.replace(/-/g, '');
+      if (nextValue !== value) {
+        input.value = nextValue;
       }
-
-      sync();
-      toggle.addEventListener('change', sync);
-
-      function limitLength(this: HTMLInputElement) {
-        const maxLength = 9 + (this.value.match(/-/g) || []).length;
-        if (this.value.length > maxLength) {
-          this.value = this.value.slice(0, maxLength);
-          this.checkValidity();
-        }
-      }
-
-      input.addEventListener('input', limitLength.bind(input));
-    });
+    }
+    const didFormat = input.value !== value;
+    if (didFormat) {
+      input.checkValidity();
+    }
   }
-}
 
-document.addEventListener('DOMContentLoaded', formatSSNFieldAndLimitLength);
+  sync();
+  toggle.addEventListener('change', sync);
+
+  function limitLength(this: HTMLInputElement) {
+    const maxLength = 9 + (this.value.match(/-/g) || []).length;
+    if (this.value.length > maxLength) {
+      this.value = this.value.slice(0, maxLength);
+      this.checkValidity();
+    }
+  }
+
+  input.addEventListener('input', limitLength.bind(input));
+});

--- a/app/javascript/packs/state-guidance.ts
+++ b/app/javascript/packs/state-guidance.ts
@@ -57,8 +57,6 @@ function onIdentityDocJurisdictionSelection() {
 
 document.getElementById('idv_form_state')?.addEventListener('change', onStateSelectionChange);
 
-document.addEventListener('DOMContentLoaded', () => {
-  onStateSelectionChange();
-  onIdentityDocStateSelection();
-  onIdentityDocJurisdictionSelection();
-});
+onStateSelectionChange();
+onIdentityDocStateSelection();
+onIdentityDocJurisdictionSelection();


### PR DESCRIPTION
## 🛠 Summary of changes

Updates code which binds events to `DOMContentLoaded` to execute immediately.

This event is typically used to ensure that all content is present on a page before executing JavaScript, in case the script is loaded earlier than the elements it references. Packs are always loaded as the last content of every page ([source](https://github.com/18F/identity-idp/blob/83ec71c3912c259be6dc7f93426df5c81a69edb3/app/views/layouts/base.html.erb#L75)), so it's not necessary to wait before referencing these elements.

This also relates to #11096 and #11126, where `defer` has the effect of delaying `DOMContentLoaded` being fired, unlike asynchronous scripts. We can offset this by not relying on the `DOMContentLoaded`.

>The DOMContentLoaded event fires when the HTML document has been completely parsed, and all deferred scripts ([<script defer src="…">](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#defer) and [<script type="module">](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#module)) have downloaded and executed. It doesn't wait for other things like images, subframes, and async scripts to finish loading.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event

## 📜 Testing Plan

Verify no regressions in affected code:

- Mock device profile on the SSN step of IdV
- SSN formatting and visibility toggle on SSN step of IdV
- State-specific guidance for IPP 